### PR TITLE
[:has()] Invalidation fails with some complex nested cases with :is()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-in-is-non-subject-compound-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-in-is-non-subject-compound-expected.txt
@@ -1,0 +1,5 @@
+
+PASS initial: #subject is grey
+PASS insert .test under #trigger: #subject becomes red
+PASS remove .test: #subject returns to grey
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-in-is-non-subject-compound.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-in-is-non-subject-compound.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>:has() invalidation when :has() is in a non-subject compound of an enclosing :is()</title>
+<link rel="help" href="https://drafts.csswg.org/selectors/#relational">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+div { color: grey }
+/* :has() sits in the leftmost (ancestor) compound of the :is() argument; the actual
+   has-bearer is some ancestor of #outer, not #outer itself. */
+#outer:is(:has(.test) .outer) #subject { color: red }
+</style>
+<div>
+  <div id="trigger">
+    <div id="outer" class="outer">
+      <div id="subject"></div>
+    </div>
+  </div>
+</div>
+<script>
+const grey = 'rgb(128, 128, 128)';
+const red = 'rgb(255, 0, 0)';
+
+test(() => {
+  assert_equals(getComputedStyle(subject).color, grey);
+}, 'initial: #subject is grey');
+
+test(() => {
+  const testElement = document.createElement('div');
+  testElement.className = 'test';
+  trigger.appendChild(testElement);
+  assert_equals(getComputedStyle(subject).color, red);
+}, 'insert .test under #trigger: #subject becomes red');
+
+test(() => {
+  trigger.querySelector('.test').remove();
+  assert_equals(getComputedStyle(subject).color, grey);
+}, 'remove .test: #subject returns to grey');
+</script>

--- a/Source/WebCore/style/RuleFeature.cpp
+++ b/Source/WebCore/style/RuleFeature.cpp
@@ -252,6 +252,12 @@ struct RuleFeatureSet::RecursiveCollectionContext {
     const CSSSelector* hasPseudoClass { nullptr };
     bool isNestedInLogicalCombination { false };
     bool crossedScopeBreakingCombinator { false };
+    // Set when :has() sits in a non-subject compound of an enclosing :is()/:not() argument,
+    // e.g. `A:is(:has(X) C)`. The has-bearer is then ancestral to the :is() subject rather
+    // than the :is() subject itself, so the has-bearer can be anywhere relative to elements
+    // matching :has() arg simples — invariant "has-bearer is an ancestor of changed element"
+    // does not hold. Treat as scope-breaking.
+    bool hasInNonSubjectCompoundOfLogical { false };
 };
 
 void RuleFeatureSet::collectFeaturesFromSelector(SelectorFeatures& selectorFeatures, const CSSSelector& selector, MatchElement matchElement)
@@ -265,6 +271,10 @@ void RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFeatures& se
     const CSSSelector* selector = &firstSelector;
     bool isRightmostCompound = true;
     bool crossedScopeBreakingCombinator = context.crossedScopeBreakingCombinator;
+    // Tracks whether this walk has crossed any non-Subselector relation. Used at :has() entry
+    // to detect whether :has() sits in the subject compound of an enclosing :is()/:not()
+    // argument (no crossing → subject compound; crossed → non-subject/ancestor compound).
+    bool crossedCombinator = false;
 
     // When walking a :has() argument chain, emit hasPseudoClasses entries for compounds
     // at sibling combinator boundaries or containing positional pseudo-classes.
@@ -293,6 +303,8 @@ void RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFeatures& se
         // inside :is when :has() itself is in sibling/subject position). Otherwise the matched
         // element is always within the scope subtree and the scope selector can bound traversal.
         auto scopeSources = [&] -> Vector<const CSSSelector*> {
+            if (context.hasInNonSubjectCompoundOfLogical)
+                return { };
             if (context.isNestedInLogicalCombination && crossedScopeBreakingCombinator)
                 return { };
             auto result = context.outerCompoundSelectors;
@@ -334,19 +346,29 @@ void RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFeatures& se
             for (auto& subSelector : *selectorList) {
                 auto subResult = computeSubSelectorMatchElement(matchElement, *selector, subSelector);
 
-                RecursiveCollectionContext subContext { subResult, subSelectorIsNegation, context.outerCompoundSelectors, context.hasPseudoClass, context.isNestedInLogicalCombination, crossedScopeBreakingCombinator };
+                RecursiveCollectionContext subContext { subResult, subSelectorIsNegation, context.outerCompoundSelectors, context.hasPseudoClass, context.isNestedInLogicalCombination, crossedScopeBreakingCombinator, context.hasInNonSubjectCompoundOfLogical };
 
                 // When entering a logical combination (not :has() itself), record the outer compound
-                // so nested :has() can use it for scope selector extraction.
-                // Mark as nested so only sibling boundary entries are emitted, not rightmost.
+                // so nested :has() can use it for scope selector extraction. Only do this for
+                // :is()/:not() appearing outside :has(); :is()/:not() inside a :has() argument
+                // describes descendants of the has-bearer, not ancestors, and must not be merged
+                // into the scope compound.
                 if (selector->match() == CSSSelector::Match::PseudoClass && isLogicalCombinationPseudoClass(selector->pseudoClass()) && selector->pseudoClass() != CSSSelector::PseudoClass::Has) {
-                    subContext.outerCompoundSelectors.append(selector);
                     if (subContext.hasPseudoClass)
                         subContext.isNestedInLogicalCombination = true;
+                    else
+                        subContext.outerCompoundSelectors.append(selector);
                 }
 
-                if (selector->match() == CSSSelector::Match::PseudoClass && selector->pseudoClass() == CSSSelector::PseudoClass::Has)
+                if (selector->match() == CSSSelector::Match::PseudoClass && selector->pseudoClass() == CSSSelector::PseudoClass::Has) {
                     subContext.hasPseudoClass = selector;
+                    // If :has() is inside a :is()/:not() argument and the walk has crossed a
+                    // combinator before reaching :has(), :has() sits in an ancestor compound
+                    // of that argument's subject. The has-bearer is then ancestral to the
+                    // :is() subject and outerCompoundSelectors no longer constrain it.
+                    if (!context.outerCompoundSelectors.isEmpty() && crossedCombinator)
+                        subContext.hasInNonSubjectCompoundOfLogical = true;
+                }
 
                 recursivelyCollectFeaturesFromSelector(selectorFeatures, subSelector, subContext);
             }
@@ -357,6 +379,8 @@ void RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFeatures& se
 
         auto relation = selector->relation();
         isRightmostCompound = false;
+        if (relation != CSSSelector::Relation::Subselector)
+            crossedCombinator = true;
 
         if (context.isNestedInLogicalCombination && matchElement.hasRelation && isHasScopeBreakingCombinator(relation, *matchElement.hasRelation))
             crossedScopeBreakingCombinator = true;


### PR DESCRIPTION
#### fada6de9d9a6463838ac524cff4d37f29fc18ed9
<pre>
[:has()] Invalidation fails with some complex nested cases with :is()
<a href="https://bugs.webkit.org/show_bug.cgi?id=314503">https://bugs.webkit.org/show_bug.cgi?id=314503</a>
<a href="https://rdar.apple.com/176719780">rdar://176719780</a>

Reviewed by Alan Baradlay.

For rules like `#outer:is(:has(.test) .outer)`, where :has() sits in a
non-subject compound of an enclosing :is() argument, the has-bearer is
some ancestor of the :is() subject, not the :is() subject itself. The
scope selector built from outerCompoundSelectors + :has() peers
(`#outer` here) therefore points at the wrong element, and the
scope-bounded ancestor walk in StyleInvalidator skips the actual
has-bearer and misses invalidation entirely.

A related case is :is()/:not() appearing inside a :has() argument: those
peers describe descendants of the has-bearer (e.g. `.descendant` in
`.red:has(.descendant:is(.x .y))`) rather than ancestors and must not be
merged into the scope compound either.

Track combinator crossings in the current walk and add
hasInNonSubjectCompoundOfLogical, set at :has() entry when both
outerCompoundSelectors is non-empty and a combinator was crossed before
reaching :has(). When set, scope generation produces an empty (scope-
breaking) result so the invalidator falls through to a universal walk.
Also gate the outerCompoundSelectors append so :is()/:not() inside :has()
no longer pollutes the scope compound.

Test: imported/w3c/web-platform-tests/css/selectors/invalidation/has-in-is-non-subject-compound.html
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-in-is-non-subject-compound-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/has-in-is-non-subject-compound.html: Added.
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::RuleFeatureSet::recursivelyCollectFeaturesFromSelector):

Canonical link: <a href="https://commits.webkit.org/312966@main">https://commits.webkit.org/312966@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12ffdc87a5a25cf379dc0af5650fe7b34cf09533

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161712 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35186 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28289 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170615 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118083 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f2bb906f-d503-4ef8-8404-ebf9c155a885) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163581 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35287 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35187 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125459 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/96660b75-427a-46b9-b857-de34f159cb34) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164671 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27771 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/145252 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106055 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ce09702c-f99f-4938-b817-ee227192cba0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26820 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25330 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18336 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136513 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23007 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173103 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20144 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24648 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133751 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34860 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29422 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133756 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36124 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34844 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144802 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96860 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28293 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21624 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34354 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101799 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33854 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34097 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34003 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->