### PR TITLE
Correct URL parser invocation on the Notification object

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/notifications/icon-url-encoding-euc-kr.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/notifications/icon-url-encoding-euc-kr.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS icon-url-encoding-euc-kr
+

--- a/LayoutTests/imported/w3c/web-platform-tests/notifications/icon-url-encoding-euc-kr.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/notifications/icon-url-encoding-euc-kr.https.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="euc-kr">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  // This file is actually ascii, because otherwise text editors would have hard time.
+
+  promise_test(async (t) => {
+    // "icon" in Korean language
+    const iconKorean = "\uc544\uc744\ucf58";
+    const n = new Notification("title", { icon: `?icon=${iconKorean}` })
+    t.add_cleanup(() => n.close());
+
+    assert_equals(new URL(n.icon).search, "?icon=%EC%95%84%EC%9D%84%EC%BD%98", "icon encoded with utf-8");
+  })
+</script>

--- a/Source/WebCore/Modules/notifications/Notification.cpp
+++ b/Source/WebCore/Modules/notifications/Notification.cpp
@@ -189,14 +189,14 @@ Notification::Notification(ScriptExecutionContext& context, WTF::UUID identifier
 
 #if ENABLE(DECLARATIVE_WEB_PUSH)
     if (!options.navigate.isEmpty()) {
-        auto navigate = context.completeURL(WTF::move(options.navigate).isolatedCopy());
+        auto navigate = context.completeURL(WTF::move(options.navigate).isolatedCopy(), ScriptExecutionContext::ForceUTF8::Yes);
         if (navigate.isValid())
             m_navigate = WTF::move(navigate);
     }
 #endif
 
     if (!options.icon.isEmpty()) {
-        auto iconURL = context.completeURL(WTF::move(options.icon).isolatedCopy());
+        auto iconURL = context.completeURL(WTF::move(options.icon).isolatedCopy(), ScriptExecutionContext::ForceUTF8::Yes);
         if (iconURL.isValid())
             m_icon = iconURL;
     }


### PR DESCRIPTION
#### 2c9e4723db2bcfa66cf838b5e26d7ff0e15bd330
<pre>
Correct URL parser invocation on the Notification object
<a href="https://bugs.webkit.org/show_bug.cgi?id=314504">https://bugs.webkit.org/show_bug.cgi?id=314504</a>

Reviewed by Chris Dumez.

The URL parser defaults to using UTF-8 to encode the query parameter.
Unfortunately our code still defaults to inverse. (To be fixed
separately.)

Test: imported/w3c/web-platform-tests/notifications/icon-url-encoding-euc-kr.https.html
Canonical link: <a href="https://commits.webkit.org/312988@main">https://commits.webkit.org/312988@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5392d3a82950c75dc757e9a8f81e931234090998

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161684 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35158 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28261 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170587 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118055 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ac5b9f66-7f80-4248-960b-8dacf8c1f8a8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163553 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35259 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35159 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125437 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88362 "1 flakes 2 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2259e16b-21ce-4d7d-b20c-7d7f06e1542f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164643 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27745 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145226 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106033 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/73f0587f-1523-4b43-a62c-85c08c7bab23) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26794 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25303 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18308 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136487 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/22981 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173075 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20116 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24622 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133729 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34832 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29396 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133734 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34816 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144776 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96814 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24562 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28267 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21596 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34326 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101771 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33826 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34069 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/33975 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->