### PR TITLE
[GStreamer][MSE] changeType to/from MP3 fails

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1835,7 +1835,7 @@ webkit.org/b/167108 imported/w3c/web-platform-tests/media-source/mediasource-dur
 
 webkit.org/b/210486 imported/w3c/web-platform-tests/media-source/mediasource-correct-frames-after-reappend.html [ Failure ]
 
-webkit.org/b/226804 imported/w3c/web-platform-tests/media-source/mediasource-changetype-play.html [ Failure Timeout ]
+webkit.org/b/226804 imported/w3c/web-platform-tests/media-source/mediasource-changetype-play.html [ Pass Timeout ]
 
 webkit.org/b/210341 media/media-source/media-mp4-h264-sequence-mode.html [ Failure ]
 

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/media-source/mediasource-changetype-play-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/media-source/mediasource-changetype-play-expected.txt
@@ -1,0 +1,21 @@
+
+PASS Check if browser supports enough test media types
+PASS Test audio-only changeType for audio/webm; codecs="vorbis" <-> audio/webm; codecs="vorbis"
+PASS Test audio-only changeType for audio/webm; codecs="vorbis" <-> audio/mp4; codecs="mp4a.40.2"
+PASS Test audio-only changeType for audio/webm; codecs="vorbis" <-> audio/mpeg
+FAIL Test audio-only changeType for audio/mp4; codecs="mp4a.40.2" <-> audio/webm; codecs="vorbis" assert_unreached: Unexpected event 'error' Reached unreachable code
+PASS Test audio-only changeType for audio/mp4; codecs="mp4a.40.2" <-> audio/mp4; codecs="mp4a.40.2"
+PASS Test audio-only changeType for audio/mp4; codecs="mp4a.40.2" <-> audio/mpeg
+PASS Test audio-only changeType for audio/mpeg <-> audio/webm; codecs="vorbis"
+PASS Test audio-only changeType for audio/mpeg <-> audio/mp4; codecs="mp4a.40.2"
+PASS Test audio-only changeType for audio/mpeg <-> audio/mpeg
+PASS Test video-only changeType for video/webm; codecs="vp8" <-> video/webm; codecs="vp8"
+PASS Test video-only changeType for video/webm; codecs="vp8" <-> video/webm; codecs="vp9"
+PASS Test video-only changeType for video/webm; codecs="vp8" <-> video/mp4; codecs="avc1.4D4001"
+PASS Test video-only changeType for video/webm; codecs="vp9" <-> video/webm; codecs="vp8"
+PASS Test video-only changeType for video/webm; codecs="vp9" <-> video/webm; codecs="vp9"
+FAIL Test video-only changeType for video/webm; codecs="vp9" <-> video/mp4; codecs="avc1.4D4001" assert_unreached: Unexpected event 'error' Reached unreachable code
+FAIL Test video-only changeType for video/mp4; codecs="avc1.4D4001" <-> video/webm; codecs="vp8" assert_unreached: Unexpected event 'error' Reached unreachable code
+FAIL Test video-only changeType for video/mp4; codecs="avc1.4D4001" <-> video/webm; codecs="vp9" assert_unreached: Unexpected event 'error' Reached unreachable code
+PASS Test video-only changeType for video/mp4; codecs="avc1.4D4001" <-> video/mp4; codecs="avc1.4D4001"
+

--- a/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp
@@ -513,6 +513,12 @@ void AppendPipeline::appsinkNewSample(const Track& track, GRefPtr<GstSample>&& s
         return;
     }
 
+    if (GST_BUFFER_FLAG_IS_SET(buffer, GST_BUFFER_FLAG_DROPPABLE)) {
+        // mpegaudioparse might emit empty Xing metadata frames, ignore them.
+        GST_DEBUG_OBJECT(pipeline(), "Ignoring droppable sample");
+        return;
+    }
+
     auto hasValidPTS = GST_BUFFER_PTS_IS_VALID(buffer);
     if (!hasValidPTS && track.streamType != StreamType::Text) {
         // When demuxing Vorbis, matroskademux creates several PTS-less frames with header information. We don't need those.


### PR DESCRIPTION
#### f062e375dbf7a746368faf8de3299d8aedbf7b88
<pre>
[GStreamer][MSE] changeType to/from MP3 fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=314480">https://bugs.webkit.org/show_bug.cgi?id=314480</a>

Reviewed by NOBODY (OOPS!).

The mpegaudioparse GStreamer parser emits empty Xing metadata frames when parsing mpeg 1 layer 3
buffers, leading to incomplete sample removals after changeType which then lead to spurious caps
changes during playback where caps corresponding to the previous type would be pushed downstream,
leading to errors bubbling up to the media element.

Those empty Xing frames are marked as droppable by the parser, because they&apos;re optional for the
decoder, so don&apos;t relay them to the SourceBuffer.

This patch fixes 3 sub-tests in mediasource-changetype-play.html which now has glib baselines so
that remaining sub-tests can be fixed later while ensuring the existing passing sub-tests don&apos;t
silently regress.

* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/media-source/mediasource-changetype-play-expected.txt: Added.
* Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp:
(WebCore::AppendPipeline::appsinkNewSample):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f062e375dbf7a746368faf8de3299d8aedbf7b88

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/175816 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/49749 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/43533 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/185409 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/137999 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/177679 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51041 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/49431 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/136906 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/96220 "4 flakes 4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/178772 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/40362 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/157679 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117385 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39004 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/37386 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/149423 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37171 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/33879 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/41446 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/41592 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/187830 "Built successfully") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/49416 "Built successfully") | | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/145899 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50096 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/33795 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/145740 "Passed tests") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/40529 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/122292 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/116123 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/48603 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12151 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48005 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48237 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48062 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->