### PR TITLE
Require completeURL()'s ForceUTF8 argument

### DIFF
--- a/Source/WebCore/Modules/beacon/NavigatorBeacon.cpp
+++ b/Source/WebCore/Modules/beacon/NavigatorBeacon.cpp
@@ -111,7 +111,7 @@ void NavigatorBeacon::logError(const ResourceError& error)
 
 ExceptionOr<bool> NavigatorBeacon::sendBeacon(Document& document, const String& url, std::optional<FetchBody::Init>&& body)
 {
-    URL parsedUrl = document.completeURL(url);
+    URL parsedUrl = document.completeURL(url, ScriptExecutionContext::ForceUTF8::No);
 
     // Set parsedUrl to the result of the URL parser steps with url and base. If the algorithm returns an error, or if
     // parsedUrl's scheme is not "http" or "https", throw a "TypeError" exception and terminate these steps.

--- a/Source/WebCore/Modules/cookie-store/CookieStore.cpp
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.cpp
@@ -264,7 +264,7 @@ void CookieStore::getShared(GetType getType, CookieStoreGetOptions&& options, Re
 
     auto url = context->cookieURL();
     if (!options.url.isNull()) {
-        auto parsed = context->completeURL(options.url);
+        auto parsed = context->completeURL(options.url, ScriptExecutionContext::ForceUTF8::No);
         if (context->isDocument() && !equalIgnoringFragmentIdentifier(parsed, url)) {
             promise->reject(Exception { ExceptionCode::TypeError, "URL must match the document URL"_s });
             return;

--- a/Source/WebCore/Modules/mediasession/MediaMetadata.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaMetadata.cpp
@@ -73,7 +73,7 @@ void ArtworkImageLoader::requestImageResource()
     RefPtr document = m_document.get();
     options.contentSecurityPolicyImposition = document->isInUserAgentShadowTree() ? ContentSecurityPolicyImposition::SkipPolicyCheck : ContentSecurityPolicyImposition::DoPolicyCheck;
 
-    CachedResourceRequest request(ResourceRequest(document->completeURL(m_src)), options);
+    CachedResourceRequest request(ResourceRequest(document->completeURL(m_src, ScriptExecutionContext::ForceUTF8::No)), options);
     request.setInitiatorType(AtomString { document->documentURI() });
     m_cachedImage = protect(document->cachedResourceLoader())->requestImage(WTF::move(request)).value_or(nullptr);
 
@@ -168,7 +168,7 @@ ExceptionOr<void> MediaMetadata::setArtwork(ScriptExecutionContext& context, Vec
     Vector<MediaImage> resolvedArtwork;
     resolvedArtwork.reserveInitialCapacity(artwork.size());
     for (auto& image : artwork) {
-        auto resolvedSrc = context.completeURL(image.src);
+        auto resolvedSrc = context.completeURL(image.src, ScriptExecutionContext::ForceUTF8::No);
         if (!resolvedSrc.isValid())
             return Exception { ExceptionCode::TypeError };
         resolvedArtwork.append(MediaImage { resolvedSrc.string(), image.sizes, image.type });

--- a/Source/WebCore/Modules/plugins/YouTubePluginReplacement.cpp
+++ b/Source/WebCore/Modules/plugins/YouTubePluginReplacement.cpp
@@ -285,7 +285,7 @@ static URL processAndCreateYouTubeURL(const URL& url, bool& isYouTubeShortenedUR
 
 AtomString YouTubePluginReplacement::youTubeURL(const AtomString& srcString)
 {
-    URL srcURL = protect(m_parentElement->document())->completeURL(srcString);
+    URL srcURL = protect(m_parentElement->document())->completeURL(srcString, ScriptExecutionContext::ForceUTF8::No);
     return youTubeURLFromAbsoluteURL(srcURL, srcString);
 }
 

--- a/Source/WebCore/css/CSSStyleSheet.cpp
+++ b/Source/WebCore/css/CSSStyleSheet.cpp
@@ -110,7 +110,7 @@ ExceptionOr<Ref<CSSStyleSheet>> CSSStyleSheet::create(Document& document, Init&&
     if (init.baseURL.isNull())
         baseURL = document.baseURL();
     else {
-        baseURL = document.completeURL(init.baseURL);
+        baseURL = document.completeURL(init.baseURL, ScriptExecutionContext::ForceUTF8::No);
         if (!baseURL.isValid())
             return Exception { ExceptionCode::NotAllowedError, "Base URL is invalid"_s };
     }

--- a/Source/WebCore/css/StyleRuleImport.cpp
+++ b/Source/WebCore/css/StyleRuleImport.cpp
@@ -119,14 +119,14 @@ void StyleRuleImport::requestStyleSheet()
         // use parent styleheet's URL as the base URL
         absURL = URL(m_parentStyleSheet->baseURL(), m_strHref);
     else
-        absURL = document->completeURL(m_strHref);
+        absURL = document->completeURL(m_strHref, ScriptExecutionContext::ForceUTF8::No);
 
     // Check for a cycle in our import chain.  If we encounter a stylesheet
     // in our parent chain with the same URL, then just bail.
     RefPtr rootSheet = m_parentStyleSheet;
     for (RefPtr sheet = m_parentStyleSheet; sheet; sheet = sheet->parentStyleSheet()) {
         if (equalIgnoringFragmentIdentifier(absURL, sheet->baseURL())
-            || equalIgnoringFragmentIdentifier(absURL, document->completeURL(sheet->originalURL())))
+            || equalIgnoringFragmentIdentifier(absURL, document->completeURL(sheet->originalURL(), ScriptExecutionContext::ForceUTF8::No)))
             return;
         rootSheet = sheet;
     }

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4119,7 +4119,7 @@ void Document::implicitOpen()
 
 RefPtr<FontLoadRequest> Document::fontLoadRequest(const String& url, bool isSVG, bool isInitiatingElementInUserAgentShadowTree, LoadedFromOpaqueSource loadedFromOpaqueSource)
 {
-    RefPtr cachedFont = protect(fontLoader())->cachedFont(completeURL(url), isSVG, isInitiatingElementInUserAgentShadowTree, loadedFromOpaqueSource);
+    RefPtr cachedFont = protect(fontLoader())->cachedFont(completeURL(url, ForceUTF8::No), isSVG, isInitiatingElementInUserAgentShadowTree, loadedFromOpaqueSource);
     if (!cachedFont)
         return nullptr;
     return CachedFontLoadRequest::create(*cachedFont, *this);
@@ -4895,7 +4895,7 @@ void Document::processBaseElement()
 
     URL baseElementURL;
     if (!href.isNull())
-        baseElementURL = completeURL(href, fallbackBaseURL());
+        baseElementURL = completeURL(href, fallbackBaseURL(), ForceUTF8::No);
     if (m_baseElementURL != baseElementURL) {
         if (settings().shouldRestrictBaseURLSchemes() && !baseElementURL.isEmpty() && !baseElementURL.isValid()) {
             m_baseElementURL = { };

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -903,8 +903,8 @@ public:
     SpeculationRules& NODELETE speculationRules() const;
 
     URL baseURLForComplete(const URL& baseURLOverride) const;
-    WEBCORE_EXPORT URL completeURL(const String&, ForceUTF8 = ForceUTF8::No) const final;
-    URL completeURL(const String&, const URL& baseURLOverride, ForceUTF8 = ForceUTF8::No) const;
+    WEBCORE_EXPORT URL completeURL(const String&, ForceUTF8) const final;
+    URL completeURL(const String&, const URL& baseURLOverride, ForceUTF8) const;
 
     inline bool shouldMaskURLForBindings(const URL&) const;
     inline const URL& maskedURLForBindingsIfNeeded(const URL&) const;

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -2661,7 +2661,7 @@ URL Element::absoluteLinkURL() const
     if (linkAttribute.isEmpty())
         return URL();
 
-    return document().completeURL(linkAttribute);
+    return document().completeURL(linkAttribute, ScriptExecutionContext::ForceUTF8::No);
 }
 
 void Element::setIsLink(bool flag)
@@ -5094,7 +5094,7 @@ URL Element::getURLAttribute(const QualifiedName& name) const
             ASSERT(isURLAttribute(*attribute));
     }
 #endif
-    return document().completeURL(getAttribute(name));
+    return document().completeURL(getAttribute(name), ScriptExecutionContext::ForceUTF8::No);
 }
 
 URL Element::getNonEmptyURLAttribute(const QualifiedName& name) const
@@ -5108,7 +5108,7 @@ URL Element::getNonEmptyURLAttribute(const QualifiedName& name) const
     auto value = getAttribute(name).string().trim(isASCIIWhitespace);
     if (value.isEmpty())
         return URL();
-    return document().completeURL(value);
+    return document().completeURL(value, ScriptExecutionContext::ForceUTF8::No);
 }
 
 int Element::integralAttribute(const QualifiedName& attributeName) const
@@ -5991,7 +5991,7 @@ String Element::resolveURLStringIfNeeded(const String& urlString, ResolveURLs re
         return urlString;
 
     static MainThreadNeverDestroyed<const AtomString> maskedURLStringForBindings(document().maskedURLStringForBindings());
-    URL completeURL = base.isNull() ? document().completeURL(urlString) : URL(base, urlString);
+    URL completeURL = base.isNull() ? document().completeURL(urlString, ScriptExecutionContext::ForceUTF8::No) : URL(base, urlString);
 
     switch (resolveURLs) {
     case ResolveURLs::Yes:
@@ -6161,7 +6161,7 @@ RefPtr<Element> Element::findAnchorElementForLink(String& outAnchorName)
         return nullptr;
 
     Ref document = this->document();
-    URL url = document->completeURL(href);
+    URL url = document->completeURL(href, ScriptExecutionContext::ForceUTF8::No);
     if (!url.isValid())
         return nullptr;
 

--- a/Source/WebCore/dom/EmptyScriptExecutionContext.h
+++ b/Source/WebCore/dom/EmptyScriptExecutionContext.h
@@ -60,7 +60,7 @@ public:
     }
     const URL& url() const LIFETIME_BOUND final { return m_url; }
     const URL& cookieURL() const final { return url(); }
-    URL completeURL(const String&, ForceUTF8 = ForceUTF8::No) const final { return { }; }
+    URL completeURL(const String&, ForceUTF8) const final { return { }; }
     String userAgent(const URL&) const final { return emptyString(); }
     ReferrerPolicy referrerPolicy() const final { return ReferrerPolicy::EmptyString; }
 

--- a/Source/WebCore/dom/ProcessingInstruction.cpp
+++ b/Source/WebCore/dom/ProcessingInstruction.cpp
@@ -150,7 +150,7 @@ void ProcessingInstruction::checkStyleSheet()
             if (m_isXSL) {
                 auto options = CachedResourceLoader::defaultCachedResourceOptions();
                 options.mode = FetchOptions::Mode::SameOrigin;
-                if (auto result = protect(document->cachedResourceLoader())->requestXSLStyleSheet({ ResourceRequest(document->completeURL(href)), options }))
+                if (auto result = protect(document->cachedResourceLoader())->requestXSLStyleSheet({ ResourceRequest(document->completeURL(href, ScriptExecutionContext::ForceUTF8::No)), options }))
                     m_cachedSheet = WTF::move(result.value());
                 else
                     m_cachedSheet = nullptr;
@@ -158,7 +158,7 @@ void ProcessingInstruction::checkStyleSheet()
 #endif
             {
                 String charset = attributes->get<HashTranslatorASCIILiteral>("charset"_s);
-                CachedResourceRequest request(document->completeURL(href), CachedResourceLoader::defaultCachedResourceOptions(), std::nullopt, charset.isEmpty() ? String::fromLatin1(document->charset()) : WTF::move(charset));
+                CachedResourceRequest request(document->completeURL(href, ScriptExecutionContext::ForceUTF8::No), CachedResourceLoader::defaultCachedResourceOptions(), std::nullopt, charset.isEmpty() ? String::fromLatin1(document->charset()) : WTF::move(charset));
 
                 if (auto result = protect(document->cachedResourceLoader())->requestCSSStyleSheet(WTF::move(request)))
                     m_cachedSheet = WTF::move(result.value());

--- a/Source/WebCore/dom/ScriptElement.cpp
+++ b/Source/WebCore/dom/ScriptElement.cpp
@@ -366,7 +366,7 @@ void ScriptElement::updateTaintedOriginFromSourceURL()
     if (!page)
         return;
 
-    if (!page->requiresScriptTrackingPrivacyProtections(hasSourceAttribute() ? document->completeURL(sourceAttributeValue()) : document->url()))
+    if (!page->requiresScriptTrackingPrivacyProtections(hasSourceAttribute() ? document->completeURL(sourceAttributeValue(), ScriptExecutionContext::ForceUTF8::No) : document->url()))
         return;
 
     m_taintedOrigin = JSC::SourceTaintedOrigin::KnownTainted;
@@ -382,7 +382,7 @@ bool ScriptElement::requestClassicScript(const String& sourceURL)
         auto script = LoadableClassicScript::create(element->nonce(), element->attributeWithoutSynchronization(HTMLNames::integrityAttr), referrerPolicy(), fetchPriority(),
             element->attributeWithoutSynchronization(HTMLNames::crossoriginAttr), scriptCharset(), element->localName(), element->isInUserAgentShadowTree(), hasAsyncAttribute());
 
-        auto scriptURL = document->completeURL(sourceURL);
+        auto scriptURL = document->completeURL(sourceURL, ScriptExecutionContext::ForceUTF8::No);
         document->willLoadScriptElement(scriptURL);
 
         if (!protect(document->contentSecurityPolicy())->allowScriptForStrictDynamic(scriptURL, URL(), m_startLineNumber, element->nonce(), script->integrity(), String(), m_parserInserted))
@@ -423,7 +423,7 @@ bool ScriptElement::requestModuleScript(const String& sourceText, const TextPosi
             return false;
         }
 
-        auto moduleScriptRootURL = document->completeURL(sourceURL);
+        auto moduleScriptRootURL = document->completeURL(sourceURL, ScriptExecutionContext::ForceUTF8::No);
         if (!moduleScriptRootURL.isValid()) {
             dispatchErrorEvent();
             return false;

--- a/Source/WebCore/dom/ScriptExecutionContext.cpp
+++ b/Source/WebCore/dom/ScriptExecutionContext.cpp
@@ -525,7 +525,7 @@ bool ScriptExecutionContext::canIncludeErrorDetails(CachedScript* script, const 
     // Errors from module scripts are never muted.
     if (fromModule)
         return true;
-    URL completeSourceURL = completeURL(sourceURL);
+    URL completeSourceURL = completeURL(sourceURL, ForceUTF8::No);
     if (completeSourceURL.protocolIsData())
         return true;
     if (script) {

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -153,7 +153,7 @@ public:
 
     virtual const URL& url() const = 0;
     enum class ForceUTF8 : bool { No, Yes };
-    virtual URL completeURL(const String& url, ForceUTF8 = ForceUTF8::No) const = 0;
+    virtual URL completeURL(const String& url, ForceUTF8) const = 0;
 
     virtual const URL& cookieURL() const = 0;
 

--- a/Source/WebCore/editing/Editor.cpp
+++ b/Source/WebCore/editing/Editor.cpp
@@ -4853,7 +4853,7 @@ void Editor::registerAttachmentIdentifier(const String& identifier, const Attach
 
         String name = imageElement->attributeWithoutSynchronization(altAttr);
         if (name.isEmpty())
-            name = imageElement->document().completeURL(imageElement->imageSourceURL()).lastPathComponent().toString();
+            name = imageElement->document().completeURL(imageElement->imageSourceURL(), ScriptExecutionContext::ForceUTF8::No).lastPathComponent().toString();
 
         if (name.isEmpty())
             return std::nullopt;

--- a/Source/WebCore/editing/cocoa/EditingHTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/EditingHTMLConverter.mm
@@ -104,7 +104,7 @@ static String preferredFilenameForElement(const HTMLImageElement& element)
 
     auto suggestedName = [&] -> String {
         Ref document = element.document();
-        RetainPtr url = document->completeURL(urlString).createNSURL();
+        RetainPtr url = document->completeURL(urlString, ScriptExecutionContext::ForceUTF8::No).createNSURL();
         if (!url)
             url = [NSURL _web_URLWithString:[urlString.createNSString() stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] relativeToURL:nil];
 

--- a/Source/WebCore/editing/cocoa/NodeHTMLConverter.mm
+++ b/Source/WebCore/editing/cocoa/NodeHTMLConverter.mm
@@ -1632,9 +1632,9 @@ void HTMLConverter::_addLinkForElement(Element& element, NSRange range)
     RetainPtr urlString = element.getAttribute(hrefAttr).createNSString();
     RetainPtr strippedString = [urlString stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
     if (urlString && [urlString length] > 0 && strippedString && [strippedString length] > 0 && ![strippedString hasPrefix:@"#"]) {
-        RetainPtr url = element.document().completeURL(urlString.get()).createNSURL();
+        RetainPtr url = element.document().completeURL(urlString.get(), ScriptExecutionContext::ForceUTF8::No).createNSURL();
         if (!url)
-            url = element.document().completeURL(strippedString.get()).createNSURL();
+            url = element.document().completeURL(strippedString.get(), ScriptExecutionContext::ForceUTF8::No).createNSURL();
         if (!url)
             url = [NSURL _web_URLWithString:strippedString.get() relativeToURL:nil];
         [_attrStr addAttribute:NSLinkAttributeName value:url ? (id)url.get() : (id)urlString.get() range:range];
@@ -1794,7 +1794,7 @@ BOOL HTMLConverter::_processElement(Element& element, NSInteger depth)
 #endif
         RetainPtr urlString = element.imageSourceURL().createNSString();
         if (retval && urlString && [urlString length] > 0) {
-            RetainPtr url = element.document().completeURL(urlString.get()).createNSURL();
+            RetainPtr url = element.document().completeURL(urlString.get(), ScriptExecutionContext::ForceUTF8::No).createNSURL();
             if (!url)
                 url = [NSURL _web_URLWithString:[urlString stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] relativeToURL:nil];
 #if PLATFORM(IOS_FAMILY)
@@ -1814,14 +1814,14 @@ BOOL HTMLConverter::_processElement(Element& element, NSInteger depth)
             RetainPtr<NSURL> baseURL;
             RetainPtr<NSURL> url;
             if (baseString && [baseString length] > 0) {
-                baseURL = element.document().completeURL(baseString.get()).createNSURL();
+                baseURL = element.document().completeURL(baseString.get(), ScriptExecutionContext::ForceUTF8::No).createNSURL();
                 if (!baseURL)
                     baseURL = [NSURL _web_URLWithString:[baseString stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] relativeToURL:nil];
             }
             if (baseURL)
                 url = [NSURL _web_URLWithString:[urlString stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] relativeToURL:baseURL.get()];
             if (!url)
-                url = element.document().completeURL(urlString.get()).createNSURL();
+                url = element.document().completeURL(urlString.get(), ScriptExecutionContext::ForceUTF8::No).createNSURL();
             if (!url)
                 url = [NSURL _web_URLWithString:[urlString stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]] relativeToURL:nil];
             if (url)

--- a/Source/WebCore/editing/glib/EditorGLib.cpp
+++ b/Source/WebCore/editing/glib/EditorGLib.cpp
@@ -108,7 +108,7 @@ void Editor::writeImageToPasteboard(Pasteboard& pasteboard, Element& imageElemen
         return;
     ASSERT(pasteboardImage.image);
 
-    pasteboardImage.url.url = imageElement.document().completeURL(elementURL(imageElement));
+    pasteboardImage.url.url = imageElement.document().completeURL(elementURL(imageElement), ScriptExecutionContext::ForceUTF8::No);
     pasteboardImage.url.title = title;
     pasteboardImage.url.markup = serializeFragment(imageElement, SerializedNodes::SubtreeIncludingNode, nullptr, ResolveURLs::Yes);
     pasteboard.write(pasteboardImage);

--- a/Source/WebCore/editing/ios/EditorIOS.mm
+++ b/Source/WebCore/editing/ios/EditorIOS.mm
@@ -109,7 +109,7 @@ void Editor::writeImageToPasteboard(Pasteboard& pasteboard, Element& imageElemen
         return;
     ASSERT(cachedImage);
 
-    auto imageSourceURL = imageElement.document().completeURL(imageElement.imageSourceURL());
+    auto imageSourceURL = imageElement.document().completeURL(imageElement.imageSourceURL(), ScriptExecutionContext::ForceUTF8::No);
 
     auto pasteboardImageURL = url.isEmpty() ? imageSourceURL : url;
     if (!pasteboardImageURL.protocolIsFile()) {

--- a/Source/WebCore/html/HTMLAnchorElement.cpp
+++ b/Source/WebCore/html/HTMLAnchorElement.cpp
@@ -286,7 +286,7 @@ bool HTMLAnchorElement::draggable() const
 
 URL HTMLAnchorElement::href() const
 {
-    return protect(document())->completeURL(attributeWithoutSynchronization(hrefAttr));
+    return protect(document())->completeURL(attributeWithoutSynchronization(hrefAttr), ScriptExecutionContext::ForceUTF8::No);
 }
 
 bool HTMLAnchorElement::hasRel(Relation relation) const
@@ -367,7 +367,7 @@ void HTMLAnchorElement::sendPings(const URL& destinationURL)
     Ref document = this->document();
     SpaceSplitString pingURLs(pingValue, SpaceSplitString::ShouldFoldCase::No);
     for (auto& pingURL : pingURLs)
-        PingLoader::sendPing(*protect(document->frame()), document->completeURL(pingURL), destinationURL);
+        PingLoader::sendPing(*protect(document->frame()), document->completeURL(pingURL, ScriptExecutionContext::ForceUTF8::No), destinationURL);
 }
 
 #if USE(SYSTEM_PREVIEW)
@@ -565,7 +565,7 @@ void HTMLAnchorElement::handleClick(Event& event)
     StringBuilder url;
     url.append(StringView(attributeWithoutSynchronization(hrefAttr).string()).trim(isASCIIWhitespace));
     appendServerMapMousePosition(url, event);
-    URL completedURL = document->completeURL(url.toString());
+    URL completedURL = document->completeURL(url.toString(), ScriptExecutionContext::ForceUTF8::No);
 
 #if ENABLE(DATA_DETECTION) && PLATFORM(IOS_FAMILY)
     if (DataDetection::canPresentDataDetectorsUIForElement(*this)) {

--- a/Source/WebCore/html/HTMLBaseElement.cpp
+++ b/Source/WebCore/html/HTMLBaseElement.cpp
@@ -88,7 +88,7 @@ String HTMLBaseElement::href() const
         url = emptyAtom();
 
     Ref document = this->document();
-    auto urlRecord = document->completeURL(url, document->fallbackBaseURL());
+    auto urlRecord = document->completeURL(url, document->fallbackBaseURL(), ScriptExecutionContext::ForceUTF8::No);
     if (!urlRecord.isValid())
         return url;
 

--- a/Source/WebCore/html/HTMLBodyElement.cpp
+++ b/Source/WebCore/html/HTMLBodyElement.cpp
@@ -89,7 +89,7 @@ void HTMLBodyElement::collectPresentationalHintsForAttribute(const QualifiedName
     case AttributeNames::backgroundAttr: {
         auto url = value.string().trim(isASCIIWhitespace);
         if (!url.isEmpty())
-            style.setProperty(CSSProperty(CSSPropertyBackgroundImage, CSSImageValue::create(protect(document())->completeURL(url), localName())));
+            style.setProperty(CSSProperty(CSSPropertyBackgroundImage, CSSImageValue::create(protect(document())->completeURL(url, ScriptExecutionContext::ForceUTF8::No), localName())));
         break;
     }
     case AttributeNames::marginwidthAttr:
@@ -221,7 +221,7 @@ void HTMLBodyElement::addSubresourceAttributeURLs(ListHashSet<URL>& urls) const
 {
     HTMLElement::addSubresourceAttributeURLs(urls);
 
-    addSubresourceURL(urls, protect(document())->completeURL(attributeWithoutSynchronization(backgroundAttr)));
+    addSubresourceURL(urls, protect(document())->completeURL(attributeWithoutSynchronization(backgroundAttr), ScriptExecutionContext::ForceUTF8::No));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/html/HTMLEmbedElement.cpp
+++ b/Source/WebCore/html/HTMLEmbedElement.cpp
@@ -228,7 +228,7 @@ void HTMLEmbedElement::addSubresourceAttributeURLs(ListHashSet<URL>& urls) const
 {
     HTMLPlugInElement::addSubresourceAttributeURLs(urls);
 
-    addSubresourceURL(urls, protect(document())->completeURL(attributeWithoutSynchronization(srcAttr)));
+    addSubresourceURL(urls, protect(document())->completeURL(attributeWithoutSynchronization(srcAttr), ScriptExecutionContext::ForceUTF8::No));
 }
 
 }

--- a/Source/WebCore/html/HTMLFormControlElement.cpp
+++ b/Source/WebCore/html/HTMLFormControlElement.cpp
@@ -103,7 +103,7 @@ String HTMLFormControlElement::formAction() const
     Ref document = this->document();
     if (value.isEmpty())
         return document->url().string();
-    return document->completeURL(value).string();
+    return document->completeURL(value, ScriptExecutionContext::ForceUTF8::No).string();
 }
 
 Node::NeedsPostConnectionSteps HTMLFormControlElement::insertionSteps(InsertionType insertionType, ContainerNode& parentOfInsertedTree)

--- a/Source/WebCore/html/HTMLFormElement.cpp
+++ b/Source/WebCore/html/HTMLFormElement.cpp
@@ -682,7 +682,7 @@ String HTMLFormElement::action() const
     auto& value = attributeWithoutSynchronization(actionAttr);
     if (value.isEmpty())
         return document().url().string();
-    return document().completeURL(value).string();
+    return document().completeURL(value, ScriptExecutionContext::ForceUTF8::No).string();
 }
 
 String HTMLFormElement::method() const

--- a/Source/WebCore/html/HTMLFrameElementBase.cpp
+++ b/Source/WebCore/html/HTMLFrameElementBase.cpp
@@ -73,7 +73,7 @@ bool HTMLFrameElementBase::canLoad() const
 
 bool HTMLFrameElementBase::canLoadURL(const String& relativeURL) const
 {
-    return canLoadURL(protect(document())->completeURL(relativeURL));
+    return canLoadURL(protect(document())->completeURL(relativeURL, ScriptExecutionContext::ForceUTF8::No));
 }
 
 // Note that unlike HTMLPlugInElement::canLoadURL this uses ScriptController::canAccessFromCurrentOrigin.
@@ -109,7 +109,7 @@ void HTMLFrameElementBase::openURL(LockHistory lockHistory, LockBackForwardList 
             frameName = getIdAttribute();
     }
 
-    auto completeURL = document->completeURL(m_frameURL);
+    auto completeURL = document->completeURL(m_frameURL, ScriptExecutionContext::ForceUTF8::No);
     auto finishOpeningURL = [weakThis = WeakPtr { *this }, frameName, lockHistory, lockBackForwardList, parentFrame = WTF::move(parentFrame), completeURL] {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)

--- a/Source/WebCore/html/HTMLIFrameElement.cpp
+++ b/Source/WebCore/html/HTMLIFrameElement.cpp
@@ -220,7 +220,7 @@ bool HTMLIFrameElement::shouldLoadFrameLazily()
     Ref document = this->document();
     if (!document->settings().lazyIframeLoadingEnabled() || document->quirks().shouldDisableLazyIframeLoadingQuirk())
         return false;
-    URL completeURL = document->completeURL(frameURL());
+    URL completeURL = document->completeURL(frameURL(), ScriptExecutionContext::ForceUTF8::No);
     auto referrerPolicy = referrerPolicyFromAttribute();
     if (!m_lazyLoadFrameObserver) {
         if (isFrameLazyLoadable(document, completeURL, attributeWithoutSynchronization(HTMLNames::loadingAttr))) {

--- a/Source/WebCore/html/HTMLImageElement.cpp
+++ b/Source/WebCore/html/HTMLImageElement.cpp
@@ -253,7 +253,7 @@ void HTMLImageElement::setBestFitURLAndDPRFromImageCandidate(const ImageCandidat
 
     auto sourceURL = imageSourceURL();
     // Only complete the URL if it's non-empty to avoid resolving "" to the document base URL.
-    m_currentURL = sourceURL.isEmpty() ? URL() : protect(document())->completeURL(sourceURL);
+    m_currentURL = sourceURL.isEmpty() ? URL() : protect(document())->completeURL(sourceURL, ScriptExecutionContext::ForceUTF8::No);
 
     m_currentSrc = { };
     if (candidate.density >= 0)
@@ -733,7 +733,7 @@ String HTMLImageElement::completeURLsInAttributeValue(const URL& base, const Att
             for (const auto& candidate : imageCandidates) {
                 auto urlString = candidate.string.toString();
                 Ref document = this->document();
-                auto completeURL = base.isNull() ? document->completeURL(urlString) : URL(base, urlString);
+                auto completeURL = base.isNull() ? document->completeURL(urlString, ScriptExecutionContext::ForceUTF8::No) : URL(base, urlString);
                 if (document->shouldMaskURLForBindings(completeURL)) {
                     needsToResolveURLs = true;
                     break;
@@ -842,9 +842,9 @@ void HTMLImageElement::addSubresourceAttributeURLs(ListHashSet<URL>& urls) const
     HTMLElement::addSubresourceAttributeURLs(urls);
 
     Ref document = this->document();
-    addSubresourceURL(urls, document->completeURL(imageSourceURL()));
+    addSubresourceURL(urls, document->completeURL(imageSourceURL(), ScriptExecutionContext::ForceUTF8::No));
     // FIXME: What about when the usemap attribute begins with "#"?
-    addSubresourceURL(urls, document->completeURL(attributeWithoutSynchronization(usemapAttr)));
+    addSubresourceURL(urls, document->completeURL(attributeWithoutSynchronization(usemapAttr), ScriptExecutionContext::ForceUTF8::No));
 }
 
 void HTMLImageElement::addCandidateSubresourceURLs(ListHashSet<URL>& urls) const

--- a/Source/WebCore/html/HTMLLinkElement.cpp
+++ b/Source/WebCore/html/HTMLLinkElement.cpp
@@ -759,7 +759,7 @@ bool HTMLLinkElement::isURLAttribute(const Attribute& attribute) const
 
 URL HTMLLinkElement::href() const
 {
-    return protect(document())->completeURL(attributeWithoutSynchronization(hrefAttr));
+    return protect(document())->completeURL(attributeWithoutSynchronization(hrefAttr), ScriptExecutionContext::ForceUTF8::No);
 }
 
 const AtomString& HTMLLinkElement::rel() const
@@ -770,7 +770,7 @@ const AtomString& HTMLLinkElement::rel() const
 #if ENABLE(WEB_PAGE_SPATIAL_BACKDROP)
 URL HTMLLinkElement::environmentMap() const
 {
-    return document().completeURL(attributeWithoutSynchronization(environmentmapAttr));
+    return document().completeURL(attributeWithoutSynchronization(environmentmapAttr), ScriptExecutionContext::ForceUTF8::No);
 }
 #endif
 

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -1840,7 +1840,7 @@ void HTMLMediaElement::selectMediaResource()
                 return;
             }
 
-            auto absoluteURL = element.document().completeURL(srcValue);
+            auto absoluteURL = element.document().completeURL(srcValue, ScriptExecutionContext::ForceUTF8::No);
             if (!element.isSafeToLoadURL(absoluteURL, InvalidURLAction::Complain)) {
                 element.mediaLoadingFailed(MediaPlayer::NetworkState::FormatError);
                 return;
@@ -5713,7 +5713,7 @@ URL HTMLMediaElement::selectNextSourceChild(ContentType* contentType, InvalidURL
         // from parsing the URL specified by candidate's src attribute's value
         // relative to the candidate's node document when the src attribute was
         // last changed.
-        mediaURL = protect(source->document())->completeURL(srcValue);
+        mediaURL = protect(source->document())->completeURL(srcValue, ScriptExecutionContext::ForceUTF8::No);
 
         if (auto mediaQueryList = source->parsedMediaAttribute(protect(document())); !mediaQueryList.isEmpty()) {
             if (shouldLog)

--- a/Source/WebCore/html/HTMLObjectElement.cpp
+++ b/Source/WebCore/html/HTMLObjectElement.cpp
@@ -326,7 +326,7 @@ void HTMLObjectElement::addSubresourceAttributeURLs(ListHashSet<URL>& urls) cons
 {
     HTMLPlugInElement::addSubresourceAttributeURLs(urls);
 
-    addSubresourceURL(urls, protect(document())->completeURL(attributeWithoutSynchronization(dataAttr)));
+    addSubresourceURL(urls, protect(document())->completeURL(attributeWithoutSynchronization(dataAttr), ScriptExecutionContext::ForceUTF8::No));
 }
 
 void HTMLObjectElement::didMoveToNewDocument(Document& oldDocument, Document& newDocument)

--- a/Source/WebCore/html/HTMLPlugInElement.cpp
+++ b/Source/WebCore/html/HTMLPlugInElement.cpp
@@ -447,7 +447,7 @@ bool HTMLPlugInElement::requestObject(const String& relativeURL, const String& m
     Ref document = this->document();
     URL completedURL;
     if (!relativeURL.isEmpty())
-        completedURL = document->completeURL(relativeURL);
+        completedURL = document->completeURL(relativeURL, ScriptExecutionContext::ForceUTF8::No);
 
     if (ReplacementPlugin* replacement = pluginReplacementForType(completedURL, mimeType)) {
         LOG(Plugins, "%p - Found plug-in replacement for %s.", this, completedURL.string().utf8().data());
@@ -534,7 +534,7 @@ RenderEmbeddedObject* HTMLPlugInElement::renderEmbeddedObject() const
 
 bool HTMLPlugInElement::canLoadURL(const String& relativeURL) const
 {
-    return canLoadURL(protect(document())->completeURL(relativeURL));
+    return canLoadURL(protect(document())->completeURL(relativeURL, ScriptExecutionContext::ForceUTF8::No));
 }
 
 bool HTMLPlugInElement::canLoadURL(const URL& completeURL) const
@@ -558,7 +558,7 @@ bool HTMLPlugInElement::wouldLoadAsPlugIn(const String& relativeURL, const Strin
     ASSERT(document->frame());
     URL completedURL;
     if (!relativeURL.isEmpty())
-        completedURL = document->completeURL(relativeURL);
+        completedURL = document->completeURL(relativeURL, ScriptExecutionContext::ForceUTF8::No);
     return document->frame()->loader().client().objectContentType(completedURL, serviceType) == ObjectContentType::PlugIn;
 }
 
@@ -569,7 +569,7 @@ bool HTMLPlugInElement::isImageType()
 
     Ref document = this->document();
     if (RefPtr frame = document->frame())
-        return frame->loader().client().objectContentType(document->completeURL(m_url), m_serviceType) == ObjectContentType::Image;
+        return frame->loader().client().objectContentType(document->completeURL(m_url, ScriptExecutionContext::ForceUTF8::No), m_serviceType) == ObjectContentType::Image;
 
     return Image::supportsType(m_serviceType);
 }
@@ -688,7 +688,7 @@ bool HTMLPlugInElement::canLoadPlugInContent(const String& relativeURL, const St
     Ref document = this->document();
     URL completedURL;
     if (!relativeURL.isEmpty())
-        completedURL = document->completeURL(relativeURL);
+        completedURL = document->completeURL(relativeURL, ScriptExecutionContext::ForceUTF8::No);
 
     ASSERT(document->contentSecurityPolicy());
     CheckedRef contentSecurityPolicy = *document->contentSecurityPolicy();

--- a/Source/WebCore/html/HTMLScriptElement.cpp
+++ b/Source/WebCore/html/HTMLScriptElement.cpp
@@ -220,7 +220,7 @@ void HTMLScriptElement::addSubresourceAttributeURLs(ListHashSet<URL>& urls) cons
 {
     HTMLElement::addSubresourceAttributeURLs(urls);
 
-    addSubresourceURL(urls, protect(document())->completeURL(sourceAttributeValue()));
+    addSubresourceURL(urls, protect(document())->completeURL(sourceAttributeValue(), ScriptExecutionContext::ForceUTF8::No));
 }
 
 String HTMLScriptElement::sourceAttributeValue() const

--- a/Source/WebCore/html/HTMLTableCellElement.cpp
+++ b/Source/WebCore/html/HTMLTableCellElement.cpp
@@ -182,7 +182,7 @@ void HTMLTableCellElement::addSubresourceAttributeURLs(ListHashSet<URL>& urls) c
 {
     HTMLTablePartElement::addSubresourceAttributeURLs(urls);
 
-    addSubresourceURL(urls, protect(document())->completeURL(attributeWithoutSynchronization(backgroundAttr)));
+    addSubresourceURL(urls, protect(document())->completeURL(attributeWithoutSynchronization(backgroundAttr), ScriptExecutionContext::ForceUTF8::No));
 }
 
 HTMLTableCellElement* HTMLTableCellElement::cellAbove() const

--- a/Source/WebCore/html/HTMLTableElement.cpp
+++ b/Source/WebCore/html/HTMLTableElement.cpp
@@ -330,7 +330,7 @@ void HTMLTableElement::collectPresentationalHintsForAttribute(const QualifiedNam
         break;
     case AttributeNames::backgroundAttr:
         if (auto url = value.string().trim(isASCIIWhitespace); !url.isEmpty())
-            style.setProperty(CSSProperty(CSSPropertyBackgroundImage, CSSImageValue::create(protect(document())->completeURL(url))));
+            style.setProperty(CSSProperty(CSSPropertyBackgroundImage, CSSImageValue::create(protect(document())->completeURL(url, ScriptExecutionContext::ForceUTF8::No))));
         break;
     case AttributeNames::valignAttr:
         if (!value.isEmpty())
@@ -605,7 +605,7 @@ void HTMLTableElement::addSubresourceAttributeURLs(ListHashSet<URL>& urls) const
 {
     HTMLElement::addSubresourceAttributeURLs(urls);
 
-    addSubresourceURL(urls, protect(document())->completeURL(attributeWithoutSynchronization(backgroundAttr)));
+    addSubresourceURL(urls, protect(document())->completeURL(attributeWithoutSynchronization(backgroundAttr), ScriptExecutionContext::ForceUTF8::No));
 }
 
 }

--- a/Source/WebCore/html/HTMLTablePartElement.cpp
+++ b/Source/WebCore/html/HTMLTablePartElement.cpp
@@ -65,7 +65,7 @@ void HTMLTablePartElement::collectPresentationalHintsForAttribute(const Qualifie
         break;
     case AttributeNames::backgroundAttr:
         if (!StringView(value).containsOnly<isASCIIWhitespace<char16_t>>())
-            style.setProperty(CSSProperty(CSSPropertyBackgroundImage, CSSImageValue::create(protect(document())->completeURL(value))));
+            style.setProperty(CSSProperty(CSSPropertyBackgroundImage, CSSImageValue::create(protect(document())->completeURL(value, ScriptExecutionContext::ForceUTF8::No))));
         break;
     case AttributeNames::valignAttr:
         if (equalLettersIgnoringASCIICase(value, "top"_s))

--- a/Source/WebCore/html/HTMLVideoElement.cpp
+++ b/Source/WebCore/html/HTMLVideoElement.cpp
@@ -529,7 +529,7 @@ URL HTMLVideoElement::posterImageURL() const
     auto url = imageSourceURL().trim(isASCIIWhitespace);
     if (url.isEmpty())
         return URL();
-    return protect(document())->completeURL(url);
+    return protect(document())->completeURL(url, ScriptExecutionContext::ForceUTF8::No);
 }
 
 #if ENABLE(VIDEO_PRESENTATION_MODE)

--- a/Source/WebCore/html/MediaDocument.cpp
+++ b/Source/WebCore/html/MediaDocument.cpp
@@ -127,7 +127,7 @@ void MediaDocumentParser::createDocumentStructure()
         return;
 
     frame->loader().activeDocumentLoader()->setMainResourceDataBufferingPolicy(DataBufferingPolicy::DoNotBufferData);
-    frame->loader().setOutgoingReferrer(document->completeURL(m_outgoingReferrer));
+    frame->loader().setOutgoingReferrer(document->completeURL(m_outgoingReferrer, ScriptExecutionContext::ForceUTF8::No));
 }
 
 void MediaDocumentParser::appendBytes(DocumentWriter&, std::span<const uint8_t>)

--- a/Source/WebCore/html/ModelDocument.cpp
+++ b/Source/WebCore/html/ModelDocument.cpp
@@ -126,7 +126,7 @@ void ModelDocumentParser::createDocumentStructure()
         return;
 
     frame->loader().activeDocumentLoader()->setMainResourceDataBufferingPolicy(DataBufferingPolicy::DoNotBufferData);
-    frame->loader().setOutgoingReferrer(document->completeURL(m_outgoingReferrer));
+    frame->loader().setOutgoingReferrer(document->completeURL(m_outgoingReferrer, ScriptExecutionContext::ForceUTF8::No));
 }
 
 void ModelDocumentParser::appendBytes(DocumentWriter&, std::span<const uint8_t>)

--- a/Source/WebCore/html/PermissionsPolicy.cpp
+++ b/Source/WebCore/html/PermissionsPolicy.cpp
@@ -293,7 +293,7 @@ static Ref<SecurityOrigin> declaredOrigin(const HTMLIFrameElement& iframe)
         return document->securityOrigin();
 
     if (iframe.hasAttributeWithoutSynchronization(srcAttr)) {
-        auto url = document->completeURL(iframe.getAttribute(srcAttr));
+        auto url = document->completeURL(iframe.getAttribute(srcAttr), ScriptExecutionContext::ForceUTF8::No);
         if (url.isValid()) {
             if (url.protocolIsInHTTPFamily())
                 return SecurityOrigin::create(url);

--- a/Source/WebCore/html/parser/HTMLResourcePreloader.cpp
+++ b/Source/WebCore/html/parser/HTMLResourcePreloader.cpp
@@ -45,7 +45,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLResourcePreloader);
 
 URL PreloadRequest::completeURL(Document& document)
 {
-    return document.completeURL(m_resourceURL, m_baseURL.isEmpty() ? document.baseURL() : m_baseURL);
+    return document.completeURL(m_resourceURL, m_baseURL.isEmpty() ? document.baseURL() : m_baseURL, ScriptExecutionContext::ForceUTF8::No);
 }
 
 CachedResourceRequest PreloadRequest::resourceRequest(Document& document)

--- a/Source/WebCore/inspector/InspectorFrontendClientLocal.cpp
+++ b/Source/WebCore/inspector/InspectorFrontendClientLocal.cpp
@@ -324,7 +324,7 @@ void InspectorFrontendClientLocal::openURLExternally(const String& url)
     page->setOpenedByDOMWithOpener(true);
 
     // FIXME: Why do we compute the absolute URL with respect to |frame| instead of |mainFrame|?
-    ResourceRequest resourceRequest { protect(localFrame->document())->completeURL(url) };
+    ResourceRequest resourceRequest { protect(localFrame->document())->completeURL(url, ScriptExecutionContext::ForceUTF8::No) };
     FrameLoadRequest frameLoadRequest2 { *mainFrameDocument, mainFrameDocument->securityOrigin(), WTF::move(resourceRequest), selfTargetFrameName(), InitiatedByMainFrame::Unknown };
     localFrame->loader().changeLocation(WTF::move(frameLoadRequest2));
 }

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -1911,7 +1911,7 @@ String InspectorDOMAgent::documentURLString(Document* document)
 
 static String documentBaseURLString(Document* document)
 {
-    return document->completeURL(emptyString()).string();
+    return document->completeURL(emptyString(), ScriptExecutionContext::ForceUTF8::No).string();
 }
 
 static bool NODELETE pseudoElementType(PseudoElementType pseudoElementType, Inspector::Protocol::DOM::PseudoType* type)

--- a/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorNetworkAgent.cpp
@@ -965,7 +965,7 @@ void InspectorNetworkAgent::loadResource(const Inspector::Protocol::Network::Fra
         return;
     }
 
-    URL url = context->completeURL(urlString);
+    URL url = context->completeURL(urlString, ScriptExecutionContext::ForceUTF8::No);
     ResourceRequest request(WTF::move(url));
     request.setHTTPMethod("GET"_s);
     request.setHiddenFromInspector(true);

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -2492,7 +2492,7 @@ void DocumentLoader::startIconLoading()
 
     auto findResult = m_linkIcons.findIf([](auto& icon) { return icon.type == LinkIconType::Favicon; });
     if (findResult == notFound && document->url().protocolIsInHTTPFamily())
-        m_linkIcons.append({ document->completeURL("/favicon.ico"_s), LinkIconType::Favicon, String(), std::nullopt, { } });
+        m_linkIcons.append({ document->completeURL("/favicon.ico"_s, ScriptExecutionContext::ForceUTF8::No), LinkIconType::Favicon, String(), std::nullopt, { } });
 
     if (!m_linkIcons.size())
         return;

--- a/Source/WebCore/loader/FormSubmission.cpp
+++ b/Source/WebCore/loader/FormSubmission.cpp
@@ -190,7 +190,7 @@ RefPtr<FormSubmission> FormSubmission::create(HTMLFormElement& form, HTMLFormCon
 
     Ref document = form.document();
     auto encodingType = copiedAttributes.encodingType();
-    auto actionURL = document->completeURL(copiedAttributes.action().isEmpty() ? document->url().string() : copiedAttributes.action());
+    auto actionURL = document->completeURL(copiedAttributes.action().isEmpty() ? document->url().string() : copiedAttributes.action(), ScriptExecutionContext::ForceUTF8::No);
 
     if (copiedAttributes.method() == Method::Dialog) {
         String returnValue = submitter ? submitter->resultForDialogSubmit() : emptyString();

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3557,7 +3557,7 @@ void FrameLoader::scheduleRefreshIfNeeded(Document& document, const String& cont
     double delay = 0;
     String urlString;
     if (parseMetaHTTPEquivRefresh(content, delay, urlString)) {
-        auto completedURL = urlString.isEmpty() ? document.url() : document.completeURL(urlString);
+        auto completedURL = urlString.isEmpty() ? document.url() : document.completeURL(urlString, ScriptExecutionContext::ForceUTF8::No);
         if (!completedURL.protocolIsJavaScript())
             m_frame->navigationScheduler().scheduleRedirect(document, delay, WTF::move(completedURL), isMetaRefresh);
         else {

--- a/Source/WebCore/loader/ImageLoader.cpp
+++ b/Source/WebCore/loader/ImageLoader.cpp
@@ -273,7 +273,7 @@ void ImageLoader::updateFromElement(RelevantMutation relevantMutation)
                 return;
             }
         } else
-            imageURL = document->completeURL(attr);
+            imageURL = document->completeURL(attr, ScriptExecutionContext::ForceUTF8::No);
         m_pendingURL = attr;
     }
     ResourceRequest resourceRequest(WTF::move(imageURL));

--- a/Source/WebCore/loader/LinkLoader.cpp
+++ b/Source/WebCore/loader/LinkLoader.cpp
@@ -361,9 +361,9 @@ RefPtr<LinkPreloadResourceClient> LinkLoader::preloadIfNeeded(const LinkLoadPara
     if (type == CachedResource::Type::ImageResource && !params.imageSrcSet.isEmpty()) {
         auto sourceSize = SizesAttributeParser(params.imageSizes, document).effectiveSize();
         auto candidate = bestFitSourceForImageAttributes(document.deviceScaleFactor(), params.href.string(), params.imageSrcSet, sourceSize);
-        url = document.completeURL(URL({ }, candidate.string.toString()).string());
+        url = document.completeURL(URL({ }, candidate.string.toString()).string(), ScriptExecutionContext::ForceUTF8::No);
     } else
-        url = document.completeURL(params.href.string());
+        url = document.completeURL(params.href.string(), ScriptExecutionContext::ForceUTF8::No);
 
     if (!url.isValid()) {
         if (params.relAttribute.isLinkModulePreload)
@@ -442,7 +442,7 @@ void LinkLoader::prefetchIfNeeded(const LinkLoadParameters& params, Document& do
     options.cachingPolicy = CachingPolicy::DisallowCaching;
     options.referrerPolicy = params.referrerPolicy;
     options.nonce = params.nonce;
-    if (auto result = protect(document.cachedResourceLoader())->requestLinkResource(type, CachedResourceRequest(ResourceRequest { document.completeURL(params.href.string()) }, options, priority)))
+    if (auto result = protect(document.cachedResourceLoader())->requestLinkResource(type, CachedResourceRequest(ResourceRequest { document.completeURL(params.href.string(), ScriptExecutionContext::ForceUTF8::No) }, options, priority)))
         m_cachedLinkResource = WTF::move(result.value());
     else
         m_cachedLinkResource = nullptr;

--- a/Source/WebCore/loader/NavigationScheduler.cpp
+++ b/Source/WebCore/loader/NavigationScheduler.cpp
@@ -683,7 +683,7 @@ void NavigationScheduler::scheduleLocationChange(Document& initiatingDocument, S
     if (url.hasFragmentIdentifier()
         && localFrame
         && equalIgnoringFragmentIdentifier(localFrame->document()->url(), url)) {
-        ResourceRequest resourceRequest { protect(localFrame->document())->completeURL(url.string()), referrer, ResourceRequestCachePolicy::UseProtocolCachePolicy };
+        ResourceRequest resourceRequest { protect(localFrame->document())->completeURL(url.string(), ScriptExecutionContext::ForceUTF8::No), referrer, ResourceRequestCachePolicy::UseProtocolCachePolicy };
         RefPtr frame = lexicalFrameFromCommonVM();
         auto initiatedByMainFrame = frame && frame->isMainFrame() ? InitiatedByMainFrame::Yes : InitiatedByMainFrame::Unknown;
         

--- a/Source/WebCore/loader/SubframeLoader.cpp
+++ b/Source/WebCore/loader/SubframeLoader.cpp
@@ -450,7 +450,7 @@ bool FrameLoader::SubframeLoader::loadPlugin(HTMLPlugInElement& pluginElement, c
 URL FrameLoader::SubframeLoader::completeURL(const String& url) const
 {
     ASSERT(m_frame->document());
-    return protect(m_frame->document())->completeURL(url);
+    return protect(m_frame->document())->completeURL(url, ScriptExecutionContext::ForceUTF8::No);
 }
 
 bool FrameLoader::SubframeLoader::shouldConvertInvalidURLsToBlank() const

--- a/Source/WebCore/loader/TextTrackLoader.cpp
+++ b/Source/WebCore/loader/TextTrackLoader.cpp
@@ -167,7 +167,7 @@ bool TextTrackLoader::load(const URL& url, HTMLTrackElement& element)
         return false;
 
     // FIXME: Do we really need to call completeURL here?
-    ResourceRequest resourceRequest(document->completeURL(url.string()));
+    ResourceRequest resourceRequest(document->completeURL(url.string(), ScriptExecutionContext::ForceUTF8::No));
 
     if (RefPtr mediaElement = element.mediaElement())
         resourceRequest.setInspectorInitiatorNodeIdentifier(InspectorInstrumentation::identifierForNode(*mediaElement));

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -253,7 +253,7 @@ CachedResource* CachedResourceLoader::cachedResource(const String& resourceURL) 
     ASSERT(!resourceURL.isNull());
     RefPtr document = m_document;
     ASSERT(document);
-    return document ? cachedResource(MemoryCache::removeFragmentIdentifierIfNeeded(document->completeURL(resourceURL))) : nullptr;
+    return document ? cachedResource(MemoryCache::removeFragmentIdentifierIfNeeded(document->completeURL(resourceURL, ScriptExecutionContext::ForceUTF8::No))) : nullptr;
 }
 
 CachedResource* CachedResourceLoader::cachedResource(const URL& url) const
@@ -1879,7 +1879,7 @@ bool CachedResourceLoader::isPreloaded(const String& urlString) const
     if (!document)
         return false;
 
-    const URL& url = document->completeURL(urlString);
+    const URL& url = document->completeURL(urlString, ScriptExecutionContext::ForceUTF8::No);
 
     if (!m_preloads)
         return false;

--- a/Source/WebCore/mathml/MathMLElement.cpp
+++ b/Source/WebCore/mathml/MathMLElement.cpp
@@ -307,7 +307,7 @@ void MathMLElement::defaultEventHandler(Event& event)
             const auto& href = attributeWithoutSynchronization(hrefAttr);
             event.setDefaultHandled();
             if (RefPtr frame = document().frame())
-                frame->loader().changeLocation(document().completeURL(href), selfTargetFrameName(), &event, ReferrerPolicy::EmptyString, document().shouldOpenExternalURLsPolicyToPropagate());
+                frame->loader().changeLocation(document().completeURL(href, ScriptExecutionContext::ForceUTF8::No), selfTargetFrameName(), &event, ReferrerPolicy::EmptyString, document().shouldOpenExternalURLsPolicyToPropagate());
             return;
         }
     }

--- a/Source/WebCore/page/DragController.cpp
+++ b/Source/WebCore/page/DragController.cpp
@@ -1435,7 +1435,7 @@ void DragController::doSystemDrag(DragImage image, const IntPoint& dragLoc, cons
         if (RefPtr link = containingLinkElement(*element)) {
             auto titleAttribute = link->attributeWithoutSynchronization(HTMLNames::titleAttr);
             item.title = titleAttribute.isEmpty() ? link->innerText() : titleAttribute.string();
-            item.url = frame.document()->completeURL(link->getAttribute(HTMLNames::hrefAttr));
+            item.url = frame.document()->completeURL(link->getAttribute(HTMLNames::hrefAttr), ScriptExecutionContext::ForceUTF8::No);
         }
 
 #if ENABLE(MODEL_ELEMENT_STAGE_MODE_INTERACTION)

--- a/Source/WebCore/page/EventSource.cpp
+++ b/Source/WebCore/page/EventSource.cpp
@@ -74,7 +74,7 @@ inline EventSource::EventSource(ScriptExecutionContext& context, const URL& url,
 
 ExceptionOr<Ref<EventSource>> EventSource::create(ScriptExecutionContext& context, const String& url, Init&& eventSourceInit)
 {
-    URL fullURL = context.completeURL(url);
+    URL fullURL = context.completeURL(url, ScriptExecutionContext::ForceUTF8::No);
     if (!fullURL.isValid())
         return Exception { ExceptionCode::SyntaxError };
 

--- a/Source/WebCore/page/History.cpp
+++ b/Source/WebCore/page/History.cpp
@@ -276,7 +276,7 @@ ExceptionOr<void> History::stateObjectAdded(RefPtr<SerializedScriptValue>&& data
     };
 
     if (!urlString.isEmpty()) {
-        fullURL = document->completeURL(urlString);
+        fullURL = document->completeURL(urlString, ScriptExecutionContext::ForceUTF8::No);
         if (!fullURL.isValid())
             return createBlockedURLSecurityErrorWithMessageSuffix("URL is invalid"_s);
 

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -2811,7 +2811,7 @@ void LocalDOMWindow::setLocation(LocalDOMWindow& activeWindow, const URL& comple
     // If the loader for activeWindow's frame (browsing context) has no outgoing referrer, set its outgoing referrer
     // to the URL of its parent frame's Document.
     if (RefPtr activeFrame = activeWindow.frame(); activeFrame && activeFrame->loader().outgoingReferrer().isEmpty() && localParent)
-        activeFrame->loader().setOutgoingReferrer(protect(document())->completeURL(localParent->document()->url().strippedForUseAsReferrer().string));
+        activeFrame->loader().setOutgoingReferrer(protect(document())->completeURL(localParent->document()->url().strippedForUseAsReferrer().string, ScriptExecutionContext::ForceUTF8::No));
 
     // We want a new history item if we are processing a user gesture.
     LockHistory lockHistory = (locking != SetLocationLocking::LockHistoryBasedOnGestureState || !UserGestureIndicator::processingUserGesture()) ? LockHistory::Yes : LockHistory::No;
@@ -2833,7 +2833,7 @@ ExceptionOr<RefPtr<Frame>> LocalDOMWindow::createWindow(const String& urlString,
     if (!activeDocument)
         return RefPtr<Frame> { nullptr };
 
-    URL completedURL = urlString.isEmpty() ? URL({ }, emptyString()) : protect(firstFrame.document())->completeURL(urlString);
+    URL completedURL = urlString.isEmpty() ? URL({ }, emptyString()) : protect(firstFrame.document())->completeURL(urlString, ScriptExecutionContext::ForceUTF8::No);
     if (!completedURL.isEmpty() && !completedURL.isValid())
         return Exception { ExceptionCode::SyntaxError };
 
@@ -2917,7 +2917,7 @@ static bool shouldBypassPopupBlockerForQuirk(const Document* document, const Str
 {
     if (RefPtr firstFrameDocument = document) {
         if (firstFrameDocument->quirks().shouldAllowPopupFromMicrosoftOfficeToOneDrive())
-            return firstFrameDocument->quirks().needsPopupFromMicrosoftOfficeToOneDrive(firstFrameDocument->completeURL(urlString));
+            return firstFrameDocument->quirks().needsPopupFromMicrosoftOfficeToOneDrive(firstFrameDocument->completeURL(urlString, ScriptExecutionContext::ForceUTF8::No));
     }
     return false;
 }
@@ -2946,7 +2946,7 @@ ExceptionOr<RefPtr<WindowProxy>> LocalDOMWindow::open(LocalDOMWindow& activeWind
     RefPtr userContentProvider = firstFrame->userContentProvider();
     RefPtr firstFrameDocumentLoader = firstFrameDocument ? firstFrameDocument->loader() : nullptr;
     if (firstFrameDocument && page && userContentProvider && firstFrameDocumentLoader) {
-        auto results = userContentProvider->processContentRuleListsForLoad(*page, firstFrameDocument->completeURL(urlString), ContentExtensions::ResourceType::Popup, *firstFrameDocumentLoader);
+        auto results = userContentProvider->processContentRuleListsForLoad(*page, firstFrameDocument->completeURL(urlString, ScriptExecutionContext::ForceUTF8::No), ContentExtensions::ResourceType::Popup, *firstFrameDocumentLoader);
         if (results.shouldBlock())
             return RefPtr<WindowProxy> { nullptr };
     }
@@ -2983,7 +2983,7 @@ ExceptionOr<RefPtr<WindowProxy>> LocalDOMWindow::open(LocalDOMWindow& activeWind
         if (activeDocument->canNavigate(targetFrame.get()) != CanNavigateState::Able)
             return RefPtr<WindowProxy> { nullptr };
 
-        URL completedURL = protect(firstFrame->document())->completeURL(urlString);
+        URL completedURL = protect(firstFrame->document())->completeURL(urlString, ScriptExecutionContext::ForceUTF8::No);
 
         if (protect(targetFrame->window())->isInsecureScriptAccess(activeWindow, completedURL))
             return &targetFrame->windowProxy();

--- a/Source/WebCore/page/Location.cpp
+++ b/Source/WebCore/page/Location.cpp
@@ -263,7 +263,7 @@ ExceptionOr<void> Location::replace(LocalDOMWindow& activeWindow, LocalDOMWindow
     if (!firstFrame || !firstFrame->document())
         return { };
 
-    URL completedURL = firstFrame->document()->completeURL(urlString);
+    URL completedURL = firstFrame->document()->completeURL(urlString, ScriptExecutionContext::ForceUTF8::No);
     if (!completedURL.isValid())
         return Exception { ExceptionCode::SyntaxError };
 
@@ -322,7 +322,7 @@ ExceptionOr<void> Location::setLocation(LocalDOMWindow& incumbentWindow, LocalDO
     if (!firstFrame || !firstFrame->document())
         return { };
 
-    URL completedURL = firstFrame->document()->completeURL(urlString);
+    URL completedURL = firstFrame->document()->completeURL(urlString, ScriptExecutionContext::ForceUTF8::No);
 
     if (!completedURL.isValid())
         return Exception { ExceptionCode::SyntaxError, "Invalid URL"_s };

--- a/Source/WebCore/page/Navigator.cpp
+++ b/Source/WebCore/page/Navigator.cpp
@@ -135,7 +135,7 @@ static std::optional<URL> shareableURLForShareData(ScriptExecutionContext& conte
     if (data.url.isNull())
         return std::nullopt;
 
-    auto url = context.completeURL(data.url);
+    auto url = context.completeURL(data.url, ScriptExecutionContext::ForceUTF8::No);
     if (!url.isValid())
         return std::nullopt;
     if (!url.protocolIsInHTTPFamily())

--- a/Source/WebCore/page/PageSerializer.cpp
+++ b/Source/WebCore/page/PageSerializer.cpp
@@ -215,12 +215,12 @@ void PageSerializer::serializeFrame(LocalFrame* frame)
             retrieveResourcesForProperties(protect(styledElement->inlineStyle()).get(), document.get());
 
         if (RefPtr imageElement = dynamicDowncast<HTMLImageElement>(*element)) {
-            auto url = document->completeURL(imageElement->attributeWithoutSynchronization(HTMLNames::srcAttr));
+            auto url = document->completeURL(imageElement->attributeWithoutSynchronization(HTMLNames::srcAttr), ScriptExecutionContext::ForceUTF8::No);
             RefPtr cachedImage = imageElement->cachedImage();
             addImageToResources(cachedImage, imageElement->renderer(), url);
         } else if (RefPtr linkElement = dynamicDowncast<HTMLLinkElement>(*element)) {
             if (RefPtr sheet = linkElement->sheet()) {
-                auto url = document->completeURL(linkElement->attributeWithoutSynchronization(HTMLNames::hrefAttr));
+                auto url = document->completeURL(linkElement->attributeWithoutSynchronization(HTMLNames::hrefAttr), ScriptExecutionContext::ForceUTF8::No);
                 serializeCSSStyleSheet(sheet.get(), url);
                 ASSERT(m_resourceURLs.contains(url));
             }
@@ -252,7 +252,7 @@ void PageSerializer::serializeCSSStyleSheet(CSSStyleSheet* styleSheet, const URL
         RefPtr document = styleSheet->ownerDocument();
         // Some rules have resources associated with them that we need to retrieve.
         if (RefPtr importRule = dynamicDowncast<CSSImportRule>(*rule)) {
-            auto importURL = document->completeURL(importRule->href());
+            auto importURL = document->completeURL(importRule->href(), ScriptExecutionContext::ForceUTF8::No);
             if (m_resourceURLs.contains(importURL))
                 continue;
             serializeCSSStyleSheet(protect(importRule->styleSheet()).get(), importURL);
@@ -315,7 +315,7 @@ void PageSerializer::retrieveResourcesForProperties(const StyleProperties* style
         if (!image)
             continue;
 
-        addImageToResources(image, nullptr, document->completeURL(image->url().string()));
+        addImageToResources(image, nullptr, document->completeURL(image->url().string(), ScriptExecutionContext::ForceUTF8::No));
     }
 }
 

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -584,7 +584,7 @@ static inline Variant<SkipExtraction, ItemData, URL, Editable> extractItemData(N
 
     if (element->isLink()) {
         if (auto href = element->attributeWithoutSynchronization(HTMLNames::hrefAttr); !href.isEmpty()) {
-            if (auto url = protect(element->document())->completeURL(href); !url.isEmpty()) {
+            if (auto url = protect(element->document())->completeURL(href, ScriptExecutionContext::ForceUTF8::No); !url.isEmpty()) {
                 if (context.mergeParagraphs)
                     return { WTF::move(url) };
 

--- a/Source/WebCore/rendering/HitTestResult.cpp
+++ b/Source/WebCore/rendering/HitTestResult.cpp
@@ -484,7 +484,7 @@ URL HitTestResult::absoluteImageURL() const
 
     if (RefPtr element = dynamicDowncast<Element>(*imageNode); element
         && isAnyOf<HTMLEmbedElement, HTMLImageElement, HTMLInputElement, HTMLObjectElement, SVGImageElement>(*element)) {
-        auto imageURL = imageNode->document().completeURL(element->imageSourceURL());
+        auto imageURL = imageNode->document().completeURL(element->imageSourceURL(), ScriptExecutionContext::ForceUTF8::No);
         if (RefPtr page = imageNode->document().page())
             return page->applyLinkDecorationFiltering(imageURL, LinkDecorationFilteringTrigger::Unspecified);
         return imageURL;
@@ -502,7 +502,7 @@ URL HitTestResult::absolutePDFURL() const
     if (!element)
         return URL();
 
-    auto url = m_innerNonSharedNode->document().completeURL(element->url());
+    auto url = m_innerNonSharedNode->document().completeURL(element->url(), ScriptExecutionContext::ForceUTF8::No);
     if (!url.isValid())
         return URL();
 

--- a/Source/WebCore/rendering/OutlinePainter.cpp
+++ b/Source/WebCore/rendering/OutlinePainter.cpp
@@ -730,7 +730,7 @@ void OutlinePainter::addPDFURLAnnotationForLink(const RenderElement& renderer, c
             return;
         }
     }
-    m_paintInfo.context().setURLForRect(protect(element->document())->completeURL(href), urlRect);
+    m_paintInfo.context().setURLForRect(protect(element->document())->completeURL(href, ScriptExecutionContext::ForceUTF8::No), urlRect);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/RenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGImage.cpp
@@ -289,7 +289,7 @@ bool RenderSVGImage::updateImageViewport()
 
     bool updatedViewport = false;
     Ref imageElement = this->imageElement();
-    URL imageSourceURL = document().completeURL(imageElement->imageSourceURL());
+    URL imageSourceURL = document().completeURL(imageElement->imageSourceURL(), ScriptExecutionContext::ForceUTF8::No);
 
     // Images with preserveAspectRatio=none should force non-uniform scaling. This can be achieved
     // by setting the image's container size to its intrinsic size.

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGImage.cpp
@@ -123,7 +123,7 @@ bool LegacyRenderSVGImage::updateImageViewport()
     m_objectBoundingBox = calculateObjectBoundingBox();
 
     bool updatedViewport = false;
-    URL imageSourceURL = document().completeURL(imageElement().imageSourceURL());
+    URL imageSourceURL = document().completeURL(imageElement().imageSourceURL(), ScriptExecutionContext::ForceUTF8::No);
 
     // Images with preserveAspectRatio=none should force non-uniform scaling. This can be achieved
     // by setting the image's container size to its intrinsic size.

--- a/Source/WebCore/style/values/primitives/StyleURL.cpp
+++ b/Source/WebCore/style/values/primitives/StyleURL.cpp
@@ -56,7 +56,7 @@ auto toStyleWithScriptExecutionContext(const CSS::URL& url, const ScriptExecutio
 {
     if (url.resolved.isNull()) {
         return {
-            .resolved = context.completeURL(url.specified),
+            .resolved = context.completeURL(url.specified, ScriptExecutionContext::ForceUTF8::No),
             .modifiers = url.modifiers,
         };
     }

--- a/Source/WebCore/svg/SVGAElement.cpp
+++ b/Source/WebCore/svg/SVGAElement.cpp
@@ -151,7 +151,7 @@ void SVGAElement::defaultEventHandler(Event& event)
             }
 
             Ref document = this->document();
-            URL completedURL = document->completeURL(url);
+            URL completedURL = document->completeURL(url, ScriptExecutionContext::ForceUTF8::No);
 
             auto target = this->target();
             if (target.isEmpty() && attributeWithoutSynchronization(XLinkNames::showAttr) == "new"_s)

--- a/Source/WebCore/svg/SVGFEImageElement.cpp
+++ b/Source/WebCore/svg/SVGFEImageElement.cpp
@@ -87,7 +87,7 @@ void SVGFEImageElement::requestImageResource()
     ResourceLoaderOptions options = CachedResourceLoader::defaultCachedResourceOptions();
     options.contentSecurityPolicyImposition = isInUserAgentShadowTree() ? ContentSecurityPolicyImposition::SkipPolicyCheck : ContentSecurityPolicyImposition::DoPolicyCheck;
 
-    CachedResourceRequest request(ResourceRequest(document().completeURL(href())), options);
+    CachedResourceRequest request(ResourceRequest(document().completeURL(href(), ScriptExecutionContext::ForceUTF8::No)), options);
     request.setInitiator(*this);
     m_cachedImage = protect(document().cachedResourceLoader())->requestImage(WTF::move(request)).value_or(nullptr);
 
@@ -242,7 +242,7 @@ void SVGFEImageElement::addSubresourceAttributeURLs(ListHashSet<URL>& urls) cons
 {
     SVGFilterPrimitiveStandardAttributes::addSubresourceAttributeURLs(urls);
 
-    addSubresourceURL(urls, document().completeURL(href()));
+    addSubresourceURL(urls, document().completeURL(href(), ScriptExecutionContext::ForceUTF8::No));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGFontFaceUriElement.cpp
+++ b/Source/WebCore/svg/SVGFontFaceUriElement.cpp
@@ -106,7 +106,7 @@ void SVGFontFaceUriElement::loadFont()
         options.contentSecurityPolicyImposition = isInUserAgentShadowTree() ? ContentSecurityPolicyImposition::SkipPolicyCheck : ContentSecurityPolicyImposition::DoPolicyCheck;
 
         Ref cachedResourceLoader = document().cachedResourceLoader();
-        CachedResourceRequest request(ResourceRequest(document().completeURL(href)), options);
+        CachedResourceRequest request(ResourceRequest(document().completeURL(href, ScriptExecutionContext::ForceUTF8::No)), options);
         request.setInitiator(*this);
         if (auto result = cachedResourceLoader->requestFont(WTF::move(request), isSVGFontTarget(*this)))
             m_cachedFont = WTF::move(result.value());

--- a/Source/WebCore/svg/SVGImageElement.cpp
+++ b/Source/WebCore/svg/SVGImageElement.cpp
@@ -215,7 +215,7 @@ void SVGImageElement::addSubresourceAttributeURLs(ListHashSet<URL>& urls) const
 {
     SVGGraphicsElement::addSubresourceAttributeURLs(urls);
 
-    addSubresourceURL(urls, document().completeURL(href()));
+    addSubresourceURL(urls, document().completeURL(href(), ScriptExecutionContext::ForceUTF8::No));
 }
 
 void SVGImageElement::didMoveToNewDocument(Document& oldDocument, Document& newDocument)

--- a/Source/WebCore/svg/SVGScriptElement.cpp
+++ b/Source/WebCore/svg/SVGScriptElement.cpp
@@ -112,7 +112,7 @@ void SVGScriptElement::addSubresourceAttributeURLs(ListHashSet<URL>& urls) const
 {
     SVGElement::addSubresourceAttributeURLs(urls);
 
-    addSubresourceURL(urls, protect(document())->completeURL(href()));
+    addSubresourceURL(urls, protect(document())->completeURL(href(), ScriptExecutionContext::ForceUTF8::No));
 }
 Ref<Element> SVGScriptElement::cloneElementWithoutAttributesAndChildren(Document& document, CustomElementRegistry*) const
 {

--- a/Source/WebCore/svg/SVGURIReference.cpp
+++ b/Source/WebCore/svg/SVGURIReference.cpp
@@ -115,7 +115,7 @@ auto SVGURIReference::targetElementFromIRIString(const String& iri, const TreeSc
         return { };
 
     Ref document = treeScope.documentScope();
-    auto url = document->completeURL(iri);
+    auto url = document->completeURL(iri, ScriptExecutionContext::ForceUTF8::No);
     if (externalDocument) {
         // Enforce that the referenced url matches the url of the document that we've loaded for it!
         ASSERT(equalIgnoringFragmentIdentifier(url, externalDocument->url()));
@@ -148,7 +148,7 @@ bool SVGURIReference::haveLoadedRequiredResources() const
 {
     if (href().isEmpty())
         return true;
-    if (protect(contextElement().document())->completeURL(href()).protocolIsData())
+    if (protect(contextElement().document())->completeURL(href(), ScriptExecutionContext::ForceUTF8::No).protocolIsData())
         return true;
     if (!isExternalURIReference(href(), protect(contextElement().document())))
         return true;

--- a/Source/WebCore/svg/SVGURIReference.h
+++ b/Source/WebCore/svg/SVGURIReference.h
@@ -61,7 +61,7 @@ public:
             return false;
 
         // If the URI matches our documents URL, we're dealing with a local reference.
-        URL url = document.completeURL(uri);
+        URL url = document.completeURL(uri, ScriptExecutionContext::ForceUTF8::No);
         ASSERT(!url.protocolIsData());
         return !equalIgnoringFragmentIdentifier(url, document.url());
     }

--- a/Source/WebCore/svg/SVGUseElement.cpp
+++ b/Source/WebCore/svg/SVGUseElement.cpp
@@ -661,10 +661,10 @@ void SVGUseElement::updateExternalDocument()
     URL externalDocumentURL;
     Ref<Document> document = this->document();
     // FIXME: This early exit should be removed once the ASSERT(!url.protocolIsData()) is removed from isExternalURIReference().
-    if (document->completeURL(href()).protocolIsData())
+    if (document->completeURL(href(), ScriptExecutionContext::ForceUTF8::No).protocolIsData())
         return;
     if (isConnected() && isExternalURIReference(href(), document)) {
-        externalDocumentURL = document->completeURL(href());
+        externalDocumentURL = document->completeURL(href(), ScriptExecutionContext::ForceUTF8::No);
         if (!externalDocumentURL.hasFragmentIdentifier())
             externalDocumentURL = URL();
     }

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -983,7 +983,7 @@ CachedResource* Internals::resourceFromMemoryCache(const String& url)
     if (!contextDocument() || !contextDocument()->page())
         return nullptr;
 
-    ResourceRequest request(contextDocument()->completeURL(url));
+    ResourceRequest request(contextDocument()->completeURL(url, ScriptExecutionContext::ForceUTF8::No));
     request.setDomainForCachePartition(contextDocument()->domainForCachePartition());
 
     return MemoryCache::singleton().resourceForRequest(request, contextDocument()->page()->sessionID());
@@ -6011,7 +6011,7 @@ RefPtr<File> Internals::createFile(const String& path)
     if (!document)
         return nullptr;
 
-    URL url = document->completeURL(path);
+    URL url = document->completeURL(path, ScriptExecutionContext::ForceUTF8::No);
     if (!url.protocolIsFile())
         return nullptr;
 
@@ -6028,7 +6028,7 @@ void Internals::asyncCreateFile(const String& path, DOMPromiseDeferred<IDLInterf
         return;
     }
 
-    URL url = document->completeURL(path);
+    URL url = document->completeURL(path, ScriptExecutionContext::ForceUTF8::No);
     if (!url.protocolIsFile()) {
         promise.reject(ExceptionCode::InvalidStateError);
         return;
@@ -7094,7 +7094,7 @@ void Internals::hasServiceWorkerRegistration(const String& clientURL, HasRegistr
     if (!contextDocument())
         return;
 
-    URL parsedURL = contextDocument()->completeURL(clientURL);
+    URL parsedURL = contextDocument()->completeURL(clientURL, ScriptExecutionContext::ForceUTF8::No);
 
     return ServiceWorkerProvider::singleton().serviceWorkerConnection().matchRegistration(SecurityOriginData { contextDocument()->topOrigin().data() }, parsedURL, [promise = WTF::move(promise)] (auto&& result) mutable {
         promise.resolve(!!result);

--- a/Source/WebCore/workers/AbstractWorker.cpp
+++ b/Source/WebCore/workers/AbstractWorker.cpp
@@ -63,7 +63,7 @@ ExceptionOr<URL> AbstractWorker::resolveURL(const String& url)
     Ref context = *scriptExecutionContext();
 
     // FIXME: This should use the dynamic global scope (bug #27887).
-    URL scriptURL = context->completeURL(url);
+    URL scriptURL = context->completeURL(url, ScriptExecutionContext::ForceUTF8::No);
     if (!scriptURL.isValid())
         return Exception { ExceptionCode::SyntaxError };
 

--- a/Source/WebCore/workers/WorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerGlobalScope.cpp
@@ -431,7 +431,7 @@ ExceptionOr<void> WorkerGlobalScope::importScripts(const FixedVector<Variant<Ref
     Vector<URLKeepingBlobAlive> completedURLs;
     completedURLs.reserveInitialCapacity(urls.size());
     for (auto& entry : urlStrings) {
-        URL url = completeURL(entry);
+        URL url = completeURL(entry, ForceUTF8::No);
         if (!url.isValid())
             return Exception { ExceptionCode::SyntaxError };
         completedURLs.append({ WTF::move(url), m_topOrigin->data() });
@@ -645,7 +645,7 @@ Ref<FontFaceSet> WorkerGlobalScope::fonts()
 
 RefPtr<FontLoadRequest> WorkerGlobalScope::fontLoadRequest(const String& url, bool, bool, LoadedFromOpaqueSource loadedFromOpaqueSource)
 {
-    return WorkerFontLoadRequest::create(completeURL(url), loadedFromOpaqueSource);
+    return WorkerFontLoadRequest::create(completeURL(url, ForceUTF8::No), loadedFromOpaqueSource);
 }
 
 void WorkerGlobalScope::beginLoadingFontSoon(FontLoadRequest& request)

--- a/Source/WebCore/workers/WorkerGlobalScope.h
+++ b/Source/WebCore/workers/WorkerGlobalScope.h
@@ -201,7 +201,7 @@ private:
     void deleteJSCodeAndGC(Synchronous);
     void clearDecodedScriptData();
 
-    URL completeURL(const String&, ForceUTF8 = ForceUTF8::No) const final;
+    URL completeURL(const String&, ForceUTF8) const final;
     String userAgent(const URL&) const final;
 
     EventTarget* errorEventTarget() final;

--- a/Source/WebCore/workers/service/ServiceWorkerClients.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerClients.cpp
@@ -103,7 +103,7 @@ void ServiceWorkerClients::openWindow(ScriptExecutionContext& context, const Str
         return;
     }
 
-    auto url = context.completeURL(urlString);
+    auto url = context.completeURL(urlString, ScriptExecutionContext::ForceUTF8::No);
     if (!url.isValid()) {
         promise->reject(Exception { ExceptionCode::TypeError, makeString("URL string "_s, urlString, " cannot successfully be parsed"_s) });
         return;

--- a/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
@@ -188,7 +188,7 @@ void ServiceWorkerContainer::addRegistration(Variant<Ref<TrustedScriptURL>, Stri
     ServiceWorkerJobData jobData(protect(ensureSWClientConnection())->serverConnectionIdentifier(), contextIdentifier());
 
     Ref context = *scriptExecutionContext();
-    jobData.scriptURL = context->completeURL(trustedRelativeScriptURL);
+    jobData.scriptURL = context->completeURL(trustedRelativeScriptURL, ScriptExecutionContext::ForceUTF8::No);
 
     RefPtr document = dynamicDowncast<Document>(context);
     CheckedPtr contentSecurityPolicy = document ? document->contentSecurityPolicy() : nullptr;
@@ -224,7 +224,7 @@ void ServiceWorkerContainer::addRegistration(Variant<Ref<TrustedScriptURL>, Stri
     }
 
     if (!options.scope.isEmpty())
-        jobData.scopeURL = context->completeURL(options.scope);
+        jobData.scopeURL = context->completeURL(options.scope, ScriptExecutionContext::ForceUTF8::No);
     else
         jobData.scopeURL = URL(jobData.scriptURL, "./"_s);
 
@@ -333,7 +333,7 @@ void ServiceWorkerContainer::getRegistration(const String& clientURL, Ref<Deferr
     }
 
     Ref context = *scriptExecutionContext();
-    URL parsedURL = context->completeURL(clientURL);
+    URL parsedURL = context->completeURL(clientURL, ScriptExecutionContext::ForceUTF8::No);
     if (!protocolHostAndPortAreEqual(parsedURL, context->url())) {
         promise->reject(Exception { ExceptionCode::SecurityError, "Origin of clientURL is not client's origin"_s });
         return;

--- a/Source/WebCore/workers/service/ServiceWorkerRegistration.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerRegistration.cpp
@@ -377,7 +377,7 @@ void ServiceWorkerRegistration::addCookieChangeSubscriptions(Vector<CookieStoreG
         if (subscription.url.isNull())
             url = scope();
         else {
-            url = protect(scriptExecutionContext())->completeURL(subscription.url).string();
+            url = protect(scriptExecutionContext())->completeURL(subscription.url, ScriptExecutionContext::ForceUTF8::No).string();
             if (!url.startsWith(scope())) {
                 promise->reject(Exception { ExceptionCode::TypeError, "The service worker cannot subcribe to cookie changes for URLs outside of its scope"_s });
                 return;
@@ -405,7 +405,7 @@ void ServiceWorkerRegistration::removeCookieChangeSubscriptions(Vector<CookieSto
         if (subscription.url.isNull())
             url = scope();
         else {
-            url = protect(scriptExecutionContext())->completeURL(subscription.url).string();
+            url = protect(scriptExecutionContext())->completeURL(subscription.url, ScriptExecutionContext::ForceUTF8::No).string();
             if (!url.startsWith(scope())) {
                 promise->reject(Exception { ExceptionCode::TypeError, "The service worker cannot unsubcribe from cookie changes for URLs outside of its scope"_s });
                 return;

--- a/Source/WebCore/workers/service/ServiceWorkerWindowClient.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerWindowClient.cpp
@@ -73,7 +73,7 @@ void ServiceWorkerWindowClient::focus(ScriptExecutionContext& context, Ref<Defer
 
 void ServiceWorkerWindowClient::navigate(ScriptExecutionContext& context, const String& urlString, Ref<DeferredPromise>&& promise)
 {
-    auto url = context.completeURL(urlString);
+    auto url = context.completeURL(urlString, ScriptExecutionContext::ForceUTF8::No);
 
     if (!url.isValid()) {
         promise->reject(Exception { ExceptionCode::TypeError, makeString("URL string "_s, urlString, " cannot successfully be parsed"_s) });

--- a/Source/WebCore/workers/shared/SharedWorker.cpp
+++ b/Source/WebCore/workers/shared/SharedWorker.cpp
@@ -89,7 +89,7 @@ ExceptionOr<Ref<SharedWorker>> SharedWorker::create(Document& document, Variant<
     if (!document.hasBrowsingContext())
         return Exception { ExceptionCode::InvalidStateError, "No browsing context"_s };
 
-    auto url = document.completeURL(compliantScriptURLString.releaseReturnValue());
+    auto url = document.completeURL(compliantScriptURLString.releaseReturnValue(), ScriptExecutionContext::ForceUTF8::No);
     if (!url.isValid())
         return Exception { ExceptionCode::SyntaxError, "Invalid script URL"_s };
 

--- a/Source/WebCore/worklets/Worklet.cpp
+++ b/Source/WebCore/worklets/Worklet.cpp
@@ -69,7 +69,7 @@ void Worklet::addModule(const String& moduleURLString, WorkletOptions&& options,
         return;
     }
 
-    URL moduleURL = document->completeURL(moduleURLString);
+    URL moduleURL = document->completeURL(moduleURLString, ScriptExecutionContext::ForceUTF8::No);
     if (!moduleURL.isValid()) {
         promise.reject(Exception { ExceptionCode::SyntaxError, "Module URL is invalid"_s });
         return;

--- a/Source/WebCore/worklets/WorkletGlobalScope.h
+++ b/Source/WebCore/worklets/WorkletGlobalScope.h
@@ -111,7 +111,7 @@ private:
 
     std::optional<Vector<uint8_t>> serializeAndWrapCryptoKey(CryptoKeyData&&) final { RELEASE_ASSERT_NOT_REACHED(); return std::nullopt; }
     std::optional<Vector<uint8_t>> unwrapCryptoKey(const Vector<uint8_t>&) final { RELEASE_ASSERT_NOT_REACHED(); return std::nullopt; }
-    URL completeURL(const String&, ForceUTF8 = ForceUTF8::No) const final;
+    URL completeURL(const String&, ForceUTF8) const final;
     String userAgent(const URL&) const final;
     const SettingsValues& settingsValues() const LIFETIME_BOUND final { return m_settingsValues; }
 

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -334,7 +334,7 @@ ExceptionOr<void> XMLHttpRequest::setWithCredentials(bool value)
 ExceptionOr<void> XMLHttpRequest::open(const String& method, const String& url)
 {
     // If the async argument is omitted, set async to true.
-    return open(method, protect(scriptExecutionContext())->completeURL(url), true);
+    return open(method, protect(scriptExecutionContext())->completeURL(url, ScriptExecutionContext::ForceUTF8::No), true);
 }
 
 ExceptionOr<void> XMLHttpRequest::open(const String& method, const URL& url, bool async)
@@ -398,7 +398,7 @@ ExceptionOr<void> XMLHttpRequest::open(const String& method, const URL& url, boo
 
 ExceptionOr<void> XMLHttpRequest::open(const String& method, const String& url, bool async, const String& user, const String& password)
 {
-    auto urlWithCredentials = protect(scriptExecutionContext())->completeURL(url);
+    auto urlWithCredentials = protect(scriptExecutionContext())->completeURL(url, ScriptExecutionContext::ForceUTF8::No);
     if (!user.isNull())
         urlWithCredentials.setUser(user);
     if (!password.isNull())

--- a/Source/WebCore/xml/XSLImportRule.cpp
+++ b/Source/WebCore/xml/XSLImportRule.cpp
@@ -101,7 +101,7 @@ void XSLImportRule::loadSheet()
 
     auto options = CachedResourceLoader::defaultCachedResourceOptions();
     options.mode = FetchOptions::Mode::SameOrigin;
-    if (auto result = cachedResourceLoader->requestXSLStyleSheet({ ResourceRequest(protect(cachedResourceLoader->document())->completeURL(absHref)), options }))
+    if (auto result = cachedResourceLoader->requestXSLStyleSheet({ ResourceRequest(protect(cachedResourceLoader->document())->completeURL(absHref, ScriptExecutionContext::ForceUTF8::No)), options }))
         m_cachedSheet = WTF::move(result.value());
     else
         m_cachedSheet = nullptr;

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm
@@ -242,7 +242,7 @@ static void imagePositionInformation(WebPage& page, WebCore::Element& element, c
 
     auto& [renderImage, image] = *rendererAndImage;
     info.isImage = true;
-    info.imageURL = page.applyLinkDecorationFiltering(protect(element.document())->completeURL(protect(renderImage.cachedImage())->url().string()), WebCore::LinkDecorationFilteringTrigger::Unspecified);
+    info.imageURL = page.applyLinkDecorationFiltering(protect(element.document())->completeURL(protect(renderImage.cachedImage())->url().string(), WebCore::ScriptExecutionContext::ForceUTF8::No), WebCore::LinkDecorationFilteringTrigger::Unspecified);
     info.imageMIMEType = image.mimeType();
     info.isAnimatedImage = image.isAnimated();
     info.isAnimating = image.isAnimating();
@@ -295,7 +295,7 @@ static void elementPositionInformation(WebPage& page, WebCore::Element& element,
 
     if (linkElement && !info.isImageOverlayText) {
         info.isLink = true;
-        info.url = page.applyLinkDecorationFiltering(document->completeURL(linkElement->getAttribute(WebCore::HTMLNames::hrefAttr)), WebCore::LinkDecorationFilteringTrigger::Unspecified);
+        info.url = page.applyLinkDecorationFiltering(document->completeURL(linkElement->getAttribute(WebCore::HTMLNames::hrefAttr), WebCore::ScriptExecutionContext::ForceUTF8::No), WebCore::LinkDecorationFilteringTrigger::Unspecified);
 
         linkIndicatorPositionInformation(page, *linkElement, request, info);
 #if ENABLE(DATA_DETECTION) && PLATFORM(IOS_FAMILY)
@@ -321,7 +321,7 @@ static void elementPositionInformation(WebPage& page, WebCore::Element& element,
             if (request.includeImageData) {
                 if (auto rendererAndImage = imageRendererAndImage(element)) {
                     auto& [renderImage, image] = *rendererAndImage;
-                    info.imageURL = page.applyLinkDecorationFiltering(document->completeURL(protect(renderImage.cachedImage())->url().string()), WebCore::LinkDecorationFilteringTrigger::Unspecified);
+                    info.imageURL = page.applyLinkDecorationFiltering(document->completeURL(protect(renderImage.cachedImage())->url().string(), WebCore::ScriptExecutionContext::ForceUTF8::No), WebCore::LinkDecorationFilteringTrigger::Unspecified);
                     info.imageMIMEType = image.mimeType();
                     info.image = createShareableBitmap(renderImage, { WebCore::screenSize() * page.corePage()->deviceScaleFactor(), AllowAnimatedImages::Yes, UseSnapshotForTransparentImages::Yes });
                 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -9406,7 +9406,7 @@ void WebPage::requestTextRecognition(Element& element, TextRecognitionOptions&& 
             return;
 
         RefPtr cachedImage = renderImage->cachedImage();
-        auto imageURL = cachedImage ? protect(weakElement->document())->completeURL(cachedImage->url().string()) : URL { };
+        auto imageURL = cachedImage ? protect(weakElement->document())->completeURL(cachedImage->url().string(), ScriptExecutionContext::ForceUTF8::No) : URL { };
         protectedThis->sendWithAsyncReply(Messages::WebPageProxy::RequestTextRecognition(WTF::move(imageURL), WTF::move(*bitmapHandle), options.sourceLanguageIdentifier, options.targetLanguageIdentifier), [weakThis, weakElement, resolveAndRemoveHandlerFollowingError = WTF::move(resolveAndRemoveHandlerFollowingError)] (auto&& result) mutable {
             RefPtr protectedThis = weakThis.get();
             if (!protectedThis)

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -2582,7 +2582,7 @@ void WebPage::performActionOnElement(uint32_t action, const String& authorizatio
             }
             interactionNodeEditor->writeImageToPasteboard(*Pasteboard::createForCopyAndPaste(PagePasteboardContext::create(elementDocument->pageID())), *element, urlToCopy, titleToCopy);
         } else if (element->isLink())
-            interactionNodeEditor->copyURL(elementDocument->completeURL(element->attributeWithoutSynchronization(HTMLNames::hrefAttr)), element->textContent());
+            interactionNodeEditor->copyURL(elementDocument->completeURL(element->attributeWithoutSynchronization(HTMLNames::hrefAttr), ScriptExecutionContext::ForceUTF8::No), element->textContent());
 #if ENABLE(ATTACHMENT_ELEMENT)
         else if (auto attachmentInfo = protect(elementDocument->editor())->promisedAttachmentInfo(*element))
             send(Messages::WebPageProxy::WritePromisedAttachmentToPasteboard(WTF::move(attachmentInfo), authorizationToken));

--- a/Source/WebKitLegacy/mac/DOM/DOM.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOM.mm
@@ -395,7 +395,7 @@ id <DOMEventTarget> kit(EventTarget* target)
     auto* link = [self _linkElement];
     if (!link)
         return nil;
-    return link->document().completeURL(link->getAttribute(HTMLNames::hrefAttr)).createNSURL().autorelease();
+    return link->document().completeURL(link->getAttribute(HTMLNames::hrefAttr), ScriptExecutionContext::ForceUTF8::No).createNSURL().autorelease();
 }
 
 - (NSString *)hrefTarget
@@ -673,7 +673,7 @@ id <DOMEventTarget> kit(EventTarget* target)
 - (NSURL *)_getURLAttribute:(NSString *)name
 {
     auto& element = *core(self);
-    return element.document().completeURL(element.getAttribute(name)).createNSURL().autorelease();
+    return element.document().completeURL(element.getAttribute(name), ScriptExecutionContext::ForceUTF8::No).createNSURL().autorelease();
 }
 
 - (BOOL)isFocused

--- a/Source/WebKitLegacy/mac/DOM/DOMHTML.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMHTML.mm
@@ -179,7 +179,7 @@
 
 - (DOMDocumentFragment *)_createDocumentFragmentWithMarkupString:(NSString *)markupString baseURLString:(NSString *)baseURLString
 {
-    RetainPtr baseURL = core(self)->completeURL(baseURLString).createNSURL();
+    RetainPtr baseURL = core(self)->completeURL(baseURLString, WebCore::ScriptExecutionContext::ForceUTF8::No).createNSURL();
     return [self createDocumentFragmentWithMarkupString:markupString baseURL:baseURL.get()];
 }
 

--- a/Source/WebKitLegacy/mac/DOM/WebDOMOperations.mm
+++ b/Source/WebKitLegacy/mac/DOM/WebDOMOperations.mm
@@ -169,7 +169,7 @@ using namespace JSC;
 
 - (NSURL *)URLWithAttributeString:(NSString *)string
 {
-    return core(self)->completeURL(string).createNSURL().autorelease();
+    return core(self)->completeURL(string, ScriptExecutionContext::ForceUTF8::No).createNSURL().autorelease();
 }
 
 @end

--- a/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
+++ b/Source/WebKitLegacy/mac/WebCoreSupport/WebFrameLoaderClient.mm
@@ -1787,7 +1787,7 @@ RefPtr<WebCore::Widget> WebFrameLoaderClient::createPlugin(WebCore::HTMLPlugInEl
     if (errorCode && m_webFrame) {
         WebResourceDelegateImplementationCache* implementations = WebViewGetResourceLoadDelegateImplementations(webView.get());
         if (implementations->plugInFailedWithErrorFunc) {
-            URL pluginPageURL = document->completeURL(parameterValue(paramNames, paramValues, "pluginspage"_s));
+            URL pluginPageURL = document->completeURL(parameterValue(paramNames, paramValues, "pluginspage"_s), WebCore::ScriptExecutionContext::ForceUTF8::No);
             if (!pluginPageURL.protocolIsInHTTPFamily())
                 pluginPageURL = URL();
             RetainPtr pluginName = pluginPackage ? [pluginPackage pluginInfo].name.createNSString() : nil;


### PR DESCRIPTION
#### a0ba19db248492c8e8c0303f1a9414ece0812f42
<pre>
Require completeURL()&apos;s ForceUTF8 argument
<a href="https://bugs.webkit.org/show_bug.cgi?id=314506">https://bugs.webkit.org/show_bug.cgi?id=314506</a>

Reviewed by Chris Dumez.

This allows us to cleanly flip the default in a future commit. (It
defaults to UTF-8 in the URL standard.)

No behavioral changes.

Canonical link: <a href="https://commits.webkit.org/313004@main">https://commits.webkit.org/313004@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d08cc6d9dafa23d7288af1941751ae0d06be4d3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161818 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35292 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/28395 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/170721 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/118189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/163687 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35393 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35293 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/170721 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/118189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164777 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/27871 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/145350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/170721 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/18442 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/136613 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/23105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173210 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20250 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/24746 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/133852 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34966 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/29520 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/133857 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34950 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/144900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97019 "Built successfully") | | 
| [  ~~🛠 🧪 unsafe-merge~~](https://ews-build.webkit.org/#/builders/22/builds/24569 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/28388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/21723 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34460 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/101905 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33960 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34203 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34109 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->