### PR TITLE
[CSS will-change] -webkit-perspective should establish a containing block for fixed positioned descendants

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5610,7 +5610,6 @@ imported/w3c/web-platform-tests/css/css-counter-styles/upper-roman/css3-counter-
 
 # CSS will-change failures
 webkit.org/b/225035 imported/w3c/web-platform-tests/css/css-will-change/will-change-fixedpos-cb-002.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-will-change/will-change-fixpos-cb-webkit-perspective-1.html [ ImageOnlyFailure ]
 webkit.org/b/224899 imported/w3c/web-platform-tests/css/css-will-change/will-change-fixedpos-cb-005.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-will-change/will-change-stacking-context-z-index-4.html [ ImageOnlyFailure ]
 

--- a/Source/WebCore/style/values/will-change/StyleWillChange.cpp
+++ b/Source/WebCore/style/values/will-change/StyleWillChange.cpp
@@ -164,6 +164,7 @@ bool WillChangeAnimatableFeatures::Data::createsContainingBlockForAbsolutelyPosi
 bool WillChangeAnimatableFeatures::Data::createsContainingBlockForOutOfFlowPositioned(bool isRootElement) const
 {
     return containsProperty(CSSPropertyPerspective)
+        || containsProperty(CSSPropertyWebkitPerspective)
         // CSS transforms
         || containsProperty(CSSPropertyTransform)
         || containsProperty(CSSPropertyTransformStyle)


### PR DESCRIPTION
#### 80a7823219fb525f15d436935a4ae307db098e68
<pre>
[CSS will-change] -webkit-perspective should establish a containing block for fixed positioned descendants
<a href="https://bugs.webkit.org/show_bug.cgi?id=314509">https://bugs.webkit.org/show_bug.cgi?id=314509</a>
<a href="https://rdar.apple.com/176729670">rdar://176729670</a>

Reviewed by Antti Koivisto.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

Per <a href="https://drafts.csswg.org/css-will-change/#will-change">https://drafts.csswg.org/css-will-change/#will-change</a>, if any non-initial value of a
property would cause the element to generate a containing block for fixed-position
descendants, specifying that property in `will-change` must do the same.

`-webkit-perspective` is a legacy alias of `perspective`, and a non-initial value of
`perspective` establishes a containing block for fixed positioned descendants. Therefore
`will-change: -webkit-perspective` must as well.

`Style::WillChangeAnimatableFeatures::Data::createsContainingBlockForOutOfFlowPositioned`
already accounts for `CSSPropertyPerspective` but was missing the `-webkit-` alias. The
neighbouring `propertyCreatesStackingContext()` already handles both aliases, so this
fixes the parallel gap on the containing-block side.

* LayoutTests/TestExpectations: Progression
* Source/WebCore/style/values/will-change/StyleWillChange.cpp:
(WebCore::Style::WillChangeAnimatableFeatures::Data::createsContainingBlockForOutOfFlowPositioned const):

Canonical link: <a href="https://commits.webkit.org/313020@main">https://commits.webkit.org/313020@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45a02b2fff8018aa5b8fbcc6a61e74a382b4f99e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161709 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35183 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28286 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170612 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118080 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9d6fc1c5-f4ff-4c9e-999a-5b306cc6aebf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163578 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35284 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35184 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125456 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88379 "1 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/05fd8bd0-691b-4433-88fb-5fc99b06feea) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164668 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27767 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145248 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106052 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0c8f05b7-fca0-40f1-859d-4f4ead50650b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26816 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25327 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18333 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136509 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23003 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173109 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20141 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24644 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133757 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34857 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29419 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133762 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36149 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34841 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144798 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96853 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28289 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21620 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34351 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101796 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33851 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34094 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34000 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->