### PR TITLE
[CMake] Prepare for -fpch-codegen / -fpch-debuginfo

### DIFF
--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -872,6 +872,7 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     heap/WeakHandleOwner.h
     heap/WeakImpl.h
     heap/WeakInlines.h
+    heap/WeakInlinesLight.h
     heap/WeakSet.h
     heap/WeakSetInlines.h
 

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1800,6 +1800,7 @@
 		ADE802991E08F1DE0058DE78 /* JSWebAssemblyLinkError.h in Headers */ = {isa = PBXBuildFile; fileRef = ADE802941E08F1C90058DE78 /* JSWebAssemblyLinkError.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		ADE8029A1E08F1DE0058DE78 /* WebAssemblyLinkErrorConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = ADE802951E08F1C90058DE78 /* WebAssemblyLinkErrorConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		ADE8029C1E08F1DE0058DE78 /* WebAssemblyLinkErrorPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = ADE802971E08F1C90058DE78 /* WebAssemblyLinkErrorPrototype.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		AEDA37D0C69F462084E47143 /* WeakInlinesLight.h in Headers */ = {isa = PBXBuildFile; fileRef = AEDA37D0C69F462084E47142 /* WeakInlinesLight.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		B1D7736A1D0A42A4B9017DE0 /* JSCTimeZone.h in Headers */ = {isa = PBXBuildFile; fileRef = 24FF4DFDAD3D4D97BE486930 /* JSCTimeZone.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		B4C7A5933E61498DAF3D7C12 /* StructureInlinesLight.h in Headers */ = {isa = PBXBuildFile; fileRef = D8E1F0A2B3C94D7E8F1A2B3C /* StructureInlinesLight.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		BC02E90D0E1839DB000F9297 /* ErrorConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = BC02E9050E1839DB000F9297 /* ErrorConstructor.h */; };
@@ -5673,6 +5674,7 @@
 		ADE802961E08F1C90058DE78 /* WebAssemblyLinkErrorPrototype.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = WebAssemblyLinkErrorPrototype.cpp; path = js/WebAssemblyLinkErrorPrototype.cpp; sourceTree = "<group>"; };
 		ADE802971E08F1C90058DE78 /* WebAssemblyLinkErrorPrototype.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = WebAssemblyLinkErrorPrototype.h; path = js/WebAssemblyLinkErrorPrototype.h; sourceTree = "<group>"; };
 		ADE8029D1E08F2260058DE78 /* WebAssemblyLinkErrorConstructor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = WebAssemblyLinkErrorConstructor.cpp; path = js/WebAssemblyLinkErrorConstructor.cpp; sourceTree = "<group>"; };
+		AEDA37D0C69F462084E47142 /* WeakInlinesLight.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WeakInlinesLight.h; sourceTree = "<group>"; };
 		BC021BF2136900C300FC5467 /* ToolExecutable.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = ToolExecutable.xcconfig; sourceTree = "<group>"; };
 		BC02E9040E1839DB000F9297 /* ErrorConstructor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ErrorConstructor.cpp; sourceTree = "<group>"; };
 		BC02E9050E1839DB000F9297 /* ErrorConstructor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ErrorConstructor.h; sourceTree = "<group>"; };
@@ -7736,6 +7738,7 @@
 				14F7256414EE265E00B1652B /* WeakHandleOwner.h */,
 				14E84F9D14EE1ACC00D6D5D4 /* WeakImpl.h */,
 				14BE7D3217135CF400D1807A /* WeakInlines.h */,
+				AEDA37D0C69F462084E47142 /* WeakInlinesLight.h */,
 				14E84F9B14EE1ACC00D6D5D4 /* WeakSet.cpp */,
 				14E84F9C14EE1ACC00D6D5D4 /* WeakSet.h */,
 				14150132154BB13F005D8C98 /* WeakSetInlines.h */,
@@ -12851,6 +12854,7 @@
 				14F7256614EE265E00B1652B /* WeakHandleOwner.h in Headers */,
 				14E84FA214EE1ACC00D6D5D4 /* WeakImpl.h in Headers */,
 				14BE7D3317135CF400D1807A /* WeakInlines.h in Headers */,
+				AEDA37D0C69F462084E47143 /* WeakInlinesLight.h in Headers */,
 				A7CA3AE417DA41AE006538AF /* WeakMapConstructor.h in Headers */,
 				276B389F2A71D1A900252F4E /* WeakMapConstructorInlines.h in Headers */,
 				E3A32BC71FC83147007D7E76 /* WeakMapImpl.h in Headers */,

--- a/Source/JavaScriptCore/JavaScriptCorePrefix.h
+++ b/Source/JavaScriptCore/JavaScriptCorePrefix.h
@@ -60,9 +60,14 @@
 
 #ifdef __cplusplus
 #include "B3ValueRep.h"
+#include "ButterflyInlinesLight.h"
 #include "Bytecodes.h"
+#include "CacheableIdentifierInlines.h"
 #include "CodeBlock.h"
+#include "GCSegmentedArrayInlines.h"
+#include "GenericArgumentsImplInlines.h"
 #include "Heap.h"
+#include "IsoCellSetInlines.h"
 #include "JSArray.h"
 #include "JSArrayBufferView.h"
 #include "JSCJSValue.h"
@@ -72,16 +77,22 @@
 #include "JSGlobalObject.h"
 #include "JSLexicalEnvironment.h"
 #include "JSObject.h"
+#include "JSObjectInlines.h"
 #include "JSObjectRef.h"
 #include "JSString.h"
 #include "JSStringInlines.h"
 #include "MarkedBlockInlines.h"
 #include "Operations.h"
+#include "OperationsInlines.h"
+#include "OperandsInlines.h"
 #include "OptionsList.h"
 #include "Strong.h"
 #include "Structure.h"
 #include "StructureChain.h"
+#include "StructureInlinesLight.h"
+#include "UnlinkedMetadataTableInlines.h"
 #include "VM.h"
+#include "WeakGCMapInlines.h"
 #include <chrono>
 #include <functional>
 #include <list>

--- a/Source/JavaScriptCore/bytecode/PropertyInlineCacheClearingWatchpoint.cpp
+++ b/Source/JavaScriptCore/bytecode/PropertyInlineCacheClearingWatchpoint.cpp
@@ -77,6 +77,12 @@ void StructureTransitionPropertyInlineCacheClearingWatchpoint::fireInternal(VM& 
     m_key.object()->structure()->addTransitionWatchpoint(this);
 }
 
+AdaptiveValuePropertyInlineCacheClearingWatchpoint::AdaptiveValuePropertyInlineCacheClearingWatchpoint(ClangVTableWorkaroundTag, WatchpointSet& watchpointSet)
+    : m_owner(nullptr)
+    , m_watchpointSet(watchpointSet)
+{
+}
+
 void AdaptiveValuePropertyInlineCacheClearingWatchpoint::handleFire(VM& vm, const FireDetail&)
 {
     if (m_owner->ownerIsDead())

--- a/Source/JavaScriptCore/bytecode/PropertyInlineCacheClearingWatchpoint.h
+++ b/Source/JavaScriptCore/bytecode/PropertyInlineCacheClearingWatchpoint.h
@@ -97,8 +97,9 @@ public:
         RELEASE_ASSERT(key.condition().kind() == PropertyCondition::Equivalence);
     }
 
-
 private:
+    AdaptiveValuePropertyInlineCacheClearingWatchpoint(ClangVTableWorkaroundTag, WatchpointSet&);
+
     PolymorphicAccessJITStubRoutine* m_owner;
     const Ref<WatchpointSet> m_watchpointSet;
 };

--- a/Source/JavaScriptCore/bytecode/VariableWriteFireDetail.cpp
+++ b/Source/JavaScriptCore/bytecode/VariableWriteFireDetail.cpp
@@ -30,6 +30,12 @@
 
 namespace JSC {
 
+VariableWriteFireDetail::VariableWriteFireDetail(ClangVTableWorkaroundTag, const PropertyName& name)
+    : m_object(nullptr)
+    , m_name(name)
+{
+}
+
 void VariableWriteFireDetail::dump(PrintStream& out) const
 {
     out.print("Write to ", m_name, " in ", JSValue(m_object));

--- a/Source/JavaScriptCore/bytecode/VariableWriteFireDetail.h
+++ b/Source/JavaScriptCore/bytecode/VariableWriteFireDetail.h
@@ -45,6 +45,8 @@ public:
     JS_EXPORT_PRIVATE static void touch(VM&, WatchpointSet*, JSObject*, const PropertyName&);
 
 private:
+    VariableWriteFireDetail(ClangVTableWorkaroundTag, const PropertyName&);
+
     JSObject* m_object;
     const PropertyName& m_name;
 };

--- a/Source/JavaScriptCore/bytecode/Watchpoint.cpp
+++ b/Source/JavaScriptCore/bytecode/Watchpoint.cpp
@@ -44,6 +44,11 @@ namespace JSC {
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(Watchpoint);
 DEFINE_ALLOCATOR_WITH_HEAP_IDENTIFIER(WatchpointSet);
 
+StringFireDetail::StringFireDetail(ClangVTableWorkaroundTag)
+    : m_string(nullptr)
+{
+}
+
 void StringFireDetail::dump(PrintStream& out) const
 {
     out.print(m_string);

--- a/Source/JavaScriptCore/bytecode/Watchpoint.h
+++ b/Source/JavaScriptCore/bytecode/Watchpoint.h
@@ -54,7 +54,7 @@ public:
     virtual void dump(PrintStream&) const { }
 };
 
-class StringFireDetail final : public FireDetail {
+class JS_EXPORT_PRIVATE StringFireDetail final : public FireDetail {
 public:
     StringFireDetail(const char* string)
         : m_string(string)
@@ -64,6 +64,8 @@ public:
     void dump(PrintStream& out) const final;
 
 private:
+    explicit StringFireDetail(ClangVTableWorkaroundTag);
+
     const char* m_string;
 };
 

--- a/Source/JavaScriptCore/heap/WeakHandleOwner.h
+++ b/Source/JavaScriptCore/heap/WeakHandleOwner.h
@@ -33,10 +33,14 @@ class AbstractSlotVisitor;
 
 class JS_EXPORT_PRIVATE WeakHandleOwner {
 public:
+    WeakHandleOwner() = default;
     virtual ~WeakHandleOwner();
     // reason will only be non-null when generating a debug GC heap snapshot.
     virtual bool isReachableFromOpaqueRoots(Handle<Unknown>, void* context, AbstractSlotVisitor&, ASCIILiteral* reason = nullptr);
     virtual void finalize(Handle<Unknown>, void* context);
+
+private:
+    explicit WeakHandleOwner(ClangVTableWorkaroundTag);
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/heap/WeakInlines.h
+++ b/Source/JavaScriptCore/heap/WeakInlines.h
@@ -29,6 +29,7 @@
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
+#include <JavaScriptCore/WeakInlinesLight.h>
 #include <JavaScriptCore/WeakSetInlines.h>
 #include <wtf/Assertions.h>
 
@@ -107,15 +108,6 @@ template<typename T> inline T* Weak<T>::get() const
 template<typename T> inline bool Weak<T>::was(T* other) const
 {
     return static_cast<T*>(m_impl->jsValue().asCell()) == other;
-}
-
-template<typename T> inline void Weak<T>::clear()
-{
-    auto* pointer = impl();
-    if (!pointer)
-        return;
-    pointer->clear();
-    m_impl = nullptr;
 }
 
 template<typename T> inline bool Weak<T>::operator!() const

--- a/Source/JavaScriptCore/heap/WeakInlinesLight.h
+++ b/Source/JavaScriptCore/heap/WeakInlinesLight.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2012-2021 Apple Inc. All rights reserved.
+ * Copyright (C) 2012-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -23,27 +23,20 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "config.h"
-#include "WeakHandleOwner.h"
+#pragma once
+
+#include <JavaScriptCore/Weak.h>
+#include <JavaScriptCore/WeakImpl.h>
 
 namespace JSC {
 
-class SlotVisitor;
-template<typename T> class Handle;
-
-WeakHandleOwner::WeakHandleOwner(ClangVTableWorkaroundTag)
+template<typename T> inline void Weak<T>::clear()
 {
-}
-
-WeakHandleOwner::~WeakHandleOwner() = default;
-
-bool WeakHandleOwner::isReachableFromOpaqueRoots(Handle<Unknown>, void*, AbstractSlotVisitor&, ASCIILiteral*)
-{
-    return false;
-}
-
-void WeakHandleOwner::finalize(Handle<Unknown>, void*)
-{
+    auto* pointer = impl();
+    if (!pointer)
+        return;
+    pointer->clear();
+    m_impl = nullptr;
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/BufferMemoryHandle.h
+++ b/Source/JavaScriptCore/runtime/BufferMemoryHandle.h
@@ -133,7 +133,7 @@ public:
     BufferMemoryHandle(void*, size_t size, size_t mappedCapacity, PageCount initial, PageCount maximum, MemorySharingMode, MemoryMode);
     JS_EXPORT_PRIVATE ~BufferMemoryHandle();
 
-    void* memory() const;
+    JS_EXPORT_PRIVATE void* memory() const;
     size_t size(std::memory_order order = std::memory_order_seq_cst) const
     {
         if (m_sharingMode == MemorySharingMode::Default)

--- a/Source/JavaScriptCore/runtime/JSCJSValue.h
+++ b/Source/JavaScriptCore/runtime/JSCJSValue.h
@@ -334,7 +334,7 @@ public:
     JSValue toThis(JSGlobalObject*, ECMAMode) const;
 
     inline static bool equal(JSGlobalObject*, JSValue v1, JSValue v2); // Defined below
-    static bool equalSlowCase(JSGlobalObject*, JSValue v1, JSValue v2);
+    JS_EXPORT_PRIVATE static bool equalSlowCase(JSGlobalObject*, JSValue v1, JSValue v2);
     inline static bool equalSlowCaseInline(JSGlobalObject*, JSValue v1, JSValue v2); // Defined in JSCJSValueInlines.h
     inline static bool strictEqual(JSGlobalObject*, JSValue v1, JSValue v2); // Defined in JSCJSValueInlines.h
     inline static bool strictEqualForCells(JSGlobalObject*, JSCell* v1, JSCell* v2); // Defined in JSCJSValueInlines.h

--- a/Source/JavaScriptCore/runtime/JSString.h
+++ b/Source/JavaScriptCore/runtime/JSString.h
@@ -750,6 +750,8 @@ private:
     friend JSString* jsAtomString(JSGlobalObject*, VM&, JSString*, JSString*, JSString*);
 };
 
+template<> void JSRopeString::RopeBuilder<RecordOverflow>::expand();
+
 JS_EXPORT_PRIVATE JSString* jsStringWithCacheSlowCase(VM&, StringImpl&);
 
 // JSString::is8Bit is safe to be called concurrently. Concurrent threads can access is8Bit even if the main thread

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -760,7 +760,7 @@ public:
     void dump(PrintStream& out) const;
 
 private:
-    static const char* const s_nullRangeStr;
+    JS_EXPORT_PRIVATE static const char* const s_nullRangeStr;
 
     RangeState m_state { Uninitialized };
     const char* m_rangeString { nullptr };

--- a/Source/JavaScriptCore/runtime/Structure.cpp
+++ b/Source/JavaScriptCore/runtime/Structure.cpp
@@ -1364,6 +1364,11 @@ void Structure::getPropertyNamesFromStructure(VM& vm, PropertyNameArrayBuilder& 
     }
 }
 
+StructureFireDetail::StructureFireDetail(ClangVTableWorkaroundTag)
+    : m_structure(nullptr)
+{
+}
+
 void StructureFireDetail::dump(PrintStream& out) const
 {
     out.print("Structure transition from ", *m_structure);

--- a/Source/JavaScriptCore/runtime/Structure.h
+++ b/Source/JavaScriptCore/runtime/Structure.h
@@ -189,6 +189,8 @@ public:
     void dump(PrintStream& out) const final;
 
 private:
+    explicit StructureFireDetail(ClangVTableWorkaroundTag);
+
     const Structure* m_structure;
 };
 

--- a/Source/JavaScriptCore/runtime/WriteBarrier.h
+++ b/Source/JavaScriptCore/runtime/WriteBarrier.h
@@ -28,6 +28,7 @@
 #include <JavaScriptCore/GCAssertions.h>
 #include <JavaScriptCore/StructureID.h>
 #include <type_traits>
+#include <wtf/ForbidHeapAllocation.h>
 #include <wtf/RawPtrTraits.h>
 #include <wtf/RawValueTraits.h>
 #include <wtf/TZoneMalloc.h>
@@ -242,7 +243,7 @@ enum UndefinedWriteBarrierTagType { UndefinedWriteBarrierTag };
 enum NullWriteBarrierTagType { NullWriteBarrierTag };
 template <>
 class WriteBarrier<Unknown, RawValueTraits<Unknown>> : public WriteBarrierBase<Unknown, RawValueTraits<Unknown>> {
-    WTF_MAKE_TZONE_ALLOCATED_TEMPLATE(WriteBarrier);
+    WTF_FORBID_HEAP_ALLOCATION_ALLOWING_PLACEMENT_NEW;
 public:
     WriteBarrier()
     {

--- a/Source/WTF/wtf/Compiler.h
+++ b/Source/WTF/wtf/Compiler.h
@@ -725,6 +725,15 @@
 // "SwiftCXXThunk.h".
 #define HAS_SWIFTCXX_THUNK  NS_REFINED_FOR_SWIFT
 
+#ifdef __cplusplus
+namespace WTF {
+// When -fpch-debuginfo is enabled, clang sometimes forgets to emit a vtable (rdar://176736350).
+// This tag identifies an unused out-of-line constructor that reminds clang to emit a vtable.
+enum class ClangVTableWorkaroundTag { };
+} // namespace WTF
+using WTF::ClangVTableWorkaroundTag;
+#endif
+
 // This comment is incremented each time we add or remove a modulemap file, to force
 // rebuild of all WTF's dependencies. This is a workaround for rdar://151920332.
 // Current increment: 2.

--- a/Source/WTF/wtf/ThreadAssertions.h
+++ b/Source/WTF/wtf/ThreadAssertions.h
@@ -65,7 +65,7 @@ public:
 
 protected:
     static constexpr uint32_t mainThreadID { 1 };
-    static std::atomic<uint32_t> s_uid;
+    WTF_EXPORT_PRIVATE static std::atomic<uint32_t> s_uid;
     static ThreadLikeAssertion createThreadLikeAssertion(uint32_t);
 };
 

--- a/Source/WTF/wtf/text/StringImpl.cpp
+++ b/Source/WTF/wtf/text/StringImpl.cpp
@@ -182,24 +182,6 @@ template<typename CharacterType> inline Ref<StringImpl> StringImpl::createUninit
     return createUninitializedInternalNonEmpty(length, data);
 }
 
-template<typename CharacterType> inline Ref<StringImpl> StringImpl::createUninitializedInternalNonEmpty(size_t length, std::span<CharacterType>& data)
-{
-    ASSERT(length);
-
-    // Allocate a single buffer large enough to contain the StringImpl
-    // struct as well as the data which it contains. This removes one
-    // heap allocation from this call.
-    if (!isValidLength<CharacterType>(length))
-        CRASH();
-
-    SUPPRESS_UNCOUNTED_LOCAL StringImpl* string = static_cast<StringImpl*>(StringImplMalloc::malloc(allocationSize<CharacterType>(length)));
-    data = unsafeMakeSpan(string->tailPointer<CharacterType>(), length);
-    return constructInternal<CharacterType>(*string, length);
-}
-
-template Ref<StringImpl> StringImpl::createUninitializedInternalNonEmpty(size_t length, std::span<Latin1Character>& data);
-template Ref<StringImpl> StringImpl::createUninitializedInternalNonEmpty(size_t length, std::span<char16_t>& data);
-
 Ref<StringImpl> StringImpl::createUninitialized(size_t length, std::span<Latin1Character>& data)
 {
     return createUninitializedInternal(length, data);

--- a/Source/WTF/wtf/text/StringImpl.h
+++ b/Source/WTF/wtf/text/StringImpl.h
@@ -1264,6 +1264,21 @@ template<typename T> inline T* StringImpl::tailPointer()
 }
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
+template<typename CharacterType> inline Ref<StringImpl> StringImpl::createUninitializedInternalNonEmpty(size_t length, std::span<CharacterType>& data)
+{
+    ASSERT(length);
+
+    // Allocate a single buffer large enough to contain the StringImpl
+    // struct as well as the data which it contains. This removes one
+    // heap allocation from this call.
+    if (!isValidLength<CharacterType>(length))
+        CRASH();
+
+    SUPPRESS_UNCOUNTED_LOCAL StringImpl* string = static_cast<StringImpl*>(StringImplMalloc::malloc(allocationSize<CharacterType>(length)));
+    data = unsafeMakeSpan(string->tailPointer<CharacterType>(), length);
+    return constructInternal<CharacterType>(*string, length);
+}
+
 inline StringImpl* const& StringImpl::substringBuffer() const
 {
     ASSERT(bufferOwnership() == BufferSubstring);

--- a/Source/WTF/wtf/text/WTFString.h
+++ b/Source/WTF/wtf/text/WTFString.h
@@ -282,7 +282,7 @@ public:
     static String fromUTF8(const char* string) { return byteCast<char8_t>(unsafeSpan(string)); }
 
     // Convert each invalid UTF-8 sequence into a replacement character.
-    static String fromUTF8ReplacingInvalidSequences(std::span<const char8_t>);
+    WTF_EXPORT_PRIVATE static String fromUTF8ReplacingInvalidSequences(std::span<const char8_t>);
     static String fromUTF8ReplacingInvalidSequences(std::span<const Latin1Character> characters) { return fromUTF8ReplacingInvalidSequences(byteCast<char8_t>(characters)); }
 
     // Tries to convert the passed in string to UTF-8, but will fall back to Latin-1 if the string is not valid UTF-8.

--- a/Source/WebCore/WebCorePrefix.h
+++ b/Source/WebCore/WebCorePrefix.h
@@ -170,6 +170,7 @@
 #include <JavaScriptCore/OptionsList.h>
 #include <JavaScriptCore/SourceID.h>
 #include <JavaScriptCore/Weak.h>
+#include <JavaScriptCore/WeakInlinesLight.h>
 #include <set>
 #include <unicode/uscript.h>
 #include <wtf/AbstractRefCountedAndCanMakeWeakPtr.h>

--- a/Source/WebCore/dom/StyledElement.cpp
+++ b/Source/WebCore/dom/StyledElement.cpp
@@ -71,6 +71,11 @@ void StyledElement::synchronizeStyleAttributeInternalImpl()
         setSynchronizedLazyAttribute(styleAttr, inlineStyle->asTextAtom(CSS::defaultSerializationContext()));
 }
 
+StyledElement::StyledElement(ClangVTableWorkaroundTag, const QualifiedName& name, Document& document)
+    : Element(name, document, { })
+{
+}
+
 StyledElement::~StyledElement() = default;
 
 CSSStyleProperties& StyledElement::cssomStyle()

--- a/Source/WebCore/dom/StyledElement.h
+++ b/Source/WebCore/dom/StyledElement.h
@@ -95,6 +95,8 @@ protected:
     Attribute replaceURLsInAttributeValue(const Attribute&, const CSS::SerializationContext&) const override;
 
 private:
+    StyledElement(ClangVTableWorkaroundTag, const QualifiedName&, Document&);
+
     void styleAttributeChanged(const AtomString& newStyleString, AttributeModificationReason);
     void synchronizeStyleAttributeInternalImpl();
     void synchronizeStyleAttributeForSelectorInvalidation();

--- a/Source/WebCore/platform/graphics/DoublePoint.h
+++ b/Source/WebCore/platform/graphics/DoublePoint.h
@@ -106,7 +106,6 @@ public:
     WEBCORE_EXPORT DoublePoint(const POINT&);
 #endif
 
-    WEBCORE_EXPORT String toJSONString() const;
     WEBCORE_EXPORT Ref<JSON::Object> toJSONObject() const;
 
     friend bool operator==(const DoublePoint&, const DoublePoint&) = default;
@@ -155,16 +154,4 @@ WEBCORE_EXPORT WTF::TextStream& operator<<(WTF::TextStream&, const DoublePoint&)
 
 } // namespace WebCore
 
-namespace WTF {
-
-template<typename Type> struct LogArgument;
-template <>
-struct LogArgument<WebCore::DoublePoint> {
-    static String toString(const WebCore::DoublePoint& point)
-    {
-        return point.toJSONString();
-    }
-};
-
-} // namespace WTF
 

--- a/Source/bmalloc/bmalloc/TZoneHeap.h
+++ b/Source/bmalloc/bmalloc/TZoneHeap.h
@@ -336,7 +336,7 @@ public: \
         return location; \
     } \
     \
-    void* operator new(size_t size) \
+    BINLINE void* operator new(size_t size) \
     { \
         if (!s_heapRef || size != sizeof(_type)) [[unlikely]] \
             BMUST_TAIL_CALL return operatorNewSlow(size); \


### PR DESCRIPTION
#### 6b3acbd07e195a22b8f92a28f60486f968b2be4f
<pre>
[CMake] Prepare for -fpch-codegen / -fpch-debuginfo
<a href="https://bugs.webkit.org/show_bug.cgi?id=314513">https://bugs.webkit.org/show_bug.cgi?id=314513</a>
<a href="https://rdar.apple.com/176744994">rdar://176744994</a>

Reviewed by David Kilzer.

To generate code for prefix headers, we need to obey stricter hygiene about
inline functions.

* Source/JavaScriptCore/CMakeLists.txt: List our new *Inlines.h file.s

* Source/JavaScriptCore/JavaScriptCorePrefix.h: When A.h defines inline a() that
calls inline b() defined in B.h, and A.h is in the prefix header, also include
B.h in the prefix header. Otherwise, linking fails. This was always a latent
issue, but generating code surfaces it eagerly.

* Source/JavaScriptCore/bytecode/PropertyInlineCacheClearingWatchpoint.cpp:
(JSC::AdaptiveValuePropertyInlineCacheClearingWatchpoint::AdaptiveValuePropertyInlineCacheClearingWatchpoint):
* Source/JavaScriptCore/bytecode/PropertyInlineCacheClearingWatchpoint.h:
* Source/JavaScriptCore/bytecode/VariableWriteFireDetail.cpp:
(JSC::VariableWriteFireDetail::VariableWriteFireDetail):
* Source/JavaScriptCore/bytecode/VariableWriteFireDetail.h:
* Source/JavaScriptCore/bytecode/Watchpoint.cpp:
(JSC::StringFireDetail::StringFireDetail):
* Source/JavaScriptCore/bytecode/Watchpoint.h:
* Source/JavaScriptCore/heap/WeakHandleOwner.cpp:
(JSC::WeakHandleOwner::WeakHandleOwner):
* Source/JavaScriptCore/heap/WeakHandleOwner.h: Added an unused
ClangVTableWorkaroundTag constructor to work around a clang inlining bug
(<a href="https://rdar.apple.com/176736350">rdar://176736350</a>).

Added missing export macro to StringFireDetail.

* Source/JavaScriptCore/heap/WeakInlines.h:
(JSC::Weak&lt;T&gt;::clear): Deleted.
* Source/JavaScriptCore/heap/WeakInlinesLight.h: Copied from Source/JavaScriptCore/heap/WeakHandleOwner.cpp.
(JSC::Weak&lt;T&gt;::clear): Move Weak&lt;T&gt;::clear() to a separate header file to make
sure its inline callees are defined.

* Source/JavaScriptCore/runtime/BufferMemoryHandle.h:
* Source/JavaScriptCore/runtime/JSCJSValue.h: Added missing export macro.

* Source/JavaScriptCore/runtime/JSString.h: Added missing declaration.

* Source/JavaScriptCore/runtime/OptionsList.h: Added missing export macro.

* Source/JavaScriptCore/runtime/Structure.cpp:
(JSC::StructureFireDetail::StructureFireDetail):
* Source/JavaScriptCore/runtime/Structure.h: More clang workaround.

* Source/JavaScriptCore/runtime/WriteBarrier.h: Avoid using WTF_MAKE_TZONE_ALLOCATED_TEMPLATE
because we don&apos;t include the header, and anyway heap-allocating a WriteBarrier
would be uncivilized.

* Source/WTF/wtf/Compiler.h: Helper tag for our clang workaround.

* Source/WTF/wtf/ThreadAssertions.h:
* Source/WTF/wtf/text/StringImpl.h:
* Source/WTF/wtf/text/WTFString.h: Added missing export macros.

* Source/WebCore/WebCorePrefix.h: Added our new Weak&lt;T&gt;::clear() header.

* Source/WebCore/dom/StyledElement.cpp:
(WebCore::StyledElement::StyledElement):
* Source/WebCore/dom/StyledElement.h: More clang vtable workaround.

* Source/WebCore/platform/graphics/DoublePoint.h:
(WTF::LogArgument&lt;WebCore::DoublePoint&gt;::toString): Deleted. Remove toString()
and its caller because we either need to define a function or not call it, and
we were already not calling it.

* Source/bmalloc/bmalloc/TZoneHeap.h: Added a missing inline declaration.

Canonical link: <a href="https://commits.webkit.org/313034@main">https://commits.webkit.org/313034@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e82927a83dd4778dc73837ba4dd174bc4d795eaf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161742 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35216 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28319 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170645 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118113 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/050782f5-8c6f-4999-a29e-8fbb16bd041c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163611 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35317 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35217 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125492 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88410 "2 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d2fd8574-5cec-4e91-a396-b28ce0ef6656) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164701 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27802 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145284 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106088 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/85ce419e-2387-479d-83c4-ed1348b91467) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26851 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25362 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18366 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/153800 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136544 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23039 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173134 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22580 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20174 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24680 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133786 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34890 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29451 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133791 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34874 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144834 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96903 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24585 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28324 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21656 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194141 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34384 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101829 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50030 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33884 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34127 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34033 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->