### PR TITLE
[CSS Typed OM] 'will-change' should reify only `auto` and CSS-wide keywords as CSSKeywordValue

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/will-change-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/will-change-expected.txt
@@ -31,6 +31,6 @@ PASS Setting 'will-change' to a number: calc(2 + 3) throws TypeError
 PASS Setting 'will-change' to a transform: translate(50%, 50%) throws TypeError
 PASS Setting 'will-change' to a transform: perspective(10em) throws TypeError
 PASS Setting 'will-change' to a transform: translate3d(0px, 1px, 2px) translate(0px, 1px) rotate3d(1, 2, 3, 45deg) rotate(45deg) scale3d(1, 2, 3) scale(1, 2) skew(1deg, 1deg) skewX(1deg) skewY(45deg) perspective(1px) matrix3d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16) matrix(1, 2, 3, 4, 5, 6) throws TypeError
-FAIL 'will-change' does not support 'scroll-position' assert_class_string: Unsupported value must be a CSSStyleValue and not one of its subclasses expected "[object CSSStyleValue]" but got "[object CSSKeywordValue]"
+PASS 'will-change' does not support 'scroll-position'
 PASS 'will-change' does not support 'contents, foo, scroll-position'
 

--- a/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
+++ b/Source/WebCore/css/typedom/CSSStyleValueFactory.cpp
@@ -59,6 +59,7 @@
 #include "CSSValueList.h"
 #include "CSSValuePool.h"
 #include "CSSVariableData.h"
+#include "CSSWideKeyword.h"
 #include "ExceptionOr.h"
 #include "RenderStyle.h"
 #include "ScriptWrappableInlines.h"
@@ -328,6 +329,14 @@ ExceptionOr<Ref<CSSStyleValue>> CSSStyleValueFactory::reifyValue(Document& docum
             break;
         }
     } else if (auto* keywordValue = dynamicDowncast<CSSKeywordValue>(cssValue)) {
+        // For `will-change`, only `auto` and the CSS-wide keywords reify as CSSKeywordValue;
+        // other valid CSS values such as `scroll-position` and `contents` fall back to the base
+        // CSSStyleValue wrapper, matching Blink.
+        if (propertyID && *propertyID == CSSPropertyWillChange) {
+            auto keyword = keywordValue->keyword().value;
+            if (keyword != CSSValueAuto && !isCSSWideKeyword(keyword))
+                return Ref<CSSStyleValue> { CSSStyleValue::create(Ref(const_cast<CSSValue&>(cssValue))) };
+        }
         return WebCore::reifyValue(keywordValue->keyword());
     } else if (auto* customIdentValue = dynamicDowncast<CSSCustomIdentValue>(cssValue))
         return WebCore::reifyValue(customIdentValue->customIdent());


### PR DESCRIPTION
#### 1c4942666881c3fa09e56e4c186b1deaaa132189
<pre>
[CSS Typed OM] &apos;will-change&apos; should reify only `auto` and CSS-wide keywords as CSSKeywordValue
<a href="https://bugs.webkit.org/show_bug.cgi?id=314514">https://bugs.webkit.org/show_bug.cgi?id=314514</a>
<a href="https://rdar.apple.com/176745737">rdar://176745737</a>

Reviewed by NOBODY (OOPS!).

CSSStyleValueFactory::reifyValue was reifying every CSSKeywordValue as
CSSOMKeywordValue regardless of property. For `will-change`, Blink (and the
corresponding WPT test) only exposes `auto` and CSS-wide keywords as typed
CSSKeywordValue; other valid CSS values such as `scroll-position` and
`contents` fall back to the base CSSStyleValue wrapper.

Special-case `will-change` so non-`auto`, non-CSS-wide keyword values round
trip as CSSStyleValue, matching Blink and passing the WPT.

* LayoutTests/imported/w3c/web-platform-tests/css/css-typed-om/the-stylepropertymap/properties/will-change-expected.txt: Progression
* Source/WebCore/css/typedom/CSSStyleValueFactory.cpp:
(WebCore::CSSStyleValueFactory::reifyValue):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c4942666881c3fa09e56e4c186b1deaaa132189

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161720 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35194 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28297 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170623 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118091 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7a39c558-05a3-4a58-ab3f-03efe9f88b0d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163589 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35295 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35195 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125465 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88391 "1 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b87bdf7b-d48d-441d-98a0-7eadc433e5ce) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164679 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27778 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145258 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106061 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3f3d29ad-413d-455d-8d10-603e9cdd773b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26827 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25339 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18344 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136520 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23013 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173112 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20152 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24654 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133758 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34868 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29429 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133763 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34852 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144808 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96871 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28299 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21630 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34362 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101807 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33862 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34105 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34011 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->