### PR TITLE
Add WebKitAdditions CMake include path support for Mac

### DIFF
--- a/Source/cmake/OptionsCocoa.cmake
+++ b/Source/cmake/OptionsCocoa.cmake
@@ -1,3 +1,17 @@
+set(_wka_found FALSE)
+set(_wka_cmake_paths
+    "${CMAKE_SOURCE_DIR}/../Internal/WebKit"
+)
+foreach (_wka_path IN LISTS _wka_cmake_paths)
+    if (EXISTS "${_wka_path}/WebKitAdditions" AND NOT _wka_found)
+        set(WEBKIT_ADDITIONS_INCLUDE_PATH "${_wka_path}" CACHE PATH "WebKitAdditions include path" FORCE)
+        message(STATUS "WebKitAdditions (cmake): ${_wka_path}")
+        set(_wka_found TRUE)
+    endif ()
+endforeach ()
+unset(_wka_cmake_paths)
+unset(_wka_found)
+
 set(SWIFT_REQUIRED ON)
 
 # FIXME: AV1 decoding requires dav1d which uses meson. https://bugs.webkit.org/show_bug.cgi?id=314011

--- a/Source/cmake/OptionsIOS.cmake
+++ b/Source/cmake/OptionsIOS.cmake
@@ -146,21 +146,7 @@ endforeach ()
 if (NOT _wka_found)
     message(WARNING "WebKitAdditions not found -- SPI headers referencing Additions will fail")
 endif ()
-set(_wka_found FALSE)
-set(_wka_cmake_paths
-    "${CMAKE_SOURCE_DIR}/../Internal/WebKit"
-    "${CMAKE_SOURCE_DIR}/WebKitBuild/Debug/usr/local/include"
-    "${CMAKE_SOURCE_DIR}/WebKitBuild/Release/usr/local/include"
-)
-foreach (_wka_path IN LISTS _wka_cmake_paths)
-    if (EXISTS "${_wka_path}/WebKitAdditions" AND NOT _wka_found)
-        set(WEBKIT_ADDITIONS_INCLUDE_PATH "${_wka_path}" CACHE PATH "WebKitAdditions include path" FORCE)
-        message(STATUS "WebKitAdditions (cmake): ${_wka_path}")
-        set(_wka_found TRUE)
-    endif ()
-endforeach ()
 unset(_wka_compile_paths)
-unset(_wka_cmake_paths)
 unset(_wka_found)
 
 if (CMAKE_OSX_SYSROOT)

--- a/Source/cmake/OptionsMac.cmake
+++ b/Source/cmake/OptionsMac.cmake
@@ -213,4 +213,9 @@ if (EXISTS ${TOOLS_DIR}/Scripts/generate-cmake-xcode-project)
         OUTPUT_QUIET)
 endif ()
 
+if (WEBKIT_ADDITIONS_INCLUDE_PATH AND EXISTS "${WEBKIT_ADDITIONS_INCLUDE_PATH}/WebKitAdditions/CMake/OptionsMac.cmake")
+    message(STATUS "WebKitAdditions CMake: ${WEBKIT_ADDITIONS_INCLUDE_PATH}/WebKitAdditions/CMake/OptionsMac.cmake")
+    include("${WEBKIT_ADDITIONS_INCLUDE_PATH}/WebKitAdditions/CMake/OptionsMac.cmake")
+endif ()
+
 set(MiniBrowser_DERIVED_SOURCES_DIR "${CMAKE_BINARY_DIR}/DerivedSources/MiniBrowser")


### PR DESCRIPTION
#### 041db0ed21139928bbbc1b944caee2597a8bf5b7
<pre>
Add WebKitAdditions CMake include path support for Mac
<a href="https://bugs.webkit.org/show_bug.cgi?id=314515">https://bugs.webkit.org/show_bug.cgi?id=314515</a>
<a href="https://rdar.apple.com/176745928">rdar://176745928</a>

Reviewed by Pascoe.

Move WEBKIT_ADDITIONS_INCLUDE_PATH discovery from OptionsIOS.cmake to OptionsCocoa.cmake so it
applies to all Cocoa platforms, and include an optional WebKitAdditions/CMake/OptionsMac.cmake when
present. This matches what iOS already does.

* Source/cmake/OptionsCocoa.cmake:
* Source/cmake/OptionsIOS.cmake:
* Source/cmake/OptionsMac.cmake:

Canonical link: <a href="https://commits.webkit.org/313038@main">https://commits.webkit.org/313038@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f526c2cd9ce2d6b8fd5804b482fe1fef6624ea7f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161723 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35197 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28300 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170626 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118094 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b17312d5-be85-4829-988f-4b5fd716fe3f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35298 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35198 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125468 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88392 "1 flakes 1 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/25968cf5-3983-44a0-be78-37b695bfba3c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164682 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27777 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145259 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106064 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a52c661e-246a-4958-8f1a-e5c52a1c71ea) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26826 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25340 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18347 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/153780 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136519 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173115 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22561 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24655 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133761 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34871 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29430 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133766 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34855 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144809 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96876 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24589 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28300 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21631 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194122 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34365 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50018 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33865 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34108 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34014 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->