### PR TITLE
[JSC] Inline `String#startsWith` / `String#endsWith` with constant search string in DFG/FTL

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -17977,9 +17977,115 @@ void SpeculativeJIT::compileStringLastIndexOf(Node* node)
     strictInt32Result(resultGPR, node);
 }
 
+#if USE(JSVALUE64)
+static constexpr unsigned maxConstantSearchLength = 16;
+
+void SpeculativeJIT::compileStringStartsOrEndsWithConstant(Node* node, bool isStartsWith, std::span<const Latin1Character> search)
+{
+    ASSERT(!search.empty() && search.size() <= maxConstantSearchLength);
+    const unsigned searchLength = static_cast<unsigned>(search.size());
+
+    SpeculateCellOperand base(this, node->child1());
+    SpeculateCellOperand argument(this, node->child2());
+    GPRTemporary impl(this);
+    GPRTemporary length(this);
+    GPRTemporary scratch(this);
+
+    GPRReg baseGPR = base.gpr();
+    GPRReg argumentGPR = argument.gpr();
+    GPRReg implGPR = impl.gpr();
+    GPRReg lengthGPR = length.gpr();
+    GPRReg scratchGPR = scratch.gpr();
+
+    speculateString(node->child1(), baseGPR);
+    speculateString(node->child2(), argumentGPR);
+
+    JumpList trueCase;
+    JumpList falseCase;
+    JumpList slowCase;
+
+    loadPtr(Address(baseGPR, JSString::offsetOfValue()), implGPR);
+    slowCase.append(branchIfRopeStringImpl(implGPR));
+
+    load32(Address(implGPR, StringImpl::lengthMemoryOffset()), lengthGPR);
+    falseCase.append(branch32(Below, lengthGPR, TrustedImm32(searchLength)));
+
+    // 16-bit base strings (and any other rare width mismatch) fall to the runtime helper.
+    slowCase.append(branchTest32(Zero, Address(implGPR, StringImpl::flagsOffset()), TrustedImm32(StringImpl::flagIs8Bit())));
+
+    // Anchor implGPR at the start of the matched window: data[0] for startsWith, or
+    // data[length - searchLength] for endsWith.
+    loadPtr(Address(implGPR, StringImpl::dataOffset()), implGPR);
+    if (!isStartsWith) {
+        addPtr(lengthGPR, implGPR);
+        subPtr(TrustedImm32(searchLength), implGPR);
+    }
+
+    // Encode the search bytes as little-endian immediates so the comparison is a few
+    // wide loads + compares, with overlap when searchLength isn't a power of two.
+    auto chunk = [&](unsigned offset, unsigned width) -> uint64_t {
+        uint64_t value = 0;
+        for (unsigned i = 0; i < width; ++i)
+            value |= static_cast<uint64_t>(search[offset + i]) << (i * 8);
+        return value;
+    };
+
+    if (searchLength >= 8) {
+        load64(Address(implGPR), scratchGPR);
+        falseCase.append(branch64(NotEqual, scratchGPR, TrustedImm64(static_cast<int64_t>(chunk(0, 8)))));
+        if (searchLength > 8) {
+            load64(Address(implGPR, searchLength - 8), scratchGPR);
+            falseCase.append(branch64(NotEqual, scratchGPR, TrustedImm64(static_cast<int64_t>(chunk(searchLength - 8, 8)))));
+        }
+    } else if (searchLength >= 4) {
+        load32(Address(implGPR), scratchGPR);
+        falseCase.append(branch32(NotEqual, scratchGPR, TrustedImm32(static_cast<int32_t>(chunk(0, 4)))));
+        if (searchLength > 4) {
+            load32(Address(implGPR, searchLength - 4), scratchGPR);
+            falseCase.append(branch32(NotEqual, scratchGPR, TrustedImm32(static_cast<int32_t>(chunk(searchLength - 4, 4)))));
+        }
+    } else if (searchLength >= 2) {
+        load16(Address(implGPR), scratchGPR);
+        falseCase.append(branch32(NotEqual, scratchGPR, TrustedImm32(static_cast<int32_t>(chunk(0, 2)))));
+        if (searchLength > 2) {
+            load16(Address(implGPR, searchLength - 2), scratchGPR);
+            falseCase.append(branch32(NotEqual, scratchGPR, TrustedImm32(static_cast<int32_t>(chunk(searchLength - 2, 2)))));
+        }
+    } else {
+        load8(Address(implGPR), scratchGPR);
+        falseCase.append(branch32(NotEqual, scratchGPR, TrustedImm32(search[0])));
+    }
+    trueCase.append(jump());
+
+    falseCase.link(this);
+    move(TrustedImm32(0), implGPR);
+    Jump done = jump();
+
+    trueCase.link(this);
+    move(TrustedImm32(1), implGPR);
+
+    done.link(this);
+    addSlowPathGenerator(slowPathCall(
+        slowCase, this, isStartsWith ? operationStringStartsWith : operationStringEndsWith,
+        implGPR, LinkableConstant::globalObject(*this, node), baseGPR, argumentGPR));
+
+    unblessedBooleanResult(implGPR, node);
+}
+#endif // USE(JSVALUE64)
+
 void SpeculativeJIT::compileStringStartsOrEndsWith(Node* node)
 {
     bool isStartsWith = node->op() == StringStartsWith;
+
+#if USE(JSVALUE64)
+    if (!node->child3()) {
+        String search = node->child2()->tryGetString(m_graph);
+        if (!search.isNull() && search.length() >= 1 && search.length() <= maxConstantSearchLength && search.is8Bit()) {
+            compileStringStartsOrEndsWithConstant(node, isStartsWith, search.span8());
+            return;
+        }
+    }
+#endif
 
     if (node->child3()) {
         SpeculateCellOperand base(this, node->child1());

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1803,6 +1803,9 @@ public:
     void compileStringIndexOf(Node*);
     void compileStringLastIndexOf(Node*);
     void compileStringStartsOrEndsWith(Node*);
+#if USE(JSVALUE64)
+    void compileStringStartsOrEndsWithConstant(Node*, bool isStartsWith, std::span<const Latin1Character> search);
+#endif
     void compileStringSplit(Node*);
     void compileStringMatch(Node*);
     void compileDateGet(Node*);

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -12172,9 +12172,112 @@ IGNORE_CLANG_WARNINGS_END
             setInt32(vmCall(Int32, operationStringLastIndexOf, weakPointer(globalObject), base, search));
     }
 
+    static constexpr unsigned maxConstantSearchLength = 16;
+
+    void compileStringStartsOrEndsWithConstant(bool isStartsWith, std::span<const Latin1Character> search)
+    {
+        ASSERT(!search.empty() && search.size() <= maxConstantSearchLength);
+        const unsigned searchLength = static_cast<unsigned>(search.size());
+        auto* globalObject = m_graph.globalObjectFor(m_origin.semantic);
+
+        LValue base = lowString(m_node->child1());
+        LValue argument = lowString(m_node->child2());
+
+        LBasicBlock notRopeCase = m_out.newBlock();
+        LBasicBlock lengthOKCase = m_out.newBlock();
+        LBasicBlock is8BitCase = m_out.newBlock();
+        LBasicBlock trueCase = m_out.newBlock();
+        LBasicBlock falseCase = m_out.newBlock();
+        LBasicBlock slowCase = m_out.newBlock();
+        LBasicBlock continuation = m_out.newBlock();
+
+        m_out.branch(isRopeString(base, m_node->child1()), rarely(slowCase), usually(notRopeCase));
+
+        LBasicBlock lastNext = m_out.appendTo(notRopeCase, lengthOKCase);
+        LValue impl = m_out.loadPtr(base, m_heaps.JSString_value);
+        LValue length = m_out.load32(impl, m_heaps.StringImpl_length);
+        m_out.branch(m_out.below(length, m_out.constInt32(searchLength)), unsure(falseCase), unsure(lengthOKCase));
+
+        m_out.appendTo(lengthOKCase, is8BitCase);
+        m_out.branch(
+            m_out.testIsZero32(m_out.load32(impl, m_heaps.StringImpl_hashAndFlags), m_out.constInt32(StringImpl::flagIs8Bit())),
+            rarely(slowCase), usually(is8BitCase));
+
+        m_out.appendTo(is8BitCase, trueCase);
+        // Anchor the window at data[0] for startsWith, or data[length - searchLength] for endsWith.
+        LValue data = m_out.loadPtr(impl, m_heaps.StringImpl_data);
+        LValue windowBase = isStartsWith
+            ? data
+            : m_out.add(data, m_out.zeroExtPtr(m_out.sub(length, m_out.constInt32(searchLength))));
+
+        // Encode the search bytes as little-endian immediates so the comparison is a few
+        // wide loads + compares, with overlap when searchLength isn't a power of two.
+        auto chunk = [&](unsigned offset, unsigned width) -> uint64_t {
+            uint64_t value = 0;
+            for (unsigned i = 0; i < width; ++i)
+                value |= static_cast<uint64_t>(search[offset + i]) << (i * 8);
+            return value;
+        };
+        auto loadAt = [&](unsigned offset, unsigned width) -> LValue {
+            LValue ptr = m_out.add(windowBase, m_out.constIntPtr(offset));
+            TypedPointer typed(m_heaps.characters8.atAnyIndex(), ptr);
+            if (width == 8)
+                return m_out.load64(typed);
+            if (width == 4)
+                return m_out.load32(typed);
+            if (width == 2)
+                return m_out.load16ZeroExt32(typed);
+            return m_out.load8ZeroExt32(typed);
+        };
+
+        LValue matches;
+        if (searchLength >= 8) {
+            matches = m_out.equal(loadAt(0, 8), m_out.constInt64(chunk(0, 8)));
+            if (searchLength > 8)
+                matches = m_out.bitAnd(matches, m_out.equal(loadAt(searchLength - 8, 8), m_out.constInt64(chunk(searchLength - 8, 8))));
+        } else if (searchLength >= 4) {
+            matches = m_out.equal(loadAt(0, 4), m_out.constInt32(static_cast<int32_t>(chunk(0, 4))));
+            if (searchLength > 4)
+                matches = m_out.bitAnd(matches, m_out.equal(loadAt(searchLength - 4, 4), m_out.constInt32(static_cast<int32_t>(chunk(searchLength - 4, 4)))));
+        } else if (searchLength >= 2) {
+            matches = m_out.equal(loadAt(0, 2), m_out.constInt32(static_cast<int32_t>(chunk(0, 2))));
+            if (searchLength > 2)
+                matches = m_out.bitAnd(matches, m_out.equal(loadAt(searchLength - 2, 2), m_out.constInt32(static_cast<int32_t>(chunk(searchLength - 2, 2)))));
+        } else
+            matches = m_out.equal(loadAt(0, 1), m_out.constInt32(search[0]));
+        m_out.branch(matches, unsure(trueCase), unsure(falseCase));
+
+        m_out.appendTo(trueCase, falseCase);
+        ValueFromBlock trueResult = m_out.anchor(m_out.booleanTrue);
+        m_out.jump(continuation);
+
+        m_out.appendTo(falseCase, slowCase);
+        ValueFromBlock falseResult = m_out.anchor(m_out.booleanFalse);
+        m_out.jump(continuation);
+
+        m_out.appendTo(slowCase, continuation);
+        LValue slowValue = vmCall(
+            Int32, isStartsWith ? operationStringStartsWith : operationStringEndsWith,
+            weakPointer(globalObject), base, argument);
+        ValueFromBlock slowResult = m_out.anchor(slowValue);
+        m_out.jump(continuation);
+
+        m_out.appendTo(continuation, lastNext);
+        setBoolean(m_out.phi(Int32, trueResult, falseResult, slowResult));
+    }
+
     void compileStringStartsOrEndsWith()
     {
         bool isStartsWith = m_node->op() == StringStartsWith;
+
+        if (!m_node->child3()) {
+            String search = m_node->child2()->tryGetString(m_graph);
+            if (!search.isNull() && search.length() >= 1 && search.length() <= maxConstantSearchLength && search.is8Bit()) {
+                compileStringStartsOrEndsWithConstant(isStartsWith, search.span8());
+                return;
+            }
+        }
+
         LValue base = lowString(m_node->child1());
         LValue search = lowString(m_node->child2());
         auto* globalObject = m_graph.globalObjectFor(m_origin.semantic);


### PR DESCRIPTION
#### 67969621f7032db54f3cec3c893ff1b5bf212fcf
<pre>
[JSC] Inline `String#startsWith` / `String#endsWith` with constant search string in DFG/FTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=314517">https://bugs.webkit.org/show_bug.cgi?id=314517</a>

Reviewed by Yusuke Suzuki.

This patch inlines StringStartsWith / StringEndsWith when the search
string is a constant, embedding its bytes as immediate operands instead
of calling into the runtime.

The comparison uses a few wide loads with overlap when the search
length isn&apos;t a power of two: load64 for &gt;= 8 bytes, load32 for 4-7,
load16 for 2-3, load8 for 1. A 16-byte search needs at most two
load64 + cmp.

Only constant 8-bit search strings of 1-16 bytes are supported; ropes,
16-bit base strings, and variable or position-argument forms still go
through the runtime helper.

                                                  TipOfTree                  Patched

string-startswith-constant                     17.9727+-0.4341     ^      5.7938+-0.3102        ^ definitely 3.1021x faster
string-endswith-constant                       17.3566+-1.8544     ^      6.1307+-0.2170        ^ definitely 2.8311x faster
string-startswith-constant-long                16.1837+-1.2149     ^      5.8331+-0.4844        ^ definitely 2.7744x faster

* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileStringStartsOrEndsWithConstant):
(JSC::FTL::DFG::LowerDFGToB3::compileStringStartsOrEndsWith):

Canonical link: <a href="https://commits.webkit.org/313394@main">https://commits.webkit.org/313394@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9f6308a03db308db4198c7180f2ceb364ff5522

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163033 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36512 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29707 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171972 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119479 "Built successfully") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/36805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36514 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126562 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89166 "1 flakes 1 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165992 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/36805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146535 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107138 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/36805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26503 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19671 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/155172 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137702 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24264 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174475 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23919 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/26023 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25911 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134873 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36183 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30606 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134868 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36362 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/36767 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146060 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98738 "Built successfully") | 
| | [⏳ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/visionOS-26-Simulator-WK2-Tests-EWS "Waiting to run tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22898 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195434 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35679 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/107683 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50895 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35178 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/919 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35425 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35326 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->