### PR TITLE
Loading any Web Extension breaks Cloudflare bot challenges

### DIFF
--- a/Source/WebCore/page/FrameConsoleClient.cpp
+++ b/Source/WebCore/page/FrameConsoleClient.cpp
@@ -220,10 +220,8 @@ void FrameConsoleClient::messageWithTypeAndLevel(MessageType type, MessageLevel 
     auto columnNumber = message->column();
 
     auto* domGlobalObject = dynamicDowncast<JSDOMGlobalObject>(lexicalGlobalObject);
-    if (level == MessageLevel::Error && domGlobalObject && domGlobalObject->hasScriptErrorCallbacks()) {
-        auto fullMessageText = makeStringByJoining(arguments->getArgumentsAsStrings(), " "_s);
-        domGlobalObject->invokeScriptErrorCallbacks(fullMessageText, url, lineNumber, columnNumber);
-    }
+    if (level == MessageLevel::Error && domGlobalObject && domGlobalObject->hasScriptErrorCallbacks())
+        domGlobalObject->invokeScriptErrorCallbacks(messageText, url, lineNumber, columnNumber);
 
 #if ENABLE(WEBDRIVER_BIDI)
     AutomationInstrumentation::addMessageToConsole(message);

--- a/Source/WebCore/workers/WorkerConsoleClient.cpp
+++ b/Source/WebCore/workers/WorkerConsoleClient.cpp
@@ -88,10 +88,8 @@ void WorkerConsoleClient::messageWithTypeAndLevel(MessageType type, MessageLevel
     protect(m_globalScope.get())->addConsoleMessage(WTF::move(message));
 
     auto* domGlobalObject = dynamicDowncast<JSDOMGlobalObject>(exec);
-    if (level == MessageLevel::Error && domGlobalObject && domGlobalObject->hasScriptErrorCallbacks()) {
-        auto fullMessageText = makeStringByJoining(arguments->getArgumentsAsStrings(), " "_s);
-        domGlobalObject->invokeScriptErrorCallbacks(fullMessageText, url, line, column);
-    }
+    if (level == MessageLevel::Error && domGlobalObject && domGlobalObject->hasScriptErrorCallbacks())
+        domGlobalObject->invokeScriptErrorCallbacks(messageText, url, line, column);
 }
 
 void WorkerConsoleClient::count(JSC::JSGlobalObject* exec, const String& label)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionContext.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionContext.mm
@@ -1316,6 +1316,45 @@ TEST(WKWebExtensionContext, PageScriptErrorNotReportedToExtension)
     EXPECT_NS_EQUAL(manager.get().context.errors, @[ ]);
 }
 
+TEST(WKWebExtensionContext, ConsoleErrorDoesNotEvaluateArgumentsTwice)
+{
+    // Verify that console.error() does not call toString() on its arguments more than once when a
+    // main-world content script has registered script error callbacks. https://webkit.org/b/314458
+
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, "<script>var arg1Count = 0; var arg2Count = 0; console.error({ toString() { ++arg1Count; return 'error'; } }, { toString() { ++arg2Count; return 'extra'; } });</script>"_s } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *manifest = @{
+        @"manifest_version": @3,
+        @"name": @"Test Extension",
+        @"description": @"Test",
+        @"version": @"1.0",
+        @"content_scripts": @[ @{
+            @"matches": @[ @"*://localhost/*" ],
+            @"js": @[ @"content.js" ],
+            @"world": @"MAIN",
+        } ],
+    };
+
+    // Content script runs at document_end (after page scripts), reads both toString call counts,
+    // and reports them. The first argument should be evaluated exactly once (for the ConsoleMessage
+    // text); extra arguments should never be evaluated for the error callback.
+    auto *contentScript = @"browser.test.sendMessage('counts', [window.arg1Count, window.arg2Count])";
+
+    auto manager = Util::loadExtension(manifest, @{ @"content.js": contentScript });
+
+    auto *urlRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
+
+    id result = [manager runUntilTestMessage:@"counts"];
+
+    EXPECT_EQ([result[0] intValue], 1);
+    EXPECT_EQ([result[1] intValue], 0);
+    EXPECT_NS_EQUAL(manager.get().context.errors, @[ ]);
+}
+
 TEST(WKWebExtensionContext, UncaughtScriptErrorInEventListener)
 {
     auto *manifest = @{
@@ -1412,7 +1451,7 @@ TEST(WKWebExtensionContext, ConsoleErrorReportedNotLogOrWarn)
     auto *backgroundScript = Util::constructScript(@[
         @"console.log('This is a log message')",
         @"console.warn('This is a warning message')",
-        @"console.error('Failed to inject script:', new Error('Missing permission'))",
+        @"console.error('This is an error message')",
 
         @"browser.test.sendMessage('Ready')",
     ]);
@@ -1427,7 +1466,7 @@ TEST(WKWebExtensionContext, ConsoleErrorReportedNotLogOrWarn)
 
     auto *error = manager.get().context.errors.firstObject;
     EXPECT_EQ(error.code, WKWebExtensionContextErrorScriptExecutionError);
-    EXPECT_NS_EQUAL(error.localizedDescription, @"Failed to inject script: Error: Missing permission (background.js:3:14)");
+    EXPECT_NS_EQUAL(error.localizedDescription, @"This is an error message (background.js:3:14)");
 }
 
 TEST(WKWebExtensionContext, ConsoleAssertWithMessage)


### PR DESCRIPTION
#### 86d41771701417a87ec6243e65c9b769b49a35b4
<pre>
Loading any Web Extension breaks Cloudflare bot challenges
<a href="https://webkit.org/b/314458">https://webkit.org/b/314458</a>
<a href="https://rdar.apple.com/176618014">rdar://176618014</a>

Reviewed by Brian Weinstein.

When any web extension is loaded, 311150@main added script error reporting by calling
getArgumentsAsStrings() on the console.error() arguments after getFirstArgumentAsString()
had already evaluated the first argument. This caused toString() to be invoked twice on
the first argument and once on every extra argument.

Cloudflare&apos;s bot challenge passes a sentinel object to console.error() that counts
toString() invocations to detect unexpected evaluation. The extra call tripped that
detection and broke the challenge for any user with a web extension loaded.

The fix is to pass the first-argument message text directly to invokeScriptErrorCallbacks,
avoiding any re-evaluation of arguments.

Test: TestWebKitAPI.WKWebExtensionContext.ConsoleErrorDoesNotEvaluateArgumentsTwice

* Source/WebCore/page/FrameConsoleClient.cpp:
(WebCore::FrameConsoleClient::messageWithTypeAndLevel): Pass the already-computed
first-argument message text directly to invokeScriptErrorCallbacks instead of
re-evaluating all arguments via getArgumentsAsStrings().
* Source/WebCore/workers/WorkerConsoleClient.cpp:
(WebCore::WorkerConsoleClient::messageWithTypeAndLevel): Ditto.
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionContext.mm:
(TestWebKitAPI::TEST(WKWebExtensionContext, ConsoleErrorDoesNotEvaluateArgumentsTwice)): Added.
(TestWebKitAPI::TEST(WKWebExtensionContext, ConsoleErrorReportedNotLogOrWarn)): Removed second
Error argument since it is skipped now.

Canonical link: <a href="https://commits.webkit.org/313007@main">https://commits.webkit.org/313007@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a72305a70db97a1a2ff1055d4079d6ee59c10ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161829 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35303 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/28406 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/170732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/118200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163698 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35404 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35305 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/170732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/118200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164788 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/27880 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/145361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/170732 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25441 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/18453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/136622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/23116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/173221 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20308 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/24757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/173221 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34977 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/29527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/173221 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34961 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/144911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97049 "Failed to checkout and rebase branch from PR 64648") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24573 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/28400 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/21734 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/34471 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101952 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33971 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34214 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34120 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->