### PR TITLE
[JSC] Skip redundant `ModuleGraphLoadingError` reactions for already-loaded modules in `InnerModuleLoading`

### DIFF
--- a/JSTests/stress/module-loader-cached-record-dense-graph.js
+++ b/JSTests/stress/module-loader-cached-record-dense-graph.js
@@ -1,0 +1,25 @@
+//@ runDefault
+
+// Dense `export * from` graph where the same modules are requested from many
+// referrers. Exercises the InnerModuleLoading path where a request resolves
+// against an already-loaded module record (mapEntry->record() set), and the
+// ModuleGraphLoadingError reaction is skipped. All namespaces must still resolve.
+
+var abort = $vm.abort;
+
+(async function () {
+    const ns = await import("./resources/module-cached-record/dense-entry.js");
+    if (ns.shared !== 42 || ns.a !== "a" || ns.b !== "b" || ns.c !== "c")
+        throw new Error("bad namespace: " + JSON.stringify(Object.keys(ns)));
+
+    // Re-import every node — every edge is now against a fully-loaded module.
+    for (const file of ["shared", "a", "b", "c", "dense-entry"]) {
+        const m = await import(`./resources/module-cached-record/${file}.js`);
+        if (m.shared !== 42)
+            throw new Error(`bad re-import of ${file}`);
+    }
+}()).catch((error) => {
+    print(String(error));
+    print(error.stack);
+    abort();
+});

--- a/JSTests/stress/module-loader-cached-record-shared-dep-error.js
+++ b/JSTests/stress/module-loader-cached-record-shared-dep-error.js
@@ -1,0 +1,43 @@
+//@ runDefault
+
+// Error propagation through a shared module whose record is already cached.
+//
+// m-broken-dep.js parses successfully (so its ModuleRegistryEntry has a record),
+// but its dependency does-not-exist.js fails to fetch. After the first import
+// fails, the second import requests m-broken-dep.js with mapEntry->record()
+// already set — InnerModuleLoading skips the ModuleGraphLoadingError reaction
+// on the cached loadPromise. The failure must still be observed via the
+// recursion frontier.
+
+var abort = $vm.abort;
+
+async function shouldReject(promise) {
+    try {
+        await promise;
+    } catch (e) {
+        return e;
+    }
+    throw new Error("did not reject");
+}
+
+(async function () {
+    // First import: m-broken-dep.js is fetched, parsed, and its record set;
+    // the broken dependency rejects this load.
+    const e1 = await shouldReject(import("./resources/module-cached-record/referrer-a.js"));
+
+    // Second import: m-broken-dep.js's record is now cached. The error must
+    // still propagate via the synchronously re-entered InnerModuleLoading.
+    const e2 = await shouldReject(import("./resources/module-cached-record/referrer-b.js"));
+
+    // Direct re-import of the shared module also rejects.
+    const e3 = await shouldReject(import("./resources/module-cached-record/m-broken-dep.js"));
+
+    for (const e of [e1, e2, e3]) {
+        if (!String(e).includes("does-not-exist"))
+            throw new Error("unexpected error: " + e);
+    }
+}()).catch((error) => {
+    print(String(error));
+    print(error.stack);
+    abort();
+});

--- a/JSTests/stress/resources/module-cached-record/a.js
+++ b/JSTests/stress/resources/module-cached-record/a.js
@@ -1,0 +1,2 @@
+export * from "./shared.js";
+export const a = "a";

--- a/JSTests/stress/resources/module-cached-record/b.js
+++ b/JSTests/stress/resources/module-cached-record/b.js
@@ -1,0 +1,3 @@
+export * from "./shared.js";
+export * from "./a.js";
+export const b = "b";

--- a/JSTests/stress/resources/module-cached-record/c.js
+++ b/JSTests/stress/resources/module-cached-record/c.js
@@ -1,0 +1,4 @@
+export * from "./shared.js";
+export * from "./a.js";
+export * from "./b.js";
+export const c = "c";

--- a/JSTests/stress/resources/module-cached-record/dense-entry.js
+++ b/JSTests/stress/resources/module-cached-record/dense-entry.js
@@ -1,0 +1,4 @@
+export * from "./shared.js";
+export * from "./a.js";
+export * from "./b.js";
+export * from "./c.js";

--- a/JSTests/stress/resources/module-cached-record/m-broken-dep.js
+++ b/JSTests/stress/resources/module-cached-record/m-broken-dep.js
@@ -1,0 +1,4 @@
+// This module parses successfully (so its registry entry gets a record), but its
+// dependency does not exist, so loadRequestedModules for it fails.
+import "./does-not-exist.js";
+export const m = "m";

--- a/JSTests/stress/resources/module-cached-record/referrer-a.js
+++ b/JSTests/stress/resources/module-cached-record/referrer-a.js
@@ -1,0 +1,2 @@
+import "./m-broken-dep.js";
+export const ra = "ra";

--- a/JSTests/stress/resources/module-cached-record/referrer-b.js
+++ b/JSTests/stress/resources/module-cached-record/referrer-b.js
@@ -1,0 +1,2 @@
+import "./m-broken-dep.js";
+export const rb = "rb";

--- a/JSTests/stress/resources/module-cached-record/shared.js
+++ b/JSTests/stress/resources/module-cached-record/shared.js
@@ -1,0 +1,1 @@
+export const shared = 42;

--- a/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
@@ -766,10 +766,19 @@ void JSModuleLoader::innerModuleLoading(JSGlobalObject* globalObject, ModuleGrap
                 // 2.d.iii. Else,
             } else {
                 // 2.d.iii.1. Perform HostLoadImportedModule(module, request, state.[[HostDefined]], state).
+                unsigned loadedModulesCountBefore = module->loadedModules().size();
                 JSPromise* promise = hostLoadImportedModule(globalObject, cyclic, request, state, state->scriptFetcher(), true);
                 RETURN_IF_EXCEPTION(scope, void());
-                promise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::ModuleGraphLoadingError, jsUndefined(), state);
                 // 2.d.iii.2. NOTE: HostLoadImportedModule will call FinishLoadingImportedModule, which re-enters the graph loading process through ContinueModuleLoading.
+                //
+                // If module.[[LoadedModules]] grew across the HostLoadImportedModule call, the requested
+                // module was loaded synchronously, which means it was already loaded before. In that case
+                // there is no need to attach a ModuleGraphLoadingError reaction, so we skip it.
+                bool needsErrorReaction = module->loadedModules().size() == loadedModulesCountBefore;
+                ASSERT(module->loadedModules().size() <= loadedModulesCountBefore + 1);
+                ASSERT(needsErrorReaction != module->loadedModules().contains(ModuleMapKey { request.m_specifier.impl(), request.type() }));
+                if (needsErrorReaction)
+                    promise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::ModuleGraphLoadingError, jsUndefined(), state);
             }
             // 2.d.iv. If state.[[IsLoading]] is false, return UNUSED.
             if (!state->isLoading())


### PR DESCRIPTION
#### b3c012e316ed5c9aa40a4f6767f2b6806e6ae004
<pre>
[JSC] Skip redundant `ModuleGraphLoadingError` reactions for already-loaded modules in `InnerModuleLoading`
<a href="https://bugs.webkit.org/show_bug.cgi?id=314519">https://bugs.webkit.org/show_bug.cgi?id=314519</a>

Reviewed by Yusuke Suzuki.

InnerModuleLoading attaches a ModuleGraphLoadingError reaction to the promise
returned by HostLoadImportedModule for every import edge it processes. When the
requested module is already fully loaded (its registry entry has a record),
HostLoadImportedModule continued the graph synchronously via
FinishLoadingImportedModule, and any failure in that subtree is already
observable through reactions attached deeper in the recursion. The reaction on
the returned loadPromise is then a guaranteed no-op.

Detect this by checking whether module.[[LoadedModules]] grew across the call:
the only entry HostLoadImportedModule can synchronously add is the one for the
current request, and only when its record was already cached. If it grew, skip
the reaction.

For dense `export * from` graphs where the number of import edges greatly
exceeds the number of modules, most edges resolve against an already-loaded
module. On a synthetic 1000-module graph with ~125k import edges, this
eliminates 99.2% of ModuleGraphLoadingError reaction allocations and reduces
peak RSS by ~4.5% (~4 MB), with no measurable wall-clock change.

Tests: JSTests/stress/module-loader-cached-record-dense-graph.js
       JSTests/stress/module-loader-cached-record-shared-dep-error.js

* JSTests/stress/module-loader-cached-record-dense-graph.js: Added.
(async const):
(catch):
* JSTests/stress/module-loader-cached-record-shared-dep-error.js: Added.
(async shouldReject):
(async const):
(catch):
* JSTests/stress/resources/module-cached-record/a.js: Added.
* JSTests/stress/resources/module-cached-record/b.js: Added.
* JSTests/stress/resources/module-cached-record/c.js: Added.
* JSTests/stress/resources/module-cached-record/dense-entry.js: Added.
* JSTests/stress/resources/module-cached-record/m-broken-dep.js: Added.
* JSTests/stress/resources/module-cached-record/referrer-a.js: Added.
* JSTests/stress/resources/module-cached-record/referrer-b.js: Added.
* JSTests/stress/resources/module-cached-record/shared.js: Added.
* Source/JavaScriptCore/runtime/JSModuleLoader.cpp:
(JSC::JSModuleLoader::innerModuleLoading):

Canonical link: <a href="https://commits.webkit.org/313223@main">https://commits.webkit.org/313223@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd2ecbdcf2c433c4184e91579e1bfe9dc85b6ffc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161745 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35219 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28322 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170648 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118116 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35320 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35220 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125489 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88415 "18 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164704 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27798 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145281 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIAction.ClearTabSpecificActionPropertiesOnNavigation (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106085 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26847 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25360 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18369 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/153803 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136540 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23036 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173137 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22583 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20177 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24677 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133783 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34893 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29449 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133788 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36270 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34877 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144831 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96907 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28320 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21653 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194144 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34387 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101832 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50032 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33887 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34130 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34036 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->