### PR TITLE
Justification expansion is not applied around CJK Unified Ideographs Extensions E, F, G, H, and I

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-justify/text-justify-cjk-ideograph-extensions-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-justify/text-justify-cjk-ideograph-extensions-expected.txt
@@ -1,0 +1,10 @@
+
+PASS CJK Unified Ideographs Extension B (U+20000) justifies like U+4E00
+PASS CJK Unified Ideographs Extension C (U+2A700) justifies like U+4E00
+PASS CJK Unified Ideographs Extension D (U+2B740) justifies like U+4E00
+PASS CJK Unified Ideographs Extension E (U+2B820) justifies like U+4E00
+PASS CJK Unified Ideographs Extension F (U+2CEB0) justifies like U+4E00
+PASS CJK Unified Ideographs Extension I (U+2EBF0) justifies like U+4E00
+PASS CJK Unified Ideographs Extension G (U+30000) justifies like U+4E00
+PASS CJK Unified Ideographs Extension H (U+31350) justifies like U+4E00
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-justify/text-justify-cjk-ideograph-extensions.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-justify/text-justify-cjk-ideograph-extensions.html
@@ -1,0 +1,92 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Text: justification expansion around CJK Unified Ideographs Extensions B–I</title>
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#text-align-property">
+<link rel="help" href="https://drafts.csswg.org/css-text-3/#expanding-text">
+<meta name="assert" content="Codepoints from CJK Unified Ideographs Extensions B (U+20000), C (U+2A700), D (U+2B740), E (U+2B820), F (U+2CEB0), I (U+2EBF0), G (U+30000), and H (U+31350) must produce the same justification expansion behavior as U+4E00.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+.box, .ref {
+    width: 400px;
+    font: 36px/1.4 serif;
+    white-space: nowrap;
+    overflow: hidden;
+}
+.box { text-align: justify; text-align-last: justify; }
+.ref { text-align: left; }
+</style>
+</head>
+<body>
+
+<div class="box" id="box-4E00">一一一一一一</div>
+<div class="ref" id="ref-4E00">一一一一一一</div>
+
+<div class="box" id="box-20000">&#x20000;&#x20000;&#x20000;&#x20000;&#x20000;&#x20000;</div>
+<div class="ref" id="ref-20000">&#x20000;&#x20000;&#x20000;&#x20000;&#x20000;&#x20000;</div>
+
+<div class="box" id="box-2A700">&#x2A700;&#x2A700;&#x2A700;&#x2A700;&#x2A700;&#x2A700;</div>
+<div class="ref" id="ref-2A700">&#x2A700;&#x2A700;&#x2A700;&#x2A700;&#x2A700;&#x2A700;</div>
+
+<div class="box" id="box-2B740">&#x2B740;&#x2B740;&#x2B740;&#x2B740;&#x2B740;&#x2B740;</div>
+<div class="ref" id="ref-2B740">&#x2B740;&#x2B740;&#x2B740;&#x2B740;&#x2B740;&#x2B740;</div>
+
+<div class="box" id="box-2B820">&#x2B820;&#x2B820;&#x2B820;&#x2B820;&#x2B820;&#x2B820;</div>
+<div class="ref" id="ref-2B820">&#x2B820;&#x2B820;&#x2B820;&#x2B820;&#x2B820;&#x2B820;</div>
+
+<div class="box" id="box-2CEB0">&#x2CEB0;&#x2CEB0;&#x2CEB0;&#x2CEB0;&#x2CEB0;&#x2CEB0;</div>
+<div class="ref" id="ref-2CEB0">&#x2CEB0;&#x2CEB0;&#x2CEB0;&#x2CEB0;&#x2CEB0;&#x2CEB0;</div>
+
+<div class="box" id="box-2EBF0">&#x2EBF0;&#x2EBF0;&#x2EBF0;&#x2EBF0;&#x2EBF0;&#x2EBF0;</div>
+<div class="ref" id="ref-2EBF0">&#x2EBF0;&#x2EBF0;&#x2EBF0;&#x2EBF0;&#x2EBF0;&#x2EBF0;</div>
+
+<div class="box" id="box-30000">&#x30000;&#x30000;&#x30000;&#x30000;&#x30000;&#x30000;</div>
+<div class="ref" id="ref-30000">&#x30000;&#x30000;&#x30000;&#x30000;&#x30000;&#x30000;</div>
+
+<div class="box" id="box-31350">&#x31350;&#x31350;&#x31350;&#x31350;&#x31350;&#x31350;</div>
+<div class="ref" id="ref-31350">&#x31350;&#x31350;&#x31350;&#x31350;&#x31350;&#x31350;</div>
+
+<script>
+function expansionDelta(codepoint) {
+    function span(element) {
+        var range = document.createRange();
+        range.selectNodeContents(element);
+        return range.getBoundingClientRect().right - element.getBoundingClientRect().left;
+    }
+    var box = document.getElementById("box-" + codepoint);
+    var ref = document.getElementById("ref-" + codepoint);
+    return span(box) - span(ref);
+}
+
+function expands(codepoint) {
+    return expansionDelta(codepoint) > 2;
+}
+
+var baseExpands = expands("4E00");
+
+var extensions = [
+    { name: "B", codepoint: "20000" },
+    { name: "C", codepoint: "2A700" },
+    { name: "D", codepoint: "2B740" },
+    { name: "E", codepoint: "2B820" },
+    { name: "F", codepoint: "2CEB0" },
+    { name: "I", codepoint: "2EBF0" },
+    { name: "G", codepoint: "30000" },
+    { name: "H", codepoint: "31350" },
+];
+
+extensions.forEach(function(ext) {
+    test(function() {
+        assert_equals(expands(ext.codepoint), baseExpands,
+            "Extension " + ext.name + " (U+" + ext.codepoint + ") must match U+4E00 expansion behavior");
+    }, "CJK Unified Ideographs Extension " + ext.name + " (U+" + ext.codepoint + ") justifies like U+4E00");
+});
+
+document.querySelectorAll(".box, .ref").forEach(function(node) {
+    node.style.display = "none";
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -1008,9 +1008,29 @@ bool FontCascade::isCJKIdeograph(char32_t c)
     // CJK Unified Ideographs Extension D.
     if (c >= 0x2B740 && c <= 0x2B81F)
         return true;
-    
+
+    // CJK Unified Ideographs Extension E.
+    if (c >= 0x2B820 && c <= 0x2CEAF)
+        return true;
+
+    // CJK Unified Ideographs Extension F.
+    if (c >= 0x2CEB0 && c <= 0x2EBEF)
+        return true;
+
+    // CJK Unified Ideographs Extension I.
+    if (c >= 0x2EBF0 && c <= 0x2EE5F)
+        return true;
+
     // CJK Compatibility Ideographs Supplement.
     if (c >= 0x2F800 && c <= 0x2FA1F)
+        return true;
+
+    // CJK Unified Ideographs Extension G.
+    if (c >= 0x30000 && c <= 0x3134F)
+        return true;
+
+    // CJK Unified Ideographs Extension H.
+    if (c >= 0x31350 && c <= 0x323AF)
         return true;
 
     return false;


### PR DESCRIPTION
#### 1d39cc4016fdee96a921f4efca46dd2090e6d5d8
<pre>
Justification expansion is not applied around CJK Unified Ideographs Extensions E, F, G, H, and I
<a href="https://bugs.webkit.org/show_bug.cgi?id=314523">https://bugs.webkit.org/show_bug.cgi?id=314523</a>
<a href="https://rdar.apple.com/176759766">rdar://176759766</a>

Reviewed by Vitor Roriz.

FontCascade::isCJKIdeograph() has not been updated since CJK Extension D
shipped in Unicode 6.0 (2010). As a result, characters from Extensions
E (U+2B820–U+2CEAF, Unicode 8.0), F (U+2CEB0–U+2EBEF, Unicode 10.0),
G (U+30000–U+3134F, Unicode 13.0), H (U+31350–U+323AF, Unicode 15.0),
and I (U+2EBF0–U+2EE5F, Unicode 15.1) are not classified as ideographs.

The most visible consequence is that expansionOpportunityCount() does
not create expansion opportunities around these codepoints, so CJK text
composed of post-Extension-D ideographs is not justified under
text-align: justify on ports where canExpandAroundIdeographsInComplexText()
returns true (Cocoa).

Extend isCJKIdeograph() to cover the currently-assigned CJK Unified
Ideographs blocks in Plane 2 and Plane 3. isCJKIdeographOrSymbol() falls
through to isCJKIdeograph() and is updated transitively.

* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::isCJKIdeograph): Add range checks for Extensions
E, F, I (Plane 2) and G, H (Plane 3).

* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-justify/text-justify-cjk-ideograph-extensions-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-text/text-justify/text-justify-cjk-ideograph-extensions.html: Added.
Measures each extension&apos;s text-align: justify expansion against U+4E00&apos;s
baseline; passes uniformly on ports with and without ideograph expansion.

Canonical link: <a href="https://commits.webkit.org/313586@main">https://commits.webkit.org/313586@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af0a71ececcc902862fc8a7cbb616ea4e641a4ae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163414 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36897 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30113 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172354 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119861 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b985737f-06ec-4809-b8e8-f2a9c6d29b53) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165283 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37226 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36897 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126907 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89452 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/acd7b35d-2fe0-457d-8ec4-5eb6633014df) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166373 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29176 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146901 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107465 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c9e4fc3b-10c2-4934-8c7f-c2363a89a6e6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28222 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26855 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20056 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138117 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24624 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174858 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27510 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26280 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135208 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36567 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30955 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135194 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36467 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37352 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146419 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99308 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30500 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23264 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36063 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108952 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35560 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1289 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35808 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35708 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->