### PR TITLE
REGRESSION (312740@main): [ASan/TSan] `angle::PoolAllocator` has inconsistent layout across translation units, crashing GPU process on WebGL shader compile

### DIFF
--- a/Source/ThirdParty/ANGLE/src/common/PoolAlloc.h
+++ b/Source/ThirdParty/ANGLE/src/common/PoolAlloc.h
@@ -14,6 +14,10 @@
 #    pragma allow_unsafe_buffers
 #endif
 
+// This include MUST precede the ANGLE_WITH_ASAN / ANGLE_WITH_TSAN check below
+// to define those macros.
+#include "common/platform.h"
+
 #if defined(ANGLE_WITH_ASAN) || defined(ANGLE_WITH_TSAN)
 #    define ANGLE_DISABLE_POOL_ALLOC  // Use system allocator under sanitizers for accurate detection
 #elif !defined(NDEBUG)


### PR DESCRIPTION
#### 346deb2b1c821e5216eeec79689a15f1317dd278
<pre>
REGRESSION (312740@main): [ASan/TSan] `angle::PoolAllocator` has inconsistent layout across translation units, crashing GPU process on WebGL shader compile
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=314526">https://bugs.webkit.org/show_bug.cgi?id=314526</a>&gt;
&lt;<a href="https://rdar.apple.com/176749270">rdar://176749270</a>&gt;

Unreviewed build fix.

Add `#include &quot;common/platform.h&quot;` to `PoolAlloc.h` so the
`ANGLE_WITH_ASAN` / `ANGLE_WITH_TSAN` check at the top of the
header sees those macros (defined via `__has_feature()` in
`platform.h`), fixing an ODR violation where `PoolAlloc.cpp` laid
out `angle::PoolAllocator` with the full 88-byte non-sanitizer
member set while `Compiler.cpp` laid it out with the 24-byte
sanitizer-only member set.  This caused the default constructor to
write 88 bytes into the caller&apos;s 24-byte stack slot and trip
AddressSanitizer&apos;s stack-buffer-overflow check on every WebGL
shader compile.

Covered by existing tests in LayoutTests/fast/canvas/webgl/.

* Source/ThirdParty/ANGLE/src/common/PoolAlloc.h:

Canonical link: <a href="https://commits.webkit.org/312987@main">https://commits.webkit.org/312987@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d7979f2fe083469af397a568473eeca218961122

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161757 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35231 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28334 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170660 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118128 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b8dfa41a-ea1a-48d1-a5b8-0f7652fe03a4) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35332 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35232 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125501 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5d6ce9b9-03f5-49c7-bb2f-dfaac5c891ec) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164716 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27813 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145293 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106097 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/40c2fbe4-c22c-4e7c-bfff-3e9fab31a2f1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26862 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25375 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18381 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136555 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23048 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173149 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24689 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133796 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34905 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/29464 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133801 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34889 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144843 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96928 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24561 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28335 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21665 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34399 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33899 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34142 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34048 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->