### PR TITLE
[JSC][Temporal] Add ICU calendar and timezone bridge layer: CalendarICUBridge, TimeZoneICUBridge

### DIFF
--- a/Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp
+++ b/Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp
@@ -27,12 +27,15 @@
 #include "TemporalCoreTest.h"
 
 #include "CalendarArithmetic.h"
+#include "CalendarICUBridge.h"
 #include "ISO8601.h"
 #include "ISOArithmetic.h"
 #include "InstantCore.h"
+#include "JSCTimeZone.h"
 #include "Rounding.h"
 #include "TemporalCoreTypes.h"
 #include "TemporalEnums.h"
+#include "TimeZoneICUBridge.h"
 #include <stdio.h>
 #include <wtf/Int128.h>
 
@@ -324,21 +327,59 @@ static void testCalendarDateUntil()
     auto r4 = calendarDateUntil({ 1996, 3, 3 }, { 1969, 7, 24 }, TemporalUnit::Day);
     TCHECK_EQ(static_cast<int64_t>(r4.days()), -9719LL, "calendarDateUntil: -9719 days");
 
-    // temporal_rs: date_until_largest_year — Year largestUnit
-    // 2021-07-16 until 2022-07-16 = exactly 1 year
-    auto r5 = calendarDateUntil({ 2021, 7, 16 }, { 2022, 7, 16 }, TemporalUnit::Year);
-    TCHECK_EQ(static_cast<int64_t>(r5.years()), 1LL, "calendarDateUntil: 1 year");
-    TCHECK_EQ(static_cast<int64_t>(r5.months()), 0LL, "calendarDateUntil: 1y months=0");
-    TCHECK_EQ(static_cast<int64_t>(r5.days()), 0LL, "calendarDateUntil: 1y days=0");
-
-    // 2021-07-16 until 2031-07-16 = exactly 10 years
-    auto r6 = calendarDateUntil({ 2021, 7, 16 }, { 2031, 7, 16 }, TemporalUnit::Year);
-    TCHECK_EQ(static_cast<int64_t>(r6.years()), 10LL, "calendarDateUntil: 10 years");
-
-    // 2021-07-16 until 2022-07-19 = 1 year + 3 days
-    auto r7 = calendarDateUntil({ 2021, 7, 16 }, { 2022, 7, 19 }, TemporalUnit::Year);
-    TCHECK_EQ(static_cast<int64_t>(r7.years()), 1LL, "calendarDateUntil: 1y3d years");
-    TCHECK_EQ(static_cast<int64_t>(r7.days()), 3LL, "calendarDateUntil: 1y3d days");
+    // temporal_rs: date_until_largest_year — full ISO8601 table
+    // Each entry: (one, two, (years, months, weeks, days))
+    struct DateUntilCase {
+        ISO8601::PlainDate one;
+        ISO8601::PlainDate two;
+        int64_t years, months, days;
+    };
+    static const DateUntilCase cases[] = {
+        { { 2021, 7, 16 }, { 2021, 7, 16 }, 0, 0, 0 }, // same
+        { { 2021, 7, 16 }, { 2021, 7, 17 }, 0, 0, 1 }, // +1d
+        { { 2021, 7, 16 }, { 2021, 7, 23 }, 0, 0, 7 }, // +7d
+        { { 2021, 7, 16 }, { 2021, 8, 16 }, 0, 1, 0 }, // +1m
+        { { 2020, 12, 16 }, { 2021, 1, 16 }, 0, 1, 0 }, // month wrap
+        { { 2021, 1, 5 },  { 2021, 2, 5 },  0, 1, 0 }, // +1m
+        { { 2021, 1, 7 },  { 2021, 3, 7 },  0, 2, 0 }, // +2m
+        { { 2021, 7, 16 }, { 2021, 8, 17 }, 0, 1, 1 }, // +1m1d
+        { { 2021, 7, 16 }, { 2021, 8, 13 }, 0, 0, 28 }, // sub-month days
+        { { 2021, 7, 16 }, { 2021, 9, 16 }, 0, 2, 0 }, // +2m
+        { { 2021, 7, 16 }, { 2022, 7, 16 }, 1, 0, 0 }, // exactly 1y
+        { { 2021, 7, 16 }, { 2031, 7, 16 }, 10, 0, 0 }, // exactly 10y
+        { { 2021, 7, 16 }, { 2022, 7, 19 }, 1, 0, 3 }, // 1y3d
+        { { 2021, 7, 16 }, { 2022, 9, 19 }, 1, 2, 3 }, // 1y2m3d
+        { { 2021, 7, 16 }, { 2031, 12, 16 }, 10, 5, 0 }, // 10y5m
+        { { 1997, 12, 16 }, { 2021, 7, 16 }, 23, 7, 0 }, // large: 23y7m
+        { { 1997, 7, 16 }, { 2021, 7, 16 }, 24, 0, 0 }, // large: 24y
+        { { 1997, 7, 16 }, { 2021, 7, 15 }, 23, 11, 29 }, // just under 24y
+        { { 1997, 6, 16 }, { 2021, 6, 15 }, 23, 11, 30 }, // just under 24y
+        { { 1960, 2, 16 }, { 2020, 3, 16 }, 60, 1, 0 }, // 60y1m
+        { { 1960, 2, 16 }, { 2021, 3, 15 }, 61, 0, 27 }, // 61y27d
+        { { 1960, 2, 16 }, { 2020, 3, 15 }, 60, 0, 28 }, // 60y28d
+        { { 2021, 3, 30 }, { 2021, 7, 16 }, 0, 3, 16 }, // 3m16d
+        { { 2020, 3, 30 }, { 2021, 7, 16 }, 1, 3, 16 }, // 1y3m16d
+        { { 1960, 3, 30 }, { 2021, 7, 16 }, 61, 3, 16 }, // 61y3m16d
+        { { 2019, 12, 30 }, { 2021, 7, 16 }, 1, 6, 16 }, // 1y6m16d
+        { { 2020, 12, 30 }, { 2021, 7, 16 }, 0, 6, 16 }, // 6m16d
+        { { 1997, 12, 30 }, { 2021, 7, 16 }, 23, 6, 16 }, // 23y6m16d
+        { { 1, 12, 25 }, { 2021, 7, 16 }, 2019, 6, 21 }, // ancient date
+        { { 2019, 12, 30 }, { 2021, 3, 5 }, 1, 2, 5 }, // 1y2m5d
+        // Negative cases
+        { { 2021, 7, 17 }, { 2021, 7, 16 }, 0, 0, -1 },
+        { { 2021, 7, 23 }, { 2021, 7, 16 }, 0, 0, -7 },
+        { { 2021, 8, 16 }, { 2021, 7, 16 }, 0, -1, 0 },
+        { { 2021, 1, 16 }, { 2020, 12, 16 }, 0, -1, 0 },
+        { { 2021, 2, 5 },  { 2021, 1, 5 },  0, -1, 0 },
+        { { 2021, 3, 7 },  { 2021, 1, 7 },  0, -2, 0 },
+        { { 2021, 8, 17 }, { 2021, 7, 16 }, 0, -1, -1 },
+    };
+    for (auto& c : cases) {
+        auto r = calendarDateUntil(c.one, c.two, TemporalUnit::Year);
+        TCHECK_EQ(static_cast<int64_t>(r.years()),  c.years,  "dateUntilLargestYear: years");
+        TCHECK_EQ(static_cast<int64_t>(r.months()), c.months, "dateUntilLargestYear: months");
+        TCHECK_EQ(static_cast<int64_t>(r.days()),   c.days,   "dateUntilLargestYear: days");
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -976,6 +1017,522 @@ static void testCriticalUnknownAnnotation()
 }
 
 // ---------------------------------------------------------------------------
+// CalendarICUBridge tests — mirrors temporal_rs src/builtins/core/calendar.rs
+// ---------------------------------------------------------------------------
+
+static void testCalendarIsLunisolar()
+{
+    TCHECK_TRUE(!calendarIsLunisolar(calendarIDFromString("iso8601"_s)), "lunisolar: iso8601=false");
+    TCHECK_TRUE(!calendarIsLunisolar(calendarIDFromString("gregory"_s)), "lunisolar: gregory=false");
+    TCHECK_TRUE(calendarIsLunisolar(calendarIDFromString("chinese"_s)), "lunisolar: chinese=true");
+    TCHECK_TRUE(calendarIsLunisolar(calendarIDFromString("hebrew"_s)), "lunisolar: hebrew=true");
+    TCHECK_TRUE(calendarIsLunisolar(calendarIDFromString("dangi"_s)), "lunisolar: dangi=true");
+}
+
+static void testCalendarDaysInMonthISO()
+{
+    // ISO8601 days in month — basic cases
+    auto r1 = calendarDaysInMonth(calendarIDFromString("iso8601"_s), { 2020, 2, 1 }); // leap year Feb
+    TCHECK_TRUE(r1.has_value(), "daysInMonth: 2020-02 ok");
+    TCHECK_EQ(*r1, 29, "daysInMonth: 2020-02=29");
+    auto r2 = calendarDaysInMonth(calendarIDFromString("iso8601"_s), { 2021, 2, 1 }); // non-leap Feb
+    TCHECK_TRUE(r2.has_value(), "daysInMonth: 2021-02 ok");
+    TCHECK_EQ(*r2, 28, "daysInMonth: 2021-02=28");
+    auto r3 = calendarDaysInMonth(calendarIDFromString("iso8601"_s), { 2020, 1, 1 }); // January
+    TCHECK_TRUE(r3.has_value(), "daysInMonth: Jan ok");
+    TCHECK_EQ(*r3, 31, "daysInMonth: Jan=31");
+    auto r4 = calendarDaysInMonth(calendarIDFromString("iso8601"_s), { 2020, 4, 1 }); // April
+    TCHECK_TRUE(r4.has_value(), "daysInMonth: Apr ok");
+    TCHECK_EQ(*r4, 30, "daysInMonth: Apr=30");
+}
+
+static void testCalendarInLeapYearISO()
+{
+    auto r1 = calendarInLeapYear(calendarIDFromString("iso8601"_s), { 2020, 1, 1 }); // leap
+    TCHECK_TRUE(r1.has_value() && *r1, "leapYear: 2020=leap");
+    auto r2 = calendarInLeapYear(calendarIDFromString("iso8601"_s), { 2021, 1, 1 }); // non-leap
+    TCHECK_TRUE(r2.has_value() && !*r2, "leapYear: 2021=not leap");
+    auto r3 = calendarInLeapYear(calendarIDFromString("iso8601"_s), { 2000, 1, 1 }); // century leap
+    TCHECK_TRUE(r3.has_value() && *r3, "leapYear: 2000=leap");
+    auto r4 = calendarInLeapYear(calendarIDFromString("iso8601"_s), { 1900, 1, 1 }); // century non-leap
+    TCHECK_TRUE(r4.has_value() && !*r4, "leapYear: 1900=not leap");
+}
+
+static void testCalendarISO8601Fields()
+{
+    // ISO8601 calendar: year/month/day return ISO values
+    auto rYear = calendarYear(calendarIDFromString("iso8601"_s), { 2020, 6, 15 });
+    TCHECK_TRUE(rYear.has_value(), "calYear: ok");
+    TCHECK_EQ(*rYear, 2020, "calYear: iso8601 year");
+
+    auto rMonth = calendarMonth(calendarIDFromString("iso8601"_s), { 2020, 6, 15 });
+    TCHECK_TRUE(rMonth.has_value(), "calMonth: ok");
+    TCHECK_EQ(*rMonth, 6u, "calMonth: iso8601 month");
+
+    auto rDay = calendarDay(calendarIDFromString("iso8601"_s), { 2020, 6, 15 });
+    TCHECK_TRUE(rDay.has_value(), "calDay: ok");
+    TCHECK_EQ(*rDay, 15u, "calDay: iso8601 day");
+
+    // daysInYear: 2020 (leap) = 366, 2021 (non-leap) = 365
+    auto rDIY2020 = calendarDaysInYear(calendarIDFromString("iso8601"_s), { 2020, 1, 1 });
+    TCHECK_TRUE(rDIY2020.has_value(), "calDIY: 2020 ok");
+    TCHECK_EQ(*rDIY2020, 366, "calDIY: 2020=366");
+
+    auto rDIY2021 = calendarDaysInYear(calendarIDFromString("iso8601"_s), { 2021, 1, 1 });
+    TCHECK_EQ(*rDIY2021, 365, "calDIY: 2021=365");
+
+    // monthsInYear: ISO8601 always 12
+    auto rMIY = calendarMonthsInYear(calendarIDFromString("iso8601"_s), { 2020, 1, 1 });
+    TCHECK_TRUE(rMIY.has_value(), "calMIY: ok");
+    TCHECK_EQ(*rMIY, 12, "calMIY: iso8601=12");
+}
+
+static void testCalendarDateFromFields()
+{
+    using MC = ParsedMonthCode;
+    auto id = calendarIDFromString;
+
+    // --- Non-lunisolar: year + month + day ---
+    // Gregory year→ISO
+    auto r = calendarDateFromFields(id("gregory"_s), 2024, 3, 15, std::nullopt, std::nullopt, std::nullopt, TemporalOverflow::Reject);
+    TCHECK_TRUE(r.has_value() && r->year() == 2024 && r->month() == 3 && r->day() == 15, "gregory: year+month+day");
+
+    // --- Era + eraYear ---
+    // Gregory ce era
+    auto rEra = calendarDateFromFields(id("gregory"_s), 0, 3, 15, StringView("ce"_s), 2024, std::nullopt, TemporalOverflow::Reject);
+    TCHECK_TRUE(rEra.has_value() && rEra->year() == 2024 && rEra->month() == 3 && rEra->day() == 15, "gregory: ce+eraYear");
+
+    // Gregory bce era: eraYear 1 = ISO year 0
+    auto rBce = calendarDateFromFields(id("gregory"_s), 0, 1, 1, StringView("bce"_s), 1, std::nullopt, TemporalOverflow::Reject);
+    TCHECK_TRUE(rBce.has_value() && !rBce->year(), "gregory: bce eraYear 1 = ISO 0");
+
+    // Japanese: modern era (reiwa year 6 = 2024)
+    auto rJp = calendarDateFromFields(id("japanese"_s), 0, 1, 1, StringView("reiwa"_s), 6, std::nullopt, TemporalOverflow::Reject);
+    TCHECK_TRUE(rJp.has_value() && rJp->year() == 2024, "japanese: reiwa 6 = 2024");
+
+    // Japanese: pre-1868 "ce" era bypasses ICU
+    auto rJpCe = calendarDateFromFields(id("japanese"_s), 0, 6, 15, StringView("ce"_s), 1600, std::nullopt, TemporalOverflow::Reject);
+    TCHECK_TRUE(rJpCe.has_value() && rJpCe->year() == 1600 && rJpCe->month() == 6 && rJpCe->day() == 15, "japanese: ce 1600 bypass");
+
+    // ROC: positive year (roc era)
+    auto rRoc = calendarDateFromFields(id("roc"_s), 113, 1, 1, std::nullopt, std::nullopt, std::nullopt, TemporalOverflow::Reject);
+    TCHECK_TRUE(rRoc.has_value() && rRoc->year() == 2024, "roc: year 113 = 2024");
+
+    // ROC: year 0 → broc era (ISO 1911)
+    auto rRocBroc = calendarDateFromFields(id("roc"_s), 0, 1, 1, std::nullopt, std::nullopt, std::nullopt, TemporalOverflow::Reject);
+    TCHECK_TRUE(rRocBroc.has_value() && rRocBroc->year() == 1911, "roc: year 0 = ISO 1911");
+
+    // --- Month code: non-lunisolar ---
+    // Gregory M03 = March
+    auto rMc = calendarDateFromFields(id("gregory"_s), 2024, 0, 15, std::nullopt, std::nullopt, MC { 3, false }, TemporalOverflow::Reject);
+    TCHECK_TRUE(rMc.has_value() && rMc->month() == 3 && rMc->day() == 15, "gregory: monthCode M03");
+
+    // --- Month code: Hebrew leap month ---
+    // Hebrew 5784 is a leap year; M05L = Adar I
+    auto rHebLeap = calendarDateFromFields(id("hebrew"_s), 5784, 0, 1, std::nullopt, std::nullopt, MC { 5, true }, TemporalOverflow::Reject);
+    TCHECK_TRUE(rHebLeap.has_value(), "hebrew: M05L in leap year 5784");
+
+    // Hebrew 5783 is NOT a leap year; M05L constrain → same month
+    auto rHebConstrain = calendarDateFromFields(id("hebrew"_s), 5783, 0, 1, std::nullopt, std::nullopt, MC { 5, true }, TemporalOverflow::Constrain);
+    TCHECK_TRUE(rHebConstrain.has_value(), "hebrew: M05L constrain in non-leap year 5783");
+
+    // Hebrew 5783 non-leap + M05L reject → error
+    auto rHebReject = calendarDateFromFields(id("hebrew"_s), 5783, 0, 1, std::nullopt, std::nullopt, MC { 5, true }, TemporalOverflow::Reject);
+    TCHECK_TRUE(!rHebReject.has_value(), "hebrew: M05L reject in non-leap year");
+
+    // --- Overflow: constrain ---
+    // Gregory: day 32 in January → day 31
+    auto rConstrain = calendarDateFromFields(id("gregory"_s), 2024, 1, 32, std::nullopt, std::nullopt, std::nullopt, TemporalOverflow::Constrain);
+    TCHECK_TRUE(rConstrain.has_value() && rConstrain->day() == 31, "gregory: day 32 constrain → 31");
+
+    // Gregory: day 32 in January reject → error
+    auto rReject = calendarDateFromFields(id("gregory"_s), 2024, 1, 32, std::nullopt, std::nullopt, std::nullopt, TemporalOverflow::Reject);
+    TCHECK_TRUE(!rReject.has_value(), "gregory: day 32 reject → error");
+
+    // --- Invalid era ---
+    auto rBadEra = calendarDateFromFields(id("gregory"_s), 0, 1, 1, StringView("invalid"_s), 2024, std::nullopt, TemporalOverflow::Reject);
+    TCHECK_TRUE(!rBadEra.has_value(), "gregory: invalid era → error");
+}
+
+static void testCalendarICUNonISO()
+{
+    // Gregory calendar: same as ISO for modern dates
+    auto rYearG = calendarYear(calendarIDFromString("gregory"_s), { 2020, 6, 15 });
+    TCHECK_TRUE(rYearG.has_value(), "gregory: year ok");
+    TCHECK_EQ(*rYearG, 2020, "gregory: year=2020");
+
+    // Hebrew calendar: 2020-09-19 = 1 Tishri 5781 (Rosh Hashana)
+    auto rHY = calendarYear(calendarIDFromString("hebrew"_s), { 2020, 9, 19 });
+    TCHECK_TRUE(rHY.has_value(), "hebrew: year ok");
+    TCHECK_EQ(*rHY, 5781, "hebrew: Rosh Hashana 5781");
+
+    // Hebrew month: Tishri = month 1
+    auto rHM = calendarMonth(calendarIDFromString("hebrew"_s), { 2020, 9, 19 });
+    TCHECK_TRUE(rHM.has_value(), "hebrew: month ok");
+    TCHECK_EQ(*rHM, 1u, "hebrew: Tishri = month 1");
+
+    // Japanese calendar: 2020-05-01 = Reiwa 2 (令和2年)
+    // calendarYear returns ISO year; eraYear returns era year
+    auto rJY = calendarYear(calendarIDFromString("japanese"_s), { 2020, 5, 1 });
+    TCHECK_TRUE(rJY.has_value(), "japanese: year ok");
+    TCHECK_EQ(*rJY, 2020, "japanese: ISO year=2020");
+    // eraYear should be 2 (Reiwa 2)
+    auto rJEY = calendarEraYear(calendarIDFromString("japanese"_s), { 2020, 5, 1 });
+    TCHECK_TRUE(rJEY.has_value() && rJEY->has_value(), "japanese: eraYear ok");
+    TCHECK_EQ(**rJEY, 2, "japanese: eraYear=2 (Reiwa 2)");
+    // era string should be "reiwa"
+    auto rJE = calendarEra(calendarIDFromString("japanese"_s), { 2020, 5, 1 });
+    TCHECK_TRUE(rJE.has_value() && rJE->has_value(), "japanese: era ok");
+    TCHECK_TRUE(*rJE == String("reiwa"_s), "japanese: era=reiwa");
+    // Heisei era: 2019-04-30 (last day of Heisei)
+    auto rJHeisei = calendarEra(calendarIDFromString("japanese"_s), { 2019, 4, 30 });
+    TCHECK_TRUE(rJHeisei.has_value() && rJHeisei->has_value(), "japanese: heisei ok");
+    TCHECK_TRUE(*rJHeisei == String("heisei"_s), "japanese: era=heisei");
+    // Gregory: CE/BCE
+    auto rGCE = calendarEra(calendarIDFromString("gregory"_s), { 2020, 1, 1 });
+    TCHECK_TRUE(rGCE.has_value() && rGCE->has_value(), "gregory: era ce ok");
+    TCHECK_TRUE(*rGCE == String("ce"_s), "gregory: era=ce");
+    // ISO8601 has no eras -> nullopt
+    auto rIsoEra = calendarEra(calendarIDFromString("iso8601"_s), { 2020, 1, 1 });
+    TCHECK_TRUE(rIsoEra.has_value() && !rIsoEra->has_value(), "iso8601: no era");
+
+    // Chinese calendar: 2020-01-25 = Chinese New Year (1st of 1st month 2020)
+    auto rCM = calendarMonth(calendarIDFromString("chinese"_s), { 2020, 1, 25 });
+    TCHECK_TRUE(rCM.has_value(), "chinese: month ok");
+    TCHECK_EQ(*rCM, 1u, "chinese: CNY = month 1");
+    // Month code for Chinese month 1 = "M01"
+    auto rCMC = calendarMonthCode(calendarIDFromString("chinese"_s), { 2020, 1, 25 });
+    TCHECK_TRUE(rCMC.has_value(), "chinese: monthCode ok");
+    TCHECK_TRUE(*rCMC == String("M01"_s), "chinese: CNY monthCode=M01");
+
+    // Hebrew: Tishri (month 1) = "M01"; Adar I in a leap year = "M05L"
+    auto rHMC = calendarMonthCode(calendarIDFromString("hebrew"_s), { 2020, 9, 19 }); // 1 Tishri 5781
+    TCHECK_TRUE(rHMC.has_value(), "hebrew: monthCode Tishri ok");
+    TCHECK_TRUE(*rHMC == String("M01"_s), "hebrew: Tishri=M01");
+    // Hebrew 5782 is a leap year; 2022-02-03 = Adar I (M05L) in Hebrew 5782
+    auto rHAdarI = calendarMonthCode(calendarIDFromString("hebrew"_s), { 2022, 2, 3 });
+    TCHECK_TRUE(rHAdarI.has_value(), "hebrew: monthCode AdarI ok");
+    TCHECK_TRUE(*rHAdarI == String("M05L"_s), "hebrew: AdarI=M05L");
+
+    // ISO8601 month codes: M01-M12
+    auto rISOMC = calendarMonthCode(calendarIDFromString("iso8601"_s), { 2020, 6, 15 });
+    TCHECK_TRUE(rISOMC.has_value(), "iso8601: monthCode ok");
+    TCHECK_TRUE(*rISOMC == String("M06"_s), "iso8601: June=M06");
+
+    // Persian calendar: 2020-03-20 = Nowruz (1 Farvardin 1399)
+    auto rPY = calendarYear(calendarIDFromString("persian"_s), { 2020, 3, 20 });
+    TCHECK_TRUE(rPY.has_value(), "persian: year ok");
+    TCHECK_EQ(*rPY, 1399, "persian: Nowruz 1399");
+
+    // Islamic calendar: 2020-04-24 = 1 Ramadan 1441
+    auto rIM = calendarMonth(calendarIDFromString("islamic"_s), { 2020, 4, 24 });
+    TCHECK_TRUE(rIM.has_value(), "islamic: month ok");
+    TCHECK_EQ(*rIM, 9u, "islamic: Ramadan = month 9");
+
+    // Leap year in ISO: gregory tracks same as ISO
+    auto rGL = calendarInLeapYear(calendarIDFromString("gregory"_s), { 2020, 1, 1 });
+    TCHECK_TRUE(rGL.has_value() && *rGL, "gregory: 2020 leap");
+
+    // Hebrew leap year (7 in 19-year cycle): 5782 (2021-22) is leap
+    auto rHL = calendarInLeapYear(calendarIDFromString("hebrew"_s), { 2021, 9, 7 }); // 1 Tishri 5782
+    TCHECK_TRUE(rHL.has_value(), "hebrew: 5782 leap check ok");
+    // Hebrew 5782 is a leap year (has Adar II)
+    TCHECK_TRUE(*rHL, "hebrew: 5782 is leap");
+}
+
+// ---------------------------------------------------------------------------
+// TimeZoneICUBridge tests — mirrors temporal_rs src/tz.rs tests
+// ---------------------------------------------------------------------------
+
+static void testExactTimeToLocalDateAndTime()
+{
+    ISO8601::PlainDate date;
+    ISO8601::PlainTime time;
+    // epoch=0, offset=0 -> 1970-01-01T00:00:00
+    exactTimeToLocalDateAndTime(ISO8601::ExactTime(Int128(0)), 0, date, time);
+    TCHECK_EQ(date.year(), 1970, "localDT: epoch year");
+    TCHECK_EQ(date.month(), 1u, "localDT: epoch month");
+    TCHECK_EQ(date.day(), 1u, "localDT: epoch day");
+    TCHECK_EQ(time.hour(), 0u, "localDT: epoch hour");
+    // epoch=86400000000000 (1 day), offset=0 -> 1970-01-02T00:00:00
+    exactTimeToLocalDateAndTime(ISO8601::ExactTime(Int128(86400000000000LL)), 0, date, time);
+    TCHECK_EQ(date.year(), 1970, "localDT: +1day year");
+    TCHECK_EQ(date.day(), 2u, "localDT: +1day day");
+    // offset=-18000000000000 ns (UTC-5): epoch=0 -> 1969-12-31T19:00:00
+    exactTimeToLocalDateAndTime(ISO8601::ExactTime(Int128(0)), -18000000000000LL, date, time);
+    TCHECK_EQ(date.year(), 1969, "localDT: UTC-5 epoch year");
+    TCHECK_EQ(time.hour(), 19u, "localDT: UTC-5 epoch hour");
+}
+
+static void testGetOffsetNanosecondsForUTC()
+{
+    // UTC-offset timezone with offset=0 always returns 0
+    TimeZone utc = TimeZone::fromUTCOffset(0);
+    auto r = getOffsetNanosecondsFor(utc, ISO8601::ExactTime(Int128(0)));
+    TCHECK_TRUE(r.has_value(), "utcOffset: no error");
+    TCHECK_EQ(*r, 0LL, "utcOffset: UTC offset=0");
+    // Different epoch time -> still 0 for offset-0 timezone
+    auto r2 = getOffsetNanosecondsFor(utc, ISO8601::ExactTime(Int128(1000000000000000000LL)));
+    TCHECK_TRUE(r2.has_value(), "utcOffset: large epoch ok");
+    TCHECK_EQ(*r2, 0LL, "utcOffset: UTC always 0");
+}
+
+static void testTimeZoneICUWithIANA()
+{
+    // America/New_York — standard time offset: -5h = -18000000000000 ns
+    // Test with a winter date (no DST): 2020-01-15T12:00:00 UTC = 1579089600000000000 ns
+    auto nytzOpt = ISO8601::parseTemporalTimeZoneIdentifier("America/New_York"_s);
+    if (!nytzOpt) {
+        fprintf(stderr, "SKIP [IANA tests]: America/New_York not available\n");
+        return;
+    }
+    auto nytz = *nytzOpt;
+    // Winter: 2020-01-15T12:00:00Z -> UTC-5 offset
+    ISO8601::ExactTime winterEpoch(Int128(1579089600000000000LL));
+    auto offset1 = getOffsetNanosecondsFor(nytz, winterEpoch);
+    TCHECK_TRUE(offset1.has_value(), "IANA: NY winter offset ok");
+    TCHECK_EQ(*offset1, -18000000000000LL, "IANA: NY winter = UTC-5");
+
+    // Summer: 2020-07-15T12:00:00Z -> UTC-4 (EDT)
+    ISO8601::ExactTime summerEpoch(Int128(1594814400000000000LL));
+    auto offset2 = getOffsetNanosecondsFor(nytz, summerEpoch);
+    TCHECK_TRUE(offset2.has_value(), "IANA: NY summer offset ok");
+    TCHECK_EQ(*offset2, -14400000000000LL, "IANA: NY summer = UTC-4");
+
+    // getEpochNanosecondsFor: 2020-01-15T07:00:00 local (=12:00 UTC)
+    auto r = getEpochNanosecondsFor(nytz, { 2020, 1, 15 }, { 7, 0, 0, 0, 0, 0 }, TemporalDisambiguation::Compatible);
+    TCHECK_TRUE(r.has_value(), "IANA: NY getEpoch ok");
+    TCHECK_EQ(r->epochNanoseconds(), Int128(1579089600000000000LL), "IANA: NY local->UTC");
+
+    // DST gap: 2020-03-08T02:30 doesn't exist in America/New_York
+    // Compatible -> spring forward -> 03:30 = UTC 07:30 = 1583652600000000000
+    auto rDstGap = getEpochNanosecondsFor(nytz, { 2020, 3, 8 }, { 2, 30, 0, 0, 0, 0 }, TemporalDisambiguation::Compatible);
+    TCHECK_TRUE(rDstGap.has_value(), "IANA: DST gap Compatible ok");
+    // Should be in EDT territory (UTC-4): 02:30 compatible -> 03:30 EDT = 07:30 UTC
+    TCHECK_EQ(rDstGap->epochNanoseconds(), Int128(1583652600000000000LL), "IANA: DST gap = 03:30 EDT");
+}
+
+static void testToZonedDateTime()
+{
+    // temporal_rs: plain_date.rs::to_zoned_date_time
+    // PlainDate 2020-01-01 -> ZDT with UTC -> epoch = 2020-01-01T00:00:00Z
+    auto utcOpt = ISO8601::parseTemporalTimeZoneIdentifier("UTC"_s);
+    if (!utcOpt) {
+        fprintf(stderr, "SKIP [toZDT]: UTC not available\n");
+        return;
+    }
+    auto utc = *utcOpt;
+
+    auto r = getEpochNanosecondsFor(utc, { 2020, 1, 1 }, { 0, 0, 0, 0, 0, 0 }, TemporalDisambiguation::Compatible);
+    TCHECK_TRUE(r.has_value(), "toZDT: 2020-01-01 UTC ok");
+    // Verify round-trip: epoch -> local date/time
+    ISO8601::PlainDate date;
+    ISO8601::PlainTime time;
+    auto offset = getOffsetNanosecondsFor(utc, *r);
+    TCHECK_TRUE(offset.has_value(), "toZDT: offset ok");
+    exactTimeToLocalDateAndTime(*r, *offset, date, time);
+    TCHECK_EQ(date.year(), 2020, "toZDT: year=2020");
+    TCHECK_EQ(date.month(), 1u, "toZDT: month=1");
+    TCHECK_EQ(date.day(), 1u, "toZDT: day=1");
+    TCHECK_EQ(time.hour(), 0u, "toZDT: hour=0");
+    TCHECK_EQ(time.minute(), 0u, "toZDT: minute=0");
+    TCHECK_EQ(time.second(), 0u, "toZDT: second=0");
+    TCHECK_EQ(time.millisecond(), 0u, "toZDT: ms=0");
+    TCHECK_EQ(time.microsecond(), 0u, "toZDT: us=0");
+    TCHECK_EQ(time.nanosecond(), 0u, "toZDT: ns=0");
+}
+
+static void testToZonedDateTimeError()
+{
+    // temporal_rs: plain_date.rs::to_zoned_date_time_error
+    // Min date -271821-04-19 with UTC+00 -> start of day is at or before min epoch.
+    // -271821-04-18 is one day before the minimum valid Temporal date; getEpochNanosecondsFor
+    // must reject it .
+    auto utcOpt = ISO8601::parseTemporalTimeZoneIdentifier("UTC"_s);
+    if (!utcOpt) {
+        fprintf(stderr, "SKIP [toZDTErr]: UTC not available\n");
+        return;
+    }
+    auto r = getEpochNanosecondsFor(*utcOpt, { -271821, 4, 18 }, { 0, 0, 0, 0, 0, 0 }, TemporalDisambiguation::Compatible);
+    TCHECK_TRUE(!r.has_value(), "toZDTErr: day before min date rejects");
+}
+
+static void testAddZonedDateTime()
+{
+    // temporal_rs: basic_zdt_add (src/builtins/core/zoned_date_time/tests.rs)
+    auto utcOpt = ISO8601::parseTemporalTimeZoneIdentifier("UTC"_s);
+    if (!utcOpt) {
+        fprintf(stderr, "SKIP [addZonedDateTime]: UTC not available\n");
+        return;
+    }
+    auto utc = *utcOpt;
+
+    // 1. Time-only fast path (no date components): years=months=weeks=days=0
+    // temporal_rs basic_zdt_add: start=-560174321098766 ns, duration=P0DT240H+800ns
+    // result = start + 240h + 800ns = 303825678902034 ns
+    ISO8601::ExactTime start1(Int128(-560174321098766LL));
+    ISO8601::Duration d1(0, 0, 0, 0, 240, 0, 0, 0, 0, 800); // 240h + 800ns
+    auto r1 = addZonedDateTime(start1, utc, d1, TemporalOverflow::Constrain);
+    TCHECK_TRUE(r1.has_value(), "addZDT: time-only ok");
+    if (r1.has_value())
+        TCHECK_EQ(r1->epochNanoseconds(), Int128(303825678902034LL), "addZDT: time-only result");
+
+    // 2. Zero duration -> returns start unchanged
+    ISO8601::Duration zero;
+    auto r2 = addZonedDateTime(start1, utc, zero, TemporalOverflow::Constrain);
+    TCHECK_TRUE(r2.has_value(), "addZDT: zero ok");
+    if (r2.has_value())
+        TCHECK_EQ(r2->epochNanoseconds(), start1.epochNanoseconds(), "addZDT: zero = start");
+
+    // 3. Date+time path (P1DT1H with UTC): verifies getEpochNanosecondsFor + calendarDateAdd
+    // start: 2020-01-15T12:00:00Z = 1579089600000000000 ns
+    // P1D -> addedDate = 2020-01-16; re-resolve + +1h -> 2020-01-16T13:00:00Z
+    // expected: 1579089600000000000 + 86400000000000 + 3600000000000 = 1579179600000000000 ns
+    ISO8601::ExactTime start3(Int128(1579089600000000000LL));
+    ISO8601::Duration d3(0, 0, 0, 1, 1, 0, 0, 0, 0, 0); // P1DT1H
+    auto r3 = addZonedDateTime(start3, utc, d3, TemporalOverflow::Constrain);
+    TCHECK_TRUE(r3.has_value(), "addZDT: date+time ok");
+    if (r3.has_value())
+        TCHECK_EQ(r3->epochNanoseconds(), Int128(1579179600000000000LL), "addZDT: P1DT1H result");
+
+    // 4. Date-only (P1Y) path: 2020-01-15T12:00:00Z + P1Y = 2021-01-15T12:00:00Z
+    // 2021-01-15T12:00:00Z = 1610712000000000000 ns
+    ISO8601::Duration d4(1, 0, 0, 0, 0, 0, 0, 0, 0, 0); // P1Y
+    auto r4 = addZonedDateTime(start3, utc, d4, TemporalOverflow::Constrain);
+    TCHECK_TRUE(r4.has_value(), "addZDT: P1Y ok");
+    if (r4.has_value())
+        TCHECK_EQ(r4->epochNanoseconds(), Int128(1610712000000000000LL), "addZDT: P1Y result");
+}
+
+static void testGetTimeZoneTransition()
+{
+    // temporal_rs: get_time_zone_transition (src/builtins/core/zoned_date_time/tests.rs)
+
+    // 1. UTC-offset timezones have no transitions -> nullopt
+    auto utcOpt = ISO8601::parseTemporalTimeZoneIdentifier("UTC"_s);
+    if (!utcOpt) {
+        fprintf(stderr, "SKIP [getTimeZoneTransition]: UTC not available\n");
+        return;
+    }
+    auto r1 = getTimeZoneTransition(*utcOpt, ISO8601::ExactTime(Int128(0)), TransitionDirection::Next);
+    TCHECK_TRUE(r1.has_value() && !r1->has_value(), "transition: UTC no next");
+    auto r2 = getTimeZoneTransition(*utcOpt, ISO8601::ExactTime(Int128(0)), TransitionDirection::Previous);
+    TCHECK_TRUE(r2.has_value() && !r2->has_value(), "transition: UTC no previous");
+    // UTC-offset +05:30 also has no transitions
+    auto plusOpt = ISO8601::parseTemporalTimeZoneIdentifier("+05:30"_s);
+    if (plusOpt) {
+        auto r3 = getTimeZoneTransition(*plusOpt, ISO8601::ExactTime(Int128(0)), TransitionDirection::Next);
+        TCHECK_TRUE(r3.has_value() && !r3->has_value(), "transition: +05:30 no transitions");
+    }
+
+    // 2. America/New_York DST transitions from a summer 2020 date
+    // summer epoch: 2020-07-15T12:00:00Z = 1594814400000000000 ns
+    auto nyOpt = ISO8601::parseTemporalTimeZoneIdentifier("America/New_York"_s);
+    if (!nyOpt) {
+        fprintf(stderr, "SKIP [getTimeZoneTransition]: America/New_York not available\n");
+        return;
+    }
+    ISO8601::ExactTime summer2020(Int128(1594814400000000000LL));
+    // Previous: spring-forward 2020-03-08T07:00:00Z = 1583650800s * 1e9
+    auto prevR = getTimeZoneTransition(*nyOpt, summer2020, TransitionDirection::Previous);
+    TCHECK_TRUE(prevR.has_value() && prevR->has_value(), "transition: NY prev exists");
+    if (prevR.has_value() && prevR->has_value()) {
+        TCHECK_TRUE((*prevR)->epochNanoseconds() < summer2020.epochNanoseconds(), "transition: NY prev < query");
+        TCHECK_EQ((*prevR)->epochNanoseconds(), Int128(1583650800LL) * Int128(1000000000LL), "transition: NY spring 2020");
+    }
+    // Next: fall-back 2020-11-01T06:00:00Z = 1604210400s * 1e9
+    auto nextR = getTimeZoneTransition(*nyOpt, summer2020, TransitionDirection::Next);
+    TCHECK_TRUE(nextR.has_value() && nextR->has_value(), "transition: NY next exists");
+    if (nextR.has_value() && nextR->has_value()) {
+        TCHECK_TRUE((*nextR)->epochNanoseconds() > summer2020.epochNanoseconds(), "transition: NY next > query");
+        TCHECK_EQ((*nextR)->epochNanoseconds(), Int128(1604210400LL) * Int128(1000000000LL), "transition: NY fall 2020");
+    }
+
+    // 3. Europe/London: verify fake transitions (rule-change-without-offset-transition) are skipped.
+    // From temporal_rs test262 case: at 1970-01-01T00:00:00Z (epoch=0), London was on BST (+01:00).
+    // TZDB has intermediate fake entries around 1968-1971 that don't change the UTC offset —
+    // our 20-iteration skip loop must bypass them to find the real pre-BST transition.
+    auto londonOpt = ISO8601::parseTemporalTimeZoneIdentifier("Europe/London"_s);
+    if (!londonOpt) {
+        fprintf(stderr, "SKIP [getTimeZoneTransition London]: Europe/London not available\n");
+        return;
+    }
+    auto londonPrev = getTimeZoneTransition(*londonOpt, ISO8601::ExactTime(Int128(0)), TransitionDirection::Previous);
+    TCHECK_TRUE(londonPrev.has_value() && londonPrev->has_value(), "transition: London prev exists");
+    if (londonPrev.has_value() && londonPrev->has_value()) {
+        ISO8601::ExactTime tr = **londonPrev;
+        // Transition must be before epoch 0 (pre-1970)
+        TCHECK_TRUE(tr.epochNanoseconds() < Int128(0), "transition: London prev < 1970");
+        // Key property: offset actually changed at this transition (not a fake entry).
+        // Verify offset just before and at the transition differ.
+        auto offsetBefore = getOffsetNanosecondsFor(*londonOpt, ISO8601::ExactTime(tr.epochNanoseconds() - 1));
+        auto offsetAt = getOffsetNanosecondsFor(*londonOpt, tr);
+        TCHECK_TRUE(offsetBefore.has_value() && offsetAt.has_value(), "transition: London offsets ok");
+        if (offsetBefore.has_value() && offsetAt.has_value())
+            TCHECK_TRUE(*offsetBefore != *offsetAt, "transition: London real offset change (not fake)");
+    }
+}
+
+static void testTimeZoneEquals()
+{
+    // temporal_rs: canonicalize_equals (src/builtins/core/time_zone.rs)
+    // 1. Identical string -> true
+    TCHECK_TRUE(timeZoneEquals("UTC"_s, "UTC"_s), "tzEquals: UTC=UTC");
+    TCHECK_TRUE(timeZoneEquals("+05:30"_s, "+05:30"_s), "tzEquals: +05:30=+05:30");
+
+    // 2. Different strings -> false
+    TCHECK_TRUE(!timeZoneEquals("UTC"_s, "America/New_York"_s), "tzEquals: UTC!=NY");
+    TCHECK_TRUE(!timeZoneEquals("+05:30"_s, "+05:00"_s), "tzEquals: offset diff");
+
+    // 3. Offset vs named -> false
+    TCHECK_TRUE(!timeZoneEquals("+00:00"_s, "UTC"_s), "tzEquals: +00:00 != UTC (offset vs named)");
+
+    // 4. IANA aliases: Asia/Calcutta = Asia/Kolkata (canonicalized to same primary)
+    // temporal_rs: canonicalize_equals test
+    TCHECK_TRUE(timeZoneEquals("Asia/Calcutta"_s, "Asia/Kolkata"_s), "tzEquals: Calcutta=Kolkata");
+}
+
+static void testPossibleEpochNsAtLimits()
+{
+    // temporal_rs: test_possible_epoch_ns_at_limits (src/builtins/core/time_zone.rs)
+    // At the min/max Temporal boundaries, getPossibleEpochNanosecondsFor must return exactly 1 candidate.
+    // Just outside those boundaries, it must return empty (range error).
+    auto utcOpt = ISO8601::parseTemporalTimeZoneIdentifier("UTC"_s);
+    if (!utcOpt) {
+        fprintf(stderr, "SKIP [epochNsLimits]: UTC not available\n");
+        return;
+    }
+    auto utc = *utcOpt;
+
+    // UTC min boundary: -271821-04-20T00:00:00Z = exactly NS_MIN_INSTANT
+    auto rMinValid = getPossibleEpochNanosecondsFor(utc, { -271821, 4, 20 }, { 0, 0, 0, 0, 0, 0 });
+    TCHECK_TRUE(rMinValid.has_value() && std::holds_alternative<ISO8601::ExactTime>(*rMinValid), "epochNsLimits: min date = 1 candidate");
+    if (rMinValid.has_value() && std::holds_alternative<ISO8601::ExactTime>(*rMinValid))
+        TCHECK_TRUE(std::get<ISO8601::ExactTime>(*rMinValid).isValid(), "epochNsLimits: min candidate isValid");
+
+    // UTC max boundary: +275760-09-13T00:00:00Z = exactly NS_MAX_INSTANT
+    auto rMaxValid = getPossibleEpochNanosecondsFor(utc, { 275760, 9, 13 }, { 0, 0, 0, 0, 0, 0 });
+    TCHECK_TRUE(rMaxValid.has_value() && std::holds_alternative<ISO8601::ExactTime>(*rMaxValid), "epochNsLimits: max date = 1 candidate");
+    if (rMaxValid.has_value() && std::holds_alternative<ISO8601::ExactTime>(*rMaxValid))
+        TCHECK_TRUE(std::get<ISO8601::ExactTime>(*rMaxValid).isValid(), "epochNsLimits: max candidate isValid");
+
+    // Just before min: -271821-04-19T23:59:59.999999999Z = NS_MIN_INSTANT - 1ns → out of range → error or GapOffsets
+    auto rTooEarly = getPossibleEpochNanosecondsFor(utc, { -271821, 4, 19 }, { 23, 59, 59, 999, 999, 999 });
+    TCHECK_TRUE(!rTooEarly.has_value() || isGap(*rTooEarly), "epochNsLimits: too-early = error/gap");
+
+    // Just after max: +275760-09-13T00:00:00.000000001Z = NS_MAX_INSTANT + 1ns → out of range → error or GapOffsets
+    auto rTooLate = getPossibleEpochNanosecondsFor(utc, { 275760, 9, 13 }, { 0, 0, 0, 0, 0, 1 });
+    TCHECK_TRUE(!rTooLate.has_value() || isGap(*rTooLate), "epochNsLimits: too-late = error/gap");
+
+    // UTC offset timezone: +05:30 — same bounds should hold
+    auto plusOpt = ISO8601::parseTemporalTimeZoneIdentifier("+05:30"_s);
+    if (plusOpt) {
+        auto rPlusMin = getPossibleEpochNanosecondsFor(*plusOpt, { -271821, 4, 20 }, { 5, 30, 0, 0, 0, 0 });
+        TCHECK_TRUE(rPlusMin.has_value() && std::holds_alternative<ISO8601::ExactTime>(*rPlusMin), "epochNsLimits: +05:30 min ok");
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Section 1: direct temporal_rs ports
 // ---------------------------------------------------------------------------
 
@@ -1009,6 +1566,10 @@ static void runTemporalRSTests()
     testDateRoundingIncrement(); // temporal_rs: rounding_increment_observed
     testInvalidDateStrings(); // temporal_rs: invalid_strings
     testCriticalUnknownAnnotation(); // temporal_rs: argument_string_critical_unknown_annotation
+    testToZonedDateTime(); // temporal_rs: to_zoned_date_time
+    testToZonedDateTimeError(); // temporal_rs: to_zoned_date_time_error
+    testTimeZoneEquals(); // temporal_rs: canonicalize_equals
+    testAddZonedDateTime(); // temporal_rs: basic_zdt_add
 }
 
 // ---------------------------------------------------------------------------
@@ -1027,6 +1588,19 @@ static void runStressTests()
 
     // Instant
     testMaximumInstantIncrement(); // maximumInstantIncrement per unit
+
+    // ICU bridges
+    testExactTimeToLocalDateAndTime(); // epoch -> local date+time
+    testGetOffsetNanosecondsForUTC(); // UTC offset = 0
+    testPossibleEpochNsAtLimits(); // temporal_rs: test_possible_epoch_ns_at_limits
+    testGetTimeZoneTransition(); // temporal_rs: get_time_zone_transition
+    testTimeZoneICUWithIANA(); // IANA timezone with DST (America/New_York)
+    testCalendarIsLunisolar(); // lunisolar calendar detection
+    testCalendarDaysInMonthISO(); // ISO days-in-month
+    testCalendarInLeapYearISO(); // ISO leap year
+    testCalendarISO8601Fields(); // ISO field accessors
+    testCalendarICUNonISO(); // Non-ISO calendars (hebrew, chinese, japanese, persian)
+    testCalendarDateFromFields(); // calendarDateFromFields: era, monthCode, overflow, ROC, Japanese
 }
 
 } // namespace TemporalCore

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1486,11 +1486,13 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/WriteBarrierInlines.h
 
     runtime/temporal/core/CalendarArithmetic.h
+    runtime/temporal/core/CalendarICUBridge.h
     runtime/temporal/core/ISOArithmetic.h
     runtime/temporal/core/InstantCore.h
     runtime/temporal/core/Rounding.h
     runtime/temporal/core/TemporalCoreTypes.h
     runtime/temporal/core/TemporalEnums.h
+    runtime/temporal/core/TimeZoneICUBridge.h
 
     tools/Integrity.h
     tools/IntegrityInlines.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -1062,7 +1062,6 @@
 		534638751E70DDEC00F12AC1 /* DeferredWorkTimer.h in Headers */ = {isa = PBXBuildFile; fileRef = 534638741E70DDEC00F12AC1 /* DeferredWorkTimer.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		53486BB71C1795C300F6F3AF /* JSTypedArray.h in Headers */ = {isa = PBXBuildFile; fileRef = 53486BB61C1795C300F6F3AF /* JSTypedArray.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		534902851C7276B70012BCB8 /* TypedArrayCTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 534902821C7242C80012BCB8 /* TypedArrayCTest.cpp */; };
-		FF356D302FA9DACE00213929 /* TemporalCoreTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FF356D2F2FA9DACE00213929 /* TemporalCoreTest.cpp */; };
 		534C457C1BC72411007476A7 /* JSTypedArrayViewConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = 534C457B1BC72411007476A7 /* JSTypedArrayViewConstructor.h */; };
 		534E034E1E4D4B1600213F64 /* AccessCase.h in Headers */ = {isa = PBXBuildFile; fileRef = 534E034D1E4D4B1600213F64 /* AccessCase.h */; };
 		534E03541E53BD2900213F64 /* IntrinsicGetterAccessCase.h in Headers */ = {isa = PBXBuildFile; fileRef = 534E03531E53BD2900213F64 /* IntrinsicGetterAccessCase.h */; };
@@ -2339,11 +2338,14 @@
 		FF356CF72FA9832600213929 /* TemporalEnums.h in Headers */ = {isa = PBXBuildFile; fileRef = FF356CF42FA9832600213929 /* TemporalEnums.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FF356CF82FA9832600213929 /* TemporalCoreTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = FF356CF32FA9832600213929 /* TemporalCoreTypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FF356CFA2FA9837C00213929 /* TemporalObject.h in Headers */ = {isa = PBXBuildFile; fileRef = F6F1501A2693D33E004B98EF /* TemporalObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FF356D302FA9DACE00213929 /* TemporalCoreTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FF356D2F2FA9DACE00213929 /* TemporalCoreTest.cpp */; };
 		FF41590C28FF3C6B00F80B96 /* WaiterListManager.h in Headers */ = {isa = PBXBuildFile; fileRef = FF41590B28FF3C6B00F80B96 /* WaiterListManager.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FF6273A52FAD56220098B5A3 /* InstantCore.h in Headers */ = {isa = PBXBuildFile; fileRef = FF62739F2FAD56220098B5A3 /* InstantCore.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FF6273A62FAD56220098B5A3 /* Rounding.h in Headers */ = {isa = PBXBuildFile; fileRef = FF6273A32FAD56220098B5A3 /* Rounding.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FF6273A72FAD56220098B5A3 /* ISOArithmetic.h in Headers */ = {isa = PBXBuildFile; fileRef = FF6273A12FAD56220098B5A3 /* ISOArithmetic.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FF6273A82FAD56220098B5A3 /* CalendarArithmetic.h in Headers */ = {isa = PBXBuildFile; fileRef = FF62739D2FAD56220098B5A3 /* CalendarArithmetic.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FF629DA32FAE9B500098B5A3 /* CalendarICUBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = FF629D9B2FAE9B500098B5A3 /* CalendarICUBridge.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FF629DA42FAE9B500098B5A3 /* TimeZoneICUBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = FF629D9E2FAE9B500098B5A3 /* TimeZoneICUBridge.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FF6A4D7E2E663147001FB92C /* WasmModuleDebugInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = FF6A4D7D2E663147001FB92C /* WasmModuleDebugInfo.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FFA2E02A2EA16F37006661A3 /* ControlFlowTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FFA2E0222EA16F37006661A3 /* ControlFlowTests.cpp */; };
 		FFA2E02C2EA16F37006661A3 /* SpecialTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FFA2E0242EA16F37006661A3 /* SpecialTests.cpp */; };
@@ -4426,8 +4428,6 @@
 		53486BBA1C18E84500F6F3AF /* JSTypedArray.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSTypedArray.cpp; sourceTree = "<group>"; };
 		534902821C7242C80012BCB8 /* TypedArrayCTest.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = TypedArrayCTest.cpp; path = API/tests/TypedArrayCTest.cpp; sourceTree = "<group>"; };
 		534902831C7242C80012BCB8 /* TypedArrayCTest.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = TypedArrayCTest.h; path = API/tests/TypedArrayCTest.h; sourceTree = "<group>"; };
-		FF356D2E2FA9DACE00213929 /* TemporalCoreTest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = TemporalCoreTest.h; path = API/tests/TemporalCoreTest.h; sourceTree = "<group>"; };
-		FF356D2F2FA9DACE00213929 /* TemporalCoreTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = TemporalCoreTest.cpp; path = API/tests/TemporalCoreTest.cpp; sourceTree = "<group>"; };
 		534C457A1BC703DC007476A7 /* TypedArrayConstructor.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = TypedArrayConstructor.js; sourceTree = "<group>"; };
 		534C457B1BC72411007476A7 /* JSTypedArrayViewConstructor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSTypedArrayViewConstructor.h; sourceTree = "<group>"; };
 		534C457D1BC72549007476A7 /* JSTypedArrayViewConstructor.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSTypedArrayViewConstructor.cpp; sourceTree = "<group>"; };
@@ -6527,6 +6527,8 @@
 		FF356CE52FA9824300213929 /* TemporalPlainYearMonthPrototype.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TemporalPlainYearMonthPrototype.cpp; sourceTree = "<group>"; };
 		FF356CF32FA9832600213929 /* TemporalCoreTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TemporalCoreTypes.h; sourceTree = "<group>"; };
 		FF356CF42FA9832600213929 /* TemporalEnums.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TemporalEnums.h; sourceTree = "<group>"; };
+		FF356D2E2FA9DACE00213929 /* TemporalCoreTest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = TemporalCoreTest.h; path = API/tests/TemporalCoreTest.h; sourceTree = "<group>"; };
+		FF356D2F2FA9DACE00213929 /* TemporalCoreTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = TemporalCoreTest.cpp; path = API/tests/TemporalCoreTest.cpp; sourceTree = "<group>"; };
 		FF41590B28FF3C6B00F80B96 /* WaiterListManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WaiterListManager.h; sourceTree = "<group>"; };
 		FF62739D2FAD56220098B5A3 /* CalendarArithmetic.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CalendarArithmetic.h; sourceTree = "<group>"; };
 		FF62739E2FAD56220098B5A3 /* CalendarArithmetic.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CalendarArithmetic.cpp; sourceTree = "<group>"; };
@@ -6536,6 +6538,10 @@
 		FF6273A22FAD56220098B5A3 /* ISOArithmetic.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ISOArithmetic.cpp; sourceTree = "<group>"; };
 		FF6273A32FAD56220098B5A3 /* Rounding.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Rounding.h; sourceTree = "<group>"; };
 		FF6273A42FAD56220098B5A3 /* Rounding.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = Rounding.cpp; sourceTree = "<group>"; };
+		FF629D9B2FAE9B500098B5A3 /* CalendarICUBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CalendarICUBridge.h; sourceTree = "<group>"; };
+		FF629D9C2FAE9B500098B5A3 /* CalendarICUBridge.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CalendarICUBridge.cpp; sourceTree = "<group>"; };
+		FF629D9E2FAE9B500098B5A3 /* TimeZoneICUBridge.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TimeZoneICUBridge.h; sourceTree = "<group>"; };
+		FF629D9F2FAE9B500098B5A3 /* TimeZoneICUBridge.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TimeZoneICUBridge.cpp; sourceTree = "<group>"; };
 		FF6A4D7D2E663147001FB92C /* WasmModuleDebugInfo.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmModuleDebugInfo.h; sourceTree = "<group>"; };
 		FFA2E0212EA16F37006661A3 /* BinaryTests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = BinaryTests.cpp; sourceTree = "<group>"; };
 		FFA2E0222EA16F37006661A3 /* ControlFlowTests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ControlFlowTests.cpp; sourceTree = "<group>"; };
@@ -10872,6 +10878,8 @@
 			children = (
 				FF62739E2FAD56220098B5A3 /* CalendarArithmetic.cpp */,
 				FF62739D2FAD56220098B5A3 /* CalendarArithmetic.h */,
+				FF629D9C2FAE9B500098B5A3 /* CalendarICUBridge.cpp */,
+				FF629D9B2FAE9B500098B5A3 /* CalendarICUBridge.h */,
 				FF6273A02FAD56220098B5A3 /* InstantCore.cpp */,
 				FF62739F2FAD56220098B5A3 /* InstantCore.h */,
 				FF6273A22FAD56220098B5A3 /* ISOArithmetic.cpp */,
@@ -10880,6 +10888,8 @@
 				FF6273A32FAD56220098B5A3 /* Rounding.h */,
 				FF356CF32FA9832600213929 /* TemporalCoreTypes.h */,
 				FF356CF42FA9832600213929 /* TemporalEnums.h */,
+				FF629D9F2FAE9B500098B5A3 /* TimeZoneICUBridge.cpp */,
+				FF629D9E2FAE9B500098B5A3 /* TimeZoneICUBridge.h */,
 			);
 			path = core;
 			sourceTree = "<group>";
@@ -11308,6 +11318,7 @@
 				1409ECC0225E178100BEDD54 /* CacheUpdate.h in Headers */,
 				0FEC3C601F379F5300F59B6C /* CagedBarrierPtr.h in Headers */,
 				FF6273A82FAD56220098B5A3 /* CalendarArithmetic.h in Headers */,
+				FF629DA32FAE9B500098B5A3 /* CalendarICUBridge.h in Headers */,
 				BC18C3ED0E16F5CD00B34460 /* CallData.h in Headers */,
 				0F64B27A1A7957B2006E4E66 /* CallEdge.h in Headers */,
 				796DAA2B1E89CCD6005DF24A /* CalleeBits.h in Headers */,
@@ -12696,6 +12707,7 @@
 				FE3422121D6B81C30032BE88 /* ThrowScope.h in Headers */,
 				0F572D4F16879FDD00E57FBD /* ThunkGenerator.h in Headers */,
 				A7386556118697B400540279 /* ThunkGenerators.h in Headers */,
+				FF629DA42FAE9B500098B5A3 /* TimeZoneICUBridge.h in Headers */,
 				141448CD13A1783700F5BA1A /* TinyBloomFilter.h in Headers */,
 				0F55989817C86C5800A1E543 /* ToNativeFromValue.h in Headers */,
 				FE80C1971D775CDD008510C0 /* TopExceptionScope.h in Headers */,

--- a/Source/JavaScriptCore/PlatformPlayStation.cmake
+++ b/Source/JavaScriptCore/PlatformPlayStation.cmake
@@ -7,6 +7,14 @@ list(APPEND JavaScriptCore_PRIVATE_DEFINITIONS
 
 list(APPEND JavaScriptCore_PRIVATE_INCLUDE_DIRECTORIES ${MEMORY_EXTRA_INCLUDE_DIR})
 
+# PlayStation's libSceIcu_stub_weak.a does not export UCal write/mutation APIs
+# (ucal_set, ucal_add, ucal_getMillis, ucal_getTimeZoneTransitionDate, udat_clone, etc.)
+# that the Temporal ICU bridge requires. Provide stub implementations so the
+# build links successfully; stubs set U_UNSUPPORTED_ERROR so callers degrade gracefully.
+list(APPEND JavaScriptCore_SOURCES
+    runtime/temporal/core/ICUCalendarStubs.cpp
+)
+
 target_link_libraries(LLIntSettingsExtractor PRIVATE ${MEMORY_EXTRA_LIB})
 target_link_libraries(LLIntOffsetsExtractor PRIVATE ${MEMORY_EXTRA_LIB})
 

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -1152,9 +1152,11 @@ runtime/WideningNumberPredictionFuzzerAgent.cpp
 runtime/WrapForValidIteratorPrototype.cpp
 
 runtime/temporal/core/CalendarArithmetic.cpp
+runtime/temporal/core/CalendarICUBridge.cpp
 runtime/temporal/core/InstantCore.cpp
 runtime/temporal/core/ISOArithmetic.cpp
 runtime/temporal/core/Rounding.cpp
+runtime/temporal/core/TimeZoneICUBridge.cpp
 
 tools/CellList.cpp
 tools/CharacterPropertyDataGenerator.cpp

--- a/Source/JavaScriptCore/runtime/ISO8601.cpp
+++ b/Source/JavaScriptCore/runtime/ISO8601.cpp
@@ -805,6 +805,55 @@ static std::optional<TimeZoneRecord> parseTimeZone(StringParsingBuffer<Character
     }
 }
 
+// parseTimeZoneForIdentifier — like parseTimeZone but restricts inline offsets to ±HH:MM (no sub-minute).
+// Used for TemporalTimeZoneString parsing per Stage 4 spec.
+template<typename CharacterType>
+static std::optional<TimeZoneRecord> parseTimeZoneForIdentifier(StringParsingBuffer<CharacterType>& buffer)
+{
+    if (buffer.atEnd())
+        return std::nullopt;
+    switch (static_cast<char16_t>(*buffer)) {
+    // UTCDesignator
+    // https://tc39.es/proposal-temporal/#prod-UTCDesignator
+    case 'z':
+    case 'Z': {
+        buffer.advance();
+        if (!buffer.atEnd() && *buffer == '[' && canBeTimeZone(buffer, *buffer)) {
+            auto timeZone = parseTimeZoneAnnotation(buffer);
+            if (!timeZone)
+                return std::nullopt;
+            return TimeZoneRecord { true, std::nullopt, WTF::move(timeZone.value()) };
+        }
+        return TimeZoneRecord { true, std::nullopt, { } };
+    }
+    // TimeZoneUTCOffsetSign
+    // https://tc39.es/proposal-temporal/#prod-TimeZoneUTCOffsetSign
+    case '+':
+    case '-': {
+        auto offset = parseUTCOffset(buffer, false);
+        if (!offset)
+            return std::nullopt;
+        if (!buffer.atEnd() && *buffer == '[' && canBeTimeZone(buffer, *buffer)) {
+            auto timeZone = parseTimeZoneAnnotation(buffer);
+            if (!timeZone)
+                return std::nullopt;
+            return TimeZoneRecord { false, offset.value(), WTF::move(timeZone.value()) };
+        }
+        return TimeZoneRecord { false, offset.value(), { } };
+    }
+    // TimeZoneAnnotation
+    // https://tc39.es/proposal-temporal/#prod-TimeZoneAnnotation
+    case '[': {
+        auto timeZone = parseTimeZoneAnnotation(buffer);
+        if (!timeZone)
+            return std::nullopt;
+        return TimeZoneRecord { false, std::nullopt, WTF::move(timeZone.value()) };
+    }
+    default:
+        return std::nullopt;
+    }
+}
+
 template<typename CharacterType>
 static std::optional<RFC9557Annotation> parseOneRFC9557Annotation(StringParsingBuffer<CharacterType>& buffer)
 {
@@ -1981,6 +2030,68 @@ PlainDate createISODateRecord(double year, double month, double day)
 {
     ASSERT(isValidISODate(year, month, day));
     return PlainDate(year, month, day);
+}
+
+// temporal_rs: TimeZone::try_from_str (src/builtins/core/time_zone.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal-parsetemporaltimezonestring
+std::optional<TimeZone> parseTemporalTimeZoneIdentifier(StringView string)
+{
+    // 1. Let parseResult be ParseText(StringToCodePoints(timeZoneString), TimeZoneIdentifier).
+    // 2. If parseResult is a Parse Node, return ! ParseTimeZoneIdentifier(timeZoneString).
+    if (auto offset = parseUTCOffset(string, false))
+        return TimeZone::fromUTCOffset(*offset);
+    if (auto tzId = parseTimeZoneName(string))
+        return TimeZone::fromID(*tzId);
+
+    // 3. Let result be ? ParseISODateTime(timeZoneString, ...).
+    return readCharactersForParsing(string, [](auto buffer) -> std::optional<TimeZone> {
+        auto plainDate = parseDate(buffer, TemporalDateFormat::Date);
+        if (!plainDate)
+            return std::nullopt;
+
+        if (!buffer.atEnd() && (*buffer == 'T' || *buffer == 't' || *buffer == ' ')) {
+            buffer.advance();
+            auto plainTime = parseTimeSpec(buffer, Second60Mode::Accept);
+            if (!plainTime)
+                return std::nullopt;
+        }
+
+        if (buffer.atEnd() || !canBeTimeZone(buffer, *buffer))
+            return std::nullopt;
+
+        auto tzRecord = parseTimeZoneForIdentifier(buffer);
+        if (!tzRecord)
+            return std::nullopt;
+
+        if (!buffer.atEnd() && canBeRFC9557Annotation(buffer)) {
+            auto calendars = parseCalendar(buffer);
+            if (!calendars)
+                return std::nullopt;
+        }
+
+        if (!buffer.atEnd())
+            return std::nullopt;
+
+        // 4. Let timeZoneResult be result.[[TimeZone]].
+        // 5. If timeZoneResult.[[TimeZoneAnnotation]] is not ~empty~, return ! ParseTimeZoneIdentifier(timeZoneResult.[[TimeZoneAnnotation]]).
+        auto& nameOrOffset = tzRecord->m_nameOrOffset;
+        if (std::holds_alternative<int64_t>(nameOrOffset))
+            return TimeZone::fromUTCOffset(std::get<int64_t>(nameOrOffset));
+        auto& name = std::get<Vector<Latin1Character>>(nameOrOffset);
+        if (!name.isEmpty()) {
+            if (auto tzId = parseTimeZoneName(StringView(name.span())))
+                return TimeZone::fromID(*tzId);
+            return std::nullopt;
+        }
+        // 6. If timeZoneResult.[[Z]] is true, return ! ParseTimeZoneIdentifier("UTC").
+        if (tzRecord->m_z)
+            return TimeZone::fromUTCOffset(0);
+        // 7. If timeZoneResult.[[OffsetString]] is not ~empty~, return ? ParseTimeZoneIdentifier(timeZoneResult.[[OffsetString]]).
+        if (tzRecord->m_offset)
+            return TimeZone::fromUTCOffset(*tzRecord->m_offset);
+        // 8. Throw a RangeError exception.
+        return std::nullopt;
+    });
 }
 
 } // namespace ISO8601

--- a/Source/JavaScriptCore/runtime/ISO8601.h
+++ b/Source/JavaScriptCore/runtime/ISO8601.h
@@ -185,6 +185,7 @@ public:
 
     constexpr ExactTime() = default;
     constexpr ExactTime(const ExactTime&) = default;
+    constexpr ExactTime& operator=(const ExactTime&) = default;
     constexpr explicit ExactTime(Int128 epochNanoseconds) : m_epochNanoseconds(epochNanoseconds) { }
 
     static constexpr ExactTime fromEpochMilliseconds(int64_t epochMilliseconds)
@@ -497,6 +498,7 @@ PlainDate NODELETE createISODateRecord(double, double, double);
 
 std::optional<ExactTime> parseInstant(StringView);
 std::optional<ParsedMonthCode> NODELETE parseMonthCode(StringView);
+std::optional<TimeZone> JS_EXPORT_PRIVATE parseTemporalTimeZoneIdentifier(StringView);
 
 bool isDateTimeWithinLimits(int32_t year, uint8_t month, uint8_t day, unsigned hour, unsigned minute, unsigned second, unsigned millisecond, unsigned microsecond, unsigned nanosecond);
 

--- a/Source/JavaScriptCore/runtime/IntlObject.cpp
+++ b/Source/JavaScriptCore/runtime/IntlObject.cpp
@@ -1766,6 +1766,26 @@ CalendarID iso8601CalendarIDSlow()
     return iso8601CalendarIDStorage;
 }
 
+#define DEFINE_CALENDAR_ID(name, str) \
+    CalendarID name##CalendarIDStorage { std::numeric_limits<CalendarID>::max() }; \
+    CalendarID name##CalendarIDSlow() \
+    { \
+        static std::once_flag initializeOnce; \
+        std::call_once(initializeOnce, [&] { \
+            const auto& calendars = intlAvailableCalendars(); \
+            for (unsigned index = 0; index < calendars.size(); ++index) { \
+                if (calendars[index] == str) { \
+                    name##CalendarIDStorage = index; \
+                    return; \
+                } \
+            } \
+            RELEASE_ASSERT_NOT_REACHED(); \
+        }); \
+        return name##CalendarIDStorage; \
+    }
+FOR_EACH_CACHED_CALENDAR_ID(DEFINE_CALENDAR_ID)
+#undef DEFINE_CALENDAR_ID
+
 // https://tc39.es/proposal-intl-enumeration/#sec-availablecalendars
 static JSArray* availableCalendars(JSGlobalObject* globalObject)
 {

--- a/Source/JavaScriptCore/runtime/IntlObject.h
+++ b/Source/JavaScriptCore/runtime/IntlObject.h
@@ -104,7 +104,7 @@ inline const LocaleSet& intlListFormatAvailableLocales() { return intlAvailableL
 inline const LocaleSet& intlDurationFormatAvailableLocales() { return intlAvailableLocales(); }
 
 using CalendarID = unsigned;
-const Vector<String>& intlAvailableCalendars();
+JS_EXPORT_PRIVATE const Vector<String>& intlAvailableCalendars();
 
 extern CalendarID iso8601CalendarIDStorage;
 CalendarID iso8601CalendarIDSlow();
@@ -115,6 +115,40 @@ inline CalendarID iso8601CalendarID()
         return iso8601CalendarIDSlow();
     return value;
 }
+
+// Cached CalendarIDs for calendars compared frequently in the Temporal bridge layer.
+// Each follows the iso8601CalendarID() pattern: extern storage + Slow() + inline fast path.
+#define FOR_EACH_CACHED_CALENDAR_ID(macro) \
+    macro(buddhist, "buddhist"_s) \
+    macro(chinese, "chinese"_s) \
+    macro(coptic, "coptic"_s) \
+    macro(dangi, "dangi"_s) \
+    macro(ethioaa, "ethioaa"_s) \
+    macro(ethiopic, "ethiopic"_s) \
+    macro(gregory, "gregory"_s) \
+    macro(hebrew, "hebrew"_s) \
+    macro(indian, "indian"_s) \
+    macro(islamic, "islamic"_s) \
+    macro(islamicCivil, "islamic-civil"_s) \
+    macro(islamicRgsa, "islamic-rgsa"_s) \
+    macro(islamicTbla, "islamic-tbla"_s) \
+    macro(islamicUmalqura, "islamic-umalqura"_s) \
+    macro(japanese, "japanese"_s) \
+    macro(persian, "persian"_s) \
+    macro(roc, "roc"_s)
+
+#define DECLARE_CALENDAR_ID(name, str) \
+    extern CalendarID JS_EXPORT_PRIVATE name##CalendarIDStorage; \
+    CalendarID JS_EXPORT_PRIVATE name##CalendarIDSlow(); \
+    inline CalendarID name##CalendarID() \
+    { \
+        unsigned value = name##CalendarIDStorage; \
+        if (value == std::numeric_limits<CalendarID>::max()) \
+            return name##CalendarIDSlow(); \
+        return value; \
+    }
+FOR_EACH_CACHED_CALENDAR_ID(DECLARE_CALENDAR_ID)
+#undef DECLARE_CALENDAR_ID
 
 // Resolve any accepted time zone string (case-insensitive; accepts IANA primary
 // identifiers, IANA Backward links such as "Asia/Calcutta", and UTC-equivalent

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
@@ -1,0 +1,1476 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CalendarICUBridge.h"
+
+#include "DateConstructor.h"
+#include "ISOArithmetic.h"
+#include "IntlObject.h"
+#include <unicode/ucal.h>
+#include <wtf/DateMath.h>
+#include <wtf/text/MakeString.h>
+#include <wtf/unicode/icu/ICUHelpers.h>
+
+namespace JSC {
+namespace TemporalCore {
+
+CalendarID calendarIDFromString(StringView identifier)
+{
+    const auto& calendars = intlAvailableCalendars();
+    for (unsigned i = 0; i < calendars.size(); ++i) {
+        if (calendars[i] == identifier)
+            return i;
+    }
+    return iso8601CalendarID();
+}
+
+// buildICULocale — internal: maps BCP47 calendar ID to ICU locale string
+static CString buildICULocale(StringView calendarId)
+{
+    String bcp47(calendarId.toString());
+    auto mapped = mapBCP47ToICUCalendarKeyword(bcp47);
+    auto icuKeyword = mapped ? *mapped : bcp47;
+    return makeString("und@calendar="_s, icuKeyword).utf8();
+}
+
+// openCalendar — internal: opens ICU UCalendar for the given CalendarID, set to UTC.
+// NOTE: For Gregory/ISO/Japanese/Buddhist/Roc: sets Gregorian change date to -infinity for proleptic Gregorian arithmetic.
+// FIXME: Cache one UCalendar per CalendarID in a Vector<std::unique_ptr<UCalendar, ICUDeleter<ucal_close>>, numberOfCalendarIDs>
+//        to avoid repeated ucal_open overhead on hot paths like calendarYear/calendarMonth/calendarDay.
+static std::unique_ptr<UCalendar, ICUDeleter<ucal_close>> openCalendar(CalendarID calendarId)
+{
+    auto str = calendarIDToString(calendarId);
+    auto locale = buildICULocale(str);
+    UErrorCode status = U_ZERO_ERROR;
+    auto cal = std::unique_ptr<UCalendar, ICUDeleter<ucal_close>>(ucal_open(u"UTC", 3, locale.data(), UCAL_DEFAULT, &status));
+    if (U_FAILURE(status))
+        return nullptr;
+    // Set to ExactTime::minValue in ms — the minimum representable Temporal instant — making ICU
+    // use proleptic Gregorian for all valid dates (effectively -infinity for our purposes).
+    if (calendarId == gregoryCalendarID() || calendarIsISO(calendarId) || calendarId == japaneseCalendarID() || calendarId == buddhistCalendarID() || calendarId == rocCalendarID()) {
+        const double prolepticGregorianChangeMs = -8.64e15; // ExactTime::minValue / nsPerMillisecond
+        ucal_setGregorianChange(cal.get(), prolepticGregorianChangeMs, &status);
+    }
+    return cal;
+}
+
+// chineseCalendarUsesEpochOffset — probes ICU UCAL_EXTENDED_YEAR for Chinese to detect epoch-based vs ISO-proleptic year numbering.
+// Result is cached: it depends only on the ICU version, which is fixed for the process lifetime.
+bool chineseCalendarUsesEpochOffset()
+{
+    static bool cached = []() -> bool {
+        auto cal = openCalendar(chineseCalendarID());
+        if (!cal)
+            return false;
+        // Use ucal_setMillis with a precomputed ISO epoch time — NOT ucal_setDateTime which
+        // sets calendar-native fields (not ISO fields) on a non-Gregorian calendar.
+        // ISO 1972-02-15 00:00:00 UTC = 66,960,000,000 ms from Unix epoch (1970-01-01).
+        static constexpr double iso1972Feb15EpochMs = 66960000000.0;
+        UErrorCode status = U_ZERO_ERROR;
+        ucal_setMillis(cal.get(), iso1972Feb15EpochMs, &status);
+        int32_t extYear = ucal_get(cal.get(), UCAL_EXTENDED_YEAR, &status);
+        if (U_FAILURE(status))
+            return false;
+        // Epoch-based: extYear = 4608 (Chinese year for 1972 CE); ISO-proleptic: extYear = 1972.
+        return extYear > 3000;
+    }();
+    return cached;
+}
+
+// isoDateToEpochMs — internal: converts ISO PlainDate to epoch ms at noon UTC (avoids DST boundary issues)
+static double isoDateToEpochMs(const ISO8601::PlainDate& date)
+{
+    const double noonEpochOffsetMs = 43'200'000.0; // nsPerDay / nsPerMillisecond / 2
+    double days = makeDay(date.year(), date.month() - 1, date.day());
+    return makeDate(days, noonEpochOffsetMs);
+}
+
+// setCalendarToISODate — internal: sets ICU calendar to a specific ISO date via epoch milliseconds
+static bool setCalendarToISODate(UCalendar* cal, const ISO8601::PlainDate& isoDate)
+{
+    // Use a proleptic Gregorian calendar to compute epoch ms, then set ICU calendar.
+    double epochMs = isoDateToEpochMs(isoDate);
+    UErrorCode status = U_ZERO_ERROR;
+    ucal_setMillis(cal, epochMs, &status);
+    return U_SUCCESS(status);
+}
+
+// isoDateFromCalendarChecked — internal: reads back ISO date from ICU calendar's current epoch ms; returns nullopt if out of representable range
+static std::optional<ISO8601::PlainDate> isoDateFromCalendarChecked(UCalendar* cal)
+{
+    UErrorCode status = U_ZERO_ERROR;
+    double epochMs = ucal_getMillis(cal, &status);
+    if (U_FAILURE(status))
+        return std::nullopt;
+    WTF::Int64Milliseconds msWT(static_cast<int64_t>(epochMs));
+    int32_t days = WTF::msToDays(msWT);
+    auto [year, month, day] = WTF::yearMonthDayFromDays(days);
+    if (!ISO8601::isYearWithinLimits(year))
+        return std::nullopt;
+    return ISO8601::PlainDate(year, static_cast<uint8_t>(month + 1), static_cast<uint8_t>(day));
+}
+
+// isoDateFromCalendar — internal: unchecked variant of isoDateFromCalendarChecked; callers assert validity
+static ISO8601::PlainDate isoDateFromCalendar(UCalendar* cal)
+{
+    auto result = isoDateFromCalendarChecked(cal);
+    ASSERT(result);
+    return *result;
+}
+
+// Japanese era table — start years are historically fixed calendar facts.
+// icu4x: components/calendar/src/cal/japanese.rs Japanese::eras()
+struct JapaneseEra {
+    int32_t startYear;
+    ASCIILiteral name;
+};
+static constexpr JapaneseEra japaneseEras[] = {
+    { 2019, "reiwa"_s },
+    { 1989, "heisei"_s },
+    { 1926, "showa"_s },
+    { 1912, "taisho"_s },
+    { 1868, "meiji"_s },
+};
+
+// japaneseEraStartYear — no spec AO, no ICU4X equivalent (ICU4X keys on EraStartDate directly).
+// Bridges ICU4C's UCAL_ERA integer to a Gregorian start year for lookup in japaneseEras[].
+static int32_t japaneseEraStartYear(int32_t icuEraCode)
+{
+    auto cal = openCalendar(japaneseCalendarID());
+    if (!cal)
+        return INT32_MIN;
+    UErrorCode status = U_ZERO_ERROR;
+    ucal_set(cal.get(), UCAL_ERA, icuEraCode);
+    // YEAR=2: YEAR=1/January doesn't exist for eras starting mid-year (e.g. Showa on Dec 25).
+    ucal_set(cal.get(), UCAL_YEAR, 2);
+    ucal_set(cal.get(), UCAL_MONTH, UCAL_JANUARY);
+    ucal_set(cal.get(), UCAL_DAY_OF_MONTH, 1);
+    int32_t extYear = ucal_get(cal.get(), UCAL_EXTENDED_YEAR, &status);
+    if (U_FAILURE(status))
+        return INT32_MIN;
+    return extYear - 1; // EXTENDED_YEAR of YEAR=2/Jan 1 is eraStartYear+1.
+}
+
+// japaneseEraCode — inverse of japaneseEraStartYear: derives the ICU era integer from a known era start year.
+static int32_t japaneseEraCode(int32_t startYear)
+{
+    auto cal = openCalendar(japaneseCalendarID());
+    if (!cal)
+        return -1;
+    UErrorCode status = U_ZERO_ERROR;
+    ucal_set(cal.get(), UCAL_EXTENDED_YEAR, startYear + 1); // startYear+1/Jan 1 is always within the era.
+    ucal_set(cal.get(), UCAL_MONTH, UCAL_JANUARY);
+    ucal_set(cal.get(), UCAL_DAY_OF_MONTH, 1);
+    int32_t eraCode = ucal_get(cal.get(), UCAL_ERA, &status);
+    if (U_FAILURE(status))
+        return -1;
+    return eraCode;
+}
+
+// mapICUEraToTemporalEra — ICU4C has no locale-independent era identifier API (UDAT_ERA_NAMES is locale-dependent).
+// For non-Japanese calendars, era indices are 0/1 and fixed by the calendar system — hardcoded string mapping suffices.
+// For Japanese, era indices grow as new eras are added; japaneseEraStartYear derives the name via ICU4C dynamically.
+// Era strings match icu4x era_year_from_extended (gregorian.rs, japanese.rs, coptic.rs, ethiopian.rs, hebrew.rs, persian.rs, indian.rs, roc.rs).
+static std::optional<String> mapICUEraToTemporalEra(CalendarID calendarId, int32_t icuEra)
+{
+    if (!calendarHasEras(calendarId))
+        return std::nullopt;
+
+    if (calendarId == gregoryCalendarID())
+        return !icuEra ? "bce"_s : "ce"_s;
+    if (calendarId == buddhistCalendarID())
+        return "be"_s;
+    if (calendarId == japaneseCalendarID()) {
+        int32_t startYear = japaneseEraStartYear(icuEra);
+        for (auto& e : japaneseEras) {
+            if (startYear == e.startYear)
+                return String(e.name);
+        }
+        return startYear > 0 ? "ce"_s : "bce"_s;
+    }
+    if (calendarId == rocCalendarID())
+        return !icuEra ? "broc"_s : "roc"_s;
+    if (calendarId == copticCalendarID() || calendarId == ethiopicCalendarID())
+        return !icuEra ? "bce"_s : "ce"_s;
+    if (calendarId == ethioaaCalendarID())
+        return "aa"_s;
+    if (calendarId == hebrewCalendarID())
+        return "am"_s;
+    if (calendarId == indianCalendarID())
+        return "saka"_s;
+    if (calendarId == persianCalendarID())
+        return "ap"_s;
+    if (calendarIsIslamic(calendarId))
+        return "ah"_s;
+    return std::nullopt;
+}
+
+// computeMonthCode — internal: computes monthCode string from ICU calendar state (e.g. "M05L" for Hebrew Adar I)
+// icu4x: components/calendar/src/cal/hebrew.rs (Hebrew special case)
+// icu4x: components/calendar/src/cal/chinese_based.rs (Chinese/Dangi IS_LEAP_MONTH)
+static String computeMonthCode(UCalendar* cal, CalendarID calendarId)
+{
+    UErrorCode status = U_ZERO_ERROR;
+    int32_t ucalMonth = ucal_get(cal, UCAL_MONTH, &status);
+
+    if (calendarId == hebrewCalendarID()) {
+        // ICU4C Hebrew never sets IS_LEAP_MONTH=1. Instead, leap years have 13 slots
+        // (maxMonth=12, UCAL_MONTH 0-12) and non-leap years have 12 slots (maxMonth=11).
+        // Leap year slot 5 = Adar I (M05L); non-leap slot 5 = Adar (M06).
+        int32_t maxMonth = ucal_getLimit(cal, UCAL_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
+        bool isLeapYear = (maxMonth == 12);
+        if (isLeapYear && ucalMonth == 5)
+            return "M05L"_s;
+        int32_t codeNum;
+        if (isLeapYear && ucalMonth >= 6)
+            codeNum = ucalMonth; // leap post-Adar-I: M06-M12 for slots 6-12
+        else
+            codeNum = ucalMonth + 1; // non-leap all slots, or leap slots 0-4: M01-M05
+        return makeString("M"_s, codeNum < 10 ? "0"_s : ""_s, codeNum);
+    }
+
+    // Chinese/Dangi: IS_LEAP_MONTH distinguishes leap months on the same UCAL_MONTH slot.
+    int32_t month = ucalMonth + 1;
+    int32_t isLeap = ucal_get(cal, UCAL_IS_LEAP_MONTH, &status);
+    if (isLeap)
+        return makeString("M"_s, month < 10 ? "0"_s : ""_s, month, "L"_s);
+    ASSERT(U_SUCCESS(status));
+    return makeString("M"_s, month < 10 ? "0"_s : ""_s, month);
+}
+
+// computeOrdinalMonth — internal: returns 1-based ordinal month position in year, counting leap months for lunisolar
+// icu4x: components/calendar/src/date.rs Date::month().ordinal
+static uint8_t computeOrdinalMonth(UCalendar* cal, CalendarID calendarId)
+{
+    UErrorCode status = U_ZERO_ERROR;
+    int32_t month = ucal_get(cal, UCAL_MONTH, &status) + 1;
+    if (!calendarIsLunisolar(calendarId))
+        return static_cast<uint8_t>(month); // For lunisolar: the ordinal month includes leap months.
+    // UCAL_MONTH gives the underlying month index (leap months share same index).
+    // Count how many months from start of year to current position.
+    int32_t isLeap = ucal_get(cal, UCAL_IS_LEAP_MONTH, &status); // Save current state.
+    double savedMs = ucal_getMillis(cal, &status); // Go to the first day of the calendar year.
+    ucal_set(cal, UCAL_MONTH, 0);
+    ucal_set(cal, UCAL_IS_LEAP_MONTH, 0);
+    ucal_set(cal, UCAL_DAY_OF_MONTH, 1);
+
+    int32_t ordinal = 1;
+    int32_t targetMonth = month - 1; // 0-indexed for comparison with UCAL_MONTH
+    int32_t targetIsLeap = isLeap; // Walk month by month.
+    for (int i = 0; i < 15; i++) {
+        // max 13 months + safety
+        int32_t curMonth = ucal_get(cal, UCAL_MONTH, &status);
+        int32_t curLeap = ucal_get(cal, UCAL_IS_LEAP_MONTH, &status);
+        if (curMonth == targetMonth && curLeap == targetIsLeap)
+            break;
+        ucal_add(cal, UCAL_MONTH, 1, &status);
+        ordinal++;
+    }
+
+    // Restore calendar state.
+    ucal_setMillis(cal, savedMs, &status);
+    ASSERT(U_SUCCESS(status));
+    return static_cast<uint8_t>(ordinal);
+}
+
+// mapTemporalEraToICUEra — ICU4C has no set-by-era-name API; ucal_set only accepts UCAL_ERA as integer.
+// For non-Japanese calendars, era indices are 0/1 and fixed by the calendar system — hardcoded mapping suffices.
+// For Japanese, japaneseEraCode derives the integer via ICU4C dynamically using the era's historically-fixed start year.
+// Era strings match icu4x extended_year_from_era_year_unchecked (gregorian.rs, japanese.rs, coptic.rs, ethiopian.rs, hebrew.rs, persian.rs, indian.rs, roc.rs).
+static int32_t mapTemporalEraToICUEra(CalendarID calendarId, StringView era)
+{
+    if (calendarId == gregoryCalendarID())
+        return era == "bce"_s ? 0 : (era == "ce"_s ? 1 : -1);
+    if (calendarId == buddhistCalendarID())
+        return era == "be"_s ? 0 : -1;
+    if (calendarId == japaneseCalendarID()) {
+        for (auto& e : japaneseEras) {
+            if (era == StringView(e.name))
+                return japaneseEraCode(e.startYear);
+        }
+        if (era == "ce"_s)
+            return 0;
+        return -1;
+    }
+    if (calendarId == rocCalendarID())
+        return era == "broc"_s ? 0 : (era == "roc"_s ? 1 : -1);
+    if (calendarId == copticCalendarID() || calendarId == ethiopicCalendarID())
+        return era == "bce"_s ? 0 : (era == "ce"_s ? 1 : -1);
+    if (calendarId == ethioaaCalendarID())
+        return era == "aa"_s ? 0 : -1;
+    if (calendarId == hebrewCalendarID())
+        return era == "am"_s ? 0 : -1;
+    if (calendarId == indianCalendarID())
+        return era == "saka"_s ? 0 : -1;
+    if (calendarId == persianCalendarID())
+        return era == "ap"_s ? 0 : -1;
+    if (calendarIsIslamic(calendarId))
+        return era == "ah"_s ? 0 : -1;
+    return -1;
+}
+
+// isoToCalendarFields — no single temporal_rs equivalent; aggregates Calendar::year/month/month_code/day/era into one ICU pass.
+TemporalResult<CalendarFields> isoToCalendarFields(CalendarID calendarId, const ISO8601::PlainDate& isoDate)
+{
+    auto cal = openCalendar(calendarId);
+    if (!cal)
+        return makeUnexpected(rangeError("Failed to open ICU calendar"_s));
+    if (!setCalendarToISODate(cal.get(), isoDate))
+        return makeUnexpected(rangeError("Failed to set ICU calendar to ISO date"_s));
+
+    UErrorCode status = U_ZERO_ERROR;
+    CalendarFields fields;
+    // NOTE: ROC UCAL_EXTENDED_YEAR may return Gregorian year on some ICU versions; handled below.
+    fields.year = ucal_get(cal.get(), UCAL_EXTENDED_YEAR, &status);
+    if (calendarId == rocCalendarID()) {
+        int32_t era = ucal_get(cal.get(), UCAL_ERA, &status);
+        int32_t eraYear = ucal_get(cal.get(), UCAL_YEAR, &status);
+        fields.year = !era ? -(eraYear - 1) : eraYear;
+    }
+    fields.month = computeOrdinalMonth(cal.get(), calendarId);
+    fields.day = static_cast<uint8_t>(ucal_get(cal.get(), UCAL_DAY_OF_MONTH, &status));
+    fields.isLeapMonth = !!ucal_get(cal.get(), UCAL_IS_LEAP_MONTH, &status);
+    fields.monthCode = computeMonthCode(cal.get(), calendarId);
+
+    if (calendarHasEras(calendarId)) {
+        int32_t icuEra = ucal_get(cal.get(), UCAL_ERA, &status);
+        fields.era = mapICUEraToTemporalEra(calendarId, icuEra);
+        // NOTE: Japanese dates before 1873 use "ce"/"bce" per spec, not ICU era names.
+        fields.eraYear = ucal_get(cal.get(), UCAL_YEAR, &status);
+        if (calendarId == japaneseCalendarID()) {
+            if (isoDate.year() < 1873) {
+                fields.era = isoDate.year() > 0 ? "ce"_s : "bce"_s;
+                fields.eraYear = isoDate.year() > 0 ? isoDate.year() : (1 - isoDate.year());
+            } else if (fields.era && *fields.era == "ce"_s)
+                fields.eraYear = isoDate.year();
+        }
+    }
+
+    if (U_FAILURE(status))
+        return makeUnexpected(rangeError("Failed to read calendar fields from ICU"_s));
+    return fields;
+}
+
+// calendarYear — temporal_rs: Calendar::year (src/builtins/core/calendar.rs)
+//                icu4x: Date::extended_year (components/calendar/src/date.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal-calendarisotodate
+// CalendarISOToDate [[Year]] field:
+//   1. (iso8601) Return isoDate.[[Year]].
+//   2. (non-ISO) NonISOCalendarISOToDate — implementation-defined.
+TemporalResult<int32_t> calendarYear(CalendarID calendarId, const ISO8601::PlainDate& isoDate)
+{
+    // 1. Return the extended year of isoDate in calendarId.
+    auto cal = openCalendar(calendarId);
+    if (!cal)
+        return makeUnexpected(rangeError("Failed to open ICU calendar"_s));
+    if (!setCalendarToISODate(cal.get(), isoDate))
+        return makeUnexpected(rangeError("Failed to set ICU calendar"_s));
+    UErrorCode status = U_ZERO_ERROR;
+    // NOTE: ROC UCAL_EXTENDED_YEAR may return Gregorian year on some ICU versions; compute from era+year.
+    if (calendarId == rocCalendarID()) {
+        int32_t era = ucal_get(cal.get(), UCAL_ERA, &status);
+        int32_t eraYear = ucal_get(cal.get(), UCAL_YEAR, &status);
+        return !era ? -(eraYear - 1) : eraYear;
+    }
+    return ucal_get(cal.get(), UCAL_EXTENDED_YEAR, &status);
+}
+
+// calendarMonth — temporal_rs: Calendar::month (src/builtins/core/calendar.rs)
+//                 icu4x: Date::month().ordinal (components/calendar/src/date.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal-calendarisotodate
+// CalendarISOToDate [[Month]] field:
+//   1. (iso8601) Return isoDate.[[Month]].
+//   2. (non-ISO) NonISOCalendarISOToDate — implementation-defined.
+TemporalResult<uint8_t> calendarMonth(CalendarID calendarId, const ISO8601::PlainDate& isoDate)
+{
+    // 1. Return the ordinal month (1-based position in year, counting leap months) of isoDate in calendarId.
+    // NOTE: Japanese pre-1873 "ce"/"bce" eras use ISO month directly to bypass ICU Julian conversion.
+    if (calendarId == japaneseCalendarID() && isoDate.year() < 1873)
+        return isoDate.month();
+    auto cal = openCalendar(calendarId);
+    if (!cal)
+        return makeUnexpected(rangeError("Failed to open ICU calendar"_s));
+    if (!setCalendarToISODate(cal.get(), isoDate))
+        return makeUnexpected(rangeError("Failed to set ICU calendar"_s));
+    return computeOrdinalMonth(cal.get(), calendarId);
+}
+
+// calendarMonthCode — temporal_rs: Calendar::month_code (src/builtins/core/calendar.rs)
+//                     icu4x: Date::month().to_input().code() (components/calendar/src/date.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal-calendarisotodate
+// CalendarISOToDate [[MonthCode]] field:
+//   1. (iso8601) Return CreateMonthCode(isoDate.[[Month]], false).
+//   2. (non-ISO) NonISOCalendarISOToDate — implementation-defined.
+TemporalResult<String> calendarMonthCode(CalendarID calendarId, const ISO8601::PlainDate& isoDate)
+{
+    // 1. Return the month code string (e.g. "M01", "M05L") of isoDate in calendarId.
+    // NOTE: Japanese pre-1873 "ce"/"bce" eras use ISO month code directly to bypass ICU Julian conversion.
+    if (calendarId == japaneseCalendarID() && isoDate.year() < 1873)
+        return ISO8601::monthCode(isoDate.month());
+    auto cal = openCalendar(calendarId);
+    if (!cal)
+        return makeUnexpected(rangeError("Failed to open ICU calendar"_s));
+    if (!setCalendarToISODate(cal.get(), isoDate))
+        return makeUnexpected(rangeError("Failed to set ICU calendar"_s));
+    return computeMonthCode(cal.get(), calendarId);
+}
+
+// calendarDay — temporal_rs: Calendar::day (src/builtins/core/calendar.rs)
+//               icu4x: Date::day_of_month (components/calendar/src/date.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal-calendarisotodate
+// CalendarISOToDate [[Day]] field:
+//   1. (iso8601) Return isoDate.[[Day]].
+//   2. (non-ISO) NonISOCalendarISOToDate — implementation-defined.
+TemporalResult<uint8_t> calendarDay(CalendarID calendarId, const ISO8601::PlainDate& isoDate)
+{
+    // 1. Return the day-of-month of isoDate in calendarId.
+    // NOTE: Japanese pre-1873 "ce"/"bce" eras return ISO day directly to bypass ICU Julian conversion.
+    if (calendarId == japaneseCalendarID() && isoDate.year() < 1873)
+        return isoDate.day();
+    auto cal = openCalendar(calendarId);
+    if (!cal)
+        return makeUnexpected(rangeError("Failed to open ICU calendar"_s));
+    if (!setCalendarToISODate(cal.get(), isoDate))
+        return makeUnexpected(rangeError("Failed to set ICU calendar"_s));
+    UErrorCode status = U_ZERO_ERROR;
+    return static_cast<uint8_t>(ucal_get(cal.get(), UCAL_DAY_OF_MONTH, &status));
+}
+
+// calendarEra — temporal_rs: Calendar::era (src/builtins/core/calendar.rs)
+//               icu4x: Date::year() returning YearInfo / era_year (components/calendar/src/date.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal-calendarisotodate
+// CalendarISOToDate [[Era]] field:
+//   1. (iso8601) Return undefined.
+//   2. (non-ISO) NonISOCalendarISOToDate — implementation-defined.
+TemporalResult<std::optional<String>> calendarEra(CalendarID calendarId, const ISO8601::PlainDate& isoDate)
+{
+    // 1. If calendarId has no eras, return undefined.
+    if (!calendarHasEras(calendarId))
+        return std::optional<String>(std::nullopt);
+    // 2. Return the era string for isoDate in calendarId (e.g. "ce", "bce", "reiwa").
+    // NOTE: Japanese dates before 1873 use "ce"/"bce" per spec, not ICU era names.
+    auto cal = openCalendar(calendarId);
+    if (!cal)
+        return makeUnexpected(rangeError("Failed to open ICU calendar"_s));
+    if (!setCalendarToISODate(cal.get(), isoDate))
+        return makeUnexpected(rangeError("Failed to set ICU calendar"_s));
+    UErrorCode status = U_ZERO_ERROR;
+    int32_t icuEra = ucal_get(cal.get(), UCAL_ERA, &status);
+    if (U_FAILURE(status))
+        return makeUnexpected(rangeError("Failed to get era from ICU"_s));
+    if (calendarId == japaneseCalendarID() && isoDate.year() < 1873)
+        return std::optional<String>(isoDate.year() > 0 ? String("ce"_s) : String("bce"_s));
+    return mapICUEraToTemporalEra(calendarId, icuEra);
+}
+
+// calendarEraYear — temporal_rs: Calendar::era_year (src/builtins/core/calendar.rs)
+//                   icu4x: Date::era_year (components/calendar/src/date.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal-calendarisotodate
+// CalendarISOToDate [[EraYear]] field:
+//   1. (iso8601) Return undefined.
+//   2. (non-ISO) NonISOCalendarISOToDate — implementation-defined.
+TemporalResult<std::optional<int32_t>> calendarEraYear(CalendarID calendarId, const ISO8601::PlainDate& isoDate)
+{
+    // 1. If calendarId has no eras, return undefined.
+    if (!calendarHasEras(calendarId))
+        return std::optional<int32_t>(std::nullopt);
+    // 2. Return the era year (year within the current era) of isoDate in calendarId.
+    // NOTE: Japanese "ce"/"bce" fallback: eraYear is the Gregorian year.
+    auto cal = openCalendar(calendarId);
+    if (!cal)
+        return makeUnexpected(rangeError("Failed to open ICU calendar"_s));
+    if (!setCalendarToISODate(cal.get(), isoDate))
+        return makeUnexpected(rangeError("Failed to set ICU calendar"_s));
+    UErrorCode status = U_ZERO_ERROR;
+    int32_t eraYear = ucal_get(cal.get(), UCAL_YEAR, &status);
+    if (U_FAILURE(status))
+        return makeUnexpected(rangeError("Failed to get era year from ICU"_s));
+    if (calendarId == japaneseCalendarID()) {
+        if (isoDate.year() < 1873)
+            eraYear = isoDate.year() > 0 ? isoDate.year() : (1 - isoDate.year());
+        else {
+            int32_t icuEra = ucal_get(cal.get(), UCAL_ERA, &status);
+            auto era = mapICUEraToTemporalEra(calendarId, icuEra);
+            if (era && *era == "ce"_s)
+                eraYear = isoDate.year();
+        }
+    }
+    return std::optional<int32_t>(eraYear);
+}
+
+// calendarDaysInMonth — temporal_rs: Calendar::days_in_month (src/builtins/core/calendar.rs)
+//                       icu4x: Date::days_in_month (components/calendar/src/date.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal-calendarisotodate
+// CalendarISOToDate [[DaysInMonth]] field:
+//   1. (iso8601) Return ISODaysInMonth(isoDate.[[Year]], isoDate.[[Month]]).
+//   2. (non-ISO) NonISOCalendarISOToDate — implementation-defined.
+TemporalResult<int32_t> calendarDaysInMonth(CalendarID calendarId, const ISO8601::PlainDate& isoDate)
+{
+    // 1. Return the number of days in the month containing isoDate in calendarId.
+    auto cal = openCalendar(calendarId);
+    if (!cal)
+        return makeUnexpected(rangeError("Failed to open ICU calendar"_s));
+    if (!setCalendarToISODate(cal.get(), isoDate))
+        return makeUnexpected(rangeError("Failed to set ICU calendar"_s));
+    UErrorCode status = U_ZERO_ERROR;
+    return ucal_getLimit(cal.get(), UCAL_DAY_OF_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
+}
+
+// calendarDaysInYear — temporal_rs: Calendar::days_in_year (src/builtins/core/calendar.rs)
+//                      icu4x: Date::days_in_year (components/calendar/src/date.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal-calendarisotodate
+// CalendarISOToDate [[DaysInYear]] field:
+//   1. (iso8601) Return MathematicalDaysInYear(isoDate.[[Year]]).
+//   2. (non-ISO) NonISOCalendarISOToDate — implementation-defined.
+TemporalResult<int32_t> calendarDaysInYear(CalendarID calendarId, const ISO8601::PlainDate& isoDate)
+{
+    // 1. Return the number of days in the year containing isoDate in calendarId.
+    auto cal = openCalendar(calendarId);
+    if (!cal)
+        return makeUnexpected(rangeError("Failed to open ICU calendar"_s));
+    if (!setCalendarToISODate(cal.get(), isoDate))
+        return makeUnexpected(rangeError("Failed to set ICU calendar"_s));
+    UErrorCode status = U_ZERO_ERROR;
+    return ucal_getLimit(cal.get(), UCAL_DAY_OF_YEAR, UCAL_ACTUAL_MAXIMUM, &status);
+}
+
+// calendarMonthsInYear — temporal_rs: Calendar::months_in_year (src/builtins/core/calendar.rs)
+//                        icu4x: Date::months_in_year (components/calendar/src/date.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal-calendarisotodate
+// CalendarISOToDate [[MonthsInYear]] field:
+//   1. (iso8601) Return 12.
+//   2. (non-ISO) NonISOCalendarISOToDate — implementation-defined.
+TemporalResult<int32_t> calendarMonthsInYear(CalendarID calendarId, const ISO8601::PlainDate& isoDate)
+{
+    // 1. Return the number of months in the year containing isoDate in calendarId.
+    // NOTE: Lunisolar calendars may have 12 or 13 months; requires walking all months.
+    auto cal = openCalendar(calendarId);
+    if (!cal)
+        return makeUnexpected(rangeError("Failed to open ICU calendar"_s));
+    if (!setCalendarToISODate(cal.get(), isoDate))
+        return makeUnexpected(rangeError("Failed to set ICU calendar"_s));
+    UErrorCode status = U_ZERO_ERROR;
+
+    if (calendarIsLunisolar(calendarId)) {
+        // For lunisolar calendars, count months by walking from month 1 to end of year.
+        // Save current state.
+        double savedMs = ucal_getMillis(cal.get(), &status);
+        int32_t savedYear = ucal_get(cal.get(), UCAL_EXTENDED_YEAR, &status); // Go to first day of first month.
+        ucal_set(cal.get(), UCAL_MONTH, 0);
+        ucal_set(cal.get(), UCAL_IS_LEAP_MONTH, 0);
+        ucal_set(cal.get(), UCAL_DAY_OF_MONTH, 1);
+        ucal_getMillis(cal.get(), &status); // resolve
+        int32_t count = 1;
+        for (int i = 0; i < 14; i++) {
+            ucal_add(cal.get(), UCAL_MONTH, 1, &status);
+            if (U_FAILURE(status))
+                break;
+            int32_t curYear = ucal_get(cal.get(), UCAL_EXTENDED_YEAR, &status);
+            if (curYear != savedYear)
+                break;
+            count++;
+        }
+        ucal_setMillis(cal.get(), savedMs, &status);
+        return count;
+    }
+
+    return ucal_getLimit(cal.get(), UCAL_MONTH, UCAL_ACTUAL_MAXIMUM, &status) + 1;
+}
+
+// calendarInLeapYear — temporal_rs: Calendar::in_leap_year (src/builtins/core/calendar.rs)
+//   temporal_rs delegates to icu4x: AnyCalendar::is_in_leap_year (components/calendar/src/date.rs)
+//   ICU4C has no equivalent: lunisolar mirrors icu4x (months > 12); non-lunisolar uses ucal_getLimit(UCAL_DAY_OF_YEAR).
+// https://tc39.es/proposal-temporal/#sec-temporal-calendarisotodate
+// CalendarISOToDate [[InLeapYear]] field:
+//   1. (iso8601) MathematicalInLeapYear(EpochTimeForYear(year)).
+//   2. (non-ISO) NonISOCalendarISOToDate — implementation-defined.
+TemporalResult<bool> calendarInLeapYear(CalendarID calendarId, const ISO8601::PlainDate& isoDate)
+{
+    // 1. Return true if isoDate falls in a leap year in calendarId.
+    // NOTE: Lunisolar calendars: leap = 13 months in year. Others: leap = extra days in year.
+    if (calendarIsLunisolar(calendarId)) {
+        auto months = calendarMonthsInYear(calendarId, isoDate);
+        if (!months)
+            return makeUnexpected(months.error());
+        return *months > 12;
+    }
+    auto cal = openCalendar(calendarId);
+    if (!cal)
+        return makeUnexpected(rangeError("Failed to open ICU calendar"_s));
+    if (!setCalendarToISODate(cal.get(), isoDate))
+        return makeUnexpected(rangeError("Failed to set ICU calendar"_s));
+    UErrorCode status = U_ZERO_ERROR;
+    int32_t actualMax = ucal_getLimit(cal.get(), UCAL_DAY_OF_YEAR, UCAL_ACTUAL_MAXIMUM, &status);
+    int32_t leastMax = ucal_getLimit(cal.get(), UCAL_DAY_OF_YEAR, UCAL_LEAST_MAXIMUM, &status);
+    if (U_FAILURE(status))
+        return makeUnexpected(rangeError("Failed to query leap year from ICU"_s));
+    return actualMax > leastMax;
+}
+
+// setCalendarToMonthCode — internal: sets ICU calendar to the first day of the month matching monthCode in the current year.
+// icu4x: ArithmeticDate::from_input_year_month_code_day (components/calendar/src/calendar_arithmetic.rs)
+// Returns: 1 = found exact, 0 = constrained (month code doesn't exist in year), -1 = error
+static int setCalendarToMonthCode(UCalendar* cal, CalendarID calendarId, const String& monthCode, UErrorCode& status)
+{
+    auto parsed = ISO8601::parseMonthCode(monthCode);
+    if (!parsed)
+        return -1;
+
+    if (calendarId == hebrewCalendarID()) {
+        // Hebrew: walk months in the target year to find the matching month code.
+        // NOTE: UCAL_ACTUAL_MAXIMUM is unreliable for Hebrew; walk is correct and safe.
+        int32_t savedYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
+        ucal_set(cal, UCAL_MONTH, 0);
+        ucal_set(cal, UCAL_IS_LEAP_MONTH, 0);
+        ucal_set(cal, UCAL_DAY_OF_MONTH, 1);
+        ucal_getMillis(cal, &status);
+        if (U_FAILURE(status))
+            return -1;
+
+        for (int i = 0; i < 15; i++) {
+            String curCode = computeMonthCode(cal, calendarId);
+            if (curCode == monthCode)
+                return 1; // exact match
+            ucal_add(cal, UCAL_MONTH, 1, &status);
+            if (U_FAILURE(status))
+                return -1;
+            if (ucal_get(cal, UCAL_EXTENDED_YEAR, &status) != savedYear) {
+                // Month code doesn't exist in this year.
+                // For M05L (Adar I), constrain to M06 (Adar, slot 5 in non-leap year).
+                ucal_set(cal, UCAL_EXTENDED_YEAR, savedYear);
+                ucal_set(cal, UCAL_MONTH, 5);
+                ucal_set(cal, UCAL_IS_LEAP_MONTH, 0);
+                ucal_set(cal, UCAL_DAY_OF_MONTH, 1);
+                return 0; // constrained
+            }
+        }
+        return -1;
+    }
+
+    // Chinese/Dangi: walk months from start of year to find matching month code.
+    int32_t savedYear = ucal_get(cal, UCAL_EXTENDED_YEAR, &status);
+    ucal_set(cal, UCAL_MONTH, 0);
+    ucal_set(cal, UCAL_IS_LEAP_MONTH, 0);
+    ucal_set(cal, UCAL_DAY_OF_MONTH, 1);
+    ucal_getMillis(cal, &status);
+    if (U_FAILURE(status))
+        return -1;
+
+    for (int i = 0; i < 14; i++) {
+        String curCode = computeMonthCode(cal, calendarId);
+        if (curCode == monthCode)
+            return 1; // exact match
+        ucal_add(cal, UCAL_MONTH, 1, &status);
+        if (U_FAILURE(status))
+            return -1;
+        if (ucal_get(cal, UCAL_EXTENDED_YEAR, &status) != savedYear) {
+            // Month code doesn't exist in this year — constrain to last month.
+            ucal_add(cal, UCAL_MONTH, -1, &status);
+            return 0; // constrained
+        }
+    }
+    return -1;
+}
+
+// compareSurpassesLexicographic — icu4x: compare_surpasses_lexicographic (components/calendar/src/calendar_arithmetic.rs)
+static bool compareSurpassesLexicographic(
+    int32_t sign, int32_t year, const String& monthCode, int32_t day,
+    int32_t targetYear, const String& targetMonthCode, int32_t targetDay)
+{
+    if (year != targetYear)
+        return sign * (static_cast<int64_t>(year) - targetYear) > 0;
+    if (monthCode != targetMonthCode) {
+        auto ordering = codePointCompare(monthCode, targetMonthCode);
+        return sign > 0 ? ordering > 0 : ordering < 0;
+    }
+    if (day != targetDay)
+        return sign * (static_cast<int64_t>(day) - targetDay) > 0;
+    return false;
+}
+
+// compareSurpassesOrdinally — icu4x: compare_surpasses_ordinal (components/calendar/src/calendar_arithmetic.rs)
+static bool compareSurpassesOrdinally(
+    int32_t sign, int32_t year, int32_t ordinalMonth, int32_t day,
+    int32_t targetYear, int32_t targetOrdinalMonth, int32_t targetDay)
+{
+    if (year != targetYear)
+        return sign * (static_cast<int64_t>(year) - targetYear) > 0;
+    if (ordinalMonth != targetOrdinalMonth)
+        return sign * (static_cast<int64_t>(ordinalMonth) - targetOrdinalMonth) > 0;
+    if (day != targetDay)
+        return sign * (static_cast<int64_t>(day) - targetDay) > 0;
+    return false;
+}
+
+// resolveMonthCodeToOrdinal — internal: resolves a monthCode to its 1-based ordinal position in the given year
+static int32_t resolveMonthCodeToOrdinal(CalendarID calendarId, const String& monthCode, int32_t year)
+{
+    auto cal = openCalendar(calendarId);
+    if (!cal)
+        return 1;
+    UErrorCode status = U_ZERO_ERROR;
+    ucal_set(cal.get(), UCAL_EXTENDED_YEAR, year);
+    ucal_set(cal.get(), UCAL_MONTH, 0);
+    ucal_set(cal.get(), UCAL_IS_LEAP_MONTH, 0);
+    ucal_set(cal.get(), UCAL_DAY_OF_MONTH, 1);
+    ucal_getMillis(cal.get(), &status);
+
+    int32_t savedYear = ucal_get(cal.get(), UCAL_EXTENDED_YEAR, &status);
+    int32_t lastOrdinal = 1;
+    for (int i = 0; i < 14; i++) {
+        String curCode = computeMonthCode(cal.get(), calendarId);
+        if (curCode == monthCode)
+            return i + 1;
+        if (codePointCompare(curCode, monthCode) > 0) {
+            // Hebrew M05L (Adar I) constrains FORWARD to M06 (Adar) in non-leap years.
+            // icu4x components/calendar/src/cal/hebrew.rs ordinal_from_month: M05L -> ordinal 6 with Overflow::Constrain.
+            // All other calendars constrain backward to the previous existing month.
+            if (calendarId == hebrewCalendarID() && monthCode == "M05L"_s)
+                return i + 1;
+            return lastOrdinal;
+        }
+        lastOrdinal = i + 1;
+        ucal_add(cal.get(), UCAL_MONTH, 1, &status);
+        if (U_FAILURE(status) || ucal_get(cal.get(), UCAL_EXTENDED_YEAR, &status) != savedYear)
+            return lastOrdinal;
+    }
+    return lastOrdinal;
+}
+
+// nonISODateSurpasses — icu4x: surpasses() (components/calendar/src/calendar_arithmetic.rs) — two-phase lexicographic + ordinal check
+static bool nonISODateSurpasses(
+    CalendarID calendarId,
+    int32_t sign,
+    int32_t sourceYear,
+    const String& sourceMonthCode,
+    int32_t sourceDay,
+    int32_t candidateYears,
+    int32_t targetYear,
+    const String& targetMonthCode,
+    int32_t targetOrdinalMonth,
+    int32_t targetDay)
+{
+    int32_t y0 = sourceYear + candidateYears; // Phase 1: lexicographic check (year, monthCode, day).
+    if (compareSurpassesLexicographic(sign, y0, sourceMonthCode, sourceDay, targetYear, targetMonthCode, targetDay))
+        return true; // Phase 2: constrain source monthCode to year y0, compare ordinally.
+    int32_t m0 = resolveMonthCodeToOrdinal(calendarId, sourceMonthCode, y0);
+    return compareSurpassesOrdinally(sign, y0, m0, sourceDay, targetYear, targetOrdinalMonth, targetDay);
+}
+
+// calendarDateAdd — temporal_rs: Calendar::date_add (src/builtins/core/calendar.rs)
+//   temporal_rs delegates to icu4x: AnyCalendar::add -> ArithmeticDate::added (components/calendar/src/calendar_arithmetic.rs)
+//   ICU4C has no equivalent: we use ucal_add(UCAL_EXTENDED_YEAR/UCAL_MONTH) with month-code re-resolution for lunisolar.
+// https://tc39.es/proposal-temporal/#sec-temporal-calendardateadd
+// CalendarDateAdd steps:
+//   1. If iso8601 -> isoDateAdd (BalanceISOYearMonth + RegulateISODate + AddDaysToISODate). (our steps 1–2)
+//   2. (else) NonISODateAdd — implementation-defined. (our steps 3–9)
+//   3. If ISODateWithinLimits(result) is false, throw RangeError. (checked via isoDateFromCalendarChecked)
+//   4. Return result.
+TemporalResult<ISO8601::PlainDate> calendarDateAdd(CalendarID calendarId, const ISO8601::PlainDate& isoDate, const ISO8601::Duration& duration, TemporalOverflow overflow)
+{
+    // 1. If calendarId is not a lunisolar calendar, use ISO proleptic-Gregorian arithmetic.
+    // NOTE: Non-lunisolar calendars share proleptic Gregorian arithmetic; bypass ICU (gregory uses Julian pre-1582).
+    if (!calendarIsLunisolar(calendarId))
+        return isoDateAdd(isoDate, duration, overflow);
+    // 2. If there are no year or month components, day/week addition is calendar-independent; use isoDateAdd.
+    // NOTE: ICU's Chinese/Dangi approximation gives wrong results for far-future dates (year > ~2100).
+    if (!duration.years() && !duration.months())
+        return isoDateAdd(isoDate, duration, overflow);
+    // 3. Let totalDays be duration.[[Days]] + 7 × duration.[[Weeks]].
+    // NOTE: ucal_add takes int32_t; any component outside int32_t exceeds Temporal's representable range.
+    auto fitsInt32 = [](int64_t v) -> bool {
+        return v >= INT32_MIN && v <= INT32_MAX;
+    };
+    int64_t totalDays64 = duration.days() + 7LL * duration.weeks();
+    if (!fitsInt32(duration.years()) || !fitsInt32(duration.months()) || !fitsInt32(totalDays64))
+        return makeUnexpected(rangeError("duration is out of the representable range"_s));
+
+    // 4. Open ICU calendar for calendarId.
+    auto cal = openCalendar(calendarId);
+    if (!cal)
+        return makeUnexpected(rangeError("Failed to open ICU calendar"_s));
+    // 5. Set ICU calendar to isoDate.
+    if (!setCalendarToISODate(cal.get(), isoDate))
+        return makeUnexpected(rangeError("Failed to set ICU calendar"_s));
+
+    // 6. Let origMonthCode and origDay be the source month code and day (preserved across year addition per icu4x).
+    UErrorCode status = U_ZERO_ERROR;
+    String origMonthCode = computeMonthCode(cal.get(), calendarId);
+    int32_t originalDay = ucal_get(cal.get(), UCAL_DAY_OF_MONTH, &status);
+    // 7. If duration.[[Years]] ≠ 0, add years; for lunisolar, re-resolve the original month code in the new year.
+    if (duration.years()) {
+        ucal_add(cal.get(), UCAL_EXTENDED_YEAR, static_cast<int32_t>(duration.years()), &status);
+        if (calendarIsLunisolar(calendarId)) {
+            int foundState = setCalendarToMonthCode(cal.get(), calendarId, origMonthCode, status);
+            if (foundState < 0)
+                return makeUnexpected(rangeError("Failed to resolve month code after year addition"_s));
+            //    a. If overflow is ~reject~ and month code doesn't exist in new year, throw RangeError.
+            if (!foundState && overflow == TemporalOverflow::Reject)
+                return makeUnexpected(rangeError("month code does not exist in the target year (overflow: reject)"_s));
+        }
+    }
+
+    // 8. If duration.[[Months]] ≠ 0, add months.
+    if (duration.months())
+        ucal_add(cal.get(), UCAL_MONTH, static_cast<int32_t>(duration.months()), &status);
+    // 9. Clamp or reject the day to the new month's maximum.
+    // NOTE: ucal_add already clamps for constrain. For reject, check if day was reduced.
+    // Do NOT use ucal_set(DAY_OF_MONTH) after ucal_add — causes ICU state corruption on lunisolar calendars.
+    int32_t maxDay = ucal_getLimit(cal.get(), UCAL_DAY_OF_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
+    if (overflow == TemporalOverflow::Reject && originalDay > maxDay)
+        return makeUnexpected(rangeError("day is out of range for the resulting month (overflow: reject)"_s));
+    int32_t curDay = ucal_get(cal.get(), UCAL_DAY_OF_MONTH, &status);
+    if (curDay != originalDay && originalDay <= maxDay) {
+        ucal_add(cal.get(), UCAL_DAY_OF_MONTH, originalDay - curDay, &status);
+    } else if (originalDay > maxDay) {
+        int32_t adj = maxDay - curDay;
+        if (adj)
+            ucal_add(cal.get(), UCAL_DAY_OF_MONTH, adj, &status);
+    }
+
+    // 10. Add totalDays.
+    int32_t totalDays = static_cast<int32_t>(totalDays64);
+    if (totalDays)
+        ucal_add(cal.get(), UCAL_DAY_OF_MONTH, totalDays, &status);
+
+    // 11. If result is outside representable range, throw RangeError.
+    if (U_FAILURE(status))
+        return makeUnexpected(rangeError("Calendar date addition failed"_s));
+
+    // 12. Return result.
+    auto result = isoDateFromCalendarChecked(cal.get());
+    if (!result)
+        return makeUnexpected(rangeError("Result of calendar date addition is outside representable range"_s));
+    return *result;
+}
+
+// surpassesMonths — icu4x: SurpassesChecker::surpasses_months (components/calendar/src/calendar_arithmetic.rs)
+static bool surpassesMonths(
+    UCalendar* trialCal,
+    CalendarID calendarId,
+    int32_t sign,
+    int32_t sourceDay,
+    int32_t targetYear,
+    const String& targetMonthCode,
+    int32_t targetOrdinalMonth,
+    int32_t targetDay,
+    UErrorCode& status)
+{
+    ucal_add(trialCal, UCAL_MONTH, sign, &status);
+    int32_t trialYear = ucal_get(trialCal, UCAL_EXTENDED_YEAR, &status);
+    String trialMonthCode = computeMonthCode(trialCal, calendarId);
+    return nonISODateSurpasses(calendarId, sign, trialYear, trialMonthCode, sourceDay, 0, targetYear, targetMonthCode, targetOrdinalMonth, targetDay);
+}
+
+// setMonths — icu4x: SurpassesChecker::set_months (components/calendar/src/calendar_arithmetic.rs)
+static void setMonths(UCalendar* cal, int32_t sourceDay, UErrorCode& status)
+{
+    int32_t maxDay = ucal_getLimit(cal, UCAL_DAY_OF_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
+    int32_t regulatedDay = std::min(sourceDay, maxDay);
+    int32_t currentDay = ucal_get(cal, UCAL_DAY_OF_MONTH, &status);
+    if (currentDay != regulatedDay)
+        ucal_add(cal, UCAL_DAY_OF_MONTH, regulatedDay - currentDay, &status);
+}
+
+// calendarDateUntil — temporal_rs: Calendar::date_until (src/builtins/core/calendar.rs)
+//   temporal_rs delegates to icu4x: AnyCalendar::until -> ArithmeticDate::until + SurpassesChecker (components/calendar/src/calendar_arithmetic.rs)
+//   ICU4C has no equivalent: we use epoch-ms comparison + iterative ucal_add(UCAL_MONTH) walking.
+// https://tc39.es/proposal-temporal/#sec-temporal-calendardateuntil
+// CalendarDateUntil steps:
+//   1. Let sign be CompareISODate(one, two). (our step 4)
+//   2. If sign = 0, return ZeroDateDuration(). (our step 4)
+//   3. If iso8601 -> diffISODate (ISODateSurpasses algorithm). (our steps 1–2)
+//   4. Return NonISODateUntil — implementation-defined. (our steps 3–8)
+TemporalResult<ISO8601::Duration> calendarDateUntil(CalendarID calendarId, const ISO8601::PlainDate& one, const ISO8601::PlainDate& two, TemporalUnit largestUnit)
+{
+    // 1. If calendarId is not lunisolar, use ISO proleptic-Gregorian arithmetic (route through diffISODate).
+    // NOTE: ICU's 'gregory' uses Julian before 1582, causing field mismatches; always route through ISO.
+    if (!calendarIsLunisolar(calendarId))
+        return diffISODate(one, two, largestUnit);
+    // 2. If largestUnit is ~day~ or ~week~, use pure ISO day count (calendar-independent).
+    // NOTE: ICU Chinese/Dangi epoch ms is approximate for dates beyond ~year 2100; pure ISO is exact.
+    if (largestUnit == TemporalUnit::Day || largestUnit == TemporalUnit::Week)
+        return diffISODate(one, two, largestUnit);
+
+    // 3. Open ICU calendars for both endpoints one and two.
+    auto cal1 = openCalendar(calendarId);
+    auto cal2 = openCalendar(calendarId);
+    if (!cal1 || !cal2)
+        return makeUnexpected(rangeError("Failed to open ICU calendar"_s));
+    if (!setCalendarToISODate(cal1.get(), one) || !setCalendarToISODate(cal2.get(), two))
+        return makeUnexpected(rangeError("Failed to set ICU calendar"_s));
+
+    // 4. Let sign be +1 if one < two, -1 if one > two, 0 if equal. Return zero duration if sign = 0.
+    UErrorCode status = U_ZERO_ERROR;
+    double epochMs1 = ucal_getMillis(cal1.get(), &status);
+    double epochMs2 = ucal_getMillis(cal2.get(), &status);
+    int32_t sign;
+    if (epochMs1 < epochMs2)
+        sign = 1;
+    else if (epochMs1 > epochMs2)
+        sign = -1;
+    else
+        return ISO8601::Duration { };
+    // 5. Read source (one) and target (two) calendar fields: year, monthCode, day, ordinalMonth.
+    int32_t sourceYear = ucal_get(cal1.get(), UCAL_EXTENDED_YEAR, &status);
+    String sourceMonthCode = computeMonthCode(cal1.get(), calendarId);
+    int32_t sourceDay = ucal_get(cal1.get(), UCAL_DAY_OF_MONTH, &status);
+    int32_t targetYear = ucal_get(cal2.get(), UCAL_EXTENDED_YEAR, &status);
+    String targetMonthCode = computeMonthCode(cal2.get(), calendarId);
+    int32_t targetDay = ucal_get(cal2.get(), UCAL_DAY_OF_MONTH, &status);
+    int32_t targetOrdinalMonth = computeOrdinalMonth(cal2.get(), calendarId);
+    // NOTE: min_years fast-forward: pre-guess year delta that doesn't surpass (icu4x optimization).
+    int32_t yearDiff = targetYear - sourceYear;
+    int32_t minYears = !yearDiff ? 0 : yearDiff - sign;
+
+    int32_t years = 0, months = 0, weeks = 0;
+
+    // 6. If largestUnit is ~year~ or ~month~, then
+    if (largestUnit == TemporalUnit::Year || largestUnit == TemporalUnit::Month) {
+
+        //    a. If largestUnit is ~year~: count full years using nonISODateSurpasses fast-forward.
+        if (largestUnit == TemporalUnit::Year) {
+            int64_t candidateYears = minYears ? minYears : sign;
+            auto yearDoesNotSurpass = [&] {
+                return !nonISODateSurpasses(calendarId, sign, sourceYear, sourceMonthCode, sourceDay, static_cast<int32_t>(candidateYears), targetYear, targetMonthCode, targetOrdinalMonth, targetDay);
+            };
+            while (yearDoesNotSurpass()) {
+                years = static_cast<int32_t>(candidateYears);
+                candidateYears += sign;
+            }
+            //       i. Set cal1 to (one + years) using calendarDateAdd (preserves month code).
+            if (years) {
+                ISO8601::Duration yearDur;
+                yearDur.setYears(static_cast<int64_t>(years));
+                auto advanced = calendarDateAdd(calendarId, one, yearDur, TemporalOverflow::Constrain);
+                if (!advanced)
+                    return makeUnexpected(advanced.error());
+                setCalendarToISODate(cal1.get(), *advanced);
+            }
+        }
+
+        //    b. Count full months from cal1 using surpassesMonths (day=1 to avoid clamping).
+        {
+            // NOTE: lunisolar months per year vary; iterate one at a time (no min_months fast-forward).
+            int32_t candidateMonths = sign;
+            //    c. Set cal1 to (one + years) with day=1 for clamping-free month advancement.
+            double startMs = ucal_getMillis(cal1.get(), &status);
+            ucal_set(cal1.get(), UCAL_DAY_OF_MONTH, 1);
+            ucal_getMillis(cal1.get(), &status); // force ICU state resolution
+
+            auto monthDoesNotSurpass = [&] {
+                return !surpassesMonths(cal1.get(), calendarId, sign, sourceDay, targetYear, targetMonthCode, targetOrdinalMonth, targetDay, status);
+            };
+            while (monthDoesNotSurpass()) {
+                months = candidateMonths;
+                candidateMonths += sign;
+            }
+
+            // Restore cal1 to (one + years), apply total months in one ucal_add (avoids undo asymmetry).
+            ucal_setMillis(cal1.get(), startMs, &status);
+            if (months)
+                ucal_add(cal1.get(), UCAL_MONTH, months, &status);
+            //    c. Apply regulated day = min(sourceDay, end_of_month) via setMonths.
+            setMonths(cal1.get(), sourceDay, status);
+            //    d. If largestUnit is ~month~, clear years (months were counted from one + years=0).
+            if (largestUnit == TemporalUnit::Month)
+                years = 0;
+        }
+    }
+
+    // 7. Compute remaining days from the epoch ms difference between cal1 and two.
+    const double msPerDay = 86'400'000.0; // nsPerDay / nsPerMillisecond
+    if (largestUnit == TemporalUnit::Week) {
+        double dayDiff = (epochMs2 - ucal_getMillis(cal1.get(), &status)) / msPerDay;
+        //    a. If largestUnit is ~week~, extract weeks = floor(daysDiff / 7) and remaining days.
+        weeks = static_cast<int32_t>(std::trunc(dayDiff / ISO8601::daysPerWeek));
+    }
+
+    // 8. Return Duration { years, months, weeks, days }.
+    double finalMs1 = ucal_getMillis(cal1.get(), &status);
+    double daysDiff = std::trunc((epochMs2 - finalMs1) / msPerDay);
+    if (largestUnit == TemporalUnit::Week)
+        daysDiff = std::trunc(std::fmod(daysDiff, static_cast<double>(ISO8601::daysPerWeek)));
+
+    return ISO8601::Duration {
+        years,
+        months,
+        weeks,
+        static_cast<int64_t>(daysDiff),
+        0, 0, 0, 0, Int128(0), Int128(0)
+    };
+}
+
+// ecmaReferenceYear — No spec AO and no ICU4C equivalent.
+// Ported from icu4x: ecma_reference_year (components/calendar/src/cal/east_asian_traditional.rs, hijri.rs, hebrew.rs, coptic.rs).
+// Returns the extended calendar year whose ISO date falls nearest 1972 for (monthNumber, isLeapMonth, day).
+int32_t ecmaReferenceYear(CalendarID calendarId, uint8_t monthNumber, bool isLeapMonth, uint8_t day)
+{
+    bool bigDay = day > 29;
+
+    if (calendarId == chineseCalendarID() || calendarId == dangiCalendarID()) {
+        // Ported from icu4x components/calendar/src/cal/east_asian_traditional.rs (Chinese/Dangi tables).
+        // Generated by icu4x's generate_reference_years tool.
+        if (!isLeapMonth) {
+            switch (monthNumber) {
+            case 1:
+                return bigDay ? 1970 : 1972;
+            case 2:
+                return 1972;
+            case 3:
+                return bigDay ? (calendarId == dangiCalendarID() ? 1968 : 1966) : 1972;
+            case 4:
+                return bigDay ? 1970 : 1972;
+            case 5:
+                return 1972;
+            case 6:
+                return bigDay ? 1971 : 1972;
+            case 7:
+                return 1972;
+            case 8:
+                return bigDay ? 1971 : 1972;
+            case 9:
+                return 1972;
+            case 10:
+                return 1972;
+            case 11:
+                // icu4x: (11,false,true)=>1969, (11,false,false) if day>26=>1971, else=>1972
+                // bigDay (day>29) must be checked BEFORE day>26 since both can be true.
+                if (bigDay)
+                    return 1969;
+                return (day > 26) ? 1971 : 1972;
+            case 12:
+                return 1971;
+            default:
+                return 1972;
+            }
+        }
+        // Leap months — icu4x components/calendar/src/cal/east_asian_traditional.rs:ecma_reference_year_common
+        // Entries matching UseRegularIfConstrain return ecmaRefYearUseRegular:
+        // caller uses non-leap month reference year for Constrain, throws for Reject.
+        switch (monthNumber) {
+        case 1:
+            return ecmaRefYearUseRegular; // icu4x: (1, true, _) => UseRegularIfConstrain
+        case 2:
+            return bigDay ? ecmaRefYearUseRegular : 1947;
+        case 3:
+            return bigDay ? 1955 : 1966;
+        case 4:
+            return bigDay ? 1944 : 1963;
+        case 5:
+            return bigDay ? 1952 : 1971;
+        case 6:
+            return bigDay ? 1941 : 1960;
+        case 7:
+            return bigDay ? 1938 : 1968;
+        case 8:
+            return bigDay ? ecmaRefYearUseRegular : 1957;
+        case 9:
+            return bigDay ? ecmaRefYearUseRegular : 2014;
+        case 10:
+            return bigDay ? ecmaRefYearUseRegular : 1984;
+        case 11:
+            return bigDay ? ecmaRefYearUseRegular : 2033;
+        case 12:
+            return ecmaRefYearUseRegular; // icu4x: (12, true, _) => UseRegularIfConstrain
+        default:
+            return 1972;
+        }
+    }
+
+    if (calendarIsIslamic(calendarId)) {
+        // icu4x components/calendar/src/cal/hijri.rs: Islamic calendars have no leap months.
+        if (isLeapMonth)
+            return ecmaRefYearNotInCalendar;
+        // icu4x components/calendar/src/cal/hijri.rs: Islamic-civil and Islamic-tbla (tabular) use a simpler table
+        // than UmmAlQura. All months 1-10 use year 1392 for tabular variants.
+        // Month 11 threshold differs: civil (Friday epoch) = day < 26, tbla (Thu) = day < 27.
+        bool isCivil = (calendarId == islamicCivilCalendarID());
+        bool isTbla = (calendarId == islamicTblaCalendarID());
+        if (isCivil || isTbla) {
+            // icu4x: TabularAlgorithm::ecma_reference_year (components/calendar/src/cal/hijri.rs)
+            if (monthNumber <= 10)
+                return 1392;
+            if (monthNumber == 11)
+                return (day < (isCivil ? 26 : 27)) ? 1392 : 1391;
+            if (monthNumber == 12)
+                return bigDay ? 1390 : 1391;
+            return 1392;
+        }
+
+        // UmmAlQura table — icu4x: UmmAlQura::ecma_reference_year (components/calendar/src/cal/hijri.rs)
+        switch (monthNumber) {
+        case 1:
+            return 1392;
+        case 2:
+            return bigDay ? 1390 : 1392;
+        case 3:
+            return bigDay ? 1391 : 1392;
+        case 4:
+            return 1392;
+        case 5:
+            return bigDay ? 1391 : 1392;
+        case 6:
+            return 1392;
+        case 7:
+            return bigDay ? 1389 : 1392;
+        case 8:
+            return 1392;
+        case 9:
+            return 1392;
+        case 10:
+            return bigDay ? 1390 : 1392;
+        case 11:
+            return (day > 25) ? 1391 : 1392;
+        case 12:
+            return bigDay ? 1390 : 1391;
+        default:
+            return 1392;
+        }
+    }
+
+    if (calendarId == hebrewCalendarID()) {
+        // Hebrew: ported from icu4x components/calendar/src/cal/hebrew.rs reference_year_from_month_day.
+        // Dec 31, 1972 = Hebrew 4th month (Tevet), day 26, year 5733 AM.
+        // Returns Hebrew UCAL_EXTENDED_YEAR (anno mundi year).
+        if (isLeapMonth) {
+            // icu4x components/calendar/src/cal/hebrew.rs: only M05L (Adar I) is valid; all other leap months don't exist.
+            if (monthNumber == 5)
+                return 5730;
+            return ecmaRefYearNotInCalendar; // M01L, M02L, etc. are invalid in Hebrew
+        }
+        switch (monthNumber) {
+        case 1:
+            return 5733; // Tishri: all days fit
+        case 2:
+            return day <= 29 ? 5733 : 5732; // Cheshvan: 5733 has 29 days
+        case 3:
+            return day <= 29 ? 5733 : 5732; // Kislev: 5733 has 29 days
+        case 4:
+            return day <= 26 ? 5733 : 5732; // Tevet: Dec 31 = 4/26/5733
+        default:
+            return 5732; // M05-M12
+        }
+    }
+
+    if (calendarId == copticCalendarID() || calendarId == ethiopicCalendarID()) {
+        // Coptic/Ethiopian: ported from icu4x components/calendar/src/cal/coptic.rs reference_year_from_month_day.
+        // Dec 31, 1972 = Coptic 4th month (Koiak), day 22, year 1689 AM.
+        // Returns Coptic/Ethiopian UCAL_EXTENDED_YEAR.
+        // icu4x components/calendar/src/cal/coptic.rs: Coptic AM reference years (Dec 31, 1972 = Coptic 1689 M04 day22).
+        // Ethiopic (Amete Mihret): Ethiopic extended year = Coptic AM year + 276.
+        // (Coptic epoch 284 CE, Ethiopic epoch 8 CE: difference = 276 years.)
+        int32_t copticYear;
+        if (monthNumber < 4 || (monthNumber == 4 && day <= 22))
+            copticYear = 1689;
+        else if (monthNumber == 13 && day >= 6)
+            copticYear = 1687; // leap year
+        else
+            copticYear = 1688;
+        return (calendarId == ethiopicCalendarID()) ? copticYear + 276 : copticYear;
+    }
+
+    if (calendarId == ethioaaCalendarID()) {
+        // Ethioaa (Amete Alem): same month structure as Ethiopic/Coptic, but different year offset.
+        // ISO 1972-12-31 = Ethioaa 7465, M04, day 22. Offset from Coptic: Ethioaa = Coptic + 5776.
+        // M13 leap year nearest to Dec 31, 1972: year 7463 (ISO 1971).
+        if (isLeapMonth)
+            return 7464;
+        if (monthNumber < 4 || (monthNumber == 4 && day <= 22))
+            return 7465;
+        if (monthNumber == 13 && day >= 6)
+            return 7463; // leap year
+        return 7464;
+    }
+
+    if (calendarId == persianCalendarID()) {
+        // Persian (Jalali): ported from icu4x components/calendar/src/cal/persian.rs reference_year_from_month_day.
+        // Dec 31, 1972 = 10th month (Dey), day 10, year 1351 AP.
+        if (monthNumber < 10 || (monthNumber == 10 && day <= 10))
+            return 1351;
+        return 1350; // 1350 AP is a leap year
+    }
+
+    if (calendarId == indianCalendarID()) {
+        // Indian (Saka): ported from icu4x components/calendar/src/cal/indian.rs reference_year_from_month_day.
+        // Dec 31, 1972 = 10th month, day 10, year 1894 Shaka.
+        if (monthNumber < 10 || (monthNumber == 10 && day <= 10))
+            return 1894;
+        return 1893;
+    }
+
+    if (calendarId == buddhistCalendarID()) {
+        // Buddhist: ICU4C UCAL_EXTENDED_YEAR for Buddhist = ISO/Gregorian year (not Buddhist era year).
+        // So ISO year 1972 is the reference — same as gregory/japanese.
+        return 1972;
+    }
+
+    if (calendarId == rocCalendarID()) {
+        // ROC: handled via era+eraYear in calendarDateFromFields (year 61 = ROC era 1, year 61).
+        // ROC year 61 = ISO year 1972.
+        return 61;
+    }
+
+    // Japanese/Gregory/ISO and indic numeral-only calendars:
+    // UCAL_EXTENDED_YEAR for these = Gregorian/ISO year.
+    return 1972;
+}
+
+// calendarDateFromFields — temporal_rs: Calendar::date_from_fields (src/builtins/core/calendar.rs)
+//   temporal_rs delegates to icu4x: ArithmeticDate::from_fields (components/calendar/src/calendar_arithmetic.rs)
+//   ICU4C has no equivalent: we implement the same field-resolution logic using ucal_set + ucal_get.
+// https://tc39.es/proposal-temporal/#sec-temporal-calendardatefromfields
+// CalendarDateFromFields steps 1-4 (CalendarResolveFields is done by the JS-layer caller):
+//   1. (Resolved by caller.)
+//   2. Let result be ? CalendarDateToISO(calendar, fields, overflow).
+//      -> iso8601: handled by the JS layer before reaching here.
+//      -> non-ISO: implementation-defined (NonISOCalendarDateToISO); no concrete spec steps.
+//   3. If ISODateWithinLimits(result) is false, throw a RangeError.  (checked via isoDateFromCalendarChecked)
+//   4. Return result.
+TemporalResult<ISO8601::PlainDate> calendarDateFromFields(CalendarID calendarId, int32_t year, uint8_t month, uint8_t day, std::optional<StringView> era, std::optional<int32_t> eraYear, std::optional<ParsedMonthCode> monthCode, TemporalOverflow overflow)
+{
+    auto cal = openCalendar(calendarId);
+    if (!cal)
+        return makeUnexpected(rangeError("Failed to open ICU calendar"_s));
+
+    UErrorCode status = U_ZERO_ERROR;
+    ucal_clear(cal.get());
+
+    if (era && eraYear) {
+        // Japanese "ce"/"bce": eraYear IS the Gregorian year. Use ISO date path.
+        if (calendarId == japaneseCalendarID() && (*era == "ce"_s || *era == "bce"_s)) {
+            int32_t isoYear = *era == "bce"_s ? (1 - *eraYear) : *eraYear; // For Japanese "ce"/"bce" eras, the year IS the ISO year — bypass ICU to avoid
+            // Julian/Gregorian calendar switch issues for pre-1582 dates. Apply overflow.
+            uint8_t resolvedDay = day;
+            uint8_t daysInMo = static_cast<uint8_t>(ISO8601::daysInMonth(isoYear, month));
+            if (day > daysInMo) {
+                if (overflow == TemporalOverflow::Reject)
+                    return makeUnexpected(rangeError("Day is out of range for the given month"_s));
+                resolvedDay = daysInMo;
+            }
+            return ISO8601::PlainDate(isoYear, month, resolvedDay);
+        }
+        int32_t icuEra = mapTemporalEraToICUEra(calendarId, *era);
+        if (icuEra < 0)
+            return makeUnexpected(rangeError("era is not valid for this calendar"_s));
+        ucal_set(cal.get(), UCAL_ERA, icuEra);
+        ucal_set(cal.get(), UCAL_YEAR, *eraYear);
+    } else if (calendarId == rocCalendarID()) {
+        // ROC: convert temporal year to era+eraYear for ICU.
+        if (year <= 0) {
+            ucal_set(cal.get(), UCAL_ERA, 0); // broc
+            ucal_set(cal.get(), UCAL_YEAR, 1 - year);
+        } else {
+            ucal_set(cal.get(), UCAL_ERA, 1); // roc
+            ucal_set(cal.get(), UCAL_YEAR, year);
+        }
+    } else
+        ucal_set(cal.get(), UCAL_EXTENDED_YEAR, year);
+
+    if (monthCode) {
+        // Month codes > M13 are always invalid. M13 is only valid for Coptic/Ethiopian.
+        if (monthCode->monthNumber > 13)
+            return makeUnexpected(rangeError("month is out of range"_s));
+        if (monthCode->monthNumber == 13
+            && calendarId != copticCalendarID() && calendarId != ethiopicCalendarID() && calendarId != ethioaaCalendarID())
+            return makeUnexpected(rangeError("month is out of range"_s));
+
+        if (calendarIsLunisolar(calendarId)) {
+            // Lunisolar: walk months from start of year to find target monthCode.
+            // ICU4X uses precomputed year.packed.leap_month() for O(1) lookup; ICU4C
+            // doesn't expose this data, so we walk. The walk is correct and safe.
+            ucal_set(cal.get(), UCAL_MONTH, 0);
+            ucal_set(cal.get(), UCAL_IS_LEAP_MONTH, 0);
+            ucal_set(cal.get(), UCAL_DAY_OF_MONTH, 1);
+            ucal_getMillis(cal.get(), &status);
+
+            String targetCode = makeString("M"_s, monthCode->monthNumber < 10 ? "0"_s : ""_s,
+                monthCode->monthNumber, monthCode->isLeapMonth ? "L"_s : ""_s);
+            int32_t savedYear = ucal_get(cal.get(), UCAL_EXTENDED_YEAR, &status);
+            bool found = false;
+            for (int i = 0; i < 14; i++) {
+                String curCode = computeMonthCode(cal.get(), calendarId);
+                if (curCode == targetCode) {
+                    found = true;
+                    break;
+                }
+                // For constrain: if we've passed the target code, stop at previous.
+                if (codePointCompare(curCode, targetCode) > 0) {
+                    // Leap month doesn't exist — constrain to previous month.
+                    if (overflow == TemporalOverflow::Constrain && monthCode->isLeapMonth) {
+                        if (calendarId == hebrewCalendarID()) {
+                            // M05L -> M06 (Adar), which is this current month.
+                            found = true;
+                        } else {
+                            // Chinese/Dangi: M01L->M01, revert one step.
+                            ucal_add(cal.get(), UCAL_MONTH, -1, &status);
+                            found = true;
+                        }
+                    }
+                    break;
+                }
+                ucal_add(cal.get(), UCAL_MONTH, 1, &status);
+                if (U_FAILURE(status) || ucal_get(cal.get(), UCAL_EXTENDED_YEAR, &status) != savedYear) {
+                    ucal_add(cal.get(), UCAL_MONTH, -1, &status);
+                    break;
+                }
+            }
+            if (!found && overflow == TemporalOverflow::Reject)
+                return makeUnexpected(rangeError("monthCode does not exist in this calendar year"_s)); // Clamp day via ucal_add.
+            int32_t maxDay = ucal_getLimit(cal.get(), UCAL_DAY_OF_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
+            uint8_t clampedDay = day;
+            if (day > maxDay) {
+                if (overflow == TemporalOverflow::Reject)
+                    return makeUnexpected(rangeError("Day is out of range for the given month in this calendar"_s));
+                clampedDay = static_cast<uint8_t>(maxDay);
+            }
+            if (clampedDay > 1)
+                ucal_add(cal.get(), UCAL_DAY_OF_MONTH, clampedDay - 1, &status);
+        } else if (calendarId == hebrewCalendarID()) {
+            // Hebrew non-lunisolar path — shouldn't reach here since Hebrew IS lunisolar.
+            ASSERT_NOT_REACHED();
+            return makeUnexpected(rangeError("unexpected hebrew non-lunisolar path"_s));
+        } else {
+            // Non-lunisolar with monthCode (Gregorian-based calendars).
+            // Set month with day=1 first to avoid ICU normalizing out-of-range day.
+            ucal_set(cal.get(), UCAL_MONTH, monthCode->monthNumber - 1);
+            if (monthCode->isLeapMonth)
+                ucal_set(cal.get(), UCAL_IS_LEAP_MONTH, 1);
+            ucal_set(cal.get(), UCAL_DAY_OF_MONTH, 1);
+            ucal_getMillis(cal.get(), &status); // force resolution of year+month
+
+            // Now check maxDay for the resolved month.
+            int32_t maxDay = ucal_getLimit(cal.get(), UCAL_DAY_OF_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
+            if (day > maxDay) {
+                if (overflow == TemporalOverflow::Reject)
+                    return makeUnexpected(rangeError("Day is out of range for the given month in this calendar"_s));
+                ucal_set(cal.get(), UCAL_DAY_OF_MONTH, maxDay);
+            } else if (day > 1)
+                ucal_set(cal.get(), UCAL_DAY_OF_MONTH, day);
+        }
+    } else if (calendarIsLunisolar(calendarId)) {
+        // For lunisolar calendars, 'month' is the ordinal month (1-indexed).
+        // Count monthsInYear using a separate calendar to avoid state corruption.
+        ucal_set(cal.get(), UCAL_MONTH, 0);
+        ucal_set(cal.get(), UCAL_IS_LEAP_MONTH, 0);
+        ucal_set(cal.get(), UCAL_DAY_OF_MONTH, 1);
+        ucal_getMillis(cal.get(), &status);
+        if (U_FAILURE(status))
+            return makeUnexpected(rangeError("Failed to resolve lunisolar calendar"_s)); // Use a separate calendar to count months in year.
+        auto countCal = openCalendar(calendarId);
+        if (!countCal)
+            return makeUnexpected(rangeError("Failed to open counting calendar"_s));
+        ucal_setMillis(countCal.get(), ucal_getMillis(cal.get(), &status), &status);
+        int32_t savedYear = ucal_get(countCal.get(), UCAL_EXTENDED_YEAR, &status);
+        int32_t monthsInYear = 1;
+        for (int i = 0; i < 14; i++) {
+            ucal_add(countCal.get(), UCAL_MONTH, 1, &status);
+            if (U_FAILURE(status))
+                break;
+            if (ucal_get(countCal.get(), UCAL_EXTENDED_YEAR, &status) != savedYear)
+                break;
+            monthsInYear++;
+        }
+
+        // Clamp or reject month against monthsInYear.
+        uint8_t resolvedMonth = month;
+        if (month > monthsInYear) {
+            if (overflow == TemporalOverflow::Reject)
+                return makeUnexpected(rangeError("month is out of range for this calendar year"_s));
+            resolvedMonth = static_cast<uint8_t>(monthsInYear);
+        }
+
+        // Advance the original calendar to the target month.
+        if (resolvedMonth > 1) {
+            ucal_add(cal.get(), UCAL_MONTH, resolvedMonth - 1, &status);
+            if (U_FAILURE(status))
+                return makeUnexpected(rangeError("Failed to resolve lunisolar month"_s));
+        }
+
+        // Clamp day to daysInMonth if constrain.
+        int32_t maxDay = ucal_getLimit(cal.get(), UCAL_DAY_OF_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
+        uint8_t resolvedDay = day;
+        if (day > maxDay) {
+            if (overflow == TemporalOverflow::Reject)
+                return makeUnexpected(rangeError("Day is out of range for the given month in this calendar"_s));
+            resolvedDay = static_cast<uint8_t>(maxDay);
+        }
+        // Use ucal_add (not ucal_set) to advance within the month — avoids
+        // ICU's lazy-field resolution resetting the month position.
+        if (resolvedDay > 1)
+            ucal_add(cal.get(), UCAL_DAY_OF_MONTH, resolvedDay - 1, &status);
+    } else {
+        // Non-lunisolar: clamp month to calendar max.
+        int32_t maxMonth = ucal_getLimit(cal.get(), UCAL_MONTH, UCAL_ACTUAL_MAXIMUM, &status) + 1;
+        uint8_t resolvedMonth = month;
+        if (month > maxMonth) {
+            if (overflow == TemporalOverflow::Reject)
+                return makeUnexpected(rangeError("month is out of range for this calendar"_s));
+            resolvedMonth = static_cast<uint8_t>(maxMonth);
+        }
+        ucal_set(cal.get(), UCAL_MONTH, resolvedMonth - 1); // Resolve to get actual max day for this month.
+        ucal_set(cal.get(), UCAL_DAY_OF_MONTH, 1);
+        int32_t maxDay = ucal_getLimit(cal.get(), UCAL_DAY_OF_MONTH, UCAL_ACTUAL_MAXIMUM, &status);
+        uint8_t resolvedDay = day;
+        if (day > maxDay) {
+            if (overflow == TemporalOverflow::Reject)
+                return makeUnexpected(rangeError("Day is out of range for the given month in this calendar"_s));
+            resolvedDay = static_cast<uint8_t>(maxDay);
+        }
+        ucal_set(cal.get(), UCAL_DAY_OF_MONTH, resolvedDay);
+    }
+
+    if (overflow == TemporalOverflow::Reject) {
+        int32_t resolvedDay = ucal_get(cal.get(), UCAL_DAY_OF_MONTH, &status);
+        if (U_FAILURE(status))
+            return makeUnexpected(rangeError("Failed to resolve calendar date"_s));
+        if (monthCode) {
+            if (calendarIsLunisolar(calendarId)) {
+                // For lunisolar calendars, ICU slot numbers != monthCode numbers (e.g. Hebrew
+                // M05L at slot 5 gives UCAL_MONTH+1=6, and ICU4C never sets IS_LEAP_MONTH).
+                // Use computeMonthCode to verify the actual month — the walk already positioned
+                // the calendar at the target month, so we only need to verify the day.
+                if (resolvedDay != static_cast<int32_t>(day))
+                    return makeUnexpected(rangeError("Day is out of range for the given month in this calendar"_s));
+            } else {
+                int32_t resolvedMonth = ucal_get(cal.get(), UCAL_MONTH, &status) + 1;
+                int32_t resolvedLeap = ucal_get(cal.get(), UCAL_IS_LEAP_MONTH, &status);
+                bool leapMismatch = monthCode->isLeapMonth && !resolvedLeap;
+                if (resolvedDay != static_cast<int32_t>(day) || resolvedMonth != static_cast<int32_t>(monthCode->monthNumber) || leapMismatch)
+                    return makeUnexpected(rangeError("Day is out of range for the given month in this calendar"_s));
+            }
+        }
+    }
+
+    // For constrain with a leap monthCode that doesn't exist: ICU silently drops the leap
+    // flag and lands on the non-leap version of the month, which is the correct constrain
+    // behavior. No explicit fallback is needed.
+
+    return isoDateFromCalendar(cal.get());
+}
+
+} // namespace TemporalCore
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.h
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.h
@@ -1,0 +1,132 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+// JSC Temporal Core — ICU calendar bridge
+// temporal_rs reference: src/builtins/core/calendar.rs
+// Last synced: v0.2.3
+
+#include <JavaScriptCore/ISO8601.h>
+#include <JavaScriptCore/IntlObject.h>
+#include <JavaScriptCore/JSExportMacros.h>
+#include <JavaScriptCore/TemporalCoreTypes.h>
+#include <JavaScriptCore/TemporalEnums.h>
+#include <optional>
+#include <wtf/text/WTFString.h>
+
+namespace JSC {
+namespace TemporalCore {
+
+// CalendarFields — extracted calendar representation of an ISO date.
+// temporal_rs: icu4x AnyCalendarDate fields (year, month, day, era, monthCode)
+struct CalendarFields {
+    int32_t year { 0 };
+    uint8_t month { 1 };
+    uint8_t day { 1 };
+    bool isLeapMonth { false };
+    std::optional<String> era;
+    std::optional<int32_t> eraYear;
+    String monthCode;
+};
+
+CalendarID JS_EXPORT_PRIVATE calendarIDFromString(StringView);
+
+inline StringView calendarIDToString(CalendarID id) { return intlAvailableCalendars()[id]; }
+
+inline bool calendarIsISO(CalendarID id) { return id == iso8601CalendarID(); }
+
+// calendarHasEras — true for calendars that expose era/eraYear fields in Temporal.
+// Covers the 15 spec-defined era-bearing calendars; unknown future calendars default to false.
+inline bool calendarHasEras(CalendarID id)
+{
+    return id == buddhistCalendarID() || id == copticCalendarID() || id == ethioaaCalendarID()
+        || id == ethiopicCalendarID() || id == gregoryCalendarID() || id == hebrewCalendarID()
+        || id == indianCalendarID() || id == islamicCalendarID() || id == islamicCivilCalendarID()
+        || id == islamicRgsaCalendarID() || id == islamicTblaCalendarID() || id == islamicUmalquraCalendarID()
+        || id == japaneseCalendarID() || id == persianCalendarID() || id == rocCalendarID();
+}
+
+// calendarIsLunisolar — true for calendars with leap months (Chinese, Dangi, Hebrew).
+// NOTE: temporal_rs Calendar::is_iso() returns true for ISO8601 (opposite semantic).
+inline bool calendarIsLunisolar(CalendarID id)
+{
+    return id == chineseCalendarID() || id == dangiCalendarID() || id == hebrewCalendarID();
+}
+
+// Returns true for any Islamic calendar variant.
+inline bool calendarIsIslamic(CalendarID id)
+{
+    return id == islamicCalendarID() || id == islamicCivilCalendarID() || id == islamicRgsaCalendarID()
+        || id == islamicTblaCalendarID() || id == islamicUmalquraCalendarID();
+}
+
+TemporalResult<CalendarFields> isoToCalendarFields(CalendarID, const ISO8601::PlainDate& isoDate);
+
+TemporalResult<int32_t> JS_EXPORT_PRIVATE calendarYear(CalendarID, const ISO8601::PlainDate& isoDate);
+
+TemporalResult<uint8_t> JS_EXPORT_PRIVATE calendarMonth(CalendarID, const ISO8601::PlainDate& isoDate);
+
+TemporalResult<String> JS_EXPORT_PRIVATE calendarMonthCode(CalendarID, const ISO8601::PlainDate& isoDate);
+
+TemporalResult<uint8_t> JS_EXPORT_PRIVATE calendarDay(CalendarID, const ISO8601::PlainDate& isoDate);
+
+TemporalResult<std::optional<String>> JS_EXPORT_PRIVATE calendarEra(CalendarID, const ISO8601::PlainDate& isoDate);
+
+TemporalResult<std::optional<int32_t>> JS_EXPORT_PRIVATE calendarEraYear(CalendarID, const ISO8601::PlainDate& isoDate);
+
+TemporalResult<int32_t> JS_EXPORT_PRIVATE calendarDaysInMonth(CalendarID, const ISO8601::PlainDate& isoDate);
+
+TemporalResult<int32_t> JS_EXPORT_PRIVATE calendarDaysInYear(CalendarID, const ISO8601::PlainDate& isoDate);
+
+TemporalResult<int32_t> JS_EXPORT_PRIVATE calendarMonthsInYear(CalendarID, const ISO8601::PlainDate& isoDate);
+
+TemporalResult<bool> JS_EXPORT_PRIVATE calendarInLeapYear(CalendarID, const ISO8601::PlainDate& isoDate);
+
+TemporalResult<ISO8601::PlainDate> JS_EXPORT_PRIVATE calendarDateAdd(CalendarID, const ISO8601::PlainDate& isoDate, const ISO8601::Duration&, TemporalOverflow);
+
+TemporalResult<ISO8601::Duration> calendarDateUntil(CalendarID, const ISO8601::PlainDate& one, const ISO8601::PlainDate& two, TemporalUnit largestUnit);
+
+// EcmaReferenceYear — returns the extended calendar year whose ISO date falls nearest 1972 for (monthNumber, day).
+// Used by PlainMonthDay to choose a stable reference ISO year for non-ISO calendars.
+// Sentinel: ecmaReferenceYear returns this when the leap month doesn't exist near 1972
+// and the caller should use the non-leap month reference year if overflow=Constrain,
+// or throw RangeError if overflow=Reject.
+// icu4x: EcmaReferenceYearError::UseRegularIfConstrain
+static constexpr int32_t ecmaRefYearUseRegular = INT32_MIN;
+
+// Sentinel: ecmaReferenceYear returns this when the month code is invalid for this calendar
+// (the month simply doesn't exist, regardless of overflow mode).
+// icu4x: EcmaReferenceYearError::MonthNotInCalendar
+static constexpr int32_t ecmaRefYearNotInCalendar = INT32_MIN + 1;
+
+int32_t ecmaReferenceYear(CalendarID, uint8_t monthNumber, bool isLeapMonth, uint8_t day);
+
+bool JS_EXPORT_PRIVATE chineseCalendarUsesEpochOffset();
+
+TemporalResult<ISO8601::PlainDate> JS_EXPORT_PRIVATE calendarDateFromFields(CalendarID, int32_t year, uint8_t month, uint8_t day, std::optional<StringView> era, std::optional<int32_t> eraYear, std::optional<ParsedMonthCode>, TemporalOverflow);
+
+} // namespace TemporalCore
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/temporal/core/ICUCalendarStubs.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/ICUCalendarStubs.cpp
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Stub implementations for ICU calendar/formatter APIs not exported by
+// the PlayStation SDK's libSceIcu_stub_weak.a.
+//
+// PlayStation's ICU exports only *read/epoch-set* APIs:
+//   ucal_open, ucal_close, ucal_get, ucal_setMillis, ucal_setGregorianChange
+//
+// Missing (stubbed here):
+//   Write/mutation: ucal_set, ucal_setDateTime, ucal_add, ucal_clear, ucal_getLimit,
+//                   ucal_setTimeZone, ucal_getTimeZoneTransitionDate
+//   Formatter: udat_clone, udat_applyPattern
+//
+// Degradation contract:
+//   - Stubs that have UErrorCode* set U_UNSUPPORTED_ERROR so our U_FAILURE(status)
+//     guards return TemporalResult errors, which surface as RangeError in JavaScript.
+//   - ucal_set has no UErrorCode* (ICU API design), so it cannot signal failure.
+//     It is safe as a no-op because every caller either:
+//     (a) follows it with ucal_getMillis (stubbed → error caught), or
+//     (b) uses setCalendarToISODate (which calls ucal_setMillis, not ucal_set) first.
+//
+// Temporal operations on PlayStation:
+//   WORK: PlainDate/Time/DateTime, Instant, Duration (pure ISO arithmetic)
+//          ZonedDateTime with UTC-offset timezones (isUTCOffset() fast path)
+//          getOffsetNanosecondsFor on named TZs (uses ucal_setMillis + ucal_get)
+//          Non-ISO calendar property getters for non-lunisolar calendars
+//            (isoToCalendarFields via ucal_setMillis + ucal_get; computeOrdinalMonth = UCAL_MONTH+1)
+//   WRONG RESULTS (silent): lunisolar calendars (Chinese, Dangi, Hebrew) property getters
+//            (computeOrdinalMonth saves/restores state via ucal_getMillis which returns 0)
+//   THROW RangeError:
+//          ZonedDateTime with named timezones (getPossibleEpochNanosecondsFor needs ucal_setDateTime)
+//          Calendar arithmetic: add/diff for non-ISO calendars (needs ucal_add/getMillis)
+//          getTimeZoneTransition (needs ucal_getTimeZoneTransitionDate)
+
+#include "config.h"
+
+#if PLATFORM(PLAYSTATION)
+
+#include <unicode/ucal.h>
+#include <unicode/udat.h>
+
+// These extern "C" stubs use ICU's C naming convention (underscores) intentionally.
+// NOLINT(readability/naming/underscores)
+extern "C" {
+
+// ucal_set has no UErrorCode* — cannot propagate failure. Safe as no-op because
+// callers always follow it with ucal_getMillis (stubbed) or ucal_add (stubbed).
+void ucal_set(UCalendar* /*cal*/, UCalendarDateFields /*field*/, int32_t /*value*/) // NOLINT
+{
+}
+
+void ucal_setDateTime(UCalendar* /*cal*/, int32_t /*year*/, int32_t /*month*/, int32_t /*date*/, // NOLINT
+    int32_t /*hour*/, int32_t /*minute*/, int32_t /*second*/, UErrorCode* status)
+{
+    if (status && U_SUCCESS(*status))
+        *status = U_UNSUPPORTED_ERROR;
+}
+
+double ucal_getMillis(const UCalendar* /*cal*/, UErrorCode* status) // NOLINT
+{
+    if (status && U_SUCCESS(*status))
+        *status = U_UNSUPPORTED_ERROR;
+    return 0;
+}
+
+void ucal_add(UCalendar* /*cal*/, UCalendarDateFields /*field*/, int32_t /*amount*/, UErrorCode* status) // NOLINT
+{
+    if (status && U_SUCCESS(*status))
+        *status = U_UNSUPPORTED_ERROR;
+}
+
+void ucal_clear(UCalendar* /*cal*/) // NOLINT
+{
+}
+
+int32_t ucal_getLimit(const UCalendar* /*cal*/, UCalendarDateFields /*field*/, // NOLINT
+    UCalendarLimitType /*type*/, UErrorCode* status)
+{
+    if (status && U_SUCCESS(*status))
+        *status = U_UNSUPPORTED_ERROR;
+    return -1;
+}
+
+void ucal_setTimeZone(UCalendar* /*cal*/, const UChar* /*zoneID*/, int32_t /*len*/, UErrorCode* status) // NOLINT
+{
+    if (status && U_SUCCESS(*status))
+        *status = U_UNSUPPORTED_ERROR;
+}
+
+UBool ucal_getTimeZoneTransitionDate(const UCalendar* /*cal*/, UTimeZoneTransitionType /*type*/, // NOLINT
+    UDate* /*transition*/, UErrorCode* status)
+{
+    if (status && U_SUCCESS(*status))
+        *status = U_UNSUPPORTED_ERROR;
+    return false;
+}
+
+UDateFormat* udat_clone(const UDateFormat* /*fmt*/, UErrorCode* status) // NOLINT
+{
+    if (status && U_SUCCESS(*status))
+        *status = U_UNSUPPORTED_ERROR;
+    return nullptr;
+}
+
+void udat_applyPattern(UDateFormat* /*format*/, UBool /*localized*/, // NOLINT
+    const UChar* /*pattern*/, int32_t /*patternLength*/)
+{
+}
+
+} // extern "C"
+
+#endif // PLATFORM(PLAYSTATION)

--- a/Source/JavaScriptCore/runtime/temporal/core/TimeZoneICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/TimeZoneICUBridge.cpp
@@ -1,0 +1,565 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "TimeZoneICUBridge.h"
+
+#include "CalendarArithmetic.h"
+#include "CalendarICUBridge.h"
+#include "DateConstructor.h"
+#include "IntlObject.h"
+#include <unicode/ucal.h>
+#include <wtf/DateMath.h>
+#include <wtf/unicode/icu/ICUHelpers.h>
+
+namespace JSC {
+namespace TemporalCore {
+
+// openCalendarForTimeZone — internal: opens ICU UCalendar for a named (IANA) timezone
+static std::unique_ptr<UCalendar, ICUDeleter<ucal_close>> openCalendarForTimeZone(const TimeZone& timeZone)
+{
+    ASSERT(timeZone.isID());
+    String tzStr = timeZone.toICUString();
+    StringView view(tzStr);
+    auto upconverted = view.upconvertedCharacters();
+    UErrorCode status = U_ZERO_ERROR;
+    auto calendar = std::unique_ptr<UCalendar, ICUDeleter<ucal_close>>(
+        ucal_open(upconverted, view.length(), "", UCAL_DEFAULT, &status));
+    if (U_FAILURE(status))
+        return nullptr;
+    return calendar;
+}
+
+// getOffsetMsAtEpoch — internal: queries ICU for UTC+DST offset in ms at a given epoch
+static std::optional<int32_t> getOffsetMsAtEpoch(UCalendar* cal, double epochMs)
+{
+    UErrorCode status = U_ZERO_ERROR;
+    ucal_setMillis(cal, epochMs, &status);
+    if (U_FAILURE(status))
+        return std::nullopt;
+    int32_t rawOffset = ucal_get(cal, UCAL_ZONE_OFFSET, &status);
+    if (U_FAILURE(status))
+        return std::nullopt;
+    int32_t dstOffset = ucal_get(cal, UCAL_DST_OFFSET, &status);
+    if (U_FAILURE(status))
+        return std::nullopt;
+    return rawOffset + dstOffset;
+}
+
+// isoDateTimeToLocalMs — internal: converts ISO date+time to epoch ms treating local time as UTC (no offset applied)
+static double isoDateTimeToLocalMs(const ISO8601::PlainDate& date, const ISO8601::PlainTime& time)
+{
+    // makeDay takes month as 0-indexed; PlainDate month is 1-indexed.
+    double days = makeDay(date.year(), date.month() - 1, date.day());
+    double timeMs = makeTime(time.hour(), time.minute(), time.second(), time.millisecond());
+    return makeDate(days, timeMs);
+}
+
+// exactTimeToLocalDateAndTime — internal: decomposes an exact epoch time + offset into PlainDate + PlainTime.
+void exactTimeToLocalDateAndTime(ISO8601::ExactTime exactTime, int64_t offsetNs, ISO8601::PlainDate& outDate, ISO8601::PlainTime& outTime)
+{
+    int64_t epochMs = exactTime.floorEpochMilliseconds();
+    int64_t offsetMs = offsetNs / static_cast<int64_t>(ISO8601::ExactTime::nsPerMillisecond);
+    int64_t localMs = epochMs + offsetMs;
+
+    WTF::Int64Milliseconds localMsWT(localMs);
+    int32_t days = WTF::msToDays(localMsWT);
+    int32_t timeInDayMs = WTF::timeInDay(localMsWT, days);
+
+    auto [year, month, day] = WTF::yearMonthDayFromDays(days);
+    // month from yearMonthDayFromDays is 0-indexed; ISO8601::PlainDate wants 1-indexed.
+    outDate = ISO8601::PlainDate(year, static_cast<uint8_t>(month + 1), static_cast<uint8_t>(day));
+
+    const int32_t msPerHour = 3'600'000; // nsPerHour / nsPerMillisecond
+    const int32_t msPerMinute = 60'000; // nsPerMinute / nsPerMillisecond
+    const int32_t msPerSecond = 1'000; // nsPerSecond / nsPerMillisecond
+    int hour = timeInDayMs / msPerHour;
+    int minute = (timeInDayMs / msPerMinute) % 60;
+    int second = (timeInDayMs / msPerSecond) % 60;
+    int millisecond = timeInDayMs % msPerSecond;
+
+    // Sub-millisecond precision from the nanosecond timestamp.
+    auto epochNs = exactTime.epochNanoseconds();
+    auto nsInMs = static_cast<int32_t>(epochNs % ISO8601::ExactTime::nsPerMillisecond);
+    if (nsInMs < 0)
+        nsInMs += static_cast<int32_t>(ISO8601::ExactTime::nsPerMillisecond);
+    int microsecond = nsInMs / static_cast<int32_t>(ISO8601::ExactTime::nsPerMicrosecond);
+    int nanosecond = nsInMs % static_cast<int32_t>(ISO8601::ExactTime::nsPerMicrosecond);
+
+    outTime = ISO8601::PlainTime(hour, minute, second, millisecond, microsecond, nanosecond);
+}
+
+// getOffsetNanosecondsFor — temporal_rs: TimeZone::get_offset_nanos_for (src/builtins/core/time_zone.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal-getoffsetnanosecondsfor
+TemporalResult<int64_t> getOffsetNanosecondsFor(const TimeZone& timeZone, ISO8601::ExactTime exactTime)
+{
+    // 1. Let parseResult be ! ParseTimeZoneIdentifier(timeZone).
+    // 2. If parseResult.[[OffsetMinutes]] is not ~empty~, return parseResult.[[OffsetMinutes]] × (60 × 10^9).
+    if (timeZone.isUTCOffset())
+        return timeZone.utcOffsetNanoseconds();
+
+    // 3. Return GetNamedTimeZoneOffsetNanoseconds(parseResult.[[Name]], epochNs).
+    // NOTE: Implemented via ICU4C: UCAL_ZONE_OFFSET + UCAL_DST_OFFSET.
+    auto calendar = openCalendarForTimeZone(timeZone);
+    if (!calendar)
+        return makeUnexpected(rangeError("Failed to open ICU calendar for time zone"_s));
+
+    double epochMs = static_cast<double>(exactTime.floorEpochMilliseconds());
+    auto offsetMs = getOffsetMsAtEpoch(calendar.get(), epochMs);
+    if (!offsetMs)
+        return makeUnexpected(rangeError("Failed to get time zone offset from ICU"_s));
+
+    constexpr int64_t nsPerMs = 1'000'000; // nsPerMillisecond
+    return static_cast<int64_t>(*offsetMs) * nsPerMs;
+}
+
+// tryPreLMTFallback — workaround for ICU4C snapping pre-first-transition dates to the wrong year.
+// icu4x: transition_offset_at (utils/zoneinfo64/src/lib.rs) correctly uses type_offsets[0] for pre-transition dates.
+// NOTE: ICU4C ucal_setDateTime snaps to the first recorded year (e.g. 1884 for America/Vancouver); this detects that gap and queries the correct LMT offset.
+static std::optional<double> tryPreLMTFallback(UCalendar* calendar, double localMs, double icuEpochMs)
+{
+    const double oneDayMs = 86'400'000.0; // nsPerDay / nsPerMillisecond
+    if (std::abs(icuEpochMs - localMs) <= oneDayMs)
+        return std::nullopt;
+
+    auto lmtOffsetMs = getOffsetMsAtEpoch(calendar, localMs);
+    if (!lmtOffsetMs)
+        return std::nullopt;
+
+    double fallbackEpochMs = localMs - static_cast<double>(*lmtOffsetMs);
+    auto fallbackOffset = getOffsetMsAtEpoch(calendar, fallbackEpochMs);
+    if (!fallbackOffset || (fallbackEpochMs + static_cast<double>(*fallbackOffset) != localMs))
+        return std::nullopt;
+
+    return fallbackEpochMs;
+}
+
+// getNamedTimeZoneEpochNanoseconds — ICU4C implementation of the implementation-defined AO
+// https://tc39.es/proposal-temporal/#sec-getnamedtimezoneepochnanoseconds
+static TemporalResult<PossibleEpochNanoseconds> getNamedTimeZoneEpochNanoseconds(const TimeZone& timeZone, const ISO8601::PlainDate& date, const ISO8601::PlainTime& time)
+{
+    // NOTE: Sub-ms fields are added back after ms-level computation; offset changes occur at ≥second granularity.
+    Int128 subMs = static_cast<Int128>(time.microsecond()) * 1000 + static_cast<Int128>(time.nanosecond());
+
+    auto calendar = openCalendarForTimeZone(timeZone);
+    if (!calendar)
+        return makeUnexpected(rangeError("Failed to open ICU calendar for time zone"_s));
+
+    // Compute the "naive" local epoch — the local datetime treated as UTC, used for gap/fold detection.
+    double localMs = isoDateTimeToLocalMs(date, time);
+
+    auto makeExactTime = [&](double epochMs) -> ISO8601::ExactTime {
+        auto base = ISO8601::ExactTime::fromEpochMilliseconds(static_cast<int64_t>(epochMs));
+        return ISO8601::ExactTime(base.epochNanoseconds() + subMs);
+    };
+
+    // Set ICU calendar to local date+time. ICU months are 0-indexed.
+    // Explicitly set UCAL_MILLISECOND to avoid retaining a stale field (ucal_setDateTime does not set ms).
+    UErrorCode status = U_ZERO_ERROR;
+    ucal_setDateTime(calendar.get(),
+        date.year(), static_cast<int32_t>(date.month()) - 1, date.day(),
+        time.hour(), time.minute(), time.second(),
+        &status);
+    if (U_FAILURE(status))
+        return makeUnexpected(rangeError("Failed to set date/time on ICU calendar"_s));
+    ucal_set(calendar.get(), UCAL_MILLISECOND, time.millisecond());
+
+    // ICU resolves the local time to one epoch (its "default" interpretation).
+    double icuEpochMs = ucal_getMillis(calendar.get(), &status);
+    if (U_FAILURE(status))
+        return makeUnexpected(rangeError("Failed to get epoch ms from ICU calendar"_s));
+
+    auto icuOffsetMs = getOffsetMsAtEpoch(calendar.get(), icuEpochMs);
+    if (!icuOffsetMs)
+        return makeUnexpected(rangeError("Failed to get time zone offset from ICU"_s));
+
+    // If icuEpoch + offset ≠ localMs the local time is in a DST gap (spring-forward).
+    bool icuValid = (icuEpochMs + static_cast<double>(*icuOffsetMs) == localMs);
+    if (!icuValid) {
+        if (auto fallbackMs = tryPreLMTFallback(calendar.get(), localMs, icuEpochMs))
+            return PossibleEpochNanoseconds { makeExactTime(*fallbackMs) };
+
+        // Gap: store bracket offsets in GapOffsets so disambiguate needs no extra ICU calls.
+        // afterNs = post-transition offset (= the ICU-resolved offset at the gap).
+        int64_t afterNs = static_cast<int64_t>(*icuOffsetMs) * static_cast<int64_t>(ISO8601::ExactTime::nsPerMillisecond);
+        // beforeNs = pre-transition offset (find via previous transition or 1-day probe fallback).
+        int64_t beforeNs = afterNs;
+        {
+            UErrorCode s = U_ZERO_ERROR;
+            ucal_setMillis(calendar.get(), icuEpochMs, &s);
+            UDate transitionMs = 0;
+            if (!U_FAILURE(s) && ucal_getTimeZoneTransitionDate(calendar.get(), UCAL_TZ_TRANSITION_PREVIOUS, &transitionMs, &s) && !U_FAILURE(s)) {
+                auto preOffset = getOffsetMsAtEpoch(calendar.get(), transitionMs - 1.0);
+                if (preOffset)
+                    beforeNs = static_cast<int64_t>(*preOffset) * static_cast<int64_t>(ISO8601::ExactTime::nsPerMillisecond);
+            }
+            if (beforeNs == afterNs) {
+                constexpr int64_t nsPerDay = 86'400'000'000'000LL; // nsPerDay
+                Int128 naiveNs = static_cast<Int128>(localMs) * ISO8601::ExactTime::nsPerMillisecond + subMs;
+                auto offsetResult = getOffsetNanosecondsFor(timeZone, ISO8601::ExactTime(naiveNs - Int128(nsPerDay)));
+                if (offsetResult)
+                    beforeNs = *offsetResult;
+            }
+        }
+        return PossibleEpochNanoseconds { GapOffsets { beforeNs, afterNs } };
+    }
+
+    auto primaryCandidate = makeExactTime(icuEpochMs);
+
+    // Check for a second candidate (DST fold) via nearest transition boundary.
+    // 25 hours covers all known IANA single-step transitions including 24-hour date-line crossings.
+    const double maxFoldWindowMs = 90'000'000.0; // 25 hours in ms
+    std::optional<ISO8601::ExactTime> secondCandidate;
+
+    auto tryFoldFromTransition = [&](UTimeZoneTransitionType transType) -> bool {
+        UErrorCode s = U_ZERO_ERROR;
+        ucal_setMillis(calendar.get(), icuEpochMs, &s);
+        if (U_FAILURE(s))
+            return false;
+        UDate transitionMs = 0;
+        if (!ucal_getTimeZoneTransitionDate(calendar.get(), transType, &transitionMs, &s))
+            return false;
+        if (U_FAILURE(s))
+            return false;
+        if (std::abs(transitionMs - icuEpochMs) > maxFoldWindowMs)
+            return false;
+        double otherSideMs = (transType == UCAL_TZ_TRANSITION_PREVIOUS)
+            ? transitionMs - 1.0
+            : transitionMs + 1.0;
+        auto otherOffset = getOffsetMsAtEpoch(calendar.get(), otherSideMs);
+        if (!otherOffset || *otherOffset == *icuOffsetMs)
+            return false;
+        double probe = localMs - static_cast<double>(*otherOffset);
+        if (probe == icuEpochMs)
+            return false;
+        auto verifyOffset = getOffsetMsAtEpoch(calendar.get(), probe);
+        if (!verifyOffset || *verifyOffset != *otherOffset)
+            return false;
+        secondCandidate = makeExactTime(probe);
+        return true;
+    };
+
+    if (!tryFoldFromTransition(UCAL_TZ_TRANSITION_PREVIOUS))
+        tryFoldFromTransition(UCAL_TZ_TRANSITION_NEXT);
+
+    // ICU quirk: retry from 1ms later to catch transition-boundary fold case.
+    if (!secondCandidate) {
+        auto tryFoldFromOffset = [&](double probeEpochMs) -> bool {
+            UErrorCode s = U_ZERO_ERROR;
+            ucal_setMillis(calendar.get(), probeEpochMs, &s);
+            if (U_FAILURE(s))
+                return false;
+            UDate transitionMs = 0;
+            if (!ucal_getTimeZoneTransitionDate(calendar.get(), UCAL_TZ_TRANSITION_PREVIOUS, &transitionMs, &s))
+                return false;
+            if (U_FAILURE(s))
+                return false;
+            if (std::abs(transitionMs - icuEpochMs) > maxFoldWindowMs)
+                return false;
+            auto otherOffset = getOffsetMsAtEpoch(calendar.get(), transitionMs - 1.0);
+            if (!otherOffset || *otherOffset == *icuOffsetMs)
+                return false;
+            double probe = localMs - static_cast<double>(*otherOffset);
+            if (probe == icuEpochMs)
+                return false;
+            auto verifyOffset = getOffsetMsAtEpoch(calendar.get(), probe);
+            if (!verifyOffset || *verifyOffset != *otherOffset)
+                return false;
+            secondCandidate = makeExactTime(probe);
+            return true;
+        };
+        tryFoldFromOffset(icuEpochMs + 1.0);
+    }
+
+    if (!secondCandidate)
+        return PossibleEpochNanoseconds { primaryCandidate };
+
+    ISO8601::ExactTime earlier = primaryCandidate;
+    ISO8601::ExactTime later = *secondCandidate;
+    if (earlier.epochNanoseconds() > later.epochNanoseconds())
+        std::swap(earlier, later);
+    return PossibleEpochNanoseconds { std::array<ISO8601::ExactTime, 2> { earlier, later } };
+}
+
+// getPossibleEpochNanosecondsFor — temporal_rs: TimeZone::get_possible_epoch_ns_for (src/builtins/core/time_zone.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal-getpossibleepochnanoseconds
+TemporalResult<PossibleEpochNanoseconds> getPossibleEpochNanosecondsFor(const TimeZone& timeZone, const ISO8601::PlainDate& date, const ISO8601::PlainTime& time)
+{
+    // 1. Let parseResult be ! ParseTimeZoneIdentifier(timeZone).
+    // 2. If parseResult.[[OffsetMinutes]] is not ~empty~, then
+    //    a-d. Balance, check range, compute UTC epoch ns, return « epochNs ».
+    // NOTE: UTC-offset timezones always yield exactly 1 candidate; no ICU needed.
+    if (timeZone.isUTCOffset()) {
+        Int128 subMs = static_cast<Int128>(time.microsecond()) * 1000 + static_cast<Int128>(time.nanosecond());
+        int64_t offsetMs = timeZone.utcOffsetNanoseconds() / static_cast<int64_t>(ISO8601::ExactTime::nsPerMillisecond);
+        double localMs = isoDateTimeToLocalMs(date, time);
+        double epochMs = localMs - static_cast<double>(offsetMs);
+        auto base = ISO8601::ExactTime::fromEpochMilliseconds(static_cast<int64_t>(epochMs));
+        ISO8601::ExactTime exactTime(base.epochNanoseconds() + subMs);
+        if (!exactTime.isValid())
+            return makeUnexpected(rangeError("Epoch nanoseconds out of valid Temporal range"_s));
+        return PossibleEpochNanoseconds { exactTime };
+    }
+
+    // 3. Else, let possibleEpochNanoseconds be GetNamedTimeZoneEpochNanoseconds(parseResult.[[Name]], isoDateTime).
+    auto possible = getNamedTimeZoneEpochNanoseconds(timeZone, date, time);
+    if (!possible)
+        return makeUnexpected(possible.error());
+
+    // 4. For each value epochNanoseconds in possibleEpochNanoseconds:
+    //    a. If IsValidEpochNanoseconds(epochNanoseconds) is false, throw a RangeError.
+    for (auto& candidate : epochCandidates(*possible)) {
+        if (!candidate.isValid())
+            return makeUnexpected(rangeError("Epoch nanoseconds out of valid Temporal range"_s));
+    }
+
+    // 5. Return possibleEpochNanoseconds.
+    return *possible;
+}
+
+// getTimeZoneTransition — ICU4C implementation of GetNamedTimeZoneNextTransition / GetNamedTimeZonePreviousTransition
+// https://tc39.es/proposal-temporal/#sec-temporal-getnamedtimezonenexttransition (Next)
+// https://tc39.es/proposal-temporal/#sec-temporal-getnamedtimezoneprevioustransition (Previous)
+TemporalResult<std::optional<ISO8601::ExactTime>> getTimeZoneTransition(const TimeZone& timeZone, ISO8601::ExactTime exactTime, TransitionDirection direction)
+{
+    // 1. If timeZone is a UTC-offset timezone, return null (no transitions).
+    if (timeZone.isUTCOffset())
+        return std::optional<ISO8601::ExactTime> { std::nullopt };
+
+    // 2. Open ICU calendar for timeZone.
+    auto calendar = openCalendarForTimeZone(timeZone);
+    if (!calendar)
+        return makeUnexpected(rangeError("Failed to open ICU calendar for time zone"_s));
+
+    UErrorCode status = U_ZERO_ERROR;
+    // 3. Let epochMs be floor(exactTime) for Next; ceil(exactTime) for Previous (sub-ms epochs round up per spec).
+    double epochMs;
+    if (direction == TransitionDirection::Previous) {
+        // ceilEpochMs: ceiling of (epochNs / 1e6).
+        // C++ truncates toward zero — that is already the ceiling for negative values.
+        // For positive sub-ms remainder, truncation gave the floor, so add 1.
+        Int128 epochNs = exactTime.epochNanoseconds();
+        int64_t ms = static_cast<int64_t>(epochNs / static_cast<int64_t>(ISO8601::ExactTime::nsPerMillisecond));
+        if (epochNs % static_cast<int64_t>(ISO8601::ExactTime::nsPerMillisecond) > 0)
+            ms++;
+        epochMs = static_cast<double>(ms);
+    } else
+        epochMs = static_cast<double>(exactTime.floorEpochMilliseconds());
+    ucal_setMillis(calendar.get(), epochMs, &status);
+    if (U_FAILURE(status))
+        return makeUnexpected(rangeError("Failed to set epoch on ICU calendar"_s));
+
+    UTimeZoneTransitionType transType = (direction == TransitionDirection::Next) ? UCAL_TZ_TRANSITION_NEXT : UCAL_TZ_TRANSITION_PREVIOUS;
+
+    // 4. Repeat (up to 20 times to skip rule-only changes):
+    // Skip ICU transitions where the UTC offset doesn't actually change (rule changes that
+    // affect DST notation but not the offset). Spec requires: offset(t) ≠ offset(t-1).
+    for (int safetyLimit = 0; safetyLimit < 20; ++safetyLimit) {
+        //    a. Let transition be the next/previous transition from epochMs in ICU.
+        UDate transitionMs = 0;
+        bool hasTransition = ucal_getTimeZoneTransitionDate(
+            calendar.get(), transType, &transitionMs, &status);
+        if (U_FAILURE(status))
+            return makeUnexpected(rangeError("Failed to get time zone transition date from ICU"_s));
+
+        //    b. If no transition, return null.
+        if (!hasTransition)
+            return std::optional<ISO8601::ExactTime> { std::nullopt };
+
+        auto transition = ISO8601::ExactTime::fromEpochMilliseconds(static_cast<int64_t>(transitionMs));
+        //    c. If transition is out of Temporal's valid range, return null.
+        if (!transition.isValid())
+            return std::optional<ISO8601::ExactTime> { std::nullopt };
+
+        //    d. If the UTC offset actually changed at transition (offsetBefore ≠ offsetAfter), return transition.
+        // Check if offset actually changed at this transition.
+        // Compare offset just before and just after the transition.
+        double beforeMs = transitionMs - 1.0;
+        double afterMs = transitionMs;
+        UErrorCode s2 = U_ZERO_ERROR;
+        auto cal2 = openCalendarForTimeZone(timeZone);
+        if (!cal2)
+            return std::optional<ISO8601::ExactTime> { transition }; // fallback
+        ucal_setMillis(cal2.get(), beforeMs, &s2);
+        int32_t offsetBefore = ucal_get(cal2.get(), UCAL_ZONE_OFFSET, &s2) + ucal_get(cal2.get(), UCAL_DST_OFFSET, &s2);
+        ucal_setMillis(cal2.get(), afterMs, &s2);
+        int32_t offsetAfter = ucal_get(cal2.get(), UCAL_ZONE_OFFSET, &s2) + ucal_get(cal2.get(), UCAL_DST_OFFSET, &s2);
+        // NOTE: check s2 before comparing offsets — if any ucal call above failed, both
+        // offsetBefore and offsetAfter would be 0 (equal), silently skipping a real transition.
+        if (U_FAILURE(s2))
+            return std::optional<ISO8601::ExactTime> { transition }; // fallback: treat as real transition
+        if (offsetBefore != offsetAfter)
+            return std::optional<ISO8601::ExactTime> { transition };
+
+        //    e. Otherwise, advance past this transition and continue.
+        // Offset didn't change — skip and find the next/previous real transition.
+        ucal_setMillis(calendar.get(), direction == TransitionDirection::Previous ? beforeMs : transitionMs + 1.0, &status);
+    }
+    return std::optional<ISO8601::ExactTime> { std::nullopt }; // no real transition found
+}
+
+// disambiguatePossibleEpochNanoseconds — temporal_rs: TimeZone::disambiguate_possible_epoch_nanos (src/builtins/core/time_zone.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal-disambiguatepossibleepochnanoseconds
+// NOTE: For the gap case (n=0), bracket offsets are precomputed in GapOffsets { beforeNs, afterNs } to avoid extra ICU calls.
+static TemporalResult<ISO8601::ExactTime> disambiguatePossibleEpochNanoseconds(const PossibleEpochNanoseconds& possible, const ISO8601::PlainDate& date, const ISO8601::PlainTime& time, TemporalDisambiguation disambiguation)
+{
+    double localMs = isoDateTimeToLocalMs(date, time);
+    Int128 subMs = static_cast<Int128>(time.microsecond()) * 1000 + static_cast<Int128>(time.nanosecond());
+    Int128 naiveNs = static_cast<Int128>(localMs) * ISO8601::ExactTime::nsPerMillisecond + subMs;
+
+    return WTF::switchOn(possible,
+        // 1. n = elements in possibleEpochNs (encoded in Variant type).
+        // 2. If n = 1, return the sole element.
+        [](const ISO8601::ExactTime& t) -> TemporalResult<ISO8601::ExactTime> {
+            return t;
+        },
+        // 3. If n ≠ 0 (DST fold: 2 candidates [earlier, later]):
+        //    a. If disambiguation is ~earlier~ or ~compatible~, return possibleEpochNs[0].
+        //    b. If disambiguation is ~later~, return possibleEpochNs[n-1].
+        //    c. Assert: disambiguation is ~reject~. Throw a RangeError.
+        [&](const std::array<ISO8601::ExactTime, 2>& fold) -> TemporalResult<ISO8601::ExactTime> {
+            if (disambiguation == TemporalDisambiguation::Reject)
+                return makeUnexpected(rangeError("ambiguous instant: use a 'disambiguation' option to resolve"_s));
+            if (disambiguation == TemporalDisambiguation::Earlier || disambiguation == TemporalDisambiguation::Compatible)
+                return fold[0];
+            ASSERT(disambiguation == TemporalDisambiguation::Later);
+            return fold[1];
+        },
+        // 4. Assert: n = 0 (DST gap — local time does not exist).
+        // 5. If disambiguation is ~reject~, throw a RangeError.
+        // 6-20. Bracket offsets from GapOffsets; step 16 (~earlier~): naiveNs - offsetAfter; step 17-20 (~later~/~compatible~): naiveNs - offsetBefore.
+        [&](const GapOffsets& gap) -> TemporalResult<ISO8601::ExactTime> {
+            if (disambiguation == TemporalDisambiguation::Reject)
+                return makeUnexpected(rangeError("nonexistent instant: local time does not exist in this time zone (DST gap)"_s));
+            if (disambiguation == TemporalDisambiguation::Earlier)
+                return ISO8601::ExactTime(naiveNs - Int128(gap.afterNs));
+            return ISO8601::ExactTime(naiveNs - Int128(gap.beforeNs));
+        });
+}
+
+// getEpochNanosecondsFor — temporal_rs: TimeZone::get_epoch_nanoseconds_for (src/builtins/core/time_zone.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal-getepochnanosecondsfor
+TemporalResult<ISO8601::ExactTime> getEpochNanosecondsFor(const TimeZone& timeZone, const ISO8601::PlainDate& date, const ISO8601::PlainTime& time, TemporalDisambiguation disambiguation)
+{
+    // 1. Let possibleEpochNs be ? GetPossibleEpochNanosecondsFor(timeZone, date, time).
+    auto possible = getPossibleEpochNanosecondsFor(timeZone, date, time);
+    if (!possible)
+        return makeUnexpected(possible.error());
+    // 2. Return ? DisambiguatePossibleInstants(possibleEpochNs, timeZone, date, time, disambiguation).
+    return disambiguatePossibleEpochNanoseconds(*possible, date, time, disambiguation);
+}
+
+// addZonedDateTime — temporal_rs: ZonedDateTime::add_zoned_date_time (src/builtins/core/zoned_date_time.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal-addzoneddatetime
+TemporalResult<ISO8601::ExactTime> addZonedDateTime(ISO8601::ExactTime startEpochNs, const TimeZone& timeZone, const ISO8601::Duration& duration, TemporalOverflow overflow, StringView calendarId)
+{
+    // NOTE: Pre-compute the time duration (norm) as nanoseconds; used by AddInstant in steps 1 and 7.
+    CheckedInt128 m = checkedCastDoubleToInt128(duration.minutes()) + checkedCastDoubleToInt128(duration.hours()) * Int128(60);
+    CheckedInt128 s = checkedCastDoubleToInt128(duration.seconds()) + m * Int128(60);
+    CheckedInt128 ms = checkedCastDoubleToInt128(duration.milliseconds()) + s * Int128(1000);
+    CheckedInt128 us = CheckedInt128(duration.microseconds()) + ms * Int128(1000);
+    CheckedInt128 ns = CheckedInt128(duration.nanoseconds()) + us * Int128(1000);
+    ASSERT(!ns.hasOverflowed());
+    Int128 norm = ns;
+
+    // 1. If DateDurationSign(duration.[[Date]]) = 0, return ? AddInstant(epochNanoseconds, duration.[[Time]]).
+    bool noDateComponents = !duration.years() && !duration.months()
+        && !duration.weeks() && !duration.days();
+    if (noDateComponents) {
+        if (!norm)
+            return startEpochNs;
+        ISO8601::ExactTime result(startEpochNs.epochNanoseconds() + norm);
+        if (!result.isValid())
+            return makeUnexpected(rangeError("Duration addition results in an out-of-range ZonedDateTime"_s));
+        return result;
+    }
+
+    // 2. Let isoDateTime be GetISODateTimeFor(timeZone, epochNanoseconds).
+    // NOTE: GetISODateTimeFor = GetOffsetNanosecondsFor + ExactTimeToLocalDateAndTime.
+    auto offsetResult = getOffsetNanosecondsFor(timeZone, startEpochNs);
+    if (!offsetResult)
+        return makeUnexpected(offsetResult.error());
+    ISO8601::PlainDate date;
+    ISO8601::PlainTime time;
+    exactTimeToLocalDateAndTime(startEpochNs, *offsetResult, date, time);
+
+    // 3. Let addedDate be ? CalendarDateAdd(calendar, isoDateTime.[[ISODate]], duration.[[Date]], overflow).
+    ISO8601::Duration dateDuration(duration.years(), duration.months(), duration.weeks(), duration.days(), 0, 0, 0, 0, 0, 0);
+    TemporalResult<ISO8601::PlainDate> addedDateResult;
+    CalendarID calId = calendarIDFromString(calendarId);
+    if (calendarIsISO(calId))
+        addedDateResult = calendarDateAdd(date, dateDuration, overflow);
+    else
+        addedDateResult = TemporalCore::calendarDateAdd(calId, date, dateDuration, overflow);
+    if (!addedDateResult)
+        return makeUnexpected(addedDateResult.error());
+
+    // 4. Let intermediateDateTime be CombineISODateAndTimeRecord(addedDate, isoDateTime.[[Time]]).
+    // 5. If ISODateTimeWithinLimits(intermediateDateTime) is false, throw a RangeError exception.
+    if (!ISO8601::isDateTimeWithinLimits(addedDateResult->year(), addedDateResult->month(), addedDateResult->day(), time.hour(), time.minute(), time.second(), time.millisecond(), time.microsecond(), time.nanosecond()))
+        return makeUnexpected(rangeError("intermediate datetime out of range"_s));
+
+    // 6. Let intermediateNs be ! GetEpochNanosecondsFor(timeZone, intermediateDateTime, ~compatible~).
+    auto intermediateResult = getEpochNanosecondsFor(timeZone, *addedDateResult, time, TemporalDisambiguation::Compatible);
+    if (!intermediateResult)
+        return makeUnexpected(intermediateResult.error());
+
+    // 7. Return ? AddInstant(intermediateNs, duration.[[Time]]).
+    ISO8601::ExactTime result(intermediateResult->epochNanoseconds() + norm);
+    if (!result.isValid())
+        return makeUnexpected(rangeError("Duration addition results in an out-of-range ZonedDateTime"_s));
+    return result;
+}
+
+// timeZoneEquals — temporal_rs: TimeZone::time_zone_equals_with_provider (src/builtins/core/time_zone.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal-timezoneequals
+bool timeZoneEquals(StringView id1, StringView id2)
+{
+    // 1. If one is two, return true.
+    if (id1 == id2)
+        return true;
+
+    // 2. If IsOffsetTimeZoneIdentifier(one) is false and IsOffsetTimeZoneIdentifier(two) is false, then
+    //    a-b. Let recordOne/Two be GetAvailableNamedTimeZoneIdentifier(one/two).
+    //    e. If recordOne.[[PrimaryIdentifier]] is recordTwo.[[PrimaryIdentifier]], return true.
+    // NOTE: If either is an offset identifier, skip IANA comparison and fall through to step 3.
+    bool isOffset1 = !id1.isEmpty() && (id1[0] == '+' || id1[0] == '-');
+    bool isOffset2 = !id2.isEmpty() && (id2[0] == '+' || id2[0] == '-');
+    if (!isOffset1 && !isOffset2) {
+        auto primary1 = intlResolveTimeZoneID(id1);
+        auto primary2 = intlResolveTimeZoneID(id2);
+        if (primary1 && primary2 && *primary1 == *primary2)
+            return true;
+    }
+
+    // 3. Assert: if both are offset identifiers, they differ (step 1 caught equality).
+    // Available offset identifiers are in canonical form, so different strings → different minutes.
+    ASSERT(!isOffset1 || !isOffset2 || id1 != id2);
+    // 4. Return false.
+    return false;
+}
+
+} // namespace TemporalCore
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/temporal/core/TimeZoneICUBridge.h
+++ b/Source/JavaScriptCore/runtime/temporal/core/TimeZoneICUBridge.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+// JSC Temporal Core — ICU timezone bridge
+// temporal_rs reference: src/tz.rs
+// Last synced: v0.2.3
+
+#include <JavaScriptCore/ISO8601.h>
+#include <JavaScriptCore/JSCTimeZone.h>
+#include <JavaScriptCore/JSExportMacros.h>
+#include <JavaScriptCore/TemporalCoreTypes.h>
+#include <JavaScriptCore/TemporalEnums.h>
+#include <array>
+#include <span>
+
+namespace JSC {
+namespace TemporalCore {
+
+// GapOffsets carries the timezone offsets bracketing a DST spring-forward gap.
+// beforeNs: UTC offset (ns) just before the transition — used for Later/Compatible disambiguation.
+// afterNs: UTC offset (ns) just after the transition — used for Earlier disambiguation.
+struct GapOffsets {
+    int64_t beforeNs { 0 };
+    int64_t afterNs  { 0 };
+};
+
+// PossibleEpochNanoseconds — the 0/1/2 candidates for a local date+time in a timezone.
+// Matches temporal_rs CandidateEpochNanoseconds (provider/src/provider.rs).
+//   GapOffsets                          — DST gap: local time does not exist; carries gap bracket offsets
+//   ISO8601::ExactTime                  — unambiguous: exactly one candidate
+//   std::array<ISO8601::ExactTime, 2>   — DST fold: two candidates [earlier, later]
+using PossibleEpochNanoseconds = Variant<GapOffsets, ISO8601::ExactTime, std::array<ISO8601::ExactTime, 2>>;
+
+// Helper: returns true when the local time falls in a DST gap (no valid instant).
+inline bool isGap(const PossibleEpochNanoseconds& p) { return std::holds_alternative<GapOffsets>(p); }
+
+// Helper: returns a span over the ExactTime candidates (empty for gap, 1 for single, 2 for fold).
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+inline std::span<const ISO8601::ExactTime> epochCandidates(const PossibleEpochNanoseconds& p)
+{
+    if (auto* a = std::get_if<std::array<ISO8601::ExactTime, 2>>(&p))
+        return *a;
+    if (auto* t = std::get_if<ISO8601::ExactTime>(&p))
+        return std::span<const ISO8601::ExactTime>(t, t + 1);
+    return { }; // gap — no candidates
+}
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+
+void JS_EXPORT_PRIVATE exactTimeToLocalDateAndTime(ISO8601::ExactTime, int64_t offsetNs, ISO8601::PlainDate&, ISO8601::PlainTime&);
+
+bool JS_EXPORT_PRIVATE timeZoneEquals(StringView id1, StringView id2);
+
+TemporalResult<int64_t> JS_EXPORT_PRIVATE getOffsetNanosecondsFor(const TimeZone&, ISO8601::ExactTime);
+
+TemporalResult<PossibleEpochNanoseconds> JS_EXPORT_PRIVATE getPossibleEpochNanosecondsFor(const TimeZone&, const ISO8601::PlainDate&, const ISO8601::PlainTime&);
+
+TemporalResult<std::optional<ISO8601::ExactTime>> JS_EXPORT_PRIVATE getTimeZoneTransition(const TimeZone&, ISO8601::ExactTime, TransitionDirection);
+
+TemporalResult<ISO8601::ExactTime> JS_EXPORT_PRIVATE getEpochNanosecondsFor(const TimeZone&, const ISO8601::PlainDate&, const ISO8601::PlainTime&, TemporalDisambiguation);
+
+TemporalResult<ISO8601::ExactTime> JS_EXPORT_PRIVATE addZonedDateTime(ISO8601::ExactTime startEpochNs, const TimeZone&, const ISO8601::Duration&, TemporalOverflow, StringView calendarId = "iso8601"_s);
+
+} // namespace TemporalCore
+} // namespace JSC


### PR DESCRIPTION
#### 15fb1d899a7efc65333c8e6f6a7514f0a4eac2c2
<pre>
[JSC][Temporal] Add ICU calendar and timezone bridge layer: CalendarICUBridge, TimeZoneICUBridge
<a href="https://bugs.webkit.org/show_bug.cgi?id=314532">https://bugs.webkit.org/show_bug.cgi?id=314532</a>
<a href="https://rdar.apple.com/176765786">rdar://176765786</a>

Reviewed by Yusuke Suzuki.

Adds ICU-backed bridge for non-ISO calendar field access and timezone
operations, building on the pure C++ core layer from the previous commit.

CalendarICUBridge implements calendar field accessors (year, month, day,
era, monthCode, daysInMonth, etc.) for all 26 calendar systems. Calendars
are identified by CalendarID (unsigned index into intlAvailableCalendars()),
with calendarIDFromString/calendarIDToString for string conversion.
IntlObject.h adds FOR_EACH_CACHED_CALENDAR_ID, caching 17 named CalendarIDs
globally so calendarHasEras, calendarIsLunisolar, calendarIsIslamic and all
internal comparisons use integer equality instead of string comparisons.
The lunisolar path ports icu4x&apos;s ArithmeticDate::until and SurpassesChecker
for correct month counting. ecmaReferenceYear ports icu4x&apos;s CLDR-derived
reference year tables for PlainMonthDay in non-ISO calendars. Japanese era
mapping uses japaneseEraStartYear/japaneseEraCode to derive ICU era integers
from era start dates rather than hardcoding ICU&apos;s internal sequence numbers.
chineseCalendarUsesEpochOffset result is cached via magic static (depends
only on ICU version, fixed for process lifetime).

TimeZoneICUBridge implements GetNamedTimeZoneEpochNanoseconds (0/1/2
candidates for DST gap/normal/fold), GetOffsetNanosecondsFor,
GetNamedTimeZoneNextTransition/PreviousTransition, GetEpochNanosecondsFor,
DisambiguatePossibleEpochNanoseconds, and AddZonedDateTime. The DST gap
case returns GapOffsets (before/after bracket offsets), matching the
temporal_rs CandidateEpochNanoseconds Variant design.

ISO8601.cpp adds parseTemporalTimeZoneIdentifier (implements
ParseTemporalTimeZoneString) and parseTimeZoneForIdentifier (restricts
inline UTC offsets to ±HH:MM, no sub-minute precision).

ICUCalendarStubs.cpp provides PlayStation no-op stubs for write-side ICU APIs.

Test: Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp
Canonical link: <a href="https://commits.webkit.org/313057@main">https://commits.webkit.org/313057@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3f118a14f90660de312090686d9108ea78bb954

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161922 "8 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35397 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28499 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170825 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118293 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35499 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35398 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125635 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88535 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164881 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27959 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145442 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106230 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27008 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25522 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18546 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/153981 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136701 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23196 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173314 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22760 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20409 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24837 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133936 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35070 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29609 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133941 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36174 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35054 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144991 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97149 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28473 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21816 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194321 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34564 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102049 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50078 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34065 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34307 "Built successfully") | | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34213 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | | | 
<!--EWS-Status-Bubble-End-->