### PR TITLE
[JSC] Follow-up change after inlined small sort

### DIFF
--- a/JSTests/stress/array-sort-inline-bigint-comparator.js
+++ b/JSTests/stress/array-sort-inline-bigint-comparator.js
@@ -1,0 +1,97 @@
+// Array.prototype.sort(comparator) must throw TypeError when the comparator
+// returns a BigInt (or Symbol), because runtime/StableSort.h's
+// coerceComparatorResultToBoolean finishes with `toNumber(cmp) < 0`, and
+// ToNumber on a BigInt/Symbol throws TypeError.
+//
+// Before the fix, the DFG ArraySortIntrinsic modelled the coercion as
+// `CompareLess(cmp, 0) || cmp === false`. CompareLess's generic runtime path
+// (jsLess) handles BigInt-vs-Number via bigIntCompare without calling ToNumber,
+// so if CompareLess ever ran in the inlined fast path with a BigInt input (for
+// instance via UntypedUse specialization from polymorphic warmup), the sort
+// would silently succeed where baseline throws. The fix replaces the numeric
+// branch with an explicit ToNumber node, which throws for BigInt/Symbol and
+// brings the DFG intrinsic in line with baseline regardless of speculation
+// outcome.
+
+function sortIt(a, c) { return a.sort(c); }
+
+function expectTypeError(body, desc) {
+    try { body(); }
+    catch (e) {
+        if (!(e instanceof TypeError))
+            throw new Error(desc + ": expected TypeError, got " + e);
+        return;
+    }
+    throw new Error(desc + ": expected TypeError, got no throw");
+}
+
+// --- Case 1: BigInt-only warmup. Drives whatever speculation path the DFG
+// picks when it has only seen BigInt returns.
+for (let i = 0; i < testLoopCount; ++i)
+    expectTypeError(() => sortIt([5, 3, 1, 4, 2], () => -1n), "BigInt-only warmup iter " + i);
+
+// --- Case 2: Int32 warmup, then a BigInt-returning comparator. The Int32
+// speculation in the inlined CompareLess/ToNumber chain will fail on a BigInt
+// input, but the slow path / baseline must still throw.
+for (let i = 0; i < testLoopCount; ++i)
+    sortIt([5, 3, 1, 4, 2], (a, b) => a - b);
+for (let i = 0; i < testLoopCount; ++i)
+    expectTypeError(() => sortIt([5, 3, 1, 4, 2], () => -1n), "after Int32 warmup iter " + i);
+
+// --- Case 3: Mixed warmup (Int32, Boolean, Object) to push CompareLess toward
+// UntypedUse. This is the scenario the old code was most vulnerable in: the
+// old CompareLess-on-BigInt would NOT throw (returns true via bigIntCompare),
+// so the fix's ToNumber is what keeps us correct here.
+for (let i = 0; i < testLoopCount; ++i) {
+    sortIt([5, 3, 1, 4, 2], (a, b) => a - b);
+    sortIt([5, 3, 1, 4, 2], (a, b) => a > b);        // boolean
+    sortIt([5, 3, 1, 4, 2], (a, b) => ({ valueOf() { return a - b; } })); // object
+}
+for (let i = 0; i < testLoopCount; ++i)
+    expectTypeError(() => sortIt([5, 3, 1, 4, 2], () => -1n), "after polymorphic warmup iter " + i);
+
+// --- Case 4: Positive BigInt. `toNumber(1n)` also throws, so this must throw too.
+for (let i = 0; i < testLoopCount; ++i)
+    expectTypeError(() => sortIt([5, 3, 1, 4, 2], () => 1n), "positive BigInt iter " + i);
+
+// --- Case 5: 0n (zero BigInt). `toNumber(0n)` also throws.
+for (let i = 0; i < testLoopCount; ++i)
+    expectTypeError(() => sortIt([5, 3, 1, 4, 2], () => 0n), "zero BigInt iter " + i);
+
+// --- Case 6: Symbol comparator return. `toNumber(Symbol)` throws TypeError.
+for (let i = 0; i < testLoopCount; ++i)
+    expectTypeError(() => sortIt([5, 3, 1, 4, 2], () => Symbol.iterator), "Symbol iter " + i);
+
+// --- Case 7: Object whose valueOf returns a BigInt. ToPrimitive-then-ToNumber
+// still throws.
+for (let i = 0; i < testLoopCount; ++i) {
+    const obj = { valueOf() { return -1n; } };
+    expectTypeError(() => sortIt([5, 3, 1, 4, 2], () => obj), "object-valueOf-BigInt iter " + i);
+}
+
+// --- Case 8: Early-BigInt in an otherwise-numeric comparator. The comparator
+// returns Int32 for most pairs but BigInt for one specific (pivot, current)
+// pair that actually occurs during insertion sort of [5, 3, 1, 4, 2] --
+// the last comparison is cmp(2, 1) when placing pivot=2. Sorting must throw
+// once it hits the BigInt case.
+for (let i = 0; i < testLoopCount; ++i) {
+    const cmp = (a, b) => (a === 2 && b === 1) ? -1n : (a - b);
+    expectTypeError(() => sortIt([5, 3, 1, 4, 2], cmp), "mid-sort BigInt iter " + i);
+}
+
+// --- Case 9: length-2 array (tiny fast path). Still must throw.
+for (let i = 0; i < testLoopCount; ++i)
+    expectTypeError(() => sortIt([2, 1], () => -1n), "len2 BigInt iter " + i);
+
+// --- Sanity: non-BigInt comparators must NOT throw, to catch any accidental
+// over-throwing regression in the ToNumber path.
+for (let i = 0; i < testLoopCount; ++i) {
+    const r = sortIt([5, 3, 1, 4, 2], (a, b) => a - b);
+    if (r[0] !== 1 || r[4] !== 5) throw new Error("regression in numeric sort: " + r);
+}
+for (let i = 0; i < testLoopCount; ++i) {
+    // null / undefined / string: must not throw.
+    sortIt([5, 3, 1, 4, 2], () => null);
+    sortIt([5, 3, 1, 4, 2], () => undefined);
+    sortIt([5, 3, 1, 4, 2], () => "abc");
+}

--- a/JSTests/stress/array-sort-inline-contiguous-undefined.js
+++ b/JSTests/stress/array-sort-inline-contiguous-undefined.js
@@ -1,0 +1,74 @@
+// Array.prototype.sort must sort `undefined` elements to the tail per ECMA-262
+// without passing them to the comparator. The inlined-sort fast path copies the
+// receiver into a scratch butterfly during its compact phase; it must treat a
+// Contiguous-array `undefined` the same as a hole (returning the sentinel and
+// falling back to the slow path) so undefined ordering matches the spec.
+
+function sortIt(a, c) { return a.sort(c); }
+
+// A comparator that never triggers a BadType OSR exit on undefined (`<` / `>`
+// coerce undefined to NaN, which is valid everywhere). Without the fix, the
+// inlined fast path happily copies `undefined` into scratch and the insertion
+// sort leaves it in place -- producing a wildly-wrong result.
+function cmp(a, b) { return a < b ? -1 : a > b ? 1 : 0; }
+
+function checkSortedWithUndefinedAtEnd(r, expectedNumbers, expectedUndefined, desc) {
+    const totalLen = expectedNumbers.length + expectedUndefined;
+    if (r.length !== totalLen)
+        throw new Error(desc + ": wrong length " + r.length);
+    for (let i = 0; i < expectedNumbers.length; ++i) {
+        if (r[i] !== expectedNumbers[i])
+            throw new Error(desc + ": wrong order at [" + i + "]: got " + r[i] + " expected " + expectedNumbers[i]);
+    }
+    for (let i = expectedNumbers.length; i < totalLen; ++i) {
+        if (r[i] !== undefined)
+            throw new Error(desc + ": expected undefined at [" + i + "] got " + r[i]);
+        if (!(i in r))
+            throw new Error(desc + ": undefined at [" + i + "] became a hole");
+    }
+}
+
+// Length 7 (inside the 16-slot fast path), Contiguous, with interior undefined.
+for (let i = 0; i < testLoopCount; ++i) {
+    const r = sortIt([5, undefined, 3, 1, undefined, 4, 2], cmp);
+    checkSortedWithUndefinedAtEnd(r, [1, 2, 3, 4, 5], 2, "len7 iter " + i);
+}
+
+// A custom comparator that, if ever actually handed `undefined`, flags the error.
+// The spec says the comparator is never called with undefined, so this must
+// never throw regardless of tier.
+function strictCmp(a, b) {
+    if (a === undefined || b === undefined)
+        throw new Error("comparator saw undefined");
+    return a - b;
+}
+for (let i = 0; i < testLoopCount; ++i) {
+    const r = sortIt([3, undefined, 1, 2, undefined], strictCmp);
+    checkSortedWithUndefinedAtEnd(r, [1, 2, 3], 2, "strict iter " + i);
+}
+
+// Length 2 fast path: pair of undefined must round-trip as a pair of undefined.
+for (let i = 0; i < testLoopCount; ++i) {
+    const r = sortIt([undefined, undefined], cmp);
+    checkSortedWithUndefinedAtEnd(r, [], 2, "pair iter " + i);
+}
+
+// Single undefined at the front of a Contiguous array.
+for (let i = 0; i < testLoopCount; ++i) {
+    const r = sortIt([undefined, 3, 1, 2], cmp);
+    checkSortedWithUndefinedAtEnd(r, [1, 2, 3], 1, "front iter " + i);
+}
+
+// Single undefined at the back.
+for (let i = 0; i < testLoopCount; ++i) {
+    const r = sortIt([3, 1, 2, undefined], cmp);
+    checkSortedWithUndefinedAtEnd(r, [1, 2, 3], 1, "back iter " + i);
+}
+
+// Dense Contiguous without any undefined: fast path must still produce a
+// correct sort (regression guard on the new Contiguous-undefined branch).
+for (let i = 0; i < testLoopCount; ++i) {
+    const r = sortIt(["b", "d", "a", "c"], cmp);
+    if (r[0] !== "a" || r[1] !== "b" || r[2] !== "c" || r[3] !== "d")
+        throw new Error("dense iter " + i + " wrong: " + JSON.stringify(r));
+}

--- a/JSTests/stress/array-sort-inline-mixed-sizes.js
+++ b/JSTests/stress/array-sort-inline-mixed-sizes.js
@@ -1,3 +1,6 @@
+//@ runDefault
+//@ requireOptions("--useConcurrentJIT=0")
+//
 // A single sort call site that alternates between small (length <= 16,
 // inlined insertion sort) and large (length > 16, inlined slow-path
 // DirectCall to arrayProtoFuncSort) arrays must compile once and stay

--- a/JSTests/stress/array-sort-inline-osr-exit-in-comparator.js
+++ b/JSTests/stress/array-sort-inline-osr-exit-in-comparator.js
@@ -1,3 +1,6 @@
+//@ runDefault
+//@ requireOptions("--useConcurrentJIT=0")
+//
 // Verifies that triggering OSR exit inside the comparator (mid-sort, after the
 // DFG ArraySortIntrinsic's inlined body has started rearranging the receiver)
 // still produces a correctly sorted array with the original multiset intact.

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -11832,7 +11832,9 @@ auto ByteCodeParser::handleArraySort(Node* callee, Operand resultOperand, CallVa
     //           if (j < 0) goto placePivot;                       //   CompareLess(j, 0) -> innerExit / innerCmpBlock
     //           JSValue current = scratch[j];                     // innerCmpBlock
     //           JSValue cmp = comparator(pivot, current);         //   inlined or Call
-    //           if (!(cmp < 0)) goto placePivot;                  //   CompareLess(cmp, 0) -> innerShift / innerExit
+    //           if (cmp === false) goto shift;                    //   CompareStrictEq(cmp, false) -> innerShift / numericBlock
+    //           if (ToNumber(cmp) < 0) goto shift;                //   numericBlock: ToNumber -> CompareLess -> innerShift / innerExit
+    //           else goto placePivot;
     //           scratch[j + 1] = current;                         // innerShift
     //           j = j - 1;                                        // innerShift
     //           continue;                                         //   Jump -> innerHeader
@@ -11985,30 +11987,30 @@ auto ByteCodeParser::handleArraySort(Node* callee, Operand resultOperand, CallVa
         flush(tmpCmpResult);
         emitExitOK();
 
-        // Match StableSort.h's coerceComparatorResultToBoolean: shift when `cmp < 0`
-        // (numeric path) OR when `cmp === false` (legacy boolean special-case,
-        // webkit.org/b/47825). CompareLess(cmp, 0) alone misses the boolean-false case
-        // because `false` coerces to 0 (not `< 0`), so a second branch on
-        // CompareStrictEq(cmp, false) recovers that case.
-        Node* cmpIsNeg = addToGraph(CompareLess, Edge(cmpResult), Edge(jsConstant(jsNumber(0))));
-        BasicBlock* checkFalseBlock = allocateUntargetableBlock();
+        // Match StableSort's coerceComparatorResultToBoolean:
+        //   if cmp === false           -> shift (legacy boolean special-case, webkit.org/b/47825)
+        //   else                       -> shift iff ToNumber(cmp) < 0
+        Node* cmpIsFalse = addToGraph(CompareStrictEq, Edge(cmpResult), Edge(jsConstant(jsBoolean(false))));
+        BasicBlock* numericBlock = allocateUntargetableBlock();
         {
             BranchData* branchData = m_graph.m_branchData.add();
             branchData->taken = BranchTarget(innerShift);
-            branchData->notTaken = BranchTarget(checkFalseBlock);
-            addToGraph(Branch, OpInfo(branchData), cmpIsNeg);
+            branchData->notTaken = BranchTarget(numericBlock);
+            addToGraph(Branch, OpInfo(branchData), cmpIsFalse);
             flushForTerminal();
         }
 
-        m_currentBlock = checkFalseBlock;
+        m_currentBlock = numericBlock;
         clearCaches();
         emitExitOK();
         keepUsesOfCurrentInstructionAlive(m_currentInstruction, m_currentIndex.checkpoint());
-        Node* cmpIsFalse = addToGraph(CompareStrictEq, Edge(get(tmpCmpResult)), Edge(jsConstant(jsBoolean(false))));
+        Node* numericCmp = addToGraph(ToNumber, OpInfo(0), OpInfo(), get(tmpCmpResult));
+        emitExitOK();
+        Node* cmpIsNeg = addToGraph(CompareLess, Edge(numericCmp), Edge(jsConstant(jsNumber(0))));
         BranchData* branchData = m_graph.m_branchData.add();
         branchData->taken = BranchTarget(innerShift);
         branchData->notTaken = BranchTarget(innerExit);
-        addToGraph(Branch, OpInfo(branchData), cmpIsFalse);
+        addToGraph(Branch, OpInfo(branchData), cmpIsNeg);
         flushForTerminal();
     }
 
@@ -12026,6 +12028,7 @@ auto ByteCodeParser::handleArraySort(Node* callee, Operand resultOperand, CallVa
         Node* jMinusOne = addToGraph(ArithAdd, OpInfo(Arith::Unchecked), OpInfo(SpecInt32Only), Edge(j, Int32Use), Edge(jsConstant(jsNumber(-1)), Int32Use));
         set(tmpJ, jMinusOne, ImmediateNakedSet);
         addToGraph(Jump, OpInfo(innerHeader));
+        flushForTerminal();
     }
 
     {
@@ -12042,6 +12045,7 @@ auto ByteCodeParser::handleArraySort(Node* callee, Operand resultOperand, CallVa
         Node* nextI = addToGraph(ArithAdd, OpInfo(Arith::Unchecked), OpInfo(SpecInt32Only), Edge(i, Int32Use), Edge(jsConstant(jsNumber(1)), Int32Use));
         set(tmpI, nextI, ImmediateNakedSet);
         addToGraph(Jump, OpInfo(outerHeader));
+        flushForTerminal();
     }
 
     // Commit: verify length stability (current butterfly length == the stashed pre-sort

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -15444,11 +15444,14 @@ void SpeculativeJIT::compileArraySortCompact(Node* node)
     auto loop = label();
     auto done = branchSub32(Signed, counterGPR, TrustedImm32(1), counterGPR);
     load64(BaseIndex(butterflyGPR, counterGPR, TimesEight, 0), valueGPR);
-    Jump hole = branchTest64(Zero, valueGPR);
+    JumpList holes;
+    holes.append(branchTest64(Zero, valueGPR));
+    if (node->arrayMode().type() == Array::Contiguous)
+        holes.append(branch64(Equal, valueGPR, TrustedImm64(JSValue::encode(jsUndefined()))));
     store64(valueGPR, BaseIndex(scratchGPR, counterGPR, TimesEight, JSCellButterfly::offsetOfData()));
     jump().linkTo(loop, this);
 
-    hole.link(this);
+    holes.link(this);
     move(TrustedImmPtr(std::bit_cast<void*>(vm().m_sortScratchSentinel.get())), scratchGPR);
 
     done.link(this);

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -10563,7 +10563,10 @@ IGNORE_CLANG_WARNINGS_END
         m_out.appendTo(loopBody, storeSlot);
         LValue value = m_out.load64(m_out.baseIndex(sourceHeap, butterfly, index));
         ValueFromBlock holeResult = m_out.anchor(m_out.constIntPtr(std::bit_cast<void*>(vm().m_sortScratchSentinel.get())));
-        m_out.branch(m_out.isZero64(value), rarely(continuation), usually(storeSlot));
+        LValue isHole = m_out.isZero64(value);
+        if (m_node->arrayMode().type() == Array::Contiguous)
+            isHole = m_out.bitOr(isHole, m_out.equal(value, m_out.constInt64(JSValue::encode(jsUndefined()))));
+        m_out.branch(isHole, rarely(continuation), usually(storeSlot));
 
         m_out.appendTo(storeSlot, continuation);
         m_out.store64(value, m_out.baseIndex(m_heaps.indexedContiguousProperties, scratch, index, JSValue(), JSCellButterfly::offsetOfData()));


### PR DESCRIPTION
#### 9246e68afc48b1435bf66fab2d6ce8bef63ea4f6
<pre>
[JSC] Follow-up change after inlined small sort
<a href="https://bugs.webkit.org/show_bug.cgi?id=314534">https://bugs.webkit.org/show_bug.cgi?id=314534</a>
<a href="https://rdar.apple.com/176766529">rdar://176766529</a>

Reviewed by Yijia Huang.

1. Make some test exclusively using no-cjit option to stabilize as it
   relies on OSR exit occurrence. Also limiting it to Default config.
2. Use flushForTerminal() for each back-edge jump. Technically, in this
   case, not necessary, but still it is good to follow to the existing idiom.
3. Use ToNumber before comparison in Sort&apos;s result. If we have BigInt as
   a result, we will see difference. (As ToNumber(BigInt) throws an
   error).
4. Contiguous array should see undefined as a hole in sorting.

Test: JSTests/stress/array-sort-inline-bigint-comparator.js

* JSTests/stress/array-sort-inline-bigint-comparator.js: Added.
(sortIt):
(expectTypeError):
(i.b):
(i.const.obj.valueOf):
* JSTests/stress/array-sort-inline-contiguous-undefined.js: Added.
(sortIt):
(cmp):
(checkSortedWithUndefinedAtEnd):
(strictCmp):
* JSTests/stress/array-sort-inline-mixed-sizes.js:
* JSTests/stress/array-sort-inline-osr-exit-in-comparator.js:
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleArraySort):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileArraySortCompact):

Canonical link: <a href="https://commits.webkit.org/313016@main">https://commits.webkit.org/313016@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e8758ff9ec89ed259c2fb207cddb1c0c7e6258ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161853 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35327 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28430 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170756 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118224 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bdd76510-9be0-47f3-80ec-21f2a212f9be) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35429 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35329 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/125583 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88498 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2dadf8a0-7e2f-4e7a-a43d-c52a0a83a46f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164812 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/27897 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/145381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106179 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f8c829e0-afa6-4586-a78d-94c616ed4b0c) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25464 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18477 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/153912 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136639 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23136 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173245 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22691 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20332 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24777 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/133883 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35001 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/29550 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133888 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34985 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144931 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97078 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24579 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28417 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/21754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194252 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34495 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/101976 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50063 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33995 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34238 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34144 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->