### PR TITLE
[JSC] Make TemporalInstant always 16-byte aligned by setting numberOfLowerTierPreciseCells = 0

### DIFF
--- a/Source/JavaScriptCore/runtime/TemporalInstant.h
+++ b/Source/JavaScriptCore/runtime/TemporalInstant.h
@@ -31,13 +31,14 @@
 #include <JavaScriptCore/TemporalDuration.h>
 #include <JavaScriptCore/TemporalObject.h>
 #include <JavaScriptCore/VM.h>
-#include <wtf/Packed.h>
 
 namespace JSC {
 
 class TemporalInstant final : public JSNonFinalObject {
 public:
     using Base = JSNonFinalObject;
+
+    static constexpr uint8_t numberOfLowerTierPreciseCells = 0;
 
     template<typename CellType, SubspaceAccess mode>
     static GCClient::IsoSubspace* subspaceFor(VM& vm)
@@ -58,7 +59,7 @@ public:
     static TemporalInstant* fromEpochNanoseconds(JSGlobalObject*, JSValue);
     static JSValue compare(JSGlobalObject*, JSValue, JSValue);
 
-    ISO8601::ExactTime exactTime() const { return m_exactTime.get(); }
+    ISO8601::ExactTime exactTime() const { return m_exactTime; }
 
     ISO8601::Duration difference(JSGlobalObject*, TemporalInstant*, JSValue options) const;
     ISO8601::ExactTime round(JSGlobalObject*, JSValue options) const;
@@ -77,7 +78,7 @@ private:
 
     static String toString(ISO8601::ExactTime, JSObject* timeZone, PrecisionData);
 
-    Packed<ISO8601::ExactTime> m_exactTime;
+    ISO8601::ExactTime m_exactTime;
 };
 
 } // namespace JSC


### PR DESCRIPTION
#### 985e5f9eea6b97075684e8754db233d2b6bc2936
<pre>
[JSC] Make TemporalInstant always 16-byte aligned by setting numberOfLowerTierPreciseCells = 0
<a href="https://bugs.webkit.org/show_bug.cgi?id=314535">https://bugs.webkit.org/show_bug.cgi?id=314535</a>
<a href="https://rdar.apple.com/176767367">rdar://176767367</a>

Reviewed by Yijia Huang.

Setting numberOfLowerTierPreciseCells = 0 to ensure that TemporalInstant
is always 16-byte aligned. Then we can just use ExactTime without
`Packed&lt;&gt;` wrapper.

* Source/JavaScriptCore/runtime/TemporalInstant.h:

Canonical link: <a href="https://commits.webkit.org/313018@main">https://commits.webkit.org/313018@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/260522aecfab1aa6b8d71e935baf143c62405b77

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161869 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35343 "Failed to checkout and rebase branch from PR 64660") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/28446 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170772 "Failed to checkout and rebase branch from PR 64660") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/118240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35445 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/35345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/170772 "Failed to checkout and rebase branch from PR 64660") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/118240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164828 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/27916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/145402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/170772 "Failed to checkout and rebase branch from PR 64660") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/35345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/18493 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/153928 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/136658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/23157 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173261 "Failed to checkout and rebase branch from PR 64660") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22707 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/20348 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/24798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/173261 "Failed to checkout and rebase branch from PR 64660") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35017 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/35345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/173261 "Failed to checkout and rebase branch from PR 64660") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/35001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/144952 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/97095 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24581 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/35001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/21775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/194268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/34511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/101992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/194268 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/34012 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34254 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/34160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->