### PR TITLE
[Win] strict_gs_check should be enabled via compiler option

### DIFF
--- a/Source/WTF/wtf/Platform.h
+++ b/Source/WTF/wtf/Platform.h
@@ -136,15 +136,9 @@
 
 /* FIXME: Any remaining use of TARGET_OS_IPHONE should be removed outside of Apple only files and replaced with OS() checks. */
 /* Set TARGET_OS_IPHONE to 0 by default to allow using it as a guard
- * in cross-platform the same way as it is used in OS(DARWIN) code. */ 
+ * in cross-platform the same way as it is used in OS(DARWIN) code. */
 #if !defined(TARGET_OS_IPHONE) && !OS(DARWIN)
 #define TARGET_OS_IPHONE 0
-#endif
-
-/* FIXME: This does not belong in Platform.h and should instead be included in another mechanism (compiler option, prefix header, config.h, etc) */
-#if COMPILER(MSVC)
-/* Enable strict runtime stack buffer checks. */
-#pragma strict_gs_check(on)
 #endif
 
 /* FIXME: This does not belong in Platform.h and should instead be included in another mechanism (prefix header, config.h, etc) */

--- a/Source/cmake/OptionsMSVC.cmake
+++ b/Source/cmake/OptionsMSVC.cmake
@@ -63,8 +63,10 @@ endfunction()
 # Use AT&T syntax for inline asm
 MSVC_ADD_COMPILE_OPTIONS(/clang:-masm=att)
 
-# Create pdb files for debugging purposes, also for Release builds
-MSVC_ADD_COMPILE_OPTIONS(/Zi /GS)
+# Create pdb files for debugging purposes, also for Release builds.
+# /sdl enables additional security checks on top of /GS, including
+# `#pragma strict_gs_check(push, on)` applied to every function.
+MSVC_ADD_COMPILE_OPTIONS(/Zi /GS /sdl)
 
 # Disable ICF (identical code folding) optimization,
 # as it makes it unsafe to pointer-compare functions with identical definitions.


### PR DESCRIPTION
#### 4d170e06a53efbec4f31c6f58c975d5ec38def4e
<pre>
[Win] strict_gs_check should be enabled via compiler option
<a href="https://bugs.webkit.org/show_bug.cgi?id=314540">https://bugs.webkit.org/show_bug.cgi?id=314540</a>
<a href="https://rdar.apple.com/176771078">rdar://176771078</a>

Reviewed by NOBODY (OOPS!).

Let&apos;s stop emitting `#pragma strict_gs_check(on)` in Platform.h. This
should be enabled via compiler option instead.

* Source/WTF/wtf/Platform.h:
* Source/cmake/OptionsMSVC.cmake:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d170e06a53efbec4f31c6f58c975d5ec38def4e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161785 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35259 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28362 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170688 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118156 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/72839355-e7a8-4c09-9b85-f954d17c167c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35360 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35260 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125527 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88442 "1 flakes 17 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/15624118-286f-4e04-aad3-5b29a49e9e4e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164744 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27842 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145323 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106123 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c4168b07-2b60-4d91-bd44-98b92a33bb71) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26891 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25402 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18409 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/153844 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136584 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23078 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173177 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22623 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20217 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24719 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133823 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34933 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29491 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133828 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34917 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144873 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96968 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28361 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21696 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194184 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34427 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101872 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50047 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33927 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34170 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34076 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->