### PR TITLE
Fix ipc/serialized-type-info.html after SerializedScriptValue::Internals extraction

### DIFF
--- a/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
+++ b/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
@@ -255,7 +255,7 @@
     [Legacy] StructureParam WebCore::PushSubscriptionData.clientECDHPublicKey
     [Legacy] StructureParam WebCore::PushSubscriptionData.serverVAPIDPublicKey
     [Legacy] StructureParam WebCore::PushSubscriptionData.sharedAuthenticationSecret
-    [Legacy] StructureParam WebCore::SerializedScriptValue::Internals.data
+    [Legacy] StructureParam WebCore::SerializedScriptValueInternals.data
     [Legacy] StructureParam WebCore::ThreadSafeDataBufferImpl.m_data
     [Legacy] StructureParam WebCore::WebCodecsEncodedAudioChunkData.buffer
     [Legacy] StructureParam WebCore::WebCodecsEncodedVideoChunkData.buffer

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7985,8 +7985,8 @@ using WebCore::RiceSocket = std::pair<String, WebCore::RTCIceProtocol>;
 };
 #endif
 
-headers: <JavaScriptCore/WasmModule.h> <WebCore/ImageBitmap.h> <WebCore/MessagePort.h> <WebCore/OffscreenCanvas.h> <WebCore/SerializedScriptValue.h> <WebCore/SerializedScriptValueInternals.h>
-[Nested] class WebCore::SerializedScriptValue::Internals {
+headers: <JavaScriptCore/WasmModule.h> <WebCore/ImageBitmap.h> <WebCore/MessagePort.h> <WebCore/OffscreenCanvas.h>
+struct WebCore::SerializedScriptValueInternals {
     Vector<uint8_t> data;
     std::unique_ptr<Vector<JSC::ArrayBufferContents>> arrayBufferContentsArray;
 #if ENABLE(WEB_RTC)


### PR DESCRIPTION
#### 156ba0aa843a65701198edff17818ed802a7a9e5
<pre>
Fix ipc/serialized-type-info.html after SerializedScriptValue::Internals extraction
<a href="https://bugs.webkit.org/show_bug.cgi?id=314542">https://bugs.webkit.org/show_bug.cgi?id=314542</a>

Reviewed by Chris Dumez.

312862@main extracted SerializedScriptValue::Internals into a top-level
WebCore::SerializedScriptValueInternals struct and switched m_internals to
std::unique_ptr&lt;WebCore::SerializedScriptValueInternals&gt;, but left the
WebCoreArgumentCoders.serialization.in declaration under the old nested
name. IPC.serializedTypeInfo therefore keys the description under
&quot;WebCore::SerializedScriptValue::Internals&quot; while SerializedScriptValue&apos;s
member unwraps to &quot;WebCore::SerializedScriptValueInternals&quot;, so the test
reports the latter as a type needing a description.

Rename the serialization declaration to struct
WebCore::SerializedScriptValueInternals and drop [Nested]. Update the
matching opaque_ipc_types.tracking.in entry. With [Nested] gone,
&lt;WebCore/SerializedScriptValueInternals.h&gt; is auto-inferred from the
namespace+name; also drop the redundant &lt;WebCore/SerializedScriptValue.h&gt;
(already auto-inferred from the [RefCounted] class declaration below).

Canonical link: <a href="https://commits.webkit.org/313002@main">https://commits.webkit.org/313002@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba25b87ac76a9aedcc06c72ed526d092c886953f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161789 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35263 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28366 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170692 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118160 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8ebc1e78-f85c-46c5-8a97-92eb60edd074) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35364 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35264 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125528 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/903cee8f-e608-40b7-8b8d-27980262fc07) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164748 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27841 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145324 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106124 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3c9c028b-0315-4727-83c5-08e0ae5366c3) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/161109 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26890 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25406 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18413 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136583 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173181 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20221 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24720 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133824 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34937 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29494 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133829 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34921 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144874 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96975 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24566 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28362 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21697 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34431 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101876 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33931 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34174 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34080 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->