### PR TITLE
REGRESSION(311577@main): [GTK][GStreamer][Rice] WebKitNetworkProcess is using massive amounts of CPU and spanning several threads named webrtc-rice-XX

### DIFF
--- a/Source/WebKit/NetworkProcess/webrtc/rice/RiceBackend.cpp
+++ b/Source/WebKit/NetworkProcess/webrtc/rice/RiceBackend.cpp
@@ -148,9 +148,15 @@ RiceBackend::RiceBackend(NetworkConnectionToWebProcess& connection)
 
 RiceBackend::~RiceBackend()
 {
-    for (auto& socketData : m_sockets.values()) {
+    auto streamIds = copyToVector(m_udpAddresses.keys());
+    for (auto streamId : streamIds)
+        finalizeStream(streamId);
+
+    Locker locker { m_socketsLock };
+    while (!m_sockets.isEmpty()) {
+        auto socketData = m_sockets.takeFirst();
         GRefPtr source = socketData.source;
-        if (!source) [[unlikely]]
+        if (!source)
             continue;
 
         g_source_destroy(source.get());
@@ -177,11 +183,13 @@ std::optional<SharedPreferencesForWebProcess> RiceBackend::sharedPreferencesForW
 
 GRefPtr<RiceSockets> RiceBackend::getSocketsForStream(unsigned streamId)
 {
+    Locker locker { m_socketsLock };
     return m_sockets.get(streamId).sockets;
 }
 
 GRefPtr<GSource> RiceBackend::getRecvSourceForStream(unsigned streamId)
 {
+    Locker locker { m_socketsLock };
     return m_sockets.get(streamId).source;
 }
 
@@ -301,9 +309,27 @@ void RiceBackend::finalizeStream(unsigned streamId)
 
         return true;
     });
-    auto data = m_sockets.take(streamId);
-    if (data.source)
-        g_source_destroy(data.source.get());
+
+    m_tcpAddresses.removeIf([&](auto& keyValue) -> bool {
+        auto& [key, addresses] = keyValue;
+        if (key != streamId)
+            return false;
+
+        auto riceSockets = getSocketsForStream(streamId);
+        for (auto& [localAddressString, remoteAddressString] : addresses) {
+            GUniquePtr<RiceAddress> localAddress(riceAddressFromString(localAddressString));
+            GUniquePtr<RiceAddress> remoteAddress(riceAddressFromString(remoteAddressString));
+            rice_sockets_remove_tcp(riceSockets.get(), localAddress.get(), remoteAddress.get());
+        }
+        return true;
+    });
+
+    {
+        Locker locker { m_socketsLock };
+        auto data = m_sockets.take(streamId);
+        if (data.source)
+            g_source_destroy(data.source.get());
+    }
 }
 
 void RiceBackend::gatherSocketAddresses(ScriptExecutionContextIdentifier identifier, unsigned streamId, unsigned minRtpPort, unsigned maxRtpPort, GatherSocketAddressesCallback&& completionHandler)
@@ -363,7 +389,7 @@ void RiceBackend::gatherSocketAddresses(ScriptExecutionContextIdentifier identif
                     return;
                 auto sockets = backend->getSocketsForStream(recvData->streamId);
                 rice_sockets_add_tcp(sockets.get(), socket);
-                backend->configureSocketBufferSizes();
+                backend->configureSockets();
             }, recvData, reinterpret_cast<RiceIoDestroy>(destroyRecvSourceData)));
 
             GUniquePtr<RiceAddress> localAddress(rice_tcp_listener_local_addr(tcpListener.get()));
@@ -381,7 +407,7 @@ void RiceBackend::gatherSocketAddresses(ScriptExecutionContextIdentifier identif
                 return;
             auto sockets = backend->getSocketsForStream(recvData->streamId);
             rice_sockets_add_tcp(sockets.get(), socket);
-            backend->configureSocketBufferSizes();
+            backend->configureSockets();
         }, recvData, reinterpret_cast<RiceIoDestroy>(destroyRecvSourceData)));
 
         GUniquePtr<RiceAddress> tcpListenerLocalAddress(rice_tcp_listener_local_addr(tcpListener.get()));
@@ -397,9 +423,6 @@ void RiceBackend::gatherSocketAddresses(ScriptExecutionContextIdentifier identif
     recvData->streamId = streamId;
 
     g_source_set_callback(source.get(), static_cast<GSourceFunc>([](auto userData) -> gboolean {
-        RiceIoRecv recv;
-        std::array<uint8_t, 16384> data;
-
         auto sourceData = reinterpret_cast<RecvSourceData*>(userData);
         RefPtr backend = sourceData->backend.get();
         if (!backend)
@@ -407,36 +430,38 @@ void RiceBackend::gatherSocketAddresses(ScriptExecutionContextIdentifier identif
 
         auto sockets = backend->getSocketsForStream(sourceData->streamId);
         if (!sockets)
-            return G_SOURCE_CONTINUE;
+            return G_SOURCE_REMOVE;
 
-        while (true) {
-            rice_sockets_recv(sockets.get(), data.data(), data.size(), &recv);
-            switch (recv.tag) {
-            case RICE_IO_RECV_WOULD_BLOCK:
-                rice_recv_clear(&recv);
-                return G_SOURCE_CONTINUE;
-            case RICE_IO_RECV_DATA: {
-                auto from = riceAddressToString(recv.data.from);
-                auto to = riceAddressToString(recv.data.to);
-                auto protocol = toRTCIceProtocol(recv.data.transport);
-                auto handle = SharedMemoryHandle::createCopy(std::span { data }.first(recv.data.len), SharedMemoryProtection::ReadOnly);
-                if (!handle) [[unlikely]]
-                    break;
-                backend->notifyIncomingData(sourceData->streamId, protocol, WTF::move(from), WTF::move(to), WTF::move(*handle));
+        bool isClosed = false;
+        RiceIoRecv recv;
+        std::array<uint8_t, 16384> data;
+        rice_sockets_recv(sockets.get(), data.data(), data.size(), &recv);
+        switch (recv.tag) {
+        case RICE_IO_RECV_WOULD_BLOCK:
+            break;
+        case RICE_IO_RECV_DATA: {
+            auto from = riceAddressToString(recv.data.from);
+            auto to = riceAddressToString(recv.data.to);
+            auto protocol = toRTCIceProtocol(recv.data.transport);
+            auto handle = SharedMemoryHandle::createCopy(std::span { data }.first(recv.data.len), SharedMemoryProtection::ReadOnly);
+            if (!handle) [[unlikely]]
                 break;
-            }
-            case RICE_IO_RECV_CLOSED:
-                // This enum value is currently unused in rice-io.
-                break;
-            }
-            rice_recv_clear(&recv);
+            backend->notifyIncomingData(sourceData->streamId, protocol, WTF::move(from), WTF::move(to), WTF::move(*handle));
+            break;
         }
-
-        return G_SOURCE_CONTINUE;
+        case RICE_IO_RECV_CLOSED:
+            isClosed = true;
+            break;
+        }
+        rice_recv_clear(&recv);
+        return isClosed ? G_SOURCE_REMOVE : G_SOURCE_CONTINUE;
     }), recvData, reinterpret_cast<GDestroyNotify>(destroyRecvSourceData));
 
     g_source_attach(source.get(), m_runLoop->mainContext());
-    m_sockets.add(streamId, SocketData { WTF::move(sockets), WTF::move(source) });
+    {
+        Locker locker { m_socketsLock };
+        m_sockets.add(streamId, SocketData { WTF::move(sockets), WTF::move(source) });
+    }
     m_udpAddresses.add(streamId, WTF::move(udpAddresses));
 
     completionHandler({ WTF::move(gatheredAddresses), WTF::move(turnAddresses) });
@@ -461,9 +486,10 @@ void RiceBackend::setSocketTypeOfService(unsigned streamId, unsigned value)
 
 void RiceBackend::allocateSocket(unsigned streamId, unsigned componentId, WebCore::RTCIceProtocol protocol, const String& from, const String& to)
 {
-    // FIXME: TCP sockets support requires further debugging. For now keep it disabled to un-tangle post-commit bots.
-    // https://bugs.webkit.org/show_bug.cgi?id=313710
+    // Old rice-io versions lack socket close notifications support and socket timeout configuration support.
+#if !RICE_CHECK_VERSION(0, 4, 3)
     return;
+#endif
 
     if (protocol == WebCore::RTCIceProtocol::Udp)
         return;
@@ -494,8 +520,13 @@ void RiceBackend::allocateSocket(unsigned streamId, unsigned componentId, WebCor
         GUniquePtr<RiceAddress> localAddress(rice_tcp_socket_local_addr(socket));
         auto localAddressString = riceAddressToString(localAddress.get());
 
+        auto tcpAddresses = backend->m_tcpAddresses.ensure(data->streamId, [] {
+            return Vector<std::pair<String, String>> { };
+        });
+        tcpAddresses.iterator->value.append({ localAddressString, data->to });
+
         rice_sockets_add_tcp(sockets.get(), socket);
-        backend->configureSocketBufferSizes();
+        backend->configureSockets();
 
         callOnMainRunLoopAndWait([&, address = WTF::move(localAddressString)] mutable {
             if (RefPtr connection = backend->messageSenderConnection())
@@ -513,15 +544,30 @@ void RiceBackend::removeSocket(unsigned streamId, unsigned componentId, WebCore:
     GUniquePtr<RiceAddress> remoteAddress(riceAddressFromString(to));
     auto sockets = getSocketsForStream(streamId);
     rice_sockets_remove_tcp(sockets.get(), localAddress.get(), remoteAddress.get());
+    m_tcpAddresses.removeIf([&](auto& item) -> bool {
+        auto& [key, addresses] = item;
+        if (key != streamId)
+            return false;
+
+        addresses.removeFirstMatching([&](const auto& pair) -> bool {
+            return pair.first == from && pair.second == to;
+        });
+        return addresses.isEmpty();
+    });
 }
 
-void RiceBackend::configureSocketBufferSizes()
+void RiceBackend::configureSockets()
 {
     // Setting same librice socket size options as LibWebRTC. 1MB for incoming streams and 256Kb for outgoing streams.
     static const uint32_t receiveBufferSize = 1048576;
     static const uint32_t sendBufferSize = 262144;
-    for (auto& data : m_sockets.values())
+    Locker locker { m_socketsLock };
+    for (auto& data : m_sockets.values()) {
         rice_sockets_set_buffer_sizes(data.sockets.get(), sendBufferSize, receiveBufferSize);
+#if RICE_CHECK_VERSION(0, 4, 3)
+        rice_sockets_set_timeouts(data.sockets.get(), 1000000, 1000000);
+#endif
+    }
 }
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/webrtc/rice/RiceBackend.h
+++ b/Source/WebKit/NetworkProcess/webrtc/rice/RiceBackend.h
@@ -108,15 +108,17 @@ private:
 
     RefPtr<RunLoop> m_runLoop;
 
-    void configureSocketBufferSizes();
+    void configureSockets();
 
     struct SocketData {
         GRefPtr<RiceSockets> sockets;
         GRefPtr<GSource> source;
     };
-    HashMap<unsigned, SocketData, WTF::IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> m_sockets;
+    Lock m_socketsLock;
+    HashMap<unsigned, SocketData, WTF::IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> m_sockets WTF_GUARDED_BY_LOCK(m_socketsLock);
 
     HashMap<unsigned, Vector<GUniquePtr<RiceAddress>>, WTF::IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> m_udpAddresses;
+    HashMap<unsigned, Vector<std::pair<String, String>>, WTF::IntHash<unsigned>, WTF::UnsignedWithZeroKeyHashTraits<unsigned>> m_tcpAddresses;
     Vector<GRefPtr<RiceTcpListener>> m_tcpListeners;
 
     HashMap<String, GUniquePtr<RiceAddress>> m_addressCache;

--- a/Tools/Scripts/webkitpy/port/glib.py
+++ b/Tools/Scripts/webkitpy/port/glib.py
@@ -154,8 +154,8 @@ class GLibPort(Port):
         # actual sound card.
         environment['WEBKIT_GST_MAX_NUMBER_OF_AUDIO_OUTPUT_CHANNELS'] = '2'
 
-        # Workaround for bots not using latest SDK version.
-        environment['RICE_LOG'] = 'none'
+        # LibRice logging, example: RICE_LOG=trace.
+        self._copy_values_from_environ_with_prefix(environment, 'RICE_')
 
         if self.get_option("leaks"):
             # Turn off GLib memory optimisations https://wiki.gnome.org/Valgrind.


### PR DESCRIPTION
#### ecec9b6009d9e06e0958c87e6304a6fc98f263e4
<pre>
REGRESSION(311577@main): [GTK][GStreamer][Rice] WebKitNetworkProcess is using massive amounts of CPU and spanning several threads named webrtc-rice-XX
<a href="https://bugs.webkit.org/show_bug.cgi?id=313710">https://bugs.webkit.org/show_bug.cgi?id=313710</a>

Reviewed by Xabier Rodriguez-Calvar.

Un-register TCP and UDP sockets from the librice I/O registry when destroying the backend. The recv
GSource was also prone to infinite looping due to missing RICE_IO_RECV_CLOSED notifications from
rice-io and infinite blocking on rice_sockets_recv() due to lack of configured timeout on the
sockets.

* Source/WebKit/NetworkProcess/webrtc/rice/RiceBackend.cpp:
(WebKit::RiceBackend::~RiceBackend):
(WebKit::RiceBackend::finalizeStream):
(WebKit::RiceBackend::allocateSocket):
(WebKit::RiceBackend::removeSocket):
* Source/WebKit/NetworkProcess/webrtc/rice/RiceBackend.h:

Canonical link: <a href="https://commits.webkit.org/313309@main">https://commits.webkit.org/313309@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/682dc70e75a85af6907230530b5fa202063c4551

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162745 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36221 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29371 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171683 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119191 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164614 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36325 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36225 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126317 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165704 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28669 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146231 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106894 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/162065 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27715 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26247 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19383 "Built successfully") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137423 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23960 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174187 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21500 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25605 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134627 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35895 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30348 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134622 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36318 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35879 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145756 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98277 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/29164 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22592 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35389 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/103140 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34890 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35135 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35038 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->