### PR TITLE
ANGLE: Metal: Avoid using pointers in BufferPool::allocate

### DIFF
--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/BufferMtl.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/BufferMtl.h
@@ -48,13 +48,12 @@ struct ConversionBufferMtl
     ~ConversionBufferMtl();
 
     // One state value determines if we need to re-stream vertex data.
-    bool dirty;
+    bool dirty{true};
 
     // The conversion is stored in a dynamic buffer.
-    mtl::BufferPool data;
-    // These properties are to be filled by user of this buffer conversion
-    mtl::BufferRef convertedBuffer;
-    size_t convertedOffset;
+    mtl::BufferPool bufferPool;
+    // The buffer is to be filled by user of this buffer conversion.
+    mtl::BufferSlice buffer;
 };
 
 struct VertexConversionBufferMtl : public ConversionBufferMtl

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/BufferMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/BufferMtl.mm
@@ -57,9 +57,8 @@ bool isOffsetAndSizeMetalBlitCompatible(size_t offset, size_t size)
 ConversionBufferMtl::ConversionBufferMtl(ContextMtl *contextMtl,
                                          size_t initialSize,
                                          size_t alignment)
-    : dirty(true), convertedBuffer(nullptr), convertedOffset(0)
 {
-    data.initialize(contextMtl, initialSize, alignment, 0);
+    bufferPool.initialize(contextMtl, initialSize, alignment, 0);
 }
 
 ConversionBufferMtl::~ConversionBufferMtl() = default;
@@ -390,7 +389,7 @@ ConversionBufferMtl *BufferMtl::getVertexConversionBuffer(ContextMtl *context,
     mVertexConversionBuffers.emplace_back(context, formatID, stride, offset);
     ConversionBufferMtl *conv        = &mVertexConversionBuffers.back();
     const angle::Format &angleFormat = angle::Format::Get(formatID);
-    conv->data.updateAlignment(context, angleFormat.pixelBytes);
+    conv->bufferPool.updateAlignment(context, angleFormat.pixelBytes);
 
     return conv;
 }
@@ -443,23 +442,20 @@ void BufferMtl::markConversionBuffersDirty()
 {
     for (VertexConversionBufferMtl &buffer : mVertexConversionBuffers)
     {
-        buffer.dirty           = true;
-        buffer.convertedBuffer = nullptr;
-        buffer.convertedOffset = 0;
+        buffer.dirty  = true;
+        buffer.buffer = {};
     }
 
     for (IndexConversionBufferMtl &buffer : mIndexConversionBuffers)
     {
-        buffer.dirty           = true;
-        buffer.convertedBuffer = nullptr;
-        buffer.convertedOffset = 0;
+        buffer.dirty  = true;
+        buffer.buffer = {};
     }
 
     for (UniformConversionBufferMtl &buffer : mUniformConversionBuffers)
     {
-        buffer.dirty           = true;
-        buffer.convertedBuffer = nullptr;
-        buffer.convertedOffset = 0;
+        buffer.dirty  = true;
+        buffer.buffer = {};
     }
     mRestartRangeCache.reset();
 }

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ContextMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ContextMtl.mm
@@ -92,7 +92,7 @@ angle::Result AllocateTriangleFanBufferFromPool(ContextMtl *context,
     ANGLE_TRY(mtl::GetTriangleFanIndicesCount(context, vertexCount, &numIndices));
 
     pool->releaseInFlightBuffers(context);
-    ANGLE_TRY(pool->allocate(context, numIndices * sizeof(uint32_t), nullptr, outBuffer));
+    ANGLE_TRY(pool->allocate(context, numIndices * sizeof(uint32_t), outBuffer));
     *numElemsOut = numIndices;
 
     return angle::Result::Continue;
@@ -104,7 +104,7 @@ angle::Result AllocateBufferFromPool(ContextMtl *context,
                                      mtl::BufferSlice *outBuffer)
 {
     pool->releaseInFlightBuffers(context);
-    ANGLE_TRY(pool->allocate(context, indicesToReserve * sizeof(uint32_t), nullptr, outBuffer));
+    ANGLE_TRY(pool->allocate(context, indicesToReserve * sizeof(uint32_t), outBuffer));
 
     return angle::Result::Continue;
 }
@@ -151,8 +151,8 @@ class LineLoopLastSegmentHelper
 
         indexBufferPool->releaseInFlightBuffers(mContextMtl);
 
-        ANGLE_TRY(indexBufferPool->allocate(mContextMtl, 2 * sizeof(uint32_t), nullptr,
-                                            &mLineLoopIndexBuffer));
+        ANGLE_TRY(
+            indexBufferPool->allocate(mContextMtl, 2 * sizeof(uint32_t), &mLineLoopIndexBuffer));
 
         if (indexTypeOrNone == gl::DrawElementsType::InvalidEnum)
         {

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ProgramExecutableMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ProgramExecutableMtl.mm
@@ -12,6 +12,7 @@
 
 #include "libANGLE/renderer/metal/ProgramExecutableMtl.h"
 
+#include "common/span_util.h"
 #include "libANGLE/renderer/metal/BufferMtl.h"
 #include "libANGLE/renderer/metal/ContextMtl.h"
 #include "libANGLE/renderer/metal/TextureMtl.h"
@@ -145,7 +146,6 @@ angle::Result ConvertUniformBufferData(ContextMtl *contextMtl,
                                        size_t sizeToCopy,
                                        mtl::BufferSlice *outBuffer)
 {
-    uint8_t *dst             = nullptr;
     const uint8_t *maxSrcPtr = sourceData + sizeToCopy;
     dynamicBuffer->releaseInFlightBuffers(contextMtl);
 
@@ -157,6 +157,7 @@ angle::Result ConvertUniformBufferData(ContextMtl *contextMtl,
     size_t numBlocksToCopy =
         (sizeToCopy + blockConversionInfo.stdSize() - 1) / blockConversionInfo.stdSize();
     size_t bytesToAllocate = numBlocksToCopy * blockConversionInfo.metalSize();
+    angle::Span<uint8_t> dst;
     ANGLE_TRY(dynamicBuffer->allocate(contextMtl, bytesToAllocate, &dst, outBuffer));
 
     const std::vector<sh::BlockMemberInfo> &stdConversions = blockConversionInfo.stdInfo();
@@ -183,8 +184,9 @@ angle::Result ConvertUniformBufferData(ContextMtl *contextMtl,
                 if (gl::IsMatrixType(mtlIterator->type))
                 {
 
-                    void *dstMat = dst + mtlIterator->offset + mtlArrayOffset +
-                                   blockConversionInfo.metalSize() * i;
+                    void *dstMat = dst.subspan(mtlIterator->offset + mtlArrayOffset +
+                                               blockConversionInfo.metalSize() * i)
+                                       .data();
                     const void *srcMat = sourceData + stdIterator->offset + stdArrayOffset +
                                          blockConversionInfo.stdSize() * i;
                     // Transpose matricies into column major order, if they're row major encoded.
@@ -213,16 +215,18 @@ angle::Result ConvertUniformBufferData(ContextMtl *contextMtl,
                              gl::VariableComponentSize(GL_BOOL) * boolCol);
                         unsigned int srcValue =
                             srcBool < maxSrcPtr ? *((unsigned int *)(srcBool)) : 0;
-                        uint8_t *dstBool = dst + mtlIterator->offset + mtlArrayOffset +
-                                           blockConversionInfo.metalSize() * i +
-                                           sizeof(bool) * boolCol;
+                        uint8_t *dstBool = dst.subspan(mtlIterator->offset + mtlArrayOffset +
+                                                       blockConversionInfo.metalSize() * i +
+                                                       sizeof(bool) * boolCol)
+                                               .data();
                         *dstBool = (srcValue != 0);
                     }
                 }
                 else
                 {
-                    memcpy_guarded(dst + mtlIterator->offset + mtlArrayOffset +
-                                       blockConversionInfo.metalSize() * i,
+                    memcpy_guarded(dst.subspan(mtlIterator->offset + mtlArrayOffset +
+                                               blockConversionInfo.metalSize() * i)
+                                       .data(),
                                    sourceData + stdIterator->offset + stdArrayOffset +
                                        blockConversionInfo.stdSize() * i,
                                    maxSrcPtr, mtl::GetMetalSizeForGLType(mtlIterator->type));
@@ -1094,15 +1098,11 @@ angle::Result ProgramExecutableMtl::commitUniforms(ContextMtl *context,
 
             ASSERT(uniformBlock.uniformData.size() <= mtl::kDefaultUniformsMaxSize);
             mtl::BufferSlice uniformBuffer;
-            uint8_t *ptrOut;
-            // Allocate a new Uniform buffer
-            ANGLE_TRY(bufferPool->allocate(context, uniformBlock.uniformData.size(), &ptrOut,
+            angle::Span<uint8_t> mapped;
+            ANGLE_TRY(bufferPool->allocate(context, uniformBlock.uniformData.size(), &mapped,
                                            &uniformBuffer));
-            // Copy the uniform result
-            memcpy(ptrOut, uniformBlock.uniformData.data(), uniformBlock.uniformData.size());
-            // Commit
+            angle::SpanMemcpy(mapped, uniformBlock.uniformData.span());
             ANGLE_TRY(bufferPool->commit(context));
-            // Set buffer
             cmdEncoder->setBuffer(shaderType, uniformBuffer.buffer(), uniformBuffer.offset(),
                                   mtl::kDefaultUniformsBindingIndex);
         }
@@ -1318,11 +1318,9 @@ angle::Result ProgramExecutableMtl::legalizeUniformBufferOffsets(ContextMtl *con
                     bufferMtl->getBufferDataReadOnly(context, conversion->initialSrcOffset());
 
                 mtl::BufferSlice converted;
-                ANGLE_TRY(ConvertUniformBufferData(context, conversionInfo, &conversion->data,
+                ANGLE_TRY(ConvertUniformBufferData(context, conversionInfo, &conversion->bufferPool,
                                                    source.data(), source.size(), &converted));
-                conversion->convertedBuffer = converted.buffer();
-                conversion->convertedOffset = converted.offset();
-
+                conversion->buffer = std::move(converted);
                 conversion->dirty = false;
             }
             // Calculate offset in new block.
@@ -1332,12 +1330,10 @@ angle::Result ProgramExecutableMtl::legalizeUniformBufferOffsets(ContextMtl *con
                 (unsigned int)(dstOffsetSource / conversionInfo.stdSize());
             size_t bytesToOffset = numBlocksToOffset * conversionInfo.metalSize();
 
-            size_t resultOffset = conversion->convertedOffset + bytesToOffset;
             mLegalizedOffsetedUniformBuffers[bufferIndex] =
-                mtl::BufferSlice(conversion->convertedBuffer).subslice(resultOffset);
+                conversion->buffer.subslice(bytesToOffset);
             // Ensure that the converted info can fit in the buffer.
-            ASSERT(conversion->convertedOffset + bytesToOffset + conversionInfo.metalSize() <=
-                   conversion->convertedBuffer->size());
+            ASSERT(bytesToOffset + conversionInfo.metalSize() <= conversion->buffer.size());
         }
         else
         {
@@ -1405,8 +1401,7 @@ angle::Result ProgramExecutableMtl::encodeUniformBuffersInfoArgumentBuffer(
     mtl::BufferSlice argumentBuffer;
     bufferEncoder.bufferPool.releaseInFlightBuffers(context);
     ANGLE_TRY(bufferEncoder.bufferPool.allocate(
-        context, bufferEncoder.metalArgBufferEncoder.get().encodedLength, nullptr,
-        &argumentBuffer));
+        context, bufferEncoder.metalArgBufferEncoder.get().encodedLength, &argumentBuffer));
 
     // MTLArgumentEncoder is modifying the buffer indirectly on CPU. We need to call map()
     // so that the buffer's data changes could be flushed to the GPU side later.

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ProvokingVertexHelper.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ProvokingVertexHelper.mm
@@ -217,7 +217,7 @@ angle::Result ProvokingVertexHelper::preconditionIndexBuffer(ContextMtl *context
     checkedBufferSize += indexOffset;
 
     ANGLE_CHECK_GL_MATH(context, checkedBufferSize.IsValid());
-    ANGLE_TRY(mIndexBuffers.allocate(context, checkedBufferSize.ValueOrDie(), nullptr, &newBuffer));
+    ANGLE_TRY(mIndexBuffers.allocate(context, checkedBufferSize.ValueOrDie(), &newBuffer));
     auto threadsPerThreadgroup = MTLSizeMake(MIN(primCount, 64u), 1, 1);
 
     mtl::ComputeCommandEncoder *encoder =
@@ -268,7 +268,7 @@ angle::Result ProvokingVertexHelper::generateIndexBuffer(ContextMtl *context,
     checkedBufferSize *= indexSize;
 
     ANGLE_CHECK_GL_MATH(context, checkedBufferSize.IsValid());
-    ANGLE_TRY(mIndexBuffers.allocate(context, checkedBufferSize.ValueOrDie(), nullptr, &newBuffer));
+    ANGLE_TRY(mIndexBuffers.allocate(context, checkedBufferSize.ValueOrDie(), &newBuffer));
     auto threadsPerThreadgroup = MTLSizeMake(MIN(primCount, 64u), 1, 1);
 
     mtl::ComputeCommandEncoder *encoder =

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/VertexArrayMtl.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/VertexArrayMtl.h
@@ -87,13 +87,6 @@ class VertexArrayMtl : public VertexArrayImpl
                                               const void *sourcePointer,
                                               mtl::BufferSlice *outIdxBuffer);
 
-    angle::Result convertIndexBufferGPU(const gl::Context *glContext,
-                                        gl::DrawElementsType indexType,
-                                        BufferMtl *idxBuffer,
-                                        size_t offset,
-                                        size_t indexCount,
-                                        IndexConversionBufferMtl *conversion);
-
     angle::Result convertVertexBuffer(const gl::Context *glContext,
                                       BufferMtl *srcBuffer,
                                       const gl::VertexBinding &binding,

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/VertexArrayMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/VertexArrayMtl.mm
@@ -22,6 +22,7 @@
 #include "libANGLE/renderer/metal/mtl_format_utils.h"
 
 #include "common/debug.h"
+#include "common/span_util.h"
 #include "common/utilities.h"
 
 namespace rx
@@ -38,19 +39,16 @@ angle::Result StreamVertexData(ContextMtl *contextMtl,
                                size_t vertexCount,
                                size_t stride,
                                VertexCopyFunction vertexLoadFunction,
-                               SimpleWeakBufferHolderMtl *bufferHolder,
-                               size_t *bufferOffsetOut)
+                               mtl::BufferSlice *outBuffer)
 {
     ANGLE_CHECK(contextMtl, vertexLoadFunction, gl::err::kInternalError, GL_INVALID_OPERATION);
-    uint8_t *dst = nullptr;
+    angle::Span<uint8_t> newBufferData;
     mtl::BufferSlice newBuffer;
-    ANGLE_TRY(dynamicBuffer->allocate(contextMtl, bytesToAllocate, &dst, &newBuffer));
-    bufferHolder->set(newBuffer.buffer());
-    *bufferOffsetOut = newBuffer.offset();
-    dst += destOffset;
-    vertexLoadFunction(sourceData, stride, vertexCount, dst);
+    ANGLE_TRY(dynamicBuffer->allocate(contextMtl, bytesToAllocate, &newBufferData, &newBuffer));
+    vertexLoadFunction(sourceData, stride, vertexCount, newBufferData.subspan(destOffset).data());
 
     ANGLE_TRY(dynamicBuffer->commit(contextMtl));
+    *outBuffer = std::move(newBuffer);
     return angle::Result::Continue;
 }
 
@@ -65,72 +63,42 @@ const mtl::VertexFormat &GetVertexConversionFormat(ContextMtl *contextMtl,
     return packedFormat;
 }
 
-size_t GetIndexConvertedBufferSize(gl::DrawElementsType indexType, size_t indexCount)
+void StreamIndexData(ContextMtl *contextMtl,
+                     gl::DrawElementsType indexType,
+                     size_t indexCount,
+                     angle::Span<const uint8_t> source,
+                     angle::Span<uint8_t> destination,
+                     bool primitiveRestartEnabled)
 {
-    size_t elementSize = gl::GetDrawElementsTypeSize(indexType);
-    if (indexType == gl::DrawElementsType::UnsignedByte)
-    {
-        // 8-bit indices are not supported by Metal, so they are promoted to
-        // 16-bit indices below
-        elementSize = sizeof(GLushort);
-    }
-
-    const size_t amount = elementSize * indexCount;
-
-    return amount;
-}
-
-angle::Result StreamIndexData(ContextMtl *contextMtl,
-                              mtl::BufferPool *dynamicBuffer,
-                              const uint8_t *sourcePointer,
-                              gl::DrawElementsType indexType,
-                              size_t indexCount,
-                              bool primitiveRestartEnabled,
-                              mtl::BufferSlice *outBuffer)
-{
-    dynamicBuffer->releaseInFlightBuffers(contextMtl);
-    const size_t amount = GetIndexConvertedBufferSize(indexType, indexCount);
-    GLubyte *dst        = nullptr;
-    mtl::BufferSlice buffer;
-    ANGLE_TRY(dynamicBuffer->allocate(contextMtl, amount, &dst, &buffer));
-
+    RELEASE_ASSERT(source.size() <= destination.size());
     if (indexType == gl::DrawElementsType::UnsignedByte)
     {
         // Unsigned bytes don't have direct support in Metal so we have to expand the
         // memory to a GLushort.
-        const GLubyte *in     = static_cast<const GLubyte *>(sourcePointer);
-        GLushort *expandedDst = reinterpret_cast<GLushort *>(dst);
-
+        angle::Span<uint16_t> expanded = reinterpret_span<uint16_t>(destination);
+        auto s                         = source.begin();
+        auto sourceEnd                 = source.end();
+        auto d                         = expanded.begin();
         if (primitiveRestartEnabled)
         {
-            for (size_t index = 0; index < indexCount; index++)
+            for (; s != sourceEnd; s++, d++)
             {
-                if (in[index] == 0xFF)
-                {
-                    expandedDst[index] = 0xFFFF;
-                }
-                else
-                {
-                    expandedDst[index] = static_cast<GLushort>(in[index]);
-                }
+                uint8_t value = *s;
+                *d            = value == 0xFF ? 0xFFFF : static_cast<uint16_t>(value);
             }
-        }  // if (primitiveRestartEnabled)
+        }
         else
         {
-            for (size_t index = 0; index < indexCount; index++)
+            for (; s != sourceEnd; s++, d++)
             {
-                expandedDst[index] = static_cast<GLushort>(in[index]);
+                *d = static_cast<uint16_t>(*s);
             }
         }  // if (primitiveRestartEnabled)
     }
     else
     {
-        memcpy(dst, sourcePointer, amount);
+        SpanMemcpy(destination, source);
     }
-    ANGLE_TRY(dynamicBuffer->commit(contextMtl));
-
-    *outBuffer = buffer;
-    return angle::Result::Continue;
 }
 
 size_t GetVertexCount(BufferMtl *srcBuffer,
@@ -173,11 +141,6 @@ size_t GetVertexCountWithConversion(BufferMtl *srcBuffer,
         numVertices += static_cast<size_t>(bytes) / binding.getStride();
 
     return numVertices;
-}
-inline size_t GetIndexCount(BufferMtl *srcBuffer, size_t offset, gl::DrawElementsType indexType)
-{
-    size_t elementSize = gl::GetDrawElementsTypeSize(indexType);
-    return (srcBuffer->size() - offset) / elementSize;
 }
 
 inline void SetDefaultVertexBufferLayout(mtl::VertexBufferLayoutDesc *layout)
@@ -617,11 +580,10 @@ angle::Result VertexArrayMtl::updateClientAttribs(const gl::Context *context,
                 // in use.
                 mDynamicVertexData.updateAlignment(contextMtl,
                                                    streamFormat.actualAngleFormat().pixelBytes);
+                mtl::BufferSlice streamedBuffer;
                 ANGLE_TRY(StreamVertexData(contextMtl, &mDynamicVertexData, src, bytesToAllocate,
                                            destOffset, elementCount, binding.getStride(),
-                                           streamFormat.vertexLoadFunction,
-                                           &mConvertedArrayBufferHolders[attribIndex],
-                                           &mCurrentArrayBufferOffsets[attribIndex]));
+                                           streamFormat.vertexLoadFunction, &streamedBuffer));
                 if (contextMtl->getDisplay()->getFeatures().flushAfterStreamVertexData.enabled)
                 {
                     // WaitUntilScheduled is needed for this workaround. NoWait does not have the
@@ -629,6 +591,8 @@ angle::Result VertexArrayMtl::updateClientAttribs(const gl::Context *context,
                     contextMtl->flushCommandBuffer(mtl::WaitUntilScheduled);
                 }
 
+                mConvertedArrayBufferHolders[attribIndex].set(streamedBuffer.buffer());
+                mCurrentArrayBufferOffsets[attribIndex] = streamedBuffer.offset();
                 mCurrentArrayBuffers[attribIndex] = &mConvertedArrayBufferHolders[attribIndex];
             }
         }  // if (needStreaming)
@@ -867,68 +831,47 @@ angle::Result VertexArrayMtl::convertIndexBuffer(const gl::Context *glContext,
     if (!conversion->dirty)
     {
         // reuse the converted buffer
-        size_t resultOffset = conversion->convertedOffset + alignedOffset;
-        *outIdxBuffer       = mtl::BufferSlice(conversion->convertedBuffer).subslice(resultOffset);
+        *outIdxBuffer = conversion->buffer.subslice(alignedOffset);
         return angle::Result::Continue;
     }
 
-    size_t indexCount = GetIndexCount(idxBuffer, offsetModulo, indexType);
-    if ((!contextMtl->getDisplay()->getFeatures().hasCheapRenderPass.enabled &&
+    DisplayMtl *display = contextMtl->getDisplay();
+
+    const size_t elementSize = gl::GetDrawElementsTypeSize(indexType);
+    const size_t indexCount  = (idxBuffer->size() - offsetModulo) / elementSize;
+    const size_t indexSize   = indexCount * elementSize;
+    const size_t convertedIndexSize =
+        indexType == gl::DrawElementsType::UnsignedByte ? indexSize * 2 : indexSize;
+    conversion->bufferPool.releaseInFlightBuffers(contextMtl);
+    mtl::BufferSlice converted;
+
+    if ((!display->getFeatures().hasCheapRenderPass.enabled &&
          contextMtl->getRenderCommandEncoder()))
     {
+        angle::Span<uint8_t> destination;
+        ANGLE_TRY(conversion->bufferPool.allocate(contextMtl, convertedIndexSize, &destination,
+                                                  &converted));
+
         // We shouldn't use GPU to convert when we are in a middle of a render pass.
-        mtl::BufferSlice streamed;
-        ANGLE_TRY(StreamIndexData(contextMtl, &conversion->data,
-                                  idxBuffer->getBufferDataReadOnly(contextMtl, offsetModulo).data(),
-                                  indexType, indexCount, glState.isPrimitiveRestartEnabled(),
-                                  &streamed));
-        conversion->convertedBuffer = streamed.buffer();
-        conversion->convertedOffset = streamed.offset();
-        conversion->dirty           = false;
+        angle::Span<const uint8_t> source =
+            idxBuffer->getBufferDataReadOnly(contextMtl, offsetModulo).first(indexSize);
+        StreamIndexData(contextMtl, indexType, indexCount, source, destination,
+                        glState.isPrimitiveRestartEnabled());
     }
     else
     {
-        ANGLE_TRY(convertIndexBufferGPU(glContext, indexType, idxBuffer, offsetModulo, indexCount,
-                                        conversion));
+        mtl::BufferSlice source =
+            mtl::BufferSlice(idxBuffer->getCurrentBuffer()).subslice(offsetModulo);
+        ANGLE_TRY(conversion->bufferPool.allocate(contextMtl, convertedIndexSize, &converted));
+        ANGLE_TRY(display->getUtils().convertIndexBufferGPU(
+            contextMtl, indexType, static_cast<uint32_t>(indexCount), source, converted,
+            glState.isPrimitiveRestartEnabled()));
     }
-    // Calculate ranges for prim restart simple types.
-    size_t resultOffset = conversion->convertedOffset + alignedOffset;
-    *outIdxBuffer       = mtl::BufferSlice(conversion->convertedBuffer).subslice(resultOffset);
-
-    return angle::Result::Continue;
-}
-
-angle::Result VertexArrayMtl::convertIndexBufferGPU(const gl::Context *glContext,
-                                                    gl::DrawElementsType indexType,
-                                                    BufferMtl *idxBuffer,
-                                                    size_t offset,
-                                                    size_t indexCount,
-                                                    IndexConversionBufferMtl *conversion)
-{
-    ContextMtl *contextMtl = mtl::GetImpl(glContext);
-    DisplayMtl *display    = contextMtl->getDisplay();
-
-    const size_t amount = GetIndexConvertedBufferSize(indexType, indexCount);
-
-    // Allocate new buffer, save it in conversion struct so that we can reuse it when the content
-    // of the original buffer is not dirty.
-    conversion->data.releaseInFlightBuffers(contextMtl);
-    mtl::BufferSlice converted;
-    ANGLE_TRY(conversion->data.allocate(contextMtl, amount, nullptr, &converted));
-    conversion->convertedBuffer = converted.buffer();
-    conversion->convertedOffset = converted.offset();
-
-    // Do the conversion on GPU.
-    ANGLE_TRY(display->getUtils().convertIndexBufferGPU(
-        contextMtl, {indexType, static_cast<uint32_t>(indexCount), idxBuffer->getCurrentBuffer(),
-                     static_cast<uint32_t>(offset), conversion->convertedBuffer,
-                     static_cast<uint32_t>(conversion->convertedOffset),
-                     glContext->getState().isPrimitiveRestartEnabled()}));
-
-    ANGLE_TRY(conversion->data.commit(contextMtl));
-
-    ASSERT(conversion->dirty);
+    ANGLE_TRY(conversion->bufferPool.commit(contextMtl));
     conversion->dirty = false;
+    conversion->buffer = std::move(converted);
+    // Calculate ranges for prim restart simple types.
+    *outIdxBuffer = conversion->buffer.subslice(alignedOffset);
 
     return angle::Result::Continue;
 }
@@ -942,10 +885,19 @@ angle::Result VertexArrayMtl::streamIndexBufferFromClient(const gl::Context *con
     ASSERT(getElementArrayBuffer() == nullptr);
     ContextMtl *contextMtl = mtl::GetImpl(context);
 
-    auto srcData = static_cast<const uint8_t *>(sourcePointer);
-    ANGLE_TRY(StreamIndexData(contextMtl, &mDynamicIndexData, srcData, indexType, indexCount,
-                              context->getState().isPrimitiveRestartEnabled(), outIdxBuffer));
-
+    const size_t elementSize = gl::GetDrawElementsTypeSize(indexType);
+    const size_t indexSize   = indexCount * elementSize;
+    angle::Span<const uint8_t> source(static_cast<const uint8_t *>(sourcePointer), indexSize);
+    const size_t convertedIndexSize =
+        indexType == gl::DrawElementsType::UnsignedByte ? indexSize * 2 : indexSize;
+    mDynamicIndexData.releaseInFlightBuffers(contextMtl);
+    mtl::BufferSlice converted;
+    angle::Span<uint8_t> dstData;
+    ANGLE_TRY(mDynamicIndexData.allocate(contextMtl, convertedIndexSize, &dstData, &converted));
+    StreamIndexData(contextMtl, indexType, indexCount, source, dstData,
+                    context->getState().isPrimitiveRestartEnabled());
+    ANGLE_TRY(mDynamicIndexData.commit(contextMtl));
+    *outIdxBuffer = std::move(converted);
     return angle::Result::Continue;
 }
 
@@ -985,9 +937,9 @@ angle::Result VertexArrayMtl::convertVertexBuffer(const gl::Context *glContext,
         VertexConversionBufferMtl *vertexConversionMtl =
             static_cast<VertexConversionBufferMtl *>(conversion);
         ASSERT((binding.getOffset() - vertexConversionMtl->offset) % binding.getStride() == 0);
-        mConvertedArrayBufferHolders[attribIndex].set(conversion->convertedBuffer);
+        mConvertedArrayBufferHolders[attribIndex].set(conversion->buffer.buffer());
         mCurrentArrayBufferOffsets[attribIndex] =
-            conversion->convertedOffset +
+            conversion->buffer.offset() +
             stride * ((binding.getOffset() - vertexConversionMtl->offset) / binding.getStride());
 
         mCurrentArrayBuffers[attribIndex]       = &mConvertedArrayBufferHolders[attribIndex];
@@ -1004,8 +956,8 @@ angle::Result VertexArrayMtl::convertVertexBuffer(const gl::Context *glContext,
 
     bool canExpandComponentsOnGPU = convertedFormat.actualSameGLType;
 
-    conversion->data.releaseInFlightBuffers(contextMtl);
-    conversion->data.updateAlignment(contextMtl, convertedAngleFormat.pixelBytes);
+    conversion->bufferPool.releaseInFlightBuffers(contextMtl);
+    conversion->bufferPool.updateAlignment(contextMtl, convertedAngleFormat.pixelBytes);
 
     if (canConvertToFloatOnGPU || canExpandComponentsOnGPU)
     {
@@ -1019,9 +971,9 @@ angle::Result VertexArrayMtl::convertVertexBuffer(const gl::Context *glContext,
                                          convertedFormat, stride, numVertices, conversion));
     }
 
-    mConvertedArrayBufferHolders[attribIndex].set(conversion->convertedBuffer);
+    mConvertedArrayBufferHolders[attribIndex].set(conversion->buffer.buffer());
     mCurrentArrayBufferOffsets[attribIndex] =
-        conversion->convertedOffset +
+        conversion->buffer.offset() +
         stride *
             ((binding.getOffset() - static_cast<VertexConversionBufferMtl *>(conversion)->offset) /
              binding.getStride());
@@ -1058,12 +1010,11 @@ angle::Result VertexArrayMtl::convertVertexBufferCPU(ContextMtl *contextMtl,
     size_t srcOffset = MIN(binding.getOffset(), static_cast<GLintptr>(vertexConverison->offset));
     angle::Span<const uint8_t> srcBytes = srcBuffer->getBufferDataReadOnly(contextMtl, srcOffset);
     ANGLE_CHECK_GL_ALLOC(contextMtl, !srcBytes.empty());
-    SimpleWeakBufferHolderMtl conversionBufferHolder;
-    ANGLE_TRY(StreamVertexData(contextMtl, &conversion->data, srcBytes.data(),
+    mtl::BufferSlice convertedBuffer;
+    ANGLE_TRY(StreamVertexData(contextMtl, &conversion->bufferPool, srcBytes.data(),
                                numVertices * targetStride, 0, numVertices, binding.getStride(),
-                               convertedFormat.vertexLoadFunction, &conversionBufferHolder,
-                               &conversion->convertedOffset));
-    conversion->convertedBuffer = conversionBufferHolder.getCurrentBuffer();
+                               convertedFormat.vertexLoadFunction, &convertedBuffer));
+    conversion->buffer = std::move(convertedBuffer);
     return angle::Result::Continue;
 }
 
@@ -1080,8 +1031,7 @@ angle::Result VertexArrayMtl::convertVertexBufferGPU(const gl::Context *glContex
     ContextMtl *contextMtl = mtl::GetImpl(glContext);
 
     mtl::BufferSlice newBuffer;
-    ANGLE_TRY(
-        conversion->data.allocate(contextMtl, numVertices * targetStride, nullptr, &newBuffer));
+    ANGLE_TRY(conversion->bufferPool.allocate(contextMtl, numVertices * targetStride, &newBuffer));
 
     GLintptr bindingOffset = binding.getOffset();
 
@@ -1128,10 +1078,9 @@ angle::Result VertexArrayMtl::convertVertexBufferGPU(const gl::Context *glContex
             contextMtl, convertedFormat.intendedAngleFormat(), params));
     }
 
-    ANGLE_TRY(conversion->data.commit(contextMtl));
+    ANGLE_TRY(conversion->bufferPool.commit(contextMtl));
 
-    conversion->convertedBuffer = newBuffer.buffer();
-    conversion->convertedOffset = newBuffer.offset();
+    conversion->buffer = std::move(newBuffer);
 
     return angle::Result::Continue;
 }

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_buffer_pool.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_buffer_pool.h
@@ -54,13 +54,15 @@ class BufferPool
 
     // This call will allocate a new region at the end of the buffer. It internally may trigger
     // a new buffer to be created (which is returned in the optional parameter
-    // `newBufferAllocatedOut`).  The new region will be in the returned BufferSlice. If
-    // a memory pointer is given, the buffer will be automatically map()ed.
+    // `newBufferAllocatedOut`).  The new region will be in the returned BufferSlice.
+
+    angle::Result allocate(ContextMtl *contextMtl, size_t sizeInBytes, BufferSlice *outBuffer);
+
+    // The buffer will be automatically mapped and the mapped region returned in outMappedData.
     angle::Result allocate(ContextMtl *contextMtl,
                            size_t sizeInBytes,
-                           uint8_t **ptrOut            = nullptr,
-                           BufferSlice *outBuffer      = nullptr,
-                           bool *newBufferAllocatedOut = nullptr);
+                           angle::Span<uint8_t> *outMappedData,
+                           BufferSlice *outBuffer);
 
     // After a sequence of CPU writes, call commit to ensure the data is visible to the GPU.
     // Note: the data will only be made visible to the GPU if the buffer's storage mode is not

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_buffer_pool.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_buffer_pool.mm
@@ -154,9 +154,19 @@ angle::Result BufferPool::allocateNewBuffer(ContextMtl *contextMtl)
 
 angle::Result BufferPool::allocate(ContextMtl *contextMtl,
                                    size_t sizeInBytes,
-                                   uint8_t **ptrOut,
-                                   BufferSlice *outBuffer,
-                                   bool *newBufferAllocatedOut)
+                                   angle::Span<uint8_t> *mappedOut,
+                                   BufferSlice *outBuffer)
+{
+    ANGLE_TRY(allocate(contextMtl, sizeInBytes, outBuffer));
+    // We don't need to synchronize with GPU access, since allocation should return a
+    // non-overlapped region each time.
+    *mappedOut = mBuffer->mapNoSync(contextMtl, outBuffer->offset(), sizeInBytes);
+    return angle::Result::Continue;
+}
+
+angle::Result BufferPool::allocate(ContextMtl *contextMtl,
+                                   size_t sizeInBytes,
+                                   BufferSlice *outBuffer)
 {
     size_t sizeToAllocate = roundUp(sizeInBytes, mAlignment);
 
@@ -197,26 +207,9 @@ angle::Result BufferPool::allocate(ContextMtl *contextMtl,
 
         mNextAllocationOffset = 0;
         mLastFlushOffset      = 0;
-
-        if (newBufferAllocatedOut != nullptr)
-        {
-            *newBufferAllocatedOut = true;
-        }
-    }
-    else if (newBufferAllocatedOut != nullptr)
-    {
-        *newBufferAllocatedOut = false;
     }
 
     ASSERT(mBuffer != nullptr);
-
-    // Optionally map() the buffer if possible
-    if (ptrOut)
-    {
-        // We don't need to synchronize with GPU access, since allocation should return a
-        // non-overlapped region each time.
-        *ptrOut = mBuffer->mapNoSync(contextMtl, mNextAllocationOffset).data();
-    }
 
     if (outBuffer != nullptr)
     {

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_render_utils.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_render_utils.h
@@ -128,19 +128,6 @@ struct TriFanOrLineLoopFromArrayParams
     uint32_t dstOffset;
 };
 
-struct IndexConversionParams
-{
-
-    gl::DrawElementsType srcType;
-    uint32_t indexCount;
-    const BufferRef &srcBuffer;
-    uint32_t srcOffset;
-    const BufferRef &dstBuffer;
-    // Must be multiples of kIndexBufferOffsetAlignment
-    uint32_t dstOffset;
-    bool primitiveRestartEnabled = false;
-};
-
 struct IndexGenerationParams
 {
     gl::DrawElementsType srcType;
@@ -379,7 +366,11 @@ class IndexGeneratorUtils final : angle::NonCopyable
 {
   public:
     angle::Result convertIndexBufferGPU(ContextMtl *contextMtl,
-                                        const IndexConversionParams &params);
+                                        gl::DrawElementsType srcType,
+                                        uint32_t indexCount,
+                                        const BufferSlice &srcBuffer,
+                                        const BufferSlice &dstBuffer,
+                                        bool primitiveRestartEnabled);
     angle::Result generateTriFanBufferFromArrays(ContextMtl *contextMtl,
                                                  const TriFanOrLineLoopFromArrayParams &params);
     // Generate triangle fan index buffer for glDrawElements().
@@ -703,7 +694,11 @@ class RenderUtils : angle::NonCopyable
 
     // See IndexGeneratorUtils
     angle::Result convertIndexBufferGPU(ContextMtl *contextMtl,
-                                        const IndexConversionParams &params);
+                                        gl::DrawElementsType srcType,
+                                        uint32_t indexCount,
+                                        const BufferSlice &srcBuffer,
+                                        const BufferSlice &dstBuffer,
+                                        bool primitiveRestartEnabled);
     angle::Result generateTriFanBufferFromArrays(ContextMtl *contextMtl,
                                                  const TriFanOrLineLoopFromArrayParams &params);
     angle::Result generateTriFanBufferFromElementsArray(ContextMtl *contextMtl,

--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_render_utils.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_render_utils.mm
@@ -871,9 +871,14 @@ angle::Result RenderUtils::blitStencilViaCopyBuffer(const gl::Context *context,
 }
 
 angle::Result RenderUtils::convertIndexBufferGPU(ContextMtl *contextMtl,
-                                                 const IndexConversionParams &params)
+                                                 gl::DrawElementsType srcType,
+                                                 uint32_t indexCount,
+                                                 const BufferSlice &srcBuffer,
+                                                 const BufferSlice &dstBuffer,
+                                                 bool primitiveRestartEnabled)
 {
-    return mIndexUtils.convertIndexBufferGPU(contextMtl, params);
+    return mIndexUtils.convertIndexBufferGPU(contextMtl, srcType, indexCount, srcBuffer, dstBuffer,
+                                             primitiveRestartEnabled);
 }
 angle::Result RenderUtils::generateTriFanBufferFromArrays(
     ContextMtl *contextMtl,
@@ -1800,31 +1805,37 @@ angle::Result IndexGeneratorUtils::getLineLoopFromArrayGeneratorPipeline(
 }
 
 angle::Result IndexGeneratorUtils::convertIndexBufferGPU(ContextMtl *contextMtl,
-                                                         const IndexConversionParams &params)
+                                                         gl::DrawElementsType srcType,
+                                                         uint32_t indexCount,
+                                                         const BufferSlice &srcBuffer,
+                                                         const BufferSlice &dstBuffer,
+                                                         bool primitiveRestartEnabled)
 {
     ComputeCommandEncoder *cmdEncoder = contextMtl->getIndexPreprocessingCommandEncoder();
     ASSERT(cmdEncoder);
 
+    uint32_t srcOffset = static_cast<uint32_t>(srcBuffer.offset());
+    uint32_t dstOffset = static_cast<uint32_t>(dstBuffer.offset());
+
     angle::ObjCPtr<id<MTLComputePipelineState>> pipelineState;
-    ANGLE_TRY(
-        getIndexConversionPipeline(contextMtl, params.srcType, params.srcOffset, &pipelineState));
+    ANGLE_TRY(getIndexConversionPipeline(contextMtl, srcType, srcOffset, &pipelineState));
 
     ASSERT(pipelineState);
 
     cmdEncoder->setComputePipelineState(pipelineState);
 
-    ASSERT((params.dstOffset % kIndexBufferOffsetAlignment) == 0);
+    ASSERT((dstOffset % kIndexBufferOffsetAlignment) == 0);
 
     IndexConversionUniform uniform;
-    uniform.srcOffset               = params.srcOffset;
-    uniform.indexCount              = params.indexCount;
-    uniform.primitiveRestartEnabled = params.primitiveRestartEnabled;
+    uniform.srcOffset               = srcOffset;
+    uniform.indexCount              = indexCount;
+    uniform.primitiveRestartEnabled = primitiveRestartEnabled;
 
     cmdEncoder->setData(uniform, 0);
-    cmdEncoder->setBuffer(params.srcBuffer, 0, 1);
-    cmdEncoder->setBufferForWrite(params.dstBuffer, params.dstOffset, 2);
+    cmdEncoder->setBuffer(srcBuffer.buffer(), 0, 1);
+    cmdEncoder->setBufferForWrite(dstBuffer.buffer(), dstBuffer.offset(), 2);
 
-    DispatchCompute(contextMtl, cmdEncoder, pipelineState, params.indexCount);
+    DispatchCompute(contextMtl, cmdEncoder, pipelineState, indexCount);
 
     return angle::Result::Continue;
 }

--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/BufferPoolTestMetal.mm
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/BufferPoolTestMetal.mm
@@ -76,48 +76,43 @@ TEST_P(BufferPoolTest, AllocationOffsetNoTruncation)
     bufferPool.initialize(contextMtl, kLargeSize, kAlignment, 10);
 
     // Perform first allocation
-    uint8_t *ptr1       = nullptr;
+    angle::Span<uint8_t> mappedData1;
     mtl::BufferSlice buf1;
-    bool newBuffer1     = false;
 
-    ASSERT_EQ(bufferPool.allocate(contextMtl, kLargeSize, &ptr1, &buf1, &newBuffer1),
+    ASSERT_EQ(bufferPool.allocate(contextMtl, kLargeSize, &mappedData1, &buf1),
               angle::Result::Continue);
-    EXPECT_TRUE(newBuffer1);
     EXPECT_EQ(buf1.offset(), 0u);
-    EXPECT_NE(ptr1, nullptr);
+    EXPECT_FALSE(mappedData1.empty());
     EXPECT_NE(buf1.buffer(), nullptr);
 
     // Fill first allocation with a known pattern (0xAA)
     // We only fill the first 4KB to avoid spending too much time on this test
     constexpr size_t kPatternSize = 4096;
-    memset(ptr1, 0xAA, kPatternSize);
+    memset(mappedData1.data(), 0xAA, kPatternSize);
 
     // Commit the first allocation to ensure it's written to the buffer
     ASSERT_EQ(bufferPool.commit(contextMtl), angle::Result::Continue);
 
     // Perform second allocation
-    uint8_t *ptr2       = nullptr;
+    angle::Span<uint8_t> mappedData2;
     mtl::BufferSlice buf2;
-    bool newBuffer2     = false;
 
-    ASSERT_EQ(bufferPool.allocate(contextMtl, kSmallSize, &ptr2, &buf2, &newBuffer2),
+    ASSERT_EQ(bufferPool.allocate(contextMtl, kSmallSize, &mappedData2, &buf2),
               angle::Result::Continue);
 
     // With the fix (size_t), a new buffer should be allocated since the calculated offset
     // exceeds the buffer size. Otherwise (no fix), the offset would truncate and
     // potentially reuse the same buffer incorrectly, causing memory corruption.
-    EXPECT_TRUE(newBuffer2);
-
     // The offset should be 0 in the new buffer (not a truncated large value)
     EXPECT_EQ(buf2.offset(), 0u);
-    EXPECT_NE(ptr2, nullptr);
+    EXPECT_FALSE(mappedData2.empty());
     EXPECT_NE(buf2.buffer(), nullptr);
 
     // Buffers should be different
     EXPECT_NE(buf1.buffer().get(), buf2.buffer().get());
 
     // Fill second allocation with a different pattern (0xBB)
-    memset(ptr2, 0xBB, kSmallSize);
+    memset(mappedData2.data(), 0xBB, kSmallSize);
 
     // Commit the second allocation
     ASSERT_EQ(bufferPool.commit(contextMtl), angle::Result::Continue);


### PR DESCRIPTION
#### 46f5d284a13d5f286b9d68fc66e0ce29164352f2
<pre>
ANGLE: Metal: Avoid using pointers in BufferPool::allocate
<a href="https://bugs.webkit.org/show_bug.cgi?id=314181">https://bugs.webkit.org/show_bug.cgi?id=314181</a>
<a href="https://rdar.apple.com/176343541">rdar://176343541</a>

Reviewed by Dan Glastonbury.

Use angle::Span&lt;uint8_t&gt; instead of uint8_t* for mapping out the
allocated buffer slice.

* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/BufferMtl.h:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/BufferMtl.mm:
(rx::ConversionBufferMtl::ConversionBufferMtl):
(rx::BufferMtl::getVertexConversionBuffer):
(rx::BufferMtl::markConversionBuffersDirty):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ContextMtl.mm:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ProgramExecutableMtl.mm:
(rx::ProgramExecutableMtl::commitUniforms):
(rx::ProgramExecutableMtl::legalizeUniformBufferOffsets):
(rx::ProgramExecutableMtl::encodeUniformBuffersInfoArgumentBuffer):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/ProvokingVertexHelper.mm:
(rx::ProvokingVertexHelper::preconditionIndexBuffer):
(rx::ProvokingVertexHelper::generateIndexBuffer):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/VertexArrayMtl.h:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/VertexArrayMtl.mm:
(rx::VertexArrayMtl::updateClientAttribs):
(rx::VertexArrayMtl::convertIndexBuffer):
(rx::VertexArrayMtl::streamIndexBufferFromClient):
(rx::VertexArrayMtl::convertVertexBuffer):
(rx::VertexArrayMtl::convertVertexBufferCPU):
(rx::VertexArrayMtl::convertVertexBufferGPU):
(rx::VertexArrayMtl::convertIndexBufferGPU): Deleted.
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_buffer_pool.h:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_buffer_pool.mm:
(rx::mtl::BufferPool::allocate):
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_render_utils.h:
* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/mtl_render_utils.mm:
(rx::mtl::RenderUtils::convertIndexBufferGPU):
(rx::mtl::IndexGeneratorUtils::convertIndexBufferGPU):
* Source/ThirdParty/ANGLE/src/tests/gl_tests/BufferPoolTestMetal.mm:
(angle::TEST_P):

Canonical link: <a href="https://commits.webkit.org/313076@main">https://commits.webkit.org/313076@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5a3346b5d3c44449fc310ec002c1a1e9707c759

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162018 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35493 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28598 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170926 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118389 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/96bf1108-e3ec-4ce0-bab0-1b46e767d223) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35595 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35494 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125732 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88603 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ebd8172b-c9cc-4c21-906d-24c30afad897) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164977 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28044 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145534 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106314 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/57ef1ecf-2b44-4346-99cc-16b281dbe4b9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27093 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25606 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18646 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136786 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23288 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173414 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24929 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134023 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35166 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29691 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134029 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36187 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35150 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145083 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97285 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28555 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21908 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34660 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34161 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34403 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34309 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->