### PR TITLE
[:has() perf] Use scope selectors to limit traversal in class/attribute/pseudo-class invalidation

### DIFF
--- a/LayoutTests/fast/selectors/has-invalidation-traversal-size-expected.txt
+++ b/LayoutTests/fast/selectors/has-invalidation-traversal-size-expected.txt
@@ -42,4 +42,18 @@
   Traversal count: 7
 .c22:has(.trigger22) .target with no .c22 ancestor - skip invalidation
   Traversal count: 0
+.c22:has(.trigger22) .target class toggle with no .c22 ancestor - skip invalidation
+  Traversal count: 0
+.c23:has(#trigger23) .target id toggle with no .c23 ancestor - skip invalidation
+  Traversal count: 0
+.c24:has([data-trigger24]) .target attribute toggle with no .c24 ancestor - skip invalidation
+  Traversal count: 0
+.c25:has(:checked) .target pseudo-class toggle with no .c25 ancestor - skip invalidation
+  Traversal count: 1
+.c26:has(.trigger26) .target class toggle with .c26 ancestor - bounded invalidation
+  Traversal count: 7
+.c28:has([data-trigger28]) .target attribute toggle with .c28 ancestor - bounded invalidation
+  Traversal count: 14
+.c29:has(:checked) .target pseudo-class toggle with .c29 ancestor - bounded invalidation
+  Traversal count: 8
 

--- a/LayoutTests/fast/selectors/has-invalidation-traversal-size.html
+++ b/LayoutTests/fast/selectors/has-invalidation-traversal-size.html
@@ -46,6 +46,18 @@
 .c21 div:is(.other:has(.trigger)) .target { color: green; }
 /* Scope selector has no matching ancestor - invalidation is skipped entirely */
 .c22:has(.trigger22) .target { color: green; }
+/* Scope-bounded traversal for id change invalidation */
+.c23:has(#trigger23) .target { color: green; }
+/* Scope-bounded traversal for attribute change invalidation */
+.c24:has([data-trigger24]) .target { color: green; }
+/* Scope-bounded traversal for pseudo-class change invalidation */
+.c25:has(:checked) .target { color: green; }
+/* Scope-bounded class change with matching ancestor - bounded to .c26 subtree */
+.c26:has(.trigger26) .target { color: green; }
+/* Scope-bounded attribute change with matching ancestor - bounded to .c28 subtree */
+.c28:has([data-trigger28]) .target { color: green; }
+/* Scope-bounded pseudo-class change with matching ancestor - bounded to .c29 subtree */
+.c29:has(:checked) .target { color: green; }
 </style>
 <script>
 if (window.testRunner)
@@ -252,6 +264,69 @@ runTest(".c22:has(.trigger22) .target with no .c22 ancestor - skip invalidation"
     trigger.className = "trigger22";
     container.appendChild(trigger);
 }, false);
+
+runTest(".c22:has(.trigger22) .target class toggle with no .c22 ancestor - skip invalidation", null, function(existing) {
+    existing.className = "trigger22";
+}, false, { setup: function(container) {
+    // Pre-insert a class-less element; toggling .trigger22 on it exercises ClassChangeInvalidation
+    // without triggering invalidation from removing another class (like .other) used elsewhere.
+    var existing = document.createElement("div");
+    container.appendChild(existing);
+    return existing;
+} });
+
+runTest(".c23:has(#trigger23) .target id toggle with no .c23 ancestor - skip invalidation", null, function(existing) {
+    existing.id = "trigger23";
+}, false, { setup: function(container) {
+    var existing = document.createElement("div");
+    container.appendChild(existing);
+    return existing;
+} });
+
+runTest(".c24:has([data-trigger24]) .target attribute toggle with no .c24 ancestor - skip invalidation", null, function(existing) {
+    existing.setAttribute("data-trigger24", "");
+}, false, { setup: function(container) {
+    var existing = document.createElement("div");
+    container.appendChild(existing);
+    return existing;
+} });
+
+runTest(".c25:has(:checked) .target pseudo-class toggle with no .c25 ancestor - skip invalidation", null, function(existing) {
+    existing.checked = true;
+}, false, { setup: function(container) {
+    var existing = document.createElement("input");
+    existing.type = "checkbox";
+    container.appendChild(existing);
+    return existing;
+} });
+
+// The following cases exercise the same *ChangeInvalidation entry points when the scope
+// selector does match an ancestor. Without scope wired these would traverse document-wide;
+// with scope they are bounded to the .c26/28/29 subtree.
+runTest(".c26:has(.trigger26) .target class toggle with .c26 ancestor - bounded invalidation", "c26", function(existing) {
+    existing.className = "trigger26";
+}, true, { setup: function(container) {
+    var existing = document.createElement("div");
+    container.appendChild(existing);
+    return existing;
+} });
+
+runTest(".c28:has([data-trigger28]) .target attribute toggle with .c28 ancestor - bounded invalidation", "c28", function(existing) {
+    existing.setAttribute("data-trigger28", "");
+}, true, { setup: function(container) {
+    var existing = document.createElement("div");
+    container.appendChild(existing);
+    return existing;
+} });
+
+runTest(".c29:has(:checked) .target pseudo-class toggle with .c29 ancestor - bounded invalidation", "c29", function(existing) {
+    existing.checked = true;
+}, true, { setup: function(container) {
+    var existing = document.createElement("input");
+    existing.type = "checkbox";
+    container.appendChild(existing);
+    return existing;
+} });
 </script>
 </script>
 </body>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8639,3 +8639,7 @@ webgl/webgl2-provoking-vertex-primitive-restart-uint16-nocrash.html [ Skip ]
 webkit.org/b/314022 [ Release ] fast/scrolling/ios/iframe-scroll-into-view.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/314216 imported/w3c/web-platform-tests/css/css-position/fixed-z-index-blend.html [ Pass ImageOnlyFailure ]
+
+# iOS UA stylesheet has :checked form-control rules that add self-invalidation, changing
+# traversal counts compared to macOS.
+fast/selectors/has-invalidation-traversal-size.html [ Skip ]

--- a/Source/WebCore/style/RuleFeature.cpp
+++ b/Source/WebCore/style/RuleFeature.cpp
@@ -77,15 +77,10 @@ const CSSSelector& RuleAndSelector::selector() const
     return styleRule->selectorList().selectorAt(selectorIndex);
 }
 
-RuleFeature::RuleFeature(const RuleData& ruleData, MatchElement matchElement, IsNegation isNegation)
+RuleFeature::RuleFeature(const RuleData& ruleData, MatchElement matchElement, IsNegation isNegation, CSSSelectorList&& invalidationSelector, CSSSelectorList&& scopeSelector)
     : RuleAndSelector(ruleData)
     , matchElement(matchElement)
     , isNegation(isNegation)
-{
-}
-
-RuleFeatureWithInvalidationSelector::RuleFeatureWithInvalidationSelector(const RuleData& data, MatchElement matchElement, IsNegation isNegation, CSSSelectorList&& invalidationSelector, CSSSelectorList&& scopeSelector)
-    : RuleFeature(data, matchElement, isNegation)
     , invalidationSelector(WTF::move(invalidationSelector))
     , scopeSelector(WTF::move(scopeSelector))
 {
@@ -276,6 +271,31 @@ void RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFeatures& se
     // argument (no crossing → subject compound; crossed → non-subject/ancestor compound).
     bool crossedCombinator = false;
 
+    // Scope selector for :has() features. Inside nested :is()/:not() we can only bound with
+    // outer compound peers if we haven't crossed a combinator that reaches outside the :has()
+    // scope (e.g. descendant inside :is, or sibling inside :is when :has() itself is in
+    // sibling/subject position). Otherwise the matched element may be outside the scope subtree.
+    auto scopeSourcesForHasPseudo = [&] -> Vector<const CSSSelector*> {
+        if (context.hasInNonSubjectCompoundOfLogical)
+            return { };
+        if (context.isNestedInLogicalCombination && crossedScopeBreakingCombinator)
+            return { };
+        auto result = context.outerCompoundSelectors;
+        result.append(context.hasPseudoClass);
+        return result;
+    };
+
+    // Scope selector for non-:has()-pseudo features (class/id/attribute/pseudo-class). Bounds
+    // the ancestor walk performed by Invalidator's Ancestor+Descendant :has() path when such
+    // a feature is toggled on an existing element inside a :has() argument. Emit only when
+    // the has-bearer is guaranteed to be an ancestor of the element matching the feature
+    // (i.e., scope-breaking flags are clear).
+    auto scopeSourcesForFeature = [&] -> Vector<const CSSSelector*> {
+        if (!context.hasPseudoClass)
+            return { };
+        return scopeSourcesForHasPseudo();
+    };
+
     // When walking a :has() argument chain, emit hasPseudoClasses entries for compounds
     // at sibling combinator boundaries or containing positional pseudo-classes.
     // Child mutations can break sibling adjacency and change positional matching,
@@ -298,20 +318,7 @@ void RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFeatures& se
             if (!compoundIsAffectedByChildMutation())
                 return;
         }
-        // Entries inside nested :is()/:not() can only match elements outside the :has() scope if
-        // we crossed a combinator that reaches outside (e.g. descendant inside :is, or sibling
-        // inside :is when :has() itself is in sibling/subject position). Otherwise the matched
-        // element is always within the scope subtree and the scope selector can bound traversal.
-        auto scopeSources = [&] -> Vector<const CSSSelector*> {
-            if (context.hasInNonSubjectCompoundOfLogical)
-                return { };
-            if (context.isNestedInLogicalCombination && crossedScopeBreakingCombinator)
-                return { };
-            auto result = context.outerCompoundSelectors;
-            result.append(context.hasPseudoClass);
-            return result;
-        }();
-        selectorFeatures.hasPseudoClasses.append({ selector, matchElement, context.isNegation, WTF::move(scopeSources) });
+        selectorFeatures.hasPseudoClasses.append({ selector, matchElement, context.isNegation, scopeSourcesForHasPseudo() });
     };
 
     while (true) {
@@ -320,20 +327,20 @@ void RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFeatures& se
             if (matchElement.relation == MatchElement::Relation::Parent || matchElement.relation == MatchElement::Relation::Ancestor)
                 idsMatchingAncestorsInRules.add(selector->value());
             else if (matchElement.hasRelation || matchElement.relation == MatchElement::Relation::AnySibling || matchElement.relation == MatchElement::Relation::Host || matchElement.relation == MatchElement::Relation::HostChild)
-                selectorFeatures.ids.append({ selector, matchElement, context.isNegation });
+                selectorFeatures.ids.append({ selector, matchElement, context.isNegation, scopeSourcesForFeature() });
         } else if (selector->match() == CSSSelector::Match::Class)
-            selectorFeatures.classes.append({ selector, matchElement, context.isNegation });
+            selectorFeatures.classes.append({ selector, matchElement, context.isNegation, scopeSourcesForFeature() });
         else if (selector->isAttributeSelector()) {
             attributeLowercaseLocalNamesInRules.add(selector->attribute().localNameLowercase());
             attributeLocalNamesInRules.add(selector->attribute().localName());
-            selectorFeatures.attributes.append({ selector, matchElement, context.isNegation });
+            selectorFeatures.attributes.append({ selector, matchElement, context.isNegation, scopeSourcesForFeature() });
         } else if (selector->match() == CSSSelector::Match::PseudoElement) {
             // Don't put anything here as selectors that differ by pseudo-element only are collected only once.
             // Pseudo-elements are handled in collectPseudoElementFeatures.
         } else if (selector->match() == CSSSelector::Match::PseudoClass) {
             bool isLogicalCombination = isLogicalCombinationPseudoClass(selector->pseudoClass());
             if (!isLogicalCombination)
-                selectorFeatures.pseudoClasses.append({ selector, matchElement, context.isNegation });
+                selectorFeatures.pseudoClasses.append({ selector, matchElement, context.isNegation, scopeSourcesForFeature() });
         }
 
         collectHasPseudoClassFeatureIfNeeded();
@@ -475,9 +482,13 @@ void RuleFeatureSet::collectFeatures(CollectionContext& collectionContext, const
         featureVector.append(WTF::move(featureToAdd));
     };
 
+    auto scopeSelectorFromSources = [](const Vector<const CSSSelector*>& scopeSources) {
+        return scopeSources.isEmpty() ? CSSSelectorList { } : CSSSelectorParser::makeHasScopeSelector(scopeSources);
+    };
+
     auto addToMap = [&]<typename HostAffectingNames>(auto& map, auto& entries, HostAffectingNames hostAffectingNames) {
         for (auto& entry : entries) {
-            auto& [selector, matchElement, isNegation] = entry;
+            auto& [selector, matchElement, isNegation, scopeSources] = entry;
             auto& name = selector->value();
 
             auto& featureVector = *map.ensure(name, [] {
@@ -487,7 +498,9 @@ void RuleFeatureSet::collectFeatures(CollectionContext& collectionContext, const
             addToVector(featureVector, RuleFeature {
                 ruleData,
                 matchElement,
-                isNegation
+                isNegation,
+                { },
+                scopeSelectorFromSources(scopeSources)
             });
 
             setUsesRelation(matchElement.relation);
@@ -503,16 +516,17 @@ void RuleFeatureSet::collectFeatures(CollectionContext& collectionContext, const
     addToMap(classRules, selectorFeatures.classes, &classesAffectingHost);
 
     for (auto& entry : selectorFeatures.attributes) {
-        auto& [selector, matchElement, isNegation] = entry;
+        auto& [selector, matchElement, isNegation, scopeSources] = entry;
         auto& featureVector = *attributeRules.ensure(selector->attribute().localNameLowercase(), [] {
-            return makeUnique<Vector<RuleFeatureWithInvalidationSelector>>();
+            return makeUnique<RuleFeatureVector>();
         }).iterator->value;
 
-        addToVector(featureVector, RuleFeatureWithInvalidationSelector {
+        addToVector(featureVector, RuleFeature {
             ruleData,
             matchElement,
             isNegation,
-            CSSSelectorList::makeCopyingSimpleSelector(*selector)
+            CSSSelectorList::makeCopyingSimpleSelector(*selector),
+            scopeSelectorFromSources(scopeSources)
         });
 
         if (matchElement.relation == MatchElement::Relation::Host)
@@ -521,7 +535,7 @@ void RuleFeatureSet::collectFeatures(CollectionContext& collectionContext, const
     }
 
     for (auto& entry : selectorFeatures.pseudoClasses) {
-        auto& [selector, matchElement, isNegation] = entry;
+        auto& [selector, matchElement, isNegation, scopeSources] = entry;
         auto& featureVector = *pseudoClassRules.ensure(makePseudoClassInvalidationKey(selector->pseudoClass(), *selector), [] {
             return makeUnique<Vector<RuleFeature>>();
         }).iterator->value;
@@ -529,7 +543,9 @@ void RuleFeatureSet::collectFeatures(CollectionContext& collectionContext, const
         addToVector(featureVector, RuleFeature {
             ruleData,
             matchElement,
-            isNegation
+            isNegation,
+            { },
+            scopeSelectorFromSources(scopeSources)
         });
 
         if (matchElement.relation == MatchElement::Relation::Host)
@@ -543,10 +559,10 @@ void RuleFeatureSet::collectFeatures(CollectionContext& collectionContext, const
         auto& [selector, matchElement, isNegation, scopeSources] = entry;
         // The selector argument points to a selector inside :has() selector list instead of :has() itself.
         auto& featureVector = *hasPseudoClassRules.ensure(makePseudoClassInvalidationKey(CSSSelector::PseudoClass::Has, *selector), [] {
-            return makeUnique<Vector<RuleFeatureWithInvalidationSelector>>();
+            return makeUnique<RuleFeatureVector>();
         }).iterator->value;
 
-        addToVector(featureVector, RuleFeatureWithInvalidationSelector {
+        addToVector(featureVector, RuleFeature {
             ruleData,
             matchElement,
             isNegation,

--- a/Source/WebCore/style/RuleFeature.h
+++ b/Source/WebCore/style/RuleFeature.h
@@ -94,19 +94,18 @@ struct RuleAndSelector {
 };
 
 struct RuleFeature : public RuleAndSelector {
-    RuleFeature(const RuleData&, MatchElement, IsNegation);
+    RuleFeature(const RuleData&, MatchElement, IsNegation, CSSSelectorList&& invalidationSelector = { }, CSSSelectorList&& scopeSelector = { });
 
     MatchElement matchElement;
     IsNegation isNegation; // Whether the selector is in a (non-paired) :not() context.
-};
-static_assert(sizeof(RuleFeature) <= 16, "RuleFeature is a frequently allocated object. Keep it small.");
-
-struct RuleFeatureWithInvalidationSelector : public RuleFeature {
-    RuleFeatureWithInvalidationSelector(const RuleData&, MatchElement, IsNegation, CSSSelectorList&& invalidationSelector, CSSSelectorList&& scopeSelector = { });
-
+    // Invalidation selector is used for attribute selector and :has() invalidation.
+    // For attribute selectors it is the simple selector for fast testing whether an attribute mutation may have an effect.
+    // For :has() it is the complex argument selector for testing if adding or removing a node may affect :has() matching.
     CSSSelectorList invalidationSelector;
+    // Selector for the :has() scope element, used to bound invalidation traversal.
     CSSSelectorList scopeSelector;
 };
+static_assert(sizeof(RuleFeature) <= 32, "RuleFeature is a frequently allocated object. Keep it small.");
 #pragma pack(pop)
 
 using PseudoClassInvalidationKey = std::tuple<unsigned, uint8_t, AtomString>;
@@ -145,9 +144,9 @@ struct RuleFeatureSet {
 
     HashMap<AtomString, std::unique_ptr<RuleFeatureVector>> idRules;
     HashMap<AtomString, std::unique_ptr<RuleFeatureVector>> classRules;
-    HashMap<AtomString, std::unique_ptr<Vector<RuleFeatureWithInvalidationSelector>>> attributeRules;
+    HashMap<AtomString, std::unique_ptr<RuleFeatureVector>> attributeRules;
     HashMap<PseudoClassInvalidationKey, std::unique_ptr<RuleFeatureVector>> pseudoClassRules;
-    HashMap<PseudoClassInvalidationKey, std::unique_ptr<Vector<RuleFeatureWithInvalidationSelector>>> hasPseudoClassRules;
+    HashMap<PseudoClassInvalidationKey, std::unique_ptr<RuleFeatureVector>> hasPseudoClassRules;
 
     HashSet<AtomString> classesAffectingHost;
     HashSet<AtomString> attributesAffectingHost;
@@ -163,14 +162,13 @@ struct RuleFeatureSet {
 
 private:
     struct SelectorFeatures {
-        using InvalidationFeature = std::tuple<const CSSSelector*, MatchElement, IsNegation>;
-        using HasInvalidationFeature = std::tuple<const CSSSelector*, MatchElement, IsNegation, Vector<const CSSSelector*>>;
+        using InvalidationFeature = std::tuple<const CSSSelector*, MatchElement, IsNegation, Vector<const CSSSelector*>>;
 
         Vector<InvalidationFeature> ids;
         Vector<InvalidationFeature> classes;
         Vector<InvalidationFeature> attributes;
         Vector<InvalidationFeature> pseudoClasses;
-        Vector<HasInvalidationFeature> hasPseudoClasses;
+        Vector<InvalidationFeature> hasPseudoClasses;
     };
     struct RecursiveCollectionContext;
     void collectFeaturesFromSelector(SelectorFeatures&, const CSSSelector&, MatchElement = { MatchElement::Relation::Subject, { } });

--- a/Source/WebCore/style/StyleScopeRuleSets.cpp
+++ b/Source/WebCore/style/StyleScopeRuleSets.cpp
@@ -293,8 +293,8 @@ void ScopeRuleSets::collectFeatures() const
     m_features.shrinkToFit();
 }
 
-template<typename KeyType, typename RuleFeatureVectorType, typename Hash, typename HashTraits>
-static Vector<InvalidationRuleSet>* ensureInvalidationRuleSets(const KeyType& key, HashMap<KeyType, std::unique_ptr<Vector<InvalidationRuleSet>>, Hash, HashTraits>& ruleSetMap, const HashMap<KeyType, std::unique_ptr<RuleFeatureVectorType>, Hash, HashTraits>& ruleFeatures)
+template<typename KeyType, typename Hash, typename HashTraits>
+static Vector<InvalidationRuleSet>* ensureInvalidationRuleSets(const KeyType& key, HashMap<KeyType, std::unique_ptr<Vector<InvalidationRuleSet>>, Hash, HashTraits>& ruleSetMap, const HashMap<KeyType, std::unique_ptr<RuleFeatureVector>, Hash, HashTraits>& ruleFeatures)
 {
     return ruleSetMap.ensure(key, [&] () -> std::unique_ptr<Vector<InvalidationRuleSet>> {
         auto* features = ruleFeatures.get(key);
@@ -329,12 +329,7 @@ static Vector<InvalidationRuleSet>* ensureInvalidationRuleSets(const KeyType& ke
         HashMap<GenericHashKey<RuleSetKey>, RefPtr<RuleSet>> ruleSetMap;
 
         for (auto& feature : *features) {
-            auto key = [&] {
-                if constexpr (std::is_same_v<typename RuleFeatureVectorType::ValueType, RuleFeatureWithInvalidationSelector>)
-                    return GenericHashKey<RuleSetKey> { { feature.matchElement, feature.isNegation, &feature.invalidationSelector, &feature.scopeSelector } };
-                else
-                    return GenericHashKey<RuleSetKey> { { feature.matchElement, feature.isNegation } };
-            }();
+            auto key = GenericHashKey<RuleSetKey> { { feature.matchElement, feature.isNegation, &feature.invalidationSelector, &feature.scopeSelector } };
 
             auto& ruleSet = ruleSetMap.ensure(key, [] {
                 return RuleSet::create();
@@ -347,9 +342,9 @@ static Vector<InvalidationRuleSet>* ensureInvalidationRuleSets(const KeyType& ke
             auto& key = entry.key.key();
             entry.value->shrinkToFit();
             auto invalidationSelector = [&] {
-                if (key.invalidationSelector && key.scopeSelector && !key.scopeSelector->isEmpty())
+                if (!key.invalidationSelector->isEmpty() && !key.scopeSelector->isEmpty())
                     return CSSSelectorParser::makeHasArgumentWithScope(key.invalidationSelector->first(), key.scopeSelector->first());
-                if (key.invalidationSelector)
+                if (!key.invalidationSelector->isEmpty())
                     return CSSSelectorList { *key.invalidationSelector };
                 return CSSSelectorList { };
             }();
@@ -358,7 +353,7 @@ static Vector<InvalidationRuleSet>* ensureInvalidationRuleSets(const KeyType& ke
                 WTF::move(invalidationSelector),
                 key.matchElement,
                 key.isNegation,
-                key.scopeSelector ? *key.scopeSelector : CSSSelectorList { }
+                *key.scopeSelector
             };
         }));
     }).iterator->value.get();


### PR DESCRIPTION
#### 5719b6566bbf264bd8ad79b2cdc9b21c23a8e582
<pre>
[:has() perf] Use scope selectors to limit traversal in class/attribute/pseudo-class invalidation
<a href="https://bugs.webkit.org/show_bug.cgi?id=314541">https://bugs.webkit.org/show_bug.cgi?id=314541</a>
<a href="https://rdar.apple.com/176771971">rdar://176771971</a>

Reviewed by Alan Baradlay.

So far these optimizations have been used for child change invalidation (tree shape
mutation) only.

* LayoutTests/fast/selectors/has-invalidation-traversal-size-expected.txt:
* LayoutTests/fast/selectors/has-invalidation-traversal-size.html:
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::RuleFeature::RuleFeature):
(WebCore::Style::RuleFeatureSet::recursivelyCollectFeaturesFromSelector):
(WebCore::Style::RuleFeatureSet::collectFeatures):

Collect scope selectors for class/id/attribute/pseudo-class features, not just ones used for child change invalidation.

(WebCore::Style::RuleFeatureWithInvalidationSelector::RuleFeatureWithInvalidationSelector): Deleted.
* Source/WebCore/style/RuleFeature.h:
(WebCore::Style::RuleFeature::RuleFeature):

Size of RuleFeature grows by two pointers. This shouldn&apos;t be a problem, we have started deduplicating features
since and we have way fewer of them than we used to have.

(WebCore::Style::RuleFeatureWithInvalidationSelector::RuleFeatureWithInvalidationSelector): Deleted.

Merge RuleFeatureWithInvalidationSelector into RuleFeature so all feature kinds can
carry an optional scopeSelector. This also simplified code and we can remove templating.

* Source/WebCore/style/StyleScopeRuleSets.cpp:
(WebCore::Style::ensureInvalidationRuleSets):

Canonical link: <a href="https://commits.webkit.org/313009@main">https://commits.webkit.org/313009@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/248594576999eaf1eef4343034dca10e7adb838c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161811 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35285 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28388 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170714 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118182 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/893e2c6d-9010-403d-9c7c-fd559e7d20ff) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163680 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35386 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35286 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125548 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88466 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7574cda3-8f8e-4a98-8c80-5ee23644ed2c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164770 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27863 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145344 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106144 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d368819c-2cb1-4afa-8685-96ed9bea74bc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26912 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25426 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18435 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136605 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23099 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173203 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20243 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24740 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133845 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34959 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29514 "Found 1 new test failure: imported/w3c/web-platform-tests/fullscreen/model/move-to-fullscreen-iframe.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133850 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36147 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34943 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144894 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97005 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28381 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21717 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34453 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101898 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33953 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34196 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34102 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->