### PR TITLE
[JSC] Store computed hash in RTT and RTTGroup

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp
@@ -386,6 +386,9 @@ inline bool equalFieldTypes(FieldType a, IntraLookupA&& aIntra, FieldType b, Int
 template<typename IntraLookup>
 unsigned hashRTTForRecGroup(const RTT& rtt, IntraLookup&& intra)
 {
+    if (unsigned hash = rtt.hashMayBeEmpty())
+        return hash;
+
     unsigned h = static_cast<unsigned>(rtt.kind());
     h = WTF::pairIntHash(h, rtt.isFinalType() ? 1 : 0);
     h = WTF::pairIntHash(h, rtt.displaySizeExcludingThis());
@@ -415,6 +418,8 @@ unsigned hashRTTForRecGroup(const RTT& rtt, IntraLookup&& intra)
         h = WTF::pairIntHash(h, hashFieldType(rtt.arrayPayload().elementType(), intra));
         break;
     }
+
+    rtt.setHash(h);
     return h;
 }
 
@@ -659,11 +664,16 @@ Ref<const RTT> TypeInformation::getCanonicalRTT(TypeIndex type)
 // =====================================================================
 unsigned CanonicalRecursionGroupEntryHash::hash(const CanonicalRecursionGroupEntry& entry)
 {
+    if (unsigned hash = entry.group->hashMayBeEmpty())
+        return hash;
+
     const auto& rtts = entry.group->rtts();
     GroupLookup lookup { entry.group };
     unsigned h = rtts.size();
     for (const auto& rtt : rtts)
         h = WTF::pairIntHash(h, hashRTTForRecGroup(rtt, lookup));
+
+    entry.group->setHash(h);
     return h;
 }
 

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -966,6 +966,19 @@ public:
     static constexpr ptrdiff_t offsetOfTailCallBytecode() { return OBJECT_OFFSETOF(RTT, m_tailCallBytecode); }
     using TrailingArrayType::offsetOfData;
 
+    unsigned hashMayBeEmpty() const
+    {
+        return m_hash;
+    }
+
+    void setHash(unsigned hash) const
+    {
+        if (!hash)
+            m_hash = 1;
+        else
+            m_hash = hash;
+    }
+
 private:
     // Templated payload-aware constructors. Initialize m_payload in the
     // initializer list so the Variant is never observed in an unset state
@@ -1006,6 +1019,7 @@ private:
     const bool m_isFinalType { false };
     const unsigned m_displaySizeExcludingThis { };
     const StructFieldCount m_fieldCount { 0 };
+    mutable unsigned m_hash { 0 };
     mutable RefPtr<const RTTGroup> m_group { nullptr };
     mutable uint32_t m_canonicalIndexInGroup { 0 };
     mutable uint32_t m_virtualRefCount { 0 };
@@ -1050,6 +1064,19 @@ public:
     uint32_t virtualRefCount() const { return m_virtualRefCount; }
     void setVirtualRefCount(uint32_t value) const { m_virtualRefCount = value; }
 
+    unsigned hashMayBeEmpty() const
+    {
+        return m_hash;
+    }
+
+    void setHash(unsigned hash) const
+    {
+        if (!hash)
+            m_hash = 1;
+        else
+            m_hash = hash;
+    }
+
 private:
     explicit RTTGroup(Vector<Ref<const RTT>>&& rtts)
         : m_rtts(WTF::move(rtts))
@@ -1057,6 +1084,7 @@ private:
 
     Vector<Ref<const RTT>> m_rtts;
     mutable uint32_t m_virtualRefCount { 0 };
+    mutable unsigned m_hash { 0 };
 };
 
 // Isorecursive canonical recursion-group entry. Wraps an owning Ref to the


### PR DESCRIPTION
#### c7a996580d731750dd282ba2c449fe0e4931de90
<pre>
[JSC] Store computed hash in RTT and RTTGroup
<a href="https://bugs.webkit.org/show_bug.cgi?id=314543">https://bugs.webkit.org/show_bug.cgi?id=314543</a>
<a href="https://rdar.apple.com/176774716">rdar://176774716</a>

Reviewed by Keith Miller.

Hash computation of RTT / RTTGroup is costly. Let&apos;s cache the result.

* Source/JavaScriptCore/wasm/WasmTypeDefinition.cpp:
(JSC::Wasm::hashRTTForRecGroup):
(JSC::Wasm::CanonicalRecursionGroupEntryHash::hash):
* Source/JavaScriptCore/wasm/WasmTypeDefinition.h:

Canonical link: <a href="https://commits.webkit.org/313011@main">https://commits.webkit.org/313011@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2e2cd84af6fe8a3d761782bf5c2fdf1b8b0a3c8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161794 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35268 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28371 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170697 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118165 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f794993b-0504-4fb8-acfb-a4eb618bd60f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35369 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35269 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125537 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88457 "17 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3894520c-9bd2-430d-91d4-e25a18e75ed0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164753 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27848 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145329 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIAction.ClearTabSpecificActionPropertiesOnNavigation (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106133 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1f01017d-eb5f-4643-bcb5-5295b7fedce7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26897 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25411 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18418 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/153853 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136590 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23084 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173186 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22632 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20226 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24725 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133833 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34942 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29499 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133838 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34926 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144879 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96981 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24575 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28370 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21702 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194193 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34436 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101881 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50050 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33936 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34179 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34085 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->