### PR TITLE
WebKit.AccessibilityChildrenPreventsProcessSuspensionOnFrontmostTab API test is flaky

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/EnableAccessibility.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/EnableAccessibility.mm
@@ -135,8 +135,12 @@ TEST(WebKit, AccessibilityChildrenPreventsProcessSuspensionOnFrontmostTab)
     [webView synchronouslyLoadTestPageNamed:@"simple"];
 
     // Page should acquire the remote AX element activity when -accessibilityChildren runs to keep itself running as long as it's attached to a window.
-    RetainPtr<NSArray> children = [webView accessibilityChildren];
-    EXPECT_GT([children count], (NSUInteger)0);
+    // The remote AX element token arrives asynchronously from the WebProcess, so poll until it is available.
+    RetainPtr<NSArray> children;
+    EXPECT_TRUE(TestWebKitAPI::Util::waitFor([&] {
+        children = [webView accessibilityChildren];
+        return [children count] > 0;
+    }));
     EXPECT_TRUE([webView _hasAccessibilityActivityForTesting]);
 
     // Page should drop the AX activity after being removed from the window. Test in a Util::waitFor


### PR DESCRIPTION
#### 0d413afc34892b073ae15d899834307910820aa8
<pre>
WebKit.AccessibilityChildrenPreventsProcessSuspensionOnFrontmostTab API test is flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=314544">https://bugs.webkit.org/show_bug.cgi?id=314544</a>
<a href="https://rdar.apple.com/176588587">rdar://176588587</a>

Reviewed by Ben Nham.

The remote AX element token is sent asynchronously from the WebProcess via the
RegisterWebProcessAccessibilityToken IPC. The test calls -accessibilityChildren
immediately after -synchronouslyLoadTestPageNamed:, which only waits for the
navigation to finish, not for the AX token IPC to arrive.

When the token has not arrived yet, WebViewImpl::accessibilityAttributeValue&apos;s
NSAccessibilityChildrenAttribute branch sees a null m_remoteAccessibilityChild,
returns nil, and skips the call to takeAccessibilityActivityWhenInWindow().
This causes all three EXPECTs in the test to fail in sequence:

1. [children count] is 0 because the children array is nil.
2. _hasAccessibilityActivityForTesting is false because takeAccessibilityActivity()
   was never called.
3. After re-adding the view to the window, _hasAccessibilityActivityForTesting
   is still false because m_takeAccessibilityActivityWhenInWindow was never set,
   so WebProcessActivityState::viewDidEnterWindow() does nothing.

Wrap the first -accessibilityChildren read in a Util::waitFor that polls until
the token has been received. Once that first call succeeds, the rest of the
test is deterministic.

* Tools/TestWebKitAPI/Tests/WebKit/WKPage/cocoa/EnableAccessibility.mm:
(TEST(WebKit, AccessibilityChildrenPreventsProcessSuspensionOnFrontmostTab)):

Canonical link: <a href="https://commits.webkit.org/313040@main">https://commits.webkit.org/313040@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ab8bcf9d36b67865ce6d64b62fca036a722cf65

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161796 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35270 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28373 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170699 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118167 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163665 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35371 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35271 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125532 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88450 "2 flakes 17 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164755 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27846 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145327 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106128 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26895 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25412 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18420 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136588 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23082 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173188 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24723 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133828 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34944 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29500 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133833 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34928 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144877 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/96984 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24591 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28365 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21700 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34438 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33938 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34181 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34087 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->