### PR TITLE
REGRESSION (Safari 26): setProperty fails to apply !important priority to existing inline style if integer value is <= 255, breaking cascade

### DIFF
--- a/LayoutTests/fast/css/CSSStyleDeclaration-setProperty-important-priority-change-expected.txt
+++ b/LayoutTests/fast/css/CSSStyleDeclaration-setProperty-important-priority-change-expected.txt
@@ -1,0 +1,7 @@
+
+PASS Baseline: non-important inline width is overridden by stylesheet !important
+PASS Upgrading priority to !important with an unchanged value updates layout
+PASS Downgrading priority from !important with an unchanged value updates layout
+PASS Priority-only toggles update layout for additional integer values
+PASS Priority-only upgrade works for large integer values
+

--- a/LayoutTests/fast/css/CSSStyleDeclaration-setProperty-important-priority-change.html
+++ b/LayoutTests/fast/css/CSSStyleDeclaration-setProperty-important-priority-change.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>CSSStyleDeclaration.setProperty(): changing only the priority must update the cascade</title>
+<link rel="help" href="https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-setproperty">
+<link rel="help" href="https://drafts.csswg.org/css-cascade/#importance">
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<style>
+  #target { width: 100px !important; }
+</style>
+</head>
+<body>
+<div id="target"></div>
+<script>
+const target = document.getElementById("target");
+
+test(() => {
+    target.style.setProperty("width", "255px");
+    assert_equals(target.style.getPropertyPriority("width"), "");
+    assert_equals(target.offsetWidth, 100,
+        "stylesheet !important wins over non-important inline style");
+}, "Baseline: non-important inline width is overridden by stylesheet !important");
+
+test(() => {
+    target.style.setProperty("width", "255px", "important");
+    assert_equals(target.style.getPropertyPriority("width"), "important");
+    assert_equals(target.offsetWidth, 255,
+        "inline !important (higher specificity) wins over stylesheet !important");
+}, "Upgrading priority to !important with an unchanged value updates layout");
+
+test(() => {
+    target.style.setProperty("width", "255px");
+    assert_equals(target.style.getPropertyPriority("width"), "");
+    assert_equals(target.offsetWidth, 100,
+        "after dropping !important, stylesheet !important wins again");
+}, "Downgrading priority from !important with an unchanged value updates layout");
+
+test(() => {
+    target.style.setProperty("width", "10px");
+    assert_equals(target.offsetWidth, 100);
+    target.style.setProperty("width", "10px", "important");
+    assert_equals(target.offsetWidth, 10,
+        "inline !important wins for a different integer value too");
+    target.style.setProperty("width", "10px");
+    assert_equals(target.offsetWidth, 100,
+        "dropping !important reverts to stylesheet !important");
+}, "Priority-only toggles update layout for additional integer values");
+
+test(() => {
+    target.style.setProperty("width", "300px");
+    assert_equals(target.offsetWidth, 100);
+    target.style.setProperty("width", "300px", "important");
+    assert_equals(target.offsetWidth, 300);
+}, "Priority-only upgrade works for large integer values");
+</script>
+</body>
+</html>

--- a/Source/WebCore/style/MatchResultCache.cpp
+++ b/Source/WebCore/style/MatchResultCache.cpp
@@ -46,6 +46,7 @@ namespace Style {
 
 struct OriginalInlineProperty {
     CSSPropertyID propertyID;
+    bool wasImportant { false };
     RefPtr<const CSSValue> valueIfUnchanged;
 };
 
@@ -62,6 +63,7 @@ struct MatchResultCache::Entry : CanMakeCheckedPtr<MatchResultCache::Entry> {
         for (auto property : inlineStyle) {
             originalInlineProperties.append({
                 .propertyID = property.id(),
+                .wasImportant = property.isImportant(),
                 .valueIfUnchanged = property.value()
             });
         }
@@ -119,10 +121,11 @@ PropertyCascade::IncludedProperties MatchResultCache::computeAndUpdateChangedPro
 
         ASSERT(originalProperties[index].propertyID == propertyID);
 
-        if (originalProperties[index].valueIfUnchanged == currentProperty.value())
+        if (originalProperties[index].valueIfUnchanged == currentProperty.value()
+            && originalProperties[index].wasImportant == currentProperty.isImportant())
             continue;
 
-        // Assume that if a value changes ones then it will change more. Don't track changes anymore.
+        // Assume that if a value or priority changes once then it will change more. Don't track changes anymore.
         originalProperties[index].valueIfUnchanged = nullptr;
 
         // FIXME: Support custom properties.


### PR DESCRIPTION
#### e297a5ca30f391ba691db0adfa2cae369a11122c
<pre>
REGRESSION (Safari 26): setProperty fails to apply !important priority to existing inline style if integer value is &lt;= 255, breaking cascade
<a href="https://bugs.webkit.org/show_bug.cgi?id=313840">https://bugs.webkit.org/show_bug.cgi?id=313840</a>
<a href="https://rdar.apple.com/176099619">rdar://176099619</a>

Reviewed by Antti Koivisto.

MatchResultCache snapshots each inline property as a (propertyID,
CSSValue*) pair and treats a property as unchanged when the value
pointer matches. It never captured the !important bit. CSSValuePool
interns CSSPrimitiveValue instances for integer pixel/number/percent
values 0-255, so re-applying the same value string with a flipped
priority (e.g. setProperty(&apos;width&apos;, &apos;255px&apos;, &apos;important&apos;) after
setProperty(&apos;width&apos;, &apos;255px&apos;)) yields the same pointer. The cache
concluded nothing had changed: the style builder skipped the property,
the cached RenderStyle was reused, and the stylesheet&apos;s !important
rule kept winning the cascade even though the inline declaration had
been upgraded to !important. Integer values &gt;= 256 bypass the pool
and allocate a fresh CSSPrimitiveValue, which is why the bug only
manifests for small integers.

Track the original importance alongside the value pointer and treat
a priority flip as a change. The existing &quot;clear on first change&quot;
sentinel (valueIfUnchanged = nullptr) continues to force subsequent
iterations to re-run the cascade.

* Source/WebCore/style/MatchResultCache.cpp:
(WebCore::Style::MatchResultCache::Entry::Entry): Snapshot
property.isImportant() into OriginalInlineProperty::wasImportant.
(WebCore::Style::MatchResultCache::computeAndUpdateChangedProperties):
Compare wasImportant against the current priority in addition to
the value pointer.

* LayoutTests/fast/css/CSSStyleDeclaration-setProperty-important-priority-change-expected.txt: Added.
* LayoutTests/fast/css/CSSStyleDeclaration-setProperty-important-priority-change.html: Added.

Canonical link: <a href="https://commits.webkit.org/313159@main">https://commits.webkit.org/313159@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d2c1cdb0ac4c0d6e7cfd5417701e67b80d5b12e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161809 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35283 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28386 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170712 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118180 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163678 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35384 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35284 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125546 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88463 "17 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164768 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27861 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145341 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106142 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26910 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25424 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18433 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136603 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23096 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173201 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20241 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24737 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133843 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34957 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29512 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133848 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36239 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34941 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144891 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97003 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28379 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21714 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34451 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101896 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33951 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34194 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34100 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->