### PR TITLE
Cherry-pick 312751@main (69a399de80ab). https://bugs.webkit.org/show_bug.cgi?id=314139

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1186,7 +1186,6 @@ webkit.org/b/264558 fast/forms/vertical-writing-mode/listbox-horizontal-scrollba
 imported/w3c/web-platform-tests/css/CSS2/floats/line-pushed-by-floats-crash.html [ Skip ]
 imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-vs-float-clearance-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-text/letter-spacing/letter-spacing-ligatures-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-text/line-break/line-break-anywhere-overrides-uax-behavior-015.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-text/text-align/text-align-last-justify-br.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-text/text-autospace/text-autospace-mixed-001.html [ Failure ]
 imported/w3c/web-platform-tests/css/CSS2/visudet/height-applies-to-010a.xht [ ImageOnlyFailure ]
@@ -1511,6 +1510,8 @@ webkit.org/b/218372 http/tests/canvas/color-fonts/text-sbix-4.html [ ImageOnlyFa
 # Missing support for EXIF orientation in OpenType-SVG fonts.
 fast/text/otsvg-spacing.html [ ImageOnlyFailure ]
 fast/text/otsvg-spacing-canvas.html [ ImageOnlyFailure ]
+
+fast/text/cjk-multi-codepoint-cluster-vertical.html [ ImageOnlyFailure ]
 
 # system-ui support
 webkit.org/b/221445 fast/text/system-font-width-2.html [ Skip ]
@@ -2113,15 +2114,11 @@ webkit.org/b/273396 fast/canvas/canvas-layer-filter-text-drawing.html [ ImageOnl
 webkit.org/b/273396 fast/clip/overflow-hidden-with-border-radius-overflow-clipping-parent.html [ ImageOnlyFailure ]
 webkit.org/b/273396 fast/css/ignore-empty-focus-ring-rects.html [ ImageOnlyFailure ]
 webkit.org/b/273396 fast/css3-text/css3-text-decoration/text-decoration-skip/text-decoration-skip-ink-svg.html [ ImageOnlyFailure ]
-webkit.org/b/273396 fast/encoding/denormalised-voiced-japanese-chars.html [ ImageOnlyFailure ]
-webkit.org/b/273396 fast/images/animated-avif.html [ ImageOnlyFailure Pass ]
 webkit.org/b/273396 fast/inline/hidpi-outline-inline-box-writing-modes.html [ ImageOnlyFailure ]
 webkit.org/b/273396 fast/masking/clip-path-inset-large-radii.html [ ImageOnlyFailure ]
 webkit.org/b/273396 fast/multicol/clipped-video-in-second-column.html [ ImageOnlyFailure ]
 webkit.org/b/273396 fast/multicol/fixed-stack.html [ ImageOnlyFailure ]
 webkit.org/b/273396 fast/text/canvas-color-fonts/stroke-gradient-COLR.html [ ImageOnlyFailure ]
-webkit.org/b/273396 fast/text/international/kana-voiced-sound-marks-1.html [ ImageOnlyFailure ]
-webkit.org/b/273396 fast/text/international/kana-voiced-sound-marks-2.html [ ImageOnlyFailure ]
 webkit.org/b/273396 imported/blink/fast/multicol/client-rects-rtl.html [ ImageOnlyFailure ]
 webkit.org/b/273396 imported/w3c/web-platform-tests/css/compositing/mix-blend-mode/mix-blend-mode-paragraph-background-image.html [ ImageOnlyFailure ]
 webkit.org/b/273396 imported/w3c/web-platform-tests/css/compositing/mix-blend-mode/mix-blend-mode-paragraph.html [ ImageOnlyFailure ]
@@ -2156,13 +2153,9 @@ webkit.org/b/273396 imported/w3c/web-platform-tests/css/css-text-decor/text-shad
 imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/svg-fill-none.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-text-decor/text-shadow/svg-stroke-dasharray.html [ ImageOnlyFailure ]
 webkit.org/b/273396 imported/w3c/web-platform-tests/css/css-text/hyphens/hyphens-vertical-001.html [ ImageOnlyFailure ]
-webkit.org/b/273396 imported/w3c/web-platform-tests/css/css-text/line-break/line-break-anywhere-overrides-uax-behavior-011.html [ ImageOnlyFailure ]
-webkit.org/b/273396 imported/w3c/web-platform-tests/css/css-text/line-break/line-break-anywhere-overrides-uax-behavior-012.html [ ImageOnlyFailure ]
 webkit.org/b/273396 imported/w3c/web-platform-tests/css/css-view-transitions/backdrop-filter-animated.html [ ImageOnlyFailure ]
 webkit.org/b/273396 imported/w3c/web-platform-tests/css/css-view-transitions/rotated-cat-off-top-edge.html [ ImageOnlyFailure ]
 webkit.org/b/273396 mathml/presentation/mo-stacked-glyphs.html [ ImageOnlyFailure ]
-
-webkit.org/b/273476 fast/text/thai-joiner.html [ Failure ]
 
 webkit.org/b/273477 fast/writing-mode/vertical-subst-font-vert-no-dflt.html [ ImageOnlyFailure ]
 
@@ -3035,9 +3028,6 @@ webkit.org/b/216350 imported/w3c/web-platform-tests/selection/collapse-00.html [
 webkit.org/b/216350 imported/w3c/web-platform-tests/selection/collapse-15.html [ Skip ]
 webkit.org/b/216350 imported/w3c/web-platform-tests/selection/collapse-45.html [ Skip ]
 
-# Failing since r266683.
-webkit.org/b/216358 imported/w3c/web-platform-tests/css/css-fonts/font-feature-resolution-001.html [ ImageOnlyFailure ]
-
 # WIRELESS_PLAYBACK_TARGET not enabled.
 media/airplay-target-availability.html
 webkit.org/b/205112 media/remoteplayback-cancel-invalid.html [ Skip ]
@@ -3785,7 +3775,6 @@ webkit.org/b/176648 fast/text/mark-matches-broken-line-rendering.html [ ImageOnl
 webkit.org/b/176648 fast/text/mark-matches-rendering.html [ ImageOnlyFailure ]
 webkit.org/b/176649 fast/text/international/synthesized-italic-vertical.html [ ImageOnlyFailure ]
 webkit.org/b/177936 fast/text/all-small-caps-whitespace.html [ ImageOnlyFailure ]
-webkit.org/b/177936 fast/text/selection-in-initial-advance-region.html [ Failure ]
 webkit.org/b/177937 fast/text/unknown-char-notdef.html [ ImageOnlyFailure ]
 webkit.org/b/179611 imported/w3c/web-platform-tests/xhr/send-entity-body-document.htm [ Pass Failure ]
 webkit.org/b/182763 accessibility/notification-listeners.html [ Failure ]

--- a/PerformanceTests/Layout/deep-nesting-overflow-siblings.html
+++ b/PerformanceTests/Layout/deep-nesting-overflow-siblings.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script src="../resources/runner.js"></script>
+<script>
+// Deep markup that exceeds the parser's max DOM tree depth (default 512), so the
+// parser produces a long flat run of overflow siblings at the depth boundary.
+// 100000 spans ~= 999500 overflow siblings, matching the regression magnitude observed
+// in the original Mail thread (~15s render time pre-fix).
+const depth = 100000;
+let markup = "<!DOCTYPE html><body>";
+for (let i = 0; i < depth; ++i)
+    markup += "<span>";
+
+let iframe;
+
+function setup() {
+    if (iframe)
+        document.body.removeChild(iframe);
+    iframe = document.createElement("iframe");
+    iframe.sandbox = "allow-same-origin";
+    document.body.appendChild(iframe);
+    iframe.contentDocument.open();
+    iframe.contentDocument.write(markup);
+    iframe.contentDocument.close();
+}
+
+PerfTestRunner.measureTime({
+    description: "Render time for deeply-nested HTML that exceeds the parser's max DOM tree depth and produces a long run of overflow siblings.",
+    setup: setup,
+    run: function () {
+        iframe.contentDocument.body.offsetHeight;
+    }
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/skia/ComplexTextControllerSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/ComplexTextControllerSkia.cpp
@@ -219,6 +219,7 @@ void ComplexTextController::collectComplexTextRunsForCharacters(std::span<const 
     auto language = hb_language_from_string(m_fontCascade->fontDescription().computedLocale().string().utf8().data(), -1);
 
     auto shapeFunction = [&](const HBRun& run) {
+        hb_buffer_set_cluster_level(buffer.get(), HB_BUFFER_CLUSTER_LEVEL_CHARACTERS);
         hb_buffer_set_language(buffer.get(), language);
 
         hb_buffer_set_script(buffer.get(), hb_icu_script_to_script(run.script));

--- a/Source/WebCore/platform/graphics/skia/FontCascadeSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/FontCascadeSkia.cpp
@@ -167,7 +167,7 @@ RefPtr<const Font> FontCascade::fontForCombiningCharacterSequence(StringView str
         }
     }
 
-    return nullptr;
+    return baseCharacterGlyphData.font.get();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -1257,7 +1257,12 @@ void TreeResolver::resolveComposedTree()
 
         Ref element = Ref { downcast<Element>(node.get()) };
 
-        if (it.depth() > Settings::defaultMaximumRenderTreeDepth) {
+        // At the maximum render tree depth, only the first child per parent gets a renderer.
+        // The HTML parser caps DOM depth by attaching overflow elements as siblings at this
+        // boundary (see HTMLConstructionSite::attachLater); skipping later siblings here keeps
+        // those overflow elements from being styled and laid out.
+        if (auto depth = it.depth(); depth > Settings::defaultMaximumRenderTreeDepth
+            || (depth == Settings::defaultMaximumRenderTreeDepth && element->previousElementSibling())) {
             resetStyleForNonRenderedDescendants(element.get());
             it.traverseNextSkippingChildren();
             continue;


### PR DESCRIPTION
#### 024db53352818c8e3958b536472f23daaf4b1af1
<pre>
Cherry-pick 312751@main (69a399de80ab). <a href="https://bugs.webkit.org/show_bug.cgi?id=314139">https://bugs.webkit.org/show_bug.cgi?id=314139</a>

    REGRESSION (297241@main): Overflow siblings at parser&apos;s max DOM tree depth get fully rendered, causing slow layout
    <a href="https://bugs.webkit.org/show_bug.cgi?id=314139">https://bugs.webkit.org/show_bug.cgi?id=314139</a>
    <a href="https://rdar.apple.com/172219636">rdar://172219636</a>

    Reviewed by Sammy Gill and Alan Baradlay.

    When the parser&apos;s DOM depth cap is reached, HTMLConstructionSite::attachLater
    attaches further elements as siblings at the boundary depth (see 297241@main).
    The render tree&apos;s depth check skipped elements above the cap but not at it,
    so the overflow run was fully styled and laid out — causing ~15s render times
    on content with thousands of overflow siblings (e.g. mail with embedded crash
    logs containing unmatched &lt;unavailable&gt; tags).

    At the maximum render tree depth, skip elements that have a previous element
    sibling. The single legitimate deepest element keeps its renderer; the
    overflow siblings get none.

    * PerformanceTests/Layout/deep-nesting-overflow-siblings.html: Added.
    * Source/WebCore/style/StyleTreeResolver.cpp:
    (WebCore::Style::TreeResolver::resolveComposedTree):

    Canonical link: <a href="https://commits.webkit.org/312751@main">https://commits.webkit.org/312751@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.486@webkitglib/2.52">https://commits.webkit.org/305877.486@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### cb96444da8f4ed8ba4e8f4139e582f5226f6ef01
<pre>
Cherry-pick 312992@main (d86ea95fa305). <a href="https://bugs.webkit.org/show_bug.cgi?id=310352">https://bugs.webkit.org/show_bug.cgi?id=310352</a>

    [Skia] Fix missing glyph before ZWJ/ZWNJ if no font is found for the cluster
    <a href="https://bugs.webkit.org/show_bug.cgi?id=310352">https://bugs.webkit.org/show_bug.cgi?id=310352</a>

    Reviewed by Carlos Garcia Campos.

    For example, &quot;X&amp;zwj;&quot; showed a .notdef glyph if no font was found for the
    cluster because FontCascade::fontForCombiningCharacterSequence() returned nullptr
    for it.

    Changed FontCascade::fontForCombiningCharacterSequence() to return a font for
    the base character if no font is found for the cluster.

    After the above change, the layout test
    imported/w3c/web-platform-tests/css/css-text/line-break/line-break-anywhere-overrides-uax-behavior-016.html
    failed. HarfBuzz shaped &quot; &amp;zwj;&quot; as two space glyphs, and the second space
    glyph had zero width, and the cluster of both glyphs was associated with the
    first space character. Then, ComplexTextController::adjustGlyphsAndAdvances()
    treated the second space glyph with zero width as a space character. To work
    around this problem, we used HB_BUFFER_CLUSTER_LEVEL_CHARACTERS to separate the
    cluster. Thus, the cluster for the second space glyph is now ZWJ.

    Tests: fast/text/thai-joiner.html

    * LayoutTests/platform/glib/TestExpectations:
    * Source/WebCore/platform/graphics/skia/ComplexTextControllerSkia.cpp:
    (WebCore::ComplexTextController::collectComplexTextRunsForCharacters):
    * Source/WebCore/platform/graphics/skia/FontCascadeSkia.cpp:
    (WebCore::FontCascade::fontForCombiningCharacterSequence const):

    Canonical link: <a href="https://commits.webkit.org/312992@main">https://commits.webkit.org/312992@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.485@webkitglib/2.52">https://commits.webkit.org/305877.485@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b5d870b47f337fd1956d29013e70166197fc699

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161821 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35295 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28398 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170724 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/118192 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163690 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35396 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35296 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125557 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/118192 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164780 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/35396 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/28398 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106153 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/35396 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/35296 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18445 "Unable to build WebKit without PR, please check manually (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/35396 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/28398 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173213 "Built successfully") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20302 "Failed to checkout and rebase branch from PR 64674") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/28398 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133855 "Passed tests") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34969 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/35296 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133860 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34953 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/28398 "Unable to build WebKit without PR, please check manually (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/97025 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24582 "Built successfully and passed tests") | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/34953 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/28398 "Unable to build WebKit without PR, please check manually (failure)") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34463 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101946 "Failed to checkout and rebase branch from PR 64674") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33963 "Unable to build WebKit without PR, please check manually (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34206 "Unable to build WebKit without PR, please check manually (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34112 "Unable to build WebKit without PR, please check manually (failure)") | | | 
<!--EWS-Status-Bubble-End-->