### PR TITLE
[MSE] mediasource-duration WPT test fails on multi-track content

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/media-source/mediasource-duration-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/media-source/mediasource-duration-expected.txt
@@ -1,7 +1,7 @@
 
-FAIL Test seek starts on duration truncation below currentTime The object is in an invalid state.
-FAIL Test appendBuffer completes previous seek to truncated duration The object is in an invalid state.
-FAIL Test endOfStream completes previous seek to truncated duration The object is in an invalid state.
+PASS Test seek starts on duration truncation below currentTime
+PASS Test appendBuffer completes previous seek to truncated duration
+PASS Test endOfStream completes previous seek to truncated duration
 PASS Test setting same duration multiple times does not fire duplicate durationchange
 PASS Test setting the duration to less than the highest starting presentation timestamp will throw
 PASS Truncating the duration throws an InvalidStateError exception when new duration is less than the highest buffered range start time of one of the track buffers

--- a/LayoutTests/imported/w3c/web-platform-tests/media-source/mediasource-duration.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/media-source/mediasource-duration.html
@@ -368,7 +368,6 @@
           mediasource_testafterdataloaded(function(test, mediaElement, mediaSource, segmentInfo, sourceBuffer, mediaData)
           {
               assert_greater_than(segmentInfo.duration, 2, 'Sufficient test media duration');
-              mediaElement.play();
               sourceBuffer.appendBuffer(mediaData);
               test.expectEvent(sourceBuffer, 'updateend', 'Media data appended to the SourceBuffer');
               test.waitForExpectedEvents(function()

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1645,8 +1645,6 @@ webkit.org/b/221100 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-a
 
 webkit.org/b/222205 css3/calc/transforms-translate.html [ Pass ImageOnlyFailure ]
 
-webkit.org/b/222422 imported/w3c/web-platform-tests/media-source/mediasource-duration.html [ Pass Failure Slow ]
-
 webkit.org/b/222573 media/media-fullscreen-pause-inline.html [ Pass Failure ]
 
 webkit.org/b/222692 inspector/page/empty-or-missing-resources.html [ Pass Timeout ]

--- a/Source/WebCore/Modules/mediasource/MediaSource.cpp
+++ b/Source/WebCore/Modules/mediasource/MediaSource.cpp
@@ -704,7 +704,11 @@ ExceptionOr<void> MediaSource::setDurationInternal(const MediaTime& newDuration)
 
     // 4. If new duration is less than highest end time, then
     // 4.1. Update new duration to equal highest end time.
-    auto duration = highestEndTime.isValid() && newDuration < highestEndTime ? highestEndTime : newDuration;
+    // Use <= so that when the JS-supplied duration equals highest end time, we
+    // pick the precise rational MediaTime from highest end time rather than the
+    // DoubleValue MediaTime created from the JS Number, preserving precision
+    // through the seek path.
+    auto duration = highestEndTime.isValid() && newDuration <= highestEndTime ? highestEndTime : newDuration;
 
     ALWAYS_LOG(LOGIDENTIFIER, duration);
 

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
@@ -537,7 +537,7 @@ void AudioVideoRendererAVFObjC::notifyTimeReachedAndStall(const MediaTime& timeB
         [protectedThis->m_synchronizer setRate:0 time:PAL::toCMTime(timeBoundary)];
         protectedThis->m_lastSetSyncRate = 0;
 
-        callback(now);
+        callback(timeBoundary);
     }).get()];
 }
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -107,6 +107,7 @@ public:
     void durationChanged();
 
     void effectiveRateChanged();
+    void notifyEndOfMediaIfNeeded();
     void setNaturalSize(const FloatSize&);
     void characteristicsFromMediaSourceChanged() final;
 

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -1039,6 +1039,27 @@ void MediaPlayerPrivateMediaSourceAVFObjC::effectiveRateChanged()
     ALWAYS_LOG(LOGIDENTIFIER, effectiveRate());
     if (RefPtr player = m_player.get())
         player->rateChanged();
+    notifyEndOfMediaIfNeeded();
+}
+
+void MediaPlayerPrivateMediaSourceAVFObjC::notifyEndOfMediaIfNeeded()
+{
+    assertIsMainThread();
+    // Observed: in some runs, playback drains at end of media (the renderer
+    // stops producing frames) without the boundary observer programmed in
+    // bufferedChanged() firing. The effective rate still transitions to 0
+    // in that case, which gives us a reliable signal: if MediaSource has
+    // transitioned to 'ended' and there is no future data past the current
+    // time, route a timeChanged() through so HTMLMediaElement's
+    // mediaPlayerTimeChanged schedules the 'ended' event.
+    if (effectiveRate())
+        return;
+    RefPtr mediaSourcePrivate = m_mediaSourcePrivate;
+    if (!mediaSourcePrivate || !mediaSourcePrivate->isEnded())
+        return;
+    if (mediaSourcePrivate->hasFutureTime(currentTime()))
+        return;
+    timeChanged();
 }
 
 void MediaPlayerPrivateMediaSourceAVFObjC::setNaturalSize(const FloatSize& size)
@@ -1182,10 +1203,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::mediaSourceHasRetrievedAllData()
 {
     assertIsMainThread();
     setNetworkState(MediaPlayer::NetworkState::Loaded);
-    if (!effectiveRate()) {
-        // Playback had stalled; make transition for the element to ended if needed.
-        timeChanged();
-    }
+    notifyEndOfMediaIfNeeded();
 }
 
 ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN


### PR DESCRIPTION
#### a243dd0c442e7b4cdd6e5d854116281599c6bafc
<pre>
[MSE] mediasource-duration WPT test fails on multi-track content
<a href="https://bugs.webkit.org/show_bug.cgi?id=222422">https://bugs.webkit.org/show_bug.cgi?id=222422</a>
<a href="https://rdar.apple.com/176599938">rdar://176599938</a>

Reviewed by Eric Carlson.

Several independent bugs along the duration-truncation seek path caused
the mediasource-duration WPT test to fail on multi-track mp4 content:

1. MediaSource::setDurationInternal lost MediaTime precision when the
   JS-supplied duration equalled the highest buffered end time. The JS
   Number arrives as a MediaTime constructed via createWithDouble (the
   &quot;DoubleValue&quot; form, which holds a raw double). The spec normalisation
   step 4 only swaps to the precise rational highestEndTime when
   newDuration is *strictly less* than it; on equality the imprecise
   DoubleValue won, then propagated through durationChanged -&gt;
   mediaPlayerDurationChanged -&gt; seekInternal as the seek target.
   Eventually SourceBufferPrivate::computeSeekTime saw a DoubleValue
   target and rounded it to MediaTime::DefaultTimeScale (10M), losing
   precision. Use &lt;= so that the precise rational from the buffered
   ranges is picked on equality, and the precise value flows through to
   computeSeekTime where the DoubleValue branch is skipped entirely.

2. AudioVideoRendererAVFObjC::notifyTimeReachedAndStall&apos;s boundary
   observer callback fired the WebContent-side callback with `now`
   (currentTime() captured before re-pinning the synchronizer), even
   though it then re-set the synchronizer to the precise timeBoundary
   immediately after. The reported time therefore carried the
   synchronizer&apos;s timescale-rounded value rather than the precise
   requested value. Fire callback(timeBoundary) so the value matches
   what the synchronizer was just pinned to.

3. The same boundary observer also called pause() and timeChanged()
   unconditionally. During an in-flight seek (e.g. the seek triggered by
   a duration truncation), pausing mid-seek and firing timeChanged()
   races with the seek&apos;s own state transitions and produces
   spec-incorrect event ordering (timeupdate before seeking). Skip both
   calls when seeking() is true and let the seek path drive state
   transitions.

4. The &quot;setting same duration multiple times does not fire duplicate
   durationchange&quot; subtest timed out ~60% of the time in WebKitTestRunner
   because the &apos;ended&apos; event was never scheduled. Log-traced cause: after
   endOfStream() the boundary observer is programmed at
   stallAtTime = highestEndTime (audio-sample-aligned, longer than the
   video-frame-aligned end). Playback drains naturally - currentTime
   advances to exactly highestEndTime and stops - but
   AVSampleBufferRenderSynchronizer&apos;s boundary-time observer does not
   fire in that case. The effectiveRate-changed listener, however, does
   fire when the synchronizer rate drops to 0 at drain. Use that as a
   reliable signal: in MediaPlayerPrivateMediaSourceAVFObjC::
   effectiveRateChanged(), when effectiveRate == 0 and MediaSource is
   in the &apos;ended&apos; state and MediaSourcePrivate::hasFutureTime(currentTime)
   is false, route a timeChanged() through so
   HTMLMediaElement::mediaPlayerTimeChanged schedules the &apos;ended&apos; event
   (currentTime == duration at this point, satisfying its now &gt;= dur
   check). The existing &apos;if (!effectiveRate()) timeChanged()&apos; fallback
   in mediaSourceHasRetrievedAllData() is replaced with the same helper
   for consistency; the isEnded() gate is always true in that context
   (the caller sets m_ended = true before dispatching), making the gate
   explicit and symmetric with the effectiveRateChanged site.

* LayoutTests/imported/w3c/web-platform-tests/media-source/mediasource-duration-expected.txt:
  Three subtests now pass.
* LayoutTests/imported/w3c/web-platform-tests/media-source/mediasource-duration.html: The last test was invalid.
It adds data from 0.095 and expect the mediaElement&apos;s play promise to be resolved ; it can&apos;t be as with this starting
gap there&apos;s nothing to play. Remove the call to play() it&apos;s not required for this test.
* LayoutTests/platform/mac/TestExpectations: Drop the flaky/Failure
  expectation that covered these failures.
* Source/WebCore/Modules/mediasource/MediaSource.cpp:
(WebCore::MediaSource::setDurationInternal):
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::notifyTimeReachedAndStall):
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::bufferedChanged):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::effectiveRateChanged):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::notifyEndOfMediaIfNeeded):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::mediaSourceHasRetrievedAllData):

Canonical link: <a href="https://commits.webkit.org/313385@main">https://commits.webkit.org/313385@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dcbf807a8a990f43c1e110f1645ca2457e1114b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163012 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36491 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29681 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171951 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119458 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7a108520-18a5-4b29-9294-60b9cbc800a8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164881 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/36829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36493 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126543 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/89151 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/67f5fa6a-3307-4682-b438-db99b21e0e10) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165971 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/36829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146511 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107119 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4d408e3a-a68a-4601-a0c5-85540defb339) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/36829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26480 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19650 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137679 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24240 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174454 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/25953 "Found 1 new failure in wasm/WasmConstExprGenerator.cpp") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25887 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134853 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36162 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30583 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134848 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36359 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/36713 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146036 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98705 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/29956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22874 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35658 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/107608 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35157 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/895 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35404 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35305 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->