### PR TITLE
REGRESSION(285929@main-285928@main): [ iOS Debug ] WKWebExtensionAPI* tests are flaky timeout.

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIRuntime.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIRuntime.mm
@@ -1171,12 +1171,7 @@ TEST(WKWebExtensionAPIRuntime, SendMessageWithoutUserGestureFromContentScript)
     [manager run];
 }
 
-// FIXME rdar://147858640
-#if PLATFORM(IOS) && !defined(NDEBUG)
-TEST(WKWebExtensionAPIRuntime, DISABLED_ConnectFromContentScript)
-#else
 TEST(WKWebExtensionAPIRuntime, ConnectFromContentScript)
-#endif
 {
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
@@ -1199,30 +1194,33 @@ TEST(WKWebExtensionAPIRuntime, ConnectFromContentScript)
         @"    browser.test.assertEq(message, 'Hello', 'Should receive the correct message content')",
         @"    port?.postMessage('Received')",
         @"  })",
-        @"})"
+        @"})",
+
+        @"browser.test.sendMessage('Load Tab')"
     ]);
 
     auto *contentScript = Util::constructScript(@[
-        @"setTimeout(() => {",
-        @"  const port = browser.runtime?.connect({ name: 'testPort' })",
-        @"  browser.test.assertEq(typeof port, 'object', 'Port should be an object')",
-        @"  browser.test.assertEq(port?.name, 'testPort', 'Port name should be testPort')",
-        @"  browser.test.assertEq(port?.sender, null, 'Port sender should be null')",
+        @"const port = browser.runtime?.connect({ name: 'testPort' })",
+        @"browser.test.assertEq(typeof port, 'object', 'Port should be an object')",
+        @"browser.test.assertEq(port?.name, 'testPort', 'Port name should be testPort')",
+        @"browser.test.assertEq(port?.sender, null, 'Port sender should be null')",
 
-        @"  port?.postMessage('Hello')",
+        @"port?.postMessage('Hello')",
 
-        @"  port?.onMessage.addListener((response) => {",
-        @"    browser.test.assertEq(response, 'Received', 'Should get the response from the background script')",
+        @"port?.onMessage.addListener((response) => {",
+        @"  browser.test.assertEq(response, 'Received', 'Should get the response from the background script')",
 
-        @"    browser.test.notifyPass()",
-        @"  })",
-        @"}, 1000)"
+        @"  browser.test.notifyPass()",
+        @"})"
     ]);
 
     auto manager = Util::loadExtension(runtimeContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
 
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+
+    [manager runUntilTestMessage:@"Load Tab"];
+
     [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
@@ -1355,12 +1353,7 @@ TEST(WKWebExtensionAPIRuntime, ConnectFromSubframe)
     [manager run];
 }
 
-// FIXME rdar://147858640
-#if PLATFORM(IOS) && !defined(NDEBUG)
-TEST(WKWebExtensionAPIRuntime, DISABLED_ConnectFromContentScriptWithMultipleListeners)
-#else
 TEST(WKWebExtensionAPIRuntime, ConnectFromContentScriptWithMultipleListeners)
-#endif
 {
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
@@ -1401,43 +1394,41 @@ TEST(WKWebExtensionAPIRuntime, ConnectFromContentScriptWithMultipleListeners)
         @"    browser.test.assertEq(message, 'Hello', 'Should receive the correct message content in second listener')",
         @"    port?.postMessage('Received')",
         @"  })",
-        @"})"
+        @"})",
+
+        @"browser.test.sendMessage('Load Tab')"
     ]);
 
     auto *contentScript = Util::constructScript(@[
-        @"setTimeout(() => {",
-        @"  const port = browser.runtime?.connect({ name: 'testPort' })",
-        @"  browser.test.assertEq(typeof port, 'object', 'Port should be an object')",
-        @"  browser.test.assertEq(port?.name, 'testPort', 'Port name should be testPort')",
-        @"  browser.test.assertEq(port?.sender, null, 'Port sender should be null')",
+        @"const port = browser.runtime?.connect({ name: 'testPort' })",
+        @"browser.test.assertEq(typeof port, 'object', 'Port should be an object')",
+        @"browser.test.assertEq(port?.name, 'testPort', 'Port name should be testPort')",
+        @"browser.test.assertEq(port?.sender, null, 'Port sender should be null')",
 
-        @"  port?.postMessage('Hello')",
+        @"port?.postMessage('Hello')",
 
-        @"  let receivedMessages = 0",
-        @"  port?.onMessage.addListener((response) => {",
-        @"    browser.test.assertEq(response, 'Received', 'Should get the response from the background script')",
+        @"let receivedMessages = 0",
+        @"port?.onMessage.addListener((response) => {",
+        @"  browser.test.assertEq(response, 'Received', 'Should get the response from the background script')",
 
-        @"    if (++receivedMessages === 2)",
-        @"      browser.test.notifyPass()",
-        @"  })",
-        @"}, 1000)"
+        @"  if (++receivedMessages === 2)",
+        @"    browser.test.notifyPass()",
+        @"})"
     ]);
 
     auto manager = Util::loadExtension(runtimeContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
 
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+
+    [manager runUntilTestMessage:@"Load Tab"];
+
     [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
 
-// FIXME rdar://147858640
-#if PLATFORM(IOS) && !defined(NDEBUG)
-TEST(WKWebExtensionAPIRuntime, DISABLED_PortDisconnectFromContentScript)
-#else
 TEST(WKWebExtensionAPIRuntime, PortDisconnectFromContentScript)
-#endif
 {
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
@@ -1456,41 +1447,39 @@ TEST(WKWebExtensionAPIRuntime, PortDisconnectFromContentScript)
 
         @"    browser.test.notifyPass()",
         @"  })",
-        @"})"
+        @"})",
+
+        @"browser.test.sendMessage('Load Tab')"
     ]);
 
     auto *contentScript = Util::constructScript(@[
-        @"setTimeout(() => {",
-        @"  const port = browser.runtime?.connect({ name: 'testPort' })",
-        @"  browser.test.assertEq(typeof port, 'object', 'Port should be an object')",
-        @"  browser.test.assertEq(port?.name, 'testPort', 'Port name should be testPort')",
-        @"  browser.test.assertEq(port?.sender, null, 'Port sender should be null')",
+        @"const port = browser.runtime?.connect({ name: 'testPort' })",
+        @"browser.test.assertEq(typeof port, 'object', 'Port should be an object')",
+        @"browser.test.assertEq(port?.name, 'testPort', 'Port name should be testPort')",
+        @"browser.test.assertEq(port?.sender, null, 'Port sender should be null')",
 
-        @"  port?.postMessage('Message from content script to background')",
+        @"port?.postMessage('Message from content script to background')",
 
-        @"  port?.onDisconnect.addListener(() => {",
-        @"    browser.test.assertTrue(true, 'Should trigger the onDisconnect event in the content script')",
-        @"  })",
+        @"port?.onDisconnect.addListener(() => {",
+        @"  browser.test.assertTrue(true, 'Should trigger the onDisconnect event in the content script')",
+        @"})",
 
-        @"  port?.disconnect()",
-        @"}, 1000)"
+        @"port?.disconnect()"
     ]);
 
     auto manager = Util::loadExtension(runtimeContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
 
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+
+    [manager runUntilTestMessage:@"Load Tab"];
+
     [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
 
-// FIXME rdar://147858640
-#if PLATFORM(IOS) && !defined(NDEBUG)
-TEST(WKWebExtensionAPIRuntime, DISABLED_PortDisconnectFromContentScriptWithMultipleListeners)
-#else
 TEST(WKWebExtensionAPIRuntime, PortDisconnectFromContentScriptWithMultipleListeners)
-#endif
 {
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
@@ -1516,33 +1505,36 @@ TEST(WKWebExtensionAPIRuntime, PortDisconnectFromContentScriptWithMultipleListen
 
         @"    port?.postMessage('Response from background script 2')",
         @"  })",
-        @"})"
+        @"})",
+
+        @"browser.test.sendMessage('Load Tab')"
     ]);
 
     auto *contentScript = Util::constructScript(@[
         @"let messagesReceived = 0",
 
-        @"setTimeout(() => {",
-        @"  const port = browser.runtime?.connect({ name: 'testPort' })",
-        @"  browser.test.assertEq(typeof port, 'object', 'Port should be an object')",
-        @"  browser.test.assertEq(port?.name, 'testPort', 'Port name should be testPort')",
-        @"  browser.test.assertEq(port?.sender, null, 'Port sender should be null')",
+        @"const port = browser.runtime?.connect({ name: 'testPort' })",
+        @"browser.test.assertEq(typeof port, 'object', 'Port should be an object')",
+        @"browser.test.assertEq(port?.name, 'testPort', 'Port name should be testPort')",
+        @"browser.test.assertEq(port?.sender, null, 'Port sender should be null')",
 
-        @"  port?.postMessage('Message from content script')",
+        @"port?.postMessage('Message from content script')",
 
-        @"  port?.onMessage.addListener((message) => {",
-        @"    browser.test.assertTrue(message?.startsWith('Response from background script '), 'Should receive the correct message content')",
+        @"port?.onMessage.addListener((message) => {",
+        @"  browser.test.assertTrue(message?.startsWith('Response from background script '), 'Should receive the correct message content')",
 
-        @"    if (++messagesReceived === 2)",
-        @"      browser.test.notifyPass()",
-        @"  })",
-        @"}, 1000)"
+        @"  if (++messagesReceived === 2)",
+        @"    browser.test.notifyPass()",
+        @"})"
     ]);
 
     auto manager = Util::loadExtension(runtimeContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
 
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+
+    [manager runUntilTestMessage:@"Load Tab"];
+
     [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
@@ -1863,19 +1855,17 @@ TEST(WKWebExtensionAPIRuntime, ConnectFromWebPage)
 
     auto *webpageScript = Util::constructScript(@[
         @"<script>",
-        @"setTimeout(() => {",
         [NSString stringWithFormat:@"const port = browser?.runtime?.connect('%@', { name: 'testPort' })", uniqueIdentifier],
-        @"  browser.test.assertEq(typeof port, 'object', 'Port should be an object')",
-        @"  browser.test.assertEq(port?.name, 'testPort', 'Port name should be testPort')",
-        @"  browser.test.assertEq(port?.sender, null, 'Port sender should be null')",
+        @"browser.test.assertEq(typeof port, 'object', 'Port should be an object')",
+        @"browser.test.assertEq(port?.name, 'testPort', 'Port name should be testPort')",
+        @"browser.test.assertEq(port?.sender, null, 'Port sender should be null')",
 
-        @"  port?.postMessage('Hello')",
+        @"port?.postMessage('Hello')",
 
-        @"  port?.onMessage.addListener((response) => {",
-        @"    browser.test.assertEq(response, 'Received')",
-        @"    port?.postMessage('Success')",
-        @"  })",
-        @"}, 1000)",
+        @"port?.onMessage.addListener((response) => {",
+        @"  browser.test.assertEq(response, 'Received')",
+        @"  port?.postMessage('Success')",
+        @"})",
         @"</script>"
     ]);
 
@@ -1930,17 +1920,15 @@ TEST(WKWebExtensionAPIRuntime, ConnectFromWebPageWithImmediateMessage)
 
     auto *webpageScript = Util::constructScript(@[
         @"<script>",
-        @"setTimeout(() => {",
         [NSString stringWithFormat:@"const port = browser?.runtime?.connect('%@', { name: 'testPort' })", uniqueIdentifier],
-        @"  console.assert(typeof port === 'object', 'Port should be an object')",
-        @"  console.assert(port?.name === 'testPort', 'Port name should be testPort')",
-        @"  console.assert(port?.sender === null, 'Port sender should be null')",
+        @"console.assert(typeof port === 'object', 'Port should be an object')",
+        @"console.assert(port?.name === 'testPort', 'Port name should be testPort')",
+        @"console.assert(port?.sender === null, 'Port sender should be null')",
 
-        @"  port?.onMessage.addListener((message) => {",
-        @"    console.assert(message === 'Hello from Background', 'Should receive the correct message content')",
-        @"    browser.test.notifyPass()",
-        @"  })",
-        @"}, 1000)",
+        @"port?.onMessage.addListener((message) => {",
+        @"  console.assert(message === 'Hello from Background', 'Should receive the correct message content')",
+        @"  browser.test.notifyPass()",
+        @"})",
         @"</script>"
     ]);
 
@@ -2024,13 +2012,11 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromWebPage)
 
     auto *webpageScript = Util::constructScript(@[
         @"<script>",
-        @"setTimeout(() => {",
         [NSString stringWithFormat:@"browser.runtime.sendMessage('%@', 'Hello', (response) => {", uniqueIdentifier],
         @"  browser.test.assertEq(response, 'Received')",
 
         @"  browser.test.notifyPass()",
         @"})",
-        @"}, 1000)",
         @"</script>"
     ]);
 
@@ -2113,9 +2099,7 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromWebPageWithTabFrameAndAsyncReply)
         @"browser.runtime.onMessageExternal.addListener((message, sender, sendResponse) => {",
         @"  browser.test.assertEq(message?.content, 'Hello from webpage', 'Should receive the correct message from the web page')",
 
-        @"  setTimeout(() => sendResponse({ content: 'Async reply from background' }), 500)",
-
-        @"  return true",
+        @"  sendResponse({ content: 'Async reply from background' })",
         @"})",
 
         @"browser.test.sendMessage('Load Tabs')"
@@ -2137,13 +2121,11 @@ TEST(WKWebExtensionAPIRuntime, SendMessageFromWebPageWithTabFrameAndAsyncReply)
 
     auto *webpageScript = Util::constructScript(@[
         @"<script>",
-        @"setTimeout(() => {",
-        @"  browser.runtime.sendMessage('org.webkit.test.extension (SendMessageTest)', { content: 'Hello from webpage' }, (response) => {",
-        @"    browser.test.assertEq(response?.content, 'Async reply from background', 'Should receive the correct reply from the extension frame')",
+        @"browser.runtime.sendMessage('org.webkit.test.extension (SendMessageTest)', { content: 'Hello from webpage' }, (response) => {",
+        @"  browser.test.assertEq(response?.content, 'Async reply from background', 'Should receive the correct reply from the extension frame')",
 
-        @"    browser.test.notifyPass()",
-        @"  })",
-        @"}, 1000)",
+        @"  browser.test.notifyPass()",
+        @"})",
         @"</script>"
     ]);
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIStorage.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIStorage.mm
@@ -108,12 +108,7 @@ TEST(WKWebExtensionAPIStorage, UndefinedProperties)
     Util::loadAndRunExtension(storageManifest, @{ @"background.js": backgroundScript });
 }
 
-// FIXME rdar://147858640
-#if PLATFORM(IOS) && !defined(NDEBUG)
-TEST(WKWebExtensionAPIStorage, DISABLED_SetAccessLevelTrustedContexts)
-#else
 TEST(WKWebExtensionAPIStorage, SetAccessLevelTrustedContexts)
-#endif
 {
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } }
@@ -132,7 +127,9 @@ TEST(WKWebExtensionAPIStorage, SetAccessLevelTrustedContexts)
         @"  browser.test.assertEq(response?.content, undefined)",
 
         @"  browser.test.notifyPass()",
-        @"})"
+        @"})",
+
+        @"browser.test.sendMessage('Load Tab')"
     ]);
 
     auto *contentScript = Util::constructScript(@[
@@ -142,24 +139,22 @@ TEST(WKWebExtensionAPIStorage, SetAccessLevelTrustedContexts)
         @"  sendResponse({ content: browser?.storage?.session })",
         @"})",
 
-        @"setTimeout(() => browser.runtime.sendMessage('Ready'), 1000)"
+        @"browser.runtime.sendMessage('Ready')"
     ]);
 
     auto manager = Util::loadExtension(storageManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
 
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+
+    [manager runUntilTestMessage:@"Load Tab"];
+
     [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
 }
 
-// FIXME rdar://147858640
-#if PLATFORM(IOS) && !defined(NDEBUG)
-TEST(WKWebExtensionAPIStorage, DISABLED_SetAccessLevelTrustedAndUntrustedContexts)
-#else
 TEST(WKWebExtensionAPIStorage, SetAccessLevelTrustedAndUntrustedContexts)
-#endif
 {
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } }
@@ -178,7 +173,9 @@ TEST(WKWebExtensionAPIStorage, SetAccessLevelTrustedAndUntrustedContexts)
         @"  browser.test.assertEq(response?.content, 'object')",
 
         @"  browser.test.notifyPass()",
-        @"})"
+        @"})",
+
+        @"browser.test.sendMessage('Load Tab')"
     ]);
 
     auto *contentScript = Util::constructScript(@[
@@ -188,13 +185,16 @@ TEST(WKWebExtensionAPIStorage, SetAccessLevelTrustedAndUntrustedContexts)
         @"  sendResponse({ content: typeof browser?.storage?.session })",
         @"})",
 
-        @"setTimeout(() => browser.runtime.sendMessage('Ready'), 1000)"
+        @"browser.runtime.sendMessage('Ready')"
     ]);
 
     auto manager = Util::loadExtension(storageManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
 
     auto *urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+
+    [manager runUntilTestMessage:@"Load Tab"];
+
     [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPITabs.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPITabs.mm
@@ -1577,12 +1577,7 @@ TEST(WKWebExtensionAPITabs, HighlightedAlsoActivatesTab)
     Util::loadAndRunExtension(tabsManifest, @{ @"background.js": backgroundScript });
 }
 
-// FIXME rdar://147858640
-#if PLATFORM(IOS) && !defined(NDEBUG)
-TEST(WKWebExtensionAPITabs, DISABLED_SendMessage)
-#else
 TEST(WKWebExtensionAPITabs, SendMessage)
-#endif
 {
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
@@ -1599,7 +1594,9 @@ TEST(WKWebExtensionAPITabs, SendMessage)
         @"  browser.test.assertEq(response?.content, 'Received', 'Should get the response from the content script')",
 
         @"  browser.test.notifyPass()",
-        @"})"
+        @"})",
+
+        @"browser.test.sendMessage('Load Tab')"
     ]);
 
     auto *contentScript = Util::constructScript(@[
@@ -1620,24 +1617,22 @@ TEST(WKWebExtensionAPITabs, SendMessage)
         @"  sendResponse({ content: 'Received' })",
         @"})",
 
-        @"setTimeout(() => browser.runtime.sendMessage('Ready'), 1000)"
+        @"browser.runtime.sendMessage('Ready')"
     ]);
 
     auto manager = Util::loadExtension(tabsContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
 
     RetainPtr urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+
+    [manager runUntilTestMessage:@"Load Tab"];
+
     [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
 
-// FIXME rdar://147858640
-#if PLATFORM(IOS) && !defined(NDEBUG)
-TEST(WKWebExtensionAPITabs, DISABLED_SendMessageWithAsyncReply)
-#else
 TEST(WKWebExtensionAPITabs, SendMessageWithAsyncReply)
-#endif
 {
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
@@ -1654,7 +1649,9 @@ TEST(WKWebExtensionAPITabs, SendMessageWithAsyncReply)
         @"  browser.test.assertEq(response?.content, 'Received', 'Should get the response from the content script')",
 
         @"  browser.test.notifyPass()",
-        @"})"
+        @"})",
+
+        @"browser.test.sendMessage('Load Tab')"
     ]);
 
     auto *contentScript = Util::constructScript(@[
@@ -1672,29 +1669,27 @@ TEST(WKWebExtensionAPITabs, SendMessageWithAsyncReply)
         @"  browser.test.assertEq(sender.tab, undefined, 'sender.tab should be undefined')",
         @"  browser.test.assertEq(sender.frameId, undefined, 'sender.frameId should be undefined')",
 
-        @"  setTimeout(() => sendResponse({ content: 'Received' }), 1000)",
+        @"  sendResponse({ content: 'Received' })",
 
         @"  return true",
         @"})",
 
-        @"setTimeout(() => browser.runtime.sendMessage('Ready'), 1000)"
+        @"browser.runtime.sendMessage('Ready')"
     ]);
 
     auto manager = Util::loadExtension(tabsContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
 
     RetainPtr urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+
+    [manager runUntilTestMessage:@"Load Tab"];
+
     [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
 
-// FIXME rdar://147858640
-#if PLATFORM(IOS) && !defined(NDEBUG)
-TEST(WKWebExtensionAPITabs, DISABLED_SendMessageWithPromiseReply)
-#else
 TEST(WKWebExtensionAPITabs, SendMessageWithPromiseReply)
-#endif
 {
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
@@ -1711,7 +1706,9 @@ TEST(WKWebExtensionAPITabs, SendMessageWithPromiseReply)
         @"  browser.test.assertEq(response?.content, 'Received', 'Should get the response from the content script')",
 
         @"  browser.test.notifyPass()",
-        @"})"
+        @"})",
+
+        @"browser.test.sendMessage('Load Tab')"
     ]);
 
     auto *contentScript = Util::constructScript(@[
@@ -1732,24 +1729,22 @@ TEST(WKWebExtensionAPITabs, SendMessageWithPromiseReply)
         @"  return Promise.resolve({ content: 'Received' })",
         @"})",
 
-        @"setTimeout(() => browser.runtime.sendMessage('Ready'), 1000)"
+        @"browser.runtime.sendMessage('Ready')"
     ]);
 
     auto manager = Util::loadExtension(tabsContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
 
     RetainPtr urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+
+    [manager runUntilTestMessage:@"Load Tab"];
+
     [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
 
-// FIXME rdar://147858640
-#if PLATFORM(IOS) && !defined(NDEBUG)
-TEST(WKWebExtensionAPITabs, DISABLED_SendMessageWithAsyncPromiseReply)
-#else
 TEST(WKWebExtensionAPITabs, SendMessageWithAsyncPromiseReply)
-#endif
 {
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
@@ -1766,7 +1761,9 @@ TEST(WKWebExtensionAPITabs, SendMessageWithAsyncPromiseReply)
         @"  browser.test.assertEq(response?.content, 'Received', 'Should get the response from the content script')",
 
         @"  browser.test.notifyPass()",
-        @"})"
+        @"})",
+
+        @"browser.test.sendMessage('Load Tab')"
     ]);
 
     auto *contentScript = Util::constructScript(@[
@@ -1785,28 +1782,26 @@ TEST(WKWebExtensionAPITabs, SendMessageWithAsyncPromiseReply)
         @"  browser.test.assertEq(sender.frameId, undefined, 'sender.frameId should be undefined')",
 
         @"  return new Promise((resolve) => {",
-        @"    setTimeout(() => resolve({ content: 'Received' }), 1000)",
+        @"    resolve({ content: 'Received' })",
         @"  })",
         @"})",
 
-        @"setTimeout(() => browser.runtime.sendMessage('Ready'), 1000)"
+        @"browser.runtime.sendMessage('Ready')"
     ]);
 
     auto manager = Util::loadExtension(tabsContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
 
     RetainPtr urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+
+    [manager runUntilTestMessage:@"Load Tab"];
+
     [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
 
-// FIXME rdar://147858640
-#if PLATFORM(IOS) && !defined(NDEBUG)
-TEST(WKWebExtensionAPITabs, DISABLED_SendMessageWithoutReply)
-#else
 TEST(WKWebExtensionAPITabs, SendMessageWithoutReply)
-#endif
 {
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
@@ -1821,7 +1816,9 @@ TEST(WKWebExtensionAPITabs, SendMessageWithoutReply)
         @"  browser.test.assertEq(response, undefined, 'Should resolve with undefined as there was no reply')",
 
         @"  browser.test.notifyPass()",
-        @"})"
+        @"})",
+
+        @"browser.test.sendMessage('Load Tab')"
     ]);
 
     auto *contentScript = Util::constructScript(@[
@@ -1842,13 +1839,16 @@ TEST(WKWebExtensionAPITabs, SendMessageWithoutReply)
         @"  return false",
         @"})",
 
-        @"setTimeout(() => browser.runtime.sendMessage('Ready'), 1000)"
+        @"browser.runtime.sendMessage('Ready')"
     ]);
 
     auto manager = Util::loadExtension(tabsContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
 
     RetainPtr urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+
+    [manager runUntilTestMessage:@"Load Tab"];
+
     [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
@@ -1926,7 +1926,14 @@ TEST(WKWebExtensionAPITabs, SendMessageFromBackgroundToSubframe)
     auto *backgroundScript = Util::constructScript(@[
         @"browser.test.sendMessage('Load Tab')",
 
-        @"await new Promise(resolve => setTimeout(resolve, 1500))",
+        @"await new Promise(resolve => {",
+        @"  browser.runtime.onMessage.addListener(function handler(message) {",
+        @"    if (message === 'Subframe Ready') {",
+        @"      browser.runtime.onMessage.removeListener(handler)",
+        @"      resolve()",
+        @"    }",
+        @"  })",
+        @"})",
 
         @"const tabs = await browser.tabs.query({ })",
         @"browser.test.assertEq(tabs.length, 1)",
@@ -1938,6 +1945,8 @@ TEST(WKWebExtensionAPITabs, SendMessageFromBackgroundToSubframe)
     ]);
 
     auto *contentScript = Util::constructScript(@[
+        @"browser.runtime.sendMessage('Subframe Ready')",
+
         @"browser.runtime.onMessage.addListener((message, sender) => {",
         @"  browser.test.assertEq(message?.content, 'Hello Subframe', 'Should receive the correct message from the background page')",
         @"  return Promise.resolve({ content: 'Received from subframe' })",
@@ -2626,12 +2635,7 @@ TEST(WKWebExtensionAPITabs, DISABLED_PortPostMessageGestureFromContentScriptIsNo
     [manager run];
 }
 
-// FIXME rdar://147858640
-#if PLATFORM(IOS) && !defined(NDEBUG)
-TEST(WKWebExtensionAPITabs, DISABLED_Connect)
-#else
 TEST(WKWebExtensionAPITabs, Connect)
-#endif
 {
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
@@ -2656,7 +2660,9 @@ TEST(WKWebExtensionAPITabs, Connect)
 
         @"    browser.test.notifyPass()",
         @"  })",
-        @"})"
+        @"})",
+
+        @"browser.test.sendMessage('Load Tab')"
     ]);
 
     auto *contentScript = Util::constructScript(@[
@@ -2678,15 +2684,16 @@ TEST(WKWebExtensionAPITabs, Connect)
         @"  })",
         @"})",
 
-        @"setTimeout(() => {",
-        @"  browser.runtime.sendMessage({ readyToConnect: true })",
-        @"}, 1000)"
+        @"browser.runtime.sendMessage({ readyToConnect: true })"
     ]);
 
     auto manager = Util::loadExtension(tabsContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
 
     RetainPtr urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+
+    [manager runUntilTestMessage:@"Load Tab"];
+
     [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
@@ -2834,7 +2841,14 @@ TEST(WKWebExtensionAPITabs, ConnectToSubframe)
     auto *backgroundScript = Util::constructScript(@[
         @"browser.test.sendMessage('Load Tab')",
 
-        @"await new Promise(resolve => setTimeout(resolve, 1500))",
+        @"await new Promise(resolve => {",
+        @"  browser.runtime.onMessage.addListener(function handler(message) {",
+        @"    if (message === 'Subframe Ready') {",
+        @"      browser.runtime.onMessage.removeListener(handler)",
+        @"      resolve()",
+        @"    }",
+        @"  })",
+        @"})",
 
         @"const tabs = await browser.tabs.query({ })",
         @"browser.test.assertEq(tabs.length, 1)",
@@ -2852,6 +2866,8 @@ TEST(WKWebExtensionAPITabs, ConnectToSubframe)
     ]);
 
     auto *contentScript = Util::constructScript(@[
+        @"browser.runtime.sendMessage('Subframe Ready')",
+
         @"browser.runtime.onConnect.addListener((port) => {",
         @"  browser.test.assertEq(port.name, 'testPort', 'Port name should be testPort')",
 
@@ -2898,12 +2914,7 @@ TEST(WKWebExtensionAPITabs, ConnectToSubframe)
     [manager run];
 }
 
-// FIXME rdar://147858640
-#if PLATFORM(IOS) && !defined(NDEBUG)
-TEST(WKWebExtensionAPITabs, DISABLED_PortDisconnect)
-#else
 TEST(WKWebExtensionAPITabs, PortDisconnect)
-#endif
 {
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
@@ -2928,7 +2939,9 @@ TEST(WKWebExtensionAPITabs, PortDisconnect)
         @"  })",
 
         @"  port.disconnect()",
-        @"})"
+        @"})",
+
+        @"browser.test.sendMessage('Load Tab')"
     ]);
 
     auto *contentScript = Util::constructScript(@[
@@ -2943,26 +2956,22 @@ TEST(WKWebExtensionAPITabs, PortDisconnect)
         @"  })",
         @"})",
 
-        @"setTimeout(() => {",
-        @"  browser.runtime.sendMessage({ readyToConnect: true })",
-        @"}, 1000)"
+        @"browser.runtime.sendMessage({ readyToConnect: true })"
     ]);
 
     auto manager = Util::loadExtension(tabsContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
 
     RetainPtr urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+
+    [manager runUntilTestMessage:@"Load Tab"];
+
     [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
 
-// FIXME rdar://147858640
-#if PLATFORM(IOS) && !defined(NDEBUG)
-TEST(WKWebExtensionAPITabs, DISABLED_ConnectWithMultipleListeners)
-#else
 TEST(WKWebExtensionAPITabs, ConnectWithMultipleListeners)
-#endif
 {
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
@@ -2989,7 +2998,9 @@ TEST(WKWebExtensionAPITabs, ConnectWithMultipleListeners)
         @"    if (++receivedMessages === 2)",
         @"      browser.test.notifyPass()",
         @"  })",
-        @"})"
+        @"})",
+
+        @"browser.test.sendMessage('Load Tab')"
     ]);
 
     auto *contentScript = Util::constructScript(@[
@@ -3016,26 +3027,22 @@ TEST(WKWebExtensionAPITabs, ConnectWithMultipleListeners)
         @"  })",
         @"})",
 
-        @"setTimeout(() => {",
-        @"  browser.runtime.sendMessage({ readyToConnect: true })",
-        @"}, 1000)"
+        @"browser.runtime.sendMessage({ readyToConnect: true })"
     ]);
 
     auto manager = Util::loadExtension(tabsContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
 
     RetainPtr urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+
+    [manager runUntilTestMessage:@"Load Tab"];
+
     [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];
 }
 
-// FIXME rdar://147858640
-#if PLATFORM(IOS) && !defined(NDEBUG)
-TEST(WKWebExtensionAPITabs, DISABLED_PortDisconnectWithMultipleListeners)
-#else
 TEST(WKWebExtensionAPITabs, PortDisconnectWithMultipleListeners)
-#endif
 {
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
@@ -3062,7 +3069,9 @@ TEST(WKWebExtensionAPITabs, PortDisconnectWithMultipleListeners)
         @"    if (++receivedMessages === 2)",
         @"      browser.test.notifyPass()",
         @"  })",
-        @"})"
+        @"})",
+
+        @"browser.test.sendMessage('Load Tab')"
     ]);
 
     auto *contentScript = Util::constructScript(@[
@@ -3081,15 +3090,16 @@ TEST(WKWebExtensionAPITabs, PortDisconnectWithMultipleListeners)
         @"  })",
         @"})",
 
-        @"setTimeout(() => {",
-        @"  browser.runtime.sendMessage({ readyToConnect: true })",
-        @"}, 1000)"
+        @"browser.runtime.sendMessage({ readyToConnect: true })"
     ]);
 
     auto manager = Util::loadExtension(tabsContentScriptManifest, @{ @"background.js": backgroundScript, @"content.js": contentScript });
 
     RetainPtr urlRequest = server.requestWithLocalhost();
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.get().URL];
+
+    [manager runUntilTestMessage:@"Load Tab"];
+
     [manager.get().defaultTab.webView loadRequest:urlRequest.get()];
 
     [manager run];


### PR DESCRIPTION
#### d2bbeb82975126c7c8bfc7933f867e3811b25793
<pre>
REGRESSION(285929@main-285928@main): [ iOS Debug ] WKWebExtensionAPI* tests are flaky timeout.
<a href="https://webkit.org/b/290403">https://webkit.org/b/290403</a>
<a href="https://rdar.apple.com/problem/147858640">rdar://problem/147858640</a>

Reviewed by Brian Weinstein.

Replace setTimeout-based synchronization in web extension tests with explicit `browser.test.sendMessage` /
`runUntilTestMessage` handshakes. These older tests were written before that pattern was established
and never got updated, causing intermittent failures on both macOS and iOS where the 1–2 second delays
were insufficient to guarantee the background script was ready before a tab URL was loaded.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIRuntime.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, ConnectFromContentScript)):
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, ConnectFromContentScriptWithMultipleListeners)):
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, PortDisconnectFromContentScript)):
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, PortDisconnectFromContentScriptWithMultipleListeners)):
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, ConnectFromWebPage)):
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, ConnectFromWebPageWithImmediateMessage)):
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, SendMessageFromWebPage)):
(TestWebKitAPI::TEST(WKWebExtensionAPIRuntime, SendMessageFromWebPageWithTabFrameAndAsyncReply)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIStorage.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIStorage, SetAccessLevelTrustedContexts)):
(TestWebKitAPI::TEST(WKWebExtensionAPIStorage, SetAccessLevelTrustedAndUntrustedContexts)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPITabs.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, SendMessage)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, SendMessageWithAsyncReply)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, SendMessageWithPromiseReply)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, SendMessageWithAsyncPromiseReply)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, SendMessageWithoutReply)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, SendMessageFromBackgroundToSubframe)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, Connect)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, ConnectToSubframe)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, PortDisconnect)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, ConnectWithMultipleListeners)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, PortDisconnectWithMultipleListeners)):

Canonical link: <a href="https://commits.webkit.org/313046@main">https://commits.webkit.org/313046@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/02c8755e6646269825db007ea919a72e42c828cc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161827 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35301 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28404 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170730 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118198 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dd6c243d-d4d1-4084-8096-ce298c623732) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163696 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35402 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35303 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125561 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88478 "17 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7ab27338-0825-4f92-9abf-3f690ee6524b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164786 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27878 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145359 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106157 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/af5785a3-684b-4ea4-b14c-bc7610de66c1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26927 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25443 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18451 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136620 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23114 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173219 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24755 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133860 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34975 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29529 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133865 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34959 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144909 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97047 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24593 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28397 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21732 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34469 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33969 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34212 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34118 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->