### PR TITLE
[visionOS release] overlay-region/full-page-horizontal.html is flaky text failure.

### DIFF
--- a/LayoutTests/overlay-region/scrollable-axes-change-expected.txt
+++ b/LayoutTests/overlay-region/scrollable-axes-change-expected.txt
@@ -1,0 +1,1 @@
+      (scrolling behavior 1)

--- a/LayoutTests/overlay-region/scrollable-axes-change.html
+++ b/LayoutTests/overlay-region/scrollable-axes-change.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ OverlayRegionsEnabled=true AsyncOverflowScrollingEnabled=true AsyncFrameScrollingEnabled=true ContentInsetBackgroundFillEnabled=false ] -->
+<html>
+<head>
+    <meta charset="utf-8" />
+    <style>
+        html, body { margin: 0; padding: 0; }
+
+        #content {
+            height: 3000px;
+            width: 100vw;
+        }
+
+        #content.horizontal {
+            height: 100vh;
+            width: 3000px;
+        }
+    </style>
+    <script src="../resources/ui-helper.js"></script>
+    <script src="./overlay-region-helper.js"></script>
+</head>
+<body>
+<div id="content"></div>
+
+<pre id="results"></pre>
+<script>
+if (window.testRunner) {
+    testRunner.waitUntilDone();
+    testRunner.dumpAsText();
+}
+
+window.onload = async function () {
+    if (!window.internals)
+        return;
+
+    await UIHelper.ensureStablePresentationUpdate();
+
+    document.getElementById("content").classList.add("horizontal");
+    await UIHelper.ensureStablePresentationUpdate();
+
+    results.textContent = filterUIViewTree(await UIHelper.getUIViewTree());
+    document.getElementById('content').remove();
+
+    testRunner.notifyDone();
+};
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/visionos/TestExpectations
+++ b/LayoutTests/platform/visionos/TestExpectations
@@ -215,7 +215,6 @@ webkit.org/b/313782 interaction-region/paused-video-regions.html [ Failure ]
 ###################################################################################################
 ### START OF Flaky tests
 
-webkit.org/b/309297 overlay-region/full-page-horizontal.html [ Pass Failure ]
 webkit.org/b/305613 overlay-region/clipping.html [ Pass Failure ]
 
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h
@@ -130,6 +130,7 @@ private:
 #endif
 
     bool m_needsOverlayRegionScrollViewSelection { false };
+    bool m_needsOverlayRegionBehaviorUpdate { false };
     RetainPtr<WKBaseScrollView> m_selectedOverlayRegionScrollView;
 #endif
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
@@ -141,6 +141,7 @@ void RemoteScrollingCoordinatorProxyIOS::selectOverlayRegionScrollViewIfNeeded()
         return;
 
     m_needsOverlayRegionScrollViewSelection = false;
+    bool needsBehaviorUpdate = std::exchange(m_needsOverlayRegionBehaviorUpdate, false);
 
     Ref page = webPageProxy();
 
@@ -195,8 +196,11 @@ void RemoteScrollingCoordinatorProxyIOS::selectOverlayRegionScrollViewIfNeeded()
         }
     }
 
-    if (newSelectedScrollView == m_selectedOverlayRegionScrollView)
+    if (newSelectedScrollView == m_selectedOverlayRegionScrollView) {
+        if (newSelectedScrollView && needsBehaviorUpdate)
+            [newSelectedScrollView _updateOverlayRegionsBehavior:YES];
         return;
+    }
 
     if (m_selectedOverlayRegionScrollView) {
         [m_selectedOverlayRegionScrollView _updateOverlayRegionsBehavior:NO];
@@ -530,6 +534,8 @@ void RemoteScrollingCoordinatorProxyIOS::connectStateNodeLayers(ScrollingStateTr
             || currNode->hasChangedProperty(ScrollingStateNode::Property::ScrollContainerLayer)
             || currNode->hasChangedProperty(ScrollingStateNode::Property::ScrolledContentsLayer))
             m_needsOverlayRegionScrollViewSelection = true;
+        if (currNode->hasChangedProperty(ScrollingStateNode::Property::TotalContentsSize))
+            m_needsOverlayRegionBehaviorUpdate = true;
 #endif
 
         switch (currNode->nodeType()) {


### PR DESCRIPTION
#### 8065d5ec268671270242e5533eea3970cfddfce5
<pre>
[visionOS release] overlay-region/full-page-horizontal.html is flaky text failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=309297">https://bugs.webkit.org/show_bug.cgi?id=309297</a>
&lt;<a href="https://rdar.apple.com/171843270">rdar://171843270</a>&gt;

Reviewed by Mike Wyrzykowski.

The flakyness revealed a real issue where, when a ScrollView went from
vertically scrollable to horizontally scrollable, we wouldn&apos;t update
the OverlayRegion behavior.

Test: overlay-region/scrollable-axes-change.html
      overlay-region/full-page-horizontal.html

* LayoutTests/overlay-region/scrollable-axes-change-expected.txt: Added.
* LayoutTests/overlay-region/scrollable-axes-change.html: Added.
Add a test that specifically targets this bugs and fails 100% without
the fix.
* LayoutTests/platform/visionos/TestExpectations:
Re-enable the flaky test.

* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm:
(WebKit::RemoteScrollingCoordinatorProxyIOS::selectOverlayRegionScrollViewIfNeeded):
(WebKit::RemoteScrollingCoordinatorProxyIOS::connectStateNodeLayers):
Keep track of TotalContentsSize updates so that, even if the selected
ScrollView doesn&apos;t change, we still update the OverlayRegion behavior.

Canonical link: <a href="https://commits.webkit.org/313070@main">https://commits.webkit.org/313070@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82628e64567afda183215cfc015881bb9e8aeab7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161830 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35304 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28407 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170733 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118201 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/968ed9de-42a4-4b04-91d1-72c5b46bf93b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35405 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35306 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125563 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88480 "1 flakes 18 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bef92c97-d535-4012-8b10-31fd9d6f79da) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164789 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27877 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145362 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106159 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9fcec3f8-aacc-4915-95b5-46633d6cde5b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26926 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25444 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18454 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136619 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23117 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173222 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20309 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24758 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133862 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34978 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29530 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133867 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36182 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34962 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144912 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97050 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28394 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21735 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34472 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101953 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33972 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34215 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34121 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->