### PR TITLE
[WebXR Layers] Nothing is rendered in threejs XR examples

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrProjectionLayer_initialTextureSize.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrProjectionLayer_initialTextureSize.https-expected.txt
@@ -1,0 +1,4 @@
+
+PASS XRProjectionLayer reports a non-zero texture size before the first XR animation frame, scaled by scaleFactor - webgl
+PASS XRProjectionLayer reports a non-zero texture size before the first XR animation frame, scaled by scaleFactor - webgl2
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrProjectionLayer_initialTextureSize.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrProjectionLayer_initialTextureSize.https.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/webxr_util.js"></script>
+<script src="../resources/webxr_test_constants.js"></script>
+
+<script>
+
+  function testProjectionLayerInitialSize(xrSession, deviceController, t, { gl }) {
+    return new Promise((resolve) => {
+      t.step(() => {
+        const binding = new XRWebGLBinding(xrSession, gl);
+        // disable the depth swapchain so the test does not depend on WEBGL_depth_texture being available on non-WebGL2 contexts.
+        const fullScale = binding.createProjectionLayer({ scaleFactor: 1.0, depthFormat: 0 });
+
+        assert_greater_than(fullScale.textureWidth, 0, "textureWidth must be non-zero immediately after createProjectionLayer()");
+        assert_greater_than(fullScale.textureHeight, 0, "textureHeight must be non-zero immediately after createProjectionLayer()");
+
+        // disable the depth swapchain so the test does not depend on WEBGL_depth_texture being available on non-WebGL2 contexts.
+        const halfScale = binding.createProjectionLayer({ scaleFactor: 0.5, depthFormat: 0 });
+
+        assert_greater_than(halfScale.textureWidth, 0, "textureWidth must be non-zero immediately after createProjectionLayer() with scaleFactor 0.5");
+        assert_greater_than(halfScale.textureHeight, 0, "textureHeight must be non-zero immediately after createProjectionLayer() with scaleFactor 0.5");
+        assert_less_than(halfScale.textureWidth, fullScale.textureWidth, "scaleFactor 0.5 should produce a narrower texture than scaleFactor 1.0");
+        assert_less_than(halfScale.textureHeight, fullScale.textureHeight, "scaleFactor 0.5 should produce a shorter texture than scaleFactor 1.0");
+      });
+      resolve();
+    });
+  }
+
+  xr_session_promise_test("XRProjectionLayer reports a non-zero texture size before the first XR animation frame, scaled by scaleFactor",
+    testProjectionLayerInitialSize, TRACKED_IMMERSIVE_DEVICE, 'immersive-vr', { requiredFeatures: ['layers'] });
+
+</script>

--- a/Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.cpp
@@ -101,15 +101,16 @@ RefPtr<WebGLRenderingContextBase> WebXRWebGLSwapchain::context()
     return m_context;
 }
 
-std::unique_ptr<WebXRWebGLSharedImageSwapchain> WebXRWebGLSharedImageSwapchain::create(WebGLRenderingContextBase& context, SwapchainTargets targets, GCGLenum format, bool clearOnAccess, size_t imageCount)
+std::unique_ptr<WebXRWebGLSharedImageSwapchain> WebXRWebGLSharedImageSwapchain::create(WebGLRenderingContextBase& context, SwapchainTargets targets, GCGLenum format, IntSize initialSize, bool clearOnAccess, size_t imageCount)
 {
-    return std::unique_ptr<WebXRWebGLSharedImageSwapchain>(new WebXRWebGLSharedImageSwapchain(context, targets, format, clearOnAccess, imageCount));
+    return std::unique_ptr<WebXRWebGLSharedImageSwapchain>(new WebXRWebGLSharedImageSwapchain(context, targets, format, initialSize, clearOnAccess, imageCount));
 }
 
-WebXRWebGLSharedImageSwapchain::WebXRWebGLSharedImageSwapchain(WebGLRenderingContextBase& context, SwapchainTargets targets, GCGLenum format, bool clearOnAccess, size_t imageCount)
+WebXRWebGLSharedImageSwapchain::WebXRWebGLSharedImageSwapchain(WebGLRenderingContextBase& context, SwapchainTargets targets, GCGLenum format, IntSize initialSize, bool clearOnAccess, size_t imageCount)
     : WebXRWebGLSwapchain(context, targets, clearOnAccess, imageCount)
     , m_format(format)
 {
+    m_texSize = initialSize;
 }
 
 WebXRWebGLSharedImageSwapchain::~WebXRWebGLSharedImageSwapchain()

--- a/Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.h
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.h
@@ -108,7 +108,7 @@ protected:
 // It manages the lifecycle of these shared images and binds them to the WebGL context for rendering.
 class WebXRWebGLSharedImageSwapchain final : public WebXRWebGLSwapchain {
 public:
-    static std::unique_ptr<WebXRWebGLSharedImageSwapchain> create(WebGLRenderingContextBase&, SwapchainTargets, GCGLenum format, bool clearOnAccess, size_t imageCount);
+    static std::unique_ptr<WebXRWebGLSharedImageSwapchain> create(WebGLRenderingContextBase&, SwapchainTargets, GCGLenum format, IntSize initialSize, bool clearOnAccess, size_t imageCount);
     ~WebXRWebGLSharedImageSwapchain() override;
 
     PlatformGLObject currentTexture() override;
@@ -119,7 +119,7 @@ public:
     bool allTexturesAreBound() const override;
 
 private:
-    WebXRWebGLSharedImageSwapchain(WebGLRenderingContextBase&, SwapchainTargets, GCGLenum format, bool clearOnAccess, size_t imageCount);
+    WebXRWebGLSharedImageSwapchain(WebGLRenderingContextBase&, SwapchainTargets, GCGLenum format, IntSize initialSize, bool clearOnAccess, size_t imageCount);
     void setupExternalImage(GraphicsContextGL&, const PlatformXR::FrameData::LayerSetupData&);
 
     const WebXRExternalImages* reusableTextures(const PlatformXR::FrameData::ExternalTextureData&) const;

--- a/Source/WebCore/Modules/webxr/XRWebGLLayerBacking.cpp
+++ b/Source/WebCore/Modules/webxr/XRWebGLLayerBacking.cpp
@@ -177,7 +177,7 @@ ExceptionOr<XRWebGLLayerBacking::XRLayerSwapchains> XRWebGLLayerBacking::createP
 
 ExceptionOr<XRWebGLLayerBacking::XRLayerSwapchains> XRWebGLLayerBacking::createColorAndDepthSwapchains(WebGLRenderingContextBase& context, PlatformXR::LayerHandle handle, GCGLenum colorFormat, std::optional<GCGLenum> depthFormat, IntSize size, bool clearOnAccess, size_t numImages)
 {
-    auto colorSwapchain = WebXRWebGLSharedImageSwapchain::create(context, WebXRSwapchain::SwapchainTargetFlags::Color, colorFormat, clearOnAccess, numImages);
+    auto colorSwapchain = WebXRWebGLSharedImageSwapchain::create(context, WebXRSwapchain::SwapchainTargetFlags::Color, colorFormat, size, clearOnAccess, numImages);
     if (!colorSwapchain)
         return Exception { ExceptionCode::OperationError, "Failed to create a WebGL swapchain."_s };
 


### PR DESCRIPTION
#### 6ba71881df7b187b73d128b6e96437d4bb8b2579
<pre>
[WebXR Layers] Nothing is rendered in threejs XR examples
<a href="https://bugs.webkit.org/show_bug.cgi?id=314556">https://bugs.webkit.org/show_bug.cgi?id=314556</a>

Reviewed by Dan Glastonbury.

Soon after creating a projection layer the size of the textures backing
that layer should be available and exposed to JS. However the current
code was waiting for the first texture to be created and available to
set the size. It&apos;s fine to set the available size at creation time as
specs describes them as the &quot;recommended width/height of color textures
for this layer&quot; based on what the device says and the scale factor.

That was the reason why threejs examples were failing, because they were
checking the size of the textures soon after creating the layer without
waiting for the first rAF.

Test: imported/w3c/web-platform-tests/webxr/layers/xrProjectionLayer_initialTextureSize.https.html

* LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrProjectionLayer_initialTextureSize.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrProjectionLayer_initialTextureSize.https.html: Added.
* Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.cpp:
(WebCore::WebXRWebGLSharedImageSwapchain::create):
(WebCore::WebXRWebGLSharedImageSwapchain::WebXRWebGLSharedImageSwapchain):
* Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.h:
* Source/WebCore/Modules/webxr/XRWebGLLayerBacking.cpp:
(WebCore::XRWebGLLayerBacking::createColorAndDepthSwapchains):

Canonical link: <a href="https://commits.webkit.org/313067@main">https://commits.webkit.org/313067@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7205c561d78b5b2d989d9748c6a8a49d7efb59db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161841 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35315 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28418 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170744 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118212 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163710 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35416 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35317 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125573 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88487 "17 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164800 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27887 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145375 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106169 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26936 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25452 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18465 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136629 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23130 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173233 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20320 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24771 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133872 "Found 1 new test failure: accessibility/aria-owns-deep-chain-no-timeout.html (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34989 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29538 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133877 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36180 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34973 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144925 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97064 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28406 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21748 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34483 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101964 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33983 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34226 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34132 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->