### PR TITLE
[GFC] Implement logic to determine if grid item has a preferred aspect ratio .

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
@@ -81,7 +81,7 @@ static std::optional<LayoutUnit> NODELETE inlineTransferredSizeSuggestion(const 
 
 static LayoutUnit inlineContentSizeSuggestion(const PlacedGridItem& gridItem, const IntegrationUtils& integrationUtils)
 {
-    ASSERT(!gridItem.hasPreferredAspectRatio(), "Grid items with preferred aspect ratio not supported yet.");
+    ASSERT(!gridItem.preferredAspectRatio(), "Grid items with preferred aspect ratio not supported yet.");
     return integrationUtils.minContentWidth(gridItem.layoutBox());
 }
 
@@ -102,7 +102,7 @@ static std::optional<LayoutUnit> NODELETE blockTransferredSizeSuggestion(const P
 
 static LayoutUnit blockContentSizeSuggestion(const PlacedGridItem& gridItem, const IntegrationUtils& integrationUtils)
 {
-    ASSERT(!gridItem.hasPreferredAspectRatio(), "Grid items with preferred aspect ratio not supported yet.");
+    ASSERT(!gridItem.preferredAspectRatio(), "Grid items with preferred aspect ratio not supported yet.");
     return integrationUtils.minContentHeight(gridItem.layoutBox());
 }
 
@@ -146,7 +146,7 @@ LayoutUnit usedInlineSizeForGridItem(const PlacedGridItem& placedGridItem, Layou
         // while still respecting the constraints imposed by min-height/min-width/max-height/max-width.
         auto& marginStart = inlineAxisSizes.marginStart;
         auto& marginEnd = inlineAxisSizes.marginEnd;
-        if ((alignmentPosition == ItemPosition::Normal) && !placedGridItem.hasPreferredAspectRatio() && !placedGridItem.isReplacedElement()
+        if ((alignmentPosition == ItemPosition::Normal) && !placedGridItem.preferredAspectRatio() && !placedGridItem.isReplacedElement()
             && !marginStart.isAuto() && !marginEnd.isAuto()) {
             auto& usedZoom = placedGridItem.usedZoom();
 
@@ -297,7 +297,7 @@ LayoutUnit usedBlockSizeForGridItem(const PlacedGridItem& placedGridItem, Layout
         // while still respecting the constraints imposed by min-height/min-width/max-height/max-width.
         auto& marginStart = blockAxisSizes.marginStart;
         auto& marginEnd = blockAxisSizes.marginEnd;
-        if ((alignmentPosition == ItemPosition::Normal) && !placedGridItem.hasPreferredAspectRatio() && !placedGridItem.isReplacedElement()
+        if ((alignmentPosition == ItemPosition::Normal) && !placedGridItem.preferredAspectRatio() && !placedGridItem.isReplacedElement()
             && !marginStart.isAuto() && !marginEnd.isAuto()) {
             auto& usedZoom = placedGridItem.usedZoom();
 

--- a/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.cpp
@@ -55,5 +55,45 @@ PlacedGridItem::PlacedGridItem(const ElementBox& gridItem, const GridAreaLines& 
 {
 }
 
+// https://drafts.csswg.org/css-sizing-4/#aspect-ratio
+std::optional<double> PlacedGridItem::preferredAspectRatio() const
+{
+    auto& computedAspectRatio = protect(m_layoutBox->style())->aspectRatio();
+
+    auto isDegenerateRatio = [&] {
+        auto ratio = computedAspectRatio.tryRatio();
+        return !ratio || !ratio->numerator.value || !ratio->denominator.value;
+    };
+
+    // "If the <ratio> is degenerate, the property instead behaves as auto."
+    //
+    // auto: "Replaced elements with a natural aspect ratio use that aspect ratio;
+    // otherwise the box has no preferred aspect ratio."
+    if (computedAspectRatio.isAuto() || isDegenerateRatio()) {
+        if (m_layoutBox->isReplacedBox() && m_layoutBox->hasIntrinsicRatio())
+            return m_layoutBox->intrinsicRatio();
+        return { };
+    }
+
+    // <ratio>: "The box's preferred aspect ratio is the specified ratio of width / height."
+    if (computedAspectRatio.isRatio()) {
+        auto ratio = *computedAspectRatio.tryRatio();
+        return ratio.numerator.value / ratio.denominator.value;
+    }
+
+    // auto && <ratio>: "The preferred aspect ratio is the specified ratio of width / height
+    // unless it is a replaced element with a natural aspect ratio, in which case that aspect
+    // ratio is used instead."
+    if (computedAspectRatio.isAutoAndRatio()) {
+        if (m_layoutBox->isReplacedBox() && m_layoutBox->hasIntrinsicRatio())
+            return m_layoutBox->intrinsicRatio();
+        auto ratio = *computedAspectRatio.tryRatio();
+        return ratio.numerator.value / ratio.denominator.value;
+    }
+
+    ASSERT_NOT_REACHED();
+    return { };
+}
+
 } // namespace Layout
 } // namespace WebCore

--- a/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.h
+++ b/Source/WebCore/layout/formattingContexts/grid/PlacedGridItem.h
@@ -69,8 +69,7 @@ public:
 
     const WritingMode& writingMode() const LIFETIME_BOUND { return m_writingMode; }
 
-    // FIXME: Add support for grid item's with preferred aspect ratios.
-    bool hasPreferredAspectRatio() const { return false; }
+    std::optional<double> preferredAspectRatio() const;
     bool isReplacedElement() const { return m_layoutBox->isReplacedBox(); }
 
     const GridAreaLines& gridAreaLines() const LIFETIME_BOUND { return m_gridAreaLines; }
@@ -79,6 +78,7 @@ public:
 
 private:
     PlacedGridItem(const ElementBox& gridItem, const GridAreaLines&, const BoxGeometry& gridItemGeometry,  const RenderStyle& gridContainerWritingMode, const RenderStyle& gridItemWritingMode);
+
     const CheckedRef<const ElementBox> m_layoutBox;
 
     const ComputedSizes m_inlineAxisSizes;


### PR DESCRIPTION
#### 2a4dad78a1274bfc014f6dd1b93e978240d3ea61
<pre>
[GFC] Implement logic to determine if grid item has a preferred aspect ratio .
<a href="https://bugs.webkit.org/show_bug.cgi?id=314557">https://bugs.webkit.org/show_bug.cgi?id=314557</a>
<a href="https://rdar.apple.com/176798557">rdar://176798557</a>

Reviewed by Alan Baradlay.

Grid will base some behavior dependent on whether the grid item has a
preferred aspect ratio. We currently store a bit on PlacedGridItem.
which is initialized to false without any other logic to change this
value. We can remove this bit and instead have a function that
determines and returns a preferred aspect ratio based upon:

<a href="https://drafts.csswg.org/css-sizing-4/#aspect-ratio">https://drafts.csswg.org/css-sizing-4/#aspect-ratio</a>
Canonical link: <a href="https://commits.webkit.org/313033@main">https://commits.webkit.org/313033@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d30a98756ee58f5eb3fc20e3d459ac58d636dca7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161882 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35356 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28459 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170785 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118253 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/04a6f669-741d-4981-94b7-d421b32740bd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163751 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35458 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35358 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125601 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/78836101-86a0-418f-9453-3ce89a1d0854) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164841 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27924 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145400 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106197 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/23910db5-c3b3-4dd0-85cc-001b989a4e95) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26973 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25486 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18506 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136666 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23155 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173274 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20361 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24796 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133901 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35030 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29573 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133906 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36162 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35014 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144950 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97109 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28435 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21773 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34524 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102005 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34025 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34267 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34173 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->