### PR TITLE
[WebXR Layers] Only first frame is rendered in threejs samples

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrSession_updateRenderState_preservesLayers.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrSession_updateRenderState_preservesLayers.https-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Layers installed via updateRenderState are preserved across subsequent partial updates - webgl
+PASS Layers installed via updateRenderState are preserved across subsequent partial updates - webgl2
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrSession_updateRenderState_preservesLayers.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrSession_updateRenderState_preservesLayers.https.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/webxr_util.js"></script>
+<script src="../resources/webxr_test_constants.js"></script>
+
+<script>
+
+  function testLayersPersistAcrossUpdates(xrSession, deviceController, t, { gl }) {
+    return new Promise((resolve, reject) => {
+      const binding = new XRWebGLBinding(xrSession, gl);
+      // disable the depth swapchain so the test does not depend on WEBGL_depth_texture on non-WebGL2 contexts.
+      const projectionLayer = binding.createProjectionLayer({
+        scaleFactor: 1.0,
+        depthFormat: 0,
+      });
+
+      xrSession.updateRenderState({ layers: [projectionLayer] });
+
+      xrSession.requestAnimationFrame(() => {
+        t.step(() => {
+          assert_equals(xrSession.renderState.layers.length, 1, "layers should be installed after the first frame");
+          assert_equals(xrSession.renderState.layers[0], projectionLayer, "installed layer should match the one passed to updateRenderState");
+        });
+
+        // Second update that does NOT mention layers. Verify the render state clone does not drop the projection layer.
+        xrSession.updateRenderState({ depthNear: 0.5 });
+
+        xrSession.requestAnimationFrame(() => {
+          t.step(() => {
+            assert_equals(xrSession.renderState.depthNear, 0.5, "depthNear should reflect the second updateRenderState call");
+            assert_equals(xrSession.renderState.layers.length, 1, "layers must not be cleared by an unrelated updateRenderState call");
+            assert_equals(xrSession.renderState.layers[0], projectionLayer, "the original projection layer must still be active");
+          });
+          resolve();
+        });
+      });
+    });
+  }
+
+  xr_session_promise_test("Layers installed via updateRenderState are preserved across subsequent partial updates",
+    testLayersPersistAcrossUpdates, TRACKED_IMMERSIVE_DEVICE, 'immersive-vr', { requiredFeatures: ['layers'] });
+
+</script>

--- a/Source/WebCore/Modules/webxr/WebXRRenderState.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRRenderState.cpp
@@ -59,7 +59,12 @@ WebXRRenderState::WebXRRenderState(const WebXRRenderState& other)
     : m_depth(other.m_depth)
     , m_passthroughFullyObscured(other.m_passthroughFullyObscured)
     , m_inlineVerticalFieldOfView(other.m_inlineVerticalFieldOfView)
-    , m_baseLayer(other.baseLayer())
+    , m_baseLayer(other.m_baseLayer)
+#if ENABLE(WEBXR_LAYERS)
+    , m_layers(other.m_layers)
+#endif
+    , m_outputCanvas(other.m_outputCanvas)
+    , m_compositionEnabled(other.m_compositionEnabled)
 {
 }
 


### PR DESCRIPTION
#### 253177b8b3e7a330eb9a6083be6c1e98de5753ea
<pre>
[WebXR Layers] Only first frame is rendered in threejs samples
<a href="https://bugs.webkit.org/show_bug.cgi?id=314558">https://bugs.webkit.org/show_bug.cgi?id=314558</a>

Reviewed by Dan Glastonbury.

WebXRRenderState&apos;s copy constructor (used by clone(), which builds the
pending render state in WebXRSession::updateRenderState) did not copy
m_layers (apart from m_outputCanvas and m_compositionEnabled). As a
consequence, any follow-up updateRenderState() call that only updates
unrelated fields (e.g. depthNear) cloned the active state, populated
only the requested fields, and then replaced the active render state at
the end of the frame with one that has an empty layers list.

As the list of layers to render was empty, nothing was submitted to the
compositor. That was the reason why no updates where shown after those
updateRenderState calls.

Test: imported/w3c/web-platform-tests/webxr/layers/xrSession_updateRenderState_preservesLayers.https.html

* LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrSession_updateRenderState_preservesLayers.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrSession_updateRenderState_preservesLayers.https.html: Added.
* Source/WebCore/Modules/webxr/WebXRRenderState.cpp:
(WebCore::WebXRRenderState::WebXRRenderState):

Canonical link: <a href="https://commits.webkit.org/313069@main">https://commits.webkit.org/313069@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/40ed9bcd8a5605b979003abcdc9266ed2dca05f0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161846 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35320 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28423 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170749 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118217 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163715 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35421 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35322 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125577 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88490 "2 flakes 18 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164805 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27890 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145371 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106173 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26939 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25455 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18470 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136632 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23126 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173238 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20325 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24767 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133876 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34994 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29541 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133881 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36181 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34978 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144921 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97070 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28408 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21744 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34488 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101969 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33988 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34231 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34137 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->