### PR TITLE
[GFC] Implement stubs for determining if a grid item's computed overflow is a scrollable value .

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
@@ -106,16 +106,20 @@ static LayoutUnit blockContentSizeSuggestion(const PlacedGridItem& gridItem, con
     return integrationUtils.minContentHeight(gridItem.layoutBox());
 }
 
-static bool NODELETE hasScrollableInlineOverflow(const PlacedGridItem&)
+// https://drafts.csswg.org/css-overflow-3/#overflow-properties
+// The scroll, auto, and hidden values are known as the scrollable values of overflow.
+static bool NODELETE hasScrollableInlineComputedOverflowValue(const PlacedGridItem& gridItem)
 {
-    notImplemented();
-    return false;
+    auto computedOverflow = gridItem.layoutBox().style().overflowX();
+    return computedOverflow == Overflow::Hidden || computedOverflow == Overflow::Scroll || computedOverflow == Overflow::Auto;
 }
 
-static bool NODELETE hasScrollableBlockOverflow(const PlacedGridItem&)
+// https://drafts.csswg.org/css-overflow-3/#overflow-properties
+// The scroll, auto, and hidden values are known as the scrollable values of overflow.
+static bool NODELETE hasScrollableBlockComputedOverflowValue(const PlacedGridItem& gridItem)
 {
-    notImplemented();
-    return false;
+    auto computedOverflow = gridItem.layoutBox().style().overflowY();
+    return computedOverflow == Overflow::Hidden || computedOverflow == Overflow::Scroll || computedOverflow == Overflow::Auto;
 }
 
 LayoutUnit usedInlineSizeForGridItem(const PlacedGridItem& placedGridItem, LayoutUnit borderAndPadding,
@@ -184,10 +188,8 @@ static LayoutUnit automaticMinimumInlineSize(const PlacedGridItem& gridItem, Lay
     // if it spans more than one track in that axis, none of those tracks are flexible
     //
     // Otherwise, the automatic minimum size is zero, as usual.
-    if (hasScrollableInlineOverflow(gridItem)) {
-        ASSERT_NOT_IMPLEMENTED_YET();
+    if (hasScrollableInlineComputedOverflowValue(gridItem))
         return { };
-    }
 
     auto gridItemColumnStartLine = gridItem.columnStartLine();
     auto gridItemColumnEndLine = gridItem.columnEndLine();
@@ -236,10 +238,8 @@ static LayoutUnit automaticMinimumBlockSize(const PlacedGridItem& gridItem, Layo
     // if it spans more than one track in that axis, none of those tracks are flexible
     //
     // Otherwise, the automatic minimum size is zero, as usual.
-    if (hasScrollableBlockOverflow(gridItem)) {
-        ASSERT_NOT_IMPLEMENTED_YET();
+    if (hasScrollableBlockComputedOverflowValue(gridItem))
         return { };
-    }
 
     auto gridItemRowStartLine = gridItem.rowStartLine();
     auto gridItemRowEndLine = gridItem.rowEndLine();


### PR DESCRIPTION
#### b96b602c32609b0e80fa3db7793fadf663d7c4d5
<pre>
[GFC] Implement stubs for determining if a grid item&apos;s computed overflow is a scrollable value .
<a href="https://bugs.webkit.org/show_bug.cgi?id=314559">https://bugs.webkit.org/show_bug.cgi?id=314559</a>
<a href="https://rdar.apple.com/problem/176799526">rdar://problem/176799526</a>

Reviewed by Alan Baradlay.

In order to determine if we are going to apply the &quot;automatic minimum
size,&quot; logic that grid defines we need to check the computed overflow
value in that dimension. We can only apply that logic if that value is
not a scrollable value. In this patch we implement this straightforward
logic to return the correct value based off the computed style.

(WebCore::Layout::GridLayoutUtils::hasScrollableInlineComputedOverflowValue):
(WebCore::Layout::GridLayoutUtils::hasScrollableBlockComputedOverflowValue):
(WebCore::Layout::GridLayoutUtils::hasScrollableInlineOverflow): Deleted.
(WebCore::Layout::GridLayoutUtils::hasScrollableBlockOverflow): Deleted.
Rename the function to make it clear that we are checking the computed
value and not checking if the grid item&apos;s content overflowed the item.

Canonical link: <a href="https://commits.webkit.org/313030@main">https://commits.webkit.org/313030@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e7dba0115737b04526d40ebf44e11dcbd4edaef4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161851 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35325 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28428 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170754 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118222 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/758dee7f-5027-4e45-95c2-b415d80605c5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163720 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35427 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35327 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125580 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4dca9ca0-445f-4d8c-ab55-44f1118a2241) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164810 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27900 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145376 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106176 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c8ad9e83-e28f-4312-a557-536dba39e48b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26949 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25461 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18475 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136642 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23131 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173243 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20330 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24772 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133879 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/34999 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29547 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133884 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36158 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/34983 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144926 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97076 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28414 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21749 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34493 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101974 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/33993 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34236 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34142 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->