### PR TITLE
[AppKit Gestures] Clean up the implementation of WKTextSelectionController.isTextSelected(at:) a bit

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/WKTextSelectionRect.h
+++ b/Source/WebKit/UIProcess/Cocoa/WKTextSelectionRect.h
@@ -23,6 +23,8 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#import <wtf/Platform.h>
+
 #if PLATFORM(IOS_FAMILY) || HAVE(NSTEXTPLACEHOLDER_RECTS)
 
 #if PLATFORM(IOS_FAMILY)
@@ -35,6 +37,8 @@ namespace WebCore {
 class FloatQuad;
 class SelectionGeometry;
 }
+
+NS_HEADER_AUDIT_BEGIN(nullability, sendability)
 
 @class WKTextSelectionRect;
 
@@ -50,8 +54,10 @@ class SelectionGeometry;
 #endif
 
 - (instancetype)initWithCGRect:(CGRect)rect;
-- (instancetype)initWithSelectionGeometry:(const WebCore::SelectionGeometry&)selectionGeometry delegate:(id<WKTextSelectionRectDelegate>)delegate;
+- (instancetype)initWithSelectionGeometry:(const WebCore::SelectionGeometry&)selectionGeometry delegate:(nullable id<WKTextSelectionRectDelegate>)delegate;
 
 @end
 
-#endif // PLATFORM(COCOA)
+NS_HEADER_AUDIT_END(nullability, sendability)
+
+#endif // PLATFORM(IOS_FAMILY) || HAVE(NSTEXTPLACEHOLDER_RECTS)

--- a/Source/WebKit/UIProcess/mac/WKTextSelectionController.swift
+++ b/Source/WebKit/UIProcess/mac/WKTextSelectionController.swift
@@ -108,36 +108,24 @@ extension WKTextSelectionController {
         Logger.viewGestures.log("[pageProxyID=\(page.logIdentifier())] \(#function) point: \(String(reflecting: point))")
 
         let editorState = page.editorState
-        let hasSelection = editorState.selectionType != .None
 
-        if !hasSelection || !editorState.hasPostLayoutAndVisualData() {
-            Logger.viewGestures.log(
-                "[pageProxyID=\(page.logIdentifier())] Editor state has no selection, post layout data, or visual data"
-            )
+        guard editorState.selectionType == .Range else {
+            Logger.viewGestures.log("[pageProxyID=\(page.logIdentifier())] Selection is not a range")
             return false
         }
 
-        let isRange = editorState.selectionType == .Range
-        let isContentEditable = editorState.isContentEditable
-
-        if !isContentEditable && !isRange {
-            Logger.viewGestures.log("[pageProxyID=\(page.logIdentifier())] Selection is neither contenteditable nor a range")
+        guard let visualData = Optional(fromCxx: editorState.visualData), Optional(fromCxx: editorState.postLayoutData) != nil else {
+            Logger.viewGestures.log("[pageProxyID=\(page.logIdentifier())] Editor state has no post layout data or visual data")
             return false
         }
 
-        // FIXME: If the state's selection is not a range, is the number of selection geometries always zero?
-        // If so, then the rest of the logic in this function can be elided in that case.
+        let selectionGeometries = Array(visualData.selectionGeometries)
 
-        var selectionRects: [WKTextSelectionRect] = []
-        let selectionGeometries = editorState.visualData.pointee.selectionGeometries
-
-        // FIXME: `WTF::Vector` should be able to be used as a Swift `Sequence`.
-        for i in 0..<selectionGeometries.size() {
-            let selectionGeometry = unsafe selectionGeometries.__atUnsafe(i).pointee
-            selectionRects.append(.init(selectionGeometry: selectionGeometry, delegate: nil))
+        let result = selectionGeometries.contains {
+            let selectionRect = WKTextSelectionRect(selectionGeometry: $0, delegate: nil)
+            return selectionRect.rect.contains(point)
         }
 
-        let result = selectionRects.contains { $0.rect.contains(point) }
         Logger.viewGestures.log("[pageProxyID=\(page.logIdentifier())] Text is selected => \(result)")
 
         return result


### PR DESCRIPTION
#### 8f97d7737f3b3fcd614648d8cf772b1f77814f20
<pre>
[AppKit Gestures] Clean up the implementation of WKTextSelectionController.isTextSelected(at:) a bit
<a href="https://bugs.webkit.org/show_bug.cgi?id=314571">https://bugs.webkit.org/show_bug.cgi?id=314571</a>
<a href="https://rdar.apple.com/176807516">rdar://176807516</a>

Reviewed by Tim Horton.

Simplify some logic and use the latest Swift-Cxx interop capabilities.

* Source/WebKit/UIProcess/Cocoa/WKTextSelectionRect.h:
* Source/WebKit/UIProcess/mac/WKTextSelectionController.swift:
(WKTextSelectionController.isTextSelected(at:)):

Canonical link: <a href="https://commits.webkit.org/313022@main">https://commits.webkit.org/313022@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aef4d625bfe0ca2c491e526b3b2c8d8d7782444c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161873 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35347 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28450 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170776 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118244 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dd63b430-55c7-4f72-9a76-7ff65c56899b) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35449 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35349 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125597 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d6e25f2f-1b1b-4dc7-bb98-c35e8aaef21a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164832 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27915 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145393 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106193 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0ae4ace7-cee0-48e3-960f-90a21842b6a6) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/26964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25480 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18497 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136657 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173265 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20352 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24789 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133897 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35021 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/29566 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133902 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36152 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35005 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144943 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97099 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28430 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/21766 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34515 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/101996 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34016 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34258 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34164 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->