### PR TITLE
Justification expansion opportunities are miscounted inside emoji ZWJ sequences

### DIFF
--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -38,6 +38,7 @@
 #include "TextShapingResultAndDisplayList.h"
 #include "WidthIterator.h"
 #include <ranges>
+#include <unicode/ubrk.h>
 #include <wtf/MainThread.h>
 #include <wtf/MathExtras.h>
 #include <wtf/NeverDestroyed.h>
@@ -45,7 +46,9 @@
 #include <wtf/SortedArrayMap.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/AtomStringHash.h>
+#include <wtf/text/CharacterProperties.h>
 #include <wtf/text/StringBuilder.h>
+#include <wtf/text/TextBreakIterator.h>
 #include <wtf/text/TextStream.h>
 
 namespace WebCore {
@@ -1213,49 +1216,78 @@ std::pair<unsigned, bool> FontCascade::expansionOpportunityCountInternal(std::sp
         ++count;
         isAfterExpansion = true;
     }
-    if (direction == TextDirection::LTR) {
-        for (size_t i = 0; i < characters.size(); ++i) {
-            char32_t character = characters[i];
-            if (treatAsSpace(character)) {
-                ++count;
-                isAfterExpansion = true;
-                continue;
-            }
-            if (U16_IS_LEAD(character) && i + 1 < characters.size() && U16_IS_TRAIL(characters[i + 1])) {
-                character = U16_GET_SUPPLEMENTARY(character, characters[i + 1]);
-                ++i;
-            }
-            if (canExpandAroundIdeographsInComplexText() && isCJKIdeographOrSymbol(character)) {
-                if (!isAfterExpansion)
-                    ++count;
-                ++count;
-                isAfterExpansion = true;
-                continue;
-            }
-            isAfterExpansion = false;
-        }
-    } else {
-        for (size_t i = characters.size(); i > 0; --i) {
-            char32_t character = characters[i - 1];
-            if (treatAsSpace(character)) {
-                ++count;
-                isAfterExpansion = true;
-                continue;
-            }
-            if (U16_IS_TRAIL(character) && i > 1 && U16_IS_LEAD(characters[i - 2])) {
-                character = U16_GET_SUPPLEMENTARY(characters[i - 2], character);
-                --i;
-            }
-            if (canExpandAroundIdeographsInComplexText() && isCJKIdeographOrSymbol(character)) {
-                if (!isAfterExpansion)
-                    ++count;
-                ++count;
-                isAfterExpansion = true;
-                continue;
-            }
-            isAfterExpansion = false;
+
+    // Fast path: when no character can participate in a multi-codepoint grapheme
+    // cluster, the legacy codepoint loop produces the same result as the cluster
+    // iterator. Anything below U+0300 is neither a surrogate, a combining mark,
+    // a ZWJ, a variation selector, nor any other default-ignorable code point, so
+    // surrogate merging and default-ignorable handling are both no-ops. Avoiding
+    // NonSharedCharacterBreakIterator keeps the common line-layout case allocation-free.
+    bool mayFormMultiCodepointClusters = false;
+    for (auto character : characters) {
+        if (character >= 0x0300) {
+            mayFormMultiCodepointClusters = true;
+            break;
         }
     }
+
+    auto visitCodepoint = [&](char32_t character) {
+        if (treatAsSpace(character)) {
+            ++count;
+            isAfterExpansion = true;
+            return;
+        }
+        if (canExpandAroundIdeographsInComplexText() && isCJKIdeographOrSymbol(character)) {
+            if (!isAfterExpansion)
+                ++count;
+            ++count;
+            isAfterExpansion = true;
+            return;
+        }
+        if (!isDefaultIgnorableCodePoint(character))
+            isAfterExpansion = false;
+    };
+
+    if (!mayFormMultiCodepointClusters) {
+        auto simpleLoop = [&](const auto& range) {
+            for (auto character : range)
+                visitCodepoint(character);
+        };
+        if (direction == TextDirection::LTR)
+            simpleLoop(characters);
+        else
+            simpleLoop(characters | std::views::reverse);
+    } else {
+        // Iterate in grapheme clusters so multi-codepoint sequences (e.g. emoji
+        // ZWJ sequences) contribute a single expansion opportunity rather than
+        // one per codepoint.
+        auto visitCluster = [&](size_t clusterStart) {
+            char32_t character = characters[clusterStart];
+            if (U16_IS_LEAD(character) && clusterStart + 1 < characters.size() && U16_IS_TRAIL(characters[clusterStart + 1]))
+                character = U16_GET_SUPPLEMENTARY(character, characters[clusterStart + 1]);
+            visitCodepoint(character);
+        };
+
+        NonSharedCharacterBreakIterator clusterIterator { StringView { characters } };
+        if (direction == TextDirection::LTR) {
+            int32_t start = 0;
+            int32_t length = static_cast<int32_t>(characters.size());
+            while (start < length) {
+                visitCluster(static_cast<size_t>(start));
+                int32_t next = ubrk_following(clusterIterator, start);
+                if (next == UBRK_DONE)
+                    break;
+                start = next;
+            }
+        } else {
+            int32_t start = ubrk_preceding(clusterIterator, static_cast<int32_t>(characters.size()));
+            while (start != UBRK_DONE) {
+                visitCluster(static_cast<size_t>(start));
+                start = ubrk_preceding(clusterIterator, start);
+            }
+        }
+    }
+
     if (!isAfterExpansion && expansionBehavior.right == ExpansionBehavior::Behavior::Force) {
         ++count;
         isAfterExpansion = true;

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -181,7 +181,7 @@ public:
 
     // Returns (the number of opportunities, whether the last expansion is a trailing expansion)
     // If there are no opportunities, the bool will be true iff we are forbidding leading expansions.
-    static std::pair<unsigned, bool> expansionOpportunityCount(StringView, TextDirection, ExpansionBehavior);
+    WEBCORE_EXPORT static std::pair<unsigned, bool> expansionOpportunityCount(StringView, TextDirection, ExpansionBehavior);
 
     // Whether or not there is an expansion opportunity just before the first character
     // Note that this does not take a isAfterExpansion flag; this assumes that isAfterExpansion is false

--- a/Tools/TestWebKitAPI/Tests/WebCore/FontCascade.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/FontCascade.cpp
@@ -25,7 +25,10 @@
  */
 
 #include "config.h"
-#include <WebCore/FontCascade.h>
+#include <WebCore/FontCascadeInlines.h>
+#include <WebCore/TextFlags.h>
+#include <WebCore/WritingMode.h>
+#include <wtf/text/WTFString.h>
 
 namespace TestWebKitAPI {
 
@@ -129,4 +132,32 @@ TEST(FontCascadeTest, characterRangeCodePath_NonSurrogates)
     // U+FE20 through U+FE2F Combining half marks
     testCodePathRange({ 0xFE20, 0xFE2F, CodePath::Complex });
 }
+
+// Emoji ZWJ sequences (e.g. U+1F635 U+200D U+1F4AB, "face with spiral eyes")
+// are a single grapheme cluster and must contribute only two expansion
+// opportunities under text-align: justify — one before the cluster, one
+// after. Iterating UTF-16 code units instead would count the inner emoji
+// codepoints as extra ideograph-or-symbol boundaries and inflate the count.
+TEST(FontCascadeTest, ExpansionOpportunityCountEmojiZWJ)
+{
+    String source(u"a\U0001F635\u200D\U0001F4ABz");
+
+    // Only ports that expand around ideographs in complex text participate
+    // in the CJK/symbol classification path — elsewhere no ideograph
+    // opportunities are counted, regardless of cluster boundaries.
+#if PLATFORM(COCOA)
+    constexpr unsigned expectedCount = 2u;
+#else
+    constexpr unsigned expectedCount = 0u;
+#endif
+
+    auto ltr = FontCascade::expansionOpportunityCount(StringView(source), TextDirection::LTR, ExpansionBehavior::defaultBehavior());
+    EXPECT_EQ(expectedCount, ltr.first);
+    EXPECT_FALSE(ltr.second);
+
+    auto rtl = FontCascade::expansionOpportunityCount(StringView(source), TextDirection::RTL, ExpansionBehavior::defaultBehavior());
+    EXPECT_EQ(expectedCount, rtl.first);
+    EXPECT_FALSE(rtl.second);
 }
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### 136e2ac8911a56e6875b5367cd0f27950fc12cef
<pre>
Justification expansion opportunities are miscounted inside emoji ZWJ sequences
<a href="https://bugs.webkit.org/show_bug.cgi?id=314539">https://bugs.webkit.org/show_bug.cgi?id=314539</a>
<a href="https://rdar.apple.com/176807515">rdar://176807515</a>

Reviewed by NOBODY (OOPS!).

Merge (Inspired by): <a href="https://chromium-review.googlesource.com/c/chromium/src/+/7104662">https://chromium-review.googlesource.com/c/chromium/src/+/7104662</a>

FontCascade::expansionOpportunityCountInternal(std::span&lt;const char16_t&gt;, ...)
iterates UTF-16 code units (with surrogate-pair merging) rather than
grapheme clusters, so a multi-codepoint emoji ZWJ sequence like
U+1F635 U+200D U+1F4AB is visited as three codepoints. Two of them
(U+1F635 and U+1F4AB) pass isCJKIdeographOrSymbol() and therefore
contribute extra expansion opportunities inside the cluster, which
inflates the total opportunity count and causes text-align: justify to
inject spacing between the glyphs of a single emoji.

Additionally, the non-ideograph branch unconditionally resets
isAfterExpansion to false. The ZWJ (U+200D) between the two emoji then
resets the state, so the second emoji is counted as if it opened a fresh
expansion boundary. Default-ignorable code points should not clear the
post-expansion flag.

Drive the loop with NonSharedCharacterBreakIterator so each cluster is
visited exactly once, and skip default-ignorable code points when
clearing isAfterExpansion.

Keep the common line-layout case allocation-free with a fast-path check:
if every character is below U+0300 the string cannot contain surrogates,
combining marks, ZWJ, variation selectors, or any other default-ignorable
code point, so the legacy per-codepoint loop yields the same result as
the cluster iterator. Only fall back to NonSharedCharacterBreakIterator
when that precondition fails.

Export FontCascade::expansionOpportunityCount so it can be exercised
directly by the TestWebKitAPI unit test added with this change.

Test: Tools/TestWebKitAPI/Tests/WebCore/FontCascade.cpp

* Source/WebCore/platform/graphics/FontCascade.h:
Add WEBCORE_EXPORT to expansionOpportunityCount so tests can link
against it.

* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::expansionOpportunityCountInternal): Scan once for
any character &gt;= U+0300; if none are present, run the simple codepoint
loop. Otherwise iterate grapheme clusters via ubrk_following and
ubrk_preceding, and guard the state-reset branch with
isDefaultIgnorableCodePoint.

* Tools/TestWebKitAPI/Tests/WebCore/FontCascade.cpp:
(TestWebKitAPI::FontCascadeTest.ExpansionOpportunityCountEmojiZWJ):
Added. Asserts that an emoji ZWJ sequence between two ASCII letters
contributes exactly two expansion opportunities on Cocoa (and zero
elsewhere), not four; mirrors Blink&apos;s CharacterTest.ExpansionOpportunityEmoji.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/136e2ac8911a56e6875b5367cd0f27950fc12cef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161878 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35352 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28455 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170781 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118249 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/35b85300-a1aa-45da-9895-8c6530b195eb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163747 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35454 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35354 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125599 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88510 "1 flakes 17 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0a349afe-2a1b-4507-9fa4-7ff8855a22b8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164837 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27921 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145410 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106195 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6199e908-3986-45c1-b281-89f15671cd77) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/26970 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25483 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18502 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136663 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23165 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173270 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20357 "Found 1 new failure in platform/graphics/FontCascade.cpp") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24806 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133899 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35026 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29569 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133904 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; 1 api test failed or timed out; 1 api test failed or timed out; Compiled WebKit; run-api-tests-without-change; Passed API tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35010 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144960 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97104 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28437 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21783 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34520 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102001 "Found 1 new failure in platform/graphics/FontCascade.cpp") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34021 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34263 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34169 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->