### PR TITLE
[LegacySVG] getScreenCTM() returns incorrect result when document is scrolled under a CSS-transformed ancestor

### DIFF
--- a/LayoutTests/svg/dom/getScreenCTM-ancestor-transform-expected.txt
+++ b/LayoutTests/svg/dom/getScreenCTM-ancestor-transform-expected.txt
@@ -1,0 +1,9 @@
+
+PASS getScreenCTM: Outermost SVG element ancestor position/transform
+PASS getScreenCTM: Outermost SVG element ancestor position/transform 1
+PASS getScreenCTM: Outermost SVG element ancestor position/transform 2
+PASS getScreenCTM: Outermost SVG element ancestor position/transform 3
+PASS getScreenCTM: Outermost SVG element ancestor position/transform 4
+PASS getScreenCTM: Outermost SVG element ancestor position/transform 5
+PASS getScreenCTM: Outermost SVG element ancestor position/transform 6
+

--- a/LayoutTests/svg/dom/getScreenCTM-ancestor-transform.html
+++ b/LayoutTests/svg/dom/getScreenCTM-ancestor-transform.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<title>getScreenCTM: Outermost SVG element ancestor position/transform</title>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<body>
+<script>
+function to_array(matrix) {
+  return [ matrix.a, matrix.b, matrix.c, matrix.d, matrix.e, matrix.f ];
+}
+
+function assert_array_approx_equals(actual, expected) {
+  assert_equals(actual.length, expected.length);
+  for (let i = 0; i < expected.length; ++i)
+    assert_approx_equals(actual[i], expected[i], 0.0005);
+}
+
+function check_screen_ctm(document_data, expected_array) {
+  async_test(t => {
+    let blob = new Blob([ '<!DOCTYPE html>', document_data ], { type: 'text/html' });
+    let iframe = document.createElement('iframe');
+    iframe.src = URL.createObjectURL(blob);
+    iframe.onload = t.step_func_done(() => {
+      var ctm = iframe.contentDocument.querySelector("rect").getScreenCTM();
+      iframe.remove();
+      assert_array_approx_equals(to_array(ctm), expected_array);
+    });
+    document.body.appendChild(iframe);
+  });
+}
+
+const COMMON_PAYLOAD = '<svg display="block"><rect width="100" height="100"/></svg></div>';
+
+check_screen_ctm('<div>' + COMMON_PAYLOAD,
+                 [ 1, 0, 0, 1, 8, 8 ]);
+check_screen_ctm('<div style="transform: translateX(100px)">' + COMMON_PAYLOAD,
+                 [ 1, 0, 0, 1, 108, 8 ]);
+check_screen_ctm('<div style="transform: translate(100px, 100px)">' + COMMON_PAYLOAD,
+                 [ 1, 0, 0, 1, 108, 108 ]);
+check_screen_ctm('<div style="transform: rotate(45deg); width: 300px;">' + COMMON_PAYLOAD,
+                 [ 0.707, 0.707, -0.707, 0.707, 104.967, -76.099 ]);
+check_screen_ctm('<div style="transform: rotate(45deg) scale(10); width: 300px;">' + COMMON_PAYLOAD,
+                 [ 7.071, 7.071, -7.071, 7.071, -372.330, -1507.990 ]);
+check_screen_ctm('<div style="height: 400px"></div><div style="transform: rotate(45deg); width: 300px;">' + COMMON_PAYLOAD,
+                 [ 0.707, 0.707, -0.707, 0.707, 104.967, 400 + -76.099 ]);
+check_screen_ctm('<div style="height: 400px"></div><div style="transform: rotate(45deg); width: 300px;">' + COMMON_PAYLOAD +
+                 '<script>window.scrollBy(0, 200)<'+'/script>',
+                 [ 0.707, 0.707, -0.707, 0.707, 104.967, -200 + 400 + -76.099 ]);
+</script>

--- a/Source/WebCore/svg/SVGSVGElement.cpp
+++ b/Source/WebCore/svg/SVGSVGElement.cpp
@@ -474,11 +474,12 @@ AffineTransform SVGSVGElement::localCoordinateSpaceTransform(CTMScope mode) cons
                 transform.translate(location.x() - viewBoxTransform.e(), location.y() - viewBoxTransform.f());
             }
 
-            // Respect scroll offset.
+            // Subtract scroll offset in screen space (adjust e/f directly).
             if (RefPtr view = document().view()) {
                 LayoutPoint scrollPosition = view->scrollPosition();
                 scrollPosition.scale(1 / pageZoomFactor);
-                transform.translate(-scrollPosition);
+                transform.setE(transform.e() - scrollPosition.x().toDouble());
+                transform.setF(transform.f() - scrollPosition.y().toDouble());
             }
         }
     }


### PR DESCRIPTION
#### 584db591a774cd41fb0b8e8c89c1d4244ced8094
<pre>
[LegacySVG] getScreenCTM() returns incorrect result when document is scrolled under a CSS-transformed ancestor
<a href="https://bugs.webkit.org/show_bug.cgi?id=314578">https://bugs.webkit.org/show_bug.cgi?id=314578</a>
<a href="https://rdar.apple.com/176814876">rdar://176814876</a>

Reviewed by Brent Fulgham.

Per spec [1], getScreenCTM() must include the transforms from the
outermost &lt;svg&gt;&apos;s CSS box up through every ancestor box to the initial
containing block.

The legacy outermost-&lt;svg&gt; path in localCoordinateSpaceTransform()
applied the scroll offset via transform.translate(-scrollPosition), which
post-multiplies it into the SVG&apos;s local space. Any non-trivial ancestor
CSS transform (rotate/scale) then rotates or scales that scroll vector,
so getScreenCTM() returns the wrong e/f when the page is scrolled under
such an ancestor.

Subtract the scroll offset from the output e/f components directly so it
is applied in screen space, after the ancestor transforms.

NOTE: This bug only exists in the Legacy SVG engine.

[1] <a href="https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGGraphicsElement__getScreenCTM">https://w3c.github.io/svgwg/svg2-draft/types.html#__svg__SVGGraphicsElement__getScreenCTM</a>

Merge (Test only): <a href="https://chromium.googlesource.com/chromium/src.git/+/2ad2a9bf7205ec77843cf27a7964fda92df386b2">https://chromium.googlesource.com/chromium/src.git/+/2ad2a9bf7205ec77843cf27a7964fda92df386b2</a>

Test: svg/dom/getScreenCTM-ancestor-transform.html

* Source/WebCore/svg/SVGSVGElement.cpp:
(WebCore::SVGSVGElement::localCoordinateSpaceTransform const):
* LayoutTests/svg/dom/getScreenCTM-ancestor-transform-expected.txt: Added.
* LayoutTests/svg/dom/getScreenCTM-ancestor-transform.html: Added.

Canonical link: <a href="https://commits.webkit.org/313111@main">https://commits.webkit.org/313111@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bed97067c200488a6f84804a4f00ddc315d9cdb1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162101 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35576 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28691 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171009 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118474 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/703ea3d0-c00e-41de-b2ac-421b032c1463) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163970 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35684 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35578 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125805 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88666 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2ffa22c1-0162-43de-be83-6e7fcb897407) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165060 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28127 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145605 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/106383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2bcd24be-0be3-4b44-9c7c-db00cdd4e848) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27174 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25685 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18730 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136873 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23351 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173500 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20858 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24994 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134098 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35250 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29773 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134100 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36207 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35233 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145147 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97428 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28623 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21975 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34744 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102498 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34244 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34486 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34392 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->