### PR TITLE
Cherry-pick 312598@main (640e6ff568d1). https://bugs.webkit.org/show_bug.cgi?id=314034

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -9046,6 +9046,13 @@ PlatformMediaSession::DisplayType HTMLMediaElement::displayType() const
 
 bool HTMLMediaElement::canProduceAudio() const
 {
+    return m_cachedCanProduceAudio.load(std::memory_order_relaxed);
+}
+
+bool HTMLMediaElement::computeCanProduceAudio() const
+{
+    ASSERT(isMainThread());
+
 #if ENABLE(WIRELESS_PLAYBACK_TARGET)
     // Because the remote target could unmute playback without notifying us, we must assume
     // that we may be playing audio.
@@ -10262,6 +10269,7 @@ RefPtr<MediaSessionManagerInterface> HTMLMediaElement::sessionManager() const
 
 void HTMLMediaElement::canProduceAudioChanged()
 {
+    m_cachedCanProduceAudio.store(computeCanProduceAudio(), std::memory_order_relaxed);
     protectedMediaSession()->canProduceAudioChanged();
     updateSleepDisabling();
 }

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -1059,6 +1059,7 @@ private:
     bool shouldOverrideBackgroundPlaybackRestriction(PlatformMediaSession::InterruptionType) const override;
     bool shouldOverrideBackgroundLoadingRestriction() const override;
     bool canProduceAudio() const final;
+    bool computeCanProduceAudio() const;
     bool isEnded() const final { return ended(); }
     MediaTime mediaSessionDuration() const final;
     bool hasMediaStreamSource() const final;
@@ -1445,6 +1446,9 @@ private:
     bool m_wasInterruptedForInvisibleAutoplay { false };
 
     bool m_showingStats { false };
+
+    // Cached by canProduceAudioChanged() so virtualHasPendingActivity() can read it safely from the GC thread.
+    std::atomic<bool> m_cachedCanProduceAudio { false };
 
 #if ENABLE(SPEECH_SYNTHESIS)
     RefPtr<SpeechSynthesis> m_speechSynthesis;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h
@@ -40,7 +40,7 @@
 #include <wtf/LoggerHelper.h>
 #include <wtf/MediaTime.h>
 #include <wtf/NativePromise.h>
-#include <wtf/RefCountedAndCanMakeWeakPtr.h>
+#include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/WeakPtr.h>
 
@@ -66,13 +66,14 @@ class VideoMediaSampleRenderer;
 class VideoTrackPrivate;
 
 class MediaPlayerPrivateMediaSourceAVFObjC
-    : public RefCountedAndCanMakeWeakPtr<MediaPlayerPrivateMediaSourceAVFObjC>
-    , public MediaPlayerPrivateInterface
+    : public MediaPlayerPrivateInterface
+    , public ThreadSafeRefCounted<MediaPlayerPrivateMediaSourceAVFObjC, WTF::DestructionThread::Main>
+    , public CanMakeWeakPtr<MediaPlayerPrivateMediaSourceAVFObjC>
     , private LoggerHelper
 {
 public:
-    void ref() const final { RefCounted::ref(); }
-    void deref() const final { RefCounted::deref(); }
+    void ref() const final { ThreadSafeRefCounted::ref(); }
+    void deref() const final { ThreadSafeRefCounted::deref(); }
 
     explicit MediaPlayerPrivateMediaSourceAVFObjC(MediaPlayer&);
     virtual ~MediaPlayerPrivateMediaSourceAVFObjC();

--- a/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
+++ b/Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h
@@ -194,6 +194,7 @@ public:
     void getSource(CompletionHandler<void(String&&)>&&);
 
     void setContentRuleListStore(API::ContentRuleListStore&);
+    API::ContentRuleListStore* contentRuleListStore() const { return m_contentRuleListStore; }
 
 private:
     friend class NeverDestroyed<ResourceMonitorURLsController, MainRunLoopAccessTraits>;

--- a/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
+++ b/Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp
@@ -46,6 +46,7 @@
 #include <wtf/CrossThreadCopier.h>
 #include <wtf/FileHandle.h>
 #include <wtf/FileSystem.h>
+#include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/RunLoop.h>
 #include <wtf/StdLibExtras.h>
@@ -59,10 +60,35 @@ namespace API {
 using namespace WebKit::NetworkCache;
 using namespace FileSystem;
 
-static WorkQueue& fileSystemQueueSingleton()
+static HashMap<WTF::String, std::pair<Ref<WorkQueue>, unsigned>>& workQueueMap()
 {
-    static MainRunLoopNeverDestroyed<Ref<WorkQueue>> fileSystemQueue = WorkQueue::create("ContentRuleListStore FileSystem Queue"_s);
-    return fileSystemQueue.get().get();
+    static MainRunLoopNeverDestroyed<HashMap<WTF::String, std::pair<Ref<WorkQueue>, unsigned>>> map;
+    return map.get();
+}
+
+static WorkQueue& retainWorkQueueForPath(const WTF::String& path)
+{
+    auto& map = workQueueMap();
+    auto result = map.ensure(path, [] {
+        return std::pair { WorkQueue::create("ContentRuleListStore Queue"_s), 0u };
+    });
+    ++result.iterator->value.second;
+    return result.iterator->value.first.get();
+}
+
+static void releaseWorkQueueForPath(const WTF::String& path)
+{
+    auto& map = workQueueMap();
+    auto it = map.find(path);
+    RELEASE_ASSERT(it != map.end());
+    if (!--it->value.second)
+        map.remove(it);
+}
+
+static WTF::String resolvedStorePath(const WTF::String& storePath)
+{
+    makeAllDirectories(storePath);
+    return realPath(storePath);
 }
 
 ContentRuleListStore& ContentRuleListStore::defaultStoreSingleton()
@@ -82,12 +108,15 @@ ContentRuleListStore::ContentRuleListStore()
 }
 
 ContentRuleListStore::ContentRuleListStore(const WTF::String& storePath)
-    : m_storePath(storePath)
+    : m_storePath(resolvedStorePath(storePath))
+    , m_workQueue(retainWorkQueueForPath(m_storePath))
 {
-    makeAllDirectories(storePath);
 }
 
-ContentRuleListStore::~ContentRuleListStore() = default;
+ContentRuleListStore::~ContentRuleListStore()
+{
+    releaseWorkQueueForPath(m_storePath);
+}
 
 static constexpr auto constructedPathPrefix { "ContentRuleList-"_s };
 
@@ -536,7 +565,7 @@ void ContentRuleListStore::lookupContentRuleListFile(WTF::String&& filePath, WTF
 {
     ASSERT(RunLoop::isMain());
 
-    fileSystemQueueSingleton().dispatch([protectedThis = Ref { *this }, filePath = WTF::move(filePath).isolatedCopy(), identifier = WTF::move(identifier).isolatedCopy(), completionHandler = WTF::move(completionHandler)]() mutable {
+    m_workQueue->dispatch([protectedThis = Ref { *this }, filePath = WTF::move(filePath).isolatedCopy(), identifier = WTF::move(identifier).isolatedCopy(), completionHandler = WTF::move(completionHandler)]() mutable {
         auto contentRuleList = openAndMapContentRuleList(filePath);
         if (!contentRuleList) {
             RunLoop::mainSingleton().dispatch([protectedThis = WTF::move(protectedThis), completionHandler = WTF::move(completionHandler)] () mutable {
@@ -573,7 +602,7 @@ void ContentRuleListStore::getAvailableContentRuleListIdentifiers(CompletionHand
 {
     ASSERT(RunLoop::isMain());
 
-    fileSystemQueueSingleton().dispatch([protectedThis = Ref { *this }, storePath = m_storePath.isolatedCopy(), completionHandler = WTF::move(completionHandler)]() mutable {
+    m_workQueue->dispatch([protectedThis = Ref { *this }, storePath = m_storePath.isolatedCopy(), completionHandler = WTF::move(completionHandler)]() mutable {
         Vector<WTF::String> identifiers;
         for (auto& fileName : listDirectory(storePath)) {
             if (fileName.startsWith(constructedPathPrefix))
@@ -606,7 +635,7 @@ void ContentRuleListStore::compileContentRuleListFile(WTF::String&& filePath, WT
             return completionHandler(nullptr, parsedRules.error());
     }
 
-    fileSystemQueueSingleton().dispatch([protectedThis = Ref { *this }, filePath = WTF::move(filePath).isolatedCopy(), identifier = WTF::move(identifier).isolatedCopy(), json = WTF::move(json).isolatedCopy(), parsedRules = crossThreadCopy(WTF::move(parsedRules).value()), storePath = m_storePath.isolatedCopy(), completionHandler = WTF::move(completionHandler), cssSelectorsAllowed] () mutable {
+    m_workQueue->dispatch([protectedThis = Ref { *this }, filePath = WTF::move(filePath).isolatedCopy(), identifier = WTF::move(identifier).isolatedCopy(), json = WTF::move(json).isolatedCopy(), parsedRules = crossThreadCopy(WTF::move(parsedRules).value()), storePath = m_storePath.isolatedCopy(), completionHandler = WTF::move(completionHandler), cssSelectorsAllowed] () mutable {
         if (cssSelectorsAllowed == WebCore::ContentExtensions::CSSSelectorsAllowed::No) {
             auto parsedRulesOnBackgroundQueue = WebCore::ContentExtensions::parseRuleList(json, cssSelectorsAllowed);
             if (!parsedRulesOnBackgroundQueue.has_value())
@@ -641,7 +670,7 @@ void ContentRuleListStore::removeContentRuleListFile(WTF::String&& filePath, Com
 {
     ASSERT(RunLoop::isMain());
 
-    fileSystemQueueSingleton().dispatch([protectedThis = Ref { *this }, filePath = WTF::move(filePath).isolatedCopy(), completionHandler = WTF::move(completionHandler)]() mutable {
+    m_workQueue->dispatch([protectedThis = Ref { *this }, filePath = WTF::move(filePath).isolatedCopy(), completionHandler = WTF::move(completionHandler)]() mutable {
         auto complete = [protectedThis = WTF::move(protectedThis), completionHandler = WTF::move(completionHandler)](std::error_code error) mutable {
             RunLoop::mainSingleton().dispatch([protectedThis = WTF::move(protectedThis), completionHandler = WTF::move(completionHandler), error = WTF::move(error)] () mutable {
                 completionHandler(error);
@@ -744,7 +773,7 @@ void ContentRuleListStore::getContentRuleListSource(WTF::String&& identifier, Co
 {
     ASSERT(RunLoop::isMain());
 
-    fileSystemQueueSingleton().dispatch([protectedThis = Ref { *this }, filePath = constructedPath(m_storePath, identifier).isolatedCopy(), completionHandler = WTF::move(completionHandler)]() mutable {
+    m_workQueue->dispatch([protectedThis = Ref { *this }, filePath = constructedPath(m_storePath, identifier).isolatedCopy(), completionHandler = WTF::move(completionHandler)]() mutable {
         auto complete = [protectedThis = WTF::move(protectedThis), completionHandler = WTF::move(completionHandler)](WTF::String&& source) mutable {
             RunLoop::mainSingleton().dispatch([protectedThis = WTF::move(protectedThis), completionHandler = WTF::move(completionHandler), source = WTF::move(source).isolatedCopy()] () mutable {
                 completionHandler(source);

--- a/Source/WebKit/UIProcess/API/APIContentRuleListStore.h
+++ b/Source/WebKit/UIProcess/API/APIContentRuleListStore.h
@@ -29,6 +29,7 @@
 #include <WebCore/ContentExtensionParser.h>
 #include <system_error>
 #include <wtf/Forward.h>
+#include <wtf/WorkQueue.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -82,6 +83,7 @@ private:
     WTF::String defaultStorePath();
 
     const WTF::String m_storePath;
+    const Ref<WorkQueue> m_workQueue;
 #endif // ENABLE(CONTENT_EXTENSIONS)
 };
 

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -47,7 +47,7 @@
 #import "SandboxUtilities.h"
 #import "TextChecker.h"
 #import "WKContentRuleListInternal.h"
-#import "WKContentRuleListStore.h"
+#import "WKContentRuleListStoreInternal.h"
 #import "WebBackForwardCache.h"
 #import "WebCompiledContentRuleList.h"
 #import "WebMemoryPressureHandler.h"
@@ -1472,7 +1472,13 @@ void WebProcessPool::platformCompileResourceMonitorRuleList(const String& rulesT
 {
     StringView view { rulesText };
     RetainPtr source = view.createNSStringWithoutCopying();
+
+#if ENABLE(ADVANCED_PRIVACY_PROTECTIONS)
+    auto& controller = ResourceMonitorURLsController::singleton();
+    RetainPtr store = controller.contentRuleListStore() ? WebKit::wrapper(*controller.contentRuleListStore()) : [WKContentRuleListStore defaultStore];
+#else
     RetainPtr store = [WKContentRuleListStore defaultStore];
+#endif
 
     [store compileContentRuleListForIdentifier:WebKitResourceMonitorURLsForTestingIdentifier encodedContentRuleList:source.get() completionHandler:makeBlockPtr([completionHandler = WTF::move(completionHandler)](WKContentRuleList *list, NSError *error) mutable {
         if (error || !list)


### PR DESCRIPTION
#### 822a38e50852b4412cc9cb83bdc7a1f42df7b686
<pre>
Cherry-pick 312598@main (640e6ff568d1). <a href="https://bugs.webkit.org/show_bug.cgi?id=314034">https://bugs.webkit.org/show_bug.cgi?id=314034</a>

    ASSERT under HTMLMediaElement::virtualHasPendingActivity
    <a href="https://bugs.webkit.org/show_bug.cgi?id=314034">https://bugs.webkit.org/show_bug.cgi?id=314034</a>
    <a href="https://rdar.apple.com/176143872">rdar://176143872</a>

    Reviewed by Jean-Yves Avenard and Ryosuke Niwa.

    Many MediaPlayerPrivateMediaSourceAVFObjC member variables are a main-thread-only but
    it can be access from the worker thread by the MediaSource/Private, so its destructor
    should always run on the main thread.

    While investigation this it was observed that HTMLMediaElement::virtualHasPendingActivity
    may be called from the GC thread but it calls HTMLMediaElement::canProduceAudio() which
    calls MediaPlayer::hasAudio() and creates a temporary RefPtr to the MediaPlayerPrivate.
    This is unnecessary as every MediaPlayer notifies HTMLMediaElement when its ability to
    produce audio changes, so fix this by caching `canProduceAudio` in a std::atomic which is
    updated only on the main thread whenever relevant state changes. canProduceAudio()
    now just returns the cached value and is safe to call from any thread.

    * Source/WebCore/html/HTMLMediaElement.cpp:
    (WebCore::HTMLMediaElement::canProduceAudio const):
    (WebCore::HTMLMediaElement::computeCanProduceAudio const):
    (WebCore::HTMLMediaElement::canProduceAudioChanged):
    * Source/WebCore/html/HTMLMediaElement.h:
    * Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.h:

    Canonical link: <a href="https://commits.webkit.org/312598@main">https://commits.webkit.org/312598@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.488@webkitglib/2.52">https://commits.webkit.org/305877.488@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### af08d1599d8b7003dc8328873ecf2b992693813d
<pre>
Cherry-pick 312745@main (af0162d45a8f). <a href="https://bugs.webkit.org/show_bug.cgi?id=307300">https://bugs.webkit.org/show_bug.cgi?id=307300</a>

    REGRESSION (297757@main): [ Tahoe wk2 debug arm64 ] Multiple http/tests/iframe-monitor tests are consistent timeouts
    <a href="https://bugs.webkit.org/show_bug.cgi?id=307300">https://bugs.webkit.org/show_bug.cgi?id=307300</a>
    <a href="https://rdar.apple.com/169934202">rdar://169934202</a>

    Reviewed by Basuke Suzuki.

    297757@main fixed parallel compilations for the same identifier racing on the same
    file by replacing per-instance work queues with a single static serial WorkQueue
    shared across all ContentRuleListStore instances. This was too aggressive: it
    serializes all operations (compiles, reads, removes) across all stores globally,
    even when they operate on different directories and cannot conflict.

    On Tahoe bots running multiple WebKitTestRunner instances, this causes two problems:

    1. Cross-process filesystem contention: platformCompileResourceMonitorRuleList()
       was using [WKContentRuleListStore defaultStore] whose directory is shared across
       all WKTR instances. Multiple processes writing the same file concurrently makes
       compilation extremely slow.

    2. Within-process queue starvation: the built-in resource monitor rule list
       compilation (triggered by page navigation via ResourceMonitorURLsController::prepare())
       and the test&apos;s rule list compilation both serialize on the same global queue.
       If the built-in list is large, it blocks the test&apos;s compilation past the timeout.

    Fix both issues:

    - Replace the global static serial queue with a per-directory serial WorkQueue,
      keyed by store path. Stores sharing the same directory serialize on the same
      queue (preventing the race that 297757@main fixed), while stores with different
      directories operate in parallel. The queue map is reference-counted so entries
      are cleaned up when the last store for a given path is destroyed.

    - Have platformCompileResourceMonitorRuleList() use the per-pid store configured
      by WKTR (via ResourceMonitorURLsController) instead of the shared default store,
      eliminating cross-process filesystem contention.

    * LayoutTests/platform/mac-wk2/TestExpectations:
    * Source/WebKit/Platform/cocoa/WebPrivacyHelpers.h:
    (WebKit::ResourceMonitorURLsController::contentRuleListStore const):
    * Source/WebKit/UIProcess/API/APIContentRuleListStore.cpp:
    (API::workQueueMap):
    (API::retainWorkQueueForPath):
    (API::releaseWorkQueueForPath):
    (API::ContentRuleListStore::ContentRuleListStore):
    (API::ContentRuleListStore::~ContentRuleListStore):
    (API::ContentRuleListStore::lookupContentRuleListFile):
    (API::ContentRuleListStore::getAvailableContentRuleListIdentifiers):
    (API::ContentRuleListStore::compileContentRuleListFile):
    (API::ContentRuleListStore::removeContentRuleListFile):
    (API::ContentRuleListStore::getContentRuleListSource):
    * Source/WebKit/UIProcess/API/APIContentRuleListStore.h:
    * Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm:
    (WebKit::WebProcessPool::platformCompileResourceMonitorRuleList):

    Canonical link: <a href="https://commits.webkit.org/312745@main">https://commits.webkit.org/312745@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.487@webkitglib/2.52">https://commits.webkit.org/305877.487@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1c89ffafc0ce3f46ad4d511cd3708efd392c24e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161899 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35373 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28476 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170802 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/118270 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163768 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35475 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35375 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125616 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/118270 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164858 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/35475 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/28476 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106212 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/35475 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/35375 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18523 "Unable to build WebKit without PR, please check manually (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/35475 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/28476 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173291 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20397 "Build is being retried. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Checked out pull request; Failed to build and analyze WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/28476 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133917 "Passed tests") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35047 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/35375 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133922 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35031 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/28476 "Unable to build WebKit without PR, please check manually (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/97126 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24604 "Built successfully and passed tests") | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/35031 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/28476 "Unable to build WebKit without PR, please check manually (failure)") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34541 "Unable to build WebKit without PR, please check manually (failure)") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102030 "Build is being retried. Recent messages:OS: Tahoe (26.3.1), Xcode: 26.2; Checked out pull request; Failed to build and analyze WebKit") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34042 "Unable to build WebKit without PR, please check manually (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34284 "Unable to build WebKit without PR, please check manually (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34190 "Unable to build WebKit without PR, please check manually (failure)") | | | 
<!--EWS-Status-Bubble-End-->