### PR TITLE
Use-after-free of StreamingCompiler::m_ticket

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp
+++ b/Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp
@@ -63,17 +63,18 @@ StreamingCompiler::StreamingCompiler(VM& vm, CompilerMode compilerMode, JSGlobal
     dependencies.append(globalObject);
     if (importObject)
         dependencies.append(importObject);
-    m_ticket = vm.deferredWorkTimer->addPendingWork(DeferredWorkTimer::WorkType::AtSomePoint, vm, promise, WTF::move(dependencies));
-    ASSERT(vm.deferredWorkTimer->hasPendingWork(m_ticket));
-    ASSERT(vm.deferredWorkTimer->hasDependencyInPendingWork(m_ticket, globalObject));
-    ASSERT(!importObject || vm.deferredWorkTimer->hasDependencyInPendingWork(m_ticket, importObject));
+    auto ticketPtr = vm.deferredWorkTimer->addPendingWork(DeferredWorkTimer::WorkType::AtSomePoint, vm, promise, WTF::move(dependencies));
+    m_ticket = ticketPtr;
+    ASSERT(vm.deferredWorkTimer->hasPendingWork(ticketPtr));
+    ASSERT(vm.deferredWorkTimer->hasDependencyInPendingWork(ticketPtr, globalObject));
+    ASSERT(!importObject || vm.deferredWorkTimer->hasDependencyInPendingWork(ticketPtr, importObject));
 }
 
 StreamingCompiler::~StreamingCompiler()
 {
-    if (m_ticket) {
-        auto ticket = std::exchange(m_ticket, nullptr);
-        m_vm.deferredWorkTimer->scheduleWorkSoon(ticket, [](DeferredWorkTimer::Ticket) { });
+    if (auto ticket = m_ticket.get()) {
+        m_ticket = nullptr;
+        m_vm.deferredWorkTimer->scheduleWorkSoon(ticket.get(), [](DeferredWorkTimer::Ticket) { });
     }
 }
 
@@ -150,10 +151,12 @@ void StreamingCompiler::didComplete()
     };
 
     auto result = makeValidationResult(*m_plan);
-    auto ticket = std::exchange(m_ticket, nullptr);
+    auto ticket = takeTicketIfActive();
+    if (!ticket)
+        return;
     switch (m_compilerMode) {
     case CompilerMode::Validation: {
-        m_vm.deferredWorkTimer->scheduleWorkSoon(ticket, [result = WTF::move(result), compileOptions = WTF::move(m_compileOptions)](DeferredWorkTimer::Ticket ticket) mutable {
+        m_vm.deferredWorkTimer->scheduleWorkSoon(ticket.get(), [result = WTF::move(result), compileOptions = WTF::move(m_compileOptions)](DeferredWorkTimer::Ticket ticket) mutable {
             JSPromise* promise = uncheckedDowncast<JSPromise>(ticket->target());
             JSGlobalObject* globalObject = uncheckedDowncast<JSGlobalObject>(ticket->dependencies()[0]);
             VM& vm = globalObject->vm();
@@ -185,7 +188,7 @@ void StreamingCompiler::didComplete()
 
     case CompilerMode::FullCompile: {
         RefPtr<SourceProvider> provider = m_source.provider();
-        m_vm.deferredWorkTimer->scheduleWorkSoon(ticket, [result = WTF::move(result), provider = WTF::move(provider), compileOptions = WTF::move(m_compileOptions)](DeferredWorkTimer::Ticket ticket) mutable {
+        m_vm.deferredWorkTimer->scheduleWorkSoon(ticket.get(), [result = WTF::move(result), provider = WTF::move(provider), compileOptions = WTF::move(m_compileOptions)](DeferredWorkTimer::Ticket ticket) mutable {
             JSPromise* promise = uncheckedDowncast<JSPromise>(ticket->target());
             JSGlobalObject* globalObject = uncheckedDowncast<JSGlobalObject>(ticket->dependencies()[0]);
             JSObject* importObject = uncheckedDowncast<JSObject>(ticket->dependencies()[1]);
@@ -243,14 +246,15 @@ void StreamingCompiler::fail(JSGlobalObject* globalObject, JSValue error)
             return;
         m_eagerFailed = true;
     }
-    auto ticket = std::exchange(m_ticket, nullptr);
+    auto ticket = takeTicketIfActive();
+    if (!ticket)
+        return;
     JSPromise* promise = uncheckedDowncast<JSPromise>(ticket->target());
     // The pending work TicketData was keeping the promise alive. We need to
     // make sure it is reachable from the stack before we remove it from the
-    // pending work list. Note: m_ticket stores it as a PackedPtr, which is not
-    // scannable by the GC.
+    // pending work list.
     WTF::compilerFence();
-    m_vm.deferredWorkTimer->cancelPendingWork(ticket);
+    m_vm.deferredWorkTimer->cancelPendingWork(ticket.get());
     promise->reject(m_vm, globalObject, error);
 }
 
@@ -263,8 +267,27 @@ void StreamingCompiler::cancel()
             return;
         m_eagerFailed = true;
     }
-    auto ticket = std::exchange(m_ticket, nullptr);
-    m_vm.deferredWorkTimer->cancelPendingWork(ticket);
+    auto ticket = takeTicketIfActive();
+    if (!ticket)
+        return;
+    m_vm.deferredWorkTimer->cancelPendingWork(ticket.get());
+}
+
+RefPtr<DeferredWorkTimer::TicketData> StreamingCompiler::takeTicketIfActive()
+{
+    auto ticket = m_ticket.get();
+    m_ticket = nullptr;
+    if (!ticket || ticket->isCancelled())
+        return nullptr;
+    return ticket;
+}
+
+JSGlobalObject* StreamingCompiler::globalObjectIfActive()
+{
+    auto ticket = m_ticket.get();
+    if (!ticket || ticket->isCancelled())
+        return nullptr;
+    return jsCast<JSGlobalObject*>(ticket->dependencies()[0]);
 }
 
 

--- a/Source/JavaScriptCore/wasm/WasmStreamingCompiler.h
+++ b/Source/JavaScriptCore/wasm/WasmStreamingCompiler.h
@@ -68,6 +68,8 @@ public:
 
     void didCompileFunction(StreamingPlan&);
 
+    JS_EXPORT_PRIVATE JSGlobalObject* globalObjectIfActive();
+
 private:
     JS_EXPORT_PRIVATE StreamingCompiler(VM&, CompilerMode, JSGlobalObject*, JSPromise*, JSObject* importObject, std::optional<WebAssemblyCompileOptions>&&, const SourceCode&, String wasmSourceURL);
 
@@ -75,6 +77,7 @@ private:
     void didFinishParsing() final;
     void didComplete() WTF_REQUIRES_LOCK(m_lock);
     void completeIfNecessary() WTF_REQUIRES_LOCK(m_lock);
+    RefPtr<DeferredWorkTimer::TicketData> takeTicketIfActive();
 
     VM& m_vm;
     CompilerMode m_compilerMode;
@@ -84,7 +87,7 @@ private:
     std::optional<WebAssemblyCompileOptions> m_compileOptions;
     Lock m_lock;
     unsigned m_remainingCompilationRequests { 0 };
-    DeferredWorkTimer::Ticket m_ticket;
+    ThreadSafeWeakPtr<DeferredWorkTimer::TicketData> m_ticket;
     const Ref<Wasm::ModuleInformation> m_info;
     StreamingParser m_parser;
     RefPtr<EntryPlan> m_plan;

--- a/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
+++ b/Source/WebCore/bindings/js/JSDOMGlobalObject.cpp
@@ -595,9 +595,13 @@ static JSC::JSPromise* handleResponseOnStreamingAction(JSC::JSGlobalObject* glob
     auto compiler = JSC::Wasm::StreamingCompiler::create(vm, compilerMode, globalObject, downcast<JSC::JSPromise>(deferred->promise()), importObject, WTF::move(compileOptions), JSC::makeSource("handleResponseOnStreamingAction"_s, JSC::SourceOrigin(), JSC::SourceTaintedOrigin::Untainted), inputResponse->url());
 
     if (inputResponse->isBodyReceivedByChunk()) {
-        inputResponse->consumeBodyReceivedByChunk([globalObject, compiler = WTF::move(compiler)](auto&& result) mutable {
-            VM& vm = globalObject->vm();
+        inputResponse->consumeBodyReceivedByChunk([vmPtr = &vm, compiler = WTF::move(compiler)](auto&& result) mutable {
+            auto& vm = *vmPtr;
             JSLockHolder lock(vm);
+
+            auto* globalObject = compiler->globalObjectIfActive();
+            if (!globalObject)
+                return;
 
             if (result.hasException()) {
                 auto exception = result.exception();


### PR DESCRIPTION
#### 0e880588009db7a6719cbe40bcdb11d63e158a76
<pre>
Use-after-free of StreamingCompiler::m_ticket
<a href="https://bugs.webkit.org/show_bug.cgi?id=309590">https://bugs.webkit.org/show_bug.cgi?id=309590</a>
<a href="https://rdar.apple.com/172087002">rdar://172087002</a>

Reviewed by Marcus Plutowski.

This patch fixes the possibility of a UAF when Wasm streaming compiler is invoked in an
iframe which is disposed of before compilation finishes.

The result of streaming compilation is expected by a lambda created when the compilation
starts. The lambda captures a raw pointer to the globalObject and (transitively via the
streaming compiler) a raw pointer to the TicketData associated with the compilation
request. However, it&apos;s possible for the lambda to outlive those two objects. This happens
in the context of an iframe if the iframe is removed before the compilation finishes. In
that case the globalObject of the iframe is collected and the ticket is cancelled and
destroyed. When compilation finishes, the lambda ends up dereferencing dangling pointers.

This patch makes the following changes:

StreamingCompiler now holds TicketData via a ThreadSafeWeakPtr&lt;TicketData&gt;. Every use site
promotes that weak pointer to a RefPtr and checks for both null (ticket destroyed) and
isCancelled (ticket present but cancelled). This promote-and-check sequence is factored
into a private takeTicketIfActive() helper.

In JSDOMGlobalObject.cpp, the lambda does not capture the raw globalObject pointer.
Instead, it fetches the globalObject from the ticket via the compiler using the streaming
compiler&apos;s new method globalObjectIfActive(). The method returns a nullptr if the ticket
is no longer there or has been cancelled.

Testing: the failure scenario is not directly testable.

* Source/JavaScriptCore/wasm/WasmStreamingCompiler.cpp:
(JSC::Wasm::StreamingCompiler::StreamingCompiler):
(JSC::Wasm::StreamingCompiler::~StreamingCompiler):
(JSC::Wasm::StreamingCompiler::didComplete):
(JSC::Wasm::StreamingCompiler::fail):
(JSC::Wasm::StreamingCompiler::cancel):
(JSC::Wasm::StreamingCompiler::takeTicketIfActive):
(JSC::Wasm::StreamingCompiler::globalObjectIfActive):
* Source/JavaScriptCore/wasm/WasmStreamingCompiler.h:
* Source/WebCore/bindings/js/JSDOMGlobalObject.cpp:
(WebCore::handleResponseOnStreamingAction):

Originally-landed-as: <a href="https://commits.webkit.org/305413.457@safari-7624-branch">305413.457@safari-7624-branch</a> (0e0b5050073d). rdar://176062632
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0e880588009db7a6719cbe40bcdb11d63e158a76

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161917 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35391 "Hash 0e880588 for PR 64702 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28494 "Hash 0e880588 for PR 64702 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170820 "Hash 0e880588 for PR 64702 does not build (failure)") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/118288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163786 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/35497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35393 "Hash 0e880588 for PR 64702 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/170820 "Hash 0e880588 for PR 64702 does not build (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/118288 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164876 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/35497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/28494 "Hash 0e880588 for PR 64702 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/170820 "Hash 0e880588 for PR 64702 does not build (failure)") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/35497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/35393 "Hash 0e880588 for PR 64702 does not build (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18541 "Hash 0e880588 for PR 64702 does not build (failure)") | | 
| [  ~~🛠 🧪 jsc~~](https://ews-build.webkit.org/#/builders/20/builds/153976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/35497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/28494 "Hash 0e880588 for PR 64702 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173309 "Hash 0e880588 for PR 64702 does not build (failure)") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/22755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20404 "Failed to build and analyze WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/28494 "Hash 0e880588 for PR 64702 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/173309 "Hash 0e880588 for PR 64702 does not build (failure)") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35065 "Hash 0e880588 for PR 64702 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/35393 "Hash 0e880588 for PR 64702 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/173309 "Hash 0e880588 for PR 64702 does not build (failure)") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/35049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/28494 "Hash 0e880588 for PR 64702 does not build (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/97144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/35049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/28494 "Hash 0e880588 for PR 64702 does not build (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194316 "Built successfully") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34559 "Hash 0e880588 for PR 64702 does not build (failure)") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102044 "Build is in progress. Recent messages:") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/50076 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34060 "Hash 0e880588 for PR 64702 does not build (failure)") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34302 "Hash 0e880588 for PR 64702 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34208 "Hash 0e880588 for PR 64702 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->