### PR TITLE
[WebKitGTK] apply-build-revision-to-files.py should support "Canonical-link"

### DIFF
--- a/Tools/glib/apply-build-revision-to-files.py
+++ b/Tools/glib/apply-build-revision-to-files.py
@@ -20,36 +20,37 @@ import os
 import sys
 from pathlib import Path
 import subprocess
-try:
-    from urllib.parse import urlparse  # pylint: disable=E0611
-except ImportError:
-    from urlparse import urlparse
+from urllib.parse import urlparse
 
 WEBKIT_TOP_LEVEL = Path(__file__).parent.parent.parent.resolve()
 
 
 def get_revision_from_most_recent_git_commit():
-    with open(os.devnull, 'w') as devnull:
-        try:
-            commit_message = subprocess.check_output(("git", "log", "-1", "--pretty=%B", "HEAD"), stderr=devnull)
-        except subprocess.CalledProcessError:
-            # This may happen with shallow checkouts whose HEAD has been
-            # modified; there is no origin reference anymore, and git
-            # will fail - let's pretend that this is not a repo at all
-            return None
+    try:
+        commit_message = subprocess.run(
+            ('git', 'log', '-1', '--pretty=%B', 'HEAD'),
+            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, check=True,
+        ).stdout
+    except subprocess.CalledProcessError:
+        # This may happen with shallow checkouts whose HEAD has been
+        # modified; there is no origin reference anymore, and git
+        # will fail - let's pretend that this is not a repo at all
+        return None
 
-        # Commit messages tend to be huge and the metadata we're looking
-        # for is at the very end. Also a spoofed 'Canonical link' mention
-        # could appear early on. So make sure we get the right metadata by
-        # reversing the contents. And this is a micro-optimization as well.
-        for line in reversed(commit_message.splitlines()):
-            parsed = line.split(b':')
-            key = parsed[0]
-            contents = b':'.join(parsed[1:])
-            if key == b'Canonical link':
-                url = contents.decode('utf-8').strip()
-                revision = urlparse(url).path[1:]  # strip leading /
-                return revision
+    trailer_output = subprocess.run(
+        ['git',
+         '-c', 'trailer.Canonical-link.key=Canonical-link',
+         '-c', 'trailer.Identifier.key=Identifier',
+         '-c', 'trailer.git-svn-id.key=git-svn-id',
+         'interpret-trailers', '--parse', '--no-divider'],
+        input=commit_message.replace(b'\nCanonical link:', b'\nCanonical-link:'),
+        stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, check=True,
+    ).stdout
+    for line in trailer_output.splitlines():
+        if line.startswith(b'Canonical-link:'):
+            url = line[len(b'Canonical-link:'):].decode('utf-8').strip()
+            revision = urlparse(url).path[1:]  # strip leading /
+            return revision
     return None
 
 def get_build_revision():


### PR DESCRIPTION
#### f97ce6819bb95f33a87e4b7bbb7f6a80c781004f
<pre>
[WebKitGTK] apply-build-revision-to-files.py should support &quot;Canonical-link&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=301471">https://bugs.webkit.org/show_bug.cgi?id=301471</a>

Reviewed by Claudio Saavedra.

This makes a few drive-by changes too:

 * This gets rid of the Python 2 `urlparse` import.

 * We now use `subprocess.run` instead of `subprocess.check_output`.

 * We now use `subprocess.DEVNULL` instead of opening `os.devnull`.

* Tools/glib/apply-build-revision-to-files.py:
(get_revision_from_most_recent_git_commit):

Canonical link: <a href="https://commits.webkit.org/313429@main">https://commits.webkit.org/313429@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ae48667884aea316e50a11bb0b3721e235ae97a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161920 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35394 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28497 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170823 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118291 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163789 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35496 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35396 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125631 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88533 "1 flakes 17 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164879 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27957 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145439 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106227 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1eef1687-3376-4032-8c07-8f296f258dbd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27006 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25519 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18544 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc-x86-64 ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136699 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23194 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173312 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24835 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133932 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35068 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29606 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133937 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35052 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144989 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97147 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24812 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28468 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21814 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34562 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34063 "Built successfully") | [⏳ 🧪 mac-site-isolation ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Site-Isolation-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34305 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34211 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->