### PR TITLE
WebKit.TabOutOfWebView API test fails in some configurations

### DIFF
--- a/Tools/TestWebKitAPI/Helpers/mac/OffscreenWindow.mm
+++ b/Tools/TestWebKitAPI/Helpers/mac/OffscreenWindow.mm
@@ -63,4 +63,13 @@
     return YES;
 }
 
+// Make -[NSApplication sendAction:to:from:] work by manually vending this
+// window as the window to dispatch actions to. Otherwise, AppKit defaults
+// to sending actions to the key window, which this will never REALLY be
+// (it only pretends), because it's offscreen.
+- (NSWindow *)_startingWindowForSendAction:(SEL)action
+{
+    return self;
+}
+
 @end


### PR DESCRIPTION
#### 2c408d4afd94f422caa592ded1011352e85b9647
<pre>
WebKit.TabOutOfWebView API test fails in some configurations
<a href="https://bugs.webkit.org/show_bug.cgi?id=314587">https://bugs.webkit.org/show_bug.cgi?id=314587</a>
<a href="https://rdar.apple.com/176427119">rdar://176427119</a>

Reviewed by Richard Robinson.

* Tools/TestWebKitAPI/Helpers/mac/OffscreenWindow.mm:
(-[OffscreenWindow _startingWindowForSendAction:]):
When AppKit uses sendEvent: instead of a manual responder chain walk to dispatch
focus changes, WebKit.TabOutOfWebView fails, because sendEvent: uses the
key window to figure out where to send events, which is nil in WKTR.

Make use of some (sadly) IPI to redirect sendEvent: to our offscreen window.

Canonical link: <a href="https://commits.webkit.org/313050@main">https://commits.webkit.org/313050@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73aabab0226b36bacb2b431dcb846cd4041a1002

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161924 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35399 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28501 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170827 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118295 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f1b3d4e5-0e1b-4f28-82bf-994626efb38d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163793 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35501 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35400 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125633 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88537 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9b487263-1aae-46c9-a450-5ba6e572854f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164883 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27964 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145444 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106228 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/03053c21-831c-441c-9c0c-51342f581e1e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27013 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25526 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18548 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136706 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23198 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173316 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24839 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133934 "Found 1 new test failure: accessibility/aria-owns-deep-chain-no-timeout.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35072 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29613 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133939 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35056 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144993 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97154 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24595 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28475 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21818 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34566 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102051 "Build is in progress. Recent messages:") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34067 "Built successfully") | | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34309 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34215 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->