### PR TITLE
REGRESSION (233458@main): [Big Sur release WK2] imported/w3c/web-platform-tests/media-source/mediasource-changetype-play-implicit.html is a flaky crash

### DIFF
--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -387,7 +387,8 @@ void SourceBufferPrivate::setMediaSourceEnded(bool isEnded)
                 TrackBuffer& trackBuffer = trackBufferPair.second;
                 TrackID trackID = trackBufferPair.first;
 
-                buffer.trySignalAllSamplesInTrackEnqueued(trackBuffer, trackID);
+                trackBuffer.setEnqueueDiscontinuityBoundary(MediaTime::positiveInfiniteTime());
+                buffer.provideMediaData(trackBuffer, trackID);
             }
         }
     });

--- a/Source/WebCore/platform/graphics/TrackBuffer.cpp
+++ b/Source/WebCore/platform/graphics/TrackBuffer.cpp
@@ -220,7 +220,7 @@ void TrackBuffer::updateMinimumUpcomingPresentationTime()
 bool TrackBuffer::reenqueueMediaForTime(const MediaTime& time, const MediaTime& timeFudgeFactor, bool isEnded)
 {
     clearDecodeQueue();
-    m_enqueueDiscontinuityBoundary = time + m_discontinuityTolerance;
+    m_enqueueDiscontinuityBoundary = isEnded ? MediaTime::positiveInfiniteTime() : time + m_discontinuityTolerance;
 
     m_needsReenqueueing = false;
 


### PR DESCRIPTION
#### ad28cac52a3cf5eae6564b3134a2e5fd4a155d28
<pre>
REGRESSION (<a href="https://commits.webkit.org/233458@main">233458@main</a>): [Big Sur release WK2] imported/w3c/web-platform-tests/media-source/mediasource-changetype-play-implicit.html is a flaky crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=221143">https://bugs.webkit.org/show_bug.cgi?id=221143</a>
<a href="https://rdar.apple.com/73763073">rdar://73763073</a>

Reviewed by NOBODY (OOPS!).

This patch addresses a race condition introduced when the semaphore-based synchronization
was removed from SourceBufferParserAVFObjC and SourceBufferParserWebM, replacing it with
a media sample caching mechanism.

Following <a href="https://commits.webkit.org/233458@main">233458@main</a>, mediasource-changetype-play-implicit.html test was flaky because of
a race between setMediaSourceEnded and the final sample enqueue. MediaSourcePriate::endOfStream()
could leave samples permanently stuck in the decode queue behind the enqueue discontinuity
boundary. Since no more appends or seeks would occur after endOfStream(), nothing would
ever unblock those samples, and the &quot;all samples in track enqueued&quot; signal would never
fire. This would sometimes causing the player to hang instead of reaching the &quot;ended&quot; state.

This patch Fix this by lifting the discontinuity boundary when the media source enters the
ended state. Once we know no more data is coming, temporal gaps in the decode queue are no
longer a concern. The renderer should receive all remaining samples so playback can fully
complete. The renderer&apos;s own isReadyForMoreSamples gate still provides flow control.

Tests: imported/w3c/web-platform-tests/media-source/mediasource-changetype-play-implicit.html

* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::setMediaSourceEnded): When transitioning to ended, set the
discontinuity boundary to positive infinity for each track and call provideMediaData to
drain any previously-stuck samples.
* Source/WebCore/platform/graphics/TrackBuffer.cpp:
(WebCore::TrackBuffer::reenqueueMediaForTime): When isEnded is true, use an infinite
discontinuity boundary so that a reenqueue occurring after endOfStream() does not
re-introduce the stuck-samples condition.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ad28cac52a3cf5eae6564b3134a2e5fd4a155d28

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161925 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35400 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28502 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170828 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118296 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163794 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35502 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35401 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125636 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88538 "1 flakes 18 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164884 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27965 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145446 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106231 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27014 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25527 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18549 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136707 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23200 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173317 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20412 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24841 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133940 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35073 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29614 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133945 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35057 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/144995 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97155 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28477 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21820 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34567 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102052 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34068 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34310 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34216 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->