### PR TITLE
[AppKit Gestures] AppKitGesturesTests.doubleClickingInWordSelectsWord(contentEditable:clickHandler:) test is failing

### DIFF
--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.h
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.h
@@ -56,7 +56,8 @@ OBJC_CLASS NSPanGestureRecognizer;
 
 - (instancetype)initWithPage:(std::reference_wrapper<WebKit::WebPageProxy>)page viewImpl:(std::reference_wrapper<WebKit::WebViewImpl>)viewImpl;
 - (void)enableGesturesIfNeeded;
-- (void)cancelClick;
+- (void)beginSuppressingSingleClickGestureForTextSelection;
+- (void)endSuppressingSingleClickGestureForTextSelection;
 - (NSGestureRecognizer *)activeDragGestureRecognizer;
 - (void)setGestureDraggingSession:(NSDraggingSession *)session;
 - (void)clearGestureDragState;

--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
@@ -169,6 +169,7 @@ static WebCore::FloatSize toRawPlatformDelta(WebCore::FloatSize delta)
     bool _isClickHighlightIDValid;
     bool _hasHighlightForPotentialClick;
     bool _isExpectingFastClickCommit;
+    bool _isSuppressingSingleClickGestureForTextSelection;
 
     std::optional<WebKit::TransactionID> _layerTreeTransactionIdAtLastInteractionStart;
     Markable<WebKit::ClickIdentifier> _latestClickID;
@@ -298,12 +299,33 @@ static WebCore::FloatSize toRawPlatformDelta(WebCore::FloatSize delta)
     [gesture setEnabled:gestureEnabled];
 }
 
-- (void)cancelClick
+- (void)beginSuppressingSingleClickGestureForTextSelection
 {
-    [self _handleClickCancelled];
+    RefPtr page = _page.get();
+    if (!page) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
 
-    if (RefPtr page = _page.get())
-        page->cancelPotentialClick();
+    WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(page->logIdentifier(), "Begin suppressing single-click gesture for text selection");
+
+    _isSuppressingSingleClickGestureForTextSelection = true;
+
+    [self _handleClickCancelled];
+    page->cancelPotentialClick();
+}
+
+- (void)endSuppressingSingleClickGestureForTextSelection
+{
+    RefPtr page = _page.get();
+    if (!page) {
+        ASSERT_NOT_REACHED();
+        return;
+    }
+
+    WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(page->logIdentifier(), "End suppressing single-click gesture for text selection");
+
+    _isSuppressingSingleClickGestureForTextSelection = false;
 }
 
 #pragma mark - Gesture Recognition
@@ -448,20 +470,35 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 
 - (void)mouseTrackingGestureRecognized:(NSGestureRecognizer *)gesture
 {
-    if (_dragGestureHasSentMouseDown)
-        return;
-
     CheckedPtr viewImpl = _viewImpl.get();
-    if (!viewImpl)
+    if (!viewImpl) {
+        ASSERT_NOT_REACHED();
         return;
+    }
 
     RetainPtr webView = viewImpl->view();
-    if (!webView)
+    if (!webView) {
+        ASSERT_NOT_REACHED();
         return;
+    }
 
     RefPtr page = _page.get();
-    if (!page)
+    if (!page) {
+        ASSERT_NOT_REACHED();
         return;
+    }
+
+    WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(page->logIdentifier(), "%@", gesture);
+
+    if (_dragGestureHasSentMouseDown) {
+        WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(page->logIdentifier(), "Exiting early because _dragGestureHasSentMouseDown is true");
+        return;
+    }
+
+    if (_isSuppressingSingleClickGestureForTextSelection) {
+        WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(page->logIdentifier(), "Exiting early because _isSuppressingSingleClickGestureForTextSelection is true");
+        return;
+    }
 
     if (_mouseTrackingGestureRecognizer != gesture)
         return;
@@ -619,6 +656,9 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 
 - (void)_handleClickBegan:(NSGestureRecognizer *)gesture
 {
+    if (_isSuppressingSingleClickGestureForTextSelection)
+        return;
+
     CheckedPtr viewImpl = _viewImpl.get();
     if (!viewImpl)
         return;
@@ -937,6 +977,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     [self _handleClickCancelled];
     _mouseTrackingHasSentMouseDown = false;
     _isMomentumActive = false;
+    _isSuppressingSingleClickGestureForTextSelection = false;
     _latestClickID.reset();
     _layerTreeTransactionIdAtLastInteractionStart.reset();
 }

--- a/Source/WebKit/UIProcess/mac/WKTextSelectionController.swift
+++ b/Source/WebKit/UIProcess/mac/WKTextSelectionController.swift
@@ -139,7 +139,9 @@ extension WKTextSelectionController {
             return false
         }
 
-        Logger.viewGestures.log("[pageProxyID=\(page.logIdentifier())] \(#function) point: \(String(reflecting: point))")
+        Logger.viewGestures.log(
+            "[pageProxyID=\(page.logIdentifier())] \(#function) point: \(String(reflecting: point)) placeAtWordBoundary: \(placeAtWordBoundary)"
+        )
 
         let previousState = page.editorState
         let previousVisualData = Optional(fromCxx: previousState.visualData)
@@ -233,7 +235,7 @@ extension WKTextSelectionController {
 
         currentRangeSelectionGranularity = granularity
 
-        impl.cancelClick()
+        impl.beginSuppressingSingleClickGestureForTextSelection()
 
         Task.immediate {
             await page.selectText(
@@ -269,11 +271,13 @@ extension WKTextSelectionController {
 
     @objc(endRangeSelectionAtPoint:)
     func endRangeSelection(at point: NSPoint) {
-        guard let page = view._protectedPage().get() else {
+        guard let page = view._protectedPage().get(), let impl = view._impl() else {
             return
         }
 
         Logger.viewGestures.log("[pageProxyID=\(page.logIdentifier())] \(#function) point: \(String(reflecting: point))")
+
+        impl.endSuppressingSingleClickGestureForTextSelection()
 
         guard currentRangeSelectionGranularity != nil else {
             assertionFailure("endRangeSelection was called with a nil currentRangeSelectionGranularity")

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -880,7 +880,8 @@ public:
 #if HAVE(APPKIT_GESTURES_SUPPORT)
     void addTextSelectionManager();
     bool isTextSelectedAtPoint(NSPoint);
-    void cancelClick();
+    void beginSuppressingSingleClickGestureForTextSelection();
+    void endSuppressingSingleClickGestureForTextSelection();
 #endif
 
 private:

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -7653,9 +7653,14 @@ bool WebViewImpl::isTextSelectedAtPoint(NSPoint point)
     return [m_textSelectionController isTextSelectedAtPoint:point];
 }
 
-void WebViewImpl::cancelClick()
+void WebViewImpl::beginSuppressingSingleClickGestureForTextSelection()
 {
-    [m_appKitGestureController cancelClick];
+    [m_appKitGestureController beginSuppressingSingleClickGestureForTextSelection];
+}
+
+void WebViewImpl::endSuppressingSingleClickGestureForTextSelection()
+{
+    [m_appKitGestureController endSuppressingSingleClickGestureForTextSelection];
 }
 #endif // HAVE(APPKIT_GESTURES_SUPPORT)
 


### PR DESCRIPTION
#### f0276e0b14b798fac70f9d5f9e8d3f4fedb17813
<pre>
[AppKit Gestures] AppKitGesturesTests.doubleClickingInWordSelectsWord(contentEditable:clickHandler:) test is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=314591">https://bugs.webkit.org/show_bug.cgi?id=314591</a>
<a href="https://rdar.apple.com/176821429">rdar://176821429</a>

Reviewed by Abrar Rahman Protyasha.

Widen the fix that was previously done with `cancelClick` to instead be a scoped suppression mechanism
to stop and suppress clicks generated by both the single click GR or the mouse tracking GR.

* Source/WebKit/UIProcess/mac/WKAppKitGestureController.h:
* Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm:
(-[WKAppKitGestureController beginSuppressingSingleClickGestureForTextSelection]):
(-[WKAppKitGestureController endSuppressingSingleClickGestureForTextSelection]):
(-[WKAppKitGestureController mouseTrackingGestureRecognized:]):
(-[WKAppKitGestureController _handleClickBegan:]):
(-[WKAppKitGestureController reset]):
(-[WKAppKitGestureController cancelClick]): Deleted.
* Source/WebKit/UIProcess/mac/WKTextSelectionController.swift:
(WKTextSelectionController.moveInsertionCursor(to:placeAtWordBoundary:)):
(WKTextSelectionController.beginRangeSelection(at:with:)):
(WKTextSelectionController.endRangeSelection(at:)):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::beginSuppressingSingleClickGestureForTextSelection):
(WebKit::WebViewImpl::endSuppressingSingleClickGestureForTextSelection):
(WebKit::WebViewImpl::cancelClick): Deleted.

Canonical link: <a href="https://commits.webkit.org/313054@main">https://commits.webkit.org/313054@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bbcb56fcfdefeeaf77de1e554335cc6a7dd1ff87

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161928 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35403 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28506 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170831 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118299 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bf13b61d-fbb2-4a50-a9cd-ef7229f7b8d3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35505 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35404 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125637 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e593c909-3b74-401c-9914-1e859e0ee329) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164887 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27960 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/145451 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106232 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6f8a6bda-0dcb-491d-8c10-d8f62a6aab00) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27009 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25525 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18552 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136702 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23205 "Build is in progress. Recent messages:") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173320 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20415 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24846 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133937 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35076 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29612 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133942 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36172 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35060 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145000 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97158 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28476 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21825 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34570 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102055 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34071 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34313 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34219 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->