### PR TITLE
[BFCache] CachedPage::restore() leaks cached frame state when focus restoration is skipped

### DIFF
--- a/Source/WebCore/history/CachedPage.cpp
+++ b/Source/WebCore/history/CachedPage.cpp
@@ -134,8 +134,14 @@ void CachedPage::restore(Page& page)
 
     // Restore the focus appearance for the focused element.
     RefPtr focusedOrMainFrame = page.focusController().focusedOrMainFrame();
-    if (!focusedOrMainFrame)
+    if (!focusedOrMainFrame) {
+        // The cached page's data has already been transferred to the live page by open();
+        // release the cached frame state even though the focus restoration block is skipped
+        // (e.g. iframe-process restoration where the page's main frame is a RemoteFrame
+        // and focusController has no focused or main local frame to operate on).
+        clear();
         return;
+    }
 
     RefPtr focusedDocument = focusedOrMainFrame->document();
     if (RefPtr element = focusedDocument->focusedElement()) {


### PR DESCRIPTION
#### 11ea563010703b5a65ae224eeb9f5afb447fa6d0
<pre>
[BFCache] CachedPage::restore() leaks cached frame state when focus restoration is skipped
<a href="https://bugs.webkit.org/show_bug.cgi?id=314583">https://bugs.webkit.org/show_bug.cgi?id=314583</a>
<a href="https://rdar.apple.com/176824162">rdar://176824162</a>

Reviewed by Ryosuke Niwa.

CachedPage::restore() has an early-return at `if (!focusedOrMainFrame) return;`
that bypasses the `clear()` call at the end of the function. The cached frame
state (m_cachedMainFrame holding CachedFrames with documents/views) is never
released, even though the cached page&apos;s data has already been transferred to
the live page by m_cachedMainFrame-&gt;open().

This causes ~CachedPage to call m_cachedMainFrame-&gt;destroy() later. After the
fix in bug 314238 (which destroys child CachedFrames before checking
m_document), destroy() now descends into child CachedFrames whose documents
have already been resumed by open() (state = NotInBackForwardCache). The
ASSERT in CachedFrame::destroy()

    ASSERT(document-&gt;backForwardCacheState() == Document::InBackForwardCache);

fires, and the subsequent destroy code path corrupts live document state
(detachViewsAndDocumentLoader, detachFromPage, removeAllEventListeners),
hanging the WebContent process.

The early-return path is reached when page.focusController().focusedOrMainFrame()
returns null, which happens for iframe-process BFCache restoration where the
page&apos;s main frame is a RemoteFrame and there is no LocalFrame to focus.

Call clear() in the early-return branch to release the cached frame state,
since open() has already done its work and the cached storage is no longer
needed.

* Source/WebCore/history/CachedPage.cpp:
(WebCore::CachedPage::restore):

Canonical link: <a href="https://commits.webkit.org/313043@main">https://commits.webkit.org/313043@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/00f03221e76159b68fffb29204f4f9fa5ef82e26

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161930 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35405 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28508 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170833 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118301 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163799 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35507 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35406 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125639 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88541 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164889 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27968 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/145456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106234 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27017 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18554 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/136710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23210 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173322 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/20417 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24851 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/133941 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35078 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29615 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133946 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36165 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35062 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145005 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97160 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28479 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/21830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34572 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102057 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34073 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34315 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34221 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->