### PR TITLE
[JSC][JSPI] Include everything above the suspending frame record into the evacuated stack

### DIFF
--- a/JSTests/wasm/stress/jspi-multivalue-return.js
+++ b/JSTests/wasm/stress/jspi-multivalue-return.js
@@ -1,0 +1,136 @@
+//@ requireOptions("--useJSPI=1")
+
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+// Test JSPI with multi-value returns from a suspending import.
+// Exercises the WasmToJS thunk's result area when the slice bottom
+// must account for the full stackOffset allocation.
+
+let fiveI64 = `
+(module
+  (import "env" "s" (func $s (param i32) (result i64 i64 i64 i64 i64)))
+  (func $entry (export "entry") (param $p0 i32) (result i32)
+    local.get $p0
+    call $s
+    drop
+    drop
+    drop
+    drop
+    i32.wrap_i64
+  )
+)`;
+
+let threeI64 = `
+(module
+  (import "env" "s" (func $s (param i32) (result i64 i64 i64)))
+  (func $entry (export "entry") (param $p0 i32) (result i32)
+    local.get $p0
+    call $s
+    drop
+    drop
+    i32.wrap_i64
+  )
+)`;
+
+let mixedTypes = `
+(module
+  (import "env" "s" (func $s (param i32) (result f64 f32 i32 i64 f64 f32)))
+  (func $entry (export "entry") (param $p0 i32) (result i32)
+    local.get $p0
+    call $s
+    drop
+    drop
+    drop
+    drop
+    drop
+    i32.trunc_sat_f64_s
+  )
+)`;
+
+let deepStack = `
+(module
+  (import "env" "s" (func $s (param i32) (result i64 i64 i64 i64 i64)))
+  (func $inner (param $p0 i32) (result i32)
+    local.get $p0
+    call $s
+    drop
+    drop
+    drop
+    drop
+    i32.wrap_i64
+  )
+  (func $middle (param $p0 i32) (result i32)
+    local.get $p0
+    call $inner
+    i32.const 100
+    i32.add
+  )
+  (func $entry (export "entry") (param $p0 i32) (result i32)
+    local.get $p0
+    call $middle
+    i32.const 200
+    i32.add
+  )
+)`;
+
+async function testFiveI64() {
+    async function suspend(x) {
+        return [BigInt(0x42), BigInt(0x43), BigInt(0x44), BigInt(0x45), BigInt(0x46)];
+    }
+
+    const instance = await instantiate(fiveI64, {
+        env: { s: new WebAssembly.Suspending(suspend) }
+    });
+    const entry = WebAssembly.promising(instance.exports.entry);
+
+    for (let i = 0; i < wasmTestLoopCount; i++)
+        assert.eq(await entry(0), 0x42);
+}
+
+async function testThreeI64() {
+    async function suspend(x) {
+        return [BigInt(10), BigInt(20), BigInt(30)];
+    }
+
+    const instance = await instantiate(threeI64, {
+        env: { s: new WebAssembly.Suspending(suspend) }
+    });
+    const entry = WebAssembly.promising(instance.exports.entry);
+
+    for (let i = 0; i < wasmTestLoopCount; i++)
+        assert.eq(await entry(0), 10);
+}
+
+async function testMixedTypes() {
+    async function suspend(x) {
+        return [7.0, 3.14, 99, BigInt(12345), 2.718, 1.5];
+    }
+
+    const instance = await instantiate(mixedTypes, {
+        env: { s: new WebAssembly.Suspending(suspend) }
+    });
+    const entry = WebAssembly.promising(instance.exports.entry);
+
+    for (let i = 0; i < wasmTestLoopCount; i++)
+        assert.eq(await entry(0), 7);
+}
+
+async function testDeepStack() {
+    async function suspend(x) {
+        return [BigInt(50), BigInt(0), BigInt(0), BigInt(0), BigInt(0)];
+    }
+
+    const instance = await instantiate(deepStack, {
+        env: { s: new WebAssembly.Suspending(suspend) }
+    });
+    const entry = WebAssembly.promising(instance.exports.entry);
+
+    for (let i = 0; i < wasmTestLoopCount; i++)
+        assert.eq(await entry(0), 350);
+}
+
+await testFiveI64();
+await testThreeI64();
+await testMixedTypes();
+await testDeepStack();

--- a/Source/JavaScriptCore/runtime/EvacuatedStack.cpp
+++ b/Source/JavaScriptCore/runtime/EvacuatedStack.cpp
@@ -131,6 +131,9 @@ static const Register* NODELETE topOfFrame(const CallFrame* callFrame)
     // We include a few extra slots above the frame record via the
     // headroomSlotCount parameter of StackSlicer::evacuatePendingSlice, but we still count
     // the frame record as the real top of a Wasm frame and the bottom of the next frame.
+    // FIXME: when we start relying on FragSlicer, this simple guesstimate should be changed
+    // to analyze callees and ensure that frames of those that share stack data are kept together
+    // in one slice.
     CalleeBits calleeBits = callFrame->callee();
     if (calleeBits.isNativeCallee()) {
         auto* nativeCallee = calleeBits.asNativeCallee();
@@ -154,6 +157,11 @@ static const Register* NODELETE topOfFrame(const CallFrame* callFrame)
     }
 }
 
+static ALWAYS_INLINE const Register* bottomOfCallerFrame(const CallFrame* callFrame)
+{
+    return callFrame->registers() + CallerFrameAndPC::sizeInRegisters;
+}
+
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
 static std::optional<Wasm::CompilationMode> NODELETE compilationModeOfCallee(CalleeBits calleeBits)
@@ -171,6 +179,13 @@ static std::optional<Wasm::CompilationMode> NODELETE compilationModeOfCallee(Cal
 // frame because IPInt stores register values there before a call. Some frame types do not
 // actually use this many slots, but it appears tiering up breaks without a consistent headroom.
 constexpr unsigned standardHeadroom = 8;
+
+void StackSlicerBase::setErrorMessageWithCompilationMode(ASCIILiteral messagePrefix, Wasm::CompilationMode mode)
+{
+    StringPrintStream modeDescription;
+    modeDescription.print(mode);
+    m_errorMessage = makeString(messagePrefix, modeDescription.toString());
+}
 
 void StackSlicerBase::commitPendingSliceWithAdditionalFrame(CallFrame* callFrame)
 {
@@ -312,11 +327,27 @@ IterationStatus SlabSlicer::step(VM& vm, StackVisitor& visitor)
     switch (m_state) {
     case State::Initial: {
         if (!compilationMode) {
-            m_futureSliceBottom = topOfFrame(callFrame);
+            m_futureSliceBottom = bottomOfCallerFrame(callFrame);
             m_futureReturnFromFrame = callFrame;
-            m_state = State::Scanning;
+            m_state = State::ExpectingWasmToJS;
         } else {
             m_errorMessage = "expected suspending frame not found"_s;
+            m_state = State::Failure;
+        }
+        break;
+    }
+    case State::ExpectingWasmToJS: {
+        if (compilationMode.has_value()) {
+            if (*compilationMode == Wasm::CompilationMode::WasmToJSMode) {
+                ASSERT(m_futureReturnFromFrame);
+                m_pendingFrameRecords.append(callFrame);
+                m_state = State::Scanning;
+            } else {
+                setErrorMessageWithCompilationMode("expected WasmToJS, got: "_s, *compilationMode);
+                m_state = State::Failure;
+            }
+        } else {
+            m_errorMessage = "expected WasmToJS, got a non-Wasm frame"_s;
             m_state = State::Failure;
         }
         break;
@@ -339,9 +370,7 @@ IterationStatus SlabSlicer::step(VM& vm, StackVisitor& visitor)
                 break;
             }
             default: {
-                StringPrintStream modeDescription;
-                modeDescription.print(*compilationMode);
-                m_errorMessage = makeString("encountered an unrecognized type of Wasm frame: "_s, modeDescription.toString());
+                setErrorMessageWithCompilationMode("unrecognized type of Wasm frame: "_s, *compilationMode);
                 m_state = State::Failure;
             }
             }
@@ -402,22 +431,27 @@ IterationStatus FragSlicer::step(VM& vm, StackVisitor& visitor)
     switch (m_state) {
     case State::Initial: {
         if (!compilationMode) {
-            m_futureSliceBottom = topOfFrame(callFrame);
+            m_futureSliceBottom = bottomOfCallerFrame(callFrame);
             m_futureReturnFromFrame = callFrame;
-            m_state = State::ScannedSuspending;
+            m_state = State::ExpectingWasmToJS;
         } else {
             m_errorMessage = "expected suspending frame not found"_s;
             m_state = State::Failure;
         }
         break;
     }
-    case State::ScannedSuspending: {
-        if (compilationMode == Wasm::CompilationMode::WasmToJSMode) {
-            ASSERT(m_futureReturnFromFrame);
-            m_pendingFrameRecords.append(callFrame);
-            m_state = State::ScannedWasmToJS;
+    case State::ExpectingWasmToJS: {
+        if (compilationMode.has_value()) {
+            if (*compilationMode == Wasm::CompilationMode::WasmToJSMode) {
+                ASSERT(m_futureReturnFromFrame);
+                m_pendingFrameRecords.append(callFrame);
+                m_state = State::ScannedWasmToJS;
+            } else {
+                setErrorMessageWithCompilationMode("expected WasmToJS, got: "_s, *compilationMode);
+                m_state = State::Failure;
+            }
         } else {
-            m_errorMessage = "suspending frame not followed by a WasmToJS frame as expected"_s;
+            m_errorMessage = "expected WasmToJS, got a non-Wasm frame"_s;
             m_state = State::Failure;
         }
         break;
@@ -461,9 +495,7 @@ IterationStatus FragSlicer::step(VM& vm, StackVisitor& visitor)
                 break;
             }
             default: {
-                StringPrintStream modeDescription;
-                modeDescription.print(*compilationMode);
-                m_errorMessage = makeString("encountered an unrecognized type of Wasm frame: "_s, modeDescription.toString());
+                setErrorMessageWithCompilationMode("unrecognized type of Wasm frame: "_s, *compilationMode);
                 m_state = State::Failure;
             }
             }

--- a/Source/JavaScriptCore/runtime/EvacuatedStack.h
+++ b/Source/JavaScriptCore/runtime/EvacuatedStack.h
@@ -33,6 +33,7 @@
 #include <JavaScriptCore/Options.h>
 #include <JavaScriptCore/Register.h>
 #include <JavaScriptCore/VMEntryRecord.h>
+#include <JavaScriptCore/WasmCompilationMode.h>
 
 #include <wtf/TrailingArray.h>
 #include <wtf/Vector.h>
@@ -136,6 +137,8 @@ public:
     CallFrame* teleportFrame() const { return m_teleportFrame; }
 
 protected:
+    void setErrorMessageWithCompilationMode(ASCIILiteral messagePrefix, Wasm::CompilationMode);
+
     // Create a slice for the stack area identified by the future bottom and top pointers.
     // Include extra 'headroomSlotCount' registers above the actual frame top pointer.
     // The amount of the headroom is dictated by the frame callee.
@@ -173,6 +176,7 @@ public:
 private:
     enum class State {
         Initial,
+        ExpectingWasmToJS,
         Scanning,
         ScannedJSToWasm,
         // The following are the three final states
@@ -197,7 +201,7 @@ public:
 private:
     enum class State {
         Initial,
-        ScannedSuspending,
+        ExpectingWasmToJS,
         ScannedWasmToJS,
         ScanningWasm,
         ScannedJSToWasm,


### PR DESCRIPTION
#### 67ef3c5d8bb6f44864d1612edd999cc3f2269a9f
<pre>
[JSC][JSPI] Include everything above the suspending frame record into the evacuated stack
<a href="https://bugs.webkit.org/show_bug.cgi?id=314586">https://bugs.webkit.org/show_bug.cgi?id=314586</a>
<a href="https://rdar.apple.com/176472734">rdar://176472734</a>

Reviewed by Keith Miller.

The bottom of stack evacuated for JSPI contains a WasmToJS frame. Arguments for the JS
function it calls are allocated within that frame. The arguments space is effectively
shared between the frames, and WasmToJS stub may use it for marshalling multiple return
values. When capturing the stack for evacuation, we should start the bottom of the
evacuated slice right above the frame record of the suspending frame, matching the
position of sp in WasmToJS stub before the suspending function was called.

Key change:

- Changed the computation of m_futureSliceBottom in the Initial state of SlabSlicer and FragSlicer.

Other changes:

- Added a new SlabSlicer state, ExpectingWasmToJS, to better check that stack structure matches
our expectations.

- The new state is very similar to the existing FragSlicer state ScannedSuspending.
Renamed ScannedSuspending to ExpectingWasmToJS to make the correspondence clear.

- Factored out the boilerplate of m_errorMessage to an error message containing the
unexpected slicer state into a method.

Testing:

  JSTests/wasm/stress/jspi-multivalue-return.js

Canonical link: <a href="https://commits.webkit.org/313172@main">https://commits.webkit.org/313172@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9b58095744e42ae3abfe37d329571a12713aece7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161937 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35412 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28515 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170840 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118308 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cc7ce16c-9e58-4053-acda-fc374dbda039) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35514 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35413 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125644 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88543 "17 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1faf7e84-42d6-4e3c-acef-ac3dbafd9731) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164896 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27969 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145464 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIAction.ClearTabSpecificActionPropertiesOnNavigation (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106239 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27018 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25532 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18561 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/153996 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136711 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23218 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173329 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22775 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20424 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24859 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133945 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35085 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29618 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133950 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36245 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35069 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145013 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97167 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28483 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21838 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194336 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34579 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102064 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50081 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34080 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34322 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34228 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->