### PR TITLE
Web Inspector: `TestHarness.expect(Not)Null` should account for `undefined`

### DIFF
--- a/LayoutTests/inspector/unit-tests/test-harness-expect-functions-expected.txt
+++ b/LayoutTests/inspector/unit-tests/test-harness-expect-functions-expected.txt
@@ -125,6 +125,7 @@ FAIL: expectNotEmpty should not be called with a non-object:
 -- Running test case: InspectorTest.expectNull
 Expected to PASS
 PASS: expectNull(null)
+PASS: expectNull(undefined)
 Expected to FAIL
 FAIL: expectNull(true)
     Expected: null
@@ -138,9 +139,6 @@ FAIL: expectNull(1)
 FAIL: expectNull("")
     Expected: null
     Actual: ""
-FAIL: expectNull(undefined)
-    Expected: null
-    Actual: undefined
 FAIL: expectNull({})
     Expected: null
     Actual: {}
@@ -154,13 +152,15 @@ PASS: expectNotNull(true)
 PASS: expectNotNull(false)
 PASS: expectNotNull(1)
 PASS: expectNotNull("")
-PASS: expectNotNull(undefined)
 PASS: expectNotNull({})
 PASS: expectNotNull([])
 Expected to FAIL
 FAIL: expectNotNull(null)
     Expected: not null
     Actual: null
+FAIL: expectNotNull(undefined)
+    Expected: not null
+    Actual: undefined
 
 -- Running test case: InspectorTest.expectEqual
 Expected to PASS

--- a/LayoutTests/inspector/unit-tests/test-harness-expect-functions.html
+++ b/LayoutTests/inspector/unit-tests/test-harness-expect-functions.html
@@ -64,8 +64,8 @@ function test()
 
     let expectNullTestCase = {
         functionName: "expectNull",
-        passingInputs: [null],
-        failingInputs: [true, false, 1, "", undefined, {}, []]
+        passingInputs: [null, undefined],
+        failingInputs: [true, false, 1, "", {}, []],
     };
     addTestCase(expectNullTestCase);
     addInverseTestCase("expectNotNull", expectNullTestCase);

--- a/Source/WebInspectorUI/UserInterface/Test/TestHarness.js
+++ b/Source/WebInspectorUI/UserInterface/Test/TestHarness.js
@@ -173,12 +173,12 @@ TestHarness = class TestHarness extends WI.Object
 
     expectNull(actual, message)
     {
-        this._expect(TestHarness.ExpectationType.Null, actual === null, message, actual, null);
+        this._expect(TestHarness.ExpectationType.Null, actual === null || actual === undefined, message, actual, null);
     }
 
     expectNotNull(actual, message)
     {
-        this._expect(TestHarness.ExpectationType.NotNull, actual !== null, message, actual);
+        this._expect(TestHarness.ExpectationType.NotNull, actual !== null && actual !== undefined, message, actual);
     }
 
     expectEqual(actual, expected, message)


### PR DESCRIPTION
#### e01a74ffaab3600aea2da3667edd8dd0da20a9e8
<pre>
Web Inspector: `TestHarness.expect(Not)Null` should account for `undefined`
<a href="https://bugs.webkit.org/show_bug.cgi?id=314687">https://bugs.webkit.org/show_bug.cgi?id=314687</a>

Reviewed by Devin Rousso.

We recently wasted significant debugging time on a bot failure where a
protocol agent was undefined rather than null, but expectNotNull for
that agent happily passed while subsequent test cases crashed.
expectNotNull(value) was implemented as `value !== null` (strict), which
means expectNotNull(undefined) silently passes. This should&apos;ve never
been the intent: callers use expectNotNull to assert they have a real
value, and undefined is just as invalid as null in that context.

Change both checks to use loose equality:
- expectNotNull: `value != null` (fails for both null and undefined)
- expectNull: `value == null` (passes for both null and undefined)

This makes them behave like &quot;has a value&quot; / &quot;has no value&quot; checks, which
matches how they&apos;re used in practice throughout the test suite.

This should not regress any existing tests. One caveat is expectNull now
becomes more permissive (accepts undefined in addition to null). In case
someone specifically needs to assert `=== null` and not undefined,
they&apos;ll need to use expectEqual(value, null), though that scenario
shouldn&apos;t arise often in practice.

* Source/WebInspectorUI/UserInterface/Test/TestHarness.js:
(TestHarness.prototype.expectNull):
(TestHarness.prototype.expectNotNull):
Linter disallows loose equality (== and !=), so we explicitly compare
against both null and undefined to achieve the same result.

* LayoutTests/inspector/unit-tests/test-harness-expect-functions-expected.txt:
* LayoutTests/inspector/unit-tests/test-harness-expect-functions.html:

Canonical link: <a href="https://commits.webkit.org/313273@main">https://commits.webkit.org/313273@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/93e269b29316f132c61dc810442b70f70190f846

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162652 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36128 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29268 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171590 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/119098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8f502621-87d4-4ff0-aa3b-d30c35719e9f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36232 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36132 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/126238 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/119098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cfc608bb-ff96-406f-b423-201cb274bc69) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165611 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/28589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/146137 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106816 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9de2ed25-b572-4799-81ec-358580ea3bdd) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19290 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23867 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174094 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21407 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25512 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/134548 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35802 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134544 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35786 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145663 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98138 "Failed to checkout and rebase branch from PR 64711") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24717 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/29082 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/22497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35296 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/103047 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34797 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35042 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34945 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->