### PR TITLE
SubtreeScrollbarChangesState should specify which scrollbars it wants to track.

### DIFF
--- a/LayoutTests/fast/overflow/intrinsic-width-container-with-scrollable-descendant-vertical-lr-expected.html
+++ b/LayoutTests/fast/overflow/intrinsic-width-container-with-scrollable-descendant-vertical-lr-expected.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  writing-mode: vertical-lr;
+  background-color: green;
+  inline-size: intrinsic;
+}
+.parent {
+  block-size: 79px;
+  overflow-x: scroll;
+}
+.content {
+  inline-size: 10px;
+  block-size: 80px;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=parent>
+    <div class=content></div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/fast/overflow/intrinsic-width-container-with-scrollable-descendant-vertical-lr.html
+++ b/LayoutTests/fast/overflow/intrinsic-width-container-with-scrollable-descendant-vertical-lr.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  writing-mode: vertical-lr;
+  background-color: green;
+  inline-size: intrinsic;
+}
+.parent {
+  block-size: 79px;
+  overflow: auto;
+}
+.content {
+  inline-size: 10px;
+  block-size: 80px;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=parent>
+    <div class=content></div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/flex-orthogonal-writing-mode-with-scrollable-descendant-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/flex-orthogonal-writing-mode-with-scrollable-descendant-expected.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  float: left;
+  background-color: green;
+}
+.parent {
+  height: 79px;
+  overflow-y: scroll;
+}
+.content {
+  width: 10px;
+  height: 80px;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=parent>
+    <div class=content></div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/flex-orthogonal-writing-mode-with-scrollable-descendant.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/flex-orthogonal-writing-mode-with-scrollable-descendant.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="match" href="orthogonal-writing-mode-with-scrollable-descendant-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#scrollbar-sizing">
+<style>
+.outer {
+  display: flex;
+  writing-mode: vertical-lr;
+}
+.orthogonal {
+  writing-mode: horizontal-tb;
+  background-color: green;
+}
+.parent {
+  height: 79px;
+  overflow: auto;
+}
+.content {
+  width: 10px;
+  height: 80px;
+}
+</style>
+</head>
+<body>
+<div class=outer>
+  <div class=orthogonal>
+    <div class=parent>
+      <div class=content></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/grid-orthogonal-writing-mode-with-scrollable-descendant-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/grid-orthogonal-writing-mode-with-scrollable-descendant-expected.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  float: left;
+  background-color: green;
+}
+.parent {
+  height: 79px;
+  overflow-y: scroll;
+}
+.content {
+  width: 10px;
+  height: 80px;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=parent>
+    <div class=content></div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/grid-orthogonal-writing-mode-with-scrollable-descendant.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/grid-orthogonal-writing-mode-with-scrollable-descendant.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="match" href="orthogonal-writing-mode-with-scrollable-descendant-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#scrollbar-sizing">
+<style>
+.outer {
+  display: grid;
+  writing-mode: vertical-lr;
+}
+.orthogonal {
+  writing-mode: horizontal-tb;
+  background-color: green;
+}
+.parent {
+  height: 79px;
+  overflow: auto;
+}
+.content {
+  width: 10px;
+  height: 80px;
+}
+</style>
+</head>
+<body>
+<div class=outer>
+  <div class=orthogonal>
+    <div class=parent>
+      <div class=content></div>
+    </div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-width-container-with-scrollable-descendant-vertical-rl-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-width-container-with-scrollable-descendant-vertical-rl-expected.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  writing-mode: vertical-rl;
+  background-color: green;
+  inline-size: max-content;
+}
+.parent {
+  block-size: 79px;
+  overflow-x: scroll;
+}
+.content {
+  inline-size: 10px;
+  block-size: 80px;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=parent>
+    <div class=content></div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-width-container-with-scrollable-descendant-vertical-rl-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-width-container-with-scrollable-descendant-vertical-rl-ref.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+.container {
+  writing-mode: vertical-rl;
+  background-color: green;
+  inline-size: max-content;
+}
+.parent {
+  block-size: 79px;
+  overflow-x: scroll;
+}
+.content {
+  inline-size: 10px;
+  block-size: 80px;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=parent>
+    <div class=content></div>
+  </div>
+</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-width-container-with-scrollable-descendant-vertical-rl.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/max-width-container-with-scrollable-descendant-vertical-rl.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+<link rel="match" href="max-width-container-with-scrollable-descendant-vertical-rl-ref.html">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#scrollbar-sizing">
+<style>
+.container {
+  writing-mode: vertical-rl;
+  background-color: green;
+  inline-size: max-content;
+}
+.parent {
+  block-size: 79px;
+  overflow: auto;
+}
+.content {
+  inline-size: 10px;
+  block-size: 80px;
+}
+</style>
+</head>
+<body>
+<div class=container>
+  <div class=parent>
+    <div class=content></div>
+  </div>
+</div>
+</body>
+</html>

--- a/Source/WebCore/rendering/RelayoutScopeForScrollbarChange.cpp
+++ b/Source/WebCore/rendering/RelayoutScopeForScrollbarChange.cpp
@@ -33,6 +33,16 @@
 
 namespace WebCore {
 
+static EnumSet<ScrollbarOrientation> mapScrollbarChangesToOrientations(OptionSet<ScrollbarUpdateScope::ScrollbarChange> scrollbarChanges)
+{
+    EnumSet<ScrollbarOrientation> orientationsForChangedScrollbars;
+    if (scrollbarChanges.contains(ScrollbarUpdateScope::ScrollbarChange::AutoVerticalScrollBarChanged))
+        orientationsForChangedScrollbars.add(ScrollbarOrientation::Vertical);
+    if (scrollbarChanges.contains(ScrollbarUpdateScope::ScrollbarChange::AutoHorizontalScrollbarChanged))
+        orientationsForChangedScrollbars.add(ScrollbarOrientation::Horizontal);
+    return orientationsForChangedScrollbars;
+}
+
 RelayoutScopeForScrollbarChange::RelayoutScopeForScrollbarChange(RenderBlock& renderBlock, InOverflowRelayout inOverflowRelayout)
     : m_renderBlock(renderBlock)
     , m_inOverflowRelayout(inOverflowRelayout)
@@ -57,8 +67,11 @@ RelayoutScopeForScrollbarChange::~RelayoutScopeForScrollbarChange()
         if (m_inOverflowRelayout == InOverflowRelayout::No) {
             if (auto& subtreeScrollbarChangesState = m_renderBlock->layoutContext().subtreeScrollbarChangesState(); subtreeScrollbarChangesState && subtreeScrollbarChangesState->isEligibleForScrollbarHandlingByAncestor(m_renderBlock.get())) {
                 ASSERT(m_renderBlock.ptr() != subtreeScrollbarChangesState->subtreeRoot.ptr());
-                subtreeScrollbarChangesState->renderersWithScrollbarChange.add(m_renderBlock);
-                return;
+                auto orientationsForChangedScrollbars = mapScrollbarChangesToOrientations(scrollbarChanges);
+                if (auto sizesAffectedFromScrollbarChanges = subtreeScrollbarChangesState->sizesAffectedForSubtreeRootFromScrollbarChanges(m_renderBlock, orientationsForChangedScrollbars)) {
+                    subtreeScrollbarChangesState->addRendererWithScrollbarChange(m_renderBlock, sizesAffectedFromScrollbarChanges);
+                    return;
+                }
             }
             m_renderBlock->scrollbarsChanged(scrollbarChanges.contains(ScrollbarChange::AutoHorizontalScrollbarChanged), scrollbarChanges.contains(ScrollbarChange::AutoVerticalScrollBarChanged));
             RenderBlock::relayoutRenderBlockForScrollbarChange(m_renderBlock.get());

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -532,10 +532,10 @@ void RenderBlock::relayoutRenderBlockForScrollbarChange(RenderBlock& block)
     block.layoutBlock(RelayoutChildren::Yes);
 }
 
-static bool needsToTrackDescendantScrollbarChanges(const RenderBlock& renderBlock, const LocalFrameViewLayoutContext& layoutContext)
+static EnumSet<LogicalBoxAxis> sizesAffectedByScrollbarsForSubtreeRoot(const RenderBlock& renderBlock, const LocalFrameViewLayoutContext& layoutContext)
 {
     if (renderBlock.isRenderView())
-        return false;
+        return { };
 
     // FIXME: This list contains content that should be supported
     // but need additional invesigation to get working correctly.
@@ -545,23 +545,23 @@ static bool needsToTrackDescendantScrollbarChanges(const RenderBlock& renderBloc
         return true;
     };
     if (!isSupportedForDescendantTracking())
-        return false;
+        return { };
 
     if (layoutContext.subtreeScrollbarChangesState())
-        return false;
+        return { };
 
     auto& style = renderBlock.style();
     auto& computedLogicalWidth = style.logicalWidth();
     if (computedLogicalWidth.isFixed())
-        return false;
+        return { };
 
     if (computedLogicalWidth.isIntrinsic() || computedLogicalWidth.isMinIntrinsic())
-        return true;
+        return LogicalBoxAxis::Inline;
 
     if (renderBlock.sizesPreferredLogicalWidthToFitContent())
-        return true;
+        return LogicalBoxAxis::Inline;
 
-    return false;
+    return { };
 }
 
 static bool canContainDescendantScrollbarChanges(const RenderBlock& renderBlock, const LocalFrameViewLayoutContext& layoutContext)
@@ -578,8 +578,8 @@ void RenderBlock::layout()
     // Table cells call layoutBlock directly, so don't add any logic here. Put code into layoutBlock().
     {
         auto scope = LayoutScope { *this };
-        if (needsToTrackDescendantScrollbarChanges(*this, layoutContext)) {
-            SubtreeScrollbarChangesStateScope subtreeScrollbarChangesStateScope(layoutContext, *this);
+        if (auto sizesAffectedForSubtreeRoot = sizesAffectedByScrollbarsForSubtreeRoot(*this, layoutContext)) {
+            SubtreeScrollbarChangesStateScope subtreeScrollbarChangesStateScope(layoutContext, *this, sizesAffectedForSubtreeRoot);
             SubtreeScrollbarChangesHandler descendantScrollbarChangesHandler(*this);
             layoutBlock(RelayoutChildren::No);
         } else if (canContainDescendantScrollbarChanges(*this, layoutContext)) {

--- a/Source/WebCore/rendering/SubtreeScrollbarChangesState.cpp
+++ b/Source/WebCore/rendering/SubtreeScrollbarChangesState.cpp
@@ -41,10 +41,58 @@ bool SubtreeScrollbarChangesState::isEligibleForScrollbarHandlingByAncestor(cons
     return !is<HTMLTextAreaElement>(renderer.element());
 }
 
-SubtreeScrollbarChangesStateScope::SubtreeScrollbarChangesStateScope(LocalFrameViewLayoutContext& layoutContext, RenderBlock& subtreeRoot)
+EnumSet<LogicalBoxAxis> SubtreeScrollbarChangesState::sizesAffectedForSubtreeRootFromScrollbarChanges(const RenderBlock& rendererWithScrollbarChanges, EnumSet<ScrollbarOrientation> orientationsForChangedScrollbars) const
+{
+    auto subtreeRootWritingMode = subtreeRoot->writingMode();
+    auto translateToSubtreeRootAxis = [&](BoxAxis perpendicularAxis) {
+        auto axis = mapAxisPhysicalToLogical(subtreeRootWritingMode, perpendicularAxis);
+        // FIXME:
+        //   <div class="outer" style="writing-mode: vertical-lr">
+        //     <div class="parent" style="writing-mode: horizontal-tb; overflow: auto">
+        //       <div class="content"></div>
+        //     </div>
+        //   </div>
+        //
+        // .outer is the subtree root (orthogonal to body, hence shrink-to-fit). When
+        // .content overflows, .parent gains a vertical scrollbar. In .outer's frame
+        // (vertical-lr) that scrollbar consumes block-axis space, so without this
+        // remap we'd classify the change as Block and discard it. But in .parent's
+        // frame (horizontal-tb) the same scrollbar consumes inline-axis space, so
+        // .parent's preferred inline-size grows. The only thing that propagates that
+        // growth up to .outer is the brute-force subtreeRoot->layoutBlock(RelayoutChildren::Yes)
+        // at the end of the handler, which reruns orthogonal-flow sizing. We have to do
+        // this remapping in order to maintain functionality but this should really be
+        // treated as a change to the content's block axis size for the subtree root.
+        if (axis == LogicalBoxAxis::Block && subtreeRootWritingMode.isOrthogonal(rendererWithScrollbarChanges.writingMode()))
+            axis = LogicalBoxAxis::Inline;
+        return axis;
+    };
+
+    EnumSet<LogicalBoxAxis> sizesAffectedFromScrollbarChanges;
+    if (orientationsForChangedScrollbars.contains(ScrollbarOrientation::Vertical))
+        sizesAffectedFromScrollbarChanges.add(translateToSubtreeRootAxis(BoxAxis::Horizontal));
+    if (orientationsForChangedScrollbars.contains(ScrollbarOrientation::Horizontal))
+        sizesAffectedFromScrollbarChanges.add(translateToSubtreeRootAxis(BoxAxis::Vertical));
+    return sizesAffectedFromScrollbarChanges & sizesAffectedForSubtreeRoot;
+}
+
+void SubtreeScrollbarChangesState::addRendererWithScrollbarChange(RenderBlock& renderer, EnumSet<LogicalBoxAxis> sizesAffectedFromScrollbarChanges)
+{
+    ASSERT(sizesAffectedForSubtreeRoot.containsAll(sizesAffectedFromScrollbarChanges));
+    auto currentEntryIndex = rendererScrollbarChanges.findIf([&](auto& rendererScrollbarChange) {
+        return rendererScrollbarChange.renderer.ptr() == &renderer;
+    });
+    if (currentEntryIndex == notFound) {
+        rendererScrollbarChanges.append({ renderer, sizesAffectedFromScrollbarChanges });
+        return;
+    }
+    rendererScrollbarChanges[currentEntryIndex].sizesAffectedFromScrollbarChanges.add(sizesAffectedFromScrollbarChanges);
+}
+
+SubtreeScrollbarChangesStateScope::SubtreeScrollbarChangesStateScope(LocalFrameViewLayoutContext& layoutContext, RenderBlock& subtreeRoot, EnumSet<LogicalBoxAxis> sizesAffectedForSubtreeRoot)
     : m_layoutContext(layoutContext)
 {
-    layoutContext.setSubtreeScrollbarChangesState(SubtreeScrollbarChangesState { subtreeRoot, { } });
+    layoutContext.setSubtreeScrollbarChangesState(SubtreeScrollbarChangesState { subtreeRoot, sizesAffectedForSubtreeRoot, { } });
 }
 
 SubtreeScrollbarChangesStateScope::~SubtreeScrollbarChangesStateScope()
@@ -64,8 +112,8 @@ SubtreeScrollbarChangesHandler::SubtreeScrollbarChangesHandler(RenderBlock& rend
 
     bool isSubtreeRootHandlingScrollbarChanges = subtreeScrollbarChangesState->subtreeRoot.ptr() == &rendererHandlingScrollbarChanges;
     if (!isSubtreeRootHandlingScrollbarChanges) {
-        m_renderersWithScrollbarChangesHandledByAncestor = WTF::move(subtreeScrollbarChangesState->renderersWithScrollbarChange);
-        layoutContext->setSubtreeScrollbarChangesState(SubtreeScrollbarChangesState { subtreeScrollbarChangesState->subtreeRoot, { } });
+        m_rendererScrollbarChangesHandledByAncestor = WTF::move(subtreeScrollbarChangesState->rendererScrollbarChanges);
+        layoutContext->setSubtreeScrollbarChangesState(SubtreeScrollbarChangesState { subtreeScrollbarChangesState->subtreeRoot, subtreeScrollbarChangesState->sizesAffectedForSubtreeRoot, { } });
     }
 }
 
@@ -76,9 +124,9 @@ SubtreeScrollbarChangesHandler::~SubtreeScrollbarChangesHandler()
     auto& subtreeScrollbarChangesState = layoutContext->subtreeScrollbarChangesState();
     bool isSubtreeRootHandlingScrollbarChanges = subtreeScrollbarChangesState->subtreeRoot.ptr() == m_rendererHandlingScrollbarChanges.ptr();
 
-    auto descendantsWithScrollbarChange = WTF::move(subtreeScrollbarChangesState->renderersWithScrollbarChange);
+    auto descendantsWithScrollbarChange = WTF::move(subtreeScrollbarChangesState->rendererScrollbarChanges);
     auto restoreRenderersWithScrollbarChanges = makeScopeExit([&]() {
-        subtreeScrollbarChangesState->renderersWithScrollbarChange = WTF::move(m_renderersWithScrollbarChangesHandledByAncestor);
+        subtreeScrollbarChangesState->rendererScrollbarChanges = WTF::move(m_rendererScrollbarChangesHandledByAncestor);
         ASSERT(descendantsWithScrollbarChange.isEmpty());
     });
 
@@ -86,23 +134,24 @@ SubtreeScrollbarChangesHandler::~SubtreeScrollbarChangesHandler()
         return;
 
 #if ASSERT_ENABLED
-    for (auto& renderer : descendantsWithScrollbarChange)
-        ASSERT(subtreeScrollbarChangesState->isEligibleForScrollbarHandlingByAncestor(renderer.get()));
+    for (auto& rendererScrollbarChange : descendantsWithScrollbarChange)
+        ASSERT(subtreeScrollbarChangesState->isEligibleForScrollbarHandlingByAncestor(rendererScrollbarChange.renderer.get()));
 #endif
 
     if (!isSubtreeRootHandlingScrollbarChanges) {
-        while (!descendantsWithScrollbarChange.isEmpty()) {
-            CheckedPtr rendererWithScrollbarChange = descendantsWithScrollbarChange.takeFirst();
-            RenderBlock::relayoutRenderBlockForScrollbarChange(*rendererWithScrollbarChange);
-        }
+        for (auto& rendererScrollbarChange : descendantsWithScrollbarChange)
+            RenderBlock::relayoutRenderBlockForScrollbarChange(rendererScrollbarChange.renderer.get());
+        descendantsWithScrollbarChange.clear();
         return;
     }
 
     auto& subtreeRoot = subtreeScrollbarChangesState->subtreeRoot;
-    while (!descendantsWithScrollbarChange.isEmpty()) {
-        CheckedPtr rendererWithScrollbarChange = descendantsWithScrollbarChange.takeFirst();
-        rendererWithScrollbarChange->invalidateContentLogicalWidths(MarkingBehavior::MarkContainingBlockChain, protect(subtreeRoot->containingBlock()));
+    for (auto& rendererScrollbarChange : descendantsWithScrollbarChange) {
+        if (rendererScrollbarChange.sizesAffectedFromScrollbarChanges.containsOnly(LogicalBoxAxis::Block))
+            continue;
+        protect(rendererScrollbarChange.renderer)->invalidateContentLogicalWidths(MarkingBehavior::MarkContainingBlockChain, protect(subtreeRoot->containingBlock()));
     }
+    descendantsWithScrollbarChange.clear();
 
     subtreeRoot->setNeedsLayout(MarkingBehavior::MarkOnlyThis);
     subtreeRoot->layoutBlock(RelayoutChildren::Yes);

--- a/Source/WebCore/rendering/SubtreeScrollbarChangesState.h
+++ b/Source/WebCore/rendering/SubtreeScrollbarChangesState.h
@@ -26,16 +26,24 @@
 #pragma once
 
 #include <wtf/CheckedRef.h>
-#include <wtf/ListHashSet.h>
 
 namespace WebCore {
 
 class RenderBlock;
 
+struct RendererScrollbarChange {
+    CheckedRef<RenderBlock> renderer;
+    // Relative to the subtree root.
+    EnumSet<LogicalBoxAxis> sizesAffectedFromScrollbarChanges;
+};
+
 struct SubtreeScrollbarChangesState {
     CheckedRef<RenderBlock> subtreeRoot;
-    ListHashSet<CheckedRef<RenderBlock>> renderersWithScrollbarChange;
+    EnumSet<LogicalBoxAxis> sizesAffectedForSubtreeRoot;
+    Vector<RendererScrollbarChange> rendererScrollbarChanges;
 
+    EnumSet<LogicalBoxAxis> sizesAffectedForSubtreeRootFromScrollbarChanges(const RenderBlock& rendererWithScrollbarChanges, EnumSet<ScrollbarOrientation> orientationsForChangedScrollbars) const;
+    void addRendererWithScrollbarChange(RenderBlock&, EnumSet<LogicalBoxAxis> sizesAffectedFromScrollbarChanges);
     static bool isEligibleForScrollbarHandlingByAncestor(const RenderBlock&);
 };
 
@@ -44,7 +52,7 @@ class LocalFrameViewLayoutContext;
 class SubtreeScrollbarChangesStateScope {
     WTF_MAKE_NONCOPYABLE(SubtreeScrollbarChangesStateScope);
 public:
-    SubtreeScrollbarChangesStateScope(LocalFrameViewLayoutContext&, RenderBlock& subtreeRoot);
+    SubtreeScrollbarChangesStateScope(LocalFrameViewLayoutContext&, RenderBlock& subtreeRoot, EnumSet<LogicalBoxAxis>);
     ~SubtreeScrollbarChangesStateScope();
 private:
     const CheckedRef<LocalFrameViewLayoutContext> m_layoutContext;
@@ -56,7 +64,7 @@ public:
     ~SubtreeScrollbarChangesHandler();
 private:
     const CheckedRef<RenderBlock> m_rendererHandlingScrollbarChanges;
-    ListHashSet<CheckedRef<RenderBlock>> m_renderersWithScrollbarChangesHandledByAncestor;
+    Vector<RendererScrollbarChange> m_rendererScrollbarChangesHandledByAncestor;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 967dcf8bdd957d0c5e563ff3325871a2fc3e3f5b
<pre>
SubtreeScrollbarChangesState should specify which scrollbars it wants to track.
<a href="https://bugs.webkit.org/show_bug.cgi?id=314656">https://bugs.webkit.org/show_bug.cgi?id=314656</a>
<a href="https://rdar.apple.com/problem/176905445">rdar://problem/176905445</a>

Reviewed by Alan Baradlay.

Currently, when we create SubtreeScrollbarChangesState we are saying
that we want to keep track of any descendant for any type of scrollbar
change. This may be not exactly true because in certain cases we may
want to know if a descendant has a certain type of scrollbar change. For
example, if a renderer has width: max-content then we only want to know
if a descendant gains a scrollbar that affects its inline-size in order
to make sure our max-content width is correct.

* Source/WebCore/rendering/RelayoutScopeForScrollbarChange.cpp:
(WebCore::mapScrollbarChangesToOrientations):
(WebCore::RelayoutScopeForScrollbarChange::~RelayoutScopeForScrollbarChange):
We want to only add the renderer to SubtreeScrollbarChangesState if the
scrollbar that changed affects one of the sizes that the state is
keeping track of.

* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::sizesAffectedByScrollbarsForSubtreeRoot):
We currently only want to track scrollbar changes if the logical width
is intrinsic which means that we only care about scrollbar changes that
affect the inline-size.

(WebCore::RenderBlock::layout):
* Source/WebCore/rendering/SubtreeScrollbarChangesState.cpp:
(WebCore::SubtreeScrollbarChangesState::sizesAffectedForSubtreeRootFromScrollbarChanges):
(WebCore::SubtreeScrollbarChangesState::addRendererWithScrollbarChange):
Since we are not just keeping track of the renderers anymore we changed
the underlying data structure to be a Vector. This makes the code a bit
more simple and I expect this list to not get very large. If that second
part ends up not becoming true we can build upon this a bit more and use
a different data structure.

Canonical link: <a href="https://commits.webkit.org/314175@main">https://commits.webkit.org/314175@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ffd125ad6689ff61e3abe841eb05a29abf429efe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165332 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38823 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32403 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174376 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122589 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/363c8bf6-9c74-4c2f-bdd5-fa2b6459f526) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167200 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39160 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38827 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128482 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90428 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9be4ce30-19ee-4f07-a802-2a6a0149da13) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168291 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30790 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148537 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109007 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1b406a1f-52ed-48c0-9fac-03ab05118008) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28461 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22450 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/139733 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26235 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176897 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/29798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27940 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136807 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38891 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32599 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136743 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36863 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39581 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148031 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101925 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32012 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24898 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38091 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111165 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37488 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2976 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37734 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37632 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->