### PR TITLE
MediaUsageManagerCocoa::removeMediaSession doesn't clear UsageTrackingAgent state when being released

### DIFF
--- a/Source/WebKit/UIProcess/Media/cocoa/MediaUsageManagerCocoa.mm
+++ b/Source/WebKit/UIProcess/Media/cocoa/MediaUsageManagerCocoa.mm
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2020 Apple Inc. All rights reserved.
+ * Copyright (C) 2020-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -102,8 +102,10 @@ MediaUsageManagerCocoa::~MediaUsageManagerCocoa()
 void MediaUsageManagerCocoa::reset()
 {
     for (auto& session : m_mediaSessions.values()) {
-        if (session->usageTracker && session->mediaUsageInfo && session->mediaUsageInfo->isPlaying)
+        if (session->usageTracker && session->mediaUsageInfo && session->mediaUsageInfo->isPlaying) {
             [session->usageTracker stop];
+            session->usageTracker = nullptr;
+        }
     }
     m_mediaSessions.clear();
 }
@@ -119,7 +121,11 @@ void MediaUsageManagerCocoa::addMediaSession(WebCore::MediaSessionIdentifier ide
 void MediaUsageManagerCocoa::removeMediaSession(WebCore::MediaSessionIdentifier identifier)
 {
     ASSERT(m_mediaSessions.contains(identifier));
-    m_mediaSessions.remove(identifier);
+    auto session = m_mediaSessions.take(identifier);
+    if (session && session->usageTracker) {
+        [session->usageTracker stop];
+        session->usageTracker = nullptr;
+    }
 }
 
 void MediaUsageManagerCocoa::updateMediaUsage(WebCore::MediaSessionIdentifier identifier, const WebCore::MediaUsageInfo& mediaUsageInfo)

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2010-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2010-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2012 Intel Corporation. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -8207,6 +8207,11 @@ void WebPageProxy::didCommitLoadForFrame(IPC::Connection& connection, FrameIdent
         m_shouldListenToVoiceActivity = false;
         m_mutedCaptureKindsDesiredByWebApp = { };
     }
+#endif
+
+#if ENABLE(MEDIA_USAGE)
+    if (frame->isMainFrame() && m_mediaUsageManager)
+        m_mediaUsageManager->reset();
 #endif
 
 #if ENABLE(EXTENSION_CAPABILITIES)


### PR DESCRIPTION
#### 749fddf048e05e5090b6a3120911ff4a439cb801
<pre>
MediaUsageManagerCocoa::removeMediaSession doesn&apos;t clear UsageTrackingAgent state when being released
<a href="https://bugs.webkit.org/show_bug.cgi?id=314593">https://bugs.webkit.org/show_bug.cgi?id=314593</a>
<a href="https://rdar.apple.com/176832251">rdar://176832251</a>

Reviewed by Ben Nham.

While investigating spurious no-crash-log WebKitTestRunner crashes, I noticed that we
were periodically being terminated by the kernel for exceeding the process limit of 2048
kqworkloops. This was happening because we only call `-stop` on playing media sessions,
which allows any stopped sessions to leak their UsageTrackingAgent connections.

This can happen when a media element is playing, and the page (or test case) navigates
away. removeMediaSession gets called by the MediaElementSession&apos;s destructor and clears
its collection of media sessions without ensuring any active usageTrackers are stopped.

This may happen when a page navigates and the &quot;pause&quot; message is not received in the
UIProcess side before the page teardown begins.

After further testing showed that calling &apos;stop&apos; was insufficent to close the XPC connections,
I reviewed ScreenTime&apos;s use of this API. This revealed that we always need to nil out
the usageTracker object after calling stop on it to ensure the XPC connection is closed.

* Source/WebKit/UIProcess/Media/cocoa/MediaUsageManagerCocoa.mm:
(WebKit::MediaUsageManagerCocoa::reset): Always nil out the usageTracker after stopping.
(WebKit::MediaUsageManagerCocoa::removeMediaSession): Check the session being removed for
an active usageTracker member, and call `stop` when one exists, and nil the object after
calling stop.
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didCommitLoadForFrame): Add m_mediaUsageManager-&gt;reset() on main
frame navigation. This missing call was causing media sessions to accumulate across test
iterations.

Canonical link: <a href="https://commits.webkit.org/313125@main">https://commits.webkit.org/313125@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/82547ae70a553ad166c097ff29fe1595ffc86776

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162126 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35601 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28715 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171034 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118499 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/229b7453-676c-4383-8fb7-d4fd5f41e4f3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35706 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35603 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125824 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88685 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cd379f60-a92e-48e2-a92b-ae6a760714eb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165085 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28145 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145627 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIAction.ClearTabSpecificActionPropertiesOnNavigation (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106402 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3bb2b91f-5007-42f8-8750-a1da610d75e2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27192 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25709 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18755 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136891 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173527 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20881 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25016 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134118 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35276 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29797 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134119 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36218 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35259 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145169 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97462 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28652 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21997 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34769 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102521 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34269 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34514 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34417 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->