### PR TITLE
[JSC] Remove MustGenerate from Int32Use / DoubleRepUse ArithDiv / ArithMod

### DIFF
--- a/JSTests/stress/arith-div-mod-must-generate-clear.js
+++ b/JSTests/stress/arith-div-mod-must-generate-clear.js
@@ -1,0 +1,319 @@
+// Regression test for clearing NodeMustGenerate on ArithDiv / ArithMod
+// in DFGFixupPhase (for Int32 / Int52 / DoubleRep inputs), together with
+// DFGMayExit treating Arith::Unchecked Int32 / Int52 Div/Mod as non-exiting
+// and StrengthReduction switching ArithMod(x, power-of-two) from
+// CheckOverflow to Unchecked.
+//
+// The DCE-after-fixup behavior must preserve observable semantics: if the
+// result is used anywhere (including an observable operand conversion), the
+// value is correct; if the result is unused, the program must not diverge
+// from the pre-optimization behavior (in particular: no spurious exceptions,
+// no stale values on uses, and the OSR exit machinery must still agree with
+// mayExit).
+
+function assertEq(actual, expected, label) {
+    if (actual !== expected)
+        throw new Error(`${label}: expected ${expected}, got ${actual}`);
+}
+
+function assertNegZero(value, label) {
+    if (value !== 0 || 1 / value !== -Infinity)
+        throw new Error(`${label}: expected -0, got ${value}`);
+}
+
+function assertPosZero(value, label) {
+    if (value !== 0 || 1 / value !== Infinity)
+        throw new Error(`${label}: expected +0, got ${value}`);
+}
+
+// ===== Unused Int32 ArithDiv with Unchecked mode =====
+// (x / y) | 0 is truncate-to-int32 + can-ignore-NaN/Inf + can-ignore-negZero,
+// so FixupPhase sets Arith::Unchecked on the ArithDiv. With NodeMustGenerate
+// cleared, the outer | 0 consumes the div; here we still read the result so
+// we can verify correctness. The sibling test below drops the result to
+// exercise DCE.
+function divInt32Unchecked(a, b) {
+    return (a / b) | 0;
+}
+noInline(divInt32Unchecked);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    assertEq(divInt32Unchecked(42, 5), 8, "divInt32Unchecked normal");
+    // chillDiv: x / 0 = 0 in unchecked mode, | 0 preserves 0
+    assertEq(divInt32Unchecked(42, 0), 0, "divInt32Unchecked zero divisor");
+    // INT_MIN / -1 would overflow in checked mode; chillDiv returns numerator here.
+    assertEq(divInt32Unchecked(-2147483648, -1), -2147483648 | 0, "divInt32Unchecked INT_MIN / -1");
+}
+
+// ===== Unused Int32 ArithDiv / ArithMod — DCE-visible pattern =====
+// The result is assigned to a local that's never read. With the fix, DCE
+// removes the ArithDiv/ArithMod. We verify the function still returns the
+// expected value (so we know no OSR exit was forced) and that calls with
+// zero divisors don't throw / don't corrupt anything.
+function divUnusedResult(a, b) {
+    var unused = (a / b) | 0;
+    return a + b;
+}
+noInline(divUnusedResult);
+
+function modUnusedResult(a, b) {
+    var unused = (a % b) | 0;
+    return a + b;
+}
+noInline(modUnusedResult);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    assertEq(divUnusedResult(17, 3), 20, "divUnusedResult normal");
+    assertEq(divUnusedResult(17, 0), 17, "divUnusedResult zero divisor");
+    assertEq(divUnusedResult(-2147483648, -1), -2147483649, "divUnusedResult INT_MIN / -1");
+
+    assertEq(modUnusedResult(17, 3), 20, "modUnusedResult normal");
+    assertEq(modUnusedResult(17, 0), 17, "modUnusedResult zero divisor");
+    assertEq(modUnusedResult(-2147483648, -1), -2147483649, "modUnusedResult INT_MIN / -1");
+}
+
+// ===== Unused Int52 ArithMod — DCE-visible pattern =====
+// Int52 path in fixupArithDiv: when modShouldSpeculateInt52 and the
+// bytecode flags allow it, mode is Unchecked and MustGenerate is cleared.
+function modInt52Unused(a, b) {
+    var unused = (a % b) | 0;
+    return a;
+}
+noInline(modInt52Unused);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    assertEq(modInt52Unused(2147483648, 7), 2147483648, "modInt52Unused normal");
+    assertEq(modInt52Unused(2147483648, 0), 2147483648, "modInt52Unused zero divisor");
+    assertEq(modInt52Unused(-4503599627370496, 1000000007), -4503599627370496, "modInt52Unused large negative");
+}
+
+// ===== Unused Double ArithDiv / ArithMod — DCE-visible pattern =====
+// fixupArithDiv non-integer fallback: setResult(NodeResultDouble) + clearFlags.
+function divDoubleUnused(a, b) {
+    var unused = a / b;
+    return a + b;
+}
+noInline(divDoubleUnused);
+
+function modDoubleUnused(a, b) {
+    var unused = a % b;
+    return a + b;
+}
+noInline(modDoubleUnused);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    assertEq(divDoubleUnused(3.5, 2.0), 5.5, "divDoubleUnused normal");
+    assertEq(divDoubleUnused(3.5, 0.0), 3.5, "divDoubleUnused zero divisor produces Infinity-but-unused");
+    assertEq(modDoubleUnused(3.5, 2.0), 5.5, "modDoubleUnused normal");
+    assertEq(modDoubleUnused(3.5, 0.0), 3.5, "modDoubleUnused zero divisor produces NaN-but-unused");
+}
+
+// ===== Operand side-effects must still fire when result is DCE'd =====
+// The operands of ArithDiv/ArithMod are int32 edges; the valueOf is called
+// during ToInt32 conversion which happens BEFORE the ArithDiv. Even if DCE
+// removes the ArithDiv itself, the valueOf-driven conversions must remain
+// because they are separate nodes in the DFG.
+let sideEffectCount = 0;
+const sideEffectOperand = {
+    valueOf: function () {
+        sideEffectCount++;
+        return 7;
+    }
+};
+
+function divWithSideEffectOperand(obj, b) {
+    // (obj / b) | 0 — the |0 keeps ValueDiv's operand conversions alive
+    // through ToNumber/ToInt32. Even if the div itself is DCE'd, we don't
+    // expect the conversions to vanish because they're separate nodes.
+    var unused = (obj / b) | 0;
+    return obj + 0; // force another coerce so valueOf count is predictable
+}
+noInline(divWithSideEffectOperand);
+
+sideEffectCount = 0;
+for (let i = 0; i < testLoopCount; ++i)
+    divWithSideEffectOperand(sideEffectOperand, 2);
+// obj.valueOf is called at least for the return's `obj + 0`. The div may or
+// may not call it depending on whether the op stays ValueDiv or gets fixed
+// to Int32 with the operand pre-converted. Either way, count must be >= the
+// loop count (at least one call per iteration for the `obj + 0`).
+if (sideEffectCount < testLoopCount)
+    throw new Error(`divWithSideEffectOperand side effect count ${sideEffectCount} < ${testLoopCount}`);
+
+// ===== Strength reduction: ArithMod(x, power-of-two) in CheckOverflow mode =====
+// When mode is CheckOverflow (negative-zero doesn't matter but overflow
+// might), strength reduction now rewrites power-of-two divisors to
+// Arith::Unchecked because they can never divide by zero and can never hit
+// the INT_MIN/-1 trap. The produced value must still be correct.
+function modPow2InCheckOverflow(a, k) {
+    // Return a non-bitwise result so the caller's observed value preserves
+    // NaN/Infinity. But keep the divisor constant and power-of-two so the
+    // strength-reduction rule fires.
+    if (k === 256)
+        return a % 256;
+    if (k === 1024)
+        return a % 1024;
+    if (k === 65536)
+        return a % 65536;
+    return a % 2;
+}
+noInline(modPow2InCheckOverflow);
+
+const pow2TestValues = [0, 1, -1, 2, -2, 128, -128, 255, -255, 256, -256,
+    1023, -1024, 65535, -65536, 2147483647, -2147483648, -2147483647];
+
+for (let i = 0; i < testLoopCount; ++i) {
+    for (const v of pow2TestValues) {
+        assertEq(modPow2InCheckOverflow(v, 256), v % 256, `modPow2 ${v} % 256`);
+        assertEq(modPow2InCheckOverflow(v, 1024), v % 1024, `modPow2 ${v} % 1024`);
+        assertEq(modPow2InCheckOverflow(v, 65536), v % 65536, `modPow2 ${v} % 65536`);
+    }
+}
+
+// ===== Strength reduction: power-of-two must NOT switch to Unchecked when
+// negative-zero matters (CheckOverflowAndNegativeZero). The optimization
+// only fires on CheckOverflow. Here the result is observed as -0, so
+// negative-zero speculation must still be in effect. =====
+function modPow2PreservesNegZero(a) {
+    // -0 would be produced by (-X) % 256 when X is a multiple of 256.
+    // The caller checks 1/result, forcing negative-zero observation.
+    return a % 256;
+}
+noInline(modPow2PreservesNegZero);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    // Negative multiple of 256 produces -0.
+    assertNegZero(modPow2PreservesNegZero(-256), "modPow2PreservesNegZero -256");
+    assertNegZero(modPow2PreservesNegZero(-512), "modPow2PreservesNegZero -512");
+    assertNegZero(modPow2PreservesNegZero(-65536), "modPow2PreservesNegZero -65536");
+    // Positive multiples produce +0.
+    assertPosZero(modPow2PreservesNegZero(256), "modPow2PreservesNegZero 256");
+    assertPosZero(modPow2PreservesNegZero(512), "modPow2PreservesNegZero 512");
+    // Non-multiples: normal remainder.
+    assertEq(modPow2PreservesNegZero(-257), -1, "modPow2PreservesNegZero -257");
+    assertEq(modPow2PreservesNegZero(257), 1, "modPow2PreservesNegZero 257");
+}
+
+// ===== Strength reduction: non-power-of-two divisor must NOT switch =====
+// const > 1 but not power-of-two must stay in CheckOverflow (or whatever
+// mode FixupPhase set). Correctness check: divisor 3 behaves as integer mod.
+function modNonPow2(a) {
+    return a % 3;
+}
+noInline(modNonPow2);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    assertEq(modNonPow2(10), 1, "modNonPow2 10 % 3");
+    assertEq(modNonPow2(-10), -1, "modNonPow2 -10 % 3");
+    assertEq(modNonPow2(0), 0, "modNonPow2 0 % 3");
+}
+
+// ===== IntegerRangeOptimization interaction =====
+// After the MustGenerate-clear, the IntegerRangeOptimizationPhase must not
+// draw conclusions from the *existence* of an ArithDiv/ArithMod check
+// (because the node may have been DCE'd). This loop pattern is the classic
+// shape that drove the invariant: the mod result bounds the index, the
+// array access still needs its own bounds check.
+function rangeOptArrayMod(arr) {
+    let sum = 0;
+    for (let i = 0; i < arr.length; ++i) {
+        const idx = i % arr.length;
+        sum += arr[idx];
+    }
+    return sum;
+}
+noInline(rangeOptArrayMod);
+
+const rangeArr = [1, 2, 3, 4, 5, 6, 7, 8];
+const rangeExpected = 36;
+for (let i = 0; i < testLoopCount; ++i) {
+    assertEq(rangeOptArrayMod(rangeArr), rangeExpected, "rangeOptArrayMod");
+}
+
+// ===== Typed-array store elision + DCE of the mod node =====
+// This is the end-to-end scenario motivating the patch: DFGStrengthReduction
+// rewires PutByVal(Uint8Array, ArithMod(x, 256)) to PutByVal(Uint8Array, x).
+// Previously the ArithMod survived DCE because of NodeMustGenerate; now it
+// is removed. Correctness guard: the stored value must equal x & 0xff.
+function storeModUnused(arr, i, x) {
+    arr[i] = x % 256;
+}
+noInline(storeModUnused);
+
+const storeArr = new Uint8Array(4);
+for (let i = 0; i < testLoopCount; ++i) {
+    storeModUnused(storeArr, 0, 0x1234);
+    storeModUnused(storeArr, 1, -1);
+    storeModUnused(storeArr, 2, 2147483647);
+    storeModUnused(storeArr, 3, -2147483648);
+}
+assertEq(storeArr[0], 0x34, "storeModUnused 0x1234 -> low byte");
+assertEq(storeArr[1], 0xff, "storeModUnused -1 -> 0xff");
+assertEq(storeArr[2], 0xff, "storeModUnused INT32_MAX -> 0xff");
+assertEq(storeArr[3], 0x00, "storeModUnused INT32_MIN -> 0");
+
+// ===== Shared ArithMod: store to Uint8Array + other use =====
+// StrengthReduction rewires only the store's value edge; the other use
+// still needs the modded value. MustGenerate-clear doesn't change this
+// (the other use keeps the node alive via its edge).
+function sharedMod(arr, i, x) {
+    const m = x % 256;
+    arr[i] = m;
+    return m;
+}
+noInline(sharedMod);
+
+const sharedArr = new Uint8Array(1);
+for (let i = 0; i < testLoopCount; ++i) {
+    const r = sharedMod(sharedArr, 0, 0x1234);
+    // x % 256 in JS: 4660 % 256 = 52 (=0x34)
+    assertEq(r, 52, "sharedMod return 0x1234 % 256");
+    assertEq(sharedArr[0], 52, "sharedMod store 0x1234 low byte");
+
+    const r2 = sharedMod(sharedArr, 0, -1);
+    assertEq(r2, -1, "sharedMod return -1 % 256");
+    assertEq(sharedArr[0], 0xff, "sharedMod store -1 low byte");
+}
+
+// ===== Nested ArithMod with power-of-two: strength reduction fires
+// repeatedly because the outer mod's divisor is a multiple of the inner's.
+// The existing identity-conversion rule still applies and must continue to
+// work after the refactor. =====
+function nestedModPow2(x) {
+    return (x % 256) % 16;
+}
+noInline(nestedModPow2);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    for (const v of pow2TestValues)
+        assertEq(nestedModPow2(v), (v % 256) % 16, `nestedModPow2 ${v}`);
+}
+
+// ===== FTL warm-up: very hot loop that drives the node into FTL where
+// LICM + IntegerRangeOptimization + MovHintRemoval all consult mayExit.
+// If any of them disagree with the Fixup/StrengthReduction story, we'd see
+// divergent results or crashes here. =====
+function ftlHotMod(seed) {
+    let acc = 0;
+    for (let i = 0; i < 1000; ++i) {
+        const m = (seed + i) % 256;
+        acc = (acc + m) | 0;
+    }
+    return acc;
+}
+noInline(ftlHotMod);
+
+let ftlResult = 0;
+for (let i = 0; i < testLoopCount; ++i)
+    ftlResult = ftlHotMod(i);
+
+// Recompute the final-iteration expected value explicitly.
+{
+    let acc = 0;
+    const seed = testLoopCount - 1;
+    for (let i = 0; i < 1000; ++i) {
+        const m = (seed + i) % 256;
+        acc = (acc + m) | 0;
+    }
+    assertEq(ftlResult, acc, "ftlHotMod final iteration");
+}

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -94,6 +94,10 @@ private:
                 node->setArithMode(Arith::CheckOverflow);
             else
                 node->setArithMode(Arith::CheckOverflowAndNegativeZero);
+            // Regardless of whether we have a check, we clear MustGenerate flag. If nobody is using the output (including MovHint),
+            // we do not need to perform checks and keep this node.
+            // This condition is met only when we are not utilizing this checks as an additional constraint in integer-range-optimization.
+            node->clearFlags(NodeMustGenerate);
             return;
         }
 
@@ -105,6 +109,7 @@ private:
         // the original division.
         Node* newDivision = m_insertionSet.insertNode(m_indexInBlock, SpecBytecodeDouble, *node);
         newDivision->setResult(NodeResultDouble);
+        newDivision->clearFlags(NodeMustGenerate);
 
         node->setOp(DoubleAsInt32);
         node->children.initialize(Edge(newDivision, DoubleRepUse), Edge(), Edge());
@@ -143,6 +148,10 @@ private:
                 node->setArithMode(Arith::CheckOverflow);
             else
                 node->setArithMode(Arith::CheckOverflowAndNegativeZero);
+            // Regardless of whether we have a check, we clear MustGenerate flag. If nobody is using the output (including MovHint),
+            // we do not need to perform checks and keep this node.
+            // This condition is met only when we are not utilizing this checks as an additional constraint in integer-range-optimization.
+            node->clearFlags(NodeMustGenerate);
             node->setResult(NodeResultInt52);
             return;
         }
@@ -164,6 +173,10 @@ private:
                 node->setArithMode(Arith::CheckOverflow);
             else
                 node->setArithMode(Arith::CheckOverflowAndNegativeZero);
+            // Regardless of whether we have a check, we clear MustGenerate flag. If nobody is using the output (including MovHint),
+            // we do not need to perform checks and keep this node.
+            // This condition is met only when we are not utilizing this checks as an additional constraint in integer-range-optimization.
+            node->clearFlags(NodeMustGenerate);
             return;
         }
         if (m_graph.binaryArithShouldSpeculateInt52(node, FixupPass)) {
@@ -173,6 +186,10 @@ private:
                 node->setArithMode(Arith::CheckOverflow);
             else
                 node->setArithMode(Arith::CheckOverflowAndNegativeZero);
+            // Regardless of whether we have a check, we clear MustGenerate flag. If nobody is using the output (including MovHint),
+            // we do not need to perform checks and keep this node.
+            // This condition is met only when we are not utilizing this checks as an additional constraint in integer-range-optimization.
+            node->clearFlags(NodeMustGenerate);
             node->setResult(NodeResultInt52);
             return;
         }

--- a/Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp
@@ -1762,6 +1762,15 @@ private:
             break;
         }
 
+        case ArithMod:
+        case ArithDiv: {
+            // Regardless of whether we have a check, these nodes cleared MustGenerate flag when input is Int32Use / Int52RepUse / DoubleRepUse.
+            // If nobody is using the output (including MovHint), we do not need to perform checks and keep this node.
+            // But the above assumption gets broken when we leverages these checks to put additional constraint onto *input* of this node.
+            // This comment is noting about these condition to avoid introducing bugs.
+            break;
+        }
+
         case Phi: {
             setEquivalence(
                 NodeFlowProjection(node, NodeFlowProjection::Shadow),

--- a/Source/JavaScriptCore/dfg/DFGMayExit.cpp
+++ b/Source/JavaScriptCore/dfg/DFGMayExit.cpp
@@ -271,6 +271,8 @@ ExitMode mayExitImpl(Graph& graph, Node* node, StateType& state)
 
     case ArithAdd:
     case ArithSub:
+    case ArithDiv:
+    case ArithMod:
         if (node->arithMode() == Arith::Mode::Unchecked) {
             if (node->isBinaryInt32UseKind())
                 break;
@@ -292,12 +294,6 @@ ExitMode mayExitImpl(Graph& graph, Node* node, StateType& state)
         if (node->arithMode() == Arith::Mode::Unchecked && isInt32(node->child1().useKind()))
             break;
         if (node->child1().useKind() == DoubleRepUse)
-            break;
-        return Exits;
-
-    case ArithDiv:
-    case ArithMod:
-        if (node->isBinaryUseKind(DoubleRepUse))
             break;
         return Exits;
 

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -284,24 +284,34 @@ private:
             if (foldPurifyNaNOnBinary(m_node))
                 m_changed = true;
 
-            // On Integers
-            // In: ArithMod(ArithMod(x, const1), const2)
-            // Out: Identity(ArithMod(x, const1))
-            //     if const1 <= const2.
-            if (m_node->binaryUseKind() == Int32Use
-                && m_node->child2()->isInt32Constant()
-                && m_node->child1()->op() == ArithMod
-                && m_node->child1()->binaryUseKind() == Int32Use
-                && m_node->child1()->child2()->isInt32Constant()) {
+            if (m_node->isBinaryInt32UseKind()) {
+                if (m_node->child2()->isInt32Constant()) {
+                    int32_t const2 = m_node->child2()->asInt32();
+                    if (m_node->arithMode() == Arith::CheckOverflow) {
+                        if (const2 != 0 && const2 != -1) {
+                            m_node->setArithMode(Arith::Unchecked);
+                            m_changed = true;
+                        }
+                    }
 
-                int32_t const1 = m_node->child1()->child2()->asInt32();
-                int32_t const2 = m_node->child2()->asInt32();
+                    // On Integers
+                    // In: ArithMod(ArithMod(x, const1), const2)
+                    // Out: Identity(ArithMod(x, const1))
+                    //     if const1 <= const2.
+                    if (m_node->child1()->op() == ArithMod
+                        && m_node->child1()->binaryUseKind() == Int32Use
+                        && m_node->child1()->child2()->isInt32Constant()) {
+                        int32_t const1 = m_node->child1()->child2()->asInt32();
 
-                if (const1 == INT_MIN || const2 == INT_MIN)
-                    break; // std::abs(INT_MIN) is undefined.
+                        if (const1 == INT_MIN || const2 == INT_MIN)
+                            break; // std::abs(INT_MIN) is undefined.
 
-                if (std::abs(const1) <= std::abs(const2))
-                    convertToIdentityOverChild1();
+                        if (std::abs(const1) <= std::abs(const2)) {
+                            convertToIdentityOverChild1();
+                            break;
+                        }
+                    }
+                }
             }
             break;
         }


### PR DESCRIPTION
#### 70445421ecbf658f1036527ccfb3713942494e1f
<pre>
[JSC] Remove MustGenerate from Int32Use / DoubleRepUse ArithDiv / ArithMod
<a href="https://bugs.webkit.org/show_bug.cgi?id=314596">https://bugs.webkit.org/show_bug.cgi?id=314596</a>
<a href="https://rdar.apple.com/176834546">rdar://176834546</a>

Reviewed by Yijia Huang.

Remove MustGenerate from ArithDiv / ArithMod when they have Int32Use / DoubleRepUse.
They are OSR exit checks, not an error. If nobody is using the output of
these nodes (this of-course includes that no MovHint use too), removing them is
totally fine. Only problematic case is these checks are leveraged as an input
constraint in integer-range-optimization phase. We explicitly state this
condition in that phase.

We also add some strength-reduction: if RHS constant is neither 0 nor -1, we never overflow.
So we remove CheckOverflow flag.

Test: JSTests/stress/arith-div-mod-must-generate-clear.js
* JSTests/stress/arith-div-mod-must-generate-clear.js: Added.
(assertEq):
(divUnusedResult):
(modUnusedResult):
(modInt52Unused):
(divDoubleUnused):
(modDoubleUnused):
(const.sideEffectOperand.valueOf):
(divWithSideEffectOperand):
(modPow2InCheckOverflow):
(modPow2PreservesNegZero):
(modNonPow2):
(rangeOptArrayMod):
(storeModUnused):
(sharedMod):
(nestedModPow2):
(ftlHotMod):
(i.ftlResult.ftlHotMod):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupArithDivInt32):
(JSC::DFG::FixupPhase::fixupArithDiv):
(JSC::DFG::FixupPhase::fixupArithMul):
* Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGMayExit.cpp:
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):

Canonical link: <a href="https://commits.webkit.org/313061@main">https://commits.webkit.org/313061@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5f292b7840f8a58fcdd4287a993a6e405f19cd7e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161969 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35444 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28549 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170877 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118340 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4b69c4d0-a353-46af-b8e4-19d964c743d3) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35546 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35445 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125685 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fcc06994-708e-45c6-8151-fde243d773b7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164928 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/27995 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/145481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106268 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d68a509c-6d23-4907-8719-d115426acd9e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27044 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18596 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/154028 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136737 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23235 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173365 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22807 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20456 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24876 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133976 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35117 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29642 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133982 "Passed tests") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35101 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145030 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97207 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24601 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28507 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21855 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194369 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34611 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102096 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50099 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34112 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34354 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34260 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->