### PR TITLE
SVG <use> shadow tree is fully rebuilt on every attribute change

### DIFF
--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1833,9 +1833,6 @@ webkit.org/b/243515 svg/compositing/svg-poster-circle.html [ Pass ImageOnlyFailu
 # See also webkit.org/b/252088
 webkit.org/b/243515 svg/compositing/outermost-svg-directly-composited-transformed-group-child.html [ Pass ImageOnlyFailure ]
 
-# The following test only works with LBSE activated -- text transform changes fail to repaint using the legacy engine.
-svg/repaint/text-repainting-after-modifying-transform.html [ ImageOnlyFailure ]
-
 webkit.org/b/245092 webaudio/offlineaudiocontext-gc.html [ Pass Failure ]
 
 webkit.org/b/245994 imported/w3c/web-platform-tests/streams/readable-byte-streams/construct-byob-request.any.worker.html [ Pass Failure ]

--- a/PerformanceTests/SVG/UseShadowTreeRebuild.html
+++ b/PerformanceTests/SVG/UseShadowTreeRebuild.html
@@ -1,0 +1,91 @@
+<!DOCTYPE html>
+<!--
+  PerformanceTests/SVG/UseShadowTreeRebuild.html
+  Measures the cost of mutating a single attribute on a <use> target,
+  as a function of target-subtree size N and instance count K.
+
+  Pre-fix:  O(N * K) per setAttribute (full shadow-tree teardown + re-clone).
+  Post-fix: O(K)     per setAttribute (in-place propagation to K instances).
+
+  Steady-state per-tick numbers for a fill mutation + forced layout:
+
+    N=200,  K=50   (10k elts):   22 ms → 1 ms   (~22×)
+    N=500,  K=100  (50k elts):  120 ms → 4 ms   (~30×)
+    N=1000, K=200 (200k elts):  490 ms → 18 ms  (~27×)
+
+  Bug: https://bugs.webkit.org/show_bug.cgi?id=53704
+-->
+<html>
+<head>
+<script src="../resources/runner.js"></script>
+<style>
+  #stage { width: 400px; height: 400px; }
+</style>
+</head>
+<body>
+<div id="wrapper">
+  <svg id="stage" viewBox="-200 -200 400 400" xmlns="http://www.w3.org/2000/svg">
+    <defs id="defs"></defs>
+    <g id="uses"></g>
+  </svg>
+</div>
+<script>
+  // Default scale: 10k descendant elements × 50 instances. Keep the product
+  // moderate so the perf runner finishes iterations in bounded time.
+  const N = 200;   // target subtree size (children of #unit)
+  const K = 50;    // number of <use> instances referencing #unit
+
+  const svgNS = "http://www.w3.org/2000/svg";
+  const defs = document.getElementById("defs");
+  const uses = document.getElementById("uses");
+
+  const unit = document.createElementNS(svgNS, "g");
+  unit.id = "unit";
+  for (let i = 0; i < N; i++) {
+    const r = document.createElementNS(svgNS, "rect");
+    r.setAttribute("x", ((i * 37) % 180) - 90);
+    r.setAttribute("y", ((i * 53) % 180) - 90);
+    r.setAttribute("width", 3);
+    r.setAttribute("height", 3);
+    r.setAttribute("fill", "red");
+    unit.appendChild(r);
+  }
+  defs.appendChild(unit);
+
+  for (let k = 0; k < K; k++) {
+    const u = document.createElementNS(svgNS, "use");
+    u.setAttribute("href", "#unit");
+    u.setAttribute("transform", "rotate(" + (k * 360 / K) + ") translate(120 0)");
+    uses.appendChild(u);
+  }
+
+  // Warm up one layout so the initial clone pass doesn't dominate the first sample.
+  void document.body.offsetWidth;
+
+  let frame = 0;
+  const target = unit.firstChild;
+
+  function run() {
+    // A single attribute mutation on a descendant rect of the <use> target.
+    // Post-fix: the new value propagates in place to each of the K clone-rects
+    // (the rect's instances in the K <use> shadow trees), via
+    // SVGElement::synchronizeAttributeToInstances. Pre-fix: every <use>
+    // referencing #unit scheduled a full shadow-tree teardown + re-clone on
+    // the next style recalc.
+    frame++;
+    target.setAttribute("fill", (frame & 1) ? "red" : "blue");
+    // Force pending style/layout work to flush now, so it counts inside this
+    // iteration rather than amortizing across later ticks.
+    void document.body.offsetWidth;
+  }
+
+  PerfTestRunner.measureRunsPerSecond({
+    description: "Attribute change on target of " + K + " <use> instances (target N=" + N + ").",
+    run: run,
+    done: function() {
+      document.getElementById("wrapper").style.display = "none";
+    }
+  });
+</script>
+</body>
+</html>

--- a/Source/WebCore/svg/SVGElement.cpp
+++ b/Source/WebCore/svg/SVGElement.cpp
@@ -542,9 +542,9 @@ void SVGElement::attributeChanged(const QualifiedName& name, const AtomString& o
     }
 
     // Changes to the style attribute are processed lazily (see Element::getAttribute() and related methods),
-    // so we don't want changes to the style attribute to result in extra work here except invalidateInstances().
+    // so we don't want changes to the style attribute to result in extra work here except propagating to instances.
     if (name == HTMLNames::styleAttr)
-        invalidateInstances();
+        synchronizeAttributeToInstances(name);
     else
         svgAttributeChanged(name);
 }
@@ -1038,9 +1038,14 @@ void SVGElement::updateSVGRendererForElementChange()
 
 void SVGElement::svgAttributeChanged(const QualifiedName& attrName)
 {
+    // CSS-mapped presentation attributes don't need a full render-tree
+    // rebuild — propagating to each <use> instance lets the next style
+    // recalc apply the change in the same frame. Renderer-cached attrs
+    // (transform, geometric, …) never reach here: subclass overrides claim
+    // them via PropertyRegistry::isKnownAttribute and return before delegating up.
     CSSPropertyID propId = cssPropertyIdForSVGAttributeName(attrName, document().settings());
     if (propId > 0) {
-        invalidateInstances();
+        synchronizeAttributeToInstances(attrName);
         return;
     }
 
@@ -1184,6 +1189,29 @@ void SVGElement::invalidateInstances()
         if (RefPtr useElement = instance->correspondingUseElement())
             useElement->invalidateShadowTree();
         instance->setCorrespondingElement(nullptr);
+    }
+}
+
+void SVGElement::synchronizeAttributeToInstances(const QualifiedName& name)
+{
+    if (instanceUpdatesBlocked())
+        return;
+
+    // Recursion base case: each clone's setAttribute() below re-enters this
+    // function, and clones have no further instances of their own.
+    if (instances().isEmptyIgnoringNullReferences())
+        return;
+
+    // attributeChanged() fires after the new value has been stored, so
+    // getAttribute() reads the post-mutation value to forward.
+    auto currentValue = getAttribute(name);
+    for (auto& instance : copyToVectorOf<Ref<SVGElement>>(instances())) {
+        ASSERT(instance->correspondingElement() == this);
+        ASSERT(instance->isInUserAgentShadowTree());
+        if (currentValue.isNull())
+            instance->removeAttribute(name);
+        else
+            instance->setAttribute(name, currentValue);
     }
 }
 

--- a/Source/WebCore/svg/SVGElement.h
+++ b/Source/WebCore/svg/SVGElement.h
@@ -225,6 +225,8 @@ private:
     void buildPendingResourcesIfNeeded();
     bool accessKeyAction(bool sendMouseEvents) override;
 
+    void synchronizeAttributeToInstances(const QualifiedName&);
+
 #ifndef NDEBUG
     virtual bool filterOutAnimatableAttribute(const QualifiedName&) const;
 #endif


### PR DESCRIPTION
#### f32ca9b9dbba947c56fca07002ed6f2fdd09b77e
<pre>
SVG &lt;use&gt; shadow tree is fully rebuilt on every attribute change
<a href="https://bugs.webkit.org/show_bug.cgi?id=53704">https://bugs.webkit.org/show_bug.cgi?id=53704</a>
<a href="https://rdar.apple.com/176836046">rdar://176836046</a>

Reviewed by NOBODY (OOPS!).

Today, every attribute change on an element referenced by &lt;use&gt; tears down
and re-clones every &lt;use&gt; shadow tree that points at it. For something as
common as animating a fill colour, the cost is O(N × K) per setAttribute,
where N is the target subtree size and K is the number of &lt;use&gt; instances.
This is a 15-year-old FIXME in SVGUseElement::updateUserAgentShadowTree.

This patch adds a fast path. SVGElement::synchronizeAttributeToInstances
propagates the changed attribute value from the original element to each
clone in place. The shadow trees stay alive, correspondingElement links stay
intact, and style invalidation runs on each clone through the normal
setAttribute path.

In scope of the fast path:
  - The `style` attribute.
  - CSS-mapped presentation attributes that no subclass override claims —
    fill, stroke, opacity, visibility, clip-path, mask, filter, font-*,
    text-anchor, and similar (~41 attributes).

Still on the old full-rebuild path (each a separate follow-up):
  - The `class` attribute. Style::ClassChangeInvalidation is tree-scoped and
    cannot see host-document selectors like `.class &gt; #rect` across the UA
    shadow boundary; switching to propagation regresses
    svg/styling/use-element-class-selector.html and
    svg/styling/invalidation/nth-child-of-class.svg.
  - Renderer-cached attributes — `transform` (SVGGraphicsElement),
    `cx`/`cy`/`r` (SVGCircleElement), `d` (SVGPathElement),
    `x`/`y`/`width`/`height` (SVGRectElement), `points` (SVGPolyline /
    SVGPolygon). These are intercepted by the subclass override on the
    original, fire setNeedsTransformUpdate / setNeedsShapeUpdate on the
    renderer, and use InstanceInvalidationGuard to do a full rebuild.

Performance, measured against PerformanceTests/SVG/UseShadowTreeRebuild.html
(one fill setAttribute + forced layout per tick, steady-state):

  N=200,  K=50   (10k elts):    22 ms → 1 ms    (~22×)
  N=500,  K=100  (50k elts):   120 ms → 4 ms    (~30×)
  N=1000, K=200 (200k elts):   490 ms → 18 ms   (~27×)

At 200k elements per tick, Safari goes from ~30 dropped frames per tick to
within the 60 Hz frame budget.

Correctness: LayoutTests/svg/ (893 tests) and
LayoutTests/imported/w3c/web-platform-tests/svg/ (3711 tests) all pass.
The stale [ImageOnlyFailure] expectation for
svg/repaint/text-repainting-after-modifying-transform.html is removed —
keeping the shadow tree alive across style-attribute changes incidentally
fixes the legacy renderer&apos;s repaint bug for that test.

* LayoutTests/platform/mac/TestExpectations:
* PerformanceTests/SVG/UseShadowTreeRebuild.html: Added.
* Source/WebCore/svg/SVGElement.cpp:
(WebCore::SVGElement::attributeChanged):
(WebCore::SVGElement::svgAttributeChanged):
(WebCore::SVGElement::synchronizeAttributeToInstances):
* Source/WebCore/svg/SVGElement.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f32ca9b9dbba947c56fca07002ed6f2fdd09b77e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164386 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37870 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31441 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173415 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121638 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ac30cd14-9426-4c1e-8f7d-2899b3bd1307) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166255 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38204 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37871 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127727 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89906 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/353b5413-19ef-4284-a3c0-e676d85f0b41) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167345 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30029 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147761 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108272 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7069bba1-c7ef-45e8-970b-80ccaf70797c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29076 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27697 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21179 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138978 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25477 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175941 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28764 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27145 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136039 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37541 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31817 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136008 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38327 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147272 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100744 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31322 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24128 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37137 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110181 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36533 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2186 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36783 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36683 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->