### PR TITLE
WKAttachmentTestsMac.DraggingAttachmentBackedImagePreservesRangedSelection is a constant failure in some configurations

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKAttachmentTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKAttachmentTests.mm
@@ -1967,9 +1967,13 @@ TEST(WKAttachmentTestsMac, DraggingAttachmentBackedImagePreservesRangedSelection
 
     [webView mouseDragToPoint:CGPointMake(150, 150)];
     [webView mouseDragToPoint:CGPointMake(200, 150)];
-    [webView waitForPendingMouseEvents];
 
-    [webView mouseUpAtPoint:CGPointMake(200, 150)];
+    // Dragging here causes the WCP to initiate a drag session whose modal loop
+    // blocks on [NSApp nextEventMatchingMask:...]. We need to post a mouse-up to
+    // the event queue so the drag loop can terminate; the test helpers are insufficent
+    // since they bypass the queue via direct [NSWindow sendEvent:] dispatch.
+    // Fundamentally the same workaround done for WK1 in Pasteboard::setDragImage.
+    [NSApp postEvent:[NSEvent mouseEventWithType:NSEventTypeLeftMouseUp location:NSMakePoint(200, 150) modifierFlags:0 timestamp:[webView eventTimestamp] windowNumber:[[webView window] windowNumber] context:nil eventNumber:0 clickCount:1 pressure:0] atStart:NO];
     [webView waitForPendingMouseEvents];
 
     EXPECT_WK_STREQ("Range", [webView stringByEvaluatingJavaScript:@"getSelection().type"]);


### PR DESCRIPTION
#### b8f7b64ba81ecd34c0070b2da6222ab1fe37cb8a
<pre>
WKAttachmentTestsMac.DraggingAttachmentBackedImagePreservesRangedSelection is a constant failure in some configurations
<a href="https://bugs.webkit.org/show_bug.cgi?id=314601">https://bugs.webkit.org/show_bug.cgi?id=314601</a>
<a href="https://rdar.apple.com/176587027">rdar://176587027</a>

Reviewed by Richard Robinson.

The test was stuck because mouseDragToPoint: triggers an AppKit drag
session whose modal loop blocks on [NSApp nextEventMatchingMask:...],
but the mouseUpAtPoint: helper uses [NSWindow sendEvent:], which goes
straight to the view (bypassing the event queue).

To fix this issue, we post a mouseUp event to the NSApp event queue so
the drag loop can terminate.

This mirrors the established pattern in Pasteboard::setDragImage (WK1) of
posting events to wake NSDragManager out of its nextEvent call. Note
that this is not necessary in product code becase WindowServer
continuously feeds the app&apos;s event queue. When the user releases the
mouse, a real mouseUp arrives in the queue and the drag loop picks it up
naturally.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKAttachmentTests.mm:
(TestWebKitAPI::TEST(WKAttachmentTestsMac, DraggingAttachmentBackedImagePreservesRangedSelection)):

Canonical link: <a href="https://commits.webkit.org/313084@main">https://commits.webkit.org/313084@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/34813ad5c778e96d5fda40aba4b24c918d5e6b2e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162000 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35475 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28580 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170908 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118371 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163869 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35577 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35476 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125713 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164959 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28024 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145506 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106295 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27073 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25586 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18628 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136767 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23260 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173396 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24901 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134004 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35148 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29671 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134010 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35132 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145055 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97254 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24611 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28534 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21880 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34642 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34143 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34385 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34291 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->