### PR TITLE
AX: Represent popup value as an enum to avoid string allocation in hasPopup()

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -1157,25 +1157,24 @@ bool AXCoreObject::isRadioInput() const
     return type ? *type == InputType::Type::Radio : false;
 }
 
-String AXCoreObject::popupValue() const
+String AXCoreObject::popupValueString() const
 {
-    String explicitValue = explicitPopupValue();
-    if (!explicitValue.isEmpty())
-        return explicitValue;
-
-    // In ARIA 1.1, the implicit value for combobox became "listbox."
-    if (isComboBox())
+    switch (popupValue()) {
+    case AccessibilityPopupValue::False:
+        return "false"_s;
+    case AccessibilityPopupValue::True:
+    case AccessibilityPopupValue::Menu:
+        return "menu"_s;
+    case AccessibilityPopupValue::Listbox:
         return "listbox"_s;
-
-    // The spec states that "User agents must treat any value of aria-haspopup that is not
-    // included in the list of allowed values, including an empty string, as if the value
-    // false had been provided."
+    case AccessibilityPopupValue::Tree:
+        return "tree"_s;
+    case AccessibilityPopupValue::Grid:
+        return "grid"_s;
+    case AccessibilityPopupValue::Dialog:
+        return "dialog"_s;
+    }
     return "false"_s;
-}
-
-bool AXCoreObject::hasPopup() const
-{
-    return !equalLettersIgnoringASCIICase(popupValue(), "false"_s);
 }
 
 bool AXCoreObject::selfOrAncestorLinkHasPopup() const

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -187,7 +187,17 @@ enum class AccessibilityObjectInclusion : uint8_t {
     DefaultBehavior,
 };
 
-enum class AccessibilityCurrentState { False, True, Page, Step, Location, Date, Time };
+enum class AccessibilityCurrentState : uint8_t { False, True, Page, Step, Location, Date, Time };
+
+enum class AccessibilityPopupValue : uint8_t {
+    False,
+    True,
+    Menu,
+    Listbox,
+    Tree,
+    Grid,
+    Dialog,
+};
 
 enum class AccessibilityButtonState {
     Off = 0,
@@ -803,10 +813,10 @@ public:
     virtual bool containsOnlyStaticText() const;
     bool isStaticTextLabel() const { return role() == AccessibilityRole::Label && containsOnlyStaticText(); }
 
-    bool hasPopup() const;
+    bool hasPopup() const { return popupValue() != AccessibilityPopupValue::False; }
     bool selfOrAncestorLinkHasPopup() const;
-    virtual String explicitPopupValue() const = 0;
-    String popupValue() const;
+    virtual AccessibilityPopupValue popupValue() const = 0;
+    String popupValueString() const;
     virtual bool supportsHasPopup() const = 0;
     virtual bool pressedIsPresent() const = 0;
     virtual String explicitInvalidStatus() const = 0;

--- a/Source/WebCore/accessibility/AXLogger.cpp
+++ b/Source/WebCore/accessibility/AXLogger.cpp
@@ -819,9 +819,6 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
     case AXProperty::ExplicitOrientation:
         stream << "ExplicitOrientation";
         break;
-    case AXProperty::ExplicitPopupValue:
-        stream << "ExplicitPopupValue";
-        break;
     case AXProperty::ExtendedDescription:
         stream << "ExtendedDescription";
         break;
@@ -1138,6 +1135,9 @@ TextStream& operator<<(WTF::TextStream& stream, AXProperty property)
         stream << "PlatformWidget";
         break;
 #endif
+    case AXProperty::PopupValue:
+        stream << "PopupValue";
+        break;
     case AXProperty::PosInSet:
         stream << "PosInSet";
         break;

--- a/Source/WebCore/accessibility/AccessibilityObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityObject.cpp
@@ -3468,26 +3468,31 @@ bool AccessibilityObject::supportsHasPopup() const
     return hasAttribute(aria_haspopupAttr) || isComboBox();
 }
 
-String AccessibilityObject::explicitPopupValue() const
+AccessibilityPopupValue AccessibilityObject::popupValue() const
 {
     auto& hasPopup = getAttribute(aria_haspopupAttr);
     if (hasPopup.isEmpty()) {
-        // In ARIA 1.1, the implicit value for datalists became "listbox."
         if (hasDatalist())
-            return "listbox"_s;
-        return { };
+            return AccessibilityPopupValue::Listbox;
+        if (isComboBox())
+            return AccessibilityPopupValue::Listbox;
+        return AccessibilityPopupValue::False;
     }
 
-    for (auto& value : { "menu"_s, "listbox"_s, "tree"_s, "grid"_s, "dialog"_s }) {
-        // FIXME: Should fix ambiguity so we don't have to write "characters", but also don't create/destroy a String when passing an ASCIILiteral to equalIgnoringASCIICase.
-        if (equalIgnoringASCIICase(hasPopup, value))
-            return value;
-    }
-
-    // aria-haspopup specification states that true must be treated as menu.
+    if (equalLettersIgnoringASCIICase(hasPopup, "menu"_s))
+        return AccessibilityPopupValue::Menu;
+    if (equalLettersIgnoringASCIICase(hasPopup, "listbox"_s))
+        return AccessibilityPopupValue::Listbox;
+    if (equalLettersIgnoringASCIICase(hasPopup, "tree"_s))
+        return AccessibilityPopupValue::Tree;
+    if (equalLettersIgnoringASCIICase(hasPopup, "grid"_s))
+        return AccessibilityPopupValue::Grid;
+    if (equalLettersIgnoringASCIICase(hasPopup, "dialog"_s))
+        return AccessibilityPopupValue::Dialog;
     if (equalLettersIgnoringASCIICase(hasPopup, "true"_s))
-        return "menu"_s;
-    return { };
+        return AccessibilityPopupValue::Menu;
+
+    return AccessibilityPopupValue::False;
 }
 
 bool AccessibilityObject::supportsSetSize() const

--- a/Source/WebCore/accessibility/AccessibilityObject.h
+++ b/Source/WebCore/accessibility/AccessibilityObject.h
@@ -318,7 +318,7 @@ public:
 
     bool supportsARIAOwns() const override { return false; }
 
-    String explicitPopupValue() const final;
+    AccessibilityPopupValue popupValue() const final;
     bool hasDatalist() const;
     bool supportsHasPopup() const final;
     bool pressedIsPresent() const final;

--- a/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp
@@ -907,7 +907,7 @@ HashMap<String, String> AccessibilityObjectAtspi::attributes() const
         map.add("autocomplete"_s, m_coreObject->autoCompleteValue());
 
     if (m_coreObject->supportsHasPopup())
-        map.add("haspopup"_s, m_coreObject->popupValue());
+        map.add("haspopup"_s, m_coreObject->popupValueString());
 
     if (m_coreObject->supportsCurrent())
         map.add("current"_s, m_coreObject->currentValue());

--- a/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
+++ b/Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm
@@ -599,7 +599,7 @@ struct AccessibilityElementsResult {
     if (![self _prepareAccessibilityCall])
         return nil;
 
-    return self.axBackingObject->popupValue().createNSString().autorelease();
+    return self.axBackingObject->popupValueString().createNSString().autorelease();
 }
 
 - (BOOL)accessibilityIsInDescriptionListDefinition

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -310,7 +310,7 @@ private:
     int layoutCount() const final;
     double loadingProgress() const final { return tree().loadingProgress(); }
     bool supportsARIAOwns() const final { return boolAttributeValue(AXProperty::SupportsARIAOwns); }
-    String explicitPopupValue() const final { return stringAttributeValue(AXProperty::ExplicitPopupValue); }
+    AccessibilityPopupValue popupValue() const final { return static_cast<AccessibilityPopupValue>(intAttributeValue(AXProperty::PopupValue)); }
     bool pressedIsPresent() const final;
     String explicitInvalidStatus() const final { return stringAttributeValue(AXProperty::ExplicitInvalidStatus); }
     bool supportsExpanded() const final { return boolAttributeValue(AXProperty::SupportsExpanded); }

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -2167,7 +2167,7 @@ IsolatedObjectData createIsolatedObjectData(const Ref<AccessibilityObject>& axOb
         setProperty(AXProperty::MaxValueForRange, object.maxValueForRange());
         setProperty(AXProperty::MinValueForRange, object.minValueForRange());
         setProperty(AXProperty::SupportsARIAOwns, object.supportsARIAOwns());
-        setProperty(AXProperty::ExplicitPopupValue, object.explicitPopupValue().isolatedCopy());
+        setProperty(AXProperty::PopupValue, static_cast<int>(object.popupValue()));
         setProperty(AXProperty::ExplicitInvalidStatus, object.explicitInvalidStatus().isolatedCopy());
         setProperty(AXProperty::SupportsExpanded, object.supportsExpanded());
         setProperty(AXProperty::SortDirection, static_cast<int>(object.sortDirection()));

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -181,7 +181,6 @@ enum class AXProperty : uint16_t {
     ExplicitLiveRegionRelevant,
     ExplicitLiveRegionStatus,
     ExplicitOrientation,
-    ExplicitPopupValue,
     ExtendedDescription,
 #if PLATFORM(COCOA)
     Font,
@@ -269,6 +268,7 @@ enum class AXProperty : uint16_t {
 #if PLATFORM(COCOA)
     PlatformWidget,
 #endif
+    PopupValue,
     PosInSet,
     PreventKeyboardDOMEventDispatch,
     RadioButtonGroupMembers,

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -1484,7 +1484,7 @@ static id handleRequiredAttribute(WebAccessibilityObjectWrapper*, AXCoreObject& 
 
 static id handlePopupValueAttribute(WebAccessibilityObjectWrapper*, AXCoreObject& backingObject)
 {
-    return backingObject.popupValue().createNSString().autorelease();
+    return backingObject.popupValueString().createNSString().autorelease();
 }
 
 static id handleInvalidAttribute(WebAccessibilityObjectWrapper*, AXCoreObject& backingObject)


### PR DESCRIPTION
#### 3758cfaf08eb56e69ac1344a9e456c61b55af639
<pre>
AX: Represent popup value as an enum to avoid string allocation in hasPopup()
<a href="https://bugs.webkit.org/show_bug.cgi?id=314605">https://bugs.webkit.org/show_bug.cgi?id=314605</a>
<a href="https://rdar.apple.com/176848676">rdar://176848676</a>

Reviewed by Dominic Mazzoni.

Replace String-returning popupValue() / explicitPopupValue() with a single
virtual popupValue() returning AccessibilityPopupValue (uint8_t enum).
hasPopup() becomes an inline enum comparison with zero allocation.
This string allocation showed up in samples taken while using VoiceOver
on a webpage.

Platform callers (iOS, Mac, ATSPI) now use popupValueString(), which converts
the enum to a static ASCIILiteral at the API boundary. The isolated tree caches
the enum as an int rather than a String.

* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::popupValueString const):
(WebCore::AXCoreObject::popupValue const): Deleted.
(WebCore::AXCoreObject::hasPopup const): Deleted.
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::AXCoreObject::hasPopup const):
* Source/WebCore/accessibility/AXLogger.cpp:
(WebCore::operator&lt;&lt;):
* Source/WebCore/accessibility/AccessibilityObject.cpp:
(WebCore::AccessibilityObject::popupValue const):
(WebCore::AccessibilityObject::explicitPopupValue const): Deleted.
* Source/WebCore/accessibility/AccessibilityObject.h:
* Source/WebCore/accessibility/atspi/AccessibilityObjectAtspi.cpp:
(WebCore::AccessibilityObjectAtspi::attributes const):
* Source/WebCore/accessibility/ios/WebAccessibilityObjectWrapperIOS.mm:
(-[WebAccessibilityObjectWrapper accessibilityPopupValue]):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::createIsolatedObjectData):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(handlePopupValueAttribute):

Canonical link: <a href="https://commits.webkit.org/313102@main">https://commits.webkit.org/313102@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5876c3060220c5154ed119d75dd2fd74381062b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161982 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35457 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28562 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170890 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118353 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163851 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35559 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35458 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125697 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88571 "17 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164941 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28011 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145495 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106279 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27060 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25571 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18610 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136753 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23249 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173378 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20469 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24890 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/133986 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35130 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29656 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133992 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/36200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35114 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145044 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97233 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28521 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21869 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34624 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102109 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34125 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34367 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34273 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->