### PR TITLE
Differential text-alignment while stretching

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -2726,6 +2726,11 @@ imported/w3c/web-platform-tests/svg/text/reftests/text-shape-inside-002.svg [ Im
 imported/w3c/web-platform-tests/svg/text/reftests/text-xml-space-001.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/text/reftests/textpath-side-001.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/text/reftests/text-font-face-load-image.html [ Skip ]
+
+# webkit.org/b/61855: textLength with lengthAdjust="spacing" and a list-valued
+# x/y attribute still produces per-chunk div-by-zero and silently drops
+# textLength. Pinned here until the spacing-mode follow-up patch lands.
+imported/w3c/web-platform-tests/svg/text/reftests/textLength-list-y-spacing.svg [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/styling/css-linked-parameters/css-linked-parameters-precedence-1.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/styling/css-linked-parameters/css-linked-parameters-precedence-2.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/svg/styling/css-linked-parameters/img-with-linked-parameters-1.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/textLength-list-x-spacingAndGlyphs-expected.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/textLength-list-x-spacingAndGlyphs-expected.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml" viewBox="0 0 400 100"
+     class="reftest-wait"
+     onload="document.fonts.ready.then(function() { document.documentElement.classList.remove('reftest-wait'); })">
+  <metadata>
+    <h:link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+  </metadata>
+  <text x="0" y="80"
+        font-family="Ahem" font-size="50"
+        textLength="400" lengthAdjust="spacingAndGlyphs"
+        fill="black">XXXXXXXXXXXX</text>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/textLength-list-x-spacingAndGlyphs-ref.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/textLength-list-x-spacingAndGlyphs-ref.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml" viewBox="0 0 400 100"
+     class="reftest-wait"
+     onload="document.fonts.ready.then(function() { document.documentElement.classList.remove('reftest-wait'); })">
+  <metadata>
+    <h:link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+  </metadata>
+  <text x="0" y="80"
+        font-family="Ahem" font-size="50"
+        textLength="400" lengthAdjust="spacingAndGlyphs"
+        fill="black">XXXXXXXXXXXX</text>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/textLength-list-x-spacingAndGlyphs.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/textLength-list-x-spacingAndGlyphs.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml" viewBox="0 0 400 100"
+     class="reftest-wait"
+     onload="document.fonts.ready.then(function() { document.documentElement.classList.remove('reftest-wait'); })">
+  <metadata>
+    <title>textLength with lengthAdjust=spacingAndGlyphs applies across all glyphs of the element when x is a list of values</title>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextElementTextLengthAttribute"/>
+    <h:link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=61855"/>
+    <h:link rel="match" href="textLength-list-x-spacingAndGlyphs-ref.svg"/>
+    <h:link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+  </metadata>
+  <!-- Same as the y-list case but with x supplied per glyph. The explicit x
+       values match the natural advance positions for 50px Ahem ("X" = 50 units
+       wide), so visual positioning without textLength would be identical to
+       the reference. What differs is chunk-formation: WebKit starts a new chunk
+       at each explicit x, giving 12 chunks. textLength must still apply
+       element-wide; the reference below uses a single-value x (one chunk). -->
+  <text x="0 50 100 150 200 250 300 350 400 450 500 550" y="80"
+        font-family="Ahem" font-size="50"
+        textLength="400" lengthAdjust="spacingAndGlyphs"
+        fill="black">XXXXXXXXXXXX</text>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/textLength-list-y-spacing-expected.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/textLength-list-y-spacing-expected.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml" viewBox="0 0 400 100"
+     class="reftest-wait"
+     onload="document.fonts.ready.then(function() { document.documentElement.classList.remove('reftest-wait'); })">
+  <metadata>
+    <h:link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+  </metadata>
+  <text x="0" y="80"
+        font-family="Ahem" font-size="50"
+        textLength="400" lengthAdjust="spacing"
+        fill="black">XXXXXX</text>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/textLength-list-y-spacing-ref.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/textLength-list-y-spacing-ref.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml" viewBox="0 0 400 100"
+     class="reftest-wait"
+     onload="document.fonts.ready.then(function() { document.documentElement.classList.remove('reftest-wait'); })">
+  <metadata>
+    <h:link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+  </metadata>
+  <text x="0" y="80"
+        font-family="Ahem" font-size="50"
+        textLength="400" lengthAdjust="spacing"
+        fill="black">XXXXXX</text>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/textLength-list-y-spacing.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/textLength-list-y-spacing.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml" viewBox="0 0 400 100"
+     class="reftest-wait"
+     onload="document.fonts.ready.then(function() { document.documentElement.classList.remove('reftest-wait'); })">
+  <metadata>
+    <title>textLength with lengthAdjust=spacing applies across all glyphs of the element when y is a list of identical values</title>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextElementTextLengthAttribute"/>
+    <h:link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=61855"/>
+    <h:link rel="match" href="textLength-list-y-spacing-ref.svg"/>
+    <h:link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+  </metadata>
+  <!-- Same as the spacingAndGlyphs case but with lengthAdjust="spacing".
+       Currently expected to FAIL in WebKit: for list-valued y each chunk
+       contains a single character, so per-chunk shift computation divides
+       by (totalCharacters - 1) = 0 and collapses to zero shift — textLength
+       is silently ignored. Follow-up tracked as webkit.org/b/61855 (spacing
+       follow-up) / FIXME in SVGTextChunkBuilder::applyElementLevelTextLength. -->
+  <text x="0" y="80 80 80 80 80 80"
+        font-family="Ahem" font-size="50"
+        textLength="400" lengthAdjust="spacing"
+        fill="black">XXXXXX</text>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/textLength-list-y-spacingAndGlyphs-expected.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/textLength-list-y-spacingAndGlyphs-expected.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml" viewBox="0 0 400 100"
+     class="reftest-wait"
+     onload="document.fonts.ready.then(function() { document.documentElement.classList.remove('reftest-wait'); })">
+  <metadata>
+    <h:link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+  </metadata>
+  <text x="0" y="80"
+        font-family="Ahem" font-size="50"
+        textLength="400" lengthAdjust="spacingAndGlyphs"
+        fill="black">XXXXXXXXXXXX</text>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/textLength-list-y-spacingAndGlyphs-ref.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/textLength-list-y-spacingAndGlyphs-ref.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml" viewBox="0 0 400 100"
+     class="reftest-wait"
+     onload="document.fonts.ready.then(function() { document.documentElement.classList.remove('reftest-wait'); })">
+  <metadata>
+    <h:link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+  </metadata>
+  <text x="0" y="80"
+        font-family="Ahem" font-size="50"
+        textLength="400" lengthAdjust="spacingAndGlyphs"
+        fill="black">XXXXXXXXXXXX</text>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/textLength-list-y-spacingAndGlyphs.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/textLength-list-y-spacingAndGlyphs.svg
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" xmlns:h="http://www.w3.org/1999/xhtml" viewBox="0 0 400 100"
+     class="reftest-wait"
+     onload="document.fonts.ready.then(function() { document.documentElement.classList.remove('reftest-wait'); })">
+  <metadata>
+    <title>textLength with lengthAdjust=spacingAndGlyphs applies across all glyphs of the element when y is a list of identical values</title>
+    <h:link rel="help" href="https://svgwg.org/svg2-draft/text.html#TextElementTextLengthAttribute"/>
+    <h:link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=61855"/>
+    <h:link rel="match" href="textLength-list-y-spacingAndGlyphs-ref.svg"/>
+    <h:link rel="stylesheet" type="text/css" href="/fonts/ahem.css"/>
+  </metadata>
+  <!-- A list-valued y attribute splits the element into one chunk per listed
+       value in WebKit's internal representation. textLength is specified on the
+       'text' element, so it must apply across all glyphs of the element, not
+       per internal chunk. This test gives y twelve identical values — the
+       visual result must be identical to supplying a single y value, since
+       every glyph is targeted at the same baseline. -->
+  <text x="0" y="80 80 80 80 80 80 80 80 80 80 80 80"
+        font-family="Ahem" font-size="50"
+        textLength="400" lengthAdjust="spacingAndGlyphs"
+        fill="black">XXXXXXXXXXXX</text>
+</svg>

--- a/Source/WebCore/rendering/svg/SVGTextChunk.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextChunk.cpp
@@ -57,6 +57,7 @@ SVGTextChunk::SVGTextChunk(const Vector<InlineIterator::SVGTextBoxIterator>& lin
     }
 
     if (RefPtr textContentElement = SVGTextContentElement::elementFromRenderer(firstBox->renderer().parent())) {
+        m_textContentElement = textContentElement.get();
         SVGLengthContext lengthContext(textContentElement.get());
         m_desiredTextLength = textContentElement->specifiedTextLength().value(lengthContext);
 
@@ -129,7 +130,8 @@ float SVGTextChunk::totalAnchorShift() const
 
 void SVGTextChunk::layout(SVGChunkTransformMap& textBoxTransformations) const
 {
-    if (hasDesiredTextLength()) {
+    // ElementGroup mode: textLength was already applied by SVGTextChunkBuilder. webkit.org/b/61855.
+    if (hasDesiredTextLength() && m_textLengthLayoutMode == TextLengthLayoutMode::SingleChunk) {
         if (hasLengthAdjustSpacing())
             processTextLengthSpacingCorrection();
         else {

--- a/Source/WebCore/rendering/svg/SVGTextChunk.h
+++ b/Source/WebCore/rendering/svg/SVGTextChunk.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include "InlineIteratorSVGTextBox.h"
+#include <wtf/CheckedPtr.h>
 #include <wtf/HashMap.h>
 #include <wtf/OptionSet.h>
 #include <wtf/Vector.h>
@@ -29,6 +30,7 @@ namespace WebCore {
 
 class AffineTransform;
 class SVGInlineTextBox;
+class SVGTextContentElement;
 
 using SVGChunkTransformMap = HashMap<InlineIterator::SVGTextBox::Key, AffineTransform>;
 using SVGTextFragmentMap = HashMap<InlineIterator::SVGTextBox::Key, Vector<SVGTextFragment>>;
@@ -44,6 +46,8 @@ public:
     void layout(SVGChunkTransformMap&) const;
 
 private:
+    friend class SVGTextChunkBuilder;
+
     enum class ChunkStyle : uint8_t {
         MiddleAnchor = 1 << 0,
         EndAnchor = 1 << 1,
@@ -78,8 +82,18 @@ private:
     };
     Vector<BoxAndFragments> m_boxes;
 
+    // Owner used by SVGTextChunkBuilder to group chunks for element-level textLength. webkit.org/b/61855.
+    CheckedPtr<const SVGTextContentElement> m_textContentElement;
+
     float m_desiredTextLength { 0 };
     OptionSet<ChunkStyle> m_chunkStyle;
+
+    // ElementGroup: textLength applied by SVGTextChunkBuilder; layout() must skip per-chunk scaling.
+    enum class TextLengthLayoutMode : uint8_t {
+        SingleChunk,
+        ElementGroup
+    };
+    TextLengthLayoutMode m_textLengthLayoutMode { TextLengthLayoutMode::SingleChunk };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/svg/SVGTextChunkBuilder.cpp
+++ b/Source/WebCore/rendering/svg/SVGTextChunkBuilder.cpp
@@ -21,10 +21,13 @@
 #include "config.h"
 #include "SVGTextChunkBuilder.h"
 
+#include "AffineTransform.h"
 #include "SVGElement.h"
 #include "SVGInlineTextBox.h"
 #include "SVGLengthContext.h"
+#include "SVGTextContentElement.h"
 #include "SVGTextFragment.h"
+#include <wtf/HashMap.h>
 
 namespace WebCore {
 
@@ -91,10 +94,69 @@ void SVGTextChunkBuilder::layoutTextChunks(const Vector<InlineIterator::SVGTextB
     if (m_textChunks.isEmpty())
         return;
 
+    applyElementLevelTextLength();
+
     for (const auto& chunk : m_textChunks)
         chunk.layout(m_textBoxTransformations);
 
     m_textChunks.clear();
+}
+
+void SVGTextChunkBuilder::applyElementLevelTextLength()
+{
+    if (m_textChunks.size() < 2)
+        return;
+
+    HashMap<CheckedRef<const SVGTextContentElement>, Vector<SVGTextChunk*>> chunksByOwner;
+    for (auto& chunk : m_textChunks) {
+        if (!chunk.hasDesiredTextLength() || !chunk.m_textContentElement)
+            continue;
+        chunksByOwner.add(CheckedRef { *chunk.m_textContentElement }, Vector<SVGTextChunk*> { }).iterator->value.append(&chunk);
+    }
+
+    for (auto& [owner, chunks] : chunksByOwner) {
+        if (chunks.size() < 2)
+            continue;
+
+        auto* representative = chunks.first();
+
+        // FIXME: webkit.org/b/61855 — extend to lengthAdjust="spacing".
+        if (!representative->hasLengthAdjustSpacingAndGlyphs())
+            continue;
+
+        // Sum of glyph advances across the element (SVG2 §11.10).
+        float groupTotalLength = 0;
+        const SVGTextFragment* groupFirstFragment = nullptr;
+        for (auto* chunk : chunks) {
+            groupTotalLength += chunk->totalLength();
+            if (groupFirstFragment)
+                continue;
+            for (const auto& boxAndFragments : chunk->m_boxes) {
+                if (!boxAndFragments.fragments.isEmpty()) {
+                    groupFirstFragment = &boxAndFragments.fragments.first();
+                    break;
+                }
+            }
+        }
+
+        if (!groupFirstFragment || groupTotalLength <= 0)
+            continue;
+
+        float scale = representative->desiredTextLength() / groupTotalLength;
+        AffineTransform transform;
+        transform.translate(groupFirstFragment->x, groupFirstFragment->y);
+        if (representative->isVerticalText())
+            transform.scaleNonUniform(1, scale);
+        else
+            transform.scaleNonUniform(scale, 1);
+        transform.translate(-groupFirstFragment->x, -groupFirstFragment->y);
+
+        for (auto* chunk : chunks) {
+            for (const auto& boxAndFragments : chunk->m_boxes)
+                m_textBoxTransformations.set(makeKey(*boxAndFragments.box), transform);
+            chunk->m_textLengthLayoutMode = SVGTextChunk::TextLengthLayoutMode::ElementGroup;
+        }
+    }
 }
 
 }

--- a/Source/WebCore/rendering/svg/SVGTextChunkBuilder.h
+++ b/Source/WebCore/rendering/svg/SVGTextChunkBuilder.h
@@ -51,6 +51,12 @@ public:
     void layoutTextChunks(const Vector<InlineIterator::SVGTextBoxIterator>& lineLayoutBoxes, const HashSet<InlineIterator::SVGTextBox::Key>& chunkStarts, SVGTextFragmentMap&);
 
 private:
+    // SVG2 §11.10: applies 'textLength' across all chunks of an owning element when
+    // list-valued x/y splits it into per-glyph chunks. spacingAndGlyphs only;
+    // spacing, nested tspan textLength, inline-size, and forced line breaks are
+    // still per-chunk. webkit.org/b/61855.
+    void applyElementLevelTextLength();
+
     Vector<SVGTextChunk> m_textChunks;
     SVGChunkTransformMap m_textBoxTransformations;
 };


### PR DESCRIPTION
#### 6edbf3f983bd75b1ca65ebecdf0c812b404b48d5
<pre>
Differential text-alignment while stretching
<a href="https://bugs.webkit.org/show_bug.cgi?id=61855">https://bugs.webkit.org/show_bug.cgi?id=61855</a>
<a href="https://rdar.apple.com/94161279">rdar://94161279</a>

Reviewed by Nikolas Zimmermann.

When an SVG &lt;text&gt; or &lt;tspan&gt; carries a list-valued x or y attribute,
WebKit splits its content into one chunk per listed value. Each
SVGTextChunk independently carried the element&apos;s textLength and applied
lengthAdjust=&quot;spacingAndGlyphs&quot; on its own, so every glyph was scaled to
fill the full target length — the glyphs piled up on top of each other
and rendered as a horizontal black bar.

Firefox and Chrome render it correctly.

SVG 2 §11.10 scopes textLength to &quot;this element&quot;: &quot;the adjustments on
all character data within this element are controlled by the value of
&apos;textLength&apos; on this element exclusively&quot;. Apply
lengthAdjust=&quot;spacingAndGlyphs&quot; once across the group of chunks that
share an owning text content element: compute one scale and one pivot
over the group, write a single transform to every box in every chunk,
and skip per-chunk textLength application for the group. Single-chunk
elements (the common case) keep the existing fast path unchanged.

Three related cases remain unhandled and are pinned with FIXME + WPT:
* lengthAdjust=&quot;spacing&quot; with list-valued x/y,
* nested &lt;tspan textLength&gt; inside &lt;text textLength&gt;,
* and the inline-size / forced-line-break guards that per §11.10 disable
  textLength entirely.

Tests: imported/w3c/web-platform-tests/svg/text/reftests/textLength-list-x-spacingAndGlyphs-expected.svg
       imported/w3c/web-platform-tests/svg/text/reftests/textLength-list-x-spacingAndGlyphs-ref.svg
       imported/w3c/web-platform-tests/svg/text/reftests/textLength-list-x-spacingAndGlyphs.svg
       imported/w3c/web-platform-tests/svg/text/reftests/textLength-list-y-spacing-expected.svg
       imported/w3c/web-platform-tests/svg/text/reftests/textLength-list-y-spacing-ref.svg
       imported/w3c/web-platform-tests/svg/text/reftests/textLength-list-y-spacing.svg
       imported/w3c/web-platform-tests/svg/text/reftests/textLength-list-y-spacingAndGlyphs-expected.svg
       imported/w3c/web-platform-tests/svg/text/reftests/textLength-list-y-spacingAndGlyphs-ref.svg
       imported/w3c/web-platform-tests/svg/text/reftests/textLength-list-y-spacingAndGlyphs.svg

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/textLength-list-x-spacingAndGlyphs-expected.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/textLength-list-x-spacingAndGlyphs-ref.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/textLength-list-x-spacingAndGlyphs.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/textLength-list-y-spacing-expected.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/textLength-list-y-spacing-ref.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/textLength-list-y-spacing.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/textLength-list-y-spacingAndGlyphs-expected.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/textLength-list-y-spacingAndGlyphs-ref.svg: Added.
* LayoutTests/imported/w3c/web-platform-tests/svg/text/reftests/textLength-list-y-spacingAndGlyphs.svg: Added.
* Source/WebCore/rendering/svg/SVGTextChunk.cpp:
(WebCore::SVGTextChunk::SVGTextChunk):
(WebCore::SVGTextChunk::layout const):
* Source/WebCore/rendering/svg/SVGTextChunk.h:
* Source/WebCore/rendering/svg/SVGTextChunkBuilder.cpp:
(WebCore::SVGTextChunkBuilder::layoutTextChunks):
(WebCore::SVGTextChunkBuilder::applyElementLevelTextLength):
* Source/WebCore/rendering/svg/SVGTextChunkBuilder.h:

Canonical link: <a href="https://commits.webkit.org/315146@main">https://commits.webkit.org/315146@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e89704dce79268fd76e89b0f3ff8506c7b20180

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168118 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41616 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35213 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177446 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125819 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/37d010a6-4c73-427b-93e8-946bf43f675a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169984 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42050 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41630 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130815 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/05f23826-b6cc-4c08-81d6-bce6d1e42333) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171077 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33289 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151082 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111327 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/164acd60-d4f1-4c89-b7bf-0aa688da71d8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32274 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30977 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26142 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142260 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180046 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32769 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30490 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139248 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41687 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35136 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139116 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37486 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42375 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150562 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105730 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34406 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27449 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40879 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114135 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40276 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5545 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40527 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40421 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->