### PR TITLE
[CMake] Build TestWebKitAPI.wkbundle on Mac

### DIFF
--- a/Tools/TestWebKitAPI/InjectedBundle/cocoa/WebProcessPlugIn/Info.plist
+++ b/Tools/TestWebKitAPI/InjectedBundle/cocoa/WebProcessPlugIn/Info.plist
@@ -7,11 +7,11 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>en</string>
 	<key>CFBundleExecutable</key>
-	<string>$(EXECUTABLE_NAME)</string>
+	<string>${EXECUTABLE_NAME}</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
-	<string>$(PRODUCT_NAME)</string>
+	<string>${PRODUCT_NAME}</string>
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>

--- a/Tools/TestWebKitAPI/PlatformMac.cmake
+++ b/Tools/TestWebKitAPI/PlatformMac.cmake
@@ -288,6 +288,56 @@ target_link_libraries(TestWebKitAPIInjectedBundle PRIVATE
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -framework Cocoa")
 set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -framework Cocoa")
 
+# TestWebKitAPI.wkbundle -- modern Cocoa WKWebProcessPlugIn bundle loaded via
+# [_WKProcessPoolConfiguration setInjectedBundleURL:] in
+# WKWebViewConfigurationExtras._test_configurationWithTestPlugInClassName:.
+# This is a separate product from InjectedBundleTestWebKitAPI.bundle above,
+# which implements the legacy C-API injected bundle.
+add_library(TestWebKitAPIWebProcessPlugIn MODULE
+    ${TESTWEBKITAPI_DIR}/InjectedBundle/cocoa/WebProcessPlugIn/WebProcessPlugIn.mm
+    ${TESTWEBKITAPI_DIR}/InjectedBundle/cocoa/WebProcessPlugIn/WebProcessPlugInWithInternals.mm
+)
+
+target_include_directories(TestWebKitAPIWebProcessPlugIn PRIVATE
+    ${CMAKE_BINARY_DIR}
+    ${_testapi_framework_headers}
+    ${TESTWEBKITAPI_DIR}
+    ${TESTWEBKITAPI_DIR}/InjectedBundle/cocoa/WebProcessPlugIn
+)
+
+# configure_file substitutes ${EXECUTABLE_NAME}/${PRODUCT_NAME}/
+# ${PRODUCT_BUNDLE_IDENTIFIER} in the Info.plist shared with the Xcode build.
+set(EXECUTABLE_NAME TestWebKitAPI)
+set(PRODUCT_NAME TestWebKitAPI)
+set(PRODUCT_BUNDLE_IDENTIFIER com.apple.TestWebKitAPI)
+configure_file(
+    "${TESTWEBKITAPI_DIR}/InjectedBundle/cocoa/WebProcessPlugIn/Info.plist"
+    "${CMAKE_CURRENT_BINARY_DIR}/WebProcessPlugIn-Info.plist"
+)
+
+set_target_properties(TestWebKitAPIWebProcessPlugIn PROPERTIES
+    BUNDLE TRUE
+    BUNDLE_EXTENSION wkbundle
+    OUTPUT_NAME TestWebKitAPI
+    MACOSX_BUNDLE_INFO_PLIST "${CMAKE_CURRENT_BINARY_DIR}/WebProcessPlugIn-Info.plist"
+)
+
+# Same rationale as TestWebKitAPIInjectedBundle: WebCoreTestSupport references
+# WTF symbols that the hosting WebContent process provides.
+target_link_options(TestWebKitAPIWebProcessPlugIn PRIVATE "LINKER:-undefined,dynamic_lookup")
+target_link_libraries(TestWebKitAPIWebProcessPlugIn PRIVATE
+    JavaScriptCore
+    WebCoreTestSupport
+    WebKit
+    WebKit::gtest
+    "-framework Cocoa"
+    "-framework Foundation"
+)
+
+# TestWebKit loads this bundle via NSBundle lookup at runtime, so it must be
+# built and staged next to the TestWebKitAPI executable.
+add_dependencies(TestWebKit TestWebKitAPIWebProcessPlugIn)
+
 # TestWebKitAPIResources.bundle -- test resource files loaded via
 # [NSBundle.test_resourcesBundle URLForResource:withExtension:].
 # For a non-.app executable, NSBundle.mainBundle is the directory containing


### PR DESCRIPTION
#### d7f902d5847303e26dabcecb529d0953a600c457
<pre>
[CMake] Build TestWebKitAPI.wkbundle on Mac
<a href="https://bugs.webkit.org/show_bug.cgi?id=314604">https://bugs.webkit.org/show_bug.cgi?id=314604</a>
<a href="https://rdar.apple.com/176847727">rdar://176847727</a>

Reviewed by Richard Robinson and Pascoe.

The CMake Mac build produces InjectedBundleTestWebKitAPI.bundle (used by the
legacy WKPage C-API tests) but not TestWebKitAPI.wkbundle (the modern Cocoa
WKWebProcessPlugIn bundle loaded by
+[WKWebViewConfiguration _test_configurationWithTestPlugInClassName:]).
Without it, any test that opts into WebProcessPlugInWithInternals (including
every SiteIsolation.* case, InAppBrowserPrivacy, UIDelegate, WKAppHighlights,
TextPlaceholderTests, WKThumbnailView, AccessibilityIncreaseContrast,
AccessibilityReduceMotion, and others) silently loses its plug-in.

Add a new TestWebKitAPIWebProcessPlugIn MODULE target that mirrors the Xcode
WebProcessPlugIn target:

  - Sources: InjectedBundle/cocoa/WebProcessPlugIn/WebProcessPlugIn.mm and
    WebProcessPlugInWithInternals.mm (matching the two entries in the Xcode
    project&apos;s Sources build phase).
  - BUNDLE_EXTENSION wkbundle, OUTPUT_NAME TestWebKitAPI, so the product
    path matches what WKWebViewConfigurationExtras.mm passes to
    -[NSBundle URLForResource:withExtension:].
  - Info.plist generated via configure_file() from the existing source plist
    so PRODUCT_NAME / EXECUTABLE_NAME / PRODUCT_BUNDLE_IDENTIFIER are
    populated and NSPrincipalClass = WebProcessPlugIn is preserved.
  - -undefined dynamic_lookup: same rationale as TestWebKitAPIInjectedBundle
    -- WebCoreTestSupport references WTF symbols provided by the hosting
    WebContent process.
  - TestWebKit takes an add_dependencies() on the new target so it is
    staged next to the test executable before tests run.

Also switch $(EXECUTABLE_NAME) / $(PRODUCT_NAME) in the shared Info.plist
to the ${...} form so CMake&apos;s configure_file substitutes them. Xcode
accepts both variable-substitution syntaxes, so the Xcode build is
unaffected.

* Tools/TestWebKitAPI/InjectedBundle/cocoa/WebProcessPlugIn/Info.plist:
* Tools/TestWebKitAPI/PlatformMac.cmake:

Canonical link: <a href="https://commits.webkit.org/313060@main">https://commits.webkit.org/313060@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/715281b14a74b39d5c912cf96c27f1b86db9ba85

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/161987 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35462 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28567 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170895 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/118358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163856 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35564 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35463 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125701 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/118358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164946 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28012 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/145497 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106283 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27061 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25574 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18615 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/136754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23251 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173383 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24892 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/133992 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35135 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29659 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/133998 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36177 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35119 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145046 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97238 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28522 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/21871 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34629 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34130 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34372 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34278 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->