### PR TITLE
[Site Isolation] `http/tests/storageAccess/request-and-grant-access-with-per-page-scope-access-from-another-frame.https.html` fails

### DIFF
--- a/LayoutTests/http/tests/storageAccess/request-and-grant-access-cross-origin-sandboxed-iframe-from-prevalent-domain-with-user-interaction-and-access-from-right-frame.https.html
+++ b/LayoutTests/http/tests/storageAccess/request-and-grant-access-cross-origin-sandboxed-iframe-from-prevalent-domain-with-user-interaction-and-access-from-right-frame.https.html
@@ -64,7 +64,7 @@
             );
         }
 
-        function runTest() {
+        async function runTest() {
             switch (document.location.hash) {
                 case "#step1":
                     if (testRunner.isStatisticsPrevalentResource(statisticsUrl))
@@ -106,7 +106,7 @@
                 case "#step6":
                     document.location.hash = "step7";
                     // Set per-frame access since clearing access on cross-site navigation of the iframe requires per-frame access.
-                    internals.settings.setStorageAccessAPIPerPageScopeEnabled(false);
+                    await testRunner.setStorageAccessAPIPerPageScopeEnabled(false);
                     // Create iframe that will request storage access.
                     let iframeElement = document.createElement("iframe");
                     iframeElement.setAttribute("sandbox", "allow-storage-access-by-user-activation allow-scripts allow-same-origin allow-modals");
@@ -157,7 +157,7 @@
                     break;
                 case "#step11":
                     // Reset access scope.
-                    internals.settings.setStorageAccessAPIPerPageScopeEnabled(true);
+                    await testRunner.setStorageAccessAPIPerPageScopeEnabled(true);
                     setEnableFeature(false, finishJSTest);
                     break;
             }

--- a/LayoutTests/http/tests/storageAccess/request-and-grant-access-cross-origin-sandboxed-iframe-from-prevalent-domain-with-user-interaction-but-access-from-wrong-frame.https.html
+++ b/LayoutTests/http/tests/storageAccess/request-and-grant-access-cross-origin-sandboxed-iframe-from-prevalent-domain-with-user-interaction-but-access-from-wrong-frame.https.html
@@ -64,7 +64,7 @@
             );
         }
 
-        function runTest() {
+        async function runTest() {
             switch (document.location.hash) {
                 case "#step1":
                     if (testRunner.isStatisticsPrevalentResource(statisticsUrl))
@@ -106,7 +106,7 @@
                 case "#step6":
                     document.location.hash = "step7";
                     // Set per-frame access since otherwise the sibling iframe will get access.
-                    internals.settings.setStorageAccessAPIPerPageScopeEnabled(false);
+                    await testRunner.setStorageAccessAPIPerPageScopeEnabled(false);
                     let iframeElement = document.createElement("iframe");
                     iframeElement.setAttribute("sandbox", "allow-storage-access-by-user-activation allow-scripts allow-same-origin allow-modals");
                     iframeElement.onload = function() {
@@ -125,7 +125,7 @@
                     break;
                 case "#step8":
                     // Reset access scope.
-                    internals.settings.setStorageAccessAPIPerPageScopeEnabled(true);
+                    await testRunner.setStorageAccessAPIPerPageScopeEnabled(true);
                     setEnableFeature(false, finishJSTest);
                     break;
             }

--- a/LayoutTests/http/tests/storageAccess/request-and-grant-access-then-detach-should-not-have-access.https.html
+++ b/LayoutTests/http/tests/storageAccess/request-and-grant-access-then-detach-should-not-have-access.https.html
@@ -10,9 +10,9 @@
 
         window.addEventListener("message", receiveMessage, false);
 
-        function finishTest() {
+        async function finishTest() {
             // Reset access scope.
-            internals.settings.setStorageAccessAPIPerPageScopeEnabled(true);
+            await testRunner.setStorageAccessAPIPerPageScopeEnabled(true);
             setEnableFeature(false, finishJSTest);
         }
 
@@ -88,15 +88,9 @@
             }
         }
 
-        const hostUnderTest = "localhost:8443";
-        const statisticsUrl = "https://" + hostUnderTest;
-        if (document.location.hash !== "#firstPartyCookieSet" && document.location.hash !== "#elementActivated") {
-            setEnableFeature(true, function() {
-                document.location.href = statisticsUrl + "/storageAccess/resources/set-cookie.py?name=firstPartyCookie&value=value#https://127.0.0.1:8443/storageAccess/request-and-grant-access-then-detach-should-not-have-access.https.html#firstPartyCookieSet";
-            });
-        } else {
+        async function startTest() {
             // Set per-frame access since clearing access on detaching the iframe requires per-frame access.
-            internals.settings.setStorageAccessAPIPerPageScopeEnabled(false);
+            await testRunner.setStorageAccessAPIPerPageScopeEnabled(false);
 
             testRunner.setStatisticsPrevalentResource(statisticsUrl, true, function() {
                 if (!testRunner.isStatisticsPrevalentResource(statisticsUrl))
@@ -114,6 +108,16 @@
                     });
                 });
             });
+        }
+
+        const hostUnderTest = "localhost:8443";
+        const statisticsUrl = "https://" + hostUnderTest;
+        if (document.location.hash !== "#firstPartyCookieSet" && document.location.hash !== "#elementActivated") {
+            setEnableFeature(true, function() {
+                document.location.href = statisticsUrl + "/storageAccess/resources/set-cookie.py?name=firstPartyCookie&value=value#https://127.0.0.1:8443/storageAccess/request-and-grant-access-then-detach-should-not-have-access.https.html#firstPartyCookieSet";
+            });
+        } else {
+            startTest();
         }
     </script>
 </head>

--- a/LayoutTests/http/tests/storageAccess/request-and-grant-access-then-navigate-cross-site-should-not-have-access.https.html
+++ b/LayoutTests/http/tests/storageAccess/request-and-grant-access-then-navigate-cross-site-should-not-have-access.https.html
@@ -12,9 +12,9 @@
 
         window.addEventListener("message", receiveMessage, false);
 
-        function finishTest() {
+        async function finishTest() {
             // Reset access scope.
-            internals.settings.setStorageAccessAPIPerPageScopeEnabled(true);
+            await testRunner.setStorageAccessAPIPerPageScopeEnabled(true);
             setEnableFeature(false, finishJSTest);
         }
 
@@ -63,15 +63,9 @@
             activateElement("TheIframeThatRequestsStorageAccess");
         }
 
-        const hostUnderTest = "localhost:8443";
-        const statisticsUrl = "https://" + hostUnderTest;
-        if (document.location.hash !== "#firstPartyCookieSet") {
-            setEnableFeature(true, function() {
-                document.location.href = statisticsUrl + "/storageAccess/resources/set-cookie.py?name=firstPartyCookie&value=value#https://127.0.0.1:8443/storageAccess/request-and-grant-access-then-navigate-cross-site-should-not-have-access.https.html#firstPartyCookieSet";
-            });
-        } else {
+        async function startTest() {
             // Set per-frame access since clearing access on cross-site navigation of the iframe requires per-frame access.
-            internals.settings.setStorageAccessAPIPerPageScopeEnabled(false);
+            await testRunner.setStorageAccessAPIPerPageScopeEnabled(false);
             testRunner.setStatisticsPrevalentResource(statisticsUrl, true, function() {
                 if (!testRunner.isStatisticsPrevalentResource(statisticsUrl))
                     testFailed("Host did not get set as prevalent resource.");
@@ -88,6 +82,16 @@
                     });
                 });
             });
+        }
+
+        const hostUnderTest = "localhost:8443";
+        const statisticsUrl = "https://" + hostUnderTest;
+        if (document.location.hash !== "#firstPartyCookieSet") {
+            setEnableFeature(true, function() {
+                document.location.href = statisticsUrl + "/storageAccess/resources/set-cookie.py?name=firstPartyCookie&value=value#https://127.0.0.1:8443/storageAccess/request-and-grant-access-then-navigate-cross-site-should-not-have-access.https.html#firstPartyCookieSet";
+            });
+        } else {
+            startTest();
         }
     </script>
 </body>

--- a/LayoutTests/http/tests/storageAccess/request-and-grant-access-with-per-page-scope-access-from-another-frame.https.html
+++ b/LayoutTests/http/tests/storageAccess/request-and-grant-access-with-per-page-scope-access-from-another-frame.https.html
@@ -62,7 +62,7 @@
             );
         }
 
-        function runTest() {
+        async function runTest() {
             switch (document.location.hash) {
                 case "#step1":
                     // Set first-party cookie for localhost.
@@ -82,7 +82,7 @@
                     });
                     break;
                 case "#step4":
-                    internals.settings.setStorageAccessAPIPerPageScopeEnabled(true);
+                    await testRunner.setStorageAccessAPIPerPageScopeEnabled(true);
                     document.location.hash = "step5";
                     let iframeElement = document.createElement("iframe");
                     iframeElement.onload = function() {
@@ -98,7 +98,7 @@
                     openIframe(thirdPartyBaseUrl + subPathToGetCookies + "&message=Should receive cookies even though it's not the requesting frame.", runTest);
                     break;
                 case "#step6":
-                    internals.settings.setStorageAccessAPIPerPageScopeEnabled(false);
+                    await testRunner.setStorageAccessAPIPerPageScopeEnabled(false);
                     testRunner.setStatisticsShouldBlockThirdPartyCookies(false, function() {
                         setEnableFeature(false, finishJSTest);
                     });

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -224,7 +224,6 @@ http/tests/storageAccess/grant-storage-access-under-opener-at-popup-user-gesture
 http/tests/storageAccess/grant-storage-access-under-opener-at-popup-user-gesture.https.html [ Failure ]
 http/tests/storageAccess/request-and-grant-access-cross-origin-sandboxed-iframe-from-prevalent-domain-with-user-interaction-and-access-from-right-frame.https.html [ Failure ]
 http/tests/storageAccess/request-and-grant-access-then-navigate-cross-site-should-not-have-access.https.html [ Failure ]
-http/tests/storageAccess/request-and-grant-access-with-per-page-scope-access-from-another-frame.https.html [ Failure ]
 http/tests/websocket/tests/hybi/contentextensions/upgrade.html [ Failure ]
 http/tests/workers/service/client-added-to-clients-when-restored-from-page-cache.html [ Failure ]
 http/tests/workers/service/client-removed-from-clients-while-in-page-cache.html [ Failure ]

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -7989,6 +7989,21 @@ StorageAccessAPIEnabled:
       default: true
   sharedPreferenceForWebProcess: true
 
+StorageAccessAPIPerPageScopeEnabled:
+  type: bool
+  status: unstable
+  category: dom
+  humanReadableName: "Storage Access API Per-Page Scope"
+  humanReadableDescription: "When enabled, storage access granted to one frame is shared with all same-origin frames on the page"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+  sharedPreferenceForWebProcess: true
+
 StorageBlockingPolicy:
   type: uint32_t
   humanReadableName: "Storage Blocking Policy"

--- a/Source/WebCore/page/Settings.yaml
+++ b/Source/WebCore/page/Settings.yaml
@@ -392,12 +392,6 @@ ShouldInjectUserScriptsInInitialEmptyDocument:
     WebCore:
       default: false
 
-StorageAccessAPIPerPageScopeEnabled:
-  type: bool
-  defaultValue:
-    WebCore:
-      default: false
-
 StorageBlockingPolicy:
   type: uint32_t
   refinedType: StorageBlockingPolicy

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -2302,6 +2302,7 @@ if (window.testRunner) {
         await post(['SetStorageAccess', blocked]);
         callback?.();
     };
+    testRunner.setStorageAccessAPIPerPageScopeEnabled = (enabled) => post(['SetStorageAccessAPIPerPageScopeEnabled', enabled]);
     testRunner.loadedSubresourceDomains = async (callback) => { // NOLINT
         const arrays = await post(['LoadedSubresourceDomains']);
         callback?.(arrays);
@@ -2555,7 +2556,10 @@ void TestController::didReceiveScriptMessage(WKScriptMessageRef message, Complet
     if (WKStringIsEqualToUTF8CString(command, "SetStorageAccess"))
         return WKWebsiteDataStoreSetStorageAccessForTesting(websiteDataStore(), booleanValue(argument), completionHandler.leak(), adoptAndCallCompletionHandler);
 
-
+    if (WKStringIsEqualToUTF8CString(command, "SetStorageAccessAPIPerPageScopeEnabled")) {
+        setStorageAccessAPIPerPageScopeEnabled(booleanValue(argument));
+        return completionHandler(nullptr);
+    }
 
     if (WKStringIsEqualToUTF8CString(command, "GetAllStorageAccessEntries"))
         return getAllStorageAccessEntries(WTF::move(completionHandler));
@@ -5619,6 +5623,13 @@ void TestController::setRequestStorageAccessThrowsExceptionUntilReload(bool enab
     auto configuration = adoptWK(WKPageCopyPageConfiguration(m_mainWebView->page()));
     auto preferences = WKPageConfigurationGetPreferences(configuration.get());
     WKPreferencesSetBoolValueForKeyForTesting(preferences, enabled, toWK("RequestStorageAccessThrowsExceptionUntilReload").get());
+}
+
+void TestController::setStorageAccessAPIPerPageScopeEnabled(bool enabled)
+{
+    auto configuration = adoptWK(WKPageCopyPageConfiguration(m_mainWebView->page()));
+    auto preferences = WKPageConfigurationGetPreferences(configuration.get());
+    WKPreferencesSetBoolValueForKeyForTesting(preferences, enabled, toWK("StorageAccessAPIPerPageScopeEnabled").get());
 }
 
 void TestController::setResourceMonitorList(WKStringRef rulesText, CompletionHandler<void(WKTypeRef)>&& completionHandler)

--- a/Tools/WebKitTestRunner/TestController.h
+++ b/Tools/WebKitTestRunner/TestController.h
@@ -308,6 +308,7 @@ public:
 
     void getAllStorageAccessEntries(CompletionHandler<void(WKTypeRef)>&&);
     void setRequestStorageAccessThrowsExceptionUntilReload(bool enabled);
+    void setStorageAccessAPIPerPageScopeEnabled(bool);
     void loadedSubresourceDomains(CompletionHandler<void(WKTypeRef)>&&);
     void clearLoadedSubresourceDomains();
     void clearAppBoundSession();


### PR DESCRIPTION
#### f6671f0702409de0030d519d02689b0e09b9f40a
<pre>
[Site Isolation] `http/tests/storageAccess/request-and-grant-access-with-per-page-scope-access-from-another-frame.https.html` fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=314608">https://bugs.webkit.org/show_bug.cgi?id=314608</a>
<a href="https://rdar.apple.com/176851572">rdar://176851572</a>

Reviewed by Alex Christensen.

internals.settings only updates the local web process, so frames in other processes never see the
change. Add an async testRunner method that goes through the UIProcess preference path, which
broadcasts to all web content processes via preferencesDidChange. Awaiting the call in the test
ensures the broadcast round-trips before subsequent frames are loaded.

* LayoutTests/http/tests/storageAccess/request-and-grant-access-cross-origin-sandboxed-iframe-from-prevalent-domain-with-user-interaction-and-access-from-right-frame.https.html:
* LayoutTests/http/tests/storageAccess/request-and-grant-access-cross-origin-sandboxed-iframe-from-prevalent-domain-with-user-interaction-but-access-from-wrong-frame.https.html:
* LayoutTests/http/tests/storageAccess/request-and-grant-access-then-detach-should-not-have-access.https.html:
* LayoutTests/http/tests/storageAccess/request-and-grant-access-then-navigate-cross-site-should-not-have-access.https.html:
* LayoutTests/http/tests/storageAccess/request-and-grant-access-with-per-page-scope-access-from-another-frame.https.html:
* LayoutTests/platform/mac-site-isolation/TestExpectations:
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/page/Settings.yaml:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::setRequestStorageAccessThrowsExceptionUntilReload):
(WTR::TestRunner::setStorageAccessAPIPerPageScopeEnabled):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestController.cpp:
* Tools/WebKitTestRunner/TestController.h:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveSynchronousMessageFromInjectedBundle):

Canonical link: <a href="https://commits.webkit.org/313976@main">https://commits.webkit.org/313976@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/69b946ffc5f32016284ff76b2a2d176b0498ff41

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164569 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38053 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31624 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173599 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121821 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166438 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38387 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38055 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127877 "") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90014 "layout-tests (failure)") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167528 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30179 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147913 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108422 "") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29226 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27848 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21362 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/156720 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139129 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25629 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176125 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/25461 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28948 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27298 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136198 "") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38122 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31971 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136162 "re-run-api-tests (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38812 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147424 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100966 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25070 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31437 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24280 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/196972 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37320 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110364 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51736 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36718 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2343 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36966 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36866 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->