### PR TITLE
AX: Avoid unnecessary main-thread dispatch and parent search wait in cross-process search

### DIFF
--- a/Source/WebCore/accessibility/AXCrossProcessSearch.cpp
+++ b/Source/WebCore/accessibility/AXCrossProcessSearch.cpp
@@ -402,6 +402,9 @@ public:
         return didTimeout;
     }
 
+    void cancel() { m_cancelled.store(true, std::memory_order_release); }
+    bool isCancelled() const { return m_cancelled.load(std::memory_order_acquire); }
+
     void NODELETE markParentDispatched() { m_dispatchedParent.store(true, std::memory_order_release); }
     bool NODELETE didDispatchParent() const { return m_dispatchedParent.load(std::memory_order_acquire); }
 
@@ -421,6 +424,7 @@ private:
     BinarySemaphore m_semaphore;
     std::atomic<bool> m_shouldSignal { true };
     std::atomic<bool> m_dispatchedParent { false };
+    std::atomic<bool> m_cancelled { false };
     Lock m_lock;
     Vector<AccessibilityRemoteToken> m_parentTokens WTF_GUARDED_BY_LOCK(m_lock);
 };
@@ -435,6 +439,16 @@ AccessibilitySearchResults performSearchWithParentCoordination(AXCoreObject& anc
     }
 
 #if PLATFORM_SUPPORTS_REMOTE_SEARCH
+    if (criteria.immediateDescendantsOnly) {
+        // immediateDescendantsOnly searches are scoped to a specific container, so the parent
+        // frame has nothing to contribute. Skip the main-thread dispatch entirely.
+        return performSearchWithCrossProcessCoordination(anchorObject, WTF::move(criteria));
+    }
+
+    RefPtr tree = AXTreeStore<AXIsolatedTree>::isolatedTreeForID(treeID);
+    if (!tree || tree->isMainFrame() || !tree->siteIsolationEnabled())
+        return performSearchWithCrossProcessCoordination(anchorObject, WTF::move(criteria));
+
     // Save original parameters for parent coordination.
     unsigned originalLimit = criteria.resultsLimit;
     bool isForward = criteria.searchDirection == AccessibilitySearchDirection::Next;
@@ -454,12 +468,14 @@ AccessibilitySearchResults performSearchWithParentCoordination(AXCoreObject& anc
         RefPtr frame = document ? document->frame() : nullptr;
         RefPtr page = frame ? frame->page() : nullptr;
 
-        if (!frame || !page || frame->isMainFrame() || !page->settings().siteIsolationEnabled() || criteriaForParent.immediateDescendantsOnly) {
-            // Not in a child frame, site isolation is disabled, or this is an
-            // immediateDescendantsOnly search. In the latter case, the search is scoped
-            // to a specific container in the child frame, so the parent frame has nothing
-            // to contribute — skip the parent search to match non-site-isolation behavior
-            // and avoid returning unrelated elements (like the parent's ScrollBar).
+        if (!frame || !page) {
+            context->signal();
+            return;
+        }
+
+        if (context->isCancelled()) {
+            // The AX thread already found enough local results and no longer
+            // needs parent contributions. Bail to avoid unnecessary IPC.
             context->signal();
             return;
         }
@@ -468,9 +484,7 @@ AccessibilitySearchResults performSearchWithParentCoordination(AXCoreObject& anc
 
         if (shouldMockParentSearchResultsForTesting()) [[unlikely]] {
             // Testing: provide a mock parent result instead of dispatching
-            // real IPC (which deadlocks in the test runner). This lets tests
-            // verify that the parent search is correctly skipped for
-            // immediateDescendantsOnly searches (i.e. the if just above).
+            // real IPC (which deadlocks in the test runner).
             context->signal();
             return;
         }
@@ -488,6 +502,15 @@ AccessibilitySearchResults performSearchWithParentCoordination(AXCoreObject& anc
 
     // Perform local + nested remote frame search (runs in parallel with parent search).
     auto searchResults = performSearchWithCrossProcessCoordination(anchorObject, WTF::move(criteria));
+
+    // If local results already satisfy the limit, parent results won't contribute
+    // to the merged output regardless of search direction — skip the wait.
+    if (searchResults.size() >= originalLimit) {
+        // Signal to the main-thread lambda that it can skip the parent search
+        // IPC dispatch, since local results already satisfy the requested limit.
+        context->cancel();
+        return searchResults;
+    }
 
     // Wait for parent search to complete using the cascading timeout.
     if (auto remainingTimeout = computeRemainingTimeout(criteriaForParent.deadline))

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -50,6 +50,7 @@
 #include "HTMLNames.h"
 #include "LocalFrameView.h"
 #include "Logging.h"
+#include "Settings.h"
 #include <wtf/MonotonicTime.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/SetForScope.h>
@@ -83,6 +84,19 @@ AXIsolatedTree::AXIsolatedTree(AXObjectCache& axObjectCache)
 {
     AXTRACE("AXIsolatedTree::AXIsolatedTree"_s);
     AX_ASSERT(isMainThread());
+
+    // If any of these are null at construction, the cached m_isMainFrame and
+    // m_siteIsolationEnabled values below will be wrong for the tree's entire
+    // lifetime. We _should_ always have a valid document, frame, and page, hence
+    // the asserts. If this assumption proves to be wrong, we can investigate further.
+    RefPtr document = axObjectCache.document();
+    AX_ASSERT(document);
+    RefPtr frame = document ? document->frame() : nullptr;
+    AX_ASSERT(frame);
+    RefPtr page = frame ? frame->page() : nullptr;
+    AX_ASSERT(page);
+    m_isMainFrame = frame && frame->isMainFrame();
+    m_siteIsolationEnabled = page && page->settings().siteIsolationEnabled();
 }
 
 AXIsolatedTree::~AXIsolatedTree()

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -558,6 +558,8 @@ public:
 
     constexpr AXTreeID treeID() const { return m_id; }
     constexpr ProcessID processID() const { return m_processID; }
+    constexpr bool isMainFrame() const { return m_isMainFrame; }
+    constexpr bool siteIsolationEnabled() const { return m_siteIsolationEnabled; }
     void setPageActivityState(OptionSet<ActivityState>);
     WEBCORE_EXPORT OptionSet<ActivityState> pageActivityState() const;
 
@@ -737,10 +739,12 @@ private:
     // Written to by main thread under lock, accessed and applied by AX thread.
     PendingChanges m_pendingChanges WTF_GUARDED_BY_LOCK(m_changeLogLock);
 
-    // These three are placed here to fit in padding that would otherwise be between m_pendingSortedLiveRegionIDs and m_pendingSortedNonRootWebAreaIDs.
+    // These are placed here to fit in padding that would otherwise be between m_pendingSortedLiveRegionIDs and m_pendingSortedNonRootWebAreaIDs.
     OptionSet<ActivityState> m_pageActivityState;
     bool m_isEmptyContentTree { false };
     bool m_queuedForDestruction WTF_GUARDED_BY_LOCK(m_changeLogLock) { false };
+    bool m_isMainFrame { false };
+    bool m_siteIsolationEnabled { false };
 
     Markable<AXID> m_focusedNodeID;
     std::atomic<double> m_loadingProgress { 0 };


### PR DESCRIPTION
#### 73910d5d194e05db6c6205688f495bd89e64b54c
<pre>
AX: Avoid unnecessary main-thread dispatch and parent search wait in cross-process search
<a href="https://bugs.webkit.org/show_bug.cgi?id=314610">https://bugs.webkit.org/show_bug.cgi?id=314610</a>
<a href="https://rdar.apple.com/176852283">rdar://176852283</a>

Reviewed by Dominic Mazzoni.

Cache isMainFrame and siteIsolationEnabled on AXIsolatedTree so that
performSearchWithParentCoordination can short-circuit on the AX thread
without dispatching to the main thread. Previously, we always dispatched
to the main thread just to check these conditions and bail out.

Also skip waiting for the parent search when local results already
satisfy the requested limit, since the merge logic provably discards all
parent tokens in that case regardless of search direction. Cancel the
parent search context so the main-thread lambda can avoid the IPC
dispatch if it hasn&apos;t run yet.

* Source/WebCore/accessibility/AXCrossProcessSearch.cpp:
(WebCore::ParentFrameSearchContext::cancel):
(WebCore::ParentFrameSearchContext::isCancelled const):
(WebCore::performSearchWithParentCoordination):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::AXIsolatedTree):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
(WebCore::AXIsolatedTree::isMainFrame const):
(WebCore::AXIsolatedTree::siteIsolationEnabled const):

Canonical link: <a href="https://commits.webkit.org/313128@main">https://commits.webkit.org/313128@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/40e76b72c35d3a3da0be0db2b8d4758294ff31ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162109 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35584 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28698 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171017 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118482 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/09b0d33c-ac72-428b-bd0e-be7381ee823a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163978 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35689 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35586 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125811 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88671 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6c73c30d-7dce-449a-8587-a8a1db655a7a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165068 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28131 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145610 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106389 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8e4aeabb-1db0-48c9-a6f0-a5762d863770) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27178 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25694 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18738 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136877 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23356 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173510 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20864 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24999 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134105 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35259 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29782 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134106 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36221 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35242 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145152 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97444 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28635 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21980 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34752 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102504 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34252 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34497 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34400 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->