### PR TITLE
Use isb in ParkingLot spinloop on ARM64

### DIFF
--- a/Source/WTF/wtf/LockAlgorithmInlines.h
+++ b/Source/WTF/wtf/LockAlgorithmInlines.h
@@ -96,11 +96,11 @@ void LockAlgorithm<LockType, isHeldBit, hasParkedBit, Hooks>::lockSlow(Atomic<Lo
     // appendix.
 #if CPU(ARM64) && OS(MACOS)
     static constexpr unsigned spinLimit = 80;
-    static constexpr unsigned nopCount = 512;
+    static constexpr unsigned nopCount = 8;
     static constexpr unsigned yieldInterval = 16;
 #elif CPU(ARM64) && OS(IOS_FAMILY)
     static constexpr unsigned spinLimit = 40;
-    static constexpr unsigned nopCount = 1024;
+    static constexpr unsigned nopCount = 16;
     static constexpr unsigned yieldInterval = 4;
 #else
     static constexpr unsigned spinLimit = 40;
@@ -133,15 +133,8 @@ void LockAlgorithm<LockType, isHeldBit, hasParkedBit, Hooks>::lockSlow(Atomic<Lo
             // without having depressed our own priority beforehand.
             if (!(spinCount % yieldInterval))
                 Thread::yield();
-            for (unsigned i = 0; i < nopCount; i++) {
-#if CPU(ARM64)
-                // FIXME: replace with simde_mm_pause and recompute the
-                // nopCount to match.
-                asm volatile ("yield");
-#else
+            for (unsigned i = 0; i < nopCount; i++)
                 simde_mm_pause();
-#endif
-            }
             continue;
         }
 

--- a/Source/bmalloc/libpas/src/libpas/pas_internal_config.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_internal_config.h
@@ -82,7 +82,7 @@
 
 #define PAS_MEDIUM_SHARING_SHIFT         3
 
-#define PAS_MIN_OBJECTS_PER_PAGE         11
+#define PAS_MIN_OBJECTS_PER_PAGE         12
 
 #ifdef PAS_LIBMALLOC
 #define PAS_DEALLOCATION_LOG_SIZE        10


### PR DESCRIPTION
#### 1e389bdbdcc4cfcf8954427d0a44249814761b31
<pre>
Use isb in ParkingLot spinloop on ARM64
<a href="https://bugs.webkit.org/show_bug.cgi?id=314598">https://bugs.webkit.org/show_bug.cgi?id=314598</a>
<a href="https://rdar.apple.com/176840292">rdar://176840292</a>

Reviewed by Yusuke Suzuki.

Previously, ParkingLot on ARM64 used the `yield` instruction. External
experimentation has shown that it’s preferable to use an `isb`
instruction instead.
<a href="https://github.com/rust-lang/rust/commit/c064b6560b7ce0adeb9bbf5d7dcf12b1acb0c807">https://github.com/rust-lang/rust/commit/c064b6560b7ce0adeb9bbf5d7dcf12b1acb0c807</a>
The explantation there is not 100% accurate — an isb does not “put the
core to sleep” per se, but by draining the out-of-order buffer and
preventing the dispatch of younger instructions,
it does effectively throttle execution until fetch gets past the block
of isb instructions. The core continues executing but fully in-order.
The upside is more determinism and generally less power consumption.

This required retuning the nop-counts. This was done empirically.

No new tests since this is an implementation detail.

Canonical link: <a href="https://commits.webkit.org/313082@main">https://commits.webkit.org/313082@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/525d73442ba300c708316021e077dc3f501ed27a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162069 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35544 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/28649 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170977 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118440 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/18e90a8e-b889-43f2-b4f5-baf8927ff89f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35646 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35546 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/125774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88642 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/83744a37-8034-46f0-80f9-fee9f3b4420c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165028 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28085 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/145571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106356 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/88665c45-d663-41d5-b88c-5fd577039283) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/18698 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/154128 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136827 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/23325 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173467 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22907 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20815 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/24966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/134067 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35218 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29733 "Passed tests") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/134072 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36188 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35201 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/145120 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97371 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28598 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/21945 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194469 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34712 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102456 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50124 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34212 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34454 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34360 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->