### PR TITLE
[SVG] Preserve precision and skip background phases when hit-testing SVG <text>

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/elementsFromPoint-svg-text-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/elementsFromPoint-svg-text-expected.txt
@@ -4,7 +4,7 @@ Some text
 Text underText over
 
 PASS elementsFromPoint for a point inside a <text>
-FAIL elementsFromPoint for a point inside a <tspan> nested in a <text> without content assert_equals: document.elementsFromPoint(125,185) expected "tspan#tspan1, svg#svg, DIV#sandbox, BODY, HTML" but got "tspan#tspan1, text#text2, svg#svg, DIV#sandbox, BODY, HTML"
-FAIL elementsFromPoint for a point inside a <textPath> nested in a <text> without content assert_equals: document.elementsFromPoint(125,245) expected "textPath#textpath1, svg#svg, DIV#sandbox, BODY, HTML" but got "textPath#textpath1, text#text3, svg#svg, DIV#sandbox, BODY, HTML"
+PASS elementsFromPoint for a point inside a <tspan> nested in a <text> without content
+PASS elementsFromPoint for a point inside a <textPath> nested in a <text> without content
 PASS elementsFromPoint for a point inside an overlapping <tspan> nested in a <text>
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/interact/scripted/text-hittest-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/interact/scripted/text-hittest-002-expected.txt
@@ -1,5 +1,4 @@
 MMMMMM
 
-FAIL elementFromPoint(...) on <svg:text> with fill=none but fill=black descendants assert_equals: element @ (175, 25) expected Element node <tspan fill="black">MM</tspan> but got Element node <svg width="400" height="400">
-  <text x="50" y="50" font...
+PASS elementFromPoint(...) on <svg:text> with fill=none but fill=black descendants
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/interact/scripted/text-hittest-003-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/interact/scripted/text-hittest-003-expected.txt
@@ -1,5 +1,4 @@
 MM
 
-FAIL elementFromPoint(...) on visibility=hidden <svg:text> with visible descendants assert_equals: element @ (175, 25) expected Element node <tspan visibility="visible">MM</tspan> but got Element node <svg width="400" height="400">
-  <text x="50" y="50" font...
+PASS elementFromPoint(...) on visibility=hidden <svg:text> with visible descendants
 

--- a/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-002.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-002.svg
@@ -11,7 +11,7 @@
     <html:link rel="help"
           href="https://www.w3.org/TR/SVG2/shapes.html#CircleElement"/>
     <html:link rel="match"  href="pathlength-002-ref.svg" />
-    <html:meta name="fuzzy" content="0-1;0-50"/>
+    <html:meta name="fuzzy" content="0-1;0-65"/>
   </g>
 
   <g id="test-body-content" style="fill:none;stroke:black;stroke-width:5px">

--- a/LayoutTests/svg/hittest/text-clipped-expected.txt
+++ b/LayoutTests/svg/hittest/text-clipped-expected.txt
@@ -1,0 +1,4 @@
+Here is my sample text1!Here is my sample text2!Here is my sample text3!Here is my sample text4!Here is my sample text5!
+
+PASS Hittest on clipped <text>
+

--- a/LayoutTests/svg/hittest/text-clipped.html
+++ b/LayoutTests/svg/hittest/text-clipped.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<body>
+<svg height="100" width="200">
+<g>
+<defs>
+<clipPath id="clip-path-1">
+<path d="M15.5,11L84.5,11A3.5,3.5 0 0,1 88,14.5L88,36.5A3.5,3.5 0 0,1 84.5,40
+  L15.5,40A3.5,3.5 0 0,1 12,36.5L12,14.5A3.5,3.5 0 0,1 15.5,11z"></path>
+</clipPath>
+</defs>
+<text x="49.75" y="24.75" text-anchor="middle" clip-path="url(#clip-path-1)">
+<tspan x="49.75" dy="-12">Here is my sample text1!</tspan>
+<tspan x="49.75" dy="12">Here is my sample text2!</tspan>
+<tspan x="49.75" dy="12">Here is my sample text3!</tspan>
+<tspan x="49.75" dy="12">Here is my sample text4!</tspan>
+<tspan x="49.75" dy="12">Here is my sample text5!</tspan>
+</text>
+</g>
+</svg>
+
+<script>
+test(() => {
+  assert_equals(document.elementFromPoint(80, 64), document.querySelector('svg'));
+}, 'Hittest on clipped <text>');
+</script>
+</body>
+</html>

--- a/LayoutTests/svg/hittest/text-small-font-size-and-viewbox-expected.txt
+++ b/LayoutTests/svg/hittest/text-small-font-size-and-viewbox-expected.txt
@@ -1,0 +1,6 @@
+ABCDEFGH
+ABCDEFGH
+Link#3
+
+PASS Hit-test of text with fractional (< 1) font-size and small (high scalefactor) viewBox
+

--- a/LayoutTests/svg/hittest/text-small-font-size-and-viewbox.html
+++ b/LayoutTests/svg/hittest/text-small-font-size-and-viewbox.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<title>Hit-test of text with fractional (&lt; 1) font-size and small (high scalefactor) viewBox</title>
+<script src="../../resources/ahem.js"></script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<style>
+svg {
+  margin: 0px;
+  padding: 0px;
+  position: absolute;
+  top: 0px;
+  left: 0px;
+  width: 800px;
+}
+</style>
+<svg viewBox="0 0 22 28" font-family="Ahem" font-size="0.125" fill="blue">
+  <text y="2.438"><a xlink:href="#">ABCDEFGH</a></text>
+  <text y="4.698" x="7.571"><a xlink:href="#">ABCDEFGH</a></text>
+  <text y="1" x="0" transform="scale(10)"><a xlink:href="#">Link#3</a></text>
+</svg>
+<script>
+test(function() {
+  var links = document.querySelectorAll('a');
+
+  // The ideal bounding box of the first link in the document is
+  // (0.00, 85.02) - (36.36, 89.56). However, we should have some
+  // tolerance because our scaled font size is an integer.
+  [
+    { x: 2, y: 86 },
+    { x: 4, y: 87 },
+    { x: 2, y: 88 },
+    { x: 6, y: 86 },
+    { x: 4, y: 87 },
+    { x: 6, y: 88 },
+    { x: 10, y: 87 },
+    { x: 14, y: 87 },
+    { x: 18, y: 87 },
+    { x: 22, y: 87 },
+    { x: 26, y: 87 },
+  ].forEach(function(point) {
+    assert_equals(document.elementFromPoint(point.x, point.y), links[0], point.x + ',' + point.y);
+  });
+
+  // The ideal bounding box of the second link in the document is
+  // (275.31, 167.20) - (311.67, 171.75). However, we should have some
+  // tolerance because our scaled font size is an integer.
+  [
+    { x: 278, y: 169 },
+    { x: 276, y: 171 },
+    { x: 278, y: 169 },
+    { x: 280, y: 171 },
+    { x: 284, y: 169 },
+    { x: 288, y: 169 },
+    { x: 292, y: 169 },
+    { x: 296, y: 169 },
+    { x: 300, y: 169 },
+  ].forEach(function(point) {
+    assert_equals(document.elementFromPoint(point.x, point.y), links[1], point.x + ',' + point.y);
+  });
+
+  assert_equals(document.elementFromPoint(1, 330), links[2], '1,330');
+});
+</script>

--- a/LayoutTests/svg/hittest/text-small-font-size-expected.txt
+++ b/LayoutTests/svg/hittest/text-small-font-size-expected.txt
@@ -1,0 +1,6 @@
+SELECT
+foo
+
+PASS Hit-test of <text> does not hit-test the "background" (w/ small font size)
+PASS crbug.com/1295031
+

--- a/LayoutTests/svg/hittest/text-small-font-size.html
+++ b/LayoutTests/svg/hittest/text-small-font-size.html
@@ -1,0 +1,392 @@
+<!DOCTYPE html>
+<title>Hit-test of &lt;text> does not hit-test the "background" (w/ small font size)</title>
+<script src="../../resources/ahem.js"></script>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<style>
+body {
+  margin: 0;
+  padding: 0;
+}
+g text:hover {
+  fill: red;
+  cursor: crosshair;
+}
+</style>
+<svg font-family="Ahem" font-size="1.6" fill="blue" width="600" height="300">
+  <g transform="matrix(50,0,0,50,-400,-800)">
+    <text x="9.4" y="17.80">SELECT</text>
+  </g>
+
+  <!-- crbug.com/1295031 -->
+  <g transform="scale(200) translate(0, 0.6)">
+    <rect width="1135800" height="578250" fill="transparent"></rect>
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+    <g transform="scale(0.9589912023158114)">
+      
+    <g transform='translate(100, 0) scale(1)'>
+        <rect class='rect' width='500' height='600' fill="yellow"></rect>
+        <text id='fifth' class='fifth test_text' transform='translate(0, 200) scale(10)' font-size="12">foo</text>
+    </g>
+       
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+    </g>
+  </g>
+</svg>
+<script>
+// The text bouding box in the document is (70,26) - (550,106).
+test(function() {
+  var textElement = document.querySelector('text');
+  // Should hit <text>.
+  [
+    { x: 71, y: 28 },
+    { x: 71, y: 105 },
+    { x: 540, y: 105 },
+    { x: 540, y: 28 },
+  ].forEach(function(point) {
+    assert_equals(document.elementFromPoint(point.x, point.y), textElement, point.x + ',' + point.y);
+  });
+
+  var svgRoot = document.querySelector('svg');
+  // Should not hit <text>.
+  [
+    { x: 68.5, y: 26 },
+    { x: 68.5, y: 105 },
+    { x: 69, y: 107 },
+    { x: 300, y: 24.5 },
+    { x: 300, y: 107 },
+    { x: 550, y: 26 },
+    { x: 550, y: 105 },
+    { x: 550, y: 107 },
+  ].forEach(function(point) {
+    assert_equals(document.elementFromPoint(point.x, point.y), svgRoot, point.x + ',' + point.y);
+  });
+});
+
+test(() => {
+  let textElement = document.querySelectorAll('text')[1];
+  let background = document.querySelector('rect');
+  // Should not hit <text>.
+  [
+    { x: 1, y: 200 },
+  ].forEach(function(point) {
+    assert_equals(document.elementFromPoint(point.x, point.y), background, point.x + ',' + point.y);
+  });
+}, 'crbug.com/1295031');
+</script>

--- a/LayoutTests/svg/hittest/tspan-bounding-box-expected.txt
+++ b/LayoutTests/svg/hittest/tspan-bounding-box-expected.txt
@@ -1,0 +1,4 @@
+tspan inside a text.
+
+PASS tspan's bounding box was wrong on hit-testing with pointer-events:bouding-box
+

--- a/LayoutTests/svg/hittest/tspan-bounding-box.html
+++ b/LayoutTests/svg/hittest/tspan-bounding-box.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<script src="../../resources/testharness.js"></script>
+<script src="../../resources/testharnessreport.js"></script>
+<svg width="700" height="300" xmlns="http://www.w3.org/2000/svg">
+<style>
+text {
+  font-family: sans-serif;
+  /* this caused an issue */
+  pointer-events: bounding-box;
+}
+tspan:hover {
+  fill: lime;
+}
+</style>
+<text font-size="30" y="80" x="0">
+  <tspan fill="blue">tspan</tspan> inside a text.
+</text>
+</svg>
+
+<script>
+test(() => {
+  assert_not_equals(document.elementFromPoint(10, 10), document.querySelector('tspan'));
+}, 'tspan\'s bounding box was wrong on hit-testing with pointer-events:bouding-box');
+</script>

--- a/Source/WebCore/rendering/HitTestLocation.cpp
+++ b/Source/WebCore/rendering/HitTestLocation.cpp
@@ -34,6 +34,14 @@ HitTestLocation::HitTestLocation(const LayoutPoint& point)
 {
 }
 
+HitTestLocation::HitTestLocation(const FloatPoint& point)
+    : m_point { flooredLayoutPoint(point) }
+    , m_boundingBox { LayoutRect { m_point, LayoutSize { 1, 1 } } }
+    , m_transformedPoint { point }
+    , m_transformedRect { m_boundingBox }
+{
+}
+
 HitTestLocation::HitTestLocation(const FloatPoint& point, const FloatQuad& quad, RectBased rectBased)
     : m_point { flooredLayoutPoint(point) }
     , m_boundingBox { quad.enclosingBoundingBox() }

--- a/Source/WebCore/rendering/HitTestLocation.h
+++ b/Source/WebCore/rendering/HitTestLocation.h
@@ -32,6 +32,7 @@ public:
 
     WEBCORE_EXPORT HitTestLocation();
     HitTestLocation(const LayoutPoint&);
+    explicit HitTestLocation(const FloatPoint&);
     HitTestLocation(const FloatPoint&, const FloatQuad&, RectBased = RectBased::Yes);
 
     HitTestLocation(const LayoutRect&);

--- a/Source/WebCore/rendering/HitTestResult.cpp
+++ b/Source/WebCore/rendering/HitTestResult.cpp
@@ -84,7 +84,7 @@ static inline void appendToNodeSet(const HitTestResult::NodeSet& source, HitTest
 HitTestResult::HitTestResult() = default;
 
 HitTestResult::HitTestResult(const IntPoint& point)
-    : m_hitTestLocation(point)
+    : m_hitTestLocation(LayoutPoint { point })
     , m_doublePointInInnerNodeFrame(point)
 {
 }

--- a/Source/WebCore/rendering/svg/RenderSVGText.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGText.cpp
@@ -655,25 +655,34 @@ bool RenderSVGText::nodeAtFloatPoint(const HitTestRequest& request, HitTestResul
 {
     ASSERT(!document().settings().layerBasedSVGEngineEnabled());
 
+    // <text> has no background to hit-test; only the painted glyphs in the foreground phase are hittable.
+    if (hitTestAction != HitTestAction::Foreground)
+        return false;
+
+    static NeverDestroyed<SVGVisitedRendererTracking::VisitedSet> s_visitedSet;
+
+    SVGVisitedRendererTracking recursionTracking(s_visitedSet);
+    if (recursionTracking.isVisiting(*this))
+        return false;
+
+    SVGVisitedRendererTracking::Scope recursionScope(recursionTracking, *this);
+
+    FloatPoint localPoint = valueOrDefault(localToParentTransform().inverse()).mapPoint(pointInParent);
+    if (!SVGRenderSupport::pointInClippingArea(*this, localPoint))
+        return false;
+
+    HitTestLocation hitTestLocation { localPoint };
+
+    // Descend unconditionally: hitTestInlineChildren enforces per-tspan fill/stroke/visibility,
+    // so <text fill=none>/visibility=hidden must not gate out differently-styled descendants.
+    if (RenderBlock::nodeAtPoint(request, result, hitTestLocation, LayoutPoint(), hitTestAction))
+        return true;
+
     PointerEventsHitRules hitRules(PointerEventsHitRules::HitTestingTargetType::SVGText, request, usedPointerEvents());
-    if (request.isVisibleForStyle(style()) || !hitRules.requireVisible) {
-        if ((hitRules.canHitStroke && (!style().stroke().isNone() || !hitRules.requireStroke))
-            || (hitRules.canHitFill && (!style().fill().isNone() || !hitRules.requireFill))) {
-            static NeverDestroyed<SVGVisitedRendererTracking::VisitedSet> s_visitedSet;
-
-            SVGVisitedRendererTracking recursionTracking(s_visitedSet);
-            if (recursionTracking.isVisiting(*this))
-                return false;
-
-            SVGVisitedRendererTracking::Scope recursionScope(recursionTracking, *this);
-
-            FloatPoint localPoint = valueOrDefault(localToParentTransform().inverse()).mapPoint(pointInParent);
-            if (!SVGRenderSupport::pointInClippingArea(*this, localPoint))
-                return false;
-
-            HitTestLocation hitTestLocation(LayoutPoint(flooredIntPoint(localPoint)));
-            return RenderBlock::nodeAtPoint(request, result, hitTestLocation, LayoutPoint(), hitTestAction);
-        }
+    if (hitRules.canHitBoundingBox && objectBoundingBox().contains(localPoint)) {
+        updateHitTestResult(result, LayoutPoint { localPoint });
+        if (result.addNodeToListBasedTestResult(protect(nodeForHitTest()).get(), request, hitTestLocation) == HitTestProgress::Stop)
+            return true;
     }
 
     return false;
@@ -748,7 +757,7 @@ bool RenderSVGText::hitTestInlineChildren(const HitTestRequest& request, HitTest
                 if (!fragmentTransform.isIdentity())
                     fragmentQuad = fragmentTransform.mapQuad(fragmentQuad);
 
-                if (!fragmentQuad.containsPoint(locationInContainer.point()))
+                if (!fragmentQuad.containsPoint(locationInContainer.transformedPoint()))
                     continue;
 
                 renderer.updateHitTestResult(result, locationInContainer.point() - toLayoutSize(accumulatedOffset));


### PR DESCRIPTION
#### 3bae413ddad10b861c563c212c55c61b2b1f9177
<pre>
[SVG] Preserve precision and skip background phases when hit-testing SVG &lt;text&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=314616">https://bugs.webkit.org/show_bug.cgi?id=314616</a>
<a href="https://rdar.apple.com/176855164">rdar://176855164</a>

Reviewed by NOBODY (OOPS!).

Four fixes to RenderSVGText::nodeAtFloatPoint:

1. Precision. Floored the inverse-transformed local point to int before
 building the HitTestLocation. At high viewBox scale factors hits on
 fractional-height glyphs were rejected. Add a non-rect-based
 HitTestLocation(const FloatPoint&amp;) ctor (flooredLayoutPoint for
 m_point, raw FloatPoint for m_transformedPoint) and use it. Ctor is
 explicit; disambiguate HitTestResult(const IntPoint&amp;). hitTestInline-
 Children now reads transformedPoint() so per-fragment containment
 uses the unrounded coordinate.

2. Background phases. &lt;text&gt; has no background; passing hitTestAction
 through to RenderBlock::nodeAtPoint let the block-background phases
 match the inline block bounds. Early-return when hitTestAction isn&apos;t
 Foreground.

3. Parent-level pointer-events gating. The previous code consulted
 PointerEventsHitRules against the &lt;text&gt;&apos;s own style and bailed out
 if the parent failed visibility/fill/stroke checks. That swallowed
 &lt;tspan&gt; descendants with different fill or visibility. hitTestInline-
 Children already enforces those rules per child, so the parent-level
 guard was redundant and harmful. Drop it and descend unconditionally
 inside the foreground phase. Fixes text-hittest-002 (fill=none parent
 with fill=black tspan) and text-hittest-003 (visibility=hidden parent
 with visibility=visible tspan).

4. pointer-events: bounding-box. Previously served by the block-
 background phase removed in (2). Now handled explicitly after
 descent: if nothing inside was hit and canHitBoundingBox is set,
 accept the hit if objectBoundingBox() contains the local point.
 Falling back after descent matches LegacyRenderSVGShape and lets
 tspans take precedence over the bounding box.

NOTE: I imported few svg &lt;text&gt; hittesting related test cases from
Blink / Chromium, two of them were failing and now pass:

- text-small-font-size.html
- text-small-font-size-and-viewbox.html

Tests: svg/hittest/text-clipped.html
       svg/hittest/text-small-font-size-and-viewbox.html
       svg/hittest/text-small-font-size.html
       svg/hittest/tspan-bounding-box.html

* LayoutTests/imported/w3c/web-platform-tests/css/cssom-view/elementsFromPoint-svg-text-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/interact/scripted/text-hittest-002-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/interact/scripted/text-hittest-003-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/svg/shapes/reftests/pathlength-002.svg:
* LayoutTests/svg/hittest/text-clipped-expected.txt: Added.
* LayoutTests/svg/hittest/text-clipped.html: Added.
* LayoutTests/svg/hittest/text-small-font-size-and-viewbox-expected.txt: Added.
* LayoutTests/svg/hittest/text-small-font-size-and-viewbox.html: Added.
* LayoutTests/svg/hittest/text-small-font-size-expected.txt: Added.
* LayoutTests/svg/hittest/text-small-font-size.html: Added.
* LayoutTests/svg/hittest/tspan-bounding-box-expected.txt: Added.
* LayoutTests/svg/hittest/tspan-bounding-box.html: Added.
* Source/WebCore/rendering/HitTestLocation.cpp:
(WebCore::HitTestLocation::HitTestLocation):
* Source/WebCore/rendering/HitTestLocation.h:
* Source/WebCore/rendering/HitTestResult.cpp:
(WebCore::HitTestResult::HitTestResult):
* Source/WebCore/rendering/svg/RenderSVGText.cpp:
(WebCore::RenderSVGText::nodeAtFloatPoint):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3bae413ddad10b861c563c212c55c61b2b1f9177

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163762 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37246 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30465 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172784 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121013 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/346357ab-acb6-40c4-a5b7-be64ea9fe9e7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165631 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37577 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37245 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127204 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89634 "Build is in progress. Recent messages:") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/23c7be0c-8e2e-4ea3-ba4d-be7111bfabad) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166721 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29486 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147221 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107753 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/29278f7d-47d8-4814-ab79-10bf02d4e403) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28533 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27163 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20555 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138432 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24938 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175309 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28138 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26606 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135508 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36916 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31269 "Found 1 new test failure: http/tests/storageAccess/deny-due-to-no-interaction-under-general-third-party-cookie-blocking-ephemeral.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135484 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37701 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146733 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99820 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30801 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23587 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36412 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109557 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35909 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1617 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36159 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36056 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->