### PR TITLE
[Site Isolation] Verify frame tree state after goBack/goForward in MultiProcessBFCacheGoForward test

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -8891,6 +8891,7 @@ TEST(SiteIsolation, MultiProcessBFCacheGoForward)
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
     [navigationDelegate waitForDidFinishNavigationAndLoadInSubframe];
     [webView objectByEvaluatingJavaScript:@"window.__bfcacheMarker_a = true"];
+    [webView objectByEvaluatingJavaScript:@"window.__bfcacheMarker = true" inFrame:[webView firstChildFrame]];
 
     checkFrameTreesInProcesses(webView.get(), {
         { "https://a.com"_s, { { RemoteFrame } } },
@@ -8902,6 +8903,7 @@ TEST(SiteIsolation, MultiProcessBFCacheGoForward)
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://c.com/c"]]];
     [navigationDelegate waitForDidFinishNavigationAndLoadInSubframe];
     [webView objectByEvaluatingJavaScript:@"window.__bfcacheMarker_c = true"];
+    [webView objectByEvaluatingJavaScript:@"window.__bfcacheMarker = true" inFrame:[webView firstChildFrame]];
 
     checkFrameTreesInProcesses(webView.get(), {
         { "https://c.com"_s, { { RemoteFrame } } },
@@ -8915,6 +8917,21 @@ TEST(SiteIsolation, MultiProcessBFCacheGoForward)
     [navigationDelegate waitForDidFinishNavigation];
     EXPECT_TRUE([[webView objectByEvaluatingJavaScript:@"window.__bfcacheMarker_a ? true : false"] boolValue]);
 
+    // Wait for the cross-process iframe's frame tree to be fully
+    // reconstructed before asserting on iframe state. waitForDidFinishNavigation
+    // only waits for the main frame, and waitForDidFinishLoadInSubframe does
+    // not fire during BFCache restore.
+    Vector<ExpectedFrameTree> expectedAfterGoBack = {
+        { "https://a.com"_s, { { RemoteFrame } } },
+        { RemoteFrame, { { "https://b.com"_s } } },
+    };
+    while (!frameTreesMatch(frameTrees(webView.get()).get(), Vector<ExpectedFrameTree> { expectedAfterGoBack }))
+        TestWebKitAPI::Util::spinRunLoop();
+
+    EXPECT_TRUE([[webView objectByEvaluatingJavaScript:@"window.__bfcacheMarker ? true : false" inFrame:[webView firstChildFrame]] boolValue]);
+
+    checkFrameTreesInProcesses(webView.get(), WTF::move(expectedAfterGoBack));
+
     // Step 4: Go forward (navigate to C again) — this triggers the bug.
     // goToBackForwardItem is sent to a.com's process but
     // m_mainFrame->coreLocalFrame() is null, causing a silent bail-out.
@@ -8923,6 +8940,17 @@ TEST(SiteIsolation, MultiProcessBFCacheGoForward)
 
     EXPECT_WK_STREQ(@"https://c.com/c", [webView URL].absoluteString);
     EXPECT_TRUE([[webView objectByEvaluatingJavaScript:@"window.__bfcacheMarker_c ? true : false"] boolValue]);
+
+    Vector<ExpectedFrameTree> expectedAfterGoForward = {
+        { "https://c.com"_s, { { RemoteFrame } } },
+        { RemoteFrame, { { "https://a.com"_s } } },
+    };
+    while (!frameTreesMatch(frameTrees(webView.get()).get(), Vector<ExpectedFrameTree> { expectedAfterGoForward }))
+        TestWebKitAPI::Util::spinRunLoop();
+
+    EXPECT_TRUE([[webView objectByEvaluatingJavaScript:@"window.__bfcacheMarker ? true : false" inFrame:[webView firstChildFrame]] boolValue]);
+
+    checkFrameTreesInProcesses(webView.get(), WTF::move(expectedAfterGoForward));
 }
 
 TEST(SiteIsolation, MultiProcessBFCacheSameSiteNavAfterRestore)


### PR DESCRIPTION
#### e94bf7708d5e7c37e50a94461eba9753ce9831d6
<pre>
[Site Isolation] Verify frame tree state after goBack/goForward in MultiProcessBFCacheGoForward test
<a href="https://bugs.webkit.org/show_bug.cgi?id=314611">https://bugs.webkit.org/show_bug.cgi?id=314611</a>
<a href="https://rdar.apple.com/176852200">rdar://176852200</a>

Reviewed by NOBODY (OOPS!).

Followup to bug 313027.

MultiProcessBFCacheGoForward navigates between two pages that each host a
cross-site iframe, then goes back and forward to exercise multi-process
BFCache restoration. The original assertions checked only URL and a
main-frame window marker after each restore — this did not verify that
the cross-process frame tree (RemoteFrame &lt;-&gt; LocalFrame across processes)
was rebuilt, nor that iframe JavaScript state survived.

Extend the test to assert both: the full cross-process frame tree is
reconstructed identically to the original load, and a window-scoped
marker set inside the iframe before navigation is still present after
restoration.

Test-only change.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, MultiProcessBFCacheGoForward)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e94bf7708d5e7c37e50a94461eba9753ce9831d6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162154 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35630 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28744 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171062 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118527 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164023 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35734 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35631 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125844 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88706 "18 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/177a80c4-c8c1-4c06-9c96-9e449cb3f8d1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165113 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28177 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145659 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106422 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27224 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25735 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18783 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136925 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23400 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173555 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25043 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134142 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35304 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29822 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134143 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35287 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145196 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97490 "Built successfully") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28673 "Found 60 new test failures: cookies/cookie-store-start-listening-for-change-with-null-url-crash.html fast/forms/form-control-refresh/button-like-controls-text-color-matches.html http/tests/iframe-monitor/blob-resource.html http/tests/iframe-monitor/cached-resource.html http/tests/iframe-monitor/compressed-resource.html http/tests/iframe-monitor/dark-mode.html http/tests/iframe-monitor/data-url-resource.html http/tests/iframe-monitor/eligibility.html http/tests/iframe-monitor/iframe-unload.html http/tests/iframe-monitor/just-use-eligible-subresource.html ... (failure)") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22024 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34797 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34298 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34543 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34446 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->