### PR TITLE
[WTF] Fix OrderedHashTable's translate call

### DIFF
--- a/Source/WTF/wtf/OrderedHashTable.h
+++ b/Source/WTF/wtf/OrderedHashTable.h
@@ -343,6 +343,11 @@ public:
         }
 
         uint32_t newIndex = m_entriesLength;
+        // translate call may assume that entry is empty-initialized.
+        if constexpr (Traits::emptyValueIsZero)
+            zeroBytes(m_entries[newIndex]);
+        else
+            Traits::template constructEmptyValue<Traits>(m_entries[newIndex]);
         HashTranslator::translate(m_entries[newIndex], std::forward<K>(key), valueFunctor);
         m_buckets[insertSlot] = newIndex;
         auto result = AddResult { iterator(this, newIndex), true };
@@ -403,6 +408,7 @@ public:
     void reserveInitialCapacity(unsigned keyCount)
     {
         ASSERT(isEmpty());
+        ASSERT(!m_entriesLength);
         if (!keyCount)
             return;
         uint32_t newBucketCount = bucketCountForKeyCount(keyCount);

--- a/Tools/TestWebKitAPI/Tests/WTF/OrderedHashMap.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/OrderedHashMap.cpp
@@ -751,4 +751,130 @@ TEST(WTF_OrderedHashMap, HashTranslatorFindContainsGet)
     EXPECT_EQ(0u, map.get<StringViewHashTranslator>(StringView { "missing"_s }));
 }
 
+namespace {
+
+// Mirrors TrackedValue in OrderedHashSet.cpp — a value type whose operator=
+// requires the LHS to be in a constructed state (one of the known sentinels).
+// Used as the key in a map-shaped OrderedHashTable to exercise the same
+// translator-on-raw-storage path for KeyValuePair entries.
+class TrackedKey {
+public:
+    enum State : uint32_t { Garbage = 0xDEADBEEF, Empty = 0xE11E, Deleted = 0xDEAD, Live = 0xA11E };
+
+    static int liveCount;
+
+    TrackedKey() : m_state(Empty), m_value(0) { }
+    explicit TrackedKey(int v) : m_state(Live), m_value(v) { ++liveCount; }
+    TrackedKey(const TrackedKey& other) : m_state(other.m_state), m_value(other.m_value)
+    {
+        if (m_state == Live)
+            ++liveCount;
+    }
+    TrackedKey(TrackedKey&& other) noexcept : m_state(other.m_state), m_value(other.m_value)
+    {
+        if (m_state == Live)
+            ++liveCount;
+    }
+    TrackedKey(WTF::HashTableDeletedValueType) : m_state(Deleted), m_value(0) { }
+
+    ~TrackedKey()
+    {
+        if (m_state == Live)
+            --liveCount;
+        m_state = Garbage;
+    }
+
+    TrackedKey& operator=(const TrackedKey& other)
+    {
+        EXPECT_TRUE(m_state == Empty || m_state == Live || m_state == Deleted);
+        if (m_state == Live)
+            --liveCount;
+        m_state = other.m_state;
+        m_value = other.m_value;
+        if (m_state == Live)
+            ++liveCount;
+        return *this;
+    }
+
+    bool isHashTableDeletedValue() const { return m_state == Deleted; }
+    bool operator==(const TrackedKey& other) const { return m_state == other.m_state && m_value == other.m_value; }
+
+    int value() const { return m_value; }
+
+private:
+    uint32_t m_state;
+    int m_value;
+};
+
+int TrackedKey::liveCount = 0;
+
+struct TrackedKeyHash {
+    static unsigned hash(const TrackedKey& k) { return IntHash<int>::hash(k.value()); }
+    static bool equal(const TrackedKey& a, const TrackedKey& b) { return a == b; }
+};
+
+struct TrackedKeyTraits : WTF::SimpleClassHashTraits<TrackedKey> {
+    static constexpr bool emptyValueIsZero = false;
+};
+
+using TrackedKVP = KeyValuePair<TrackedKey, int>;
+
+// KeyValuePairHashTraits already computes emptyValueIsZero = KeyTraits::emptyValueIsZero &&
+// ValueTraits::emptyValueIsZero, which is false for TrackedKey, so constructEmptyValue runs.
+using TrackedKVPTraits = WTF::KeyValuePairHashTraits<TrackedKeyTraits, HashTraits<int>>;
+
+struct TrackedKVPTranslator {
+    static unsigned hash(int v) { return IntHash<int>::hash(v); }
+    static bool equal(const TrackedKey& a, int b) { return a.value() == b; }
+    static void translate(TrackedKVP& location, int v, NOESCAPE const auto&)
+    {
+        // Standard WTF translator convention: assign. Both key and value
+        // assignments require the LHS to be a constructed KeyValuePair.
+        location.key = TrackedKey(v);
+        location.value = v * 10;
+    }
+};
+
+using TrackedOrderedHashTable = WTF::OrderedHashTable<TrackedKey, TrackedKVP, WTF::KeyValuePairKeyExtractor<TrackedKVP>, TrackedKeyHash, TrackedKVPTraits, TrackedKeyTraits, WTF::HashTableMalloc>;
+
+}
+
+TEST(WTF_OrderedHashMap, HashTranslatorAddConstructsEmptyBeforeAssign)
+{
+    // Map-side equivalent of the OrderedHashSet test. Without the pre-translate
+    // constructEmptyValue, `location.key = ...` would assign into raw malloc
+    // storage and TrackedKey::operator= would EXPECT-fail because m_state would
+    // be random bits rather than one of the known sentinels.
+    TrackedKey::liveCount = 0;
+    auto noFunctor = []() ALWAYS_INLINE_LAMBDA -> TrackedKVP { return { }; };
+    {
+        TrackedOrderedHashTable table;
+        for (int i = 0; i < 32; ++i) {
+            auto r = table.add<TrackedKVPTranslator>(i, noFunctor);
+            EXPECT_TRUE(r.isNewEntry);
+        }
+        EXPECT_EQ(32u, table.size());
+
+        // Remove half, then re-add via the translator so the path also runs
+        // after internal compact/rehash activity.
+        for (int i = 0; i < 32; i += 2)
+            table.remove(TrackedKey(i));
+        EXPECT_EQ(16u, table.size());
+        for (int i = 0; i < 32; i += 2) {
+            auto r = table.add<TrackedKVPTranslator>(i, noFunctor);
+            EXPECT_TRUE(r.isNewEntry);
+        }
+        EXPECT_EQ(32u, table.size());
+
+        // Verify values survived correctly.
+        int seen = 0;
+        for (auto it = table.begin(); it != table.end(); ++it) {
+            EXPECT_EQ(it->key.value() * 10, it->value);
+            ++seen;
+        }
+        EXPECT_EQ(32, seen);
+    }
+    EXPECT_EQ(0, TrackedKey::liveCount);
+}
+
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WTF/OrderedHashSet.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/OrderedHashSet.cpp
@@ -651,4 +651,200 @@ TEST(WTF_OrderedHashSet, HashTranslatorFindContains)
     EXPECT_TRUE(missing == set.end());
 }
 
+namespace {
+
+// Mirrors the signature OrderedHashTable::add<HashTranslator> expects:
+//   translate(location, key, valueFunctor).
+// Uses plain assignment into `location` — the canonical WTF translator convention.
+// This is the shape that will silently corrupt raw storage if the entries array
+// isn't pre-initialized to an empty value before translate() runs.
+struct AssigningStringViewTranslator {
+    static unsigned hash(StringView view) { return StringHash::hash(view.toString()); }
+    static bool equal(const String& a, StringView b) { return a == b; }
+    static void translate(String& location, StringView view, NOESCAPE const auto&)
+    {
+        location = view.toString();
+    }
+};
+
+using StringOrderedHashTable = WTF::OrderedHashTable<String, String, WTF::IdentityExtractor, DefaultHash<String>, HashTraits<String>, HashTraits<String>, WTF::HashTableMalloc>;
+
+// A value type whose operator= asserts the LHS is in a constructed state
+// (one of the known sentinels). Without a pre-translate constructEmptyValue,
+// the translator's `location = ...` assigns into raw malloc storage and the
+// m_state field will be random bits, nearly always tripping the assert.
+// liveCount tracks Live-state instances only; Empty/Deleted sentinels are
+// not counted, mirroring WTF's convention that sentinels hold no resources.
+class TrackedValue {
+public:
+    enum State : uint32_t { Garbage = 0xDEADBEEF, Empty = 0xE11E, Deleted = 0xDEAD, Live = 0xA11E };
+
+    static int liveCount;
+
+    TrackedValue() : m_state(Empty), m_value(0) { }
+    explicit TrackedValue(int v) : m_state(Live), m_value(v) { ++liveCount; }
+    TrackedValue(const TrackedValue& other) : m_state(other.m_state), m_value(other.m_value)
+    {
+        if (m_state == Live)
+            ++liveCount;
+    }
+    TrackedValue(TrackedValue&& other) noexcept : m_state(other.m_state), m_value(other.m_value)
+    {
+        // Move: dst increments, src keeps its state so its destructor balances.
+        if (m_state == Live)
+            ++liveCount;
+    }
+    TrackedValue(WTF::HashTableDeletedValueType) : m_state(Deleted), m_value(0) { }
+
+    ~TrackedValue()
+    {
+        if (m_state == Live)
+            --liveCount;
+        m_state = Garbage;
+    }
+
+    TrackedValue& operator=(const TrackedValue& other)
+    {
+        // LHS must be a constructed object (Empty/Live/Deleted). Raw malloc
+        // storage will have random bits, which almost never match a sentinel.
+        EXPECT_TRUE(m_state == Empty || m_state == Live || m_state == Deleted);
+        if (m_state == Live)
+            --liveCount;
+        m_state = other.m_state;
+        m_value = other.m_value;
+        if (m_state == Live)
+            ++liveCount;
+        return *this;
+    }
+
+    bool isHashTableDeletedValue() const { return m_state == Deleted; }
+    bool operator==(const TrackedValue& other) const { return m_state == other.m_state && m_value == other.m_value; }
+
+    int value() const { return m_value; }
+
+private:
+    uint32_t m_state;
+    int m_value;
+};
+
+int TrackedValue::liveCount = 0;
+
+struct TrackedValueHash {
+    static unsigned hash(const TrackedValue& v) { return IntHash<int>::hash(v.value()); }
+    static bool equal(const TrackedValue& a, const TrackedValue& b) { return a == b; }
+};
+
+struct TrackedValueTraits : WTF::SimpleClassHashTraits<TrackedValue> {
+    // Force emptyValueIsZero=false so constructEmptyValue runs (not zeroBytes).
+    static constexpr bool emptyValueIsZero = false;
+};
+
+struct TrackedValueTranslator {
+    static unsigned hash(int v) { return IntHash<int>::hash(v); }
+    static bool equal(const TrackedValue& a, int b) { return a.value() == b; }
+    static void translate(TrackedValue& location, int v, NOESCAPE const auto&)
+    {
+        // Standard WTF translator convention: assign. LHS must be constructed.
+        location = TrackedValue(v);
+    }
+};
+
+using TrackedOrderedHashTable = WTF::OrderedHashTable<TrackedValue, TrackedValue, WTF::IdentityExtractor, TrackedValueHash, TrackedValueTraits, TrackedValueTraits, WTF::HashTableMalloc>;
+
+}
+
+TEST(WTF_OrderedHashSet, HashTranslatorAddConstructsEmptyBeforeAssign)
+{
+    // Without the pre-translate constructEmptyValue, `location = ...` inside the
+    // translator would be invoked on raw malloc storage. TrackedValue::operator=
+    // asserts its LHS is a real constructed object, so the bug would EXPECT fail.
+    TrackedValue::liveCount = 0;
+    auto noFunctor = []() ALWAYS_INLINE_LAMBDA -> TrackedValue { return TrackedValue(); };
+    {
+        TrackedOrderedHashTable table;
+        for (int i = 0; i < 32; ++i) {
+            auto r = table.add<TrackedValueTranslator>(i, noFunctor);
+            EXPECT_TRUE(r.isNewEntry);
+        }
+        EXPECT_EQ(32u, table.size());
+
+        // Force deletions then re-add; after internal compact/rehash the translator
+        // path writes into slots whose prior occupants were destructed/moved-from —
+        // each such slot must again be re-constructed-empty before translate.
+        for (int i = 0; i < 32; i += 2)
+            table.remove(TrackedValue(i));
+        EXPECT_EQ(16u, table.size());
+        for (int i = 0; i < 32; i += 2) {
+            auto r = table.add<TrackedValueTranslator>(i, noFunctor);
+            EXPECT_TRUE(r.isNewEntry);
+        }
+        EXPECT_EQ(32u, table.size());
+    }
+    // Every constructed instance must have been destructed.
+    EXPECT_EQ(0, TrackedValue::liveCount);
+}
+
+TEST(WTF_OrderedHashSet, HashTranslatorAddIntoRawStorage)
+{
+    // Exercises OrderedHashTable::add<HashTranslator>. A correctly-implemented WTF
+    // translator assigns into `location`; our entries array is raw malloc storage,
+    // so without an in-place empty-value construction before translate, String's
+    // assignment operator would deref garbage from the freshly malloc'd slot.
+    StringOrderedHashTable table;
+    auto noFunctor = []() ALWAYS_INLINE_LAMBDA -> String { return String(); };
+
+    auto a = table.add<AssigningStringViewTranslator>(StringView { "alpha"_s }, noFunctor);
+    EXPECT_TRUE(a.isNewEntry);
+    auto b = table.add<AssigningStringViewTranslator>(StringView { "beta"_s }, noFunctor);
+    EXPECT_TRUE(b.isNewEntry);
+    auto aAgain = table.add<AssigningStringViewTranslator>(StringView { "alpha"_s }, noFunctor);
+    EXPECT_FALSE(aAgain.isNewEntry);
+
+    EXPECT_EQ(2u, table.size());
+    auto it = table.begin();
+    EXPECT_EQ("alpha"_s, *it);
+    ++it;
+    EXPECT_EQ("beta"_s, *it);
+    ++it;
+    EXPECT_TRUE(it == table.end());
+}
+
+TEST(WTF_OrderedHashSet, HashTranslatorAddTriggersRehashAndCompact)
+{
+    // Adding through the translator path past initial capacity must rehash (growing
+    // the entries array and re-placement-newing into it) without disturbing any
+    // in-flight empty-value state for the slot still being populated.
+    StringOrderedHashTable table;
+    auto noFunctor = []() ALWAYS_INLINE_LAMBDA -> String { return String(); };
+
+    Vector<String> keys;
+    for (unsigned i = 0; i < 64; ++i)
+        keys.append(String::number(i));
+
+    for (const auto& k : keys)
+        table.add<AssigningStringViewTranslator>(StringView { k }, noFunctor);
+    EXPECT_EQ(64u, table.size());
+
+    // Delete half, then add again via the translator — forces compactInPlace to
+    // run, after which the next translator add lands in a slot that was previously
+    // a deleted entry. The fix must still apply in that path.
+    for (unsigned i = 0; i < 64; i += 2)
+        table.remove(keys[i]);
+    EXPECT_EQ(32u, table.size());
+
+    for (unsigned i = 0; i < 64; i += 2) {
+        auto result = table.add<AssigningStringViewTranslator>(StringView { keys[i] }, noFunctor);
+        EXPECT_TRUE(result.isNewEntry);
+    }
+    EXPECT_EQ(64u, table.size());
+
+    // Verify all keys are present and iterable.
+    unsigned count = 0;
+    for (auto it = table.begin(); it != table.end(); ++it) {
+        EXPECT_TRUE(table.contains(*it));
+        ++count;
+    }
+    EXPECT_EQ(64u, count);
+}
+
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 6dfc39d4012575285a135779386b039e8404f91b
<pre>
[WTF] Fix OrderedHashTable&apos;s translate call
<a href="https://bugs.webkit.org/show_bug.cgi?id=314619">https://bugs.webkit.org/show_bug.cgi?id=314619</a>
<a href="https://rdar.apple.com/176859032">rdar://176859032</a>

Reviewed by Sosuke Suzuki.

Currently no client exists yet, but OrderedHashTable should initialize
entry with empty state before calling translate.

Tests: Tools/TestWebKitAPI/Tests/WTF/OrderedHashMap.cpp
       Tools/TestWebKitAPI/Tests/WTF/OrderedHashSet.cpp

* Source/WTF/wtf/OrderedHashTable.h:
* Tools/TestWebKitAPI/Tests/WTF/OrderedHashMap.cpp:
(TestWebKitAPI::TEST(WTF_OrderedHashMap, HashTranslatorAddConstructsEmptyBeforeAssign)):
* Tools/TestWebKitAPI/Tests/WTF/OrderedHashSet.cpp:
(TestWebKitAPI::TEST(WTF_OrderedHashSet, HashTranslatorAddConstructsEmptyBeforeAssign)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, HashTranslatorAddIntoRawStorage)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, HashTranslatorAddTriggersRehashAndCompact)):

Canonical link: <a href="https://commits.webkit.org/313086@main">https://commits.webkit.org/313086@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/827221016cf25aa8984975ee408f87c2df7fa7fb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162007 "12 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35482 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28587 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170915 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118378 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/21daf415-da48-4b29-8178-8fa4e4417161) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163876 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35584 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35483 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125722 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88592 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/52c2febb-7c39-476c-be99-fd53d4e81ed4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164966 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28034 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145518 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106304 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6795a7a7-cfff-4340-ab49-e0abf400a1f9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27083 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25595 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18635 "Built successfully") | | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/154066 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136776 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23272 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173403 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22845 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20494 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24913 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134013 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35155 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29680 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134019 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35139 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145067 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97267 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24613 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28545 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21892 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194407 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34649 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102134 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50108 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34150 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34392 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34298 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->