### PR TITLE
X11 header pollution breaks build

### DIFF
--- a/Source/JavaScriptCore/parser/VariableEnvironment.h
+++ b/Source/JavaScriptCore/parser/VariableEnvironment.h
@@ -33,6 +33,10 @@
 #include <wtf/PackedRefPtr.h>
 #include <wtf/TZoneMalloc.h>
 
+#ifdef Success
+#undef Success
+#endif
+
 namespace JSC {
 
 struct VariableEnvironmentEntry {

--- a/Source/JavaScriptCore/runtime/DefinePropertyAttributes.h
+++ b/Source/JavaScriptCore/runtime/DefinePropertyAttributes.h
@@ -28,6 +28,10 @@
 #include <optional>
 #include <wtf/TriState.h>
 
+#ifdef False
+#undef False
+#endif
+
 namespace JSC {
 
 class DefinePropertyAttributes {

--- a/Source/WebCore/loader/cache/CachedResource.h
+++ b/Source/WebCore/loader/cache/CachedResource.h
@@ -46,6 +46,10 @@
 #include <wtf/WeakHashMap.h>
 #include <wtf/text/WTFString.h>
 
+#ifdef Status
+#undef Status
+#endif
+
 namespace WebCore {
 
 class CachedResourceCallback;

--- a/Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp
@@ -60,6 +60,10 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #include <xf86drm.h>
 #endif
 
+#ifdef None
+#undef None
+#endif
+
 namespace WebCore {
 
 #if PLATFORM(GTK) || PLATFORM(WPE)

--- a/Source/WebCore/platform/graphics/x11/XErrorTrapper.h
+++ b/Source/WebCore/platform/graphics/x11/XErrorTrapper.h
@@ -27,8 +27,20 @@
 
 #if PLATFORM(X11)
 #include <X11/Xlib.h>
+#ifdef Above
+#undef Above
+#endif
+#ifdef Always
+#undef Always
+#endif
+#ifdef Below
+#undef Below
+#endif
 #ifdef Success
 #undef Success
+#endif
+#ifdef True
+#undef True
 #endif
 #include <wtf/Vector.h>
 

--- a/Source/WebKit/UIProcess/gtk/DisplayX11.cpp
+++ b/Source/WebKit/UIProcess/gtk/DisplayX11.cpp
@@ -41,6 +41,10 @@
 #include <gdk/gdkx.h>
 #endif
 
+#ifdef Status
+#undef Status
+#endif
+
 namespace WebKit {
 using namespace WebCore;
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
@@ -56,6 +56,19 @@
 #include <GLES2/gl2.h>
 #endif
 
+#ifdef Always
+#undef Always
+#endif
+#ifdef Below
+#undef Below
+#endif
+#ifdef None
+#undef None
+#endif
+#ifdef True
+#undef True
+#endif
+
 namespace WebKit {
 using namespace WebCore;
 


### PR DESCRIPTION
#### 1e6bd7469dd191f9de711d8c54af64e8805781ed
<pre>
X11 header pollution breaks build
<a href="https://bugs.webkit.org/show_bug.cgi?id=314622">https://bugs.webkit.org/show_bug.cgi?id=314622</a>

Reviewed by NOBODY (OOPS!).

The X11 headers define a lot of common names as symbols,
various places want to use the same names as enums.
Undefine the symbols where necessary.

No new tests (OOPS!).

* Source/JavaScriptCore/parser/VariableEnvironment.h:
* Source/JavaScriptCore/runtime/DefinePropertyAttributes.h:
* Source/WebCore/loader/cache/CachedResource.h:
* Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp:
* Source/WebCore/platform/graphics/x11/XErrorTrapper.h:
* Source/WebKit/UIProcess/gtk/DisplayX11.cpp:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1e6bd7469dd191f9de711d8c54af64e8805781ed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162012 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35487 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28592 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170920 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118383 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163881 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35589 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35488 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125731 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88599 "18 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164971 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28046 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145531 "Found 2 new API test failures: TestWebKitAPI.WKWebExtensionAPIAction.ClearTabSpecificActionPropertiesOnNavigation, TestWebKitAPI.WritingTools.ShowDetailsForSuggestions (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106313 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27095 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25604 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18640 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/154071 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136788 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23285 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173408 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22850 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20499 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24926 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134022 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35160 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29689 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134028 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35144 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145080 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/97279 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28557 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21905 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194412 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34654 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102139 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50112 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34155 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34397 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34303 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->