### PR TITLE
[WebXR] Revert WebXRSession changes from 312788@main

### DIFF
--- a/Source/WebCore/Modules/webxr/WebXRSession.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSession.cpp
@@ -710,8 +710,10 @@ void WebXRSession::onFrame(PlatformXR::FrameData&& frameData)
         // 5. If the active flag of any view in the list of views has changed since the last XR animation frame, update the viewports.
         // FIXME: implement.
 
-        if (session.m_inputInitialized)
-            session.m_inputSources->update(now, session.m_frameData.inputSources);
+        // FIXME: I moved step 7 before 6 because of https://github.com/immersive-web/webxr/issues/1164
+        // 7.If session’s pending render state is not null, apply the pending render state.
+        if (session.m_pendingRenderState)
+            session.applyPendingRenderState();
 
 #if ENABLE(WEBXR_HIT_TEST)
         // Cancel hit test sources that are not referenced by the application.
@@ -738,6 +740,11 @@ void WebXRSession::onFrame(PlatformXR::FrameData&& frameData)
 
             // 6.3.Set frame’s active boolean to true.
             frame->setActive(true);
+
+            // 6.4.Apply frame updates for frame.
+            if (session.m_inputInitialized)
+                session.m_inputSources->update(now, session.m_frameData.inputSources);
+
             tracePoint(WebXRSessionFrameCallbacksStart);
             session.minimalUpdateRendering();
             // 6.5.For each entry in session’s list of currently running animation frame callbacks, in order:
@@ -779,9 +786,6 @@ void WebXRSession::onFrame(PlatformXR::FrameData&& frameData)
             if (RefPtr device = session.m_device.get())
                 device->submitFrame(WTF::move(frameLayers));
         }
-
-        if (session.m_pendingRenderState)
-            session.applyPendingRenderState();
 
         session.requestFrameIfNeeded();
     });


### PR DESCRIPTION
#### 3c73508f5ba8bf4f6cdd58ce05d4dba5d9179793
<pre>
[WebXR] Revert WebXRSession changes from 312788@main
<a href="https://bugs.webkit.org/show_bug.cgi?id=314623">https://bugs.webkit.org/show_bug.cgi?id=314623</a>
<a href="https://rdar.apple.com/176829186">rdar://176829186</a>

Reviewed by Cameron McCormack.

312788@main moved applyPendingRenderState() from before the rendering block
to after it in WebXRSession::onFrame(), and moved inputSources-&gt;update()
to run unconditionally before the render block. These changes were made to
fix an OpenXR-specific crash involving swapchain acquire/release mismatches
when activeLayerHandles changed mid-frame.

The OpenXR author has confirmed these WebXRSession changes are no longer
required for OpenXR -- the OpenXR-side changes in that commit (snapshotting
active layers at beginFrame and filtering at endFrame) are sufficient to
prevent the crash without modifying the shared WebXRSession frame loop.

Reverting restores the original frame loop ordering:
- applyPendingRenderState() before frameShouldBeRendered() (step 7 before 6)
- inputSources-&gt;update() at step 6.4 inside the render block

This fixes first-frame rendering on visionOS where the deferred
applyPendingRenderState meant frameShouldBeRendered() would see a null
baseLayer and skip the entire render block.

* Source/WebCore/Modules/webxr/WebXRSession.cpp:
(WebCore::WebXRSession::applyPendingRenderState):
(WebCore::WebXRSession::onFrame):
(WebCore::WebXRSession::updateRequestDataFromActiveRenderState): Deleted.
* Source/WebCore/Modules/webxr/WebXRSession.h:

Canonical link: <a href="https://commits.webkit.org/313131@main">https://commits.webkit.org/313131@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/726ac8af30bab322660497bbb44c852a4dd4e775

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162194 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35670 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28786 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171102 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118567 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164063 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35774 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35671 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125877 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88736 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165153 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28213 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/145701 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106455 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18823 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/136961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23440 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173596 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20949 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25083 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134175 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35344 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/29860 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/134176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36222 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35327 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145236 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97538 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28719 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22064 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34837 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102589 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34338 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34583 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34486 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->