### PR TITLE
REGRESSION(309943@main): Dragging images with draggable="true" no longer exposes file data in dataTransfer.files for same-origin drops

### DIFF
--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -4731,7 +4731,7 @@ void WebViewImpl::startDrag(const WebCore::DragItem& item, ShareableBitmap::Hand
     if (RefPtr frame = WebFrameProxy::webFrame(item.rootFrameID)) {
         // FIXME: The `dragLocationInWindowCoordinates` is in window coordinates (equivalent to root view), but `convertPointToMainFrameCoordinates`
         // expects the input to be in content coordinates of the frame corresponding to the given frame ID.
-        m_page->convertPointToMainFrameCoordinates(item.dragLocationInWindowCoordinates, item.rootFrameID, [weakThis = WeakPtr { *this }, promisedAttachmentInfo = item.promisedAttachmentInfo, dragNSImage = WTF::move(dragNSImage), size, lastMouseDownEvent = m_lastMouseDownEvent, frameID, &sourceAction = item.sourceAction] (std::optional<FloatPoint> dragLocationInMainFrameCoordinates) mutable {
+        m_page->convertPointToMainFrameCoordinates(item.dragLocationInWindowCoordinates, item.rootFrameID, [weakThis = WeakPtr { *this }, promisedAttachmentInfo = item.promisedAttachmentInfo, dragNSImage = WTF::move(dragNSImage), size, lastMouseDownEvent = m_lastMouseDownEvent, frameID](std::optional<FloatPoint> dragLocationInMainFrameCoordinates) mutable {
 
             BEGIN_BLOCK_OBJC_EXCEPTIONS
 
@@ -4745,7 +4745,7 @@ void WebViewImpl::startDrag(const WebCore::DragItem& item, ShareableBitmap::Hand
             auto clientDragLocation = IntPoint(dragLocationInMainFrameCoordinates.value());
             auto draggingFrame = NSMakeRect(clientDragLocation.x(), clientDragLocation.y() - size.height(), size.width(), size.height());
 
-            bool isImageDrag = protectedThis->m_promisedImageDragData && sourceAction == WebCore::DragSourceAction::Image;
+            bool isImageDrag = protectedThis->m_promisedImageDragData.has_value();
             bool canUseFilePromiseForImageDrag = isImageDrag && !protectedThis->m_promisedImageDragData->imageUTI.isEmpty();
 
             RetainPtr pasteboard = [NSPasteboard pasteboardWithName:NSPasteboardNameDrag];

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/DragAndDropTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/DragAndDropTests.mm
@@ -442,8 +442,7 @@ TEST(DragAndDropTests, DragSelectedTextInImageOverlay)
 
 #endif // ENABLE(IMAGE_ANALYSIS)
 
-// FIXME: Re-enable this test once webkit.org/b/314562 is resolved.
-TEST(DragAndDropTests, DISABLED_DoNotExposeCrossOriginImageData)
+TEST(DragAndDropTests, DoNotExposeCrossOriginImageData)
 {
     RetainPtr markupData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"drag-drop-cross-origin-image" withExtension:@"html"]];
     RetainPtr imageData = [NSData dataWithContentsOfURL:[NSBundle.test_resourcesBundle URLForResource:@"icon" withExtension:@"png"]];


### PR DESCRIPTION
#### 633736c7eaf4e77b229586c5ce6fb14c650f19b1
<pre>
REGRESSION(309943@main): Dragging images with draggable=&quot;true&quot; no longer exposes file data in dataTransfer.files for same-origin drops
<a href="https://bugs.webkit.org/show_bug.cgi?id=314562">https://bugs.webkit.org/show_bug.cgi?id=314562</a>
<a href="https://rdar.apple.com/176582995">rdar://176582995</a>

Reviewed by Megan Gardner and Wenson Hsieh.

309943@main replaced -dragImage: with -beginDraggingSessionWithItems:
for all drag types. The old -dragImage: path had no sourceAction gate,
and setPromisedDataForImage() unconditionally wrote image data to the
pasteboard. -dragImage: used that pre-populated pasteboard regardless
of whether the resolved drag type was Image or DHTML.

The new startDrag() code introduced a check that additionally gated the
image file-promise path on sourceAction == .Image. This broke
&lt;img draggable=&quot;true&quot;&gt; because EventHandler resolves dragState().type
to DHTML when the draggable attribute is present, even though the drag
controller still calls declareAndWriteDragImage() (based on drag source
action capability, not resolved type) and populates promised image drag
data via the SetPromisedDataForImage IPC. With sourceAction == .DHTML,
the file-promise path is skipped, writePromisedImageDragDataToPasteboard
is never called, and the pasteboard has no image data — resulting in
empty dataTransfer.files on drop.

In this patch, we address this regression by removing the .Image gate.
This brings our behavior back to pre-309943@main. The presence of
promised image drag data is the authoritative signal that image needs
file-promise treatment.

Test: TestWebKitAPI.DragAndDropTests.DoNotExposeCrossOriginImageData

* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::startDrag):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/DragAndDropTests.mm:
(TEST(DragAndDropTests, DoNotExposeCrossOriginImageData)):
(TEST(DragAndDropTests, DISABLED_DoNotExposeCrossOriginImageData)): Deleted.

Canonical link: <a href="https://commits.webkit.org/313088@main">https://commits.webkit.org/313088@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20a303ceabf9c390398f5f68225faa43a237a9bd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162020 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35495 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28600 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170928 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118391 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3e3cb6dd-891f-49d7-b8c9-330d153fa73b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163889 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35597 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35496 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125734 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164979 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28048 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145530 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106316 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27097 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25609 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18648 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136790 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23284 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173416 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20507 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24925 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134025 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35168 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29694 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134031 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35152 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145079 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97289 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24615 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28559 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21904 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34662 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102147 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34163 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34405 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34311 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->