### PR TITLE
[GTK][WPE] Skia Compositor: use Skia API to upload pixels to texture in CoordinatedPlatformLayerBufferNativeImage

### DIFF
--- a/Source/WebCore/platform/graphics/ColorMatrix.h
+++ b/Source/WebCore/platform/graphics/ColorMatrix.h
@@ -188,16 +188,6 @@ inline ColorMatrix<3, 3> hueRotateColorMatrix(float angleInDegrees)
     };
 }
 
-constexpr ColorMatrix<5, 4> swapRedBlueMatrix()
-{
-    return ColorMatrix<5, 4> {
-        0.0f, 0.0f, 1.0f, 0.0f, 0.0f,
-        0.0f, 1.0f, 0.0f, 0.0f, 0.0f,
-        1.0f, 0.0f, 0.0f, 0.0f, 0.0f,
-        0.0f, 0.0f, 0.0f, 1.0f, 0.0f,
-    };
-}
-
 template<size_t ColumnCount, size_t RowCount>
 template<size_t NumberOfComponents>
 constexpr auto ColorMatrix<ColumnCount, RowCount>::transformedColorComponents(const ColorComponents<float, NumberOfComponents>& inputVector) const -> ColorComponents<float, NumberOfComponents>

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.cpp
@@ -42,7 +42,12 @@
 #include "PlatformDisplay.h"
 #include "SkiaUtilities.h"
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkColorSpace.h>
 #include <skia/core/SkPixmap.h> // NOLINT
+#include <skia/gpu/ganesh/GrBackendSurface.h>
+#include <skia/gpu/ganesh/SkImageGanesh.h>
+#include <skia/gpu/ganesh/SkSurfaceGanesh.h>
+#include <skia/gpu/ganesh/gl/GrGLBackendSurface.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #endif
 
@@ -95,7 +100,7 @@ CoordinatedPlatformLayerBufferNativeImage::~CoordinatedPlatformLayerBufferNative
 #endif
 }
 
-bool CoordinatedPlatformLayerBufferNativeImage::tryEnsureBuffer()
+bool CoordinatedPlatformLayerBufferNativeImage::tryEnsureBuffer(UseSkiaForCompositing useSkiaForCompositing)
 {
     if (m_buffer)
         return true;
@@ -114,10 +119,23 @@ bool CoordinatedPlatformLayerBufferNativeImage::tryEnsureBuffer()
     auto* surface = m_image->platformImage().get();
     auto* imageData = cairo_image_surface_get_data(surface);
     texture->updateContents(imageData, IntRect(IntPoint(), m_size), IntPoint(), cairo_image_surface_get_stride(surface), PixelFormat::BGRA8);
+    UNUSED_PARAM(useSkiaForCompositing);
 #elif USE(SKIA)
     const auto& image = m_image->platformImage();
     SkPixmap pixmap;
-    if (image->peekPixels(&pixmap))
+    if (!image->peekPixels(&pixmap))
+        return false;
+
+    if (useSkiaForCompositing == UseSkiaForCompositing::Yes) {
+        auto& display = PlatformDisplay::sharedDisplay();
+        GLContext::ScopedGLContextCurrent scopedCurrent(*display.skiaGLContext());
+        GrBackendTexture backendTexture = texture->createSkiaBackendTexture();
+        auto surface = SkSurfaces::WrapBackendTexture(display.skiaGrContext(), backendTexture, kTopLeft_GrSurfaceOrigin, 0, kRGBA_8888_SkColorType, SkColorSpace::MakeSRGB(), nullptr);
+        if (!surface)
+            return false;
+
+        surface->writePixels(pixmap, 0, 0);
+    } else
         texture->updateContents(pixmap.addr(), IntRect(IntPoint(), m_size), IntPoint(), image->imageInfo().minRowBytes(), PixelFormat::BGRA8);
 #endif
 
@@ -140,7 +158,7 @@ void CoordinatedPlatformLayerBufferNativeImage::paintToCanvas(SkCanvas& canvas, 
 {
     waitForContentsIfNeeded();
 
-    if (!tryEnsureBuffer())
+    if (!tryEnsureBuffer(UseSkiaForCompositing::Yes))
         return;
 
     m_buffer->paintToCanvas(canvas, targetRect, paint);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.h
@@ -47,7 +47,8 @@ private:
     void paintToCanvas(SkCanvas&, const FloatRect&, const SkPaint&) override;
 #endif
 
-    bool tryEnsureBuffer();
+    enum class UseSkiaForCompositing : bool { No, Yes };
+    bool tryEnsureBuffer(UseSkiaForCompositing = UseSkiaForCompositing::No);
 
     RefPtr<NativeImage> m_image;
     std::unique_ptr<CoordinatedPlatformLayerBuffer> m_buffer;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.cpp
@@ -93,16 +93,8 @@ void CoordinatedPlatformLayerBufferRGB::paintToCanvas(SkCanvas& canvas, const Fl
     auto origin = m_flags.contains(TextureMapperFlags::ShouldFlipTexture) ? kBottomLeft_GrSurfaceOrigin : kTopLeft_GrSurfaceOrigin;
     sk_sp<SkImage> image = SkImages::BorrowTextureFrom(grContext, backendTexture, origin, kRGBA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
 
-    auto imagePaint = paint;
-    if (m_texture && m_texture->colorConvertFlags().contains(TextureMapperFlags::ShouldConvertTextureBGRAToRGBA)) {
-        const auto matrix = swapRedBlueMatrix();
-        auto bgraFilter = SkColorFilters::Matrix(matrix.data().data());
-        if (auto* colorFilter = paint.getColorFilter())
-            imagePaint.setColorFilter(colorFilter->makeComposed(bgraFilter));
-        else
-            imagePaint.setColorFilter(bgraFilter);
-    }
-    canvas.drawImageRect(image, SkRect::MakeWH(m_size.width(), m_size.height()), SkRect(targetRect), SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone), &imagePaint, SkCanvas::kFast_SrcRectConstraint);
+    ASSERT(!m_texture || !m_texture->colorConvertFlags().contains(TextureMapperFlags::ShouldConvertTextureBGRAToRGBA));
+    canvas.drawImageRect(image, SkRect::MakeWH(m_size.width(), m_size.height()), SkRect(targetRect), SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone), &paint, SkCanvas::kFast_SrcRectConstraint);
 }
 #endif
 


### PR DESCRIPTION
#### a1f766aff4083db65f1093e10ffcb962bc59ae5c
<pre>
[GTK][WPE] Skia Compositor: use Skia API to upload pixels to texture in CoordinatedPlatformLayerBufferNativeImage
<a href="https://bugs.webkit.org/show_bug.cgi?id=314630">https://bugs.webkit.org/show_bug.cgi?id=314630</a>

Reviewed by Nikolas Zimmermann.

This way the BGRA to RGBA conversion happens when uploading pixels and
we don&apos;t need to apply a filter while drawing.

* Source/WebCore/platform/graphics/ColorMatrix.h:
(WebCore::swapRedBlueMatrix): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.cpp:
(WebCore::CoordinatedPlatformLayerBufferNativeImage::tryEnsureBuffer):
(WebCore::CoordinatedPlatformLayerBufferNativeImage::paintToCanvas):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.cpp:
(WebCore::CoordinatedPlatformLayerBufferRGB::paintToCanvas):

Canonical link: <a href="https://commits.webkit.org/313079@main">https://commits.webkit.org/313079@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/490bcb6e64075f9d0dabb8b5c012568f5d42d324

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162043 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35518 "Hash 490bcb6e for PR 64747 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28623 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170951 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118414 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163912 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35620 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35519 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125754 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88622 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165002 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28067 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145552 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106336 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27116 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25626 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18671 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136809 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23306 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173439 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20662 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24947 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134045 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35192 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29711 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134051 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35175 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145101 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97334 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24610 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28577 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21926 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34685 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102297 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34186 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34428 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34334 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->