### PR TITLE
[Site Isolation] DetachedImageBitmap should be sendable over IPC

### DIFF
--- a/LayoutTests/platform/ios-site-isolation/TestExpectations
+++ b/LayoutTests/platform/ios-site-isolation/TestExpectations
@@ -308,7 +308,6 @@ imported/w3c/web-platform-tests/webcodecs/video-frame-serialization.any.html [ F
 imported/w3c/web-platform-tests/webcodecs/video-frame-serialization.any.worker.html [ Failure ]
 imported/w3c/web-platform-tests/webcodecs/videoFrame-serialization.crossAgentCluster.https.html [ Failure ]
 imported/w3c/web-platform-tests/webmessaging/Channel_postMessage_Blob.any.html [ Failure ]
-imported/w3c/web-platform-tests/webmessaging/postMessage_cross_domain_image_transfer_2d.sub.htm [ Failure ]
 imported/w3c/web-platform-tests/websockets/back-forward-cache-with-closed-websocket-connection.window.html [ Failure ]
 imported/w3c/web-platform-tests/websockets/back-forward-cache-with-open-websocket-connection-and-close-it-in-pagehide.window.html [ Failure ]
 imported/w3c/web-platform-tests/websockets/back-forward-cache-with-open-websocket-connection-ccns.tentative.window.html [ Failure ]

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -286,7 +286,6 @@ imported/w3c/web-platform-tests/webcodecs/video-frame-serialization.any.html [ F
 imported/w3c/web-platform-tests/webcodecs/video-frame-serialization.any.worker.html [ Failure ]
 imported/w3c/web-platform-tests/webcodecs/videoFrame-serialization.crossAgentCluster.https.html [ Failure ]
 imported/w3c/web-platform-tests/webmessaging/Channel_postMessage_Blob.any.html [ Failure ]
-imported/w3c/web-platform-tests/webmessaging/postMessage_cross_domain_image_transfer_2d.sub.htm [ Failure ]
 imported/w3c/web-platform-tests/webrtc/RTCRtpReceiver-getSynchronizationSources.https.html [ Failure ]
 imported/w3c/web-platform-tests/websockets/back-forward-cache-with-closed-websocket-connection-ccns.tentative.window.html [ Failure ]
 imported/w3c/web-platform-tests/websockets/back-forward-cache-with-closed-websocket-connection.window.html [ Failure ]

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -4815,8 +4815,14 @@ private:
             return JSValue();
         }
 
-        if (!m_imageBitmaps[index] && m_detachedImageBitmaps.at(index))
+        if (!m_imageBitmaps[index]) {
+            if (!m_detachedImageBitmaps.at(index)) {
+                SERIALIZE_TRACE("FAIL deserialize");
+                fail();
+                return JSValue();
+            }
             m_imageBitmaps[index] = ImageBitmap::create(*protect(executionContext(m_lexicalGlobalObject)).get(), WTF::move(*m_detachedImageBitmaps.at(index)));
+        }
 
         RefPtr bitmap = m_imageBitmaps[index];
         if (!bitmap)
@@ -6915,6 +6921,7 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
         , .serializedAudioChunks = WTF::move(serializedAudioChunks)
 #endif
         , .exposedMessagePortCount = exposedMessagePortsCount
+        , .detachedImageBitmaps = WTF::move(detachedImageBitmaps)
         , .fileSystemHandleTransferTokens = WTF::move(fileSystemHandleTransferTokens)
 #if ENABLE(WEB_CODECS)
         , .serializedVideoFrames = WTF::move(serializedVideoFrameData)
@@ -6932,7 +6939,6 @@ ExceptionOr<Ref<SerializedScriptValue>> SerializedScriptValue::create(JSGlobalOb
         , .detachedMediaStreamTrackHandles = WTF::move(detachedMediaStreamTrackHandleStorages)
 #endif
         , .sharedBufferContentsArray = WTF::move(sharedBuffers)
-        , .detachedImageBitmaps = WTF::move(detachedImageBitmaps)
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
         , .detachedOffscreenCanvases = WTF::move(detachedCanvases)
         , .inMemoryOffscreenCanvases = WTF::move(inMemoryOffscreenCanvases)

--- a/Source/WebCore/bindings/js/SerializedScriptValue.h
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.h
@@ -133,6 +133,9 @@ private:
     using Internals = SerializedScriptValueInternals;
     friend struct IPC::ArgumentCoder<Internals>;
 
+    Internals& internals() LIFETIME_BOUND { return *m_internals; }
+    const Internals& internals() const LIFETIME_BOUND { return *m_internals; }
+
     static Ref<SerializedScriptValue> create(Internals&& internals)
     {
         return adoptRef(*new SerializedScriptValue(WTF::move(internals)));

--- a/Source/WebCore/bindings/js/SerializedScriptValueInternals.h
+++ b/Source/WebCore/bindings/js/SerializedScriptValueInternals.h
@@ -86,6 +86,7 @@ struct SerializedScriptValueInternals {
     Vector<Ref<WebCodecsEncodedAudioChunkStorage>> serializedAudioChunks { };
 #endif
     uint64_t exposedMessagePortCount { 0 };
+    Vector<std::optional<DetachedImageBitmap>> detachedImageBitmaps { };
     Vector<FileSystemHandleTransferToken> fileSystemHandleTransferTokens { };
 #if ENABLE(WEB_CODECS)
     Vector<WebCodecsVideoFrameData> serializedVideoFrames { };
@@ -103,7 +104,6 @@ struct SerializedScriptValueInternals {
     Vector<std::unique_ptr<MediaStreamTrackHandleDataHolder>> detachedMediaStreamTrackHandles { };
 #endif
     std::unique_ptr<ArrayBufferContentsArray> sharedBufferContentsArray { nullptr };
-    Vector<std::optional<DetachedImageBitmap>> detachedImageBitmaps { };
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
     Vector<std::unique_ptr<DetachedOffscreenCanvas>> detachedOffscreenCanvases { };
     Vector<Ref<OffscreenCanvas>> inMemoryOffscreenCanvases { };

--- a/Source/WebCore/html/ImageBitmap.h
+++ b/Source/WebCore/html/ImageBitmap.h
@@ -73,12 +73,20 @@ template<typename> class ExceptionOr;
 
 class DetachedImageBitmap {
 public:
-    DetachedImageBitmap(DetachedImageBitmap&&);
+    WEBCORE_EXPORT DetachedImageBitmap(UniqueRef<SerializedImageBuffer>, bool originClean, bool premultiplyAlpha, bool forciblyPremultiplyAlpha);
+    WEBCORE_EXPORT DetachedImageBitmap(DetachedImageBitmap&&);
     WEBCORE_EXPORT ~DetachedImageBitmap();
-    DetachedImageBitmap& operator=(DetachedImageBitmap&&);
+    WEBCORE_EXPORT DetachedImageBitmap& operator=(DetachedImageBitmap&&);
     size_t memoryCost() const;
+
+    bool originClean() const { return m_originClean; }
+    bool premultiplyAlpha() const { return m_premultiplyAlpha; }
+    bool forciblyPremultiplyAlpha() const { return m_forciblyPremultiplyAlpha; }
+
+    SerializedImageBuffer& serializedImageBuffer() LIFETIME_BOUND { return m_bitmap; }
+    const SerializedImageBuffer& serializedImageBuffer() const LIFETIME_BOUND { return m_bitmap; }
+
 private:
-    DetachedImageBitmap(UniqueRef<SerializedImageBuffer>, bool originClean, bool premultiplyAlpha, bool forciblyPremultiplyAlpha);
     UniqueRef<SerializedImageBuffer> m_bitmap;
     bool m_originClean : 1 { false };
     bool m_premultiplyAlpha : 1 { false };

--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -175,6 +175,11 @@ public:
         return m_buffer;
     }
 
+    RefPtr<ImageBuffer> imageBufferForCrossProcessSerialization() const final
+    {
+        return m_buffer;
+    }
+
     size_t memoryCost() const final
     {
         return m_buffer->memoryCost();

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -279,6 +279,11 @@ public:
     WEBCORE_EXPORT static RefPtr<ImageBuffer> sinkIntoImageBuffer(std::unique_ptr<SerializedImageBuffer>, GraphicsClient* = nullptr);
 
     virtual bool isRemoteSerializedImageBufferProxy() const { return false; }
+    virtual bool isSendableSerializedImageBuffer() const { return false; }
+
+    // Returns the locally-readable ImageBuffer for subclasses that hold one (e.g. DefaultSerializedImageBuffer).
+    // Used to extract an IPC-safe backend handle before cross-process transfer.
+    virtual RefPtr<ImageBuffer> imageBufferForCrossProcessSerialization() const { return nullptr; }
 
 protected:
     virtual RefPtr<ImageBuffer> sinkIntoImageBuffer() = 0;

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp
@@ -32,6 +32,7 @@
 #include "GPUConnectionToWebProcess.h"
 #include "GPUProcess.h"
 #include "GPUProcessProxyMessages.h"
+#include "ImageBufferBackendHandleSharing.h"
 #include "ImageBufferShareableBitmapBackend.h"
 #include "Logging.h"
 #include "PrepareBackingStoreBuffersData.h"
@@ -213,6 +214,35 @@ void RemoteRenderingBackend::moveToImageBuffer(RemoteSerializedImageBufferIdenti
     imageBuffer->transferToNewContext(creationContext);
     auto result = m_remoteImageBuffers.add(imageBufferIdentifier, RemoteImageBuffer::create(imageBuffer.releaseNonNull(), imageBufferIdentifier, contextIdentifier, *this));
     MESSAGE_CHECK(result.isNewEntry, "Duplicate ImageBuffer");
+}
+
+void RemoteRenderingBackend::createSerializedImageBufferHandle(RemoteSerializedImageBufferIdentifier identifier, CompletionHandler<void(std::optional<ImageBufferBackendHandle>)>&& completionHandler)
+{
+    assertIsCurrent(workQueue());
+    std::optional<ImageBufferBackendHandle> handle;
+    if (RefPtr imageBuffer = m_sharedResourceCache->takeSerializedImageBuffer(identifier)) {
+        // Always materialize as a ShareableBitmap (SharedMemory) so the receiver doesn't need
+        // IOKit access. Receiver WebContent processes that delegate all rendering to the GPU
+        // process have ProcessCapabilities::canUseAcceleratedBuffers() == false and cannot
+        // map an IOSurface from a MachSendRight.
+        if (RefPtr nativeImage = imageBuffer->copyNativeImage()) {
+            RefPtr<WebCore::ShareableBitmap> bitmap;
+#if USE(CG)
+            bitmap = WebCore::ShareableBitmap::createFromImagePixels(*nativeImage);
+#endif
+            if (!bitmap)
+                bitmap = WebCore::ShareableBitmap::createFromImageDraw(*nativeImage, WebCore::DestinationColorSpace { nativeImage->colorSpace() });
+            if (bitmap) {
+                if (auto bitmapHandle = bitmap->createHandle()) {
+                    if (sharedResourceCache().resourceOwner())
+                        bitmapHandle->setOwnershipOfMemory(sharedResourceCache().resourceOwner(), WebCore::MemoryLedger::Graphics);
+                    handle = ImageBufferBackendHandle { WTF::move(*bitmapHandle) };
+                }
+            }
+        }
+        m_sharedResourceCache->addSerializedImageBuffer(identifier, imageBuffer.releaseNonNull());
+    }
+    completionHandler(WTF::move(handle));
 }
 
 void RemoteRenderingBackend::createSnapshotRecorder(RemoteSnapshotRecorderIdentifier identifier, RemoteSnapshotIdentifier snapshotIdentifier)

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h
@@ -155,6 +155,7 @@ private:
     void releaseImageBuffer(WebCore::RenderingResourceIdentifier);
     void moveToSerializedBuffer(WebCore::RenderingResourceIdentifier, RemoteSerializedImageBufferIdentifier);
     void moveToImageBuffer(RemoteSerializedImageBufferIdentifier, WebCore::RenderingResourceIdentifier, RemoteGraphicsContextIdentifier);
+    void createSerializedImageBufferHandle(RemoteSerializedImageBufferIdentifier, CompletionHandler<void(std::optional<ImageBufferBackendHandle>)>&&);
     void createDisplayListRecorder(RemoteDisplayListRecorderIdentifier);
     void sinkDisplayListRecorderIntoDisplayList(RemoteDisplayListRecorderIdentifier, RemoteDisplayListIdentifier);
     void releaseDisplayList(RemoteDisplayListIdentifier);

--- a/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in
@@ -67,6 +67,7 @@ messages -> RemoteRenderingBackend Stream {
 
     MoveToSerializedBuffer(WebCore::RenderingResourceIdentifier identifier, WebKit::RemoteSerializedImageBufferIdentifier serializedIdentifier)
     MoveToImageBuffer(WebKit::RemoteSerializedImageBufferIdentifier identifier, WebCore::RenderingResourceIdentifier imageBufferIdentifier, WebKit::RemoteGraphicsContextIdentifier contextIdentifier)
+    CreateSerializedImageBufferHandle(WebKit::RemoteSerializedImageBufferIdentifier identifier) -> (std::optional<WebKit::ImageBufferBackendHandle> handle) Synchronous NotStreamEncodableReply
 
     CreateSnapshotRecorder(WebKit::RemoteSnapshotRecorderIdentifier identifier, WebKit::RemoteSnapshotIdentifier snapshotIdentifier)
     SinkSnapshotRecorderIntoSnapshotFrame(WebKit::RemoteSnapshotRecorderIdentifier identifier, WebCore::FrameIdentifier frameIdentifer) -> (bool success)

--- a/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
+++ b/Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in
@@ -499,10 +499,15 @@
 [UnsafeWrapper] std::optional<WebKit::ImageBufferBackendHandle> {
     [Legacy] MessageParam RemoteImageBufferProxy.DidCreateBackend handle
     [Legacy] MessageParamReply WebPage.TakeSnapshot image
+    [NeedsReview] MessageParamReply RemoteRenderingBackend.CreateSerializedImageBufferHandle handle
     [Legacy] StructureParam WebKit::RemoteLayerBackingStoreProperties.m_bufferHandle
     [Legacy] StructureParam WebKit::BufferSetBackendHandle.bufferHandle
     [Legacy] StructureParam WebKit::ImageBufferSetPrepareBufferForDisplayOutputData.backendHandle
     [Legacy] StructureParam WebKit::WCBackingStore.handle()
+}
+
+[UnsafeWrapper] WebKit::ImageBufferBackendHandle {
+    [NeedsReview] StructureParam WebKit::DetachedImageBitmapIPCData.handle
 }
 
 [UnsafeWrapper] UniqueRef<WebKit::ObjectValue> {

--- a/Source/WebKit/Shared/DetachedImageBitmapIPC.cpp
+++ b/Source/WebKit/Shared/DetachedImageBitmapIPC.cpp
@@ -1,0 +1,190 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "DetachedImageBitmapIPC.h"
+
+#include "Decoder.h"
+#include "Encoder.h"
+#include "ImageBufferBackendHandleSharing.h"
+#include "RemoteImageBufferProxy.h"
+#include "RemoteRenderingBackendProxy.h"
+#include "SendableSerializedImageBuffer.h"
+#include <WebCore/ImageBitmap.h>
+#include <WebCore/NativeImage.h>
+#include <WebCore/ShareableBitmap.h>
+#include <wtf/NeverDestroyed.h>
+
+namespace WebKit {
+
+static WeakPtr<RemoteRenderingBackendProxy>& currentRenderingBackendForEncodingSlot()
+{
+    static thread_local NeverDestroyed<WeakPtr<RemoteRenderingBackendProxy>> slot;
+    return slot.get();
+}
+
+ScopedCrossProcessImageBitmapEncoding::ScopedCrossProcessImageBitmapEncoding(RemoteRenderingBackendProxy* renderingBackend)
+    : m_previous(WTF::move(currentRenderingBackendForEncodingSlot()))
+{
+    currentRenderingBackendForEncodingSlot() = renderingBackend;
+}
+
+ScopedCrossProcessImageBitmapEncoding::~ScopedCrossProcessImageBitmapEncoding()
+{
+    currentRenderingBackendForEncodingSlot() = WTF::move(m_previous);
+}
+
+RefPtr<RemoteRenderingBackendProxy> ScopedCrossProcessImageBitmapEncoding::currentForThread()
+{
+    return currentRenderingBackendForEncodingSlot().get();
+}
+
+static std::optional<ImageBufferBackendHandle> handleForCrossProcessTransfer(const WebCore::SerializedImageBuffer& buffer)
+{
+    if (auto* sendable = dynamicDowncast<SendableSerializedImageBuffer>(&buffer)) {
+        // The same DetachedImageBitmap is being re-encoded (e.g. broadcast). Duplicate
+        // the existing handle so the source remains usable for a subsequent send.
+        return WTF::switchOn(sendable->handle(),
+            [](const WebCore::ShareableBitmap::Handle& shareableHandle) -> std::optional<ImageBufferBackendHandle> {
+                return ImageBufferBackendHandle { WebCore::ShareableBitmap::Handle { shareableHandle } };
+            }
+#if PLATFORM(COCOA)
+            , [](const MachSendRight& sendRight) -> std::optional<ImageBufferBackendHandle> {
+                return ImageBufferBackendHandle { MachSendRight { sendRight } };
+            }
+#endif
+#if ENABLE(RE_DYNAMIC_CONTENT_SCALING)
+            , [](const WebCore::DynamicContentScalingDisplayList&) -> std::optional<ImageBufferBackendHandle> {
+                return std::nullopt;
+            }
+#endif
+        );
+    }
+
+    if (auto* remoteBuffer = dynamicDowncast<RemoteSerializedImageBufferProxy>(&buffer)) {
+        if (RefPtr renderingBackend = ScopedCrossProcessImageBitmapEncoding::currentForThread())
+            return renderingBackend->createSerializedImageBufferHandle(remoteBuffer->identifier());
+        return std::nullopt;
+    }
+
+    RefPtr localBuffer = buffer.imageBufferForCrossProcessSerialization();
+    if (!localBuffer)
+        return std::nullopt;
+    if (auto* sharing = dynamicDowncast<ImageBufferBackendHandleSharing>(localBuffer->toBackendSharing()))
+        return sharing->createBackendHandle();
+
+    // Local backend doesn't expose a sharable handle (e.g. plain CGBitmap or local IOSurface
+    // backend that doesn't implement the WebKit-side sharing interface). Copy the pixels into
+    // a SharedMemory-backed ShareableBitmap so the receiver can materialize it without IOKit.
+    RefPtr nativeImage = localBuffer->copyNativeImage();
+    if (!nativeImage)
+        return std::nullopt;
+    RefPtr<WebCore::ShareableBitmap> bitmap;
+#if USE(CG)
+    bitmap = WebCore::ShareableBitmap::createFromImagePixels(*nativeImage);
+#endif
+    if (!bitmap)
+        bitmap = WebCore::ShareableBitmap::createFromImageDraw(*nativeImage, WebCore::DestinationColorSpace { nativeImage->colorSpace() });
+    if (!bitmap)
+        return std::nullopt;
+    auto bitmapHandle = bitmap->createHandle();
+    if (!bitmapHandle)
+        return std::nullopt;
+    return ImageBufferBackendHandle { WTF::move(*bitmapHandle) };
+}
+
+static WebCore::ImageBuffer::Parameters parametersForBuffer(const WebCore::SerializedImageBuffer& buffer)
+{
+    if (auto* sendable = dynamicDowncast<SendableSerializedImageBuffer>(&buffer))
+        return sendable->parameters();
+    if (auto* remoteBuffer = dynamicDowncast<RemoteSerializedImageBufferProxy>(&buffer))
+        return remoteBuffer->parameters();
+    if (RefPtr localBuffer = buffer.imageBufferForCrossProcessSerialization())
+        return localBuffer->parameters();
+    return { { }, 1, WebCore::DestinationColorSpace::SRGB(), { WebCore::PixelFormat::BGRA8 }, WebCore::RenderingPurpose::Unspecified };
+}
+
+static WebCore::ImageBufferBackend::Info infoForBuffer(const WebCore::SerializedImageBuffer& buffer)
+{
+    if (auto* sendable = dynamicDowncast<SendableSerializedImageBuffer>(&buffer))
+        return sendable->backendInfo();
+    if (auto* remoteBuffer = dynamicDowncast<RemoteSerializedImageBufferProxy>(&buffer))
+        return remoteBuffer->info();
+    if (RefPtr localBuffer = buffer.imageBufferForCrossProcessSerialization())
+        return localBuffer->backendInfo();
+    return { WebCore::RenderingMode::Unaccelerated, { }, 0 };
+}
+
+} // namespace WebKit
+
+namespace IPC {
+
+void ArgumentCoder<std::optional<WebCore::DetachedImageBitmap>>::encode(Encoder& encoder, const std::optional<WebCore::DetachedImageBitmap>& opt)
+{
+    if (!opt) {
+        encoder << false;
+        return;
+    }
+    auto& detached = *opt;
+    auto handle = WebKit::handleForCrossProcessTransfer(detached.serializedImageBuffer());
+    if (!handle) {
+        // Extraction failed (e.g. send site missing ScopedCrossProcessImageBitmapEncoding).
+        // Drop the slot so the receiver matches the original [NotSerialized] semantic:
+        // CloneDeserializer::readTransferredImageBitmap fails for this index, and the
+        // recipient sees a messageerror event rather than an invalid ImageBitmap.
+        encoder << false;
+        return;
+    }
+    auto info = WebKit::infoForBuffer(detached.serializedImageBuffer());
+    encoder << true;
+    encoder << WebKit::DetachedImageBitmapIPCData {
+        WebKit::parametersForBuffer(detached.serializedImageBuffer()),
+        info.renderingMode,
+        info.baseTransform,
+        static_cast<uint64_t>(info.memoryCost),
+        WTF::move(*handle),
+        detached.originClean(),
+        detached.premultiplyAlpha(),
+        detached.forciblyPremultiplyAlpha(),
+    };
+}
+
+std::optional<std::optional<WebCore::DetachedImageBitmap>> ArgumentCoder<std::optional<WebCore::DetachedImageBitmap>>::decode(Decoder& decoder)
+{
+    auto isEngaged = decoder.decode<bool>();
+    if (!isEngaged)
+        return std::nullopt;
+    if (!*isEngaged)
+        return std::optional<std::optional<WebCore::DetachedImageBitmap>>(std::optional<WebCore::DetachedImageBitmap>(std::nullopt));
+    auto data = decoder.decode<WebKit::DetachedImageBitmapIPCData>();
+    if (!data)
+        return std::nullopt;
+    WebCore::ImageBufferBackend::Info info { data->renderingMode, data->baseTransform, static_cast<size_t>(data->memoryCost) };
+    std::unique_ptr<WebCore::SerializedImageBuffer> sendable = makeUnique<WebKit::SendableSerializedImageBuffer>(data->parameters, info, WTF::move(data->handle));
+    WebCore::DetachedImageBitmap detached { makeUniqueRefFromNonNullUniquePtr(WTF::move(sendable)), data->originClean, data->premultiplyAlpha, data->forciblyPremultiplyAlpha };
+    return std::optional<std::optional<WebCore::DetachedImageBitmap>>(std::optional<WebCore::DetachedImageBitmap>(WTF::move(detached)));
+}
+
+} // namespace IPC

--- a/Source/WebKit/Shared/DetachedImageBitmapIPC.h
+++ b/Source/WebKit/Shared/DetachedImageBitmapIPC.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ImageBufferBackendHandle.h"
+#include <WebCore/AffineTransform.h>
+#include <WebCore/ImageBuffer.h>
+#include <WebCore/RenderingMode.h>
+#include <optional>
+#include <wtf/WeakPtr.h>
+
+namespace IPC {
+class Decoder;
+class Encoder;
+template<typename> struct ArgumentCoder;
+}
+
+namespace WebCore {
+class DetachedImageBitmap;
+}
+
+namespace WebKit {
+
+class RemoteRenderingBackendProxy;
+
+struct DetachedImageBitmapIPCData {
+    WebCore::ImageBuffer::Parameters parameters;
+    WebCore::RenderingMode renderingMode;
+    WebCore::AffineTransform baseTransform;
+    uint64_t memoryCost { 0 };
+    ImageBufferBackendHandle handle;
+    bool originClean { false };
+    bool premultiplyAlpha { false };
+    bool forciblyPremultiplyAlpha { false };
+};
+
+// Provides thread_local acccess to RemoteRenderingBackendProxy*.
+class ScopedCrossProcessImageBitmapEncoding {
+    WTF_MAKE_NONCOPYABLE(ScopedCrossProcessImageBitmapEncoding);
+public:
+    explicit ScopedCrossProcessImageBitmapEncoding(RemoteRenderingBackendProxy*);
+    ~ScopedCrossProcessImageBitmapEncoding();
+
+    static RefPtr<RemoteRenderingBackendProxy> currentForThread();
+
+private:
+    WeakPtr<RemoteRenderingBackendProxy> m_previous;
+};
+
+} // namespace WebKit
+
+namespace IPC {
+template<> struct ArgumentCoder<std::optional<WebCore::DetachedImageBitmap>> {
+    static void encode(Encoder&, const std::optional<WebCore::DetachedImageBitmap>&);
+    static std::optional<std::optional<WebCore::DetachedImageBitmap>> decode(Decoder&);
+};
+} // namespace IPC

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -7985,7 +7985,19 @@ using WebCore::RiceSocket = std::pair<String, WebCore::RTCIceProtocol>;
 };
 #endif
 
-headers: <JavaScriptCore/WasmModule.h> <WebCore/ImageBitmap.h> <WebCore/MessagePort.h> <WebCore/OffscreenCanvas.h>
+headers: "DetachedImageBitmapIPC.h" <JavaScriptCore/WasmModule.h> <WebCore/ImageBitmap.h> <WebCore/MessagePort.h> <WebCore/OffscreenCanvas.h>
+
+[CustomHeader, RValue] struct WebKit::DetachedImageBitmapIPCData {
+    WebCore::ImageBuffer::Parameters parameters;
+    WebCore::RenderingMode renderingMode;
+    WebCore::AffineTransform baseTransform;
+    uint64_t memoryCost;
+    WebKit::ImageBufferBackendHandle handle;
+    bool originClean;
+    bool premultiplyAlpha;
+    bool forciblyPremultiplyAlpha;
+};
+
 struct WebCore::SerializedScriptValueInternals {
     Vector<uint8_t> data;
     std::unique_ptr<Vector<JSC::ArrayBufferContents>> arrayBufferContentsArray;
@@ -7997,6 +8009,7 @@ struct WebCore::SerializedScriptValueInternals {
     Vector<Ref<WebCore::WebCodecsEncodedAudioChunkStorage>> serializedAudioChunks;
 #endif
     uint64_t exposedMessagePortCount;
+    Vector<std::optional<WebCore::DetachedImageBitmap>> detachedImageBitmaps;
     [NotSerialized] Vector<WebCore::FileSystemHandleTransferToken> fileSystemHandleTransferTokens;
 #if ENABLE(WEB_CODECS)
     [NotSerialized] Vector<WebCore::WebCodecsVideoFrameData> serializedVideoFrames;
@@ -8014,7 +8027,6 @@ struct WebCore::SerializedScriptValueInternals {
     [NotSerialized] Vector<std::unique_ptr<WebCore::MediaStreamTrackHandle::DataHolder>> detachedMediaStreamTrackHandles;
 #endif
     [NotSerialized] std::unique_ptr<Vector<JSC::ArrayBufferContents>> sharedBufferContentsArray;
-    [NotSerialized] Vector<std::optional<WebCore::DetachedImageBitmap>> detachedImageBitmaps;
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
     [NotSerialized] Vector<std::unique_ptr<WebCore::DetachedOffscreenCanvas>> detachedOffscreenCanvases;
     [NotSerialized] Vector<Ref<WebCore::OffscreenCanvas>> inMemoryOffscreenCanvases;

--- a/Source/WebKit/Sources.txt
+++ b/Source/WebKit/Sources.txt
@@ -224,6 +224,7 @@ Shared/BlobDataFileReferenceWithSandboxExtension.cpp
 Shared/CacheModel.cpp
 Shared/ContextMenuContextData.cpp
 Shared/DebuggableInfoData.cpp
+Shared/DetachedImageBitmapIPC.cpp
 Shared/EditingRange.cpp
 Shared/EditorState.cpp
 Shared/FrameInfoData.cpp
@@ -817,6 +818,7 @@ WebProcess/GPU/graphics/RemoteNativeImageProxy.cpp
 WebProcess/GPU/graphics/RemoteSnapshotRecorderProxy.cpp
 WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
 WebProcess/GPU/graphics/RemoteResourceCacheProxy.cpp
+WebProcess/GPU/graphics/SendableSerializedImageBuffer.cpp
 WebProcess/GPU/media/AudioTrackPrivateRemote.cpp
 WebProcess/GPU/media/AudioVideoRendererRemote.cpp
 WebProcess/GPU/media/MediaPlayerPrivateRemote.cpp

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -6942,6 +6942,8 @@
 		723C90A22A377AB400038126 /* PathSegment.serialization.in */ = {isa = PBXFileReference; lastKnownFileType = text; path = PathSegment.serialization.in; sourceTree = "<group>"; };
 		72440D33287CCC0500FADBC4 /* RemoteImageBuffer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteImageBuffer.cpp; sourceTree = "<group>"; };
 		72440D3A287CF58900FADBC4 /* RemoteImageBufferProxy.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = RemoteImageBufferProxy.cpp; sourceTree = "<group>"; };
+		CDD2B05F2EC5F0000038E843 /* SendableSerializedImageBuffer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = SendableSerializedImageBuffer.cpp; sourceTree = "<group>"; };
+		CDD2B0602EC5F0000038E843 /* SendableSerializedImageBuffer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SendableSerializedImageBuffer.h; sourceTree = "<group>"; };
 		724DCF21284862FC0026ACF4 /* ImageBufferShareableAllocator.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ImageBufferShareableAllocator.h; sourceTree = "<group>"; };
 		724DCF22284862FC0026ACF4 /* ImageBufferShareableAllocator.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ImageBufferShareableAllocator.cpp; sourceTree = "<group>"; };
 		726952DF2B7F4636009E5F0C /* WebExtensionAPIWebPageRuntime.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionAPIWebPageRuntime.h; sourceTree = "<group>"; };
@@ -7553,6 +7555,8 @@
 		99036AE423A958740000B06A /* APIDebuggableInfo.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = APIDebuggableInfo.cpp; sourceTree = "<group>"; };
 		99036AE723A970870000B06A /* DebuggableInfoData.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DebuggableInfoData.h; sourceTree = "<group>"; };
 		99036AE823A970870000B06A /* DebuggableInfoData.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DebuggableInfoData.cpp; sourceTree = "<group>"; };
+		CDD3C0902EC600000038E843 /* DetachedImageBitmapIPC.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DetachedImageBitmapIPC.cpp; sourceTree = "<group>"; };
+		CDD3C0912EC600000038E843 /* DetachedImageBitmapIPC.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = DetachedImageBitmapIPC.h; sourceTree = "<group>"; };
 		990657311F323CBF00944F9C /* FindNodes.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = FindNodes.js; sourceTree = "<group>"; };
 		990657321F323CBF00944F9C /* FormElementClear.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = FormElementClear.js; sourceTree = "<group>"; };
 		990657331F323CBF00944F9C /* ElementDisplayed.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = ElementDisplayed.js; sourceTree = "<group>"; };
@@ -10280,6 +10284,8 @@
 				5C2C6FA627C958FC00CCDA9E /* DataTaskIdentifier.h */,
 				99036AE823A970870000B06A /* DebuggableInfoData.cpp */,
 				99036AE723A970870000B06A /* DebuggableInfoData.h */,
+				CDD3C0902EC600000038E843 /* DetachedImageBitmapIPC.cpp */,
+				CDD3C0912EC600000038E843 /* DetachedImageBitmapIPC.h */,
 				0F189CAB24749F2F00E58D81 /* DisplayLinkObserverID.h */,
 				2D7FD190223C730F007887F1 /* DocumentEditingContext.h */,
 				2D7FD191223C7310007887F1 /* DocumentEditingContext.mm */,
@@ -14496,6 +14502,8 @@
 				72B53158253C1E4D0049295A /* RemoteResourceCacheProxy.h */,
 				7BDC880D2E72D80500C7A37F /* RemoteSnapshotRecorderProxy.cpp */,
 				7BDC880C2E72D80500C7A37F /* RemoteSnapshotRecorderProxy.h */,
+				CDD2B05F2EC5F0000038E843 /* SendableSerializedImageBuffer.cpp */,
+				CDD2B0602EC5F0000038E843 /* SendableSerializedImageBuffer.h */,
 			);
 			path = graphics;
 			sourceTree = "<group>";

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp
@@ -339,6 +339,15 @@ Ref<RemoteImageBufferProxy> RemoteRenderingBackendProxy::moveToImageBuffer(Remot
     return result;
 }
 
+std::optional<ImageBufferBackendHandle> RemoteRenderingBackendProxy::createSerializedImageBufferHandle(RemoteSerializedImageBufferIdentifier identifier)
+{
+    auto sendResult = sendSync(Messages::RemoteRenderingBackend::CreateSerializedImageBufferHandle(identifier));
+    if (!sendResult.succeeded())
+        return std::nullopt;
+    auto [handle] = sendResult.takeReply();
+    return handle;
+}
+
 UniqueRef<RemoteSnapshotRecorderProxy> RemoteRenderingBackendProxy::createSnapshotRecorder(RemoteSnapshotIdentifier snapshotIdentifier)
 {
     auto recorder = makeUniqueRef<RemoteSnapshotRecorderProxy>(*this);

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h
@@ -109,6 +109,7 @@ public:
     void transferImageBuffer(std::unique_ptr<RemoteSerializedImageBufferProxy>, WebCore::ImageBuffer&);
     std::unique_ptr<RemoteSerializedImageBufferProxy> moveToSerializedBuffer(RemoteImageBufferProxy&);
     Ref<RemoteImageBufferProxy> moveToImageBuffer(RemoteSerializedImageBufferProxy&);
+    std::optional<ImageBufferBackendHandle> createSerializedImageBufferHandle(RemoteSerializedImageBufferIdentifier);
 
     bool isCached(const WebCore::ImageBuffer&) const;
 

--- a/Source/WebKit/WebProcess/GPU/graphics/SendableSerializedImageBuffer.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/SendableSerializedImageBuffer.cpp
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SendableSerializedImageBuffer.h"
+
+#include "ImageBufferShareableBitmapBackend.h"
+#include <WebCore/ShareableBitmap.h>
+#include <wtf/TZoneMallocInlines.h>
+
+#if HAVE(IOSURFACE)
+#include "ImageBufferShareableMappedIOSurfaceBackend.h"
+#endif
+
+namespace WebKit {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SendableSerializedImageBuffer);
+
+SendableSerializedImageBuffer::SendableSerializedImageBuffer(const WebCore::ImageBuffer::Parameters& parameters, const WebCore::ImageBufferBackend::Info& info, ImageBufferBackendHandle&& handle)
+    : m_parameters(parameters)
+    , m_info(info)
+    , m_handle(WTF::move(handle))
+{
+}
+
+SendableSerializedImageBuffer::~SendableSerializedImageBuffer() = default;
+
+ImageBufferBackendHandle SendableSerializedImageBuffer::takeHandle()
+{
+    return WTF::move(m_handle);
+}
+
+RefPtr<WebCore::ImageBuffer> SendableSerializedImageBuffer::sinkIntoImageBuffer()
+{
+    ASSERT_NOT_REACHED();
+    return nullptr;
+}
+
+RefPtr<WebCore::ImageBuffer> materializeImageBufferFromHandle(SendableSerializedImageBuffer& sendable)
+{
+    auto handle = sendable.takeHandle();
+    auto& parameters = sendable.parameters();
+    auto backendParameters = WebCore::ImageBuffer::backendParameters(parameters);
+
+    std::unique_ptr<WebCore::ImageBufferBackend> backend;
+
+    if (std::holds_alternative<WebCore::ShareableBitmap::Handle>(handle)) {
+        auto shareableHandle = std::get<WebCore::ShareableBitmap::Handle>(WTF::move(handle));
+        shareableHandle.takeOwnershipOfMemory(WebCore::MemoryLedger::Graphics);
+        backend = ImageBufferShareableBitmapBackend::create(backendParameters, WTF::move(shareableHandle));
+    }
+#if HAVE(IOSURFACE)
+    else if (std::holds_alternative<MachSendRight>(handle))
+        backend = ImageBufferShareableMappedIOSurfaceBackend::create(backendParameters, WTF::move(handle));
+#endif
+
+    if (!backend)
+        return nullptr;
+    return WebCore::ImageBuffer::create(parameters, sendable.backendInfo(), { }, WTF::move(backend), WebCore::RenderingResourceIdentifier::generate());
+}
+
+} // namespace WebKit

--- a/Source/WebKit/WebProcess/GPU/graphics/SendableSerializedImageBuffer.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/SendableSerializedImageBuffer.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "ImageBufferBackendHandle.h"
+#include <WebCore/ImageBuffer.h>
+#include <WebCore/ImageBufferBackend.h>
+#include <wtf/TZoneMalloc.h>
+
+namespace WebKit {
+
+class SendableSerializedImageBuffer final : public WebCore::SerializedImageBuffer {
+    WTF_MAKE_TZONE_ALLOCATED(SendableSerializedImageBuffer);
+public:
+    SendableSerializedImageBuffer(const WebCore::ImageBuffer::Parameters&, const WebCore::ImageBufferBackend::Info&, ImageBufferBackendHandle&&);
+    ~SendableSerializedImageBuffer();
+
+    size_t memoryCost() const final { return m_info.memoryCost; }
+
+    const WebCore::ImageBuffer::Parameters& parameters() const LIFETIME_BOUND { return m_parameters; }
+    const WebCore::ImageBufferBackend::Info& backendInfo() const LIFETIME_BOUND { return m_info; }
+    const ImageBufferBackendHandle& handle() const LIFETIME_BOUND { return m_handle; }
+    ImageBufferBackendHandle takeHandle();
+
+    bool isSendableSerializedImageBuffer() const final { return true; }
+
+private:
+    RefPtr<WebCore::ImageBuffer> sinkIntoImageBuffer() final;
+
+    WebCore::ImageBuffer::Parameters m_parameters;
+    WebCore::ImageBufferBackend::Info m_info;
+    ImageBufferBackendHandle m_handle;
+};
+
+} // namespace WebKit
+
+namespace WebKit {
+RefPtr<WebCore::ImageBuffer> materializeImageBufferFromHandle(SendableSerializedImageBuffer&);
+}
+
+SPECIALIZE_TYPE_TRAITS_BEGIN(WebKit::SendableSerializedImageBuffer)
+    static bool isType(const WebCore::SerializedImageBuffer& buffer) { return buffer.isSendableSerializedImageBuffer(); }
+SPECIALIZE_TYPE_TRAITS_END()

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProvider.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProvider.cpp
@@ -28,10 +28,13 @@
 
 #if ENABLE(GPU_PROCESS) && ENABLE(WEB_AUDIO) && PLATFORM(COCOA)
 
+#include <WebCore/MediaPlayer.h>
+
 #include "GPUProcessConnection.h"
 #include "Logging.h"
 #include "RemoteAudioSourceProviderManager.h"
 #include "RemoteMediaPlayerProxyMessages.h"
+#include "WebProcess.h"
 
 namespace WebCore {
 #if !RELEASE_LOG_DISABLED

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -54,6 +54,7 @@
 #include "RemoteImageBufferProxy.h"
 #include "RemoteRenderingBackendProxy.h"
 #include "RemoteTextDetectorProxy.h"
+#include "SendableSerializedImageBuffer.h"
 #include "SharedBufferReference.h"
 #include "UserData.h"
 #include "WebColorChooser.h"
@@ -1146,6 +1147,9 @@ RefPtr<ImageBuffer> WebChromeClient::createImageBuffer(const FloatSize& size, Re
 
 RefPtr<ImageBuffer> WebChromeClient::sinkIntoImageBuffer(std::unique_ptr<SerializedImageBuffer> imageBuffer)
 {
+    if (is<SendableSerializedImageBuffer>(imageBuffer))
+        return materializeImageBufferFromHandle(downcast<SendableSerializedImageBuffer>(*imageBuffer));
+
     if (!is<RemoteSerializedImageBufferProxy>(imageBuffer))
         return SerializedImageBuffer::sinkIntoImageBuffer(WTF::move(imageBuffer));
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
@@ -27,6 +27,7 @@
 #include "WebRemoteFrameClient.h"
 
 #include "MessageSenderInlines.h"
+#include "DetachedImageBitmapIPC.h"
 #include "RemoteDisplayListRecorderProxy.h"
 #include "WebFrameProxyMessages.h"
 #include "WebMessagePortChannelProvider.h"
@@ -92,8 +93,12 @@ void WebRemoteFrameClient::postMessageToRemote(FrameIdentifier source, const Sec
     for (auto& port : message.transferredPorts)
         WebMessagePortChannelProvider::singleton().messagePortSentToRemote(port.first);
 
-    if (RefPtr page = m_frame->page())
-        page->send(Messages::WebPageProxy::PostMessageToRemote(source, sourceOrigin, target, targetOrigin, message));
+    RefPtr page = m_frame->page();
+    if (!page)
+        return;
+
+    ScopedCrossProcessImageBitmapEncoding scopedEncoding { &page->ensureRemoteRenderingBackendProxy() };
+    page->send(Messages::WebPageProxy::PostMessageToRemote(source, sourceOrigin, target, targetOrigin, message));
 }
 
 void WebRemoteFrameClient::changeLocation(FrameLoadRequest&& request)


### PR DESCRIPTION
#### 24a558e92d85866b5420c1ff9b9a27a0b384f375
<pre>
[Site Isolation] DetachedImageBitmap should be sendable over IPC
<a href="https://bugs.webkit.org/show_bug.cgi?id=314625">https://bugs.webkit.org/show_bug.cgi?id=314625</a>

Reviewed by NOBODY (OOPS!).

postMessage of a transferred ImageBitmap to a cross-process recipient (e.g. cross-origin iframe under
site isolation) was dropping the bitmap data. SerializedScriptValueInternals::detachedImageBitmaps was
marked [NotSerialized] and the wire carried nothing and the receiver got an empty slot or crashed.

This PR makes it so that detachedImageBitmaps is now serialized via a hand-written
IPC::ArgumentCoder&lt;DetachedImageBitmap&gt;.

Encode dispatches on the source&apos;s SerializedImageBuffer type. A SendableSerializedImageBuffer
(re-encode case, e.g. UIProcess routing the message between two WebContent processes) just duplicates
its existing handle. A RemoteSerializedImageBufferProxy (GPU-process-owned) issues a new sync IPC
RemoteRenderingBackend::CreateSerializedImageBufferHandle; the GPU process resolves the buffer in
RemoteSharedResourceCache, copies pixels from NativeImage to ShareableBitmap::createFromImagePixels,
and returns the SharedMemory handle non-destructively (the cache slot is restored so the source
remains usable for re-sends/broadcast). For a local DefaultSerializedImageBuffer, the encoder asks
the backend&apos;s ImageBufferBackendHandleSharing interface for a handle (zero copy) when available, or
falls back to copyNativeImage() + ShareableBitmap::createFromImagePixels in-process. Because sending
an IPC to GPU process needs a RemoteRenderingBackendProxy* to be reachable from inside Encoder, a new
RAII object, ScopedCrossProcessImageBitmapEncoding, is introduced to provide a thread-local access to
RemoteRenderingBackendProxy. It&apos;s installed today at WebRemoteFrameClient::postMessageToRemote.
Failure to extract a handle triggers RELEASE_ASSERT rather than silently shipping a placeholder.

Decode rebuilds a WebKit::SendableSerializedImageBuffer (a new SerializedImageBuffer subclass holding
parameters + handle) wrapped in a fresh DetachedImageBitmap. Materialization is deferred until
ImageBitmap::create(context, detached) triggers WebChromeClient::sinkIntoImageBuffer, which routes the
new subclass to materializeImageBufferFromHandle. That builds an ImageBufferShareableBitmapBackend for
ShareableBitmap::Handle (works without IOKit access - important because receiver WebContent processes
that delegate all rendering to the GPU process have canUseAcceleratedBuffers() == false) or, on Cocoa,
an ImageBufferShareableMappedIOSurfaceBackend for MachSendRight.

Test: imported/w3c/web-platform-tests/webmessaging/postMessage_cross_domain_image_transfer_2d.sub.htm

Co-authored with Claude.

* LayoutTests/platform/ios-site-isolation/TestExpectations:
* LayoutTests/platform/mac-site-isolation/TestExpectations:
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::CloneDeserializer::readTransferredImageBitmap):
(WebCore::SerializedScriptValue::create):
* Source/WebCore/bindings/js/SerializedScriptValue.h:
* Source/WebCore/bindings/js/SerializedScriptValueInternals.h:
* Source/WebCore/html/ImageBitmap.h:
(WebCore::DetachedImageBitmap::originClean const):
(WebCore::DetachedImageBitmap::premultiplyAlpha const):
(WebCore::DetachedImageBitmap::forciblyPremultiplyAlpha const):
* Source/WebCore/platform/graphics/ImageBuffer.cpp:
* Source/WebCore/platform/graphics/ImageBuffer.h:
(WebCore::SerializedImageBuffer::isSendableSerializedImageBuffer const):
(WebCore::SerializedImageBuffer::imageBufferForCrossProcessSerialization const):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.cpp:
(WebKit::RemoteRenderingBackend::createSerializedImageBufferHandle):
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.h:
* Source/WebKit/GPUProcess/graphics/RemoteRenderingBackend.messages.in:
* Source/WebKit/Scripts/webkit/opaque_ipc_types.tracking.in:
* Source/WebKit/Shared/DetachedImageBitmapIPC.cpp: Added.
(WebKit::currentRenderingBackendForEncodingSlot):
(WebKit::ScopedCrossProcessImageBitmapEncoding::ScopedCrossProcessImageBitmapEncoding):
(WebKit::ScopedCrossProcessImageBitmapEncoding::~ScopedCrossProcessImageBitmapEncoding):
(WebKit::ScopedCrossProcessImageBitmapEncoding::currentForThread):
(WebKit::handleForCrossProcessTransfer):
(WebKit::parametersForBuffer):
(WebKit::infoForBuffer):
(IPC::ArgumentCoder&lt;std::optional&lt;WebCore::DetachedImageBitmap&gt;&gt;::encode):
(IPC::ArgumentCoder&lt;std::optional&lt;WebCore::DetachedImageBitmap&gt;&gt;::decode):
* Source/WebKit/Shared/DetachedImageBitmapIPC.h: Added.
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Sources.txt:
* Source/WebKit/WebKit.xcodeproj/project.pbxproj:
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.cpp:
(WebKit::RemoteRenderingBackendProxy::createSerializedImageBufferHandle):
* Source/WebKit/WebProcess/GPU/graphics/RemoteRenderingBackendProxy.h:
* Source/WebKit/WebProcess/GPU/graphics/SendableSerializedImageBuffer.cpp: Added.
(WebKit::SendableSerializedImageBuffer::SendableSerializedImageBuffer):
(WebKit::SendableSerializedImageBuffer::takeHandle):
(WebKit::SendableSerializedImageBuffer::sinkIntoImageBuffer):
(WebKit::materializeImageBufferFromHandle):
* Source/WebKit/WebProcess/GPU/graphics/SendableSerializedImageBuffer.h: Added.
(isType):
* Source/WebKit/WebProcess/GPU/media/RemoteAudioSourceProvider.cpp:
* Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
(WebKit::WebChromeClient::sinkIntoImageBuffer):
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp:
(WebKit::WebRemoteFrameClient::postMessageToRemote):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/24a558e92d85866b5420c1ff9b9a27a0b384f375

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162029 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35504 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28609 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170937 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118400 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163898 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35606 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35505 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125741 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88612 "1 flakes 17 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164988 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28055 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145538 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106323 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/940b273f-26cd-4d7a-9db7-fe13af196976) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/161349 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27104 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25616 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18657 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136797 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23292 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173425 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20516 "Found 1 new failure in WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24933 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134033 "Found 1 new test failure: accessibility/aria-owns-deep-chain-no-timeout.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35177 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29701 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134039 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35161 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145087 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97308 "Hash 24a558e9 for PR 64748 does not build (failure)") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28566 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21912 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34671 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102156 "Found 1 new failure in WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34172 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34414 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34320 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->