### PR TITLE
Cherry-pick 313064@main (65523b157f07). https://bugs.webkit.org/show_bug.cgi?id=314311

### DIFF
--- a/LayoutTests/media/media-vp8-hiddenframes.html
+++ b/LayoutTests/media/media-vp8-hiddenframes.html
@@ -1,6 +1,6 @@
 <html>
 <head>
-<meta name="fuzzy" content="maxDifference=3-207; totalPixels=27386-57600" />
+<meta name="fuzzy" content="maxDifference=2-207; totalPixels=17349-57600" />
 <title>webm file with alternate reference frame</title>
 <script src="../resources/testharness.js"></script>
 <script>window.requirePixelDump = true</script>
@@ -21,7 +21,7 @@
         v.src = "content/test-vp8-hiddenframes.webm";
         await waitFor(v, 'loadedmetadata', true);
         v.currentTime = v.duration;
-        await waitFor(v, 'seeked', true);
+        await Promise.all([ waitFor(v, 'seeked', true), waitForVideoFrame(v)]);
 
         if (window.testRunner)
             testRunner.notifyDone();

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1127,7 +1127,6 @@ webkit.org/b/169916 css3/blending/blend-mode-isolation-turn-off-self-painting-la
 webkit.org/b/169916 css3/blending/blend-mode-isolation-turn-on-self-painting-layer.html [ Failure ]
 webkit.org/b/169916 imported/blink/css3/blending/mix-blend-mode-with-squashing-layer.html [ ImageOnlyFailure ]
 
-compositing/patterns/direct-pattern-compositing-position.html [ ImageOnlyFailure ]
 compositing/repaint/needs-no-display-volatile.html [ ImageOnlyFailure Pass ]
 compositing/blend-mode/non-separable-blend-modes.html [ ImageOnlyFailure ]
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8445,6 +8445,4 @@ webkit.org/b/304995 [ Release ] imported/w3c/web-platform-tests/largest-contentf
 
 webkit.org/b/305404 imported/w3c/web-platform-tests/css/css-text-decor/text-emphasis-position-auto-001.html [ Pass ImageOnlyFailure ]
 
-webkit.org/b/305508 http/tests/resourceLoadStatistics/log-cross-site-load-with-link-decoration.html [ Pass Failure ]
-
 webkit.org/b/305605 media/volume-sleep-disable.html [ Failure ]

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2431,8 +2431,6 @@ webkit.org/b/305403 [ Sequoia ] http/tests/performance/performance-resource-timi
 [ Sequoia+ arm64 ] http/tests/media/hls/track-webvtt-multitracks.html [ Timeout ]
 [ Sequoia+ arm64 ] platform/mac/media/encrypted-media/fps-generateRequest.html [ Timeout ]
 
-webkit.org/b/305508 http/tests/resourceLoadStatistics/log-cross-site-load-with-link-decoration.html [ Pass Failure ]
-
 webkit.org/b/305581 http/tests/workers/service/shownotification-allowed.html [ Pass Failure ]
 
 webkit.org/b/303348 http/tests/site-isolation/remote-frame-loaded-while-hidden.html [ ImageOnlyFailure ]

--- a/Source/WebCore/page/scrolling/ScrollingStateNode.h
+++ b/Source/WebCore/page/scrolling/ScrollingStateNode.h
@@ -116,13 +116,21 @@ public:
 
     LayerRepresentation& operator=(const LayerRepresentation& other)
     {
+        if (this == &other)
+            return *this;
+
+        if (m_representation == PlatformLayerRepresentation && other.m_representation == PlatformLayerRepresentation) {
+            retainPlatformLayer(other.m_typelessPlatformLayer);
+            releasePlatformLayer(m_typelessPlatformLayer);
+        } else if (m_representation == PlatformLayerRepresentation)
+            releasePlatformLayer(m_typelessPlatformLayer);
+        else if (other.m_representation == PlatformLayerRepresentation)
+            retainPlatformLayer(other.m_typelessPlatformLayer);
+
         m_graphicsLayer = other.m_graphicsLayer;
         m_typelessPlatformLayer = other.m_typelessPlatformLayer;
         m_layerID = other.m_layerID;
         m_representation = other.m_representation;
-
-        if (m_representation == PlatformLayerRepresentation)
-            retainPlatformLayer(m_typelessPlatformLayer);
 
         return *this;
     }

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -605,8 +605,10 @@ bool MediaPlayerPrivateGStreamer::doSeek(const SeekTarget& target, float rate, b
     }
     auto seekFlags = static_cast<GstSeekFlags>(flag | GST_SEEK_FLAG_ACCURATE);
 
-    if (rate >= 0.0 && startTime >= duration()) {
-        GST_DEBUG_OBJECT(pipeline(), "Seek requested beyond duration, triggering EOS handler");
+    // Seeking towards the end is not well supported in oggdemux, sometimes it receives EOS
+    // while trying to retrieve a chain and thus disables seeking in push mode.
+    if (rate >= 0 && startTime == duration() && m_containerType == ContainerType::Ogg) {
+        GST_DEBUG_OBJECT(pipeline(), "Seek requested at duration for ogg media, triggering EOS handler");
         didEnd();
         return false;
     }

--- a/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp
@@ -1066,7 +1066,7 @@ void GraphicsLayerCoordinated::commitLayerChanges(CommitState& commitState, floa
 
     if (m_pendingChanges.contains(Change::ContentsTiling)) {
         m_platformLayer->setContentsTileSize(m_contentsTileSize);
-        m_platformLayer->setContentsTileSize(m_contentsTilePhase);
+        m_platformLayer->setContentsTilePhase(m_contentsTilePhase);
     }
 
     if (m_pendingChanges.contains(Change::ContentsClippingRect))

--- a/Source/WebCore/platform/mediastream/gstreamer/DesktopPortal.h
+++ b/Source/WebCore/platform/mediastream/gstreamer/DesktopPortal.h
@@ -38,6 +38,7 @@ class DesktopPortal : public RefCounted<DesktopPortal> {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(DesktopPortal);
 public:
     DesktopPortal(ASCIILiteral, GRefPtr<GDBusProxy>&&);
+    virtual ~DesktopPortal() = default;
 
     GRefPtr<GVariant> getProperty(ASCIILiteral name);
 

--- a/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
+++ b/Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp
@@ -327,6 +327,11 @@ void WebResourceLoadStatisticsStore::resourceLoadStatisticsUpdated(Vector<Resour
             return;
         }
 
+        if (statistics.isEmpty()) {
+            postTaskReply(WTF::move(completionHandler));
+            return;
+        }
+
         statisticsStore->mergeStatistics(WTF::move(statistics));
         postTaskReply(WTF::move(completionHandler));
         // We can cancel any pending request to process statistics since we're doing it synchronously below.


### PR DESCRIPTION
#### 6df9adc0d72ee63f56e79bada68dff1ddb7b9ca7
<pre>
Cherry-pick 313064@main (65523b157f07). <a href="https://bugs.webkit.org/show_bug.cgi?id=314311">https://bugs.webkit.org/show_bug.cgi?id=314311</a>

    [GStreamer] media/media-vp8-hiddenframes.html fails
    <a href="https://bugs.webkit.org/show_bug.cgi?id=314311">https://bugs.webkit.org/show_bug.cgi?id=314311</a>

    Reviewed by Xabier Rodriguez-Calvar.

    Allow seeking to the exact duration. Manually verified by removing allowed fuzzyness on the test and
    checking the last video frame is rendered instead of the first one. Fuzzy parameters were then
    adjusted to accommodate with GStreamer&apos;s vpx decoder.

    The test was also flaky on mac-intel. Ensuring the video is rendered after the seeked event fixed
    it.

    The following test performs a seek at duration for an Ogg file, which is poorly supported by
    oggdemux, so keep the previous code, basically triggering EOS as was done before this patch, but
    specially for this scenario:

    imported/w3c/web-platform-tests/html/semantics/embedded-content/media-elements/seeking/seek-to-max-value.htm

    * Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
    (WebCore::MediaPlayerPrivateGStreamer::doSeek):

    Canonical link: <a href="https://commits.webkit.org/313064@main">https://commits.webkit.org/313064@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.495@webkitglib/2.52">https://commits.webkit.org/305877.495@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 9b5c4731d8a323bf7e49ed319897fae9085b032f
<pre>
Cherry-pick 312994@main (363ce7daefe0). <a href="https://bugs.webkit.org/show_bug.cgi?id=314511">https://bugs.webkit.org/show_bug.cgi?id=314511</a>

    [GStreamer] Add a virtual DesktopPortal destructor
    <a href="https://bugs.webkit.org/show_bug.cgi?id=314511">https://bugs.webkit.org/show_bug.cgi?id=314511</a>

    Reviewed by Claudio Saavedra.

    * Source/WebCore/platform/mediastream/gstreamer/DesktopPortal.h:

    Canonical link: <a href="https://commits.webkit.org/312994@main">https://commits.webkit.org/312994@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.494@webkitglib/2.52">https://commits.webkit.org/305877.494@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 47bb36b39e7d1fc77c6142f9b290abe1b0226cba
<pre>
Cherry-pick 312950@main (bfb4c0bb6e54). <a href="https://bugs.webkit.org/show_bug.cgi?id=314358">https://bugs.webkit.org/show_bug.cgi?id=314358</a>

    WKCompositingLayer leaks
    <a href="https://bugs.webkit.org/show_bug.cgi?id=314358">https://bugs.webkit.org/show_bug.cgi?id=314358</a>
    <a href="https://rdar.apple.com/160391523">rdar://160391523</a>

    Reviewed by Tim Horton.

    Pages with subscrollers and some kinds of layer configuration changes
    triggered leaks of WKCompositingLayers (I was able to reproduce when
    playing YouTube shorts).

    The bug was that LayerRepresentation&apos;s assignment operator failed
    to release the old layer.

    The fix takes care to not release the old layer before retaining
    the new one, in case this is the only reference keeping the layer alive.

    A future PR will change LayerRepresentation to use a variant&lt;&gt;, which
    will replace this mess.

    * Source/WebCore/page/scrolling/ScrollingStateNode.h:
    (WebCore::LayerRepresentation::operator=):

    Canonical link: <a href="https://commits.webkit.org/312950@main">https://commits.webkit.org/312950@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.493@webkitglib/2.52">https://commits.webkit.org/305877.493@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### ca20ec86088c7d781ce0938edaa331f89f0dd61c
<pre>
Cherry-pick 313039@main (f08767a2f3c0). <a href="https://bugs.webkit.org/show_bug.cgi?id=305508">https://bugs.webkit.org/show_bug.cgi?id=305508</a>

    REGRESSION(304892@main?): http/tests/resourceLoadStatistics/log-cross-site-load-with-link-decoration.html is a flakey text failure
    <a href="https://bugs.webkit.org/show_bug.cgi?id=305508">https://bugs.webkit.org/show_bug.cgi?id=305508</a>
    <a href="https://rdar.apple.com/168172161">rdar://168172161</a>

    Reviewed by Brent Fulgham.

    304892@main defers old web process shutdown during commitProvisionalPage via a
    shutdownPreventingScope. This allows the old process to receive the Close message
    and flush its (potentially empty) resource load statistics to the network process.
    resourceLoadStatisticsUpdated() unconditionally calls processStatisticsAndDataRecords()
    even when there is nothing to merge. This processing iterates all domains and resets
    DataRemovalFrequency to Never for any domain that was recently flagged for removal,
    racing with logCrossSiteLoadWithLinkDecoration() which just set it to Short.

    The fix is to early-return when the statistics vector is empty since there is nothing
    to merge and no reason to trigger data records processing.

    No new tests, unskip existing test.

    * LayoutTests/platform/ios/TestExpectations:
    * LayoutTests/platform/mac-wk2/TestExpectations:
    * Source/WebKit/NetworkProcess/Classifier/WebResourceLoadStatisticsStore.cpp:
    (WebKit::WebResourceLoadStatisticsStore::resourceLoadStatisticsUpdated):

    Canonical link: <a href="https://commits.webkit.org/313039@main">https://commits.webkit.org/313039@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.492@webkitglib/2.52">https://commits.webkit.org/305877.492@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 5d7be9bf16d02fdd249c3f3a1c4a382fc0b9750e
<pre>
Cherry-pick 313063@main (ac54485f9d31). <a href="https://bugs.webkit.org/show_bug.cgi?id=307753">https://bugs.webkit.org/show_bug.cgi?id=307753</a>

    [Coordinated Graphics] directly composited tile images were stretched unexpectedly
    <a href="https://bugs.webkit.org/show_bug.cgi?id=307753">https://bugs.webkit.org/show_bug.cgi?id=307753</a>

    Reviewed by Carlos Garcia Campos.

    The tile phase was mistakenly set to the tile size.

    Tests: compositing/patterns/direct-pattern-compositing-position.html

    * LayoutTests/platform/glib/TestExpectations:
    * Source/WebCore/platform/graphics/texmap/coordinated/GraphicsLayerCoordinated.cpp:
    (WebCore::GraphicsLayerCoordinated::commitLayerChanges):

    Canonical link: <a href="https://commits.webkit.org/313063@main">https://commits.webkit.org/313063@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.491@webkitglib/2.52">https://commits.webkit.org/305877.491@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/413af59b405cf44c7c5c9640d0d97c12c9d4ff67

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162031 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35506 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28611 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170939 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/118402 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163900 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35608 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35507 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125743 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/118402 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164990 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/35608 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/28611 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106325 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/35608 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/35507 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18659 "Unable to build WebKit without PR, please check manually (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/35608 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/28611 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173427 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/20804 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/28611 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134034 "Passed tests") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35179 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/35507 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134040 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35163 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/28611 "Unable to build WebKit without PR, please check manually (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/97311 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24609 "Built successfully and passed tests") | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/35163 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/28611 "Unable to build WebKit without PR, please check manually (failure)") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34673 "Unable to build WebKit without PR, please check manually (failure)") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/102446 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34174 "Unable to build WebKit without PR, please check manually (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34416 "Unable to build WebKit without PR, please check manually (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34322 "Unable to build WebKit without PR, please check manually (failure)") | | | 
<!--EWS-Status-Bubble-End-->