### PR TITLE
Cherry-pick 312190@main (056c4c55fb09). https://bugs.webkit.org/show_bug.cgi?id=313273

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -484,6 +484,14 @@ void GStreamerRegistryScanner::initializeDecoders(const GStreamerRegistryScanner
         // MPEG-2 Part 3 Audio just defines minor extensions of MP3 adding support for more channels and bitrates.
         // GStreamer still considers it mpegversion=1, leaving mpegversion=2 for AAC (MPEG-2 Part 7 Advanced Audio Coding).
         m_decoderCodecMap.add("mp4a.69"_s, result); // Audio ISO/IEC 13818-3 (MPEG-2 Part 3 Audio)
+        // MPEG-1 Audio can be carried inside MPEG-4 Audio, for which there are standard-defined MPEG-4
+        // Audio Object Type (AOT) allocated. This is esoteric in practice and it has very limited player support.
+        // More commonly, some media manifests for MP3 in MP4 mistakingly use these MPEG-4 AOTs in their codec
+        // strings despite the MP4 bytestream actually using the (much more widely supported) MPEG-1 Object Type Indication(s)
+        // described above.
+        m_decoderCodecMap.add("mp4a.40.32"_s, result); // AOT 32: Layer-1
+        m_decoderCodecMap.add("mp4a.40.33"_s, result); // AOT 33: Layer-2
+        m_decoderCodecMap.add("mp4a.40.34"_s, result); // AOT 34: Layer-3
     }
 
     audioMpegSupported |= isContainerTypeSupported(Configuration::Decoding, "audio/mp4"_s);

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -376,12 +376,12 @@ void GStreamerRegistryScanner::refresh()
     GST_DEBUG("%s registry scanner initialized", m_isMediaSource ? "MSE" : "Regular playback");
     for (auto& mimeType : m_decoderMimeTypeSet)
         GST_DEBUG("Decoder mime-type registered: %s", mimeType.utf8().data());
-    for (auto& [codec, isHardware] : m_decoderCodecMap)
-        GST_DEBUG("%s decoder codec pattern registered: %s", isHardware ? "Hardware" : "Software", codec.utf8().data());
+    for (auto& [codec, result] : m_decoderCodecMap)
+        GST_DEBUG("%s decoder codec pattern registered: %s", result.isUsingHardware ? "Hardware" : "Software", codec.utf8().data());
     for (auto& mimeType : m_encoderMimeTypeSet)
         GST_DEBUG("Encoder mime-type registered: %s", mimeType.utf8().data());
-    for (auto& [codec, isHardware] : m_encoderCodecMap)
-        GST_DEBUG("%s encoder codec pattern registered: %s", isHardware ? "Hardware" : "Software", codec.utf8().data());
+    for (auto& [codec, result] : m_encoderCodecMap)
+        GST_DEBUG("%s encoder codec pattern registered: %s", result.isUsingHardware ? "Hardware" : "Software", codec.utf8().data());
 #endif
 }
 
@@ -434,12 +434,13 @@ void GStreamerRegistryScanner::initializeDecoders(const GStreamerRegistryScanner
 {
     m_decoderCodecMap.clear();
     m_decoderMimeTypeSet.clear();
+
+    bool audioMpegSupported = false;
     if (auto result = factories.hasElementForMediaType(ElementFactories::Type::AudioDecoder, "audio/mpeg, mpegversion=(int)4"_s)) {
+        audioMpegSupported = true;
         m_decoderMimeTypeSet.add("audio/aac"_s);
         m_decoderMimeTypeSet.add("audio/mp4"_s);
         m_decoderMimeTypeSet.add("audio/x-m4a"_s);
-        m_decoderMimeTypeSet.add("audio/mpeg"_s);
-        m_decoderMimeTypeSet.add("audio/x-mpeg"_s);
         m_decoderCodecMap.add("mpeg"_s, result);
         // AAC has accumulated lots of extensions over the years.
         // Unfortunately, decoders don't generally provide an API for querying support level, and support is not necessarily
@@ -451,7 +452,6 @@ void GStreamerRegistryScanner::initializeDecoders(const GStreamerRegistryScanner
         // Syntax: "mp4a." oti [ "." aud-oti ]
         // oti is the ObjectTypeIndication from MPEG-4 Systems (ISO 14996-1).
         // For oti=40 (MPEG-4 Audio), aud-oti represents the AOT.
-        m_decoderCodecMap.add("mp4a.67"_s, result); // MPEG-2 AAC LC
         m_decoderCodecMap.add("mp4a.40.2"_s, result); // MPEG-4 AAC LC
         m_decoderCodecMap.add("mp4a.40.02"_s, result); // MPEG-4 AAC LC
         m_decoderCodecMap.add("mp4a.40.5"_s, result); // MPEG-4 HE-AAC v1 (AAC LC + SBR)
@@ -464,6 +464,32 @@ void GStreamerRegistryScanner::initializeDecoders(const GStreamerRegistryScanner
             || WTF::equalLettersIgnoringASCIICase(value.span(), "1"_s));
         if (canPlayUsac)
             m_decoderCodecMap.add("mp4a.40.42"_s, result); // MPEG-4 Extended HE-AAC and xHE-AAC (USAC AOT)
+    }
+
+    if (auto result = factories.hasElementForMediaType(ElementFactories::Type::AudioDecoder, "audio/mpeg, mpegversion=(int)2"_s)) {
+        audioMpegSupported = true;
+        m_decoderMimeTypeSet.add("audio/mp2"_s);
+        m_decoderCodecMap.add("mp4a.67"_s, result); // MPEG-2 AAC LC
+    }
+
+    if (auto result = factories.hasElementForMediaType(ElementFactories::Type::AudioDecoder, "audio/mpeg, mpegversion=(int)1, layer=(int)[1, 3]"_s)) {
+        audioMpegSupported = true;
+        m_decoderMimeTypeSet.add("audio/mp1"_s);
+        m_decoderMimeTypeSet.add("audio/mp3"_s);
+        m_decoderMimeTypeSet.add("audio/x-mp3"_s);
+        m_decoderCodecMap.add("audio/mp3"_s, result);
+        m_decoderCodecMap.add("mp3"_s, result);
+        m_decoderCodecMap.add("mp4a.6b"_s, result); // Audio ISO/IEC 11172-3 (MPEG-1 Part 3 Audio)
+        m_decoderCodecMap.add("mp4a.6B"_s, result); // Audio ISO/IEC 11172-3 (MPEG-1 Part 3 Audio)
+        // MPEG-2 Part 3 Audio just defines minor extensions of MP3 adding support for more channels and bitrates.
+        // GStreamer still considers it mpegversion=1, leaving mpegversion=2 for AAC (MPEG-2 Part 7 Advanced Audio Coding).
+        m_decoderCodecMap.add("mp4a.69"_s, result); // Audio ISO/IEC 13818-3 (MPEG-2 Part 3 Audio)
+    }
+
+    audioMpegSupported |= isContainerTypeSupported(Configuration::Decoding, "audio/mp4"_s);
+    if (audioMpegSupported) {
+        m_decoderMimeTypeSet.add("audio/mpeg"_s);
+        m_decoderMimeTypeSet.add("audio/x-mpeg"_s);
     }
 
     auto opusSupported = factories.hasElementForMediaType(ElementFactories::Type::AudioDecoder, "audio/x-opus"_s);
@@ -545,8 +571,8 @@ void GStreamerRegistryScanner::initializeDecoders(const GStreamerRegistryScanner
     }
 
     Vector<GstCapsWebKitMapping> mseCompatibleMapping = {
-        { ElementFactories::Type::AudioDecoder, "audio/x-ac3"_s, { }, { "x-ac3"_s, "ac-3"_s, "ac3"_s } },
-        { ElementFactories::Type::AudioDecoder, "audio/x-eac3"_s, { "audio/x-ac3"_s }, { "x-eac3"_s, "ec3"_s, "ec-3"_s, "eac3"_s } },
+        { ElementFactories::Type::AudioDecoder, "audio/x-ac3"_s, { }, { "x-ac3"_s, "ac-3"_s, "ac3"_s, "mp4a.a5"_s, "mp4a.A5"_s } },
+        { ElementFactories::Type::AudioDecoder, "audio/x-eac3"_s, { "audio/x-ac3"_s }, { "x-eac3"_s, "ec3"_s, "ec-3"_s, "eac3"_s, "mp4a.a6"_s, "mp4a.A6"_s } },
         { ElementFactories::Type::AudioDecoder, "audio/x-flac"_s, { "audio/x-flac"_s, "audio/flac"_s }, { "x-flac"_s, "flac"_s, "fLaC"_s } },
     };
     fillMimeTypeSetFromCapsMapping(factories, mseCompatibleMapping);
@@ -624,27 +650,6 @@ void GStreamerRegistryScanner::initializeDecoders(const GStreamerRegistryScanner
             m_decoderMimeTypeSet.add("video/ogg"_s);
             m_decoderCodecMap.add("theora"_s, result);
         }
-    }
-
-    bool audioMpegSupported = false;
-    if (auto result = factories.hasElementForMediaType(ElementFactories::Type::AudioDecoder, "audio/mpeg, mpegversion=(int)1, layer=(int)[1, 3]"_s)) {
-        audioMpegSupported = true;
-        m_decoderMimeTypeSet.add("audio/mp1"_s);
-        m_decoderMimeTypeSet.add("audio/mp3"_s);
-        m_decoderMimeTypeSet.add("audio/x-mp3"_s);
-        m_decoderCodecMap.add("audio/mp3"_s, result);
-        m_decoderCodecMap.add("mp3"_s, result);
-    }
-
-    if (factories.hasElementForMediaType(ElementFactories::Type::AudioDecoder, "audio/mpeg, mpegversion=(int)2"_s)) {
-        audioMpegSupported = true;
-        m_decoderMimeTypeSet.add("audio/mp2"_s);
-    }
-
-    audioMpegSupported |= isContainerTypeSupported(Configuration::Decoding, "audio/mp4"_s);
-    if (audioMpegSupported) {
-        m_decoderMimeTypeSet.add("audio/mpeg"_s);
-        m_decoderMimeTypeSet.add("audio/x-mpeg"_s);
     }
 
     if (matroskaSupported) {


### PR DESCRIPTION
#### d5043a96b5d08efda8da101a7ff6691f0d8d36a3
<pre>
Cherry-pick 312190@main (056c4c55fb09). <a href="https://bugs.webkit.org/show_bug.cgi?id=313273">https://bugs.webkit.org/show_bug.cgi?id=313273</a>

    [GStreamer] 3 new failures on MVT tests hls-hlsjs-test/HLS_FMP4_MP3 after 310634@main
    <a href="https://bugs.webkit.org/show_bug.cgi?id=313273">https://bugs.webkit.org/show_bug.cgi?id=313273</a>

    Reviewed by Philippe Normand.

    There are two ways to mux MP3 in MP4: the most common is to use the
    Object Type Indication of MPEG-1 Audio. This is the most widely
    supported approach. Alternatively, it is possible to use the Object Type
    Indication of MPEG-4 Audio and inside that, use the AOT corresponding to
    MP3 (AOT=34).

    This patch makes WebKit report positively in canPlayType() for the
    second approach, not only the first.

    The second approach is rare enough I have not found any examples in the
    wild. Support for it in GStreamer is unknown. Still, it has been found
    that some streams use the codec string corresponding to the second
    approach despite using the first approach in the bytestream.

    Fixes <a href="https://bugs.webkit.org/show_bug.cgi?id=313273">https://bugs.webkit.org/show_bug.cgi?id=313273</a>

    * Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp:
    (WebCore::GStreamerRegistryScanner::initializeDecoders):

    Canonical link: <a href="https://commits.webkit.org/312190@main">https://commits.webkit.org/312190@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.490@webkitglib/2.52">https://commits.webkit.org/305877.490@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### b7ef457c9c9c43a9a27cb215cb559d6514a64df1
<pre>
Cherry-pick 311571@main (2566042879a7). <a href="https://bugs.webkit.org/show_bug.cgi?id=312501">https://bugs.webkit.org/show_bug.cgi?id=312501</a>

    [GStreamer] Report support for supported non-AAC mp4a codecs
    <a href="https://bugs.webkit.org/show_bug.cgi?id=312501">https://bugs.webkit.org/show_bug.cgi?id=312501</a>

    Reviewed by Xabier Rodriguez-Calvar.

    <a href="https://commits.webkit.org/310634@main">https://commits.webkit.org/310634@main</a> made it so that we no longer mark
    all codec strings starting with &quot;mp4a.&quot; as supported the moment we find
    an MPEG-4 AAC decoder, instead allowing only the specific codec strings
    used by AAC.

    There are however other audio codec that use strings that start with
    &quot;mp4a.&quot;, that were already working, and for which WebKit reported
    support, even if only accidentally due to finding an AAC decoder.

    Notably, this the case for MP3 (mp4a.6b and mp4a.69), AC-3 (mp4a.a5) and
    EAC-3 (mp4a.a6). This regression was identified with the MVT test suite:
    <a href="https://github.com/rdkcentral/MVT">https://github.com/rdkcentral/MVT</a>

    This patch adds those codec strings to GStreamerRegistryScanner when
    appropriate decoders are found, both fixing the regression and ensuring
    support is not reported accidentally.

    Previously the code for initializeDecoders() implied MPEG-1 and MPEG-2
    audio is not supported with MSE, even though it was already working and
    reported as supported. This patch moves the support check code to the
    part of the function common for both MSE and non-MSE.

    Support for mp4a.67 has been moved to the check for audio/mpeg,
    mpegversion=2. Although in practice virtually all AAC decoders will
    support both mpegversion=2 and mpegversion=4, this is the technically
    correct place for it.

    As a drive-by fix, the logging in GStreamerRegistryScanner::refresh()
    has been fixed: all codecs were being reported as being hardware-based
    due to leftovers from a refactor.

    * Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp:
    (WebCore::GStreamerRegistryScanner::refresh):
    (WebCore::GStreamerRegistryScanner::initializeDecoders):

    Canonical link: <a href="https://commits.webkit.org/311571@main">https://commits.webkit.org/311571@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.489@webkitglib/2.52">https://commits.webkit.org/305877.489@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bfcebe6b24595f80728897f62caebce9f43727ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162032 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35507 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28612 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170940 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/118403 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163901 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35609 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35508 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125744 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/118403 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/164991 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/35609 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/28612 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106326 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/35609 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/35508 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18660 "Unable to build WebKit without PR, please check manually (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/35609 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/28612 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173428 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/20805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/28612 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134035 "Passed tests") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35180 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/35508 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134041 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35164 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/28612 "Unable to build WebKit without PR, please check manually (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/97317 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24608 "Built successfully and passed tests") | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/35164 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/28612 "Unable to build WebKit without PR, please check manually (failure)") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34674 "Unable to build WebKit without PR, please check manually (failure)") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/102445 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34175 "Unable to build WebKit without PR, please check manually (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34417 "Unable to build WebKit without PR, please check manually (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34323 "Unable to build WebKit without PR, please check manually (failure)") | | | 
<!--EWS-Status-Bubble-End-->