### PR TITLE
[JSC] Add RISCV64 support to GdbJIT ELF records

### DIFF
--- a/Source/JavaScriptCore/jit/GdbJIT.cpp
+++ b/Source/JavaScriptCore/jit/GdbJIT.cpp
@@ -868,7 +868,7 @@ private:
             0x7F, 'E', 'L', 'F', 1, 1, 1, 0,
             0, 0, 0, 0, 0, 0, 0, 0
         };
-#elif CPU(X86_64) || CPU(ARM64)
+#elif CPU(X86_64) || CPU(ARM64) || CPU(RISCV64)
         const uint8_t ident[16] = {
             0x7F, 'E', 'L', 'F', 2, 1, 1, 0,
             0, 0, 0, 0, 0, 0, 0, 0
@@ -890,6 +890,9 @@ private:
 #elif CPU(ARM64)
         // AARCH64
         header->machine = 0xB7;
+#elif CPU(RISCV64)
+        // RISC-V 64
+        header->machine = 0xF3;
 #else
 #error Unsupported target architecture.
 #endif
@@ -991,7 +994,7 @@ public:
         uint8_t m_other;
         uint16_t m_section;
     } __attribute__((packed,aligned(1)));
-#elif CPU(X86_64) || CPU(ARM64)
+#elif CPU(X86_64) || CPU(ARM64) || CPU(RISCV64)
     struct SerializedLayout {
         SerializedLayout(uint32_t name, uintptr_t value, uintptr_t size, Binding binding, Type type, uint16_t section)
             : m_name(name)


### PR DESCRIPTION
#### 2130a345347bbda326ddb6b4779145593ea7a80c
<pre>
[JSC] Add RISCV64 support to GdbJIT ELF records

<a href="https://bugs.webkit.org/show_bug.cgi?id=314635">https://bugs.webkit.org/show_bug.cgi?id=314635</a>

Reviewed by Yusuke Suzuki.

Use the 64-bit ELF layout for RISCV64 JIT debug objects and set the ELF machine type to EM_RISCV. This lets the existing GDB JIT writer build on RISCV64 instead of taking the unsupported-architecture path.

No new tests because this is target-specific build support for JSC GDB JIT ELF metadata.

* Source/JavaScriptCore/jit/GdbJIT.cpp:

(JSC::ELF::writeHeader): Treat RISCV64 as a 64-bit ELF target and set e_machine to EM_RISCV.

Canonical link: <a href="https://commits.webkit.org/313134@main">https://commits.webkit.org/313134@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f700e3a955c849a49920ff691d7d9baa50ce2ce2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162049 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35524 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28629 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170957 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118420 "Built successfully") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35626 "Hash f700e3a9 for PR 64755 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35525 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125760 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88626 "2 flakes 18 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165008 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/35626 "Hash f700e3a9 for PR 64755 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145555 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106342 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/35626 "Hash f700e3a9 for PR 64755 does not build (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25632 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18677 "Built successfully") | 
| [✅ 🛠 🧪 jsc](https://ews-build.webkit.org/#/builders/20/builds/154108 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/35626 "Hash f700e3a9 for PR 64755 does not build (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23309 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173445 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22887 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20725 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24950 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134050 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35198 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29717 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134056 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35181 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145104 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/97345 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24636 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28581 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21929 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194449 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34691 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102360 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50116 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34192 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34434 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34340 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->