### PR TITLE
[JSC] Avoid allocating `JSSlimPromiseReaction` for the single-await case

### DIFF
--- a/JSTests/stress/promise-inline-reaction.js
+++ b/JSTests/stress/promise-inline-reaction.js
@@ -1,0 +1,262 @@
+// Stress test for the inline-reaction optimization in JSPromise: when a pending
+// promise's only reaction is an internal microtask with an undefined result
+// promise (the common `await pending_promise` case), the reaction is stored
+// inline in the promise instead of allocating a JSSlimPromiseReaction. This test
+// exercises the spill paths and edge cases that could break if the inline
+// representation, the spill logic, or the JSPromise::Flags layout changes.
+
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error(`${msg || ""}: expected ${expected} but got ${actual}`);
+}
+
+function shouldThrow(fn, expected, msg) {
+    let threw = false;
+    try { fn(); } catch (e) { threw = true; shouldBe(String(e), expected, msg); }
+    if (!threw) throw new Error(`${msg || ""}: expected to throw but did not`);
+}
+
+let failures = [];
+let pendingTests = 0;
+function asyncTest(name, fn) {
+    pendingTests++;
+    fn().then(() => {
+        pendingTests--;
+    }, (e) => {
+        pendingTests--;
+        failures.push(`${name}: ${e.stack || e}`);
+    });
+}
+
+// 1. Basic: await on a pending promise (sets the inline reaction).
+asyncTest("basic-await-pending", async () => {
+    let resolve;
+    const p = new Promise(r => resolve = r);
+    Promise.resolve().then(() => resolve(42));
+    shouldBe(await p, 42);
+});
+
+// 2. await + .then() on the same pending promise.
+//    The .then() must spill the inline reaction into a JSSlimPromiseReaction
+//    chain. Both consumers must see the value, in registration order.
+asyncTest("spill-then-after-await-attached", async () => {
+    let resolve;
+    const p = new Promise(r => resolve = r);
+    let order = [];
+    const awaiter = (async () => {
+        order.push("await:" + await p);
+    })();
+    p.then(v => order.push("then:" + v));
+    Promise.resolve().then(() => resolve(7));
+    await awaiter;
+    await Promise.resolve(); // drain the .then() callback
+    shouldBe(order.join(","), "await:7,then:7");
+});
+
+// 3. .then() before await (existing reaction chain, no inline).
+asyncTest("then-before-await", async () => {
+    let resolve;
+    const p = new Promise(r => resolve = r);
+    let order = [];
+    p.then(v => order.push("then:" + v));
+    const awaiter = (async () => { order.push("await:" + await p); })();
+    Promise.resolve().then(() => resolve(8));
+    await awaiter;
+    shouldBe(order.join(","), "then:8,await:8");
+});
+
+// 4. Many .then() after await spill: ensure the chain order is preserved.
+asyncTest("spill-many-thens", async () => {
+    let resolve;
+    const p = new Promise(r => resolve = r);
+    let order = [];
+    const awaiter = (async () => { order.push("a"); await p; order.push("a-done"); })();
+    for (let i = 0; i < 5; ++i)
+        p.then(() => order.push("t" + i));
+    Promise.resolve().then(() => resolve());
+    await awaiter;
+    await Promise.resolve();
+    shouldBe(order.join(","), "a,a-done,t0,t1,t2,t3,t4");
+});
+
+// 5. Two awaits on the same pending promise: the second await must spill.
+asyncTest("two-awaits-same-promise", async () => {
+    let resolve;
+    const p = new Promise(r => resolve = r);
+    let order = [];
+    const a1 = (async () => { order.push("a1:" + await p); })();
+    const a2 = (async () => { order.push("a2:" + await p); })();
+    Promise.resolve().then(() => resolve(99));
+    await a1;
+    await a2;
+    shouldBe(order.join(","), "a1:99,a2:99");
+});
+
+// 6. Reject path: the inline reaction must trigger the catch handler.
+asyncTest("inline-reaction-reject", async () => {
+    let reject;
+    const p = new Promise((r, j) => reject = j);
+    Promise.resolve().then(() => reject(new Error("boom")));
+    let caught;
+    try { await p; } catch (e) { caught = e.message; }
+    shouldBe(caught, "boom");
+});
+
+// 7. Reject after spilling: both the awaiter and the .catch() must observe.
+asyncTest("spill-then-reject", async () => {
+    let reject;
+    const p = new Promise((r, j) => reject = j);
+    let order = [];
+    const awaiter = (async () => {
+        try { await p; } catch (e) { order.push("await-caught:" + e.message); }
+    })();
+    p.catch(e => order.push("catch:" + e.message));
+    Promise.resolve().then(() => reject(new Error("err")));
+    await awaiter;
+    await Promise.resolve();
+    shouldBe(order.join(","), "await-caught:err,catch:err");
+});
+
+// 8. Already-fulfilled promise: must not take the inline path. await still works.
+asyncTest("fulfilled-promise-await", async () => {
+    const p = Promise.resolve(123);
+    shouldBe(await p, 123);
+});
+
+// 9. Already-rejected promise: must not take the inline path.
+asyncTest("rejected-promise-await", async () => {
+    const p = Promise.reject(new Error("pre")).then(() => {}, e => "handled:" + e.message);
+    shouldBe(await p, "handled:pre");
+});
+
+// 10. Promise piped from another (pipeFrom). The result promise of the inline
+//     reaction is non-undefined here, so it must NOT use the inline path.
+asyncTest("promise-resolve-thenable", async () => {
+    let resolve;
+    const inner = new Promise(r => resolve = r);
+    const outer = Promise.resolve(inner); // pipeFrom path
+    Promise.resolve().then(() => resolve(55));
+    shouldBe(await outer, 55);
+});
+
+// 11. for await...of with async generator (the original motivation).
+asyncTest("for-await-of", async () => {
+    async function* gen(n) {
+        for (let i = 0; i < n; ++i)
+            yield i;
+    }
+    let sum = 0;
+    for await (const x of gen(100))
+        sum += x;
+    shouldBe(sum, 4950);
+});
+
+// 12. async generator return / throw drive the inline reaction too.
+asyncTest("async-gen-return-throw", async () => {
+    async function* g() { try { yield 1; yield 2; } finally { /* */ } }
+    let it = g();
+    shouldBe((await it.next()).value, 1);
+    shouldBe((await it.return(99)).value, 99);
+
+    it = g();
+    await it.next();
+    let caught;
+    try { await it.throw(new Error("agg")); } catch (e) { caught = e.message; }
+    shouldBe(caught, "agg");
+});
+
+// 13. GC pressure during spill: the inline reaction's context cell must survive
+//     the JSSlimPromiseReaction allocation that the spill triggers.
+asyncTest("gc-pressure-during-spill", async () => {
+    for (let round = 0; round < 100; ++round) {
+        let resolve;
+        const p = new Promise(r => resolve = r);
+        const awaiter = (async () => { return await p; })();
+        // Allocate a lot to encourage GC right around the spill.
+        let garbage = [];
+        for (let i = 0; i < 100; ++i) garbage.push({ a: i, b: i, c: i });
+        p.then(() => {});  // spill
+        garbage = null;
+        Promise.resolve().then(() => resolve(round));
+        shouldBe(await awaiter, round);
+    }
+});
+
+// 14. Heavy async generator stress with GC.
+asyncTest("async-gen-gc-stress", async () => {
+    async function* g() {
+        for (let i = 0; i < 1000; ++i) {
+            yield { v: i };
+        }
+    }
+    let count = 0;
+    for await (const o of g()) {
+        if (o.v !== count) throw new Error("mismatch");
+        count++;
+    }
+    shouldBe(count, 1000);
+});
+
+// 15. Microtask ordering: the inline reaction must produce the same observable
+//     ordering as a heap-allocated JSSlimPromiseReaction would.
+asyncTest("microtask-ordering", async () => {
+    let order = [];
+    let resolve;
+    const p = new Promise(r => resolve = r);
+    const awaiter = (async () => { await p; order.push("A"); })();
+    Promise.resolve().then(() => order.push("B"));
+    Promise.resolve().then(() => { resolve(); order.push("C"); });
+    Promise.resolve().then(() => order.push("D"));
+    await awaiter;
+    await Promise.resolve();
+    await Promise.resolve();
+    // B and D fire before resolve(); A fires after resolve.
+    shouldBe(order.join(","), "B,C,D,A");
+});
+
+// 16. Spill ordering: registering .then() after the promise is already settled
+//     must not see a stale inline reaction.
+asyncTest("then-after-settle", async () => {
+    let resolve;
+    const p = new Promise(r => resolve = r);
+    let order = [];
+    const awaiter = (async () => { await p; order.push("A"); })();
+    Promise.resolve().then(() => resolve());
+    await awaiter;
+    p.then(() => order.push("late"));
+    await Promise.resolve();
+    shouldBe(order.join(","), "A,late");
+});
+
+// 17. dynamic import resolution path uses internal microtask reactions too.
+asyncTest("dynamic-import", async () => {
+    try {
+        await import("does-not-exist-xyzzy");
+        throw new Error("should not resolve");
+    } catch (e) {
+        // Any error type is fine; the point is the await on a pending
+        // import promise didn't crash or misbehave.
+    }
+});
+
+// 18. Promise with subclass thenable should not take the inline path.
+asyncTest("custom-thenable-await", async () => {
+    let resolve;
+    const inner = new Promise(r => resolve = r);
+    const thenable = {
+        then(onFulfill) { inner.then(v => onFulfill(v * 2)); }
+    };
+    Promise.resolve().then(() => resolve(10));
+    shouldBe(await thenable, 20);
+});
+
+// Drain the loop and report.
+function finish() {
+    if (pendingTests > 0) {
+        Promise.resolve().then(finish);
+        return;
+    }
+    if (failures.length)
+        throw new Error("Failures:\n" + failures.join("\n"));
+}
+finish();

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -455,6 +455,8 @@ void Interpreter::getAsyncStackTrace(JSCell* owner, Vector<StackFrame>& results,
 
     auto getContextValueFromPromise = [&](JSPromise* promise) -> JSValue {
         if (promise && promise->status() == JSPromise::Status::Pending) {
+            if (promise->hasInlineReaction())
+                return promise->inlineReactionContext();
             JSValue reactionsValue = promise->internalField(JSPromise::Field::ReactionsOrResult).get();
             if (reactionsValue) {
                 if (JSValue context = JSPromiseReaction::tryGetContext(reactionsValue))

--- a/Source/JavaScriptCore/runtime/JSMicrotask.cpp
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.cpp
@@ -1411,26 +1411,7 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
         if (!promiseSpeciesWatchpointIsValid(vm, promise)) [[unlikely]]
             RELEASE_AND_RETURN(scope, promiseResolveThenableJobWithInternalMicrotaskFastSlow(globalObject, promise, task, context));
 
-        JSValue reactionsOrResult = promise->reactionsOrResult();
-        switch (promise->status()) {
-        case JSPromise::Status::Pending: {
-            auto* reaction = JSSlimPromiseReaction::create(vm, jsUndefined(), task, context, reactionsOrResult ? uncheckedDowncast<JSPromiseReaction>(reactionsOrResult) : nullptr);
-            promise->setReactionsOrResult(vm, reaction);
-            promise->markAsHandled();
-            break;
-        }
-        case JSPromise::Status::Rejected: {
-            if (!promise->isHandled())
-                globalObject->globalObjectMethodTable()->promiseRejectionTracker(globalObject, promise, JSPromiseRejectionOperation::Handle);
-            JSPromise::rejectWithInternalMicrotask(vm, globalObject, reactionsOrResult, task, context);
-            promise->markAsHandled();
-            break;
-        }
-        case JSPromise::Status::Fulfilled: {
-            JSPromise::fulfillWithInternalMicrotask(vm, globalObject, reactionsOrResult, task, context);
-            break;
-        }
-        }
+        promise->performPromiseThenWithInternalMicrotask(vm, globalObject, task, jsUndefined(), context);
         return;
     }
 

--- a/Source/JavaScriptCore/runtime/JSPromise.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromise.cpp
@@ -247,6 +247,26 @@ JSPromise* JSPromise::rejectWithCaughtException(JSGlobalObject* globalObject, Th
     return this;
 }
 
+JSPromiseReaction* JSPromise::spillInlineReaction(VM& vm)
+{
+    ASSERT(hasInlineReaction());
+    InternalMicrotask task = inlineReactionMicrotask();
+    JSValue context = inlineReactionContext();
+    auto* reaction = JSSlimPromiseReaction::create(vm, jsUndefined(), task, context, nullptr);
+    clearInlineReaction();
+    setReactionsOrResult(vm, reaction);
+    return reaction;
+}
+
+JSPromiseReaction* JSPromise::reactionHead(VM& vm)
+{
+    ASSERT(status() == Status::Pending);
+    if (hasInlineReaction()) [[unlikely]]
+        return spillInlineReaction(vm);
+    JSValue reactionsOrResult = this->reactionsOrResult();
+    return reactionsOrResult ? uncheckedDowncast<JSPromiseReaction>(reactionsOrResult) : nullptr;
+}
+
 void JSPromise::performPromiseThen(VM& vm, JSGlobalObject* globalObject, JSValue onFulfilled, JSValue onRejected, JSValue promiseOrCapability)
 {
     bool fulfilledCallable = onFulfilled.isCallable();
@@ -255,7 +275,7 @@ void JSPromise::performPromiseThen(VM& vm, JSGlobalObject* globalObject, JSValue
     JSValue reactionsOrResult = this->reactionsOrResult();
     switch (status()) {
     case JSPromise::Status::Pending: {
-        JSPromiseReaction* existing = reactionsOrResult ? uncheckedDowncast<JSPromiseReaction>(reactionsOrResult) : nullptr;
+        JSPromiseReaction* existing = reactionHead(vm);
         JSPromiseReaction* reaction;
         if (fulfilledCallable && !rejectedCallable)
             reaction = JSSlimPromiseReaction::create(vm, promiseOrCapability, onFulfilled, true, existing);
@@ -295,7 +315,15 @@ void JSPromise::performPromiseThenWithInternalMicrotask(VM& vm, JSGlobalObject* 
     JSValue reactionsOrResult = this->reactionsOrResult();
     switch (status()) {
     case JSPromise::Status::Pending: {
-        auto* reaction = JSSlimPromiseReaction::create(vm, promise, task, context, reactionsOrResult ? uncheckedDowncast<JSPromiseReaction>(reactionsOrResult) : nullptr);
+        if (promise.isUndefined() && !reactionsOrResult) [[likely]] {
+            // setInlineReaction always stores a non-empty cell into ReactionsOrResult,
+            // so an empty ReactionsOrResult implies no inline reaction.
+            ASSERT(!hasInlineReaction());
+            setInlineReaction(vm, task, context);
+            break;
+        }
+        JSPromiseReaction* existing = reactionHead(vm);
+        auto* reaction = JSSlimPromiseReaction::create(vm, promise, task, context, existing);
         setReactionsOrResult(vm, reaction);
         markAsHandled();
         break;
@@ -337,10 +365,26 @@ bool isDefinitelyNonThenable(JSObject* object, JSGlobalObject* globalObject)
     return true;
 }
 
+ALWAYS_INLINE void JSPromise::settleInlineReaction(VM& vm, JSGlobalObject* globalObject, Status status, JSValue argument, int32_t flags)
+{
+    ASSERT(flags & hasInlineReactionFlag);
+    // setInlineReaction always sets isHandledFlag, so no rejection tracker call needed.
+    ASSERT(flags & isHandledFlag);
+    InternalMicrotask task = static_cast<InternalMicrotask>((flags & inlineReactionMicrotaskMask) >> inlineReactionMicrotaskShift);
+    JSValue context = reactionsOrResult();
+    internalField(Field::Flags).setWithoutWriteBarrier(jsNumber((flags & ~(hasInlineReactionFlag | inlineReactionMicrotaskMask)) | static_cast<int32_t>(status)));
+    internalField(Field::ReactionsOrResult).set(vm, this, argument);
+    globalObject->queueMicrotask(vm, task, static_cast<uint8_t>(status), jsUndefined(), argument, context);
+}
+
 void JSPromise::rejectPromise(VM& vm, JSGlobalObject* globalObject, JSValue argument)
 {
     ASSERT(status() == Status::Pending);
     int32_t flags = this->flags();
+
+    if (flags & hasInlineReactionFlag)
+        return settleInlineReaction(vm, globalObject, Status::Rejected, argument, flags);
+
     JSValue reactions = this->reactionsOrResult();
     internalField(Field::Flags).setWithoutWriteBarrier(jsNumber(static_cast<int32_t>(flags | static_cast<uint32_t>(Status::Rejected))));
     internalField(Field::ReactionsOrResult).set(vm, this, argument);
@@ -357,6 +401,10 @@ void JSPromise::fulfillPromise(VM& vm, JSGlobalObject* globalObject, JSValue arg
 {
     ASSERT(status() == Status::Pending);
     int32_t flags = this->flags();
+
+    if (flags & hasInlineReactionFlag)
+        return settleInlineReaction(vm, globalObject, Status::Fulfilled, argument, flags);
+
     JSValue reactions = this->reactionsOrResult();
     internalField(Field::Flags).setWithoutWriteBarrier(jsNumber(static_cast<int32_t>(flags | static_cast<uint32_t>(Status::Fulfilled))));
     internalField(Field::ReactionsOrResult).set(vm, this, argument);

--- a/Source/JavaScriptCore/runtime/JSPromise.h
+++ b/Source/JavaScriptCore/runtime/JSPromise.h
@@ -26,10 +26,9 @@
 #pragma once
 
 #include <JavaScriptCore/JSInternalFieldObjectImpl.h>
+#include <JavaScriptCore/Microtask.h>
 
 namespace JSC {
-
-enum class InternalMicrotask : uint8_t;
 
 class JSPromiseConstructor;
 class JSPromise : public JSInternalFieldObjectImpl<2> {
@@ -57,8 +56,19 @@ public:
     static constexpr int32_t isFirstResolvingFunctionCalledFlag = 8;
     static constexpr int32_t stateMask = 0b11;
 
+    // For pending promises with exactly one internal-microtask reaction whose result
+    // promise is undefined (the common await / async-generator-resume case), we avoid
+    // allocating a JSSlimPromiseReaction by storing the InternalMicrotask in the upper
+    // bits of Flags and the reaction's context in ReactionsOrResult.
+    static constexpr int32_t hasInlineReactionFlag = 16;
+    static constexpr int32_t inlineReactionMicrotaskShift = 5;
+    static constexpr int32_t inlineReactionMicrotaskMask = 0xff << inlineReactionMicrotaskShift;
+
     enum class Field : unsigned {
         Flags = 0,
+        // Pending + hasInlineReactionFlag: the inline reaction's context cell.
+        // Pending otherwise: head of the JSPromiseReaction chain (or empty).
+        // Fulfilled / Rejected: the settlement value.
         ReactionsOrResult = 1,
     };
     static_assert(numberOfInternalFields == 2);
@@ -112,6 +122,13 @@ public:
 
     JSValue reactionsOrResult() const { return internalField(Field::ReactionsOrResult).get(); };
     void setReactionsOrResult(VM& vm, JSValue value) { internalField(Field::ReactionsOrResult).set(vm, this, value); };
+
+    bool hasInlineReaction() const { return flags() & hasInlineReactionFlag; }
+    JSValue inlineReactionContext() const
+    {
+        ASSERT(hasInlineReaction());
+        return reactionsOrResult();
+    }
 
     // https://webidl.spec.whatwg.org/#mark-a-promise-as-handled
     void markAsHandled()
@@ -167,6 +184,31 @@ protected:
     }
 
 private:
+    InternalMicrotask inlineReactionMicrotask() const
+    {
+        ASSERT(hasInlineReaction());
+        return static_cast<InternalMicrotask>((flags() & inlineReactionMicrotaskMask) >> inlineReactionMicrotaskShift);
+    }
+    void setInlineReaction(VM& vm, InternalMicrotask task, JSValue context)
+    {
+        ASSERT(status() == Status::Pending);
+        ASSERT(!reactionsOrResult());
+        ASSERT(task != InternalMicrotask::None);
+        int32_t flags = this->flags();
+        ASSERT(!(flags & hasInlineReactionFlag));
+        // The inline reaction always implies markAsHandled, so set both bits in one write.
+        internalField(Field::Flags).setWithoutWriteBarrier(jsNumber(flags | hasInlineReactionFlag | isHandledFlag | (static_cast<int32_t>(task) << inlineReactionMicrotaskShift)));
+        setReactionsOrResult(vm, context);
+    }
+    void clearInlineReaction()
+    {
+        int32_t flags = this->flags();
+        ASSERT(flags & hasInlineReactionFlag);
+        internalField(Field::Flags).setWithoutWriteBarrier(jsNumber(flags & ~(hasInlineReactionFlag | inlineReactionMicrotaskMask)));
+    }
+    JSPromiseReaction* spillInlineReaction(VM&);
+    JSPromiseReaction* reactionHead(VM&);
+    void settleInlineReaction(VM&, JSGlobalObject*, Status, JSValue argument, int32_t flags);
     static void triggerPromiseReactions(VM&, JSGlobalObject*, JSPromise::Status, JSPromiseReaction* head, JSValue argument);
 };
 


### PR DESCRIPTION
#### 91ce11ddd17b5efd19d7f36509e756fec4f08a14
<pre>
[JSC] Avoid allocating `JSSlimPromiseReaction` for the single-await case
<a href="https://bugs.webkit.org/show_bug.cgi?id=314637">https://bugs.webkit.org/show_bug.cgi?id=314637</a>

Reviewed by Yusuke Suzuki.

When a pending promise gains its first reaction via
performPromiseThenWithInternalMicrotask with an undefined result promise -- the
common path for `await pendingPromise`, async generator resume, and
`for await...of` -- the reaction is fully described by an InternalMicrotask
(8 bits) and one context cell. We were heap-allocating a JSSlimPromiseReaction
(~32 bytes) just to hold those.

This patch stores that reaction inline in the promise&apos;s existing fields:
  - Flags bit 4: hasInlineReactionFlag
  - Flags bits 5-12: the InternalMicrotask
  - ReactionsOrResult: the reaction&apos;s context cell

Both fields were previously underused while pending: Flags only used bits 0-3,
and ReactionsOrResult was empty until the first reaction arrived.

When the promise settles, fulfillPromise/rejectPromise read the inline reaction
and queue the microtask directly without touching a reaction object. If a second
consumer attaches before settlement -- another `await` of the same promise, or a
`.then()` on a promise that is already being awaited -- reactionHead() spills
the inline reaction into a JSSlimPromiseReaction chain and the existing path
takes over. The spill is rare: in practice almost every awaited promise has
exactly one consumer.

In local runs of the JetStream3 async/promise-heavy subset (doxbee-promise,
doxbee-async, async-fs, lazy-collections), this looks like a slight improvement
in score and peak memory footprint, with a small drop in Eden GC count. The
numbers are noisy but the direction is consistent across runs.

Test: JSTests/stress/promise-inline-reaction.js

* JSTests/stress/promise-inline-reaction.js: Added.
(shouldBe):
(asyncTest):
(async let):
(async const):
(async Promise):
(async gen):
(async g):
(async for):
(async try):
(finish):
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::Interpreter::getAsyncStackTrace):
* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::runInternalMicrotask):
* Source/JavaScriptCore/runtime/JSPromise.cpp:
(JSC::JSPromise::spillInlineReaction):
(JSC::JSPromise::reactionHead):
(JSC::JSPromise::performPromiseThen):
(JSC::JSPromise::performPromiseThenWithInternalMicrotask):
(JSC::JSPromise::settleInlineReaction):
(JSC::JSPromise::rejectPromise):
(JSC::JSPromise::fulfillPromise):
* Source/JavaScriptCore/runtime/JSPromise.h:
(JSC::JSPromise::hasInlineReaction const):
(JSC::JSPromise::inlineReactionContext const):
(JSC::JSPromise::inlineReactionMicrotask const):
(JSC::JSPromise::setInlineReaction):
(JSC::JSPromise::clearInlineReaction):

Canonical link: <a href="https://commits.webkit.org/313138@main">https://commits.webkit.org/313138@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/03e8eff3a2bb5618e3f3445fbc7c07a4cf8cb4e5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162179 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35655 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28771 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171087 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118552 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35759 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35656 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125865 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88724 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165138 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28197 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145688 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106443 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27244 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18808 "Built successfully") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136945 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23427 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173581 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23018 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20934 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25070 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134161 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35329 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29846 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134162 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36225 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35312 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145223 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97518 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28702 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22051 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194579 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34822 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102574 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50169 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34323 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34568 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34471 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->