### PR TITLE
[MSE] timeupdate event can fire during seek operation, before the seek

### DIFF
--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -4042,6 +4042,13 @@ void HTMLMediaElement::seekTask()
     m_pendingSeekType = thisSeekType;
     setSeeking(true);
 
+    // Before scheduling the 'seeking' event, drop any queued periodic timeupdate
+    // task. Without this, a periodic timeupdate queued by playbackProgressTimerFired
+    // just before setCurrentTime could dispatch ahead of 'seeking', producing the
+    // spec-incorrect event ordering observed in mediasource-duration.html. The
+    // seek-completion timeupdate is queued separately by finishSeek and survives.
+    m_periodicTimeupdateCancellationGroup.cancel();
+
     // 10 - Queue a task to fire a simple event named seeking at the element.
     scheduleEvent(eventNames().seekingEvent);
 
@@ -5056,6 +5063,14 @@ void HTMLMediaElement::playbackProgressTimerFired()
 
 void HTMLMediaElement::scheduleTimeupdateEvent(bool periodicEvent)
 {
+    // Per HTML spec, the periodic timeupdate is only for "the time reached through the
+    // usual monotonic increase of the current playback position during normal playback".
+    // During an active seek, the seek algorithm's own events (seeking -> timeupdate ->
+    // seeked via finishSeek) are responsible for notifying the page. Suppress periodic
+    // timeupdates while seeking so they don't interleave with the seek-driven ordering.
+    if (periodicEvent && m_seeking)
+        return;
+
     MonotonicTime now = MonotonicTime::now();
     Seconds timedelta = now - m_clockTimeAtLastUpdateEvent;
 
@@ -5070,7 +5085,14 @@ void HTMLMediaElement::scheduleTimeupdateEvent(bool periodicEvent)
     // event at a given time so filter here
     MediaTime movieTime = currentMediaTime();
     if (movieTime != m_lastTimeUpdateEventMovieTime) {
-        scheduleEvent(eventNames().timeupdateEvent);
+        if (periodicEvent) {
+            // Periodic timeupdates are cancellable by the seek path — if a seek starts
+            // before this task dispatches, the pending timeupdate would race ahead of
+            // the 'seeking' event, producing spec-incorrect event ordering that fails
+            // mediasource-duration.html.
+            queueCancellableTaskToDispatchEvent(*this, TaskSource::MediaElement, m_periodicTimeupdateCancellationGroup, Event::create(eventNames().timeupdateEvent, Event::CanBubble::No, Event::IsCancelable::Yes));
+        } else
+            scheduleEvent(eventNames().timeupdateEvent);
         m_clockTimeAtLastUpdateEvent = now;
         m_lastTimeUpdateEventMovieTime = movieTime;
     }

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -1215,6 +1215,7 @@ private:
     TaskCancellationGroup m_updateShouldAutoplayTaskCancellationGroup;
     RefPtr<TimeRanges> m_playedTimeRanges;
     TaskCancellationGroup m_asyncEventsCancellationGroup;
+    TaskCancellationGroup m_periodicTimeupdateCancellationGroup;
     TaskCancellationGroup m_volumeRevertTaskCancellationGroup;
 
     PlayPromiseVector m_pendingPlayPromises;

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -779,7 +779,9 @@ void MediaPlayerPrivateMediaSourceAVFObjC::bufferedChanged()
             MediaTime now = protectedThis->currentTime();
             ALWAYS_LOG_WITH_THIS(protectedThis, logSiteIdentifier, "boundary time observer called, now = ", now);
 
-            if (stallTime == protectedThis->duration())
+            if (protectedThis->seeking())
+                return; // seek owns state transitions
+            if (now >= protectedThis->duration())
                 protectedThis->pause();
             protectedThis->timeChanged();
         });
@@ -1152,7 +1154,6 @@ void MediaPlayerPrivateMediaSourceAVFObjC::updateStateFromReadyState()
         dispatchToRendererQueue([](auto& renderer) {
             renderer.play();
         });
-        timeChanged();
     } else
         stall();
 


### PR DESCRIPTION
#### 612b528ca58713f979bb25ef03fac63f236db932
<pre>
[MSE] timeupdate event can fire during seek operation, before the seek
completes.
<a href="https://bugs.webkit.org/show_bug.cgi?id=314624">https://bugs.webkit.org/show_bug.cgi?id=314624</a>
<a href="https://rdar.apple.com/problem/176861767">rdar://problem/176861767</a>

Reviewed by Youenn Fablet.

In the WPT mediasource-duration.html test the three &quot;truncated
duration seek&quot; subtests (&quot;seek starts on duration truncation below
currentTime&quot;, &quot;appendBuffer completes previous seek to truncated
duration&quot;, &quot;endOfStream completes previous seek to truncated
duration&quot;) failed intermittently under --repeat=N stress with

  assert_equals: Event types match. expected &quot;seeking&quot; but got &quot;timeupdate&quot;

The common pattern in all three was: after a seek completes, the
subtest calls sourceBuffer.remove(truncatedDuration, Infinity),
waits for the resulting &apos;updateend&apos;, then sets
mediaSource.duration = truncatedDuration and expects the next
mediaElement event to be &apos;seeking&apos;. A &apos;timeupdate&apos; was instead
landing between the remove&apos;s updateend and the seek&apos;s seeking,
failing the assertion.

Two distinct sources of the stray timeupdate were identified.

1. MediaPlayerPrivateMediaSourceAVFObjC::stall() unconditionally
    called timeChanged() when shouldBePlaying() was still true.
    The remove()&apos;s bufferedChanged runs on the main thread with
    hasFutureTime(currentTime) = false (the range now ends before
    currentTime), which calls stall() synchronously: the renderer
    stall dispatch is asynchronous so shouldBePlaying() still
    returns true, and timeChanged() queues a scheduleTimeupdateEvent
    task at the current (stalled) movieTime. That task was then
    dispatched ahead of the subtest handler&apos;s setDuration -&gt; seek.

2. HTMLMediaElement::playbackProgressTimerFired fires
    scheduleTimeupdateEvent(periodic=true) every 250 ms. If the
    timer tick lands in the brief window between the remove&apos;s
    &apos;updateend&apos; dispatching to JS and the subtest handler calling
    setCurrentTime / setDuration, it queues a timeupdate task that
    then dispatches ahead of the seeking event. This is visible in
    a non-MSE form too — during any in-flight seek, the seek
    algorithm in the spec owns the event ordering
    (&quot;in the other cases, such as explicit seeks, relevant events
    get fired as part of the overall process of changing the
    current playback position&quot;).

Fix, in two coordinated parts.

=== Stall path ===

  * MediaPlayerPrivateMediaSourceAVFObjC::stall(): drop the
    if (shouldBePlaying()) timeChanged() call.

=== Periodic timeupdate cancellation ===

Add m_periodicTimeupdateCancellationGroup to HTMLMediaElement.
Route tasks queued by scheduleTimeupdateEvent(periodic=true)
through it, and cancel it at the top of seek() before queuing
the seeking event. This drops any playbackProgressTimer-queued
timeupdate task that is sitting in the queue just before the
seek starts, so the seek algorithm owns the event ordering as
the spec prescribes. Non-periodic timeupdate calls (finishSeek,
updateReadyState, mediaPlayerTimeChanged&apos;s discontinuity path)
continue to use the general async-events group and are not
cancelled.

Also add an early-return in scheduleTimeupdateEvent(periodicEvent)
when m_seeking is true. This covers the complementary case where
a periodic timer tick happens during an already-in-flight seek:
per spec, during an explicit seek the seek algorithm&apos;s own
events (seeking -&gt; timeupdate -&gt; seeked via finishSeek) are what
the page sees; the periodic timer contributes nothing useful.

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::seekTask):
(WebCore::HTMLMediaElement::scheduleTimeupdateEvent): early return
if (periodicEvent &amp;&amp; m_seeking); for periodic events queue the
task through m_periodicTimeupdateCancellationGroup.
* Source/WebCore/html/HTMLMediaElement.h:
* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::bufferedChanged):
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::updateStateFromReadyState):
drop timeChanged() in the shouldBePlaying branch.

Canonical link: <a href="https://commits.webkit.org/313165@main">https://commits.webkit.org/313165@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba4992ea0ca8ae3cf0348ee10d3e24ac3754faa2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162260 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35736 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28852 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171168 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/118705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164129 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35840 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35737 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125926 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/118705 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165219 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28263 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145760 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106504 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27310 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18889 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137012 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23499 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173662 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21015 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25142 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134222 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35410 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29916 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134223 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36242 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35393 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145295 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97619 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28767 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22124 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34903 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102655 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34404 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34650 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34552 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->