### PR TITLE
[MSE] 'ended' event never fires when MediaSource.endOfStream() is

### DIFF
--- a/LayoutTests/media/media-source/media-source-duration-truncation-ended-expected.txt
+++ b/LayoutTests/media/media-source/media-source-duration-truncation-ended-expected.txt
@@ -1,0 +1,28 @@
+
+RUN(video.src = URL.createObjectURL(source))
+RUN(video.muted = true)
+RUN(video.playsInline = true)
+RUN(video.disableRemotePlayback = true)
+RUN(video.autoplay = true)
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer(loader.type()))
+RUN(sourceBuffer.appendBuffer(loader.initSegment()))
+EVENT(update)
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(0)))
+EVENT(update)
+RUN(sourceBuffer.appendBuffer(loader.mediaSegment(1)))
+EVENT(update)
+RUN(video.play())
+EXPECTED (video.currentTime > 0 == 'true') OK
+EXPECTED (video.duration > video.currentTime == 'true') OK
+RUN(source.duration = sourceBuffer.buffered.end(0))
+EVENT(durationchange)
+EXPECTED (video.duration > 0 == 'true') OK
+EXPECTED (source.readyState == 'open') OK
+RUN(source.endOfStream())
+EVENT(sourceended)
+EVENT(ended)
+EXPECTED (video.ended == 'true') OK
+EXPECTED (source.readyState == 'ended') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-duration-truncation-ended.html
+++ b/LayoutTests/media/media-source/media-source-duration-truncation-ended.html
@@ -1,0 +1,110 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>ended event must fire after endOfStream when playback is parked at a buffered range end whose position now equals the truncated duration</title>
+    <script src="media-source-loader.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    // Regression test: ended event was never fired when
+    //  1) playback parked at the end of the buffered range while duration was still
+    //     greater than currentTime (so the stall-boundary callback took the
+    //     mid-content branch, not the end-of-media branch), then
+    //  2) JS truncated duration down to equal currentTime (equality case — does not
+    //     trigger HTMLMediaElement's seekInternal in mediaPlayerDurationChanged), then
+    //  3) JS called endOfStream().
+    // After the fix, MediaPlayerPrivateMediaSourceAVFObjC::mediaSourceHasRetrievedAllData
+    // re-checks end-of-media when MediaSource transitions to 'ended' and notifies
+    // HTMLMediaElement::mediaPlayerTimeChanged so the 'ended' event fires.
+
+    var loader;
+    var source;
+    var sourceBuffer;
+
+    function loaderPromise(loader) {
+        return new Promise((resolve, reject) => {
+            loader.onload = resolve;
+            loader.onerror = reject;
+        });
+    }
+
+    window.addEventListener('load', async event => {
+        findMediaElement();
+
+        loader = new MediaSourceLoader('content/test-fragmented-video-manifest.json');
+        await loaderPromise(loader);
+
+        source = new MediaSource();
+        run('video.src = URL.createObjectURL(source)');
+        run('video.muted = true');
+        run('video.playsInline = true');
+        run('video.disableRemotePlayback = true');
+        run('video.autoplay = true');
+        await waitFor(source, 'sourceopen');
+        waitFor(video, 'error').then(failTest);
+
+        // Register the 'playing' promise BEFORE appending so we don't miss the
+        // event firing synchronously-ish during the appends.
+        const playingPromise = waitFor(video, 'playing', true);
+
+        run('sourceBuffer = source.addSourceBuffer(loader.type())');
+        run('sourceBuffer.appendBuffer(loader.initSegment())');
+        await waitFor(sourceBuffer, 'update');
+
+        // Append the first two 1-second fragments; leave the rest out so playback
+        // will stall at the end of the buffered range while duration is still
+        // whatever the mp4 MOOV reports (well above 2 s).
+        run('sourceBuffer.appendBuffer(loader.mediaSegment(0))');
+        await waitFor(sourceBuffer, 'update');
+        run('sourceBuffer.appendBuffer(loader.mediaSegment(1))');
+        await waitFor(sourceBuffer, 'update');
+
+        run('video.play()');
+
+        await playingPromise;
+
+        // NOW register the 'waiting' listener — only the 'waiting' that fires
+        // after playback has actually started and reached the buffered-range end
+        // is interesting. Earlier 'waiting' events during initial load are noise.
+        const waitingPromise = waitFor(video, 'waiting', true);
+
+        // Wait for playback to exhaust the buffered range. This is the moment the
+        // stall-boundary observer fires. duration() at that moment is still the
+        // full mp4 duration (>> buffered.end), so the boundary callback takes the
+        // mid-content branch (no timeChanged, no ended).
+        await waitingPromise;
+        testExpected('video.currentTime > 0', true);
+        testExpected('video.duration > video.currentTime', true);
+
+        // Truncate duration down to the buffered-range end — the equality case
+        // that HTMLMediaElement::mediaPlayerDurationChanged's `if (now > dur)
+        // seekInternal(dur);` guard does NOT cover when currentTime already
+        // equals the new duration. Nothing here re-evaluates end-of-media.
+        run('source.duration = sourceBuffer.buffered.end(0)');
+        await waitFor(video, 'durationchange');
+        testExpected('video.duration > 0', true);
+
+        // MediaSource is still 'open' here — per MSE semantics 'ended' must not
+        // fire yet. (Note: video.ended is not a useful signal at this point — it's
+        // computed per-spec as now >= duration, which is true because setDuration
+        // just placed duration at currentTime; the 'ended' event firing is
+        // independent of that attribute value.)
+        testExpected('source.readyState', 'open');
+
+        // endOfStream transitions MediaSource to 'ended'. After this, the
+        // HTMLMediaElement 'ended' event must fire — without the fix, this
+        // waitFor(video, 'ended') times out.
+        run('source.endOfStream()');
+        await waitFor(source, 'sourceended');
+        await waitFor(video, 'ended');
+
+        testExpected('video.ended', true);
+        testExpected('source.readyState', 'ended');
+
+        endTest();
+    });
+    </script>
+</head>
+<body>
+    <video></video>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -5564,6 +5564,8 @@ ipc/empty-svgfilterrenderer-expression-crash.html [ Skip ]
 
 webkit.org/b/314373 media/media-source/media-source-real-webm-fastseek.html [ Failure ]
 webkit.org/b/314373 media/media-source/media-source-real-webm-remove.html [ Failure ]
+# test timeout, skip it for now
+webkit.org/b/314643 media/media-source/media-source-duration-truncation-ended.html [ Skip ]
 
 webkit.org/b/314491 imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.serviceworker.html [ Crash ]
 # End: Common failures between GTK and WPE.

--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -501,8 +501,6 @@ void MediaPlayerPrivateMediaSourceAVFObjC::stall()
     dispatchToRendererQueue([](auto& renderer) {
         renderer.stall();
     });
-    if (shouldBePlaying())
-        timeChanged();
 }
 
 bool MediaPlayerPrivateMediaSourceAVFObjC::playAtHostTime(const MonotonicTime& time)
@@ -558,9 +556,7 @@ void MediaPlayerPrivateMediaSourceAVFObjC::seekInternal()
 
     cancelPendingSeek();
 
-    dispatchToRendererQueue([](auto& renderer) {
-        renderer.stall();
-    });
+    stall();
 
     ALWAYS_LOG(LOGIDENTIFIER);
 
@@ -1185,6 +1181,10 @@ void MediaPlayerPrivateMediaSourceAVFObjC::mediaSourceHasRetrievedAllData()
 {
     assertIsMainThread();
     setNetworkState(MediaPlayer::NetworkState::Loaded);
+    if (!effectiveRate()) {
+        // Playback had stalled; make transition for the element to ended if needed.
+        timeChanged();
+    }
 }
 
 ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN


### PR DESCRIPTION
#### 4dd78df3a13ebaa6d39c5e2745c159ab9af0f392
<pre>
[MSE] &apos;ended&apos; event never fires when MediaSource.endOfStream() is
called while playback is parked at buffered-range end equal to
the final duration
<a href="https://bugs.webkit.org/show_bug.cgi?id=314628">https://bugs.webkit.org/show_bug.cgi?id=314628</a>
<a href="https://rdar.apple.com/problem/176863546">rdar://problem/176863546</a>

Reviewed by Jer Noble.

In the WPT mediasource-duration.html &quot;setting same duration multiple
times does not fire duplicate durationchange&quot; subtest, after the test
removes data past a target point, sets MediaSource.duration to that
point, and calls endOfStream(), the HTMLMediaElement &apos;ended&apos; event
is never fired and the test harness times out.

HTMLMediaElement::mediaPlayerTimeChanged() is the only site that
schedules &apos;ended&apos; (now &gt;= dur &amp;&amp; playbackRate &gt; 0). In this scenario
none of the existing call sites for timeChanged() reach it after
MediaSource has transitioned to &apos;ended&apos;:

  - The notifyTimeReachedAndStall boundary-observer callback fired
    earlier when playback first reached the buffered-range end, but at
    that moment duration was still the pre-truncation value, so
    stallTime != duration() and it took the mid-content branch. It
    pinned the synchronizer at the boundary and does not fire again.
  - HTMLMediaElement::mediaPlayerDurationChanged only seeks when
    now &gt; dur strictly; the equality case (currentTime == new duration)
    doesn&apos;t trigger seekInternal, so no completeSeek -&gt; timeChanged.
  - MediaSource::monitorSourceBuffers handles readyState transitions
    per MSE spec but does not schedule &apos;ended&apos;.

We stop firing a `timeupdate` event whenever we stall() this is handled
by the MediaSource::monitorSourceBuffers algorithm.

Had we stalled at the end of the video element, when endOfStream() is called
force the transition of the media element to ended by calling mediaPlayerTimeChanged.

Test: media/media-source/media-source-duration-truncation-ended.html
Canonical link: <a href="https://commits.webkit.org/313141@main">https://commits.webkit.org/313141@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b2386c19a9665cb09a3ec803a582bcb8d4a72260

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162205 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35681 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28797 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171113 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118578 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164074 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35785 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35682 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125884 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88741 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165164 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28228 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/145715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106462 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27275 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18834 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136976 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23454 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173607 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20960 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25097 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134183 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35355 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29869 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134184 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36228 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35338 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145250 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97550 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28722 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22078 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34848 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102600 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34349 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34594 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34497 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->