### PR TITLE
[CMake] REGRESSION: WebKitTestRunner crashes on launch with a linker error

### DIFF
--- a/Source/WebCore/PlatformMac.cmake
+++ b/Source/WebCore/PlatformMac.cmake
@@ -552,6 +552,7 @@ list(APPEND WebCore_SOURCES
     testing/MockContentFilter.cpp # FIXME: Compiled into WebCore because CMake links WebCoreTestSupport statically (Bug 312062).
     testing/MockContentFilterManager.cpp
     testing/MockContentFilterSettings.cpp
+    testing/MockParentalControlsURLFilter.mm
 
     workers/service/ServiceWorkerRoute.mm
 )
@@ -1104,7 +1105,6 @@ list(APPEND WebCoreTestSupport_SOURCES
     testing/MockApplePaySetupFeature.cpp
     testing/MockContentFilter.cpp
     testing/MockContentFilterSettings.cpp
-    testing/MockParentalControlsURLFilter.mm
     testing/MockMediaSessionCoordinator.cpp
     testing/MockPaymentCoordinator.cpp
     testing/MockPreviewLoaderClient.cpp

--- a/Source/WebCore/testing/MockParentalControlsURLFilter.h
+++ b/Source/WebCore/testing/MockParentalControlsURLFilter.h
@@ -36,8 +36,10 @@ namespace WebCore {
 
 class MockParentalControlsURLFilter final : public ParentalControlsURLFilter {
 public:
-    WEBCORE_TESTSUPPORT_EXPORT static Ref<MockParentalControlsURLFilter> create(Vector<URL>&& blockedURLs);
-    WEBCORE_TESTSUPPORT_EXPORT ~MockParentalControlsURLFilter();
+    // FIXME: This class should compile with WebCoreTestSupport, and then these export macros
+    // should be WEBCORE_TESTSUPPORT_EXPORT.
+    WEBCORE_EXPORT static Ref<MockParentalControlsURLFilter> create(Vector<URL>&& blockedURLs);
+    WEBCORE_EXPORT ~MockParentalControlsURLFilter();
 
 private:
     explicit MockParentalControlsURLFilter(Vector<URL>&& blockedURLs);

--- a/Source/WebKit/PlatformMac.cmake
+++ b/Source/WebKit/PlatformMac.cmake
@@ -149,9 +149,6 @@ list(APPEND WebKit_SOURCES
 list(APPEND WebKit_PRIVATE_LIBRARIES
     "-weak_framework PowerLog"
 )
-# FIXME: Replace with targeted -U flags or explicit stubs.
-# https://bugs.webkit.org/show_bug.cgi?id=312067
-list(APPEND WebKit_PRIVATE_LIBRARIES "-Wl,-undefined,dynamic_lookup")
 
 list(APPEND WebKit_PUBLIC_FRAMEWORK_HEADERS
     Shared/WebPushDaemonConstants.h

--- a/Source/WebKit/UIProcess/DisplayLinkProcessProxyClient.cpp
+++ b/Source/WebKit/UIProcess/DisplayLinkProcessProxyClient.cpp
@@ -36,6 +36,10 @@ namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(DisplayLinkProcessProxyClient);
 
+DisplayLinkProcessProxyClient::DisplayLinkProcessProxyClient(ClangVTableWorkaroundTag)
+{
+}
+
 void DisplayLinkProcessProxyClient::setConnection(RefPtr<IPC::Connection>&& connection)
 {
     Locker locker { m_connectionLock };

--- a/Source/WebKit/UIProcess/DisplayLinkProcessProxyClient.h
+++ b/Source/WebKit/UIProcess/DisplayLinkProcessProxyClient.h
@@ -41,9 +41,12 @@ public:
     WTF_MAKE_TZONE_ALLOCATED(DisplayLinkProcessProxyClient);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(DisplayLinkProcessProxyClient);
 public:
+    DisplayLinkProcessProxyClient() = default;
     void setConnection(RefPtr<IPC::Connection>&&);
 
 private:
+    explicit DisplayLinkProcessProxyClient(ClangVTableWorkaroundTag);
+
     void displayLinkFired(WebCore::PlatformDisplayID, WebCore::DisplayUpdate, bool wantsFullSpeedUpdates, bool anyObserverWantsCallback) override;
 
     Lock m_connectionLock;

--- a/Source/WebKit/UIProcess/PageClient.cpp
+++ b/Source/WebKit/UIProcess/PageClient.cpp
@@ -32,6 +32,10 @@
 
 namespace WebKit {
 
+PageClient::PageClient(ClangVTableWorkaroundTag)
+{
+}
+
 #if ENABLE(VIDEO)
 void PageClient::showCaptionDisplaySettings(WebCore::HTMLMediaElementIdentifier, const WebCore::ResolvedCaptionDisplaySettingsOptions&, CompletionHandler<void(Expected<void, WebCore::ExceptionData>&&)>&& completionHandler)
 {

--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -243,7 +243,10 @@ class WebKitWebResourceLoadManager;
 
 class PageClient : public CanMakeWeakPtr<PageClient> {
     WTF_MAKE_TZONE_ALLOCATED_INLINE(PageClient);
+private:
+    explicit PageClient(ClangVTableWorkaroundTag);
 public:
+    PageClient() = default;
     virtual ~PageClient() { }
 
     void ref() { refView(); }


### PR DESCRIPTION
#### 32f3f6f4b35f6eafedcb59db14d252c2662e07d3
<pre>
[CMake] REGRESSION: WebKitTestRunner crashes on launch with a linker error
<a href="https://bugs.webkit.org/show_bug.cgi?id=314640">https://bugs.webkit.org/show_bug.cgi?id=314640</a>
<a href="https://rdar.apple.com/176881806">rdar://176881806</a>

Reviewed by Charlie Wolfe, Pascoe, and David Kilzer.

* Source/WebCore/PlatformMac.cmake: Compile MockParentalControlsURLFilter.mm
as a part of WebCore to match the Xcode build and put the linked symbol
where the rest of the project expects it. (It&apos;s not ideal to pull a TestSupport
symbol out of the TestSupport list, but for now it&apos;s easiest to maintain if
the build systems match each other bug-for-bug.)

* Source/WebCore/testing/MockParentalControlsURLFilter.h: Use WEBCORE_EXPORT
because this file is in the WebCore file list now.

* Source/WebKit/PlatformMac.cmake: Do real linking at compile time, so that we
catch bugs like this eagerly in the future.

* Source/WebKit/UIProcess/DisplayLinkProcessProxyClient.cpp:
(WebKit::DisplayLinkProcessProxyClient::DisplayLinkProcessProxyClient):
* Source/WebKit/UIProcess/DisplayLinkProcessProxyClient.h:
* Source/WebKit/UIProcess/PageClient.cpp:
(WebKit::PageClient::PageClient):
* Source/WebKit/UIProcess/PageClient.h: Added ClangVTableWorkaroundTag for the
two classes that triggered the clang vtable linking bug.

Canonical link: <a href="https://commits.webkit.org/313089@main">https://commits.webkit.org/313089@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a67a4264fd6e5692283ed8aaa3035fb1aee1dc4c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162085 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35560 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/28665 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/170993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/118456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163954 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35662 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35562 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/170993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/118456 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165044 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/28102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/145584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/170993 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/18714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/136844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/23337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/173483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20831 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/24978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/173483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35234 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/29749 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/173483 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35217 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/145132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97406 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24616 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/28611 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/21957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34728 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102472 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/34228 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34470 "Build is in progress. Recent messages:") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/34376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->