### PR TITLE
Xvfb driver should not hang reading its socket

### DIFF
--- a/Tools/Scripts/webkitpy/port/xvfbdriver.py
+++ b/Tools/Scripts/webkitpy/port/xvfbdriver.py
@@ -42,6 +42,7 @@ _log = logging.getLogger(__name__)
 
 
 class XvfbDriver(Driver):
+    _XVFB_DISPLAY_TIMEOUT_SECONDS = 5
 
     def __init__(self, *args, **kwargs):
         Driver.__init__(self, *args, **kwargs)
@@ -61,27 +62,35 @@ class XvfbDriver(Driver):
     def _xvfb_pipe(self):
         return os.pipe()
 
+    def _xvfb_close_fd(self, fd):
+        os.close(fd)
+
     def _xvfb_read_display_id(self, read_fd):
-        while True:
+        # Xvfb writes the digits and the trailing newline in separate writes,
+        # so a single read may return just the digits; keep reading until the newline arrives.
+        deadline = time.monotonic() + self._XVFB_DISPLAY_TIMEOUT_SECONDS
+        display_id = b''
+        while not display_id.endswith(b'\n'):
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                return None
             try:
-                fd_list_ready_read = select.select([read_fd], [], [])[0]
+                ready = select.select([read_fd], [], [], remaining)[0]
             except select.error as e:
                 if e.args[0] == errno.EINTR:
                     continue
                 raise
-            if read_fd in fd_list_ready_read:
-                # We need to keep reading in a loop until getting EOL because Xvfb first writes the number and then the EOL
-                # and we shouldn't close the descriptor before reading the complete line to avoid crashing Xvfb
-                display_id = b''
-                while not display_id.endswith(b'\n'):
-                    display_id += os.read(read_fd, 256)
-                display_id = display_id.decode().strip()
-                break
-        return int(display_id)
-
-    def _xvfb_close_pipe(self, pipe_fds):
-        os.close(pipe_fds[0])
-        os.close(pipe_fds[1])
+            if read_fd not in ready:
+                return None
+            chunk = os.read(read_fd, 256)
+            if not chunk:
+                # EOF: Xvfb closed its write end (exited) without writing.
+                return None
+            display_id += chunk
+        try:
+            return int(display_id.decode().strip())
+        except ValueError:
+            return None
 
     def _xvfb_run(self, environment):
         read_fd, write_fd = self._xvfb_pipe()
@@ -92,8 +101,17 @@ class XvfbDriver(Driver):
             run_xvfb = self._port._jhbuild_wrapper + run_xvfb
         with open(os.devnull, 'w') as devnull:
             self._xvfb_process = self._port.host.executive.popen(run_xvfb, stdout=devnull, stderr=devnull, env=environment, pass_fds=[write_fd])
-        display_id = self._xvfb_read_display_id(read_fd)
-        self._xvfb_close_pipe((read_fd, write_fd))
+        # Drop our copy of the write end so the read end can observe EOF
+        # if Xvfb exits before producing a display ID.
+        self._xvfb_close_fd(write_fd)
+        try:
+            display_id = self._xvfb_read_display_id(read_fd)
+        finally:
+            self._xvfb_close_fd(read_fd)
+        if display_id is None:
+            _log.error('Xvfb did not return a display ID within %ss; killing it.',
+                       self._XVFB_DISPLAY_TIMEOUT_SECONDS)
+            self._xvfb_stop()
         return display_id
 
     def _xvfb_screen_depth(self):
@@ -147,6 +165,9 @@ class XvfbDriver(Driver):
         if display_id is None:
             self._xvfb_stop()
             display_id = self._xvfb_run(port_server_environment)
+            if display_id is None:
+                _log.error('Xvfb did not produce a display ID, retrying [ %s of 9 ].' % current_retry_start_xvfb)
+                return self._start_and_check_xvfb(port_server_environment, current_retry_start_xvfb)
 
         if current_retry_start_xvfb > 1:
             time.sleep(1)

--- a/Tools/Scripts/webkitpy/port/xvfbdriver_unittest.py
+++ b/Tools/Scripts/webkitpy/port/xvfbdriver_unittest.py
@@ -56,7 +56,7 @@ class XvfbDriverTest(unittest.TestCase):
         driver._xvfb_screen_depth = lambda: '24'
         driver._xvfb_pipe = lambda: (3, 4)
         driver._xvfb_read_display_id = lambda x: 1
-        driver._xvfb_close_pipe = lambda p: None
+        driver._xvfb_close_fd = lambda fd: None
         driver._print_screen_size_process_for_testing = print_screen_size_process if print_screen_size_process else MockProcess(driver._xvfb_screen_size())
         driver._port_server_environment = port.setup_environ_for_server(port.driver_name())
         return driver
@@ -90,6 +90,20 @@ class XvfbDriverTest(unittest.TestCase):
         expected_logs = ("MOCK popen: ['Xvfb', '-displayfd', '4', '-nolisten', 'tcp', '-ac', '-screen', '0', '1024x768x24'], env=%s\n" % driver._port_server_environment)
         expected_logs += ('The Xvfb display server "%s" is ready and replying as expected.\n' % expected_display)
         self.assertDriverStartSuccessful(driver, expected_logs=expected_logs, expected_display=":1", pixel_tests=True)
+        self.cleanup_driver(driver)
+
+    def test_xvfb_never_returns_display_id(self):
+        # Simulates the container failure where Xvfb spins on socket-listener
+        # errors without ever writing to -displayfd: _xvfb_read_display_id
+        # must return None and the start logic must retry rather than hang.
+        driver = self.make_driver()
+        driver._xvfb_read_display_id = lambda fd: None
+        with OutputCapture(level=logging.INFO) as captured:
+            self.assertRaisesRegex(RuntimeError, 'Unable to start Xvfb display server', driver.start, False, [])
+            captured_log = captured.root.log.getvalue()
+            self.assertIn('Xvfb did not produce a display ID, retrying [ 1 of 9 ].', captured_log)
+            self.assertIn('Xvfb did not produce a display ID, retrying [ 9 of 9 ].', captured_log)
+            self.assertIn('Failed to start and check that the Xvfb replies after 9 retries.', captured_log)
         self.cleanup_driver(driver)
 
     def test_xvfb_not_replying(self):


### PR DESCRIPTION
#### 28c4f179601b6894f188c47fde3e7b6638d4acb6
<pre>
Xvfb driver should not hang reading its socket
<a href="https://bugs.webkit.org/show_bug.cgi?id=314647">https://bugs.webkit.org/show_bug.cgi?id=314647</a>

Reviewed by NOBODY (OOPS!).

This allows API tests to keep running via ssh inside the webkit container
sdk
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/28c4f179601b6894f188c47fde3e7b6638d4acb6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162080 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35555 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28660 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170988 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118451 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163949 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35657 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35557 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125784 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88654 "17 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165039 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28101 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145587 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106366 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/161400 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27160 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25659 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18709 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136857 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23340 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173478 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24981 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134077 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35229 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29744 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134082 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35212 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145135 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97399 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28607 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21960 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34723 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34223 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34465 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34371 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->