### PR TITLE
Web Inspector: [SI] implement querySelector, querySelectorAll, getOuterHTML, and search for FrameDOMAgent

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/dom/query-commands-frame-target-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/query-commands-frame-target-expected.txt
@@ -1,0 +1,58 @@
+Tests FrameDOMAgent read-only queries: querySelector, querySelectorAll, getOuterHTML, and the search flow.
+
+
+
+== Running test suite: SiteIsolation.DOM.FrameDOMAgent.Queries
+-- Running test case: Setup
+PASS: Should find a cross-origin frame target.
+PASS: Frame target should have a document.
+PASS: Should find #container.
+
+-- Running test case: SiteIsolation.DOM.Queries.QuerySelector
+PASS: Should get a nodeId for '#heading'.
+PASS: Frontend should resolve the nodeId to a DOMNode.
+PASS: Resolved node should be an H1.
+PASS: Resolved node id should be 'heading'.
+
+-- Running test case: SiteIsolation.DOM.Queries.QuerySelector.NoMatch
+PASS: Should return a falsy nodeId when nothing matches.
+
+-- Running test case: SiteIsolation.DOM.Queries.QuerySelectorAll
+PASS: Should return two li.item nodeIds.
+PASS: Frontend should resolve each nodeId.
+PASS: Resolved node should be LI.
+PASS: Frontend should resolve each nodeId.
+PASS: Resolved node should be LI.
+
+-- Running test case: SiteIsolation.DOM.Queries.GetOuterHTML
+PASS: Should serialize the H1 subtree.
+
+-- Running test case: SiteIsolation.DOM.Queries.GetSupportedEventNames
+PASS: Should return an array.
+PASS: Event names list should be non-empty.
+PASS: Event names should include 'click'.
+PASS: Event names should include 'load'.
+
+-- Running test case: SiteIsolation.DOM.Queries.PushNodeByPathToFrontend
+PASS: Should resolve the path to a nodeId.
+PASS: Resolved node should be #container.
+
+-- Running test case: SiteIsolation.DOM.Queries.Search
+PASS: performSearch should return a searchId.
+PASS: Search for 'frame-root' should match exactly one node.
+PASS: getSearchResults should return resultCount ids.
+PASS: Search result should resolve on the frontend.
+PASS: Search result should be #container.
+PASS: Should produce an exception.
+Error: Missing search result for given searchId
+
+-- Running test case: SiteIsolation.DOM.Queries.Search.CaseSensitive
+PASS: Case-insensitive search for 'FRAME-ROOT' should match.
+PASS: Case-sensitive search for 'FRAME-ROOT' should not match.
+
+-- Running test case: SiteIsolation.DOM.Queries.Search.ScopedToSubtree
+PASS: Should find #list for scoping.
+PASS: Unscoped search should match the H1.
+PASS: Search scoped to #list should not match H1.
+PASS: Search scoped to #list should match 'Item'.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/dom/query-commands-frame-target.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/query-commands-frame-target.html
@@ -1,0 +1,200 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script src="../debugger/resources/site-isolation-debugger-test-utilities.js"></script>
+<script>
+function test() {
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.DOM.FrameDOMAgent.Queries");
+
+    let frameTarget = null;
+    let frameDoc = null;
+    let containerNode = null;
+
+    suite.addTestCase({
+        name: "Setup",
+        description: "Find the cross-origin frame target and expand the DOM tree.",
+        async test() {
+            let frameTargets = WI.targets.filter((t) => t.type === WI.TargetType.Frame);
+            let urlTargetMap = await fetchDocumentURLsForTargets(frameTargets);
+            let mainFrameTarget = urlTargetMap.get(WI.networkManager.mainFrame.url);
+            frameTarget = frameTargets.find((t) => t !== mainFrameTarget);
+
+            InspectorTest.expectNotNull(frameTarget, "Should find a cross-origin frame target.");
+
+            if (frameTarget.isProvisional) {
+                let committedEvent = await WI.targetManager.awaitEvent(WI.TargetManager.Event.DidCommitProvisionalTarget);
+                frameTarget = committedEvent.data.target;
+            }
+            InspectorTest.assert(!frameTarget.isProvisional, "Frame target should be committed.");
+
+            await frameTarget.ensureTargetExecutionContext();
+
+            frameDoc = WI.domManager.frameTargetDocumentForTarget(frameTarget);
+            if (!frameDoc) {
+                let docEvent = await WI.domManager.awaitEvent(WI.DOMManager.Event.FrameDocumentAvailable);
+                frameDoc = docEvent.data.document;
+            }
+            InspectorTest.expectNotNull(frameDoc, "Frame target should have a document.");
+
+            let htmlNode = frameDoc.children.find((child) => child.nodeName() === "HTML");
+            await new Promise((resolve) => htmlNode.getChildNodes(resolve));
+
+            let bodyNode = htmlNode.children.find((child) => child.nodeName() === "BODY");
+            await new Promise((resolve) => bodyNode.getChildNodes(resolve));
+
+            containerNode = bodyNode.children.find((child) => child.getAttribute("id") === "container");
+            InspectorTest.expectNotNull(containerNode, "Should find #container.");
+            await new Promise((resolve) => containerNode.getChildNodes(resolve));
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.DOM.Queries.QuerySelector",
+        description: "querySelector should return a single matching node from the frame document.",
+        async test() {
+            let nodeId = await containerNode.querySelector("#heading");
+            InspectorTest.expectNotNull(nodeId, "Should get a nodeId for '#heading'.");
+
+            let node = WI.domManager.nodeForIdInFrameTarget(nodeId, frameTarget);
+            InspectorTest.expectNotNull(node, "Frontend should resolve the nodeId to a DOMNode.");
+            InspectorTest.expectEqual(node.nodeName(), "H1", "Resolved node should be an H1.");
+            InspectorTest.expectEqual(node.getAttribute("id"), "heading", "Resolved node id should be 'heading'.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.DOM.Queries.QuerySelector.NoMatch",
+        description: "querySelector with no match should resolve to a falsy nodeId.",
+        async test() {
+            let nodeId = await containerNode.querySelector("#does-not-exist");
+            InspectorTest.expectThat(!nodeId, "Should return a falsy nodeId when nothing matches.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.DOM.Queries.QuerySelectorAll",
+        description: "querySelectorAll should return all matching nodeIds from the frame document.",
+        async test() {
+            let nodeIds = await containerNode.querySelectorAll("li.item");
+            InspectorTest.expectEqual(nodeIds.length, 2, "Should return two li.item nodeIds.");
+            for (let nodeId of nodeIds) {
+                let node = WI.domManager.nodeForIdInFrameTarget(nodeId, frameTarget);
+                InspectorTest.expectNotNull(node, "Frontend should resolve each nodeId.");
+                InspectorTest.expectEqual(node.nodeName(), "LI", "Resolved node should be LI.");
+            }
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.DOM.Queries.GetOuterHTML",
+        description: "getOuterHTML should return the serialized subtree of a frame-target node.",
+        async test() {
+            let headingId = await containerNode.querySelector("#heading");
+            let heading = WI.domManager.nodeForIdInFrameTarget(headingId, frameTarget);
+            let outerHTML = await heading.getOuterHTML();
+            InspectorTest.expectEqual(outerHTML, `<h1 id="heading">Cross-Origin Heading</h1>`, "Should serialize the H1 subtree.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.DOM.Queries.GetSupportedEventNames",
+        description: "getSupportedEventNames should return a non-empty list of event names.",
+        async test() {
+            let {eventNames} = await frameTarget.DOMAgent.getSupportedEventNames();
+            InspectorTest.expectThat(Array.isArray(eventNames), "Should return an array.");
+            InspectorTest.expectGreaterThan(eventNames.length, 0, "Event names list should be non-empty.");
+            InspectorTest.expectThat(eventNames.includes("click"), "Event names should include 'click'.");
+            InspectorTest.expectThat(eventNames.includes("load"), "Event names should include 'load'.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.DOM.Queries.PushNodeByPathToFrontend",
+        description: "pushNodeByPathToFrontend should resolve a serialized path to a backend nodeId.",
+        async test() {
+            // The backend path format is rooted at the frame's document. Walk up from
+            // containerNode, stopping at frameDoc (don't cross into the main page tree
+            // where the frame document was spliced as an iframe's contentDocument).
+            let path = [];
+            let node = containerNode;
+            while (node && node !== frameDoc) {
+                let parent = node.parentNode;
+                if (!parent)
+                    break;
+                let index = parent.children.indexOf(node);
+                path.unshift(index + "," + node.nodeName());
+                node = parent;
+            }
+            let pathString = path.join(",");
+
+            let {nodeId} = await frameTarget.DOMAgent.pushNodeByPathToFrontend(pathString);
+            InspectorTest.expectNotNull(nodeId, "Should resolve the path to a nodeId.");
+
+            let resolved = WI.domManager.nodeForIdInFrameTarget(nodeId, frameTarget);
+            InspectorTest.expectEqual(resolved, containerNode, "Resolved node should be #container.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.DOM.Queries.Search",
+        description: "performSearch / getSearchResults / discardSearchResults should work on the frame document.",
+        async test() {
+            let {searchId, resultCount} = await frameTarget.DOMAgent.performSearch.invoke({query: "frame-root"});
+            InspectorTest.expectNotNull(searchId, "performSearch should return a searchId.");
+            InspectorTest.expectEqual(resultCount, 1, "Search for 'frame-root' should match exactly one node.");
+
+            let {nodeIds} = await frameTarget.DOMAgent.getSearchResults(searchId, 0, resultCount);
+            InspectorTest.expectEqual(nodeIds.length, resultCount, "getSearchResults should return resultCount ids.");
+
+            let node = WI.domManager.nodeForIdInFrameTarget(nodeIds[0], frameTarget);
+            InspectorTest.expectNotNull(node, "Search result should resolve on the frontend.");
+            InspectorTest.expectEqual(node.getAttribute("id"), "container", "Search result should be #container.");
+
+            await frameTarget.DOMAgent.discardSearchResults(searchId);
+
+            await InspectorTest.expectException(() => frameTarget.DOMAgent.getSearchResults(searchId, 0, resultCount));
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.DOM.Queries.Search.CaseSensitive",
+        description: "performSearch with caseSensitive:true should not match differently-cased attribute values.",
+        async test() {
+            let insensitive = await frameTarget.DOMAgent.performSearch.invoke({query: "FRAME-ROOT", caseSensitive: false});
+            InspectorTest.expectGreaterThanOrEqual(insensitive.resultCount, 1, "Case-insensitive search for 'FRAME-ROOT' should match.");
+            await frameTarget.DOMAgent.discardSearchResults(insensitive.searchId);
+
+            let sensitive = await frameTarget.DOMAgent.performSearch.invoke({query: "FRAME-ROOT", caseSensitive: true});
+            InspectorTest.expectEqual(sensitive.resultCount, 0, "Case-sensitive search for 'FRAME-ROOT' should not match.");
+            await frameTarget.DOMAgent.discardSearchResults(sensitive.searchId);
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.DOM.Queries.Search.ScopedToSubtree",
+        description: "performSearch with a nodeIds subtree filter should only match within those subtrees.",
+        async test() {
+            let listId = await containerNode.querySelector("#list");
+            InspectorTest.expectNotNull(listId, "Should find #list for scoping.");
+
+            let unscoped = await frameTarget.DOMAgent.performSearch.invoke({query: "heading"});
+            InspectorTest.expectGreaterThanOrEqual(unscoped.resultCount, 1, "Unscoped search should match the H1.");
+            await frameTarget.DOMAgent.discardSearchResults(unscoped.searchId);
+
+            let scoped = await frameTarget.DOMAgent.performSearch.invoke({query: "heading", nodeIds: [listId]});
+            InspectorTest.expectEqual(scoped.resultCount, 0, "Search scoped to #list should not match H1.");
+            await frameTarget.DOMAgent.discardSearchResults(scoped.searchId);
+
+            let scopedPositive = await frameTarget.DOMAgent.performSearch.invoke({query: "Item", nodeIds: [listId]});
+            InspectorTest.expectGreaterThanOrEqual(scopedPositive.resultCount, 1, "Search scoped to #list should match 'Item'.");
+            await frameTarget.DOMAgent.discardSearchResults(scopedPositive.searchId);
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+
+<body onload="runTest()">
+<p>Tests FrameDOMAgent read-only queries: querySelector, querySelectorAll, getOuterHTML, and the search flow.</p>
+<iframe src="http://localhost:8000/site-isolation/inspector/dom/resources/dom-frame.html"></iframe>
+</body>

--- a/Source/JavaScriptCore/inspector/protocol/DOM.json
+++ b/Source/JavaScriptCore/inspector/protocol/DOM.json
@@ -332,7 +332,7 @@
         {
             "name": "querySelector",
             "description": "Executes <code>querySelector</code> on a given node.",
-            "targetTypes": ["page"],
+            "targetTypes": ["frame", "page"],
             "parameters": [
                 { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to query upon." },
                 { "name": "selector", "type": "string", "description": "Selector string." }
@@ -344,7 +344,7 @@
         {
             "name": "querySelectorAll",
             "description": "Executes <code>querySelectorAll</code> on a given node.",
-            "targetTypes": ["page"],
+            "targetTypes": ["frame", "page"],
             "parameters": [
                 { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to query upon." },
                 { "name": "selector", "type": "string", "description": "Selector string." }
@@ -727,7 +727,7 @@
         {
             "name": "pushNodeByPathToFrontend",
             "description": "Requests that the node is sent to the caller given its path.",
-            "targetTypes": ["page"],
+            "targetTypes": ["frame", "page"],
             "parameters": [
                 { "name": "path", "type": "string", "description": "Path to node in the proprietary format." }
             ],

--- a/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorDOMAgent.cpp
@@ -1206,7 +1206,7 @@ Inspector::Protocol::ErrorStringOr<std::tuple<String /* searchId */, int /* resu
 {
     Inspector::Protocol::ErrorString errorString;
 
-    // FIXME: Search works with node granularity - number of matches within node is not calculated.
+    // FIXME: <https://webkit.org/b/316549> Search works with node granularity - number of matches within node is not calculated.
     InspectorNodeFinder finder(query, caseSensitive && *caseSensitive);
 
     if (nodeIds) {

--- a/Source/WebCore/inspector/agents/frame/FrameDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/frame/FrameDOMAgent.cpp
@@ -33,6 +33,7 @@
 #include "DocumentInlines.h"
 #include "DocumentType.h"
 #include "ElementInlines.h"
+#include "EventNames.h"
 #include "FrameInlines.h"
 #include "HTMLFrameOwnerElement.h"
 #include "HTMLNames.h"
@@ -41,19 +42,24 @@
 #include "HTMLStyleElement.h"
 #include "HTMLTemplateElement.h"
 #include "InspectorDOMAgent.h"
+#include "InspectorNodeFinder.h"
 #include "InstrumentingAgents.h"
 #include "LocalFrame.h"
 #include "LocalFrameInlines.h"
+#include "NodeList.h"
 #include "PseudoElement.h"
 #include "ShadowRoot.h"
 #include "Text.h"
 #include "TextNodeTraversal.h"
+#include "markup.h"
+#include <JavaScriptCore/IdentifiersFactory.h>
 #include <JavaScriptCore/InspectorProtocolObjects.h>
 #include <pal/crypto/CryptoDigest.h>
 #include <pal/text/TextEncoding.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/Base64.h>
 #include <wtf/text/MakeString.h>
+#include <wtf/text/StringToIntegerConversion.h>
 #include <wtf/unicode/CharacterNames.h>
 
 namespace WebCore {
@@ -473,6 +479,7 @@ void FrameDOMAgent::reset()
 {
     discardBindings();
     m_document = nullptr;
+    m_searchResults.clear();
 
     m_destroyedDetachedNodeIdentifiers.clear();
     m_destroyedAttachedNodeIdentifiers.clear();
@@ -757,6 +764,185 @@ void FrameDOMAgent::frameDocumentUpdated(LocalFrame& frame)
 
     RefPtr document = frame.document();
     setDocument(document.get());
+}
+
+Inspector::CommandResult<std::optional<int>> FrameDOMAgent::querySelector(int nodeId, const String& selector)
+{
+    Inspector::Protocol::ErrorString errorString;
+
+    RefPtr node = assertNode(errorString, nodeId);
+    if (!node)
+        return makeUnexpected(errorString);
+    RefPtr containerNode = dynamicDowncast<ContainerNode>(*node);
+    if (!containerNode)
+        return makeUnexpected("Node for given nodeId is not a container node"_s);
+
+    auto queryResult = containerNode->querySelector(selector);
+    if (queryResult.hasException())
+        return makeUnexpected(InspectorDOMAgent::toErrorString(queryResult.releaseException()));
+
+    RefPtr queryResultNode = queryResult.releaseReturnValue();
+    if (!queryResultNode)
+        return { };
+
+    auto resultNodeId = pushNodePathToFrontend(errorString, queryResultNode.get());
+    if (!resultNodeId)
+        return makeUnexpected(errorString);
+
+    return { resultNodeId };
+}
+
+Inspector::CommandResult<Ref<JSON::ArrayOf<int>>> FrameDOMAgent::querySelectorAll(int nodeId, const String& selector)
+{
+    Inspector::Protocol::ErrorString errorString;
+
+    RefPtr node = assertNode(errorString, nodeId);
+    if (!node)
+        return makeUnexpected(errorString);
+    RefPtr containerNode = dynamicDowncast<ContainerNode>(*node);
+    if (!containerNode)
+        return makeUnexpected("Node for given nodeId is not a container node"_s);
+
+    auto queryResult = containerNode->querySelectorAll(selector);
+    if (queryResult.hasException())
+        return makeUnexpected(InspectorDOMAgent::toErrorString(queryResult.releaseException()));
+
+    auto nodes = queryResult.releaseReturnValue();
+
+    auto nodeIds = JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>::create();
+    for (unsigned i = 0; i < nodes->length(); ++i) {
+        RefPtr node = nodes->item(i);
+        nodeIds->addItem(pushNodePathToFrontend(node.get()));
+    }
+    return nodeIds;
+}
+
+Inspector::CommandResult<String> FrameDOMAgent::getOuterHTML(int nodeId)
+{
+    Inspector::Protocol::ErrorString errorString;
+
+    RefPtr node = assertNode(errorString, nodeId);
+    if (!node)
+        return makeUnexpected(errorString);
+
+    return serializeFragment(*node, SerializedNodes::SubtreeIncludingNode);
+}
+
+Inspector::CommandResult<Ref<JSON::ArrayOf<String>>> FrameDOMAgent::getSupportedEventNames()
+{
+    auto list = JSON::ArrayOf<String>::create();
+
+    for (auto& event : eventNames().allEventNames())
+        list->addItem(event);
+
+    return list;
+}
+
+Inspector::CommandResultOf<String, int> FrameDOMAgent::performSearch(const String& query, RefPtr<JSON::Array>&& nodeIds, std::optional<bool>&& caseSensitive)
+{
+    Inspector::Protocol::ErrorString errorString;
+
+    // FIXME: <https://webkit.org/b/316549> Search works with node granularity - number of matches within node is not calculated.
+    InspectorNodeFinder finder(query, caseSensitive && *caseSensitive);
+
+    if (nodeIds) {
+        for (auto& nodeValue : *nodeIds) {
+            auto nodeId = nodeValue->asInteger();
+            if (!nodeId)
+                return makeUnexpected("Unexpected non-integer item in given nodeIds"_s);
+
+            RefPtr node = assertNode(errorString, *nodeId);
+            if (!node)
+                return makeUnexpected(errorString);
+
+            finder.performSearch(node.get());
+        }
+    } else
+        finder.performSearch(m_document.get());
+
+    auto searchId = IdentifiersFactory::createIdentifier();
+
+    auto& resultsVector = m_searchResults.add(searchId, Vector<RefPtr<Node>>()).iterator->value;
+    for (auto& result : finder.results())
+        resultsVector.append(result);
+
+    return { { searchId, resultsVector.size() } };
+}
+
+Inspector::CommandResult<Ref<JSON::ArrayOf<int>>> FrameDOMAgent::getSearchResults(const String& searchId, int fromIndex, int toIndex)
+{
+    auto it = m_searchResults.find(searchId);
+    if (it == m_searchResults.end())
+        return makeUnexpected("Missing search result for given searchId"_s);
+
+    int size = it->value.size();
+    if (fromIndex < 0 || toIndex > size || fromIndex >= toIndex)
+        return makeUnexpected("Invalid search result range for given fromIndex and toIndex"_s);
+
+    auto nodeIds = JSON::ArrayOf<Inspector::Protocol::DOM::NodeId>::create();
+    for (int i = fromIndex; i < toIndex; ++i)
+        nodeIds->addItem(pushNodePathToFrontend((it->value)[i].get()));
+    return nodeIds;
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::discardSearchResults(const String& searchId)
+{
+    m_searchResults.remove(searchId);
+    return { };
+}
+
+RefPtr<Node> FrameDOMAgent::nodeForPath(const String& path)
+{
+    // The path is of form "1,HTML,2,BODY,1,DIV"
+    if (!m_document)
+        return nullptr;
+
+    RefPtr<Node> node = m_document;
+    auto pathTokens = StringView(path).split(',');
+    auto it = pathTokens.begin();
+    if (it == pathTokens.end())
+        return nullptr;
+
+    for (; it != pathTokens.end(); ++it) {
+        auto childNumberView = *it;
+        if (++it == pathTokens.end())
+            break;
+        auto childNumber = parseIntegerAllowingTrailingJunk<unsigned>(childNumberView);
+        if (!childNumber)
+            return nullptr;
+
+        RefPtr<Node> child;
+        if (RefPtr frameOwner = dynamicDowncast<HTMLFrameOwnerElement>(*node)) {
+            ASSERT(!*childNumber);
+            child = frameOwner->contentDocument();
+        } else {
+            if (*childNumber >= InspectorDOMAgent::innerChildNodeCount(node.get()))
+                return nullptr;
+            child = InspectorDOMAgent::innerFirstChild(node.get());
+            for (size_t j = 0; child && j < *childNumber; ++j)
+                child = InspectorDOMAgent::innerNextSibling(child.get());
+        }
+
+        auto childName = *it;
+        if (!child || child->nodeName() != childName)
+            return nullptr;
+        node = child;
+    }
+
+    return node;
+}
+
+Inspector::CommandResult<int> FrameDOMAgent::pushNodeByPathToFrontend(const String& path)
+{
+    Inspector::Protocol::ErrorString errorString;
+
+    if (RefPtr node = nodeForPath(path)) {
+        if (auto nodeId = pushNodePathToFrontend(errorString, node.get()))
+            return nodeId;
+        return makeUnexpected(errorString);
+    }
+
+    return makeUnexpected("Missing node for given path"_s);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/inspector/agents/frame/FrameDOMAgent.h
+++ b/Source/WebCore/inspector/agents/frame/FrameDOMAgent.h
@@ -165,6 +165,8 @@ private:
     void reset();
     void destroyedNodesTimerFired();
 
+    RefPtr<Node> nodeForPath(const String& path);
+
     const UniqueRef<Inspector::DOMFrontendDispatcher> m_frontendDispatcher;
     const Ref<Inspector::DOMBackendDispatcher> m_backendDispatcher;
     WeakRef<InstrumentingAgents> m_instrumentingAgents;
@@ -179,6 +181,9 @@ private:
     Vector<Inspector::Protocol::DOM::NodeId> m_destroyedDetachedNodeIdentifiers;
     Vector<std::pair<Inspector::Protocol::DOM::NodeId, Inspector::Protocol::DOM::NodeId>> m_destroyedAttachedNodeIdentifiers;
     Timer m_destroyedNodesTimer;
+
+    using SearchResults = HashMap<String, Vector<RefPtr<Node>>>;
+    SearchResults m_searchResults;
 
     bool m_suppressAttributeModifiedEvent { false };
     bool m_documentRequested { false };

--- a/Source/WebCore/inspector/agents/frame/FrameDOMAgentStubs.cpp
+++ b/Source/WebCore/inspector/agents/frame/FrameDOMAgentStubs.cpp
@@ -30,16 +30,6 @@ namespace WebCore {
 
 using namespace Inspector;
 
-Inspector::CommandResult<std::optional<int>> FrameDOMAgent::querySelector(int, const String&)
-{
-    return makeUnexpected("Not yet implemented for frame targets"_s);
-}
-
-Inspector::CommandResult<Ref<JSON::ArrayOf<int>>> FrameDOMAgent::querySelectorAll(int, const String&)
-{
-    return makeUnexpected("Not yet implemented for frame targets"_s);
-}
-
 Inspector::CommandResult<int> FrameDOMAgent::setNodeName(int, const String&)
 {
     return makeUnexpected("Not yet implemented for frame targets"_s);
@@ -66,11 +56,6 @@ Inspector::CommandResult<void> FrameDOMAgent::setAttributesAsText(int, const Str
 }
 
 Inspector::CommandResult<void> FrameDOMAgent::removeAttribute(int, const String&)
-{
-    return makeUnexpected("Not yet implemented for frame targets"_s);
-}
-
-Inspector::CommandResult<Ref<JSON::ArrayOf<String>>> FrameDOMAgent::getSupportedEventNames()
 {
     return makeUnexpected("Not yet implemented for frame targets"_s);
 }
@@ -112,32 +97,12 @@ Inspector::CommandResult<Ref<Inspector::Protocol::DOM::AccessibilityProperties>>
     return makeUnexpected("Not yet implemented for frame targets"_s);
 }
 
-Inspector::CommandResult<String> FrameDOMAgent::getOuterHTML(int)
-{
-    return makeUnexpected("Not yet implemented for frame targets"_s);
-}
-
 Inspector::CommandResult<void> FrameDOMAgent::setOuterHTML(int, const String&)
 {
     return makeUnexpected("Not yet implemented for frame targets"_s);
 }
 
 Inspector::CommandResult<void> FrameDOMAgent::insertAdjacentHTML(int, const String&, const String&)
-{
-    return makeUnexpected("Not yet implemented for frame targets"_s);
-}
-
-Inspector::CommandResultOf<String, int> FrameDOMAgent::performSearch(const String&, RefPtr<JSON::Array>&&, std::optional<bool>&&)
-{
-    return makeUnexpected("Not yet implemented for frame targets"_s);
-}
-
-Inspector::CommandResult<Ref<JSON::ArrayOf<int>>> FrameDOMAgent::getSearchResults(const String&, int, int)
-{
-    return makeUnexpected("Not yet implemented for frame targets"_s);
-}
-
-Inspector::CommandResult<void> FrameDOMAgent::discardSearchResults(const String&)
 {
     return makeUnexpected("Not yet implemented for frame targets"_s);
 }
@@ -229,11 +194,6 @@ Inspector::CommandResult<void> FrameDOMAgent::showFlexOverlay(int, Ref<JSON::Obj
 Inspector::CommandResult<void> FrameDOMAgent::hideFlexOverlay(std::optional<int>&&)
 {
     return makeUnexpected("Not supported for frame targets"_s);
-}
-
-Inspector::CommandResult<int> FrameDOMAgent::pushNodeByPathToFrontend(const String&)
-{
-    return makeUnexpected("Not yet implemented for frame targets"_s);
 }
 
 Inspector::CommandResult<Ref<Inspector::Protocol::Runtime::RemoteObject>> FrameDOMAgent::resolveNode(int, const String&)

--- a/Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js
@@ -1112,6 +1112,15 @@ WI.DOMManager = class DOMManager extends WI.Object
             this.dispatchEventToListeners(WI.DOMManager.Event.InspectedNodeChanged, {lastInspectedNode});
         };
 
+        // FIXME: <https://webkit.org/b/298980> `DOM.setInspectedNode` for cross-origin frame nodes is not yet supported;
+        // `node.id` for frame-owned nodes is a composite "frameId:nodeId" string, not a numeric backend node id.
+        if (node.owningTarget) {
+            let lastInspectedNode = this._inspectedNode;
+            this._inspectedNode = node;
+            this.dispatchEventToListeners(WI.DOMManager.Event.InspectedNodeChanged, {lastInspectedNode});
+            return;
+        }
+
         let target = WI.assumingMainTarget();
         target.DOMAgent.setInspectedNode(node.id, callback);
     }

--- a/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
+++ b/Source/WebInspectorUI/UserInterface/Models/DOMNode.js
@@ -445,6 +445,12 @@ WI.DOMNode = class DOMNode extends WI.Object
             return;
         }
 
+        // FIXME: <https://webkit.org/b/298980> Mutating nodes in cross-origin frame targets is not yet supported.
+        if (this.owningTarget) {
+            callback("ERROR: not supported on cross-origin frame nodes");
+            return;
+        }
+
         let target = WI.assumingMainTarget();
         target.DOMAgent.setNodeName(this.id, name, this._makeUndoableCallback(callback));
     }
@@ -507,6 +513,12 @@ WI.DOMNode = class DOMNode extends WI.Object
             return;
         }
 
+        // FIXME: <https://webkit.org/b/298980> Mutating nodes in cross-origin frame targets is not yet supported.
+        if (this.owningTarget) {
+            callback("ERROR: not supported on cross-origin frame nodes");
+            return;
+        }
+
         let target = WI.assumingMainTarget();
         target.DOMAgent.setNodeValue(this.id, value, this._makeUndoableCallback(callback));
     }
@@ -525,6 +537,12 @@ WI.DOMNode = class DOMNode extends WI.Object
             return;
         }
 
+        // FIXME: <https://webkit.org/b/298980> Mutating nodes in cross-origin frame targets is not yet supported.
+        if (this.owningTarget) {
+            callback("ERROR: not supported on cross-origin frame nodes");
+            return;
+        }
+
         let target = WI.assumingMainTarget();
         target.DOMAgent.setAttributesAsText(this.id, text, name, this._makeUndoableCallback(callback));
     }
@@ -537,6 +555,14 @@ WI.DOMNode = class DOMNode extends WI.Object
                 return Promise.reject("ERROR: node is destroyed");
 
             callback("ERROR: node is destroyed");
+            return;
+        }
+
+        // FIXME: <https://webkit.org/b/298980> Mutating nodes in cross-origin frame targets is not yet supported.
+        if (this.owningTarget) {
+            if (!callback)
+                return Promise.reject("ERROR: not supported on cross-origin frame nodes");
+            callback("ERROR: not supported on cross-origin frame nodes");
             return;
         }
 
@@ -561,6 +587,12 @@ WI.DOMNode = class DOMNode extends WI.Object
         console.assert(!this._destroyed, this);
         if (this._destroyed) {
             callback("ERROR: node is destroyed");
+            return;
+        }
+
+        // FIXME: <https://webkit.org/b/298980> Mutating nodes in cross-origin frame targets is not yet supported.
+        if (this.owningTarget) {
+            callback("ERROR: not supported on cross-origin frame nodes");
             return;
         }
 
@@ -610,12 +642,12 @@ WI.DOMNode = class DOMNode extends WI.Object
     {
         console.assert(!this._destroyed, this);
 
-        let target = WI.assumingMainTarget();
+        let target = this.owningTarget || WI.assumingMainTarget();
 
         if (typeof callback !== "function") {
             if (this._destroyed)
                 return Promise.reject("ERROR: node is destroyed");
-            return target.DOMAgent.querySelector(this.id, selector).then(({nodeId}) => nodeId);
+            return target.DOMAgent.querySelector(this.backendNodeId, selector).then(({nodeId}) => nodeId);
         }
 
         if (this._destroyed) {
@@ -623,19 +655,19 @@ WI.DOMNode = class DOMNode extends WI.Object
             return;
         }
 
-        target.DOMAgent.querySelector(this.id, selector, WI.DOMManager.wrapClientCallback(callback));
+        target.DOMAgent.querySelector(this.backendNodeId, selector, WI.DOMManager.wrapClientCallback(callback));
     }
 
     querySelectorAll(selector, callback)
     {
         console.assert(!this._destroyed, this);
 
-        let target = WI.assumingMainTarget();
+        let target = this.owningTarget || WI.assumingMainTarget();
 
         if (typeof callback !== "function") {
             if (this._destroyed)
                 return Promise.reject("ERROR: node is destroyed");
-            return target.DOMAgent.querySelectorAll(this.id, selector).then(({nodeIds}) => nodeIds);
+            return target.DOMAgent.querySelectorAll(this.backendNodeId, selector).then(({nodeIds}) => nodeIds);
         }
 
         if (this._destroyed) {
@@ -643,7 +675,7 @@ WI.DOMNode = class DOMNode extends WI.Object
             return;
         }
 
-        target.DOMAgent.querySelectorAll(this.id, selector, WI.DOMManager.wrapClientCallback(callback));
+        target.DOMAgent.querySelectorAll(this.backendNodeId, selector, WI.DOMManager.wrapClientCallback(callback));
     }
 
     highlight(mode)
@@ -672,6 +704,10 @@ WI.DOMNode = class DOMNode extends WI.Object
         console.assert(!this._destroyed, this);
         if (this._destroyed)
             return Promise.reject("ERROR: node is destroyed");
+
+        // FIXME: <https://webkit.org/b/298980> Layout overlays for cross-origin frame nodes are not yet supported.
+        if (this.owningTarget)
+            return Promise.reject("ERROR: not supported on cross-origin frame nodes");
 
         console.assert(Object.values(WI.DOMNode._LayoutContextTypes).includes(this.layoutContextType), this);
 
@@ -746,6 +782,10 @@ WI.DOMNode = class DOMNode extends WI.Object
         console.assert(!this._destroyed, this);
         if (this._destroyed)
             return Promise.reject("ERROR: node is destroyed");
+
+        // FIXME: <https://webkit.org/b/298980> Layout overlays for cross-origin frame nodes are not yet supported.
+        if (this.owningTarget)
+            return Promise.reject("ERROR: not supported on cross-origin frame nodes");
 
         console.assert(Object.values(WI.DOMNode._LayoutContextTypes).includes(this.layoutContextType), this);
 
@@ -883,12 +923,12 @@ WI.DOMNode = class DOMNode extends WI.Object
     {
         console.assert(!this._destroyed, this);
 
-        let target = WI.assumingMainTarget();
+        let target = this.owningTarget || WI.assumingMainTarget();
 
         if (typeof callback !== "function") {
             if (this._destroyed)
                 return Promise.reject("ERROR: node is destroyed");
-            return target.DOMAgent.getOuterHTML(this.id).then(({outerHTML}) => outerHTML);
+            return target.DOMAgent.getOuterHTML(this.backendNodeId).then(({outerHTML}) => outerHTML);
         }
 
         if (this._destroyed) {
@@ -896,7 +936,7 @@ WI.DOMNode = class DOMNode extends WI.Object
             return;
         }
 
-        target.DOMAgent.getOuterHTML(this.id, callback);
+        target.DOMAgent.getOuterHTML(this.backendNodeId, callback);
     }
 
     setOuterHTML(html, callback)
@@ -904,6 +944,12 @@ WI.DOMNode = class DOMNode extends WI.Object
         console.assert(!this._destroyed, this);
         if (this._destroyed) {
             callback("ERROR: node is destroyed");
+            return;
+        }
+
+        // FIXME: <https://webkit.org/b/298980> Mutating nodes in cross-origin frame targets is not yet supported.
+        if (this.owningTarget) {
+            callback("ERROR: not supported on cross-origin frame nodes");
             return;
         }
 
@@ -920,6 +966,10 @@ WI.DOMNode = class DOMNode extends WI.Object
         if (this.nodeType() !== Node.ELEMENT_NODE)
             return;
 
+        // FIXME: <https://webkit.org/b/298980> Mutating nodes in cross-origin frame targets is not yet supported.
+        if (this.owningTarget)
+            return;
+
         let target = WI.assumingMainTarget();
         target.DOMAgent.insertAdjacentHTML(this.id, position, html, this._makeUndoableCallback());
     }
@@ -932,6 +982,12 @@ WI.DOMNode = class DOMNode extends WI.Object
             return;
         }
 
+        // FIXME: <https://webkit.org/b/298980> Mutating nodes in cross-origin frame targets is not yet supported.
+        if (this.owningTarget) {
+            callback("ERROR: not supported on cross-origin frame nodes");
+            return;
+        }
+
         let target = WI.assumingMainTarget();
         target.DOMAgent.removeNode(this.id, this._makeUndoableCallback(callback));
     }
@@ -941,6 +997,10 @@ WI.DOMNode = class DOMNode extends WI.Object
         console.assert(!this._destroyed, this);
         if (this._destroyed)
             return Promise.reject("ERROR: node is destroyed");
+
+        // FIXME: <https://webkit.org/b/298980> Event listeners for cross-origin frame nodes are not yet supported.
+        if (this.owningTarget)
+            return Promise.resolve({listeners: []});
 
         includeAncestors ??= true;
 
@@ -957,6 +1017,12 @@ WI.DOMNode = class DOMNode extends WI.Object
     {
         console.assert(!this._destroyed, this);
         if (this._destroyed) {
+            callback({});
+            return;
+        }
+
+        // FIXME: <https://webkit.org/b/298980> Accessibility properties for cross-origin frame nodes are not yet supported.
+        if (this.owningTarget) {
             callback({});
             return;
         }
@@ -1265,6 +1331,12 @@ WI.DOMNode = class DOMNode extends WI.Object
             return;
         }
 
+        // FIXME: <https://webkit.org/b/298980> Mutating nodes in cross-origin frame targets is not yet supported.
+        if (this.owningTarget || targetNode.owningTarget || (anchorNode && anchorNode.owningTarget)) {
+            callback("ERROR: not supported on cross-origin frame nodes");
+            return;
+        }
+
         let target = WI.assumingMainTarget();
         target.DOMAgent.moveTo(this.id, targetNode.id, anchorNode ? anchorNode.id : undefined, this._makeUndoableCallback(callback));
     }
@@ -1291,6 +1363,10 @@ WI.DOMNode = class DOMNode extends WI.Object
                 return;
             pseudoClasses.remove(pseudoClass);
         }
+
+        // FIXME: <https://webkit.org/b/298980> Forcing pseudo classes on cross-origin frame nodes is not yet supported.
+        if (this.owningTarget)
+            return;
 
         function changed(error)
         {
@@ -1393,6 +1469,10 @@ WI.DOMNode = class DOMNode extends WI.Object
     // COMPATIBILITY (macOS 14.4, iOS 17.4): `DOM.getMediaStats` did not exist yet.
     async getMediaStats()
     {
+        // FIXME: <https://webkit.org/b/298980> Media stats for cross-origin frame nodes are not yet supported.
+        if (this.owningTarget)
+            return null;
+
         let target = WI.assumingMainTarget();
         let {mediaStats} = await target.DOMAgent.getMediaStats(this.id);
         return mediaStats;

--- a/Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js
+++ b/Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js
@@ -174,6 +174,10 @@ WI.DOMNodeStyles = class DOMNodeStyles extends WI.Object
 
         this._needsRefresh = false;
 
+        // FIXME: <https://webkit.org/b/298980> CSS inspection for cross-origin frame nodes requires FrameCSSAgent.
+        if (this._node.owningTarget)
+            return Promise.resolve(this);
+
         let fetchedMatchedStylesPromise = Promise.withResolvers();
         let fetchedInlineStylesPromise = Promise.withResolvers();
         let fetchedComputedStylesPromise = Promise.withResolvers();


### PR DESCRIPTION
#### b0e64776919aebb76cee7883232178b04052d020
<pre>
Web Inspector: [SI] implement querySelector, querySelectorAll, getOuterHTML, and search for FrameDOMAgent
<a href="https://bugs.webkit.org/show_bug.cgi?id=314646">https://bugs.webkit.org/show_bug.cgi?id=314646</a>
<a href="https://rdar.apple.com/176894021">rdar://176894021</a>

Reviewed by Qianlang Chen.

Builds on the FrameDOMAgent event wiring landed in bug 313550 by implementing
the remaining read-only query surface: querySelector, querySelectorAll,
getOuterHTML, getSupportedEventNames, performSearch/getSearchResults/
discardSearchResults, and pushNodeByPathToFrontend. Each operates on the
frame&apos;s local Document, mirroring InspectorDOMAgent&apos;s implementations and
keeping per-agent state (m_searchResults) isolated to that frame&apos;s process.

On the frontend, DOMNode routes querySelector, querySelectorAll, and
getOuterHTML through `owningTarget` with `backendNodeId` so cross-origin
iframe nodes query their own FrameDOMAgent rather than the page&apos;s
InspectorDOMAgent. RequestAssignedSlot and requestAssignedNodes use
nodeForIdInFrameTarget to resolve scoped IDs.

Commands that require infrastructure not yet ported to frame targets (DOM
editing via DOMEditor, overlay highlighting, accessibility, event listeners,
media stats, CSS style refresh) get defensive early-returns so interacting
with a cross-origin frame node in the Elements panel no longer crashes or
silently dispatches malformed commands. DOMNodeStyles.refresh() in
particular bails out without dispatching `Event.Refreshed` to avoid reading
a null computedStyle in BoxModelDetailsSectionRow; a full CSS integration
lands with FrameCSSAgent

Test: http/tests/site-isolation/inspector/dom/query-commands-frame-target.html

* LayoutTests/http/tests/site-isolation/inspector/dom/query-commands-frame-target-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/dom/query-commands-frame-target.html: Added.
* Source/JavaScriptCore/inspector/protocol/DOM.json:
* Source/WebCore/inspector/agents/InspectorDOMAgent.cpp:
(WebCore::InspectorDOMAgent::performSearch):
* Source/WebCore/inspector/agents/frame/FrameDOMAgent.cpp:
(WebCore::FrameDOMAgent::reset):
(WebCore::FrameDOMAgent::querySelector):
(WebCore::FrameDOMAgent::querySelectorAll):
(WebCore::FrameDOMAgent::getOuterHTML):
(WebCore::FrameDOMAgent::getSupportedEventNames):
(WebCore::FrameDOMAgent::performSearch):
(WebCore::FrameDOMAgent::getSearchResults):
(WebCore::FrameDOMAgent::discardSearchResults):
(WebCore::FrameDOMAgent::nodeForPath):
(WebCore::FrameDOMAgent::pushNodeByPathToFrontend):
* Source/WebCore/inspector/agents/frame/FrameDOMAgent.h:
* Source/WebCore/inspector/agents/frame/FrameDOMAgentStubs.cpp:
(WebCore::FrameDOMAgent::querySelector): Deleted.
(WebCore::FrameDOMAgent::querySelectorAll): Deleted.
(WebCore::FrameDOMAgent::getSupportedEventNames): Deleted.
(WebCore::FrameDOMAgent::getOuterHTML): Deleted.
(WebCore::FrameDOMAgent::performSearch): Deleted.
(WebCore::FrameDOMAgent::getSearchResults): Deleted.
(WebCore::FrameDOMAgent::discardSearchResults): Deleted.
(WebCore::FrameDOMAgent::pushNodeByPathToFrontend): Deleted.
* Source/WebInspectorUI/UserInterface/Controllers/DOMManager.js:
(WI.DOMManager.prototype.setInspectedNode):
* Source/WebInspectorUI/UserInterface/Models/DOMNode.js:
(WI.DOMNode.prototype.setNodeName):
(WI.DOMNode.prototype.setNodeValue):
(WI.DOMNode.prototype.setAttribute):
(WI.DOMNode.prototype.setAttributeValue):
(WI.DOMNode.prototype.querySelector):
(WI.DOMNode.prototype.querySelectorAll):
(WI.DOMNode.prototype.showLayoutOverlay):
(WI.DOMNode.prototype.hideLayoutOverlay):
(WI.DOMNode.prototype.getOuterHTML):
(WI.DOMNode.prototype.setOuterHTML):
(WI.DOMNode.prototype.insertAdjacentHTML):
(WI.DOMNode.prototype.removeNode):
(WI.DOMNode.prototype.getEventListeners):
(WI.DOMNode.prototype.moveTo):
(WI.DOMNode):
* Source/WebInspectorUI/UserInterface/Models/DOMNodeStyles.js:

Canonical link: <a href="https://commits.webkit.org/314831@main">https://commits.webkit.org/314831@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83aea229b06839e15151894ed8ba5766f63cb805

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167200 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40695 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34286 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176249 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/124881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0ade0fa6-b3a6-49cd-b61d-7d3d407b736b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169066 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41128 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40707 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130053 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/124881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c476716b-d403-4dc8-a2cb-58d43a780d3c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170159 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32453 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150226 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110570 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0076f436-8901-4975-85fd-bff9b27b53d9) 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31435 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Running apply-patch; Checked out pull request; Passed layout tests; 4 new passes 3 flakes 1 missing results; Uploaded test results; 4 new passes 1 flakes 1 missing results; Compiled WebKit (warnings); layout-tests; Found 1 new test failure: imported/w3c/web-platform-tests/_venv3/lib/python3.9/site-packages/setuptools/command/launcher manifest.xml (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30134 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24987 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/159363 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141541 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27915 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178790 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/28096 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31689 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29755 "Found 1 new test failure: imported/w3c/web-platform-tests/_venv3/lib/python3.9/site-packages/setuptools/command/launcher manifest.xml (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138437 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40769 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34411 "Found 1 new test failure: imported/w3c/web-platform-tests/_venv3/lib/python3.9/site-packages/setuptools/command/launcher manifest.xml (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138330 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41457 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149713 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104432 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25465 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33576 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26717 "Found 1 new test failure: imported/w3c/web-platform-tests/_venv3/lib/python3.9/site-packages/setuptools/command/launcher manifest.xml (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199877 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39961 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113040 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53744 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39358 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4815 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39608 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39502 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->