### PR TITLE
media/modern-media-controls/tracks-support/text-track-selected-via-media-api.html

### DIFF
--- a/LayoutTests/media/modern-media-controls/tracks-support/text-track-selected-via-media-api.html
+++ b/LayoutTests/media/modern-media-controls/tracks-support/text-track-selected-via-media-api.html
@@ -24,7 +24,10 @@ function subtitleTrack(language) {
 }
 
 function contextmenuItem(title) {
-    return contextmenu[0].children.find((item) => item.title === title);
+    let items = contextmenu[0]?.children ?? [];
+    let languagesItem = items.find((item) => item.title === "Languages");
+    let tracks = languagesItem?.children ?? items;
+    return tracks.find((item) => item.title === title);
 }
 
 media.addEventListener("play", () => {
@@ -43,7 +46,8 @@ media.addEventListener("play", () => {
                 shouldBeUndefined("contextmenuItem('French').checked");
 
                 debug("Selecting 'French' text track...");
-                await UIHelper.chooseMenuAction("French");
+                await UIHelper.chooseLanguageInMediaContextMenu("French");
+
                 await UIHelper.waitForContextMenuToHide();
             }
 

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -1894,6 +1894,13 @@ window.UIHelper = class UIHelper {
         });
     }
 
+    static async chooseLanguageInMediaContextMenu(language)
+    {
+        if (this.isIOSFamily())
+            await this.chooseMenuAction("Languages");
+        await this.chooseMenuAction(language);
+    }
+
     static waitForEvent(target, eventName)
     {
         return new Promise(resolve => target.addEventListener(eventName, resolve, { once: true }));

--- a/Tools/WebKitTestRunner/mac/UIScriptControllerMac.mm
+++ b/Tools/WebKitTestRunner/mac/UIScriptControllerMac.mm
@@ -48,6 +48,7 @@
 #import <pal/spi/mac/NSApplicationSPI.h>
 #import <pal/spi/mac/NSSpellCheckerSPI.h>
 #import <wtf/BlockPtr.h>
+#import <wtf/Deque.h>
 #import <wtf/WorkQueue.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 
@@ -226,15 +227,25 @@ void UIScriptControllerMac::chooseMenuAction(JSStringRef jsAction, JSValueRef ca
     unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
 
     auto action = adoptCF(JSStringCopyCFString(kCFAllocatorDefault, jsAction));
-    __block NSUInteger matchIndex = NSNotFound;
     auto activeMenu = retainPtr(webView()._activeMenu);
-    [[activeMenu itemArray] enumerateObjectsUsingBlock:^(NSMenuItem *item, NSUInteger index, BOOL *stop) {
-        if ([item.title isEqualToString:(__bridge NSString *)action.get()])
-            matchIndex = index;
-    }];
 
-    if (matchIndex != NSNotFound) {
-        [activeMenu performActionForItemAtIndex:matchIndex];
+    RetainPtr<NSMenuItem> matchItem;
+    Deque<RetainPtr<NSMenu>> queue;
+    queue.append(activeMenu.get());
+    while (!queue.isEmpty() && !matchItem) {
+        auto menu = queue.takeFirst();
+        for (NSMenuItem *item in menu.get().itemArray) {
+            if ([item.title isEqualToString:(__bridge NSString *)action.get()]) {
+                matchItem = item;
+                break;
+            }
+            if (item.hasSubmenu)
+                queue.append(item.submenu);
+        }
+    }
+
+    if (matchItem) {
+        [matchItem.get().menu performActionForItemAtIndex:[matchItem.get().menu indexOfItem:matchItem.get()]];
         [activeMenu removeAllItems];
         [activeMenu update];
         [activeMenu cancelTracking];


### PR DESCRIPTION
#### 0d9e6052f94fca462ca399257a48c5be5cd21aad
<pre>
media/modern-media-controls/tracks-support/text-track-selected-via-media-api.html
is a constant timeout on iOS and constant text failure on mac
<a href="https://bugs.webkit.org/show_bug.cgi?id=314648">https://bugs.webkit.org/show_bug.cgi?id=314648</a>
<a href="https://rdar.apple.com/176606830">rdar://176606830</a>

Reviewed by Wenson Hsieh.

text-track-selected-via-media-api.html needs to be updated to reflect the
new structure of the media controls context menu, which changed when the
feature CaptionDisplaySettings became enabled by default. Now, the text tracks
are accessed through a languages submenu.

The layout test has a javascript helper function contextMenuItem() that returns
a context menu item representing a given language string. The test uses the return
value to check that the appropriate language tracks are checked/unchecked. This
patch modifies contextMenuItem() to navigate through the languages submenu to
reach the needed context menu items.

The test uses UIHelper to simulate clicking/tapping on the context menu items. This
patch modifies the iOS path of the layout test to first call
UIHelper.chooseMenuAction(&quot;Languages&quot;) before UIHelper.chooseMenuAction(&quot;French&quot;),
as the track items are only revealed after the Languages submenu has been opened.

The approach used on iOS does not work on mac:
UIScriptControllerMac::UIHelperchooseMenuAction(&quot;Languages&quot;) simulates clicking the
languages menu item and then closing the menu, hence the subsequent
UIHelperchooseMenuAction(&quot;French&quot;) cannot find the nested French menu item. Instead, this patch
modifies UIScriptControllerMac::chooseMenuAction to recursively search through nested
submenus to find a given item, and as a result, only UIHelper.chooseMenuAction(&quot;French&quot;)
is needed on mac. The recursive search is a breadth first search, given that almost
all callers of UIScriptControllerMac::UIHelperchooseMenuAction are looking for a menu
item on the top level.

* LayoutTests/media/modern-media-controls/tracks-support/text-track-selected-via-media-api.html:
* LayoutTests/resources/ui-helper.js:
(window.UIHelper.async chooseLanguageInMediaContextMenu):
* Tools/WebKitTestRunner/mac/UIScriptControllerMac.mm:
(WTR::UIScriptControllerMac::chooseMenuAction):

Canonical link: <a href="https://commits.webkit.org/313424@main">https://commits.webkit.org/313424@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e641fe803597403e74f2893d7fb92a4c4711209a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162784 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36261 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29415 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171722 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119230 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164653 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36364 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36264 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126352 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88990 "1 flakes 17 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165743 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28696 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146273 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106929 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27742 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26277 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19422 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137450 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24002 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174226 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25647 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134661 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35934 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30380 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134656 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35918 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145798 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98333 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24810 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/29194 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22634 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35428 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34929 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/657 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35174 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35077 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->