### PR TITLE
[WebGPU] iesna.eu/?wasm=skyglow_demo fails to compile shader

### DIFF
--- a/Source/WebGPU/WGSL/Lexer.cpp
+++ b/Source/WebGPU/WGSL/Lexer.cpp
@@ -1057,7 +1057,7 @@ Token Lexer<T>::lexNumber()
         return makeToken(TokenType::Invalid);
     };
 
-    if (!fract && !exponent) {
+    if (!fract && !exponent && suffix != 'f' && suffix != 'h') {
         auto base = isHex ? 16 : 10;
         auto result = WTF::parseInteger<int64_t>(integral, base, WTF::TrailingJunkPolicy::Allow);
         if (!result)

--- a/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
+++ b/Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
@@ -143,6 +143,7 @@ TEST(WGSLLexerTests, SingleTokens)
     checkSingleFloatLiteral(".456f"_s, TokenType::FloatLiteral, 0.456f);
     checkSingleFloatLiteral("42e-3"_s, TokenType::AbstractFloatLiteral, 42e-3);
     checkSingleFloatLiteral("42e-3f"_s, TokenType::FloatLiteral, 42e-3f);
+    checkSingleFloatLiteral("34028235000000000000000000000000000000f"_s, TokenType::FloatLiteral, 34028234663852885981170418348451692544.0f);
 }
 
 TEST(WGSLLexerTests, KeywordTokens)


### PR DESCRIPTION
#### 7f23f03e34b0c96770a05ac4b49cbc4da61cce57
<pre>
[WebGPU] iesna.eu/?wasm=skyglow_demo fails to compile shader
<a href="https://bugs.webkit.org/show_bug.cgi?id=314588">https://bugs.webkit.org/show_bug.cgi?id=314588</a>
<a href="https://rdar.apple.com/176827607">rdar://176827607</a>

Reviewed by Mike Wyrzykowski.

The lexer incorrectly assumed that any float literals that didn&apos;t
have a fraction or exponent could be parsed as integers, but that
limited the size of the floats that could be parsed (only up to
19 digits). To fix that we simply check if the literal has a suffix
in addition to the existing checks for fraction and exponent.

Test: Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp
* Source/WebGPU/WGSL/Lexer.cpp:
(WGSL::Lexer&lt;T&gt;::lexNumber):
* Tools/TestWebKitAPI/Tests/WGSL/LexerTests.cpp:
(TestWGSLAPI::TEST(WGSLLexerTests, SingleTokens)):

Canonical link: <a href="https://commits.webkit.org/313133@main">https://commits.webkit.org/313133@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36e19caf0d398586713e09c524476d7e89a5f798

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162089 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35564 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28669 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170997 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118460 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ab11f2e1-81bc-483a-8165-f1d80e62bc6d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163958 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35666 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35566 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125789 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88660 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fe1c5705-f105-4d24-b0c5-e7d79c965f9a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165048 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28104 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145586 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106371 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/86378b1f-4c75-426a-a097-1c7f7a9ff1d1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27162 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25675 "Found 1 new API test failure: TestWebKitAPI.TextManipulation.CompleteTextManipulationForTitleElement (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18718 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136859 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23339 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173489 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20853 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24980 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134084 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35238 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29766 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134089 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36224 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35221 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145134 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97412 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28614 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21959 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34732 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102476 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34232 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34474 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34380 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->