### PR TITLE
Extended gamepads should always have extended gamepad layout, even if home button is absent

### DIFF
--- a/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.mm
+++ b/Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.mm
@@ -79,7 +79,8 @@ void GameControllerGamepad::setupElements()
     }
 
     RetainPtr<GCControllerButtonInput> homeButton = profile.get().buttons[GCInputButtonHome];
-    m_buttonValues.resize(homeButton ? numberOfStandardGamepadButtonsWithHomeButton : numberOfStandardGamepadButtonsWithoutHomeButton);
+    bool isExtended = m_gcController.get().extendedGamepad != nil;
+    m_buttonValues.resize((homeButton || isExtended) ? numberOfStandardGamepadButtonsWithHomeButton : numberOfStandardGamepadButtonsWithoutHomeButton);
 
     m_id = makeString(String(m_gcController.get().vendorName), m_gcController.get().extendedGamepad ? " Extended Gamepad"_s : " Gamepad"_s);
 

--- a/Source/WebCore/platform/gamepad/mac/LogitechGamepad.cpp
+++ b/Source/WebCore/platform/gamepad/mac/LogitechGamepad.cpp
@@ -46,7 +46,7 @@ LogitechGamepad::LogitechGamepad(HIDDevice&& device, unsigned index)
 
     m_mapping = standardGamepadMappingString();
 
-    m_buttonValues = Vector<SharedGamepadValue>(FillWith { }, numberOfStandardGamepadButtonsWithoutHomeButton, SharedGamepadValue { 0.0 });
+    m_buttonValues = Vector<SharedGamepadValue>(FillWith { }, numberOfStandardGamepadButtonsWithHomeButton, SharedGamepadValue { 0.0 });
 
     constexpr size_t axisCount = 4;
     m_axisValues = Vector<SharedGamepadValue>(FillWith { }, axisCount, SharedGamepadValue { 0.0 });

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/HIDGamepads.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/HIDGamepads.mm
@@ -557,7 +557,7 @@ TEST(Gamepad, LogitechBasic)
 #else
     auto expectedHID = 2u;
     auto expectedGC = 0u;
-    auto expectedButtons = 16u;
+    auto expectedButtons = 17u;
     NSSet *expectedGamepadNames = [NSSet setWithArray:@[
         @"\"46d-c216-Virtual Logitech F310\"",
         @"\"46d-c219-Virtual Logitech F710\""]];


### PR DESCRIPTION
#### db77dc012d212bfe7d28b0f594b4f385b2751cf3
<pre>
Extended gamepads should always have extended gamepad layout, even if home button is absent
<a href="https://rdar.apple.com/176585914">rdar://176585914</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=314649">https://bugs.webkit.org/show_bug.cgi?id=314649</a>

Reviewed by Chris Dumez.

GameController framework will present an extended gamepad - that matches up with the 17 button web standard for &quot;extended gamepad&quot;,
for controllers that physically only have 16 buttons.

We failed to present the 17th button (home button) to web content in this case, even if it can never be pressed.

Let&apos;s do so.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/HIDGamepads.mm
* Source/WebCore/platform/gamepad/cocoa/GameControllerGamepad.mm:
(WebCore::GameControllerGamepad::setupElements):
* Source/WebCore/platform/gamepad/mac/LogitechGamepad.cpp:
(WebCore::LogitechGamepad::LogitechGamepad):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/HIDGamepads.mm:
(TestWebKitAPI::(Gamepad, LogitechBasic)):

Canonical link: <a href="https://commits.webkit.org/313119@main">https://commits.webkit.org/313119@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74e1fd1269b2a204e5aef251fdfe62bf4e18b41d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162091 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35566 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28671 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/170999 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118462 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6c11f128-550b-40d0-bfd0-a4587ab3ec29) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163960 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35668 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35568 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125797 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88661 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b2a0564a-e8d5-4990-86ad-c017d63ee4c9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165050 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28106 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145599 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106373 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a929650c-1873-4770-8ad8-3d3e1a88c2ab) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27164 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25677 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18720 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136861 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23343 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173490 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20855 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24984 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134093 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35240 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29779 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134091 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36213 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35223 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145138 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97414 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28617 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21970 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34734 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102495 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34234 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34476 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34382 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->