### PR TITLE
CSS media-queries report zero under site isolation

### DIFF
--- a/LayoutTests/http/tests/site-isolation/device-media-features-in-cross-origin-iframe-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/device-media-features-in-cross-origin-iframe-expected.txt
@@ -1,0 +1,18 @@
+device-width, device-height, and device-aspect-ratio media features should match screen dimensions inside a cross-origin iframe under site isolation.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS result.screenWidth > 0 is true
+PASS result.screenHeight > 0 is true
+PASS result.deviceWidthZeroMatches is false
+PASS result.deviceHeightZeroMatches is false
+PASS result.minDeviceWidthMatchesScreen is true
+PASS result.maxDeviceWidthMatchesScreen is true
+PASS result.minDeviceHeightMatchesScreen is true
+PASS result.maxDeviceHeightMatchesScreen is true
+PASS result.deviceAspectRatioMatchesScreen is true
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/site-isolation/device-media-features-in-cross-origin-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/device-media-features-in-cross-origin-iframe.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html><!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+</head>
+<body>
+<iframe id="iframeTest" src="http://localhost:8000/site-isolation/resources/device-media-features-iframe.html"></iframe>
+<script>
+description("device-width, device-height, and device-aspect-ratio media features should match screen dimensions inside a cross-origin iframe under site isolation.");
+
+var jsTestIsAsync = true;
+var result = null;
+
+window.addEventListener("message", function(event) {
+    result = event.data;
+    shouldBeTrue("result.screenWidth > 0");
+    shouldBeTrue("result.screenHeight > 0");
+    shouldBeFalse("result.deviceWidthZeroMatches");
+    shouldBeFalse("result.deviceHeightZeroMatches");
+    shouldBeTrue("result.minDeviceWidthMatchesScreen");
+    shouldBeTrue("result.maxDeviceWidthMatchesScreen");
+    shouldBeTrue("result.minDeviceHeightMatchesScreen");
+    shouldBeTrue("result.maxDeviceHeightMatchesScreen");
+    shouldBeTrue("result.deviceAspectRatioMatchesScreen");
+    finishJSTest();
+}, false);
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/site-isolation/resources/device-media-features-iframe.html
+++ b/LayoutTests/http/tests/site-isolation/resources/device-media-features-iframe.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+const w = screen.width;
+const h = screen.height;
+window.parent.postMessage({
+    screenWidth: w,
+    screenHeight: h,
+    deviceWidthZeroMatches: matchMedia('(device-width: 0px)').matches,
+    deviceHeightZeroMatches: matchMedia('(device-height: 0px)').matches,
+    minDeviceWidthMatchesScreen: matchMedia(`(min-device-width: ${w}px)`).matches,
+    maxDeviceWidthMatchesScreen: matchMedia(`(max-device-width: ${w}px)`).matches,
+    minDeviceHeightMatchesScreen: matchMedia(`(min-device-height: ${h}px)`).matches,
+    maxDeviceHeightMatchesScreen: matchMedia(`(max-device-height: ${h}px)`).matches,
+    deviceAspectRatioMatchesScreen: matchMedia(`(device-aspect-ratio: ${w}/${h})`).matches,
+}, "*");
+</script>
+</body>
+</html>

--- a/Source/WebCore/css/query/MediaQueryFeatures.cpp
+++ b/Source/WebCore/css/query/MediaQueryFeatures.cpp
@@ -323,8 +323,8 @@ static const RatioSchema& deviceAspectRatioFeatureSchema()
         "device-aspect-ratio"_s,
         OptionSet<MediaQueryDynamicDependency>(),
         [](auto& context) {
-            if (RefPtr localFrame = context.document->frame()->localMainFrame()) {
-                auto screenSize = localFrame->screenSize();
+            if (RefPtr frame = context.document->frame()) {
+                auto screenSize = frame->screenSize();
                 return FloatSize { screenSize.width(), screenSize.height() };
             }
             return FloatSize { 0.0f, 0.0f };
@@ -339,8 +339,8 @@ static const LengthSchema& deviceHeightFeatureSchema()
         "device-height"_s,
         OptionSet<MediaQueryDynamicDependency>(),
         [](auto& context) {
-            if (RefPtr localFrame = context.document->frame()->localMainFrame())
-                return LayoutUnit { localFrame->screenSize().height() };
+            if (RefPtr frame = context.document->frame())
+                return LayoutUnit { frame->screenSize().height() };
             return LayoutUnit { 0.0f };
         }
     };
@@ -365,8 +365,8 @@ static const LengthSchema& deviceWidthFeatureSchema()
         "device-width"_s,
         OptionSet<MediaQueryDynamicDependency>(),
         [](auto& context) {
-            if (RefPtr localFrame = context.document->frame()->localMainFrame())
-                return LayoutUnit { localFrame->screenSize().width() };
+            if (RefPtr frame = context.document->frame())
+                return LayoutUnit { frame->screenSize().width() };
             return LayoutUnit { 0.0f };
         }
     };


### PR DESCRIPTION
#### 8c86f543c7bf066dbbdc8a2b09a65d282de7fceb
<pre>
CSS media-queries report zero under site isolation
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=314654">https://bugs.webkit.org/show_bug.cgi?id=314654</a>&gt;
&lt;<a href="https://rdar.apple.com/163298936">rdar://163298936</a>&gt;

Reviewed by Charlie Wolfe.

The `device-width`, `device-height`, and `device-aspect-ratio` media
features evaluated to zero in cross-origin iframes because they read
screen size via `localMainFrame()-&gt;screenSize()`. Under site isolation
the main frame in a cross-origin iframe&apos;s web process is a `RemoteFrame`,
so `localMainFrame()` returns nullptr and the evaluators fall through to
zero. Read `screenSize()` from the current local frame instead, matching
the pattern used by `Screen::width()` / `Screen::height()`.

Test: http/tests/site-isolation/device-media-features-in-cross-origin-iframe.html

* LayoutTests/http/tests/site-isolation/device-media-features-in-cross-origin-iframe-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/device-media-features-in-cross-origin-iframe.html: Added.
* LayoutTests/http/tests/site-isolation/resources/device-media-features-iframe.html: Added.
* Source/WebCore/css/query/MediaQueryFeatures.cpp:
(WebCore::MQ::Features::deviceAspectRatioFeatureSchema):
(WebCore::MQ::Features::deviceHeightFeatureSchema):
(WebCore::MQ::Features::deviceWidthFeatureSchema):

Canonical link: <a href="https://commits.webkit.org/313116@main">https://commits.webkit.org/313116@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e0067098eff90d67d0686069440ddd297e6f2c0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162105 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35580 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28694 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171013 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118478 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163974 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35682 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35582 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125808 "Found 1 new test failure: imported/w3c/web-platform-tests/css/mediaqueries/test_media_queries.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165064 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28123 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145608 "Found 1 new API test failure: TestWebKitAPI.WKWebExtensionAPIAction.ClearTabSpecificActionPropertiesOnNavigation (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106386 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/68814be3-61ff-4a5c-bb01-69348d2ff2e0) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27171 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25690 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18734 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136869 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23354 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173506 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20860 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/24997 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134101 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35254 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29778 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134102 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36212 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35237 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145150 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97439 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28630 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21978 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34748 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102500 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34248 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34490 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34396 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->