### PR TITLE
AX: Cache unignored children on AXIsolatedTree to eliminate redundant subtree walks

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -313,6 +313,11 @@ static bool NODELETE isValidChildForTable(AXCoreObject& object)
 
 AXCoreObject::AccessibilityChildrenVector AXCoreObject::unignoredChildren(bool updateChildrenIfNeeded)
 {
+    // NOTE: The per-object properties read below (role, IsExposableTable, IsIgnored) participate
+    // in AXIsolatedTree's cache invalidation for stitchedUnignoredChildren. If a new property
+    // becomes a dependency of this walk, update the trigger list in
+    // AXIsolatedTree::applyPendingChangesFromSnapshot.
+
     if (onlyAddsUnignoredChildren())
         return children(updateChildrenIfNeeded);
 
@@ -383,6 +388,11 @@ AXCoreObject::AccessibilityChildrenVector AXCoreObject::unignoredChildren(bool u
 
 bool AXCoreObject::hasUnignoredChild()
 {
+    if (const auto* cached = cachedUnignoredChildren()) {
+        if (!cached->isEmpty())
+            return true;
+    }
+
     const auto& children = childrenIncludingIgnored(/* updateChildrenIfNeeded */ true);
     RefPtr descendant = children.size() ? children[0].ptr() : nullptr;
     if (onlyAddsUnignoredChildren())
@@ -425,6 +435,20 @@ static AXCoreObject::AccessibilityChildrenVector childrenAfterStitching(const AX
 AXCoreObject::AccessibilityChildrenVector AXCoreObject::stitchedUnignoredChildren()
 {
     return childrenAfterStitching(unignoredChildren());
+}
+
+size_t AXCoreObject::stitchedUnignoredChildrenCount()
+{
+    return stitchedUnignoredChildren().size();
+}
+
+AXCoreObject::AccessibilityChildrenVector AXCoreObject::crossFrameUnignoredChildrenInRange(size_t start, size_t maxCount)
+{
+    auto children = crossFrameUnignoredChildren();
+    if (start >= children.size())
+        return { };
+    size_t count = std::min(maxCount, children.size() - start);
+    return AccessibilityChildrenVector { children.span().subspan(start, count) };
 }
 
 std::optional<AXStitchGroup> AXCoreObject::stitchGroupIfRepresentative() const

--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -1115,7 +1115,7 @@ public:
 
 #if ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
     bool onlyAddsUnignoredChildren() const { return isTableColumn() || role() == AccessibilityRole::TableHeaderContainer; }
-    AccessibilityChildrenVector unignoredChildren(bool updateChildrenIfNeeded = true);
+    virtual AccessibilityChildrenVector unignoredChildren(bool updateChildrenIfNeeded = true);
     bool hasUnignoredChild();
 #else
     const AccessibilityChildrenVector& unignoredChildren(bool updateChildrenIfNeeded = true) LIFETIME_BOUND { return children(updateChildrenIfNeeded); }
@@ -1125,7 +1125,11 @@ public:
         return !children.isEmpty();
     }
 #endif // ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
-    AccessibilityChildrenVector stitchedUnignoredChildren();
+    virtual AccessibilityChildrenVector stitchedUnignoredChildren();
+    virtual size_t stitchedUnignoredChildrenCount();
+    virtual const AccessibilityChildrenVector* cachedUnignoredChildren() { return nullptr; }
+    virtual const AccessibilityChildrenVector* cachedStitchedUnignoredChildren() { return nullptr; }
+    virtual AccessibilityChildrenVector crossFrameUnignoredChildrenInRange(size_t start, size_t maxCount);
 
     virtual bool isBlockFlow() const { return false; }
     bool hasStitchableRole() const

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp
@@ -323,6 +323,140 @@ const AXCoreObject::AccessibilityChildrenVector& AXIsolatedObject::children(bool
     return m_children;
 }
 
+AXIsolatedTree::CachedUnignoredChildren& AXIsolatedObject::ensureCachedUnignoredChildren()
+{
+    auto& cache = tree().cachedUnignoredChildrenMap();
+    auto result = cache.ensure(objectID(), [&] {
+        auto children = AXCoreObject::unignoredChildren();
+        bool hasPotentialStitchable = false;
+        for (const auto& child : children) {
+            if (child->hasStitchableRole()) {
+                hasPotentialStitchable = true;
+                break;
+            }
+        }
+        return AXIsolatedTree::CachedUnignoredChildren { WTF::move(children), hasPotentialStitchable };
+    });
+    return result.iterator->value;
+}
+
+#if ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
+AXCoreObject::AccessibilityChildrenVector AXIsolatedObject::unignoredChildren(bool)
+{
+    AX_ASSERT(!isMainThread());
+    return ensureCachedUnignoredChildren().children;
+}
+#endif
+
+AXCoreObject::AccessibilityChildrenVector AXIsolatedObject::stitchedUnignoredChildren()
+{
+    AX_ASSERT(!isMainThread());
+    auto& entry = ensureCachedUnignoredChildren();
+    if (!entry.hasPotentialStitchable)
+        return entry.children;
+    auto copy = entry.children;
+    copy.removeAllMatching([] (const auto& child) {
+        if (!child->hasStitchableRole())
+            return false;
+        std::optional stitchedIntoID = child->stitchedIntoID();
+        return stitchedIntoID && *stitchedIntoID != child->objectID();
+    });
+    return copy;
+}
+
+size_t AXIsolatedObject::stitchedUnignoredChildrenCount()
+{
+    AX_ASSERT(!isMainThread());
+    auto& entry = ensureCachedUnignoredChildren();
+    if (!entry.hasPotentialStitchable)
+        return entry.children.size();
+    size_t count = 0;
+    for (const auto& child : entry.children) {
+        if (!child->hasStitchableRole()) {
+            ++count;
+            continue;
+        }
+        std::optional stitchedIntoID = child->stitchedIntoID();
+        if (!stitchedIntoID || *stitchedIntoID == child->objectID())
+            ++count;
+    }
+    return count;
+}
+
+const AXCoreObject::AccessibilityChildrenVector* AXIsolatedObject::cachedUnignoredChildren()
+{
+    AX_ASSERT(!isMainThread());
+    return &ensureCachedUnignoredChildren().children;
+}
+
+const AXCoreObject::AccessibilityChildrenVector* AXIsolatedObject::cachedStitchedUnignoredChildren()
+{
+    AX_ASSERT(!isMainThread());
+    auto& entry = ensureCachedUnignoredChildren();
+    if (!entry.hasPotentialStitchable)
+        return &entry.children;
+    return nullptr;
+}
+
+AXCoreObject::AccessibilityChildrenVector AXIsolatedObject::crossFrameUnignoredChildrenInRange(size_t start, size_t maxCount)
+{
+    AX_ASSERT(!isMainThread());
+    auto& entry = ensureCachedUnignoredChildren();
+
+    if (entry.children.isEmpty()) {
+#if ENABLE_ACCESSIBILITY_LOCAL_FRAME
+        if (!start && maxCount) {
+            if (RefPtr crossFrameChild = crossFrameChildObject())
+                return { Ref { *crossFrameChild } };
+        }
+#endif
+        return { };
+    }
+
+    if (!entry.hasPotentialStitchable) {
+        if (start >= entry.children.size())
+            return { };
+        size_t end = std::min(start + maxCount, entry.children.size());
+
+        AccessibilityChildrenVector result;
+        result.reserveInitialCapacity(end - start);
+        for (size_t i = start; i < end; i++) {
+            Ref child = entry.children[i];
+#if ENABLE_ACCESSIBILITY_LOCAL_FRAME
+            if (RefPtr crossFrameChild = child->crossFrameChildObject())
+                result.append(crossFrameChild.releaseNonNull());
+            else
+#endif
+                result.append(WTF::move(child));
+        }
+        return result;
+    }
+
+    // Has potential stitchable children — need to skip stitched-away elements
+    // while computing the range relative to the stitched result.
+    AccessibilityChildrenVector result;
+    size_t stitchedIndex = 0;
+    for (const auto& child : entry.children) {
+        if (child->hasStitchableRole()) {
+            std::optional stitchedIntoID = child->stitchedIntoID();
+            if (stitchedIntoID && *stitchedIntoID != child->objectID())
+                continue;
+        }
+        if (stitchedIndex >= start + maxCount)
+            break;
+        if (stitchedIndex >= start) {
+#if ENABLE_ACCESSIBILITY_LOCAL_FRAME
+            if (RefPtr crossFrameChild = child->crossFrameChildObject())
+                result.append(*crossFrameChild);
+            else
+#endif
+                result.append(child);
+        }
+        ++stitchedIndex;
+    }
+    return result;
+}
+
 void AXIsolatedObject::setSelectedChildren(const AccessibilityChildrenVector& selectedChildren)
 {
     AX_ASSERT(selectedChildren.isEmpty() || selectedChildren[0]->isAXIsolatedObjectInstance());

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h
@@ -79,6 +79,14 @@ public:
     bool hasRowGroupTag() const final;
 
     const AccessibilityChildrenVector& children(bool updateChildrenIfNeeded = true) LIFETIME_BOUND final;
+#if ENABLE(INCLUDE_IGNORED_IN_CORE_AX_TREE)
+    AccessibilityChildrenVector unignoredChildren(bool updateChildrenIfNeeded = true) final;
+#endif
+    AccessibilityChildrenVector stitchedUnignoredChildren() final;
+    size_t stitchedUnignoredChildrenCount() final;
+    const AccessibilityChildrenVector* cachedUnignoredChildren() final;
+    const AccessibilityChildrenVector* cachedStitchedUnignoredChildren() final;
+    AccessibilityChildrenVector crossFrameUnignoredChildrenInRange(size_t start, size_t maxCount) final;
     AXIsolatedObject* parentObject() const final { return tree().objectForID(parent()); }
     AXIsolatedObject* parentObjectUnignored() const final { return downcast<AXIsolatedObject>(AXCoreObject::parentObjectUnignored()); }
     bool isEditableWebArea() const final { return boolAttributeValue(AXProperty::IsEditableWebArea); }
@@ -119,6 +127,8 @@ public:
     bool isBlockFlow() const final { return boolAttributeValue(AXProperty::IsBlockFlow); }
 
 private:
+    AXIsolatedTree::CachedUnignoredChildren& ensureCachedUnignoredChildren();
+
     constexpr ProcessID processID() const final { return tree().processID(); }
     void detachRemoteParts(AccessibilityDetachmentType) final;
     void detachPlatformWrapper(AccessibilityDetachmentType) final;

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -1599,6 +1599,16 @@ void AXIsolatedTree::applyPendingChangesFromSnapshot(PendingChanges&& snapshot)
     if (AXObjectCache::isAppleInternalInstall()) [[unlikely]]
         WTFBeginSignpostAlways(this, AccessibilityIsolatedTreeApplyPendingChanges, "tree ID: %" PRIVATE_LOG_STRING "", treeID().loggingString().utf8().data());
 
+    // Any structural change can affect some ancestor's stitchedUnignoredChildren result.
+    // Property changes that could affect the unignored-children result (IsIgnored, StitchGroups, etc.)
+    // are detected and cleared later, fused into the property-apply loop.
+    const bool hasTreeStructureChange = !snapshot.appends.isEmpty()
+        || !snapshot.subtreeRemovals.isEmpty()
+        || !snapshot.childrenUpdates.isEmpty()
+        || !snapshot.parentUpdates.isEmpty();
+    if (hasTreeStructureChange)
+        m_cachedUnignoredChildren.clear();
+
     if (snapshot.focusedNodeID != m_focusedNodeID) {
         AXLOG(makeString("focusedNodeID "_s, m_focusedNodeID ? m_focusedNodeID->loggingString() : ""_str, " pendingFocusedNodeID "_s, snapshot.focusedNodeID ? snapshot.focusedNodeID->loggingString() : ""_str));
         m_focusedNodeID = snapshot.focusedNodeID;
@@ -1660,12 +1670,31 @@ void AXIsolatedTree::applyPendingChangesFromSnapshot(PendingChanges&& snapshot)
             object->setChildrenIDs(WTF::move(update.second));
     }
 
+    bool hasUnignoredChildrenAffectingPropertyChange = false;
     for (auto& change : snapshot.propertyChanges) {
         if (RefPtr object = objectForID(change.axID)) {
-            for (auto& property : change.properties)
+            for (auto& property : change.properties) {
+                if (!hasTreeStructureChange && !hasUnignoredChildrenAffectingPropertyChange) {
+                    switch (property.first) {
+                    case AXProperty::IsIgnored:
+                    case AXProperty::IsExposableTable:
+                    case AXProperty::StitchGroups:
+                        hasUnignoredChildrenAffectingPropertyChange = true;
+                        break;
+                    default:
+                        break;
+                    }
+                }
                 object->setProperty(property.first, WTF::move(property.second));
+            }
             object->shrinkPropertiesAfterUpdates();
         }
+    }
+
+    if (hasUnignoredChildrenAffectingPropertyChange && !hasTreeStructureChange) {
+        // Something has changed that could affect any object's computed unignored children,
+        // so clear the cache.
+        m_cachedUnignoredChildren.clear();
     }
 
     if (snapshot.sortedLiveRegionIDs)

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h
@@ -477,6 +477,12 @@ public:
     }
     template<typename U> Vector<Ref<AXCoreObject>> objectsForIDs(const U&);
 
+    struct CachedUnignoredChildren {
+        Vector<Ref<AXCoreObject>> children;
+        bool hasPotentialStitchable { false };
+    };
+    HashMap<AXID, CachedUnignoredChildren>& cachedUnignoredChildrenMap() { AX_ASSERT(!isMainThread()); return m_cachedUnignoredChildren; }
+
     void generateSubtree(AccessibilityObject&);
     bool shouldCreateNodeChange(AccessibilityObject&);
     enum class ResolveNodeChanges : bool { No, Yes };
@@ -756,6 +762,11 @@ private:
     Vector<AXID> m_sortedNonRootWebAreaIDs;
     HashMap<AXID, LineRange> m_mostRecentlyPaintedText;
     HashMap<AXID, AXRelations> m_relations;
+    // Cache of unignoredChildren() results for AXIsolatedObjects. Populated lazily
+    // on cache miss; cleared in applyPendingChangesFromSnapshot when the incoming snapshot
+    // carries a change that could affect any unignored-children list (tree structure change,
+    // or IsIgnored / IsExposableTable / StitchGroups property update).
+    HashMap<AXID, CachedUnignoredChildren> m_cachedUnignoredChildren;
 #if ENABLE(ACCESSIBILITY_LOCAL_FRAME)
     AXFrameGeometry m_frameGeometry;
     IntPoint m_frameViewOriginScrollPosition;

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -4409,7 +4409,14 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_END
     if (backingObject->isTree())
         return [super accessibilityIndexOfChild:targetChild];
 
-    const auto& children = backingObject->stitchedUnignoredChildren();
+    const auto* childrenPointer = backingObject->cachedStitchedUnignoredChildren();
+    AXCoreObject::AccessibilityChildrenVector computedChildren;
+    if (!childrenPointer) {
+        computedChildren = backingObject->stitchedUnignoredChildren();
+        childrenPointer = &computedChildren;
+    }
+    const auto& children = *childrenPointer;
+
     if (!children.size()) {
         if (RetainPtr widgetChildren = renderWidgetChildren(*backingObject))
             return [widgetChildren.get() indexOfObject:targetChild];
@@ -4440,14 +4447,14 @@ ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     if (!backingObject)
         return 0;
 
-    if ([attribute isEqualToString:NSAccessibilityChildrenAttribute]) {
+    if ([attribute isEqualToString:NSAccessibilityChildrenAttribute] || [attribute isEqualToString:NSAccessibilityChildrenInNavigationOrderAttribute]) {
         // Tree items object returns a different set of children than those that are in children()
         // because an AXOutline (the mac role is becomes) has some odd stipulations.
         if (backingObject->isTree() || backingObject->isTreeItem() || backingObject->isRemoteFrame())
             return children(*backingObject).count;
 
         // FIXME: this is duplicating the logic in children(AXCoreObject&) so it should be reworked.
-        size_t childrenSize = backingObject->stitchedUnignoredChildren().size();
+        size_t childrenSize = backingObject->stitchedUnignoredChildrenCount();
         if (!childrenSize) {
 #if ENABLE(MODEL_ELEMENT_ACCESSIBILITY)
             if (backingObject->isModel())
@@ -4487,47 +4494,40 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     if (!backingObject)
         return nil;
 
-    const auto& unignoredChildren = backingObject->crossFrameUnignoredChildren();
-    if (unignoredChildren.isEmpty()) {
-        RetainPtr<NSArray> children = transformSpecialChildrenCases(*backingObject, unignoredChildren);
-        if (!children)
-            return nil;
-
-        NSUInteger childCount = [children count];
-        if (index >= childCount)
-            return nil;
-
-        NSUInteger arrayLength = std::min(childCount - index, maxCount);
-        return [children subarrayWithRange:NSMakeRange(index, arrayLength)];
-    }
-
     if (backingObject->isTree() || backingObject->isTreeItem()) {
         // Tree objects return their rows as their children & tree items return their contents sans rows.
         // We can use the original method in this case.
         return [super accessibilityArrayAttributeValues:NSAccessibilityChildrenAttribute index:index maxCount:maxCount];
     }
 
-    RetainPtr<NSArray> children = makeNSArray(unignoredChildren, returnPlatformElements);
-    unsigned childCount = [children count];
-    if (index >= childCount)
-        return nil;
+    auto childrenInRange = backingObject->crossFrameUnignoredChildrenInRange(index, maxCount);
+    if (childrenInRange.isEmpty()) {
+        if (index > 0)
+            return nil;
+        // No regular or cross-frame children. Fall back to special cases (model element, render widget).
+        AXCoreObject::AccessibilityChildrenVector emptyChildren;
+        RetainPtr<NSArray> children = transformSpecialChildrenCases(*backingObject, emptyChildren);
+        if (!children)
+            return nil;
+        NSUInteger specialCount = [children count];
+        NSUInteger arrayLength = std::min(specialCount, maxCount);
+        return [children subarrayWithRange:NSMakeRange(0, arrayLength)];
+    }
 
-    unsigned available = std::min(childCount - index, maxCount);
-
-    NSMutableArray *subarray = [NSMutableArray arrayWithCapacity:available];
-    for (unsigned added = 0; added < available; ++index, ++added) {
-        RetainPtr<WebAccessibilityObjectWrapper> wrapper = [children objectAtIndex:index];
+    NSMutableArray *subarray = [NSMutableArray arrayWithCapacity:childrenInRange.size()];
+    for (auto& child : childrenInRange) {
+        RetainPtr<WebAccessibilityObjectWrapper> wrapper = child->wrapper();
+        if (!wrapper)
+            continue;
 
         // The attachment view should be returned, otherwise AX palindrome errors occur.
         RetainPtr<id> attachmentView;
-        if (RefPtr childObject = [wrapper isKindOfClass:[WebAccessibilityObjectWrapper class]] ? wrapper.get().axBackingObject : nullptr) {
-            if (childObject->isAttachment())
-                attachmentView = [wrapper attachmentView];
-            else if (childObject->isRemoteFrame() && returnPlatformElements)
-                attachmentView = childObject->remoteFramePlatformElement();
-        }
+        if (child->isAttachment())
+            attachmentView = [wrapper attachmentView];
+        else if (child->isRemoteFrame() && returnPlatformElements)
+            attachmentView = child->remoteFramePlatformElement();
 
-        [subarray addObject:attachmentView ? attachmentView.get() : wrapper.get()];
+        [subarray addObject:attachmentView ? attachmentView.get() : (id)wrapper.get()];
     }
 
     return subarray;


### PR DESCRIPTION
#### 15c92bda16a3291a3ff5d40d140330f810280acb
<pre>
AX: Cache unignored children on AXIsolatedTree to eliminate redundant subtree walks
<a href="https://bugs.webkit.org/show_bug.cgi?id=314655">https://bugs.webkit.org/show_bug.cgi?id=314655</a>
<a href="https://rdar.apple.com/176904705">rdar://176904705</a>

Reviewed by Dominic Mazzoni.

Cache stitchedUnignoredChildren() results in a HashMap&lt;AXID, Vector&lt;Ref&lt;AXCoreObject&gt;&gt;&gt;
owned by AXIsolatedTree. The cache is populated lazily on first access and cleared
conditionally in applyPendingChangesFromSnapshot when the incoming snapshot carries a
structural change (appends, subtreeRemovals, childrenUpdates, parentUpdates) or a property
update that affects the unignored-children walk (IsIgnored, IsExposableTable, StitchGroups).

Based on logging I added while testing this change, the hit rate is extremely good:
75% on one webpage, 90% on another.

Computing unignored children is by far our most expensive operation, made worse by the introduction
of text stitching which adds more work on top, so saving work here is extremely valuable.
On a large GitHub page, holding VO-Right to move to a pre-defined spot in the middle of the page took
1min 11s before this change, and 18 seconds faster (a 3.94x speedup).

This is especially beneficial because within the scope of a single AppKit selector, AppKit may call
multiple methods on our wrapper that used to each compute the unignored children from scratch.

Additional optimizations built on the cache:

  - stitchedUnignoredChildrenCount(): returns count from cache without copying the vector.

  - cachedStitchedUnignoredChildren(): returns a pointer to the cached vector for callers
    that can iterate without copying (accessibilityIndexOfChild, handleRowsAttribute,
    handleVisibleRowsAttribute, hasUnignoredChild).

  - crossFrameUnignoredChildrenInRange(): builds only the requested subrange from the cache
    with per-element cross-frame patching, used by _accessibilityChildrenFromIndex:. This
    used to build the entire children and then pick the subrange.

  - accessibilityArrayAttributeCount: now handles AXChildrenInNavigationOrder alongside
    AXChildren, avoiding a fallthrough to AppKit&apos;s default implementation that rebuilds
    the full children NSArray just to count it. This showed up in samples.

* Source/WebCore/accessibility/AXCoreObject.cpp:
(WebCore::AXCoreObject::tabChildren):
(WebCore::AXCoreObject::unignoredChildren):
(WebCore::AXCoreObject::hasUnignoredChild):
(WebCore::AXCoreObject::stitchedUnignoredChildrenCount):
(WebCore::AXCoreObject::crossFrameUnignoredChildrenInRange):
(WebCore::AXCoreObject::selectedRadioButton):
(WebCore::AXCoreObject::selectedTabItem):
(WebCore::AXCoreObject::selectedChildren):
(WebCore::AXCoreObject::listboxSelectedChildren):
(WebCore::AXCoreObject::selectedListItems):
(WebCore::AXCoreObject::ariaTreeRows):
(WebCore::AXCoreObject::columnHeader):
(WebCore::AXCoreObject::rowHeader):
(WebCore::AXCoreObject::appendRadioButtonDescendants const):
* Source/WebCore/accessibility/AXCoreObject.h:
(WebCore::AXCoreObject::cachedStitchedUnignoredChildren):
(WebCore::AXCoreObject::unignoredChildrenFromCacheIfAvailable):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.cpp:
(WebCore::AXIsolatedObject::ensureCachedStitchedUnignoredChildren):
(WebCore::AXIsolatedObject::stitchedUnignoredChildren):
(WebCore::AXIsolatedObject::stitchedUnignoredChildrenCount):
(WebCore::AXIsolatedObject::cachedStitchedUnignoredChildren):
(WebCore::AXIsolatedObject::crossFrameUnignoredChildrenInRange):
(WebCore::AXIsolatedObject::approximateHitTest const):
(WebCore::AXIsolatedObject::relativeFrame const):
(WebCore::AXIsolatedObject::relativeFrameFromChildren const):
(WebCore::AXIsolatedObject::tableHeaderContainer):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedObject.h:
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::applyPendingChangesFromSnapshot):
(WebCore::AXIsolatedTree::lastMarker):
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.h:
(WebCore::AXIsolatedTree::cachedStitchedUnignoredChildren):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(handleRowsAttribute):
(handleVisibleRowsAttribute):
(-[WebAccessibilityObjectWrapper accessibilityIndexOfChild:]):
(-[WebAccessibilityObjectWrapper accessibilityArrayAttributeCount:]):
(-[WebAccessibilityObjectWrapper _accessibilityChildrenFromIndex:maxCount:returnPlatformElements:]):

Canonical link: <a href="https://commits.webkit.org/313177@main">https://commits.webkit.org/313177@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3faa9f7c5282d5ba700e7e0f8635d309f91a89f9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162230 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35706 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28822 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171138 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118603 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164099 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35810 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35707 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125902 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88757 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165189 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28240 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145730 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106480 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27287 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25801 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18859 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136989 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23469 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173632 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20985 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25112 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134199 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35380 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29889 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134200 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36248 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35363 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145265 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97577 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28741 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22094 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34873 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102625 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34374 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34619 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34522 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->