### PR TITLE
Disallow quick tier up recovery for builtins

### DIFF
--- a/Source/JavaScriptCore/bytecode/CodeBlock.cpp
+++ b/Source/JavaScriptCore/bytecode/CodeBlock.cpp
@@ -2867,14 +2867,18 @@ bool CodeBlock::shouldReoptimizeFromLoopNow()
 void CodeBlock::didInstallDFGCode()
 {
 #if PLATFORM(MAC)
-    // Always reset — allows quick tier-up recovery after reinstall.
-    // Enable this only on macOS due to perf regression on iOS.
-    unlinkedCodeBlock()->setQuickDFGTierUp(TriState::True);
-#else
-    // Restore old one-shot behavior — once failed, stays disabled.
+    // On macOS, normally allow tier up recovery after reinstall.
+    // However, we don't do this for builtins because we expect they
+    // are used by many workloads and we already don't persist their
+    // value profiles on UnlinkedCodeBlock; they are one-shot.
+    if (!unlinkedCodeBlock()->isBuiltinFunction()) {
+        unlinkedCodeBlock()->setQuickDFGTierUp(TriState::True);
+        return;
+    }
+#endif
+    // One-shot: once failed, stays disabled.
     if (!unlinkedCodeBlock()->hasQuickDFGTierUpUpdated())
         unlinkedCodeBlock()->setQuickDFGTierUp(TriState::True);
-#endif
 }
 
 void CodeBlock::didDFGJettison(Profiler::JettisonReason reason)
@@ -2891,18 +2895,21 @@ void CodeBlock::didFailDFGCompilation()
 #if ENABLE(FTL_JIT)
 void CodeBlock::didInstallFTLCode()
 {
-    unlinkedCodeBlock()->setQuickFTLTierUp(true);
+    // We normally allow recovery.
+    // Like DFG quick tier up, we don't allow recovery for builtins.
+    if (!unlinkedCodeBlock()->isBuiltinFunction() || !unlinkedCodeBlock()->hasQuickFTLTierUpUpdated())
+        unlinkedCodeBlock()->setQuickFTLTierUp(TriState::True);
 }
 
 void CodeBlock::didFTLJettison(Profiler::JettisonReason reason)
 {
     if (Profiler::isSpeculationFailure(reason))
-        unlinkedCodeBlock()->setQuickFTLTierUp(false);
+        unlinkedCodeBlock()->setQuickFTLTierUp(TriState::False);
 }
 
 void CodeBlock::didFailFTLCompilation()
 {
-    unlinkedCodeBlock()->setQuickFTLTierUp(false);
+    unlinkedCodeBlock()->setQuickFTLTierUp(TriState::False);
 }
 #endif
 

--- a/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
+++ b/Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h
@@ -181,8 +181,9 @@ public:
     void setQuickDFGTierUp(TriState state) { m_quickDFGTierUp = state; }
     TriState quickDFGTierUp() const { return m_quickDFGTierUp; }
 
-    bool isQuickFTLTierUp() const { return m_quickFTLTierUp; }
-    void setQuickFTLTierUp(bool value) { m_quickFTLTierUp = value; }
+    bool hasQuickFTLTierUpUpdated() const { return m_quickFTLTierUp != TriState::Indeterminate; }
+    bool isQuickFTLTierUp() const { return m_quickFTLTierUp == TriState::True; }
+    void setQuickFTLTierUp(TriState state) { m_quickFTLTierUp = state; }
 
     // Special registers
     void setThisRegister(VirtualRegister thisRegister) { m_thisRegister = thisRegister; }
@@ -440,7 +441,7 @@ private:
     bool m_hasCheckpoints : 1;
     LexicallyScopedFeatures m_lexicallyScopedFeatures : bitWidthOfLexicallyScopedFeatures { 0 };
     TriState m_quickDFGTierUp : 2 { TriState::Indeterminate };
-    bool m_quickFTLTierUp : 1 { false };
+    TriState m_quickFTLTierUp : 2 { TriState::Indeterminate };
 
 public:
     ConcurrentJSLock m_lock;


### PR DESCRIPTION
#### e9f59c8ee6e5cd7acf94b218b6e7ce93d6530a5a
<pre>
Disallow quick tier up recovery for builtins
<a href="https://bugs.webkit.org/show_bug.cgi?id=314563">https://bugs.webkit.org/show_bug.cgi?id=314563</a>
<a href="https://rdar.apple.com/176411718">rdar://176411718</a>

Reviewed by Yusuke Suzuki and Keith Miller.

In 309230@main, we allowed tier up to recover. Since js builtins are
used across many workloads, we already don&apos;t save their value profiles
to UnlinkedCodeBlock. Now, don&apos;t allow quick tier up to recover for js
builtins. Also, change m_quickFTLTierUp from bool to TriState so that we
can prevent recovery for FTL.

No new behaviour.
* Source/JavaScriptCore/bytecode/CodeBlock.cpp:
(JSC::CodeBlock::didInstallDFGCode):
(JSC::CodeBlock::didInstallFTLCode):
(JSC::CodeBlock::didFTLJettison):
(JSC::CodeBlock::didFailFTLCompilation):
* Source/JavaScriptCore/bytecode/UnlinkedCodeBlock.h:
(JSC::UnlinkedCodeBlock::hasQuickFTLTierUpUpdated const):
(JSC::UnlinkedCodeBlock::isQuickFTLTierUp const):
(JSC::UnlinkedCodeBlock::setQuickFTLTierUp):

Canonical link: <a href="https://commits.webkit.org/313155@main">https://commits.webkit.org/313155@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18701a4250635cc246a0da7866c66fe2e429b2b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162119 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35594 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28708 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171027 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118492 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6bc62bfa-5ecf-4441-b282-dd8a1dc04167) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35699 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35596 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125821 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88678 "18 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/866e85ae-5296-4a5c-bc0e-6313c804b1e1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165078 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28138 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145620 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106399 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1dab90e8-595c-4599-88dd-31fb31cc5938) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27185 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25703 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18748 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136884 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23366 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173520 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22958 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20874 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25009 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134111 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35269 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29791 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134112 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35252 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145162 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97455 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24646 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28642 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21990 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194519 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34762 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102514 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50133 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34262 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34507 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34410 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->