### PR TITLE
[CMake] TestWebKitAPI on Mac doesn't compile any tests under Tests/WebKit/WKWebView/mac/

### DIFF
--- a/Tools/TestWebKitAPI/PlatformMac.cmake
+++ b/Tools/TestWebKitAPI/PlatformMac.cmake
@@ -50,6 +50,7 @@ set(TestWebKit_DERIVED_SOURCES_DIR "${CMAKE_BINARY_DIR}/DerivedSources/TestWebKi
 
 list(APPEND TestWebKit_UNIFIED_SOURCE_LIST_FILES
     "SourcesCocoa.txt"
+    "SourcesMac.txt"
 )
 
 # Test files that reference ObjC classes from Swift-only helpers or private
@@ -111,7 +112,9 @@ list(APPEND TestWebKit_PRIVATE_INCLUDE_DIRECTORIES
     ${WebCore_PRIVATE_FRAMEWORK_HEADERS_DIR}/WebCoreTestSupport
     ${TESTWEBKITAPI_DIR}/Tests/WebCore
     ${TESTWEBKITAPI_DIR}/Tests/WebCore/cocoa
+    ${TESTWEBKITAPI_DIR}/Tests/WebKit/WKWebView
     ${TESTWEBKITAPI_DIR}/Tests/WebKit/WKWebView/ios
+    ${TESTWEBKITAPI_DIR}/Tests/WebKit/WKWebView/mac
     ${CMAKE_SOURCE_DIR}/Source/ThirdParty/libwebrtc/Source
     ${WEBKIT_DIR}/Platform/spi/Cocoa
     ${WEBKIT_DIR}/Platform/IPC
@@ -127,6 +130,7 @@ list(APPEND TestWebKit_LIBRARIES
     "-framework LocalAuthentication"
     "-framework Network"
     "-framework QuartzCore"
+    "-framework Reveal"
     "-framework UniformTypeIdentifiers"
     JavaScriptCore
     WebCoreTestSupport

--- a/Tools/TestWebKitAPI/SourcesMac.txt
+++ b/Tools/TestWebKitAPI/SourcesMac.txt
@@ -1,0 +1,118 @@
+// Copyright (C) 2026 Apple Inc. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+// 1. Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+// 2. Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+// THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+// BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+// CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+// SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+// INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+// CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+// ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+// THE POSSIBILITY OF SUCH DAMAGE.
+//
+// Mac-specific WKWebView API tests. @no-unify is applied to files whose
+// file-scope helpers (e.g. `static bool didFinishLoad;`) would collide with
+// siblings in the same unified translation unit. Removing those tags is a
+// mechanical follow-up -- wrap the statics in anonymous namespaces.
+
+Tests/WebKit/WKWebView/mac/AcceptsFirstMouse.mm @nonARC
+Tests/WebKit/WKWebView/mac/AttributedString.mm @nonARC
+Tests/WebKit/WKWebView/mac/BackForwardList.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/BackgroundColor.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/CancelLoadFromResourceLoadDelegate.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/CandidateTests.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/CloseNewWindowInNavigationPolicyDelegate.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/CloseWhileCommittingLoad.mm @nonARC
+Tests/WebKit/WKWebView/mac/ColorInputTests.mm @nonARC
+Tests/WebKit/WKWebView/mac/ContextMenuCanCopyURL.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/ContextMenuDefaultItemsHaveTags.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/ContextMenuMouseEvents.mm @nonARC
+Tests/WebKit/WKWebView/mac/ContextMenuTests.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/CrossPartitionFileSchemeAccess.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/DateInputTests.mm @nonARC
+Tests/WebKit/WKWebView/mac/DeviceScaleFactorOnBack.mm @nonARC
+Tests/WebKit/WKWebView/mac/DisableAutomaticSpellingCorrection.mm @nonARC
+Tests/WebKit/WKWebView/mac/DOMHTMLTableCellCellAbove.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/DOMHTMLVideoElementWrapper.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/DOMNode.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/DOMNodeFromJSObject.mm @nonARC
+Tests/WebKit/WKWebView/mac/DOMRangeOfString.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/DragAndDropTestsMac.mm @nonARC
+Tests/WebKit/WKWebView/mac/DynamicDeviceScaleFactor.mm @nonARC
+Tests/WebKit/WKWebView/mac/EarlyKVOCrash.mm @nonARC
+Tests/WebKit/WKWebView/mac/EditableLegacyWebView.mm @nonARC
+Tests/WebKit/WKWebView/mac/ElementAtPointInWebFrame.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/FirstResponderScrollingPosition.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/FirstResponderSuppression.mm @nonARC
+Tests/WebKit/WKWebView/mac/FontManagerTests.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/FragmentNavigation.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/FullscreenFocus.mm @nonARC
+Tests/WebKit/WKWebView/mac/FullscreenPointerLeave.mm @nonARC
+Tests/WebKit/WKWebView/mac/FullscreenZoomInitialFrame.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/GetMatchedCSSRules.mm @nonARC
+Tests/WebKit/WKWebView/mac/HIDGamepads.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/HTMLCollectionNamedItem.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/HTMLFormCollectionNamedItem.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/ImmediateActionTests.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/InspectorBar.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/InWindowFullscreen.mm @nonARC
+Tests/WebKit/WKWebView/mac/IsNavigationActionTrusted.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/JavascriptURLNavigation.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/JSWrapperForNodeInWebFrame.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/KeyboardEventTests.mm @nonARC
+Tests/WebKit/WKWebView/mac/LegacyDragAndDropTests.mm @nonARC
+Tests/WebKit/WKWebView/mac/LimitTitleSize.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/LoadWebArchive.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/LoadWebViewWithEmptyAppName.mm @nonARC
+Tests/WebKit/WKWebView/mac/MediaPlaybackSleepAssertion.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/MemoryCacheDisableWithinResourceLoadDelegate.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/MemoryCachePruneWithinResourceLoadDelegate.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/MemoryPressureHandler.mm @nonARC
+Tests/WebKit/WKWebView/mac/MenuTypesForMouseEvents.mm @nonARC
+Tests/WebKit/WKWebView/mac/MouseEventTests.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/NoPolicyDelegateResponse.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/NSResponderTests.mm @nonARC
+Tests/WebKit/WKWebView/mac/PageVisibilityStateWithWindowChanges.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/RenderedImageFromDOMNode.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/RenderedImageFromDOMRange.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/ScrollbarTests.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/ScrollingCoordinatorTests.mm @nonARC
+Tests/WebKit/WKWebView/mac/SetAndUpdateCacheModel.mm @nonARC
+Tests/WebKit/WKWebView/mac/SetDocumentURI.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/SimplifyMarkup.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/SkipAdInPictureInPicture.mm @nonARC
+Tests/WebKit/WKWebView/mac/SpellCheckerDocumentTag.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/StartLoadInDidFailProvisionalLoad.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/StopLoadingFromDidFinishLoading.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/StopLoadingFromDidReceiveResponse.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/StringByEvaluatingJavaScriptFromString.mm @nonARC
+Tests/WebKit/WKWebView/mac/StringTruncator.mm @nonARC
+Tests/WebKit/WKWebView/mac/StringWidth.mm @nonARC
+Tests/WebKit/WKWebView/mac/SubresourceErrorCrash.mm @nonARC
+Tests/WebKit/WKWebView/mac/TypingStyleCrash.mm @nonARC
+Tests/WebKit/WKWebView/mac/ViewportSizeForViewportUnits.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/WebScriptObjectDescription.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/WebViewCanPasteURL.mm @nonARC
+Tests/WebKit/WKWebView/mac/WebViewCanPasteZeroPng.mm @nonARC
+Tests/WebKit/WKWebView/mac/WebViewCloseInsideDidFinishLoadForFrame.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/WebViewDidCreateJavaScriptContext.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/WebViewDidRemoveFrameFromHierarchy.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/WebViewIconLoading.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/WebViewScheduleInRunLoop.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/WillPerformClientRedirectToURLCrash.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/WillSendSubmitEvent.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/WindowlessWebViewWithMedia.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/WKWebViewCoders.mm @nonARC
+Tests/WebKit/WKWebView/mac/WKWebViewMacEditingTests.mm @nonARC @no-unify
+Tests/WebKit/WKWebView/mac/WKWebViewTitlebarSeparatorTests.mm @nonARC


### PR DESCRIPTION
#### c92a925d7b3ef0b5bfd02cd84ffb0e3e4a6fbef2
<pre>
[CMake] TestWebKitAPI on Mac doesn&apos;t compile any tests under Tests/WebKit/WKWebView/mac/
<a href="https://bugs.webkit.org/show_bug.cgi?id=314662">https://bugs.webkit.org/show_bug.cgi?id=314662</a>
<a href="https://rdar.apple.com/176914334">rdar://176914334</a>

Reviewed by Geoffrey Garen.

The ~90 tests under Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ were
not compiled by the CMake Mac build. PlatformMac.cmake only consumed
SourcesCocoa.txt, which is shared with iOS and can&apos;t list AppKit-dependent
sources.

Add Tools/TestWebKitAPI/SourcesMac.txt listing the 90 mac-only tests and
append it to TestWebKit_UNIFIED_SOURCE_LIST_FILES in PlatformMac.cmake.

* Tools/TestWebKitAPI/PlatformMac.cmake:
* Tools/TestWebKitAPI/SourcesMac.txt: Added.

Canonical link: <a href="https://commits.webkit.org/313112@main">https://commits.webkit.org/313112@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c697e03e8349007b167779c0e9ab471f9b6d21c9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162118 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35593 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28707 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171026 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118491 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ab250cfc-0497-436f-8b25-e26dade8ff5d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163987 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35698 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35595 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125815 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88677 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/792b59bf-3c9c-42aa-b211-cec845807eb8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165077 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28135 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/145630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/106393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f7baebf1-3003-4f2b-9a87-867d93cc189d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27182 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18747 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136881 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23375 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173519 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25018 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134110 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35268 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29788 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134111 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36210 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35251 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145171 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97453 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28639 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21999 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34761 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34261 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34506 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34409 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->