### PR TITLE
[JSC] Fix wasm callee cleanup to account for multiple conservative root scans

### DIFF
--- a/Source/JavaScriptCore/heap/ConservativeRoots.cpp
+++ b/Source/JavaScriptCore/heap/ConservativeRoots.cpp
@@ -29,11 +29,8 @@
 #include "CalleeBits.h"
 #include "CodeBlock.h"
 #include "CodeBlockSetInlines.h"
-#include "HeapUtil.h"
 #include "JITStubRoutineSet.h"
 #include "JSCast.h"
-#include "JSCellInlines.h"
-#include "MarkedBlockInlines.h"
 #include "WasmCallee.h"
 #include <wtf/OSAllocator.h>
 
@@ -41,44 +38,16 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace JSC {
 
-static constexpr bool verboseWasmCalleeScan = false;
-
 ConservativeRoots::ConservativeRoots(JSC::Heap& heap)
     : m_roots(m_inlineRoots)
     , m_size(0)
     , m_capacity(inlineCapacity)
     , m_heap(heap)
 {
-#if ENABLE(WEBASSEMBLY)
-    Locker locker(heap.m_wasmCalleesPendingDestructionLock);
-    for (auto& iter : heap.m_wasmCalleesPendingDestruction) {
-        void* boxedWasmCallee = CalleeBits::boxNativeCallee(iter.ptr());
-        ASSERT_UNUSED(boxedWasmCallee, boxedWasmCallee == removeArrayPtrTag(boxedWasmCallee));
-        dataLogLnIf(verboseWasmCalleeScan, "Looking for ", RawPointer(iter.ptr()), " boxed: ", RawPointer(boxedWasmCallee));
-        // FIXME: This seems like it could have some kind of bulk add.
-        m_wasmCalleesPendingDestructionCopy.add(iter.ptr());
-        m_boxedWasmCalleeFilter.add(std::bit_cast<uintptr_t>(CalleeBits::boxNativeCallee(iter.ptr())));
-    }
-#endif
 }
 
 ConservativeRoots::~ConservativeRoots()
 {
-#if ENABLE(WEBASSEMBLY)
-    if (m_wasmCalleesPendingDestructionCopy.size()) {
-        // We need to deref these from outside the lock since other Callees could be registered by the destructors.
-        Vector<RefPtr<Wasm::Callee>, 8> wasmCalleesToRelease;
-        {
-            Locker locker(m_heap.m_wasmCalleesPendingDestructionLock);
-            wasmCalleesToRelease = m_heap.m_wasmCalleesPendingDestruction.takeIf<8>([&] (const auto& callee) {
-                dataLogLnIf(verboseWasmCalleeScan && m_wasmCalleesPendingDestructionCopy.contains(callee.ptr()), RawPointer(callee.ptr()), " was ", m_wasmCalleesDiscovered.contains(callee.ptr()) ? "discovered" : "not discovered");
-                return m_wasmCalleesPendingDestructionCopy.contains(callee.ptr()) && !m_wasmCalleesDiscovered.contains(callee.ptr());
-            });
-            dataLogLnIf(verboseWasmCalleeScan, m_heap.m_wasmCalleesPendingDestruction.size(), " callees remaining");
-        }
-    }
-#endif
-
     if (m_roots != m_inlineRoots)
         OSAllocator::decommitAndRelease(m_roots, m_capacity * sizeof(HeapCell*));
 }
@@ -125,10 +94,8 @@ inline void ConservativeRoots::genericAddPointer(char* pointer, HeapVersion mark
         if (calleeBits.isNativeCallee()) {
             if (!boxedWasmCalleeFilter.ruleOut(std::bit_cast<uintptr_t>(pointer))) {
                 Wasm::Callee* wasmCallee = static_cast<Wasm::Callee*>(calleeBits.asNativeCallee());
-                if (m_wasmCalleesPendingDestructionCopy.contains(wasmCallee)) {
-                    m_wasmCalleesDiscovered.add(wasmCallee);
+                if (m_heap.didDiscoverPendingWasmCallee(wasmCallee))
                     return;
-                }
             }
             // FIXME: We could probably just return here.
         }
@@ -225,7 +192,11 @@ void ConservativeRoots::genericAddSpan(void* begin, void* end, MarkHook& markHoo
     RELEASE_ASSERT(isPointerAligned(end));
     // Make a local copy of filters to show the compiler it won't alias, and can be register-allocated.
     TinyBloomFilter<uintptr_t> jsGCFilter = m_heap.objectSpace().blocks().filter();
-    TinyBloomFilter<uintptr_t> boxedWasmCalleeFilter = m_boxedWasmCalleeFilter;
+#if ENABLE(WEBASSEMBLY)
+    TinyBloomFilter<uintptr_t> boxedWasmCalleeFilter = m_heap.boxedWasmCalleeFilter();
+#else
+    TinyBloomFilter<uintptr_t> boxedWasmCalleeFilter;
+#endif
 
     HeapVersion markingVersion = m_heap.objectSpace().markingVersion();
     HeapVersion newlyAllocatedVersion = m_heap.objectSpace().newlyAllocatedVersion();

--- a/Source/JavaScriptCore/heap/ConservativeRoots.h
+++ b/Source/JavaScriptCore/heap/ConservativeRoots.h
@@ -55,15 +55,6 @@ private:
     
     void grow();
 
-    // We can't just use the copy of Heap::m_wasmCalleesPendingDestruction since new callees could be registered while
-    // we're actively scanning the stack. A bad race would be:
-    // 1) Start scanning the stack passing a frame with Wasm::Callee foo.
-    // 2) tier up finishes for foo and is added to Heap::m_wasmCalleesPendingDestruction
-    // 3) foo isn't added to m_wasmCalleesDiscovered
-    // 4) foo gets derefed and destroyed.
-    UncheckedKeyHashSet<const Wasm::Callee*> m_wasmCalleesPendingDestructionCopy;
-    UncheckedKeyHashSet<const Wasm::Callee*> m_wasmCalleesDiscovered;
-    TinyBloomFilter<uintptr_t> m_boxedWasmCalleeFilter;
     HeapCell** m_roots;
     size_t m_size;
     size_t m_capacity;

--- a/Source/JavaScriptCore/heap/Heap.cpp
+++ b/Source/JavaScriptCore/heap/Heap.cpp
@@ -1508,6 +1508,10 @@ NEVER_INLINE bool Heap::runBeginPhase(GCConductor conn)
 
     beginMarking();
 
+#if ENABLE(WEBASSEMBLY)
+    prepareWasmCalleeCleanup();
+#endif
+
     forEachSlotVisitor(
         [&] (SlotVisitor& visitor) {
             visitor.didStartMarking();
@@ -1718,6 +1722,10 @@ NEVER_INLINE bool Heap::runEndPhase(GCConductor conn)
 
     updateObjectCounts();
     endMarking();
+
+#if ENABLE(WEBASSEMBLY)
+    finalizeWasmCalleeCleanup();
+#endif
 
     if (Options::verifyGC()) [[unlikely]]
         verifyGC();
@@ -3505,6 +3513,50 @@ bool Heap::isWasmCalleePendingDestruction(Wasm::Callee& callee)
 {
     Locker locker(m_wasmCalleesPendingDestructionLock);
     return m_wasmCalleesPendingDestruction.contains(callee);
+}
+
+bool Heap::didDiscoverPendingWasmCallee(Wasm::Callee* callee)
+{
+    if (!m_wasmCalleesPendingDestructionSnapshot.contains(callee))
+        return false;
+    m_wasmCalleesDiscoveredDuringGC.add(callee);
+    return true;
+}
+
+void Heap::prepareWasmCalleeCleanup()
+{
+    ASSERT(worldIsStopped());
+    ASSERT(m_wasmCalleesPendingDestructionSnapshot.isEmpty());
+    ASSERT(m_wasmCalleesDiscoveredDuringGC.isEmpty());
+    m_wasmCalleesPendingDestructionSnapshot.clear();
+    m_wasmCalleesDiscoveredDuringGC.clear();
+    m_boxedWasmCalleeFilter = TinyBloomFilter<uintptr_t>();
+
+    Locker locker(m_wasmCalleesPendingDestructionLock);
+    for (auto& callee : m_wasmCalleesPendingDestruction) {
+        m_wasmCalleesPendingDestructionSnapshot.add(callee.ptr());
+        m_boxedWasmCalleeFilter.add(std::bit_cast<uintptr_t>(CalleeBits::boxNativeCallee(callee.ptr())));
+    }
+}
+
+void Heap::finalizeWasmCalleeCleanup()
+{
+    ASSERT(worldIsStopped());
+    if (m_wasmCalleesPendingDestructionSnapshot.isEmpty())
+        return;
+
+    // Release refs outside the lock since Callee destructors may call reportWasmCalleePendingDestruction.
+    Vector<RefPtr<Wasm::Callee>, 8> wasmCalleesToRelease;
+    {
+        Locker locker(m_wasmCalleesPendingDestructionLock);
+        wasmCalleesToRelease = m_wasmCalleesPendingDestruction.takeIf<8>([&](const auto& callee) {
+            return m_wasmCalleesPendingDestructionSnapshot.contains(callee.ptr())
+                && !m_wasmCalleesDiscoveredDuringGC.contains(callee.ptr());
+        });
+    }
+
+    m_wasmCalleesPendingDestructionSnapshot.clear();
+    m_wasmCalleesDiscoveredDuringGC.clear();
 }
 
 #endif

--- a/Source/JavaScriptCore/heap/Heap.h
+++ b/Source/JavaScriptCore/heap/Heap.h
@@ -635,6 +635,9 @@ public:
     // FIXME: We should have a way to clear Wasm::Callees pending destruction when the Module dies.
     void reportWasmCalleePendingDestruction(Ref<Wasm::Callee>&&);
     bool isWasmCalleePendingDestruction(Wasm::Callee&);
+
+    const TinyBloomFilter<uintptr_t>& boxedWasmCalleeFilter() const { return m_boxedWasmCalleeFilter; }
+    bool didDiscoverPendingWasmCallee(Wasm::Callee*);
 #endif
 
     // This is a debug function for checking who marked the target cell.
@@ -756,6 +759,10 @@ private:
     void gatherStackRoots(ConservativeRoots&);
     void gatherVMRoots(ConservativeRoots&);
     void beginMarking();
+#if ENABLE(WEBASSEMBLY)
+    void prepareWasmCalleeCleanup();
+    void finalizeWasmCalleeCleanup();
+#endif
     void visitCompilerWorklistWeakReferences();
     void removeDeadCompilerWorklistEntries();
     void updateObjectCounts();
@@ -944,6 +951,13 @@ private:
     
 #if ENABLE(WEBASSEMBLY)
     UncheckedKeyHashSet<Ref<Wasm::Callee>> m_wasmCalleesPendingDestruction WTF_GUARDED_BY_LOCK(m_wasmCalleesPendingDestructionLock);
+    // We snapshot m_wasmCalleesPendingDestruction at the start of GC rather than consulting it
+    // directly during scanning because new callees can be registered while we scan. Without the
+    // snapshot, a callee could be added after we already passed its frame, never get recorded
+    // as discovered, and be incorrectly destroyed.
+    UncheckedKeyHashSet<const Wasm::Callee*> m_wasmCalleesPendingDestructionSnapshot;
+    UncheckedKeyHashSet<const Wasm::Callee*> m_wasmCalleesDiscoveredDuringGC;
+    TinyBloomFilter<uintptr_t> m_boxedWasmCalleeFilter;
 #endif
 
     std::unique_ptr<MarkStackArray> m_sharedCollectorMarkStack;


### PR DESCRIPTION
#### 0c06001c552225c38d91671a97e7e7087b6c4614
<pre>
[JSC] Fix wasm callee cleanup to account for multiple conservative root scans
<a href="https://bugs.webkit.org/show_bug.cgi?id=314664">https://bugs.webkit.org/show_bug.cgi?id=314664</a>
<a href="https://rdar.apple.com/176914701">rdar://176914701</a>

Reviewed by Keith Miller.

The cleanup of Wasm callees is currently done as part of conservative roots scan.
ConservativeRoots takes a snapshot of the current contents of
Heap::m_wasmCalleesPendingDestruction. During the scan, it records the wasm callees it
encounters. After the scan, any callees present in the snapshot but not encountered while
scanning are considered unreachable in this VM and removed from
m_wasmCalleesPendingDestruction. If this VM was the only one using the callee, the
callee&apos;s refcount reaches 0 and the callee is destroyed. (The snapshot is needed to avoid
accidentally dropping callees added to m_wasmCalleesPendingDestruction during concurrent
phases and not yet seen in the scan).

This scheme needs changing now that conservative roots are also scanned as part of
scanning JSPI evacuated stacks (<a href="https://bugs.webkit.org/show_bug.cgi?id=307564).">https://bugs.webkit.org/show_bug.cgi?id=307564).</a> The core
assumption that a callee present in the pending destruction snapshot and not seen during
the scan is now unreachable does not hold anymore. A callee may be held by an evacuated
stack and not be seen in the live stack scan by the Cs constraint, or it may be held by
the live stack and not seen in an evacuated stack scan by the Pbc constraint.

This patch moves callee finalization from ConservativeRoots into Heap. The pending
destruction snapshot and the set of discovered callees are now held by the Heap, set up in
the Begin phase. ConservativeRoots records discovered callees in that central Heap-owned
discovered set and Bloom filter. In the End phase, callees recorded in the snapshot and
not seen by any of the conservative scans are cleaned out of
m_wasmCalleesPendingDestruction.

Testing:

Exercised by JSPI tests when running in debug or ASAN builds. Old behavior was causing
flaky crashes on refcount checks or freed memory access, especially with
collectContinuously turned on.

Canonical link: <a href="https://commits.webkit.org/313167@main">https://commits.webkit.org/313167@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a6130e379ff9efebf7a7b106007a42c78564f13

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162218 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35694 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28810 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171126 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118591 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35798 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35695 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125895 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165177 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28234 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145731 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106473 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27281 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25796 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18847 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136983 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23470 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173620 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23057 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20973 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25113 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134194 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35368 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29884 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134195 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36244 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35351 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145266 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97565 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28737 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22095 "Found 1 new test failure: scrollingcoordinator/mac/latching/horizontal-overflow-back-swipe.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194618 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34861 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102613 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50198 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34362 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34607 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34510 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->