### PR TITLE
[import-w3c-tests] Avoid needlessly rewriting tests on import

### DIFF
--- a/Tools/Scripts/webkitpy/w3c/test_converter.py
+++ b/Tools/Scripts/webkitpy/w3c/test_converter.py
@@ -46,13 +46,16 @@ def convert_for_webkit(new_path, filename, reference_support_info, reference_fil
 
     converter = _W3CTestConverter(new_path, filename, reference_support_info, reference_file_renames, host, webkit_test_runner_options)
     if filename.endswith('.css'):
-        return converter.add_webkit_prefix_to_unprefixed_properties_and_values(contents)
-    elif filename.endswith('.js'):
-        return ([], [], contents)
-    else:
+        result = converter.add_webkit_prefix_to_unprefixed_properties_and_values(contents)
+        if not result[0] and not result[1]:
+            return None
+        return result
+    elif filename.endswith(('.html', '.htm', '.xhtml', '.xht', '.xml', '.svg')):
         converter.feed(contents)
         converter.close()
         return converter.output()
+    else:
+        assert False, f"Unexpected file extension: {filename}"
 
 
 class _W3CTestConverter(HTMLParser):
@@ -73,6 +76,7 @@ class _W3CTestConverter(HTMLParser):
         self.reference_file_renames = reference_file_renames
         self.webkit_test_runner_options = webkit_test_runner_options
         self.has_started = False
+        self._modified = False
 
         # These settings might vary between WebKit and Blink
         css_property_file = self.path_from_webkit_root('Source', 'WebCore', 'css', 'CSSProperties.json')
@@ -87,6 +91,8 @@ class _W3CTestConverter(HTMLParser):
         self.prop_value_re = re.compile(prop_value_regex)
 
     def output(self):
+        if not self._modified:
+            return None
         return (self.converted_properties, self.converted_property_values, ''.join(self.converted_data))
 
     def path_from_webkit_root(self, *comps):
@@ -170,6 +176,7 @@ class _W3CTestConverter(HTMLParser):
         converted = text
         for path in self.reference_support_info['files']:
             if converted.find(path) != -1:
+                self._modified = True
                 # FIXME: This doesn't handle an edge case where simply removing the relative path doesn't work.
                 # See http://webkit.org/b/135677 for details.
                 new_path = re.sub(re.escape(self.reference_support_info['reference_relpath']), '', path, 1)
@@ -180,8 +187,10 @@ class _W3CTestConverter(HTMLParser):
     def convert_style_data(self, data):
         converted = self.add_webkit_prefix_to_unprefixed_properties_and_values(data)
         if converted[0]:
+            self._modified = True
             self.converted_properties.extend(list(converted[0]))
         if converted[1]:
+            self._modified = True
             self.converted_property_values.extend(list(converted[1]))
 
         if self.reference_support_info is None or self.reference_support_info == {}:
@@ -198,7 +207,10 @@ class _W3CTestConverter(HTMLParser):
                 converted = re.sub(re.escape(attr[1]), new_style, converted)
             if attr[0] == 'name' and attr[1] == 'fuzzy' and tag == 'meta':
                 for rename in self.reference_file_renames:
-                    converted = re.sub(rename['src'], rename['dest'], converted)
+                    new_converted = re.sub(rename['src'], rename['dest'], converted)
+                    if new_converted != converted:
+                        self._modified = True
+                        converted = new_converted
 
         # Convert relative paths
         src_tags = ('script', 'style', 'img', 'frame', 'iframe', 'input', 'layer', 'textarea', 'video', 'audio')
@@ -220,6 +232,7 @@ class _W3CTestConverter(HTMLParser):
             return
         self.has_started = True
         if self.webkit_test_runner_options:
+            self._modified = True
             self.converted_data[-1] = self.converted_data[-1] + self.webkit_test_runner_options
 
     def handle_starttag(self, tag, attrs):

--- a/Tools/Scripts/webkitpy/w3c/test_converter_unittest.py
+++ b/Tools/Scripts/webkitpy/w3c/test_converter_unittest.py
@@ -91,7 +91,7 @@ CONTENT OF TEST
             converter.close()
             converted = converter.output()
 
-        self.verify_no_conversion_happened(converted, test_html)
+        self.assertIsNone(converted)
 
     def test_convert_for_webkit_harness_only(self):
         """ Tests convert_for_webkit() using a basic JS test that uses testharness.js only and has no prefixed properties """
@@ -107,10 +107,7 @@ CONTENT OF TEST
         converter.close()
         converted = converter.output()
 
-        self.verify_conversion_happened(converted)
-        self.verify_test_harness_paths(converted[2], 1, 1)
-        self.verify_prefixed_properties(converted, [])
-        self.verify_prefixed_property_values(converted, [])
+        self.assertIsNone(converted)
 
     def test_convert_for_webkit_properties_only(self):
         """ Tests convert_for_webkit() using a test that has 2 prefixed properties: 1 in a style block + 1 inline style """
@@ -195,8 +192,7 @@ CONTENT OF TEST
             converter.close()
             converted = converter.output()
 
-        self.verify_conversion_happened(converted)
-        self.verify_test_harness_paths(converted[2], 2, 1)
+        self.assertIsNone(converted)
 
     def test_convert_prefixed_properties(self):
         """ Tests convert_prefixed_properties() file that has 20 properties requiring the -webkit- prefix:

--- a/Tools/Scripts/webkitpy/w3c/test_importer.py
+++ b/Tools/Scripts/webkitpy/w3c/test_importer.py
@@ -660,7 +660,7 @@ class TestImporter(object):
                 mimetype = mimetypes.guess_type(orig_filepath)
                 is_resource = file_to_copy.get('is_resource', False)
                 if should_rewrite_files and not is_resource and ('text/' in str(mimetype[0]) or 'application/' in str(mimetype[0])) \
-                                        and ('html' in str(mimetype[0]) or 'xml' in str(mimetype[0])  or 'css' in str(mimetype[0]) or 'javascript' in str(mimetype[0])):
+                                        and ('html' in str(mimetype[0]) or 'xml' in str(mimetype[0])  or 'css' in str(mimetype[0])):
                     _log.info("Rewriting: %s" % new_filepath)
                     try:
                         converted_file = convert_for_webkit(new_path, filename=orig_filepath, reference_support_info=reference_support_info, reference_file_renames=reference_file_renames, host=self.host, webkit_test_runner_options=self._webkit_test_runner_options(new_filepath))

--- a/Tools/Scripts/webkitpy/w3c/test_importer_unittest.py
+++ b/Tools/Scripts/webkitpy/w3c/test_importer_unittest.py
@@ -753,6 +753,22 @@ class TestImporterTest(unittest.TestCase):
         self.assertTrue(fs.exists('/test.checkout/LayoutTests/platform/test-linux-x86_64/w3c/web-platform-tests/t/test-expected.txt'))
         self.assertTrue(fs.exists('/test.checkout/LayoutTests/platform/unknown-platform/w3c/web-platform-tests/t/test-expected.txt'))
 
+    def test_unmodified_files_not_rewritten(self):
+        """HTML files that need no conversion should be copied verbatim, not parsed and re-serialized."""
+        # HTMLParser lowercases end tags, so this content would be mangled by a parse/serialize cycle.
+        TEST_HTML = '<!DOCTYPE html>\n<script src="/resources/testharness.js"></script>\n<script src="/resources/testharnessreport.js"></script>\n<p>Content</P></BODY></HTML>'
+        FAKE_FILES = {
+            f'{FAKE_WPT_DIR}/t/test.html': TEST_HTML,
+            '/mock-checkout/Source/WebCore/css/CSSProperties.json': '{"properties":{}}',
+            '/mock-checkout/Source/WebCore/css/CSSValueKeywords.in': '',
+        }
+        FAKE_FILES.update(FAKE_RESOURCES)
+
+        fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '--no-clean-dest-dir', '-d', 'w3c'], FAKE_FILES)
+
+        imported = fs.read_text_file('/mock-checkout/LayoutTests/w3c/web-platform-tests/t/test.html')
+        self.assertEqual(imported, TEST_HTML)
+
     def test_resource_files_not_rewritten(self):
         """Resource HTML files should be copied without HTML parsing to avoid corrupting non-UTF-8 encoded content."""
         RESOURCE_HTML = '<span data-bytes="1B 24 42 26 41 1B 28 42">&A</span>'


### PR DESCRIPTION
#### 5a55efcfb4ea7be0aac38200beeb3d4a77f4754c
<pre>
[import-w3c-tests] Avoid needlessly rewriting tests on import
<a href="https://bugs.webkit.org/show_bug.cgi?id=314663">https://bugs.webkit.org/show_bug.cgi?id=314663</a>
<a href="https://rdar.apple.com/176914827">rdar://176914827</a>

Reviewed by Ryosuke Niwa and Anne van Kesteren.

* Tools/Scripts/webkitpy/w3c/test_converter.py:
(convert_for_webkit): Return None when there&apos;s nothing to modified; assert we only get expected file extensions.
(_W3CTestConverter.__init__): Add _W3CTestConverter._modified.
(_W3CTestConverter.output): Return None if nothing is modified.
(_W3CTestConverter.convert_reference_relpaths): Set modified.
(_W3CTestConverter.convert_style_data): Set modified.
(_W3CTestConverter.convert_attributes_if_needed): Set modified.
(_W3CTestConverter.add_webkit_test_runner_options_if_needed): Set modified.
* Tools/Scripts/webkitpy/w3c/test_converter_unittest.py: Update tests for None.
* Tools/Scripts/webkitpy/w3c/test_importer.py:
(TestImporter.import_tests): Don&apos;t pass JS to the rewriter.
* Tools/Scripts/webkitpy/w3c/test_importer_unittest.py:
(TestImporterTest.test_unmodified_files_not_rewritten): Add a test that we don&apos;t rewrite everything.

Canonical link: <a href="https://commits.webkit.org/313428@main">https://commits.webkit.org/313428@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8637410e7d0dbcf6f033ad58e0006117d7fbb029

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162122 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35597 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28711 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171030 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118495 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6e9ba734-269a-4c01-9eaa-45d702d54037) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/163991 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35702 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35599 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125817 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88683 "17 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/acfcc8ac-557d-44ef-9fb2-58854c019222) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165081 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28139 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145617 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106395 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6b90a18f-aa6d-46c6-9b4c-da3900670b43) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/161442 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27186 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25704 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18751 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136885 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23363 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173523 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25006 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134113 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35272 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29792 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134114 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35255 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145159 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97458 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24813 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28644 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/21987 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34765 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34265 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/49 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34510 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34413 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->