### PR TITLE
[Site Isolation] Handle RemoteFrames in AuthenticatorCoordinator::scopeAndCrossOriginParent

### DIFF
--- a/LayoutTests/platform/ios-site-isolation/TestExpectations
+++ b/LayoutTests/platform/ios-site-isolation/TestExpectations
@@ -4,7 +4,6 @@
 # Tests that crash #
 ####################
 http/tests/security/top-level-unique-origin2.https.html [ Crash ]
-http/wpt/webauthn/public-key-credential-same-origin-with-ancestors.https.html [ Crash ]
 imported/w3c/web-platform-tests/content-security-policy/inheritance/history.sub.html [ Crash ]
 imported/w3c/web-platform-tests/content-security-policy/inheritance/window-open-local-after-network-scheme.sub.html [ Crash ]
 imported/w3c/web-platform-tests/speculation-rules/prefetch/redirect-url.https.html?origin=cross-site-redirect [ Crash ]

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -238,7 +238,6 @@ http/wpt/css/css-view-transitions/navigation/old_vt_promises_bfcache.html [ Fail
 http/wpt/fetch/inspect-preflight.html [ Failure ]
 http/wpt/html/browsers/browsing-the-web/navigating-across-documents/navigating-iframe-sandbox.html [ Failure ]
 http/wpt/service-workers/third-party-registration.html [ Failure ]
-http/wpt/webauthn/public-key-credential-same-origin-with-ancestors.https.html [ Failure ]
 http/wpt/webcodecs/audioData-serialization.html [ Failure ]
 http/wpt/webcodecs/videoFrame-serialization.html [ Failure ]
 http/wpt/webrtc/third-party-frame-ice-candidate-filtering.html [ Failure ]

--- a/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
+++ b/Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp
@@ -39,6 +39,8 @@
 #include "DocumentSecurityOrigin.h"
 #include "FrameDestructionObserverInlines.h"
 #include "JSBasicCredential.h"
+#include "LegacySchemeRegistry.h"
+#include "LocalFrameInlines.h"
 #include "JSCredentialCreationOptions.h"
 #include "JSCredentialRequestOptions.h"
 #include "JSDOMConvertBoolean.h"
@@ -55,7 +57,7 @@
 #include "PublicKeyCredentialCreationOptions.h"
 #include "PublicKeyCredentialRequestOptions.h"
 #include "RegistrableDomain.h"
-#include "LegacySchemeRegistry.h"
+#include "RemoteFrame.h"
 #include "UnknownCredentialOptions.h"
 #include "WebAuthenticationConstants.h"
 #include "WebAuthenticationUtils.h"
@@ -107,11 +109,12 @@ static ScopeAndCrossOriginParent scopeAndCrossOriginParent(const Document& docum
     Ref origin = document.securityOrigin();
     auto url = document.url();
     std::optional<SecurityOriginData> crossOriginParent;
-    for (RefPtr parentDocument = document.parentDocument(); parentDocument; parentDocument = parentDocument->parentDocument()) {
-        if (!origin->isSameOriginDomain(protect(parentDocument->securityOrigin())) && !areRegistrableDomainsEqual(url, parentDocument->url()))
+    for (RefPtr parentFrame = document.frame() ? document.frame()->tree().parent() : nullptr; parentFrame; parentFrame = parentFrame->tree().parent()) {
+        RefPtr parentOrigin = parentFrame->frameDocumentSecurityOrigin();
+        if (!parentOrigin || is<RemoteFrame>(parentFrame) || RegistrableDomain(parentOrigin->data()) != RegistrableDomain(origin->data()))
             isSameSite = false;
-        if (!crossOriginParent && !origin->isSameOriginAs(protect(parentDocument->securityOrigin())))
-            crossOriginParent = parentDocument->securityOrigin().data();
+        if (parentOrigin && !origin->isSameOriginAs(*parentOrigin))
+            crossOriginParent = parentOrigin->data();
     }
 
     if (!crossOriginParent)


### PR DESCRIPTION
#### 073bf48042ce0c1bc752e744fd7252dfc5319399
<pre>
[Site Isolation] Handle RemoteFrames in AuthenticatorCoordinator::scopeAndCrossOriginParent
<a href="https://bugs.webkit.org/show_bug.cgi?id=314439">https://bugs.webkit.org/show_bug.cgi?id=314439</a>
<a href="https://rdar.apple.com/176593716">rdar://176593716</a>

Reviewed by Charlie Wolfe.

AuthenticatorCoordinator::scopeAndCrossOriginParent performs
security checks to check if a frame&apos;s ancestor frames are
same-origin, same-site, or cross-origin.

The method currently traverses the ancestors via the
current document&apos;s parent document (Document::parentDocument).

However, with site isolation enabled, some of the ancestor&apos;s documents
might not available if the ancestors are in a different process.

This patch updates this ancestor traversal to operate on the frame
tree and handles both Local or Remote frame cases.

In the case where the ancestor is a remote frame, we don&apos;t
have access to it&apos;s full URL. However, we can grab the registerable domain
from the SecurityOrigin and use that to perform the check which was
previously done with areRegistrableDomainsEqual.

This patch fixes http/wpt/webauthn/public-key-credential-same-origin-with-ancestors.https.html
with site isolation enabled.

* LayoutTests/platform/ios-site-isolation/TestExpectations:
* LayoutTests/platform/mac-site-isolation/TestExpectations:
* Source/WebCore/Modules/webauthn/AuthenticatorCoordinator.cpp:
(WebCore::AuthenticatorCoordinatorInternal::scopeAndCrossOriginParent):

Canonical link: <a href="https://commits.webkit.org/313422@main">https://commits.webkit.org/313422@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1f92919e09b4241abc8efea7f06c6fdd0516128e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162834 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36311 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29468 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171772 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119280 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164703 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36415 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36314 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126399 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89016 "18 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ce42ccca-7044-4c87-bc39-119b23412fde) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165793 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28744 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146313 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106976 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e5ff92be-464b-4a4f-8de2-d1e3424550a5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27790 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26325 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19472 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137499 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24042 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174276 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21799 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25687 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134708 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35984 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30428 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134703 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35969 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145838 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98389 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24809 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/29235 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22674 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35478 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/103518 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34979 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35224 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35127 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->