### PR TITLE
[macOS] webrtc/getUserMedia-webaudio-autoplay.html is a flaky text failure.

### DIFF
--- a/LayoutTests/webrtc/getUserMedia-webaudio-autoplay.html
+++ b/LayoutTests/webrtc/getUserMedia-webaudio-autoplay.html
@@ -53,6 +53,7 @@ promise_test((test) => {
         var node = context.createBufferSource();
         node.connect(context.destination);
         node.start();
+        stream.getTracks().forEach(track => track.stop());
     });
 }, "Ensuring autoplay works when starting an audio node and getUserMedia is on");
 
@@ -65,7 +66,7 @@ promise_test((test) => {
 
         var node = context.createBufferSource();
         node.connect(context.destination);
-        return context.resume();
+        return context.resume().finally(() => stream.getTracks().forEach(track => track.stop()));
     });
 }, "Ensuring autoplay works when resuming audio context and getUserMedia is on");
         </script>


### PR DESCRIPTION
#### 5c74059fe6c384ce0670c08b54f0f4c505055a47
<pre>
[macOS] webrtc/getUserMedia-webaudio-autoplay.html is a flaky text failure.
<a href="https://rdar.apple.com/176917820">rdar://176917820</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=314668">https://bugs.webkit.org/show_bug.cgi?id=314668</a>

Reviewed by NOBODY (OOPS!).

The test calls navigator.mediaDevices.getUserMedia({audio: true}) in two subtests
but never explicitly stops the resulting MediaStreamTracks. When GC finalizes the
leaked capture tracks before the page tears down, WebKit emits the warning &apos;A capture
MediaStreamTrack was destroyed without having been stopped explicitly&apos; as a CONSOLE
MESSAGE, which appears at the top of the actual output and diffs against the expected
output. The behavior is timing-dependent.

* LayoutTests/webrtc/getUserMedia-webaudio-autoplay.html:
Added explicit `MediaStreamTrack.stop()` cleanup to the two `getUserMedia`-based
subtests in `LayoutTests/webrtc/getUserMedia-webaudio-autoplay.html`:

- Subtest 3 (&quot;starting an audio node ... getUserMedia is on&quot;): stops tracks after
  `node.start()` inside the `.then`.
- Subtest 4 (&quot;resuming audio context ... getUserMedia is on&quot;): stops tracks via
  `.finally()` chained on `context.resume()`, so cleanup happens regardless of resume
   outcome and the returned promise still reflects the resume result.

This eliminates the GC-timing-dependent &quot;A capture MediaStreamTrack was destroyed without
having been stopped explicitly&quot; console warning that was diffing against the expected output.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c74059fe6c384ce0670c08b54f0f4c505055a47

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162140 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35615 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28729 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171048 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118513 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35720 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35617 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125833 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88693 "18 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165099 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28158 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145637 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106411 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27205 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25722 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18769 "Built successfully") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136904 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23381 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173541 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25024 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134131 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35290 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29810 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134132 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35273 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145177 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97476 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28660 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22005 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34783 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34283 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34528 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34431 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->