### PR TITLE
[WebKit] Apply authoritative User-Agent on redirect after policy callback

### DIFF
--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -795,6 +795,18 @@ void DocumentLoader::willSendRequest(ResourceRequest&& newRequest, const Resourc
             stopLoadingForPolicyChange(navigationPolicyDecision == NavigationPolicyDecision::LoadWillContinueInAnotherProcess ? LoadWillContinueInAnotherProcess::Yes : LoadWillContinueInAnotherProcess::No);
             break;
         case NavigationPolicyDecision::ContinueLoad:
+            // The client may have updated the User-Agent (via webView.customUserAgent,
+            // WKWebpagePreferences._customUserAgent, an Inspector override, or a quirk
+            // triggered by the redirect target URL) during the policy callback. The
+            // redirected request still carries the previous request's User-Agent
+            // header, so FrameLoader::applyUserAgentIfNeeded() would skip it. Re-apply
+            // the authoritative UA here so all sources — including URL-dependent
+            // quirks — take effect on the redirected request.
+            if (RefPtr frameLoader = this->frameLoader()) {
+                String userAgent = frameLoader->userAgent(request.url());
+                if (!userAgent.isEmpty() && userAgent != request.httpUserAgent())
+                    request.setHTTPUserAgent(WTF::move(userAgent));
+            }
             break;
         }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CustomUserAgent.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CustomUserAgent.mm
@@ -27,9 +27,15 @@
 
 #import "Helpers/DeprecatedGlobalValues.h"
 #import "Helpers/PlatformUtilities.h"
+#import "Helpers/cocoa/HTTPServer.h"
 #import "Helpers/cocoa/TestNavigationDelegate.h"
+#import "Helpers/cocoa/TestWKWebView.h"
+#import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/WKWebpagePreferencesPrivate.h>
 #import <WebKit/WebKit.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/text/MakeString.h>
+#import <wtf/text/WTFString.h>
 
 TEST(CustomUserAgent, UpdateCachedNavigatorUserAgent)
 {
@@ -61,3 +67,212 @@ TEST(CustomUserAgent, UpdateCachedNavigatorUserAgent)
     TestWebKitAPI::Util::run(&done);
     done = false;
 }
+
+namespace TestWebKitAPI {
+
+static String userAgentFromRequest(const Vector<char>& request)
+{
+    auto headers = String::fromUTF8(request.span()).split("\r\n"_s);
+    auto index = headers.findIf([](auto& header) {
+        return header.startsWith("User-Agent:"_s);
+    });
+    if (index == notFound)
+        return { };
+    return headers[index];
+}
+
+// Covers rdar://176265326. When the app updates webView.customUserAgent inside
+// decidePolicyForNavigationAction for a 302 redirect target, the redirected
+// request must carry the updated User-Agent even when no process swap occurs.
+TEST(CustomUserAgent, PageLevelCustomUserAgentUpdatedInsidePolicyAppliesToRedirectTarget)
+{
+    String receivedUserAgentOnTarget;
+    bool targetWasRequested = false;
+    HTTPServer server(HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> ConnectionTask {
+        while (true) {
+            auto request = co_await connection.awaitableReceiveHTTPRequest();
+            auto path = HTTPServer::parsePath(request);
+            if (path == "/redirect"_s) {
+                co_await connection.awaitableSend(makeString(
+                    "HTTP/1.1 302 Found\r\n"
+                    "Location: /target\r\n"
+                    "Content-Length: 0\r\n"
+                    "\r\n"_s));
+                continue;
+            }
+            if (path == "/target"_s) {
+                receivedUserAgentOnTarget = userAgentFromRequest(request);
+                targetWasRequested = true;
+                co_await connection.awaitableSend(
+                    "HTTP/1.1 200 OK\r\n"
+                    "Content-Length: 0\r\n"
+                    "\r\n"_s);
+                continue;
+            }
+            EXPECT_FALSE(true);
+        }
+    });
+
+    RetainPtr webView = adoptNS([TestWKWebView new]);
+    [webView setCustomUserAgent:@"Initial"];
+
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    navigationDelegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *navigationAction, void (^decisionHandler)(WKNavigationActionPolicy)) {
+        if ([navigationAction.request.URL.path isEqualToString:@"/target"])
+            webView.get().customUserAgent = @"Updated";
+        decisionHandler(WKNavigationActionPolicyAllow);
+    };
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    [webView loadRequest:server.request("/redirect"_s)];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    EXPECT_TRUE(targetWasRequested);
+    EXPECT_WK_STREQ("User-Agent: Updated", receivedUserAgentOnTarget.utf8().data());
+}
+
+// Same scenario as above, but using the WKWebpagePreferences SPI variant.
+// The app does not set a page-level custom UA; the delegate supplies one only
+// via preferences._customUserAgent inside the policy callback for /target.
+TEST(CustomUserAgent, WebpagePreferencesCustomUserAgentAppliesToRedirectTarget)
+{
+    String receivedUserAgentOnTarget;
+    bool targetWasRequested = false;
+    HTTPServer server(HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> ConnectionTask {
+        while (true) {
+            auto request = co_await connection.awaitableReceiveHTTPRequest();
+            auto path = HTTPServer::parsePath(request);
+            if (path == "/redirect"_s) {
+                co_await connection.awaitableSend(makeString(
+                    "HTTP/1.1 302 Found\r\n"
+                    "Location: /target\r\n"
+                    "Content-Length: 0\r\n"
+                    "\r\n"_s));
+                continue;
+            }
+            if (path == "/target"_s) {
+                receivedUserAgentOnTarget = userAgentFromRequest(request);
+                targetWasRequested = true;
+                co_await connection.awaitableSend(
+                    "HTTP/1.1 200 OK\r\n"
+                    "Content-Length: 0\r\n"
+                    "\r\n"_s);
+                continue;
+            }
+            EXPECT_FALSE(true);
+        }
+    });
+
+    RetainPtr webView = adoptNS([TestWKWebView new]);
+
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    navigationDelegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *navigationAction, WKWebpagePreferences *preferences, void (^decisionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
+        if ([navigationAction.request.URL.path isEqualToString:@"/target"])
+            preferences._customUserAgent = @"Updated";
+        decisionHandler(WKNavigationActionPolicyAllow, preferences);
+    };
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    [webView loadRequest:server.request("/redirect"_s)];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    EXPECT_TRUE(targetWasRequested);
+    EXPECT_WK_STREQ("User-Agent: Updated", receivedUserAgentOnTarget.utf8().data());
+}
+
+// Regression guard: when no custom UA is in effect, the redirect target must
+// still receive the default browser User-Agent unmodified by the fix.
+TEST(CustomUserAgent, NoCustomUserAgentRedirectUsesDefault)
+{
+    String receivedUserAgentOnTarget;
+    bool targetWasRequested = false;
+    HTTPServer server(HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> ConnectionTask {
+        while (true) {
+            auto request = co_await connection.awaitableReceiveHTTPRequest();
+            auto path = HTTPServer::parsePath(request);
+            if (path == "/redirect"_s) {
+                co_await connection.awaitableSend(makeString(
+                    "HTTP/1.1 302 Found\r\n"
+                    "Location: /target\r\n"
+                    "Content-Length: 0\r\n"
+                    "\r\n"_s));
+                continue;
+            }
+            if (path == "/target"_s) {
+                receivedUserAgentOnTarget = userAgentFromRequest(request);
+                targetWasRequested = true;
+                co_await connection.awaitableSend(
+                    "HTTP/1.1 200 OK\r\n"
+                    "Content-Length: 0\r\n"
+                    "\r\n"_s);
+                continue;
+            }
+            EXPECT_FALSE(true);
+        }
+    });
+
+    RetainPtr webView = adoptNS([TestWKWebView new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    [webView loadRequest:server.request("/redirect"_s)];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    EXPECT_TRUE(targetWasRequested);
+    EXPECT_TRUE(receivedUserAgentOnTarget.startsWith("User-Agent: Mozilla/"_s));
+}
+
+// Same scenario as PageLevel above, but using the WKWebpagePreferences
+// _customUserAgentAsSiteSpecificQuirks SPI. That value is stored on the
+// DocumentLoader as a separate field from the regular customUserAgent, so the
+// fix must resolve it through FrameLoader::userAgent() rather than checking
+// the plain customUserAgent directly.
+TEST(CustomUserAgent, WebpagePreferencesCustomUserAgentAsSiteSpecificQuirksAppliesToRedirectTarget)
+{
+    String receivedUserAgentOnTarget;
+    bool targetWasRequested = false;
+    HTTPServer server(HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> ConnectionTask {
+        while (true) {
+            auto request = co_await connection.awaitableReceiveHTTPRequest();
+            auto path = HTTPServer::parsePath(request);
+            if (path == "/redirect"_s) {
+                co_await connection.awaitableSend(makeString(
+                    "HTTP/1.1 302 Found\r\n"
+                    "Location: /target\r\n"
+                    "Content-Length: 0\r\n"
+                    "\r\n"_s));
+                continue;
+            }
+            if (path == "/target"_s) {
+                receivedUserAgentOnTarget = userAgentFromRequest(request);
+                targetWasRequested = true;
+                co_await connection.awaitableSend(
+                    "HTTP/1.1 200 OK\r\n"
+                    "Content-Length: 0\r\n"
+                    "\r\n"_s);
+                continue;
+            }
+            EXPECT_FALSE(true);
+        }
+    });
+
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    configuration.get().preferences._needsSiteSpecificQuirks = YES;
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    navigationDelegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *navigationAction, WKWebpagePreferences *preferences, void (^decisionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
+        if ([navigationAction.request.URL.path isEqualToString:@"/target"])
+            preferences._customUserAgentAsSiteSpecificQuirks = @"QuirkUA";
+        decisionHandler(WKNavigationActionPolicyAllow, preferences);
+    };
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    [webView loadRequest:server.request("/redirect"_s)];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    EXPECT_TRUE(targetWasRequested);
+    EXPECT_WK_STREQ("User-Agent: QuirkUA", receivedUserAgentOnTarget.utf8().data());
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### 9a2a1a1b69328785129d43e47f6f0e91154b00fa
<pre>
[WebKit] Apply authoritative User-Agent on redirect after policy callback
<a href="https://bugs.webkit.org/show_bug.cgi?id=313542">https://bugs.webkit.org/show_bug.cgi?id=313542</a>
<a href="https://rdar.apple.com/176265326">rdar://176265326</a>

Reviewed by Chris Dumez.

When an application updates the custom User-Agent (via WKWebView.customUserAgent,
WKWebpagePreferences._customUserAgent, or
WKWebpagePreferences._customUserAgentAsSiteSpecificQuirks) from inside
decidePolicyForNavigationAction for a 302 redirect target, the updated
User-Agent is not applied to the request that actually gets sent to the server
unless a process swap happens to be triggered by the cross-origin redirect.

In the programmatic webView.load(_:) case there is no committed document yet,
so the cross-origin redirect does not trigger a process swap. The redirected
ResourceRequest carries the original request&apos;s User-Agent header through to the
WebProcess, and FrameLoader::applyUserAgentIfNeeded() short-circuits because
the header is already present. The request reaches the server with the stale
UA.

In the link-click case, the prior page is already committed, so the cross-site
redirect triggers PSON. The replacement WebProcess rebuilds the request from
scratch using the current page-level UA, and the fresh value reaches the
server. This is incidental — the non-PSON path needs the same outcome.

Re-apply the authoritative User-Agent inside DocumentLoader::willSendRequest()&apos;s
navigation-policy completion handler when the decision is to continue the load.
FrameLoader::userAgent(url) is the same function applyUserAgentIfNeeded() uses
for initial requests and consults every UA source — storage-access quirks,
WebsitePolicies site-specific-quirks UA, the regular customUserAgent,
InspectorInstrumentation overrides, and the page-level m_userAgent — so
resolving through it here covers all of them on the redirected request too,
including URL-dependent quirks that differ between the initial URL and the
redirect target. The write is skipped when the computed UA is empty or matches
the header already on the request.

* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::willSendRequest):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CustomUserAgent.mm:

Canonical link: <a href="https://commits.webkit.org/313127@main">https://commits.webkit.org/313127@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9fb143e84f09af20996166c39c3daf0a2144ede0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162211 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35687 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28803 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171119 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/118584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164080 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35791 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35688 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/125888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/118584 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165170 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28226 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/145714 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106466 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/41f1ce58-8411-4dd3-b15d-73e43676c3d5) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27273 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/18840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/136974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23453 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173613 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20966 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25096 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/134188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35361 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/29875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/134189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36219 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35344 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145249 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97557 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28726 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/22077 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34854 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102606 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34355 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34600 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34503 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->