### PR TITLE
[Cocoa] Seeking to time zero with default controls can cause stall

### DIFF
--- a/LayoutTests/media/media-source/media-source-real-scrub-then-play-expected.txt
+++ b/LayoutTests/media/media-source/media-source-real-scrub-then-play-expected.txt
@@ -1,0 +1,12 @@
+
+EVENT(sourceopen)
+EVENT(updateend)
+EVENT(updateend)
+RUN(video.play())
+EVENT(playing)
+EXPECTED (video.currentTime >= '1') OK
+RUN(timeAfterLastSeek = video.currentTime)
+EXPECTED (video.currentTime > timeAfterLastSeek == 'true') OK
+RUN(video.pause())
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-real-scrub-then-play.html
+++ b/LayoutTests/media/media-source/media-source-real-scrub-then-play.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-real-scrub-then-play</title>
+    <script src="mp4-generator.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    // Reproduces a stall caused by backward fastSeek while playing.
+    // The renderer's synchronizer rate drops to 0 and never recovers.
+    var source;
+    var sourceBuffer;
+    var timeAfterPlay;
+    var timeLater;
+
+    async function runTest() {
+        findMediaElement();
+
+        if (!MediaSource.isTypeSupported(MP4.VIDEO_TYPE)) {
+            failTest(`${MP4.VIDEO_TYPE} is not supported`);
+            return;
+        }
+
+        source = new MediaSource();
+        video.src = URL.createObjectURL(source);
+        await waitFor(source, 'sourceopen');
+
+        sourceBuffer = source.addSourceBuffer(MP4.VIDEO_TYPE);
+
+        var initData = MP4.initSegment({
+            timescale: 1000,
+            tracks: [{ id: 1, type: 'video', timescale: 1000 }]
+        });
+        var media = MP4.mediaSegment({
+            sequenceNumber: 1,
+            tracks: [{ id: 1, type: 'video', baseDecodeTime: 0, samples: [
+                { duration: 1000, compositionTimeOffset: 0, isSync: true },
+                { duration: 1000, compositionTimeOffset: 0, isSync: false },
+                { duration: 1000, compositionTimeOffset: 0, isSync: false },
+                { duration: 1000, compositionTimeOffset: 0, isSync: false },
+                { duration: 1000, compositionTimeOffset: 0, isSync: true },
+                { duration: 1000, compositionTimeOffset: 0, isSync: false },
+                { duration: 1000, compositionTimeOffset: 0, isSync: false },
+                { duration: 1000, compositionTimeOffset: 0, isSync: false },
+            ]}]
+        });
+
+        sourceBuffer.appendBuffer(initData);
+        await waitFor(sourceBuffer, 'updateend');
+        sourceBuffer.appendBuffer(media);
+        await waitFor(sourceBuffer, 'updateend');
+
+        // Play and let video advance past 1 second
+        video.loop = true;
+        run('video.play()');
+        await waitFor(video, 'playing');
+        await testExpectedEventually('video.currentTime', 1, '>=');
+
+        // Rapid backward fastSeek while playing — triggers the stall
+        for (var j = 0; j < 10; j++) {
+            video.fastSeek(Math.max(0, video.currentTime - 0.5));
+            await sleepFor(0);
+        }
+
+        // Verify playback continues after the seeks
+        run('timeAfterLastSeek = video.currentTime');
+        await testExpectedEventually('video.currentTime > timeAfterLastSeek', true);
+
+        run('video.pause()');
+    }
+
+    window.addEventListener('load', event => {
+        runTest().then(endTest).catch(failTest);
+    });
+    </script>
+</head>
+<body>
+    <video controls></video>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
@@ -615,12 +615,18 @@ Ref<MediaTimePromise> AudioVideoRendererAVFObjC::prepareToSeek(const MediaTime& 
     bool isSynchronizerSeeking = m_isSynchronizerSeeking || std::abs((synchronizerTime - seekTime).toMicroseconds()) > 1000;
 
     if (!isSynchronizerSeeking && allRenderersHaveAvailableSamples()) {
-        ALWAYS_LOG(LOGIDENTIFIER, "Synchroniser doesn't require seeking current: ", synchronizerTime, " seeking: ", seekTime);
         // In cases where the destination seek time matches too closely the synchronizer's existing time
         // no time jumped notification will be issued. In this case, just notify the MediaPlayer that
         // the seek completed successfully.
         m_lastSeekTime = synchronizerTime;
         m_seekState = SeekCompleted;
+
+        auto shouldBePlaying = this->shouldBePlaying();
+        ALWAYS_LOG(LOGIDENTIFIER, "Synchroniser doesn't require seeking current: ", synchronizerTime, " seeking: ", seekTime, ", shouldBePlaying: ", shouldBePlaying);
+
+        if (shouldBePlaying)
+            setSynchronizerRate(m_rate, { });
+
         return MediaTimePromise::createAndResolve(m_lastSeekTime);
     }
 


### PR DESCRIPTION
#### f497e873d0b903663551e189a08bc249c4f5282d
<pre>
[Cocoa] Seeking to time zero with default controls can cause stall
<a href="https://rdar.apple.com/175877962">rdar://175877962</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=314672">https://bugs.webkit.org/show_bug.cgi?id=314672</a>

Reviewed by Jean-Yves Avenard and Eric Carlson.

When the AudioVideoRendererAVFObjC short-circuits a seek, it can leave the playback
rate set to zero, rather than reset it to the requested rate.

Test: media/media-source/media-source-real-scrub-then-play.html

* LayoutTests/media/media-source/media-source-real-scrub-then-play-expected.txt: Added.
* LayoutTests/media/media-source/media-source-real-scrub-then-play.html: Added.
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::prepareToSeek):

Canonical link: <a href="https://commits.webkit.org/313123@main">https://commits.webkit.org/313123@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/928a5ba8f974cab0c9f1e20819aee488e929358b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162144 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35619 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28733 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171052 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118517 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164013 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35724 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35621 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125835 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88697 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165103 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28159 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145643 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106413 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27206 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25725 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18773 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136905 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23386 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173545 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20899 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25029 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134134 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35294 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29813 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134135 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36217 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35277 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145182 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97480 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28665 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22010 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34787 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102539 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34287 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34532 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34435 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->