### PR TITLE
Fix will-change: z-index creating stacking-context unconditionally

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5607,7 +5607,6 @@ imported/w3c/web-platform-tests/css/css-counter-styles/upper-roman/css3-counter-
 # CSS will-change failures
 webkit.org/b/225035 imported/w3c/web-platform-tests/css/css-will-change/will-change-fixedpos-cb-002.html [ ImageOnlyFailure ]
 webkit.org/b/224899 imported/w3c/web-platform-tests/css/css-will-change/will-change-fixedpos-cb-005.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-will-change/will-change-stacking-context-z-index-4.html [ ImageOnlyFailure ]
 
 # Needs display box support.
 fast/layoutformattingcontext/ [ Skip ]

--- a/LayoutTests/compositing/repaint/compositing-toggle-in-overflow-scroll-repaint.html
+++ b/LayoutTests/compositing/repaint/compositing-toggle-in-overflow-scroll-repaint.html
@@ -7,6 +7,7 @@
             height: 400px;
             margin: 20px;
             overflow: scroll;
+            position: relative;
             will-change: z-index;
             border: 1px solid black;
         }

--- a/LayoutTests/fast/css/will-change/will-change-creates-stacking-context-inline-expected.html
+++ b/LayoutTests/fast/css/will-change/will-change-creates-stacking-context-inline-expected.html
@@ -46,7 +46,9 @@
         function doTest()
         {
             for (value of willChangeValues) {
-                makeStackingElement('opacity', value.stacking ? '0.999999' : '1');
+                // z-index: auto; isn't eligible for a stacking context by default.
+                var isStacking = value.property === 'z-index' ? false : value.stacking;
+                makeStackingElement('opacity', isStacking ? '0.999999' : '1');
             }
         }
         

--- a/Source/WebCore/animation/KeyframeEffect.cpp
+++ b/Source/WebCore/animation/KeyframeEffect.cpp
@@ -1478,7 +1478,7 @@ void KeyframeEffect::computeStackingContextImpact()
 {
     m_triggersStackingContext = false;
     for (auto property : m_blendingKeyframes.properties()) {
-        if (std::holds_alternative<CSSPropertyID>(property) && Style::WillChangeAnimatableFeature::propertyCreatesStackingContext(std::get<CSSPropertyID>(property))) {
+        if (std::holds_alternative<CSSPropertyID>(property) && Style::WillChangeAnimatableFeature::propertyCreatesStackingContext(std::get<CSSPropertyID>(property), Style::WillChangeAnimatableFeature::AllowsZIndex::Yes)) {
             m_triggersStackingContext = true;
             break;
         }

--- a/Source/WebCore/rendering/RenderInline.cpp
+++ b/Source/WebCore/rendering/RenderInline.cpp
@@ -824,7 +824,7 @@ bool RenderInline::requiresLayer() const
     return isInFlowPositioned()
         || createsGroup()
         || hasClipPath()
-        || style().willChange().canCreateStackingContext()
+        || style().willChange().canCreateStackingContext(Style::WillChangeAnimatableFeature::AllowsZIndex::No)
         || hasRunningAcceleratedAnimations()
         || requiresRenderingConsolidationForViewTransition();
 }

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -624,7 +624,7 @@ static bool canCreateStackingContext(const RenderLayer& layer)
         || renderer.style().isolation() != Isolation::Auto
         || renderer.shouldApplyPaintContainment()
         || !renderer.style().usedZIndex().isAuto()
-        || renderer.style().willChange().canCreateStackingContext()
+        || renderer.style().willChange().canCreateStackingContext(Style::WillChangeAnimatableFeature::AllowsZIndex::No)
         || layer.establishesTopLayer();
 }
 

--- a/Source/WebCore/style/StyleAdjuster.cpp
+++ b/Source/WebCore/style/StyleAdjuster.cpp
@@ -378,7 +378,7 @@ static UnicodeBidi NODELETE forceBidiIsolationForRuby(UnicodeBidi unicodeBidi)
     return UnicodeBidi::Isolate;
 }
 
-static bool shouldTreatAutoZIndexAsZero(const RenderStyle& style)
+static bool shouldTreatAutoZIndexAsZero(const RenderStyle& style, const RenderStyle* parentBoxStyle)
 {
     return !style.opacity().isOpaque()
         || style.hasTransformRelatedProperty()
@@ -394,7 +394,7 @@ static bool shouldTreatAutoZIndexAsZero(const RenderStyle& style)
         || style.isolation() != Isolation::Auto
         || style.position() == PositionType::Sticky
         || style.position() == PositionType::Fixed
-        || style.willChange().canCreateStackingContext();
+        || style.willChange().canCreateStackingContext((style.position() != PositionType::Static || (parentBoxStyle && parentBoxStyle->display().isFlexibleOrGridFormattingContextBox())) ? WillChangeAnimatableFeature::AllowsZIndex::Yes : WillChangeAnimatableFeature::AllowsZIndex::No);
 }
 
 void Adjuster::adjustFromBuilder(RenderStyle& style)
@@ -403,7 +403,7 @@ void Adjuster::adjustFromBuilder(RenderStyle& style)
     // This allows copy-on-write to trigger before caching.
 
     if (style.specifiedZIndex().isAuto()) {
-        if (shouldTreatAutoZIndexAsZero(style))
+        if (shouldTreatAutoZIndexAsZero(style, nullptr))
             style.setUsedZIndex(0);
     } else if (style.position() != PositionType::Static)
         style.setUsedZIndex(style.specifiedZIndex());
@@ -585,7 +585,7 @@ void Adjuster::adjust(RenderStyle& style) const
     if (hasAutoSpecifiedZIndex) {
         if ((m_element && m_document->documentElement() == m_element.get())
             || hasTransformRelatedProperty(style, m_element.get(), m_parentStyle)
-            || shouldTreatAutoZIndexAsZero(style)
+            || shouldTreatAutoZIndexAsZero(style, &m_parentBoxStyle)
             || isInTopLayerOrBackdrop(style, m_element.get()))
             style.setUsedZIndex(0);
         else

--- a/Source/WebCore/style/values/will-change/StyleWillChange.cpp
+++ b/Source/WebCore/style/values/will-change/StyleWillChange.cpp
@@ -43,7 +43,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(WillChangeAnimatableFeatures::Data);
 
 // "If any non-initial value of a property would create a stacking context on the element,
 // specifying that property in will-change must create a stacking context on the element."
-bool WillChangeAnimatableFeature::propertyCreatesStackingContext(CSSPropertyID property)
+bool WillChangeAnimatableFeature::propertyCreatesStackingContext(CSSPropertyID property, AllowsZIndex allowsZIndex)
 {
     switch (property) {
     case CSSPropertyPerspective:
@@ -59,7 +59,6 @@ bool WillChangeAnimatableFeature::propertyCreatesStackingContext(CSSPropertyID p
     case CSSPropertyWebkitMask:
     case CSSPropertyOpacity:
     case CSSPropertyPosition:
-    case CSSPropertyZIndex:
     case CSSPropertyWebkitBoxReflect:
     case CSSPropertyMixBlendMode:
     case CSSPropertyIsolation:
@@ -75,6 +74,8 @@ bool WillChangeAnimatableFeature::propertyCreatesStackingContext(CSSPropertyID p
     case CSSPropertyViewTransitionName:
     case CSSPropertyContain:
         return true;
+    case CSSPropertyZIndex:
+        return allowsZIndex == AllowsZIndex::Yes;
     default:
         return false;
     }
@@ -120,11 +121,19 @@ void WillChangeAnimatableFeatures::Data::initializeCachedChecks()
         if (auto* value = std::get_if<WillChangeAnimatableFeature::CustomIdentWithCachedPropertyID>(&feature.value)) {
             auto propertyID = value->propertyID;
 
-            m_canCreateStackingContext |= WillChangeAnimatableFeature::propertyCreatesStackingContext(propertyID);
             m_canTriggerCompositingOnInline |= WillChangeAnimatableFeature::propertyTriggersCompositing(propertyID);
             m_canTriggerCompositing |= m_canTriggerCompositingOnInline | WillChangeAnimatableFeature::propertyTriggersCompositingOnBoxesOnly(propertyID);
         }
     }
+}
+
+bool WillChangeAnimatableFeatures::Data::canCreateStackingContext(WillChangeAnimatableFeature::AllowsZIndex allowsZIndex) const
+{
+    return std::ranges::any_of(*this, [allowsZIndex](auto& feature) {
+        if (auto* value = std::get_if<WillChangeAnimatableFeature::CustomIdentWithCachedPropertyID>(&feature.value))
+            return WillChangeAnimatableFeature::propertyCreatesStackingContext(value->propertyID, allowsZIndex);
+        return false;
+    });
 }
 
 bool WillChangeAnimatableFeatures::Data::operator==(const WillChangeAnimatableFeatures::Data& other) const

--- a/Source/WebCore/style/values/will-change/StyleWillChange.h
+++ b/Source/WebCore/style/values/will-change/StyleWillChange.h
@@ -78,7 +78,9 @@ struct WillChangeAnimatableFeature {
     {
     }
 
-    static bool NODELETE propertyCreatesStackingContext(CSSPropertyID);
+    enum class AllowsZIndex : bool { No, Yes };
+
+    static bool NODELETE propertyCreatesStackingContext(CSSPropertyID, AllowsZIndex);
     static bool NODELETE propertyTriggersCompositing(CSSPropertyID);
     static bool NODELETE propertyTriggersCompositingOnBoxesOnly(CSSPropertyID);
 
@@ -136,7 +138,7 @@ struct WillChangeAnimatableFeatures {
     bool containsProperty(CSSPropertyID property) const { return m_data->containsProperty(property); }
     bool createsContainingBlockForAbsolutelyPositioned(bool isRootElement) const { return m_data->createsContainingBlockForAbsolutelyPositioned(isRootElement); }
     bool createsContainingBlockForOutOfFlowPositioned(bool isRootElement) const { return m_data->createsContainingBlockForOutOfFlowPositioned(isRootElement); }
-    bool canCreateStackingContext() const { return m_data->canCreateStackingContext(); }
+    bool canCreateStackingContext(WillChangeAnimatableFeature::AllowsZIndex allowsZIndex) const { return m_data->canCreateStackingContext(allowsZIndex); }
     bool canBeBackdropRoot() const { return m_data->canBeBackdropRoot(); }
     bool canTriggerCompositing() const { return m_data->canTriggerCompositing(); }
     bool canTriggerCompositingOnInline() const { return m_data->canTriggerCompositingOnInline(); }
@@ -170,7 +172,7 @@ private:
         bool createsContainingBlockForAbsolutelyPositioned(bool isRootElement) const;
         bool createsContainingBlockForOutOfFlowPositioned(bool isRootElement) const;
         bool canBeBackdropRoot() const;
-        bool canCreateStackingContext() const { return m_canCreateStackingContext; }
+        bool canCreateStackingContext(WillChangeAnimatableFeature::AllowsZIndex) const;
         bool canTriggerCompositing() const { return m_canTriggerCompositing; }
         bool canTriggerCompositingOnInline() const { return m_canTriggerCompositingOnInline; }
 
@@ -192,7 +194,6 @@ private:
 
         void initializeCachedChecks();
 
-        bool m_canCreateStackingContext { false };
         bool m_canTriggerCompositing { false };
         bool m_canTriggerCompositingOnInline { false };
     };
@@ -237,7 +238,7 @@ struct WillChange {
     bool containsProperty(CSSPropertyID property) const { return m_data && m_data->containsProperty(property); }
     bool createsContainingBlockForAbsolutelyPositioned(bool isRootElement) const { return m_data && m_data->createsContainingBlockForAbsolutelyPositioned(isRootElement); }
     bool createsContainingBlockForOutOfFlowPositioned(bool isRootElement) const { return m_data && m_data->createsContainingBlockForOutOfFlowPositioned(isRootElement); }
-    bool canCreateStackingContext() const { return m_data && m_data->canCreateStackingContext(); }
+    bool canCreateStackingContext(WillChangeAnimatableFeature::AllowsZIndex allowsZIndex) const { return m_data && m_data->canCreateStackingContext(allowsZIndex); }
     bool canBeBackdropRoot() const { return m_data && m_data->canBeBackdropRoot(); }
     bool canTriggerCompositing() const { return m_data && m_data->canTriggerCompositing(); }
     bool canTriggerCompositingOnInline() const { return m_data && m_data->canTriggerCompositingOnInline(); }


### PR DESCRIPTION
#### a7355d53763086ca44775a726b5c5475d68c7afb
<pre>
Fix will-change: z-index creating stacking-context unconditionally
<a href="https://bugs.webkit.org/show_bug.cgi?id=311827">https://bugs.webkit.org/show_bug.cgi?id=311827</a>
<a href="https://rdar.apple.com/174187601">rdar://174187601</a>

Reviewed by NOBODY (OOPS!).

Stop creating a stacking context for will-change: z-index, in cases where z-index is ineffective.

* LayoutTests/TestExpectations:
* LayoutTests/compositing/repaint/compositing-toggle-in-overflow-scroll-repaint.html:
* LayoutTests/fast/css/will-change/will-change-creates-stacking-context-inline-expected.html:
* Source/WebCore/animation/KeyframeEffect.cpp:
(WebCore::KeyframeEffect::computeStackingContextImpact):
* Source/WebCore/rendering/RenderInline.cpp:
(WebCore::RenderInline::requiresLayer const):
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::canCreateStackingContext):
* Source/WebCore/style/StyleAdjuster.cpp:
(WebCore::Style::shouldTreatAutoZIndexAsZero):
(WebCore::Style::Adjuster::adjustFromBuilder):
(WebCore::Style::Adjuster::adjust const):
* Source/WebCore/style/values/will-change/StyleWillChange.cpp:
(WebCore::Style::WillChangeAnimatableFeature::propertyCreatesStackingContext):
(WebCore::Style::WillChangeAnimatableFeatures::Data::initializeCachedChecks):
(WebCore::Style::WillChangeAnimatableFeatures::Data::canCreateStackingContext const):
* Source/WebCore/style/values/will-change/StyleWillChange.h:
(WebCore::Style::WillChangeAnimatableFeatures::canCreateStackingContext const):
(WebCore::Style::WillChange::canCreateStackingContext const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a7355d53763086ca44775a726b5c5475d68c7afb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165003 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38494 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32071 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174045 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122259 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b6b8e7e3-e706-4acd-bbe3-df661f3aced0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166871 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38828 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38495 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128222 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90259 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b28de380-8a92-438f-9c46-839dbe0e601a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167962 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30545 "Found 1 new test failure: compositing/repaint/compositing-toggle-in-overflow-scroll-repaint.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148264 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108748 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f4a28bd4-6616-45c4-a7dc-766df8ea6158) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29580 "Exiting early after 10 failures. 13 tests run. 1 failures") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28193 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21800 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139475 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25966 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176568 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29421 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27670 "Found 1 new test failure: compositing/repaint/compositing-toggle-in-overflow-scroll-repaint.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136543 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38562 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32329 "Found 1 new test failure: compositing/repaint/compositing-toggle-in-overflow-scroll-repaint.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136488 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39252 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147762 "Exiting early after 10 failures. 26 tests run. 1 failures") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101551 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31762 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24627 "1 failures") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37762 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110833 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37159 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2703 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37405 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37303 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->