### PR TITLE
[check-webkit-style] Flag deprecated js-test-pre/post/post-async.js includes

### DIFF
--- a/LayoutTests/http/tests/resources/js-test-post-async.js
+++ b/LayoutTests/http/tests/resources/js-test-post-async.js
@@ -1,3 +1,7 @@
+// DEPRECATED: Do not include this file in new tests. Use js-test.js instead,
+// which combines the functionality of js-test-pre.js, js-test-post.js, and
+// js-test-post-async.js.
+
 if (!errorMessage)
     successfullyParsed = true;
 shouldBeTrue("successfullyParsed");

--- a/LayoutTests/http/tests/resources/js-test-post.js
+++ b/LayoutTests/http/tests/resources/js-test-post.js
@@ -1,3 +1,6 @@
+// DEPRECATED: Do not include this file in new tests. Use js-test.js instead,
+// which combines the functionality of js-test-pre.js and js-test-post.js.
+
 wasPostTestScriptParsed = true;
 
 if (window.jsTestIsAsync) {

--- a/LayoutTests/http/tests/resources/js-test-pre.js
+++ b/LayoutTests/http/tests/resources/js-test-pre.js
@@ -1,3 +1,6 @@
+// DEPRECATED: Do not include this file in new tests. Use js-test.js instead,
+// which combines the functionality of js-test-pre.js and js-test-post.js.
+
 // svg/dynamic-updates tests set enablePixelTesting=true, as we want to dump text + pixel results
 if (self.testRunner)
     testRunner.dumpAsText(self.enablePixelTesting);

--- a/LayoutTests/resources/js-test-post-async.js
+++ b/LayoutTests/resources/js-test-post-async.js
@@ -1,3 +1,7 @@
+// DEPRECATED: Do not include this file in new tests. Use js-test.js instead,
+// which combines the functionality of js-test-pre.js, js-test-post.js, and
+// js-test-post-async.js.
+
 if (!errorMessage)
     successfullyParsed = true;
 shouldBeTrue("successfullyParsed");

--- a/LayoutTests/resources/js-test-post.js
+++ b/LayoutTests/resources/js-test-post.js
@@ -1,3 +1,6 @@
+// DEPRECATED: Do not include this file in new tests. Use js-test.js instead,
+// which combines the functionality of js-test-pre.js and js-test-post.js.
+
 wasPostTestScriptParsed = true;
 
 if (window.jsTestIsAsync) {

--- a/LayoutTests/resources/js-test-pre.js
+++ b/LayoutTests/resources/js-test-pre.js
@@ -1,3 +1,6 @@
+// DEPRECATED: Do not include this file in new tests. Use js-test.js instead,
+// which combines the functionality of js-test-pre.js and js-test-post.js.
+
 // svg/dynamic-updates tests set enablePixelTesting=true, as we want to dump text + pixel results
 if (self.testRunner)
     testRunner.dumpAsText(self.enablePixelTesting);

--- a/Tools/Scripts/webkitpy/style/checker.py
+++ b/Tools/Scripts/webkitpy/style/checker.py
@@ -46,6 +46,7 @@ from webkitpy.style.checkers.contributors import ContributorsChecker
 from webkitpy.style.checkers.changelog import ChangeLogChecker
 from webkitpy.style.checkers.cpp import CppChecker
 from webkitpy.style.checkers.cmake import CMakeChecker
+from webkitpy.style.checkers.deprecated_js_test_includes import categories as DeprecatedJSTestIncludesCategories
 from webkitpy.style.checkers.featuredefines import FeatureDefinesChecker
 from webkitpy.style.checkers.js import JSChecker
 from webkitpy.style.checkers.jsonchecker import JSONChecker
@@ -657,6 +658,7 @@ def _all_categories():
     # Take the union across all checkers.
     categories = CommonCategories.union(CppChecker.categories)
     categories = categories.union(CMakeChecker.categories)
+    categories = categories.union(DeprecatedJSTestIncludesCategories)
     categories = categories.union(JSChecker.categories)
     categories = categories.union(JSONChecker.categories)
     categories = categories.union(JSTestChecker.categories)

--- a/Tools/Scripts/webkitpy/style/checkers/deprecated_js_test_includes.py
+++ b/Tools/Scripts/webkitpy/style/checkers/deprecated_js_test_includes.py
@@ -1,0 +1,65 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Flags <script src="..."> includes of the deprecated js-test-pre.js / js-test-post.js / js-test-post-async.js."""
+
+import re
+
+
+categories = {'build/deprecated/js-test-helpers'}
+
+
+class DeprecatedJSTestIncludesChecker(object):
+    """Forbids including the deprecated js-test-pre.js, js-test-post.js, and
+    js-test-post-async.js helpers.
+
+    LayoutTests authors should use js-test.js instead, which combines the
+    functionality of the old pre/post(/post-async) triad.
+    """
+
+    CATEGORY = 'build/deprecated/js-test-helpers'
+
+    # Matches <script ... src="...js-test-pre.js">, the js-test-post.js
+    # counterpart, and js-test-post-async.js, with either quote style and an
+    # optional query string. Listing post-async before post in the alternation
+    # ensures it wins the longest-match for post-async filenames.
+    _DEPRECATED_INCLUDE_RE = re.compile(
+        r'''<script\b[^>]*\bsrc\s*=\s*["'][^"']*\b(?P<filename>js-test-post-async\.js|js-test-pre\.js|js-test-post\.js)(?:\?[^"']*)?["']''',
+        re.IGNORECASE,
+    )
+
+    def __init__(self, handle_style_error):
+        self._handle_style_error = handle_style_error
+
+    def check(self, lines, line_numbers=None):
+        for line_number, line in enumerate(lines):
+            match = self._DEPRECATED_INCLUDE_RE.search(line)
+            if not match:
+                continue
+            deprecated = match.group('filename').lower()
+            self._handle_style_error(
+                line_number + 1,
+                self.CATEGORY,
+                5,
+                '{} is deprecated; include LayoutTests/resources/js-test.js instead.'.format(deprecated),
+            )

--- a/Tools/Scripts/webkitpy/style/checkers/deprecated_js_test_includes_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checkers/deprecated_js_test_includes_unittest.py
@@ -1,0 +1,140 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""Unit tests for deprecated_js_test_includes.py."""
+
+import unittest
+
+from webkitpy.style.checkers.deprecated_js_test_includes import DeprecatedJSTestIncludesChecker
+
+
+class DeprecatedJSTestIncludesCheckerTest(unittest.TestCase):
+
+    def _collect_errors(self, lines):
+        errors = []
+
+        def record(line_number, category, confidence, message):
+            errors.append((line_number, category, confidence, message))
+
+        checker = DeprecatedJSTestIncludesChecker(record)
+        checker.check(lines)
+        return errors
+
+    def assertError(self, lines, expected_line_number, expected_message_substring):
+        errors = self._collect_errors(lines)
+        self.assertEqual(1, len(errors), 'expected exactly one error, got: {}'.format(errors))
+        line_number, category, confidence, message = errors[0]
+        self.assertEqual(expected_line_number, line_number)
+        self.assertEqual('build/deprecated/js-test-helpers', category)
+        self.assertEqual(5, confidence)
+        self.assertIn(expected_message_substring, message)
+        self.assertIn('js-test.js', message)
+
+    def assertNoError(self, lines):
+        errors = self._collect_errors(lines)
+        self.assertEqual([], errors)
+
+    def test_flags_pre_include_relative(self):
+        self.assertError(
+            ['<script src="../../resources/js-test-pre.js"></script>'],
+            1,
+            'js-test-pre.js',
+        )
+
+    def test_flags_post_include_relative(self):
+        self.assertError(
+            ['<script src="../../resources/js-test-post.js"></script>'],
+            1,
+            'js-test-post.js',
+        )
+
+    def test_flags_absolute_http_path(self):
+        self.assertError(
+            ['<script src="/js-test-resources/js-test-pre.js"></script>'],
+            1,
+            'js-test-pre.js',
+        )
+
+    def test_flags_single_quoted_src(self):
+        self.assertError(
+            ["<script src='resources/js-test-pre.js'></script>"],
+            1,
+            'js-test-pre.js',
+        )
+
+    def test_flags_with_type_attribute(self):
+        self.assertError(
+            ['<script type="text/javascript" src="../../resources/js-test-pre.js"></script>'],
+            1,
+            'js-test-pre.js',
+        )
+
+    def test_flags_with_query_string(self):
+        self.assertError(
+            ['<script src="resources/js-test-pre.js?v=2"></script>'],
+            1,
+            'js-test-pre.js',
+        )
+
+    def test_reports_correct_line_number(self):
+        self.assertError(
+            [
+                '<html>',
+                '<head>',
+                '<script src="../../resources/js-test-post.js"></script>',
+                '</head>',
+            ],
+            3,
+            'js-test-post.js',
+        )
+
+    def test_does_not_flag_modern_js_test(self):
+        self.assertNoError(['<script src="../../resources/js-test.js"></script>'])
+
+    def test_flags_post_async(self):
+        self.assertError(
+            ['<script src="../../resources/js-test-post-async.js"></script>'],
+            1,
+            'js-test-post-async.js',
+        )
+
+    def test_does_not_flag_unrelated_script(self):
+        self.assertNoError(
+            ['<script src="../../resources/unrelated-helper.js"></script>'],
+        )
+
+    def test_does_not_flag_plain_filename_mention(self):
+        # Just referencing the filename in prose or expectations should not fire;
+        # the rule is about <script src=...> includes.
+        self.assertNoError(['This test once used js-test-pre.js as a helper.'])
+
+    def test_case_insensitive_tag(self):
+        self.assertError(
+            ['<SCRIPT SRC="../../resources/js-test-pre.js"></SCRIPT>'],
+            1,
+            'js-test-pre.js',
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Tools/Scripts/webkitpy/style/checkers/text.py
+++ b/Tools/Scripts/webkitpy/style/checkers/text.py
@@ -30,6 +30,7 @@
 """Checks WebKit style for text files."""
 
 from webkitpy.style.checkers.common import TabChecker
+from webkitpy.style.checkers.deprecated_js_test_includes import DeprecatedJSTestIncludesChecker
 from webkitpy.style.checkers.inclusive_language import InclusiveLanguageChecker
 
 
@@ -42,7 +43,9 @@ class TextChecker(object):
         self.handle_style_error = handle_style_error
         self._tab_checker = TabChecker(file_path, handle_style_error)
         self._inclusive_language_checker = InclusiveLanguageChecker(handle_style_error)
+        self._deprecated_js_test_includes_checker = DeprecatedJSTestIncludesChecker(handle_style_error)
 
     def check(self, lines, line_numbers=None):
         self._tab_checker.check(lines)
         self._inclusive_language_checker.check(lines)
+        self._deprecated_js_test_includes_checker.check(lines)


### PR DESCRIPTION
#### ea89893f4a43fa2af08eccc6952ab51ece8afae8
<pre>
[check-webkit-style] Flag deprecated js-test-pre/post/post-async.js includes
<a href="https://bugs.webkit.org/show_bug.cgi?id=314676">https://bugs.webkit.org/show_bug.cgi?id=314676</a>
<a href="https://rdar.apple.com/176924986">rdar://176924986</a>

Reviewed by Tim Nguyen.

New tests should use LayoutTests/resources/js-test.js, which combines
the functionality of the old trio. For async tests, set
window.jsTestIsAsync = true and call finishJSTest() when done.

- Adds DeprecatedJSTestIncludesChecker, composed into TextChecker, with
  unit tests. Category build/deprecated/js-test-helpers, severity 5.
- Adds a // DEPRECATED: banner to the six resource files pointing
  authors at js-test.js. The LayoutTests/resources/ and
  http/tests/resources/ pairs remain byte-identical as JSTestChecker
  requires.

* LayoutTests/http/tests/resources/js-test-post-async.js:
* LayoutTests/http/tests/resources/js-test-post.js:
* LayoutTests/http/tests/resources/js-test-pre.js:
* LayoutTests/resources/js-test-post-async.js:
* LayoutTests/resources/js-test-post.js:
* LayoutTests/resources/js-test-pre.js:
* Tools/Scripts/webkitpy/style/checker.py:
(_all_categories):
* Tools/Scripts/webkitpy/style/checkers/deprecated_js_test_includes.py: Added.
(DeprecatedJSTestIncludesChecker):
* Tools/Scripts/webkitpy/style/checkers/deprecated_js_test_includes_unittest.py: Added.
(DeprecatedJSTestIncludesCheckerTest):
(DeprecatedJSTestIncludesCheckerTest._collect_errors):
(DeprecatedJSTestIncludesCheckerTest._collect_errors.record):
(DeprecatedJSTestIncludesCheckerTest.assertError):
(DeprecatedJSTestIncludesCheckerTest.assertNoError):
(DeprecatedJSTestIncludesCheckerTest.test_flags_pre_include_relative):
(DeprecatedJSTestIncludesCheckerTest.test_flags_post_include_relative):
(DeprecatedJSTestIncludesCheckerTest.test_flags_absolute_http_path):
(DeprecatedJSTestIncludesCheckerTest.test_flags_single_quoted_src):
(DeprecatedJSTestIncludesCheckerTest.test_flags_with_type_attribute):
(DeprecatedJSTestIncludesCheckerTest.test_flags_with_query_string):
(DeprecatedJSTestIncludesCheckerTest.test_reports_correct_line_number):
(DeprecatedJSTestIncludesCheckerTest.test_does_not_flag_modern_js_test):
(DeprecatedJSTestIncludesCheckerTest.test_flags_post_async):
(DeprecatedJSTestIncludesCheckerTest.test_does_not_flag_unrelated_script):
(DeprecatedJSTestIncludesCheckerTest.test_does_not_flag_plain_filename_mention):
(DeprecatedJSTestIncludesCheckerTest.test_case_insensitive_tag):
* Tools/Scripts/webkitpy/style/checkers/text.py:
(TextChecker.__init__):
(TextChecker.check):

Canonical link: <a href="https://commits.webkit.org/313204@main">https://commits.webkit.org/313204@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eed4407a1b9a5631836eaabe0010b09ece616d89

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162156 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35632 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28746 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171064 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118529 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164025 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35736 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35633 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125846 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88707 "1 flakes 17 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165115 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28172 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145660 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106424 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/161476 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27219 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25737 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18785 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136919 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23401 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173558 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25044 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134145 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35306 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29824 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134146 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36262 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35289 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145197 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97492 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28682 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22025 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34799 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34300 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34545 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34448 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->