### PR TITLE
Clean up standalone libpas tests on linux

### DIFF
--- a/Source/bmalloc/libpas/CMakeLists.txt
+++ b/Source/bmalloc/libpas/CMakeLists.txt
@@ -15,6 +15,34 @@ AUX_SOURCE_DIRECTORY( "src/test"         testSources     )
 AUX_SOURCE_DIRECTORY( "src/toys"         toysSources     )
 AUX_SOURCE_DIRECTORY( "src/verifier"     verifierSources )
 
+# These .c files use compound-literal field access in file-scope
+# initializers, which is a clang-only C extension.
+# See Source/bmalloc/CMakeLists.txt which does this too.
+set_source_files_properties(
+    src/libpas/bmalloc_heap.c
+    src/libpas/bmalloc_heap_config.c
+    src/libpas/bmalloc_heap_flex.c
+    src/libpas/bmalloc_heap_iso.c
+    src/libpas/bmalloc_heap_utils.c
+    src/libpas/hotbit_heap.c
+    src/libpas/hotbit_heap_config.c
+    src/libpas/iso_heap.c
+    src/libpas/iso_heap_config.c
+    src/libpas/iso_test_heap.c
+    src/libpas/iso_test_heap_config.c
+    src/libpas/jit_heap.c
+    src/libpas/minalign32_heap.c
+    src/libpas/minalign32_heap_config.c
+    src/libpas/pagesize64k_heap.c
+    src/libpas/pagesize64k_heap_config.c
+    src/libpas/pas_bitfit_page_config_kind.c
+    src/libpas/pas_heap_config_kind.c
+    src/libpas/pas_segregated_page_config_kind.c
+    src/libpas/thingy_heap.c
+    src/libpas/thingy_heap_config.c
+    PROPERTIES LANGUAGE CXX
+)
+
 # Directories
 include_directories(    ${CMAKE_SOURCE_DIR}/src/libpas 
                         ${CMAKE_SOURCE_DIR}/src/verifier
@@ -29,6 +57,13 @@ link_directories(       ${CMAKE_SOURCE_DIR}/src/libpas
                         ${CMAKE_SOURCE_DIR}/src/toys
                         ${CMAKE_SOURCE_DIR}/src/test
                         ${CMAKE_SOURCE_DIR}/src/mbmalloc )
+
+# GCC on x86_64 emits library calls (e.g. __atomic_store_16) for 128-bit
+# atomics rather than inlining them; clang inlines them directly. Link
+# libatomic so these symbols resolve when building with gcc.
+if (CMAKE_C_COMPILER_ID STREQUAL "GNU")
+    link_libraries(atomic)
+endif ()
 
 # Create libraries
 add_library(pas_lib                                 SHARED ${libpasSources})

--- a/Source/bmalloc/libpas/src/test/IsoHeapPageSharingTests.cpp
+++ b/Source/bmalloc/libpas/src/test/IsoHeapPageSharingTests.cpp
@@ -4428,9 +4428,10 @@ void addAllTests()
         ADD_TEST(testFullVdirToVdirNewLateAllocation());
         ADD_TEST(testFullVdirToVdirNewDirAllocation());
         ADD_TEST(testFullVdirToVdirNewLateDirAllocation());
-        if (hasScope("combined_use_epoch"))
+        if (hasScope("combined_use_epoch")) {
             ADD_TEST(testFullVdirToVdirNewLargeAllocation());
-        ADD_TEST(testFullVdirToVdirNewLateLargeAllocation());
+            ADD_TEST(testFullVdirToVdirNewLateLargeAllocation());
+        }
         ADD_TEST(testFullVdirToDir());
         ADD_TEST(testFullVdirToDirBackwardsTarget());
         ADD_TEST(testFullVdirToDirBackwardsSource());
@@ -4438,11 +4439,11 @@ void addAllTests()
         ADD_TEST(testFullVdirToDirNewLateAllocation());
         ADD_TEST(testFullVdirToDirNewDirAllocation());
         ADD_TEST(testFullVdirToDirNewLateDirAllocation());
-        if (hasScope("combined_use_epoch"))
+        if (hasScope("combined_use_epoch")) {
             ADD_TEST(testFullVdirToDirNewLargeAllocation());
-        else
+            ADD_TEST(testFullVdirToDirNewLateLargeAllocation());
+        } else
             ADD_TEST(testFullNotVdirButLargeToDirNewLargeAllocation());
-        ADD_TEST(testFullVdirToDirNewLateLargeAllocation());
         ADD_TEST(testFullVdirToDirNewAllocationAlsoPhysical());
         ADD_TEST(testFullVdirToDirNewLateAllocationAlsoPhysical());
         ADD_TEST(testFullVdirToLarge());

--- a/Source/bmalloc/libpas/src/test/ScavengerExternalWorkTests.cpp
+++ b/Source/bmalloc/libpas/src/test/ScavengerExternalWorkTests.cpp
@@ -63,32 +63,37 @@ inline void testForeignWorkCallbackInstallReleasesLockOnSaturation()
 
 inline void testCallbacksAreCalledWhenExpected(int scavenger_on_ms, int scavenger_off_ms)
 {
-    TestScope frequentScavenging(
-        "frequent-scavenging",
-        [] () {
-            pas_scavenger_period_in_milliseconds = 1.;
-            pas_scavenger_max_epoch_delta = -1ll * 1000ll * 1000ll;
-        });
+    std::atomic<int> counter { 0 };
+    CHECK(pas_scavenger_try_install_foreign_work_callback(incrementCounter, 1, &counter));
 
-    auto counter = 0;
-    [[maybe_unused]] void* counter_ptr = reinterpret_cast<void*>(&counter);
-    CHECK(pas_scavenger_try_install_foreign_work_callback(incrementCounter, 1, counter_ptr));
+    pas_scavenger_did_create_eligible();
+    pas_scavenger_notify_eligibility_if_needed();
 
     int prevCounterValue;
     {
-        SuspendScavengerScope suspendScavenger;
-        prevCounterValue = counter;
+        pas_scavenger_suspend();
+        prevCounterValue = counter.load();
 
         std::this_thread::sleep_for(std::chrono::milliseconds(scavenger_off_ms));
-        CHECK_EQUAL(counter, prevCounterValue);
+        CHECK_EQUAL(counter.load(), prevCounterValue);
+
+        pas_scavenger_resume();
     }
 
     std::this_thread::sleep_for(std::chrono::milliseconds(scavenger_on_ms));
-    CHECK_GREATER(counter, prevCounterValue);
+    CHECK_GREATER(counter.load(), prevCounterValue);
 }
 
 void addScavengerExternalWorkTests()
 {
-    ADD_TEST(testCallbacksAreCalledWhenExpected(50, 50));
+    {
+        TestScope frequentScavenging(
+            "frequent-scavenging",
+            [] () {
+                pas_scavenger_period_in_milliseconds = 1.;
+                pas_scavenger_max_epoch_delta = -1ll * 1000ll * 1000ll;
+            });
+        ADD_TEST(testCallbacksAreCalledWhenExpected(50, 50));
+    }
     ADD_TEST(testForeignWorkCallbackInstallReleasesLockOnSaturation());
 }

--- a/Source/bmalloc/libpas/src/test/TLCDecommitTests.cpp
+++ b/Source/bmalloc/libpas/src/test/TLCDecommitTests.cpp
@@ -56,12 +56,28 @@ size_t numCommittedPagesInTLC()
         &allocationConfig);
 }
 
+struct ExpectedPages {
+    unsigned at4KiBPages;
+    unsigned at16KiBPages;
+
+    unsigned forThisSystem() const
+    {
+        size_t pageSize = pas_page_malloc_alignment();
+        if (pageSize == 4096)
+            return at4KiBPages;
+        if (pageSize == 16384)
+            return at16KiBPages;
+        PAS_ASSERT(!"unsupported native page size for TLCDecommitTests; add a calibration");
+        return 0;
+    }
+};
+
 void testTLCDecommit(unsigned numHeaps,
                      function<bool(unsigned)> shouldStopAllocatorAtIndex,
                      bool commitWithFree,
-                     unsigned numCommittedPagesInitially,
-                     unsigned numCommittedPagesAfterDecommit,
-                     unsigned numCommittedPagesAfterRecommit)
+                     ExpectedPages numCommittedPagesInitially,
+                     ExpectedPages numCommittedPagesAfterDecommit,
+                     ExpectedPages numCommittedPagesAfterRecommit)
 {
     pas_scavenger_suspend();
     pas_local_allocator_should_stop_count_for_suspend = 100; /* request_stop should not actually stop. */
@@ -134,7 +150,7 @@ void testTLCDecommit(unsigned numHeaps,
         CHECK(pas_bitvector_get(hasAllocator, index));
     }
 
-    CHECK_EQUAL(numCommittedPagesInTLC(), numCommittedPagesInitially);
+    CHECK_EQUAL(numCommittedPagesInTLC(), numCommittedPagesInitially.forThisSystem());
 
     pas_heap_lock_lock();
     cache = pas_thread_local_cache_try_get();
@@ -160,7 +176,7 @@ void testTLCDecommit(unsigned numHeaps,
                                    pas_deallocator_scavenge_no_action,
                                    pas_thread_local_cache_decommit_if_possible_action);
 
-    CHECK_EQUAL(numCommittedPagesInTLC(), numCommittedPagesAfterDecommit);
+    CHECK_EQUAL(numCommittedPagesInTLC(), numCommittedPagesAfterDecommit.forThisSystem());
 
     if (commitWithFree) {
         for (void* object : objects)
@@ -180,7 +196,7 @@ void testTLCDecommit(unsigned numHeaps,
             CHECK_EQUAL(ptr, objects[index]);
     }
 
-    CHECK_EQUAL(numCommittedPagesInTLC(), numCommittedPagesAfterRecommit);
+    CHECK_EQUAL(numCommittedPagesInTLC(), numCommittedPagesAfterRecommit.forThisSystem());
 }
 
 void testChaosThenDecommit(unsigned numHeaps, unsigned typeSize, unsigned maxObjectsAtATime,
@@ -445,22 +461,23 @@ void addTLCDecommitTests()
                     pas_heap_runtime_config_aggressive_view_cache_capacity;
             });
     
+        /* Calibrations: {4 KiB-page count, 16 KiB-page count}. */
         ADD_TEST(testTLCDecommit(10000, [] (unsigned index) { return index < 10000; }, false,
-                                 588, 300, 304));
+                                 { 2349, 588 }, { 1196, 300 }, { 1213, 304 }));
         ADD_TEST(testTLCDecommit(10000, [] (unsigned index) { return index < 10000; }, true,
-                                 588, 300, 304));
+                                 { 2349, 588 }, { 1196, 300 }, { 1213, 304 }));
         ADD_TEST(testTLCDecommit(10000, [] (unsigned index) { return index > 10000; }, false,
-                                 588, 6, 304));
+                                 { 2349, 588 }, { 20, 6 }, { 1214, 304 }));
         ADD_TEST(testTLCDecommit(10000, [] (unsigned index) { return index > 10000; }, true,
-                                 588, 6, 304));
+                                 { 2349, 588 }, { 20, 6 }, { 1214, 304 }));
         ADD_TEST(testTLCDecommit(10000, [] (unsigned index) { return index < 100000; }, false,
-                                 588, 256, 304));
+                                 { 2349, 588 }, { 1020, 256 }, { 1213, 304 }));
         ADD_TEST(testTLCDecommit(10000, [] (unsigned index) { return index < 100000; }, true,
-                                 588, 256, 304));
+                                 { 2349, 588 }, { 1020, 256 }, { 1213, 304 }));
         ADD_TEST(testTLCDecommit(10000, [] (unsigned index) { return index > 100000; }, false,
-                                 588, 50, 304));
+                                 { 2349, 588 }, { 196, 50 }, { 1214, 304 }));
         ADD_TEST(testTLCDecommit(10000, [] (unsigned index) { return index > 100000; }, true,
-                                 588, 50, 304));
+                                 { 2349, 588 }, { 196, 50 }, { 1214, 304 }));
         ADD_TEST(testChaosThenDecommit(10000, 16, 1000, 100, 400000000, 500000));
         ADD_TEST(testChaosThenDecommit(10000, 16, 1000, 10000, 400000000, 1000000));
         ADD_TEST(testChaosThenDecommit(10000, 512, 10, 50, 500000000, 3000000));


### PR DESCRIPTION
#### 6f76fffd6651eeffadfbea02024d1e8e9bec10a3
<pre>
Clean up standalone libpas tests on linux
<a href="https://bugs.webkit.org/show_bug.cgi?id=314677">https://bugs.webkit.org/show_bug.cgi?id=314677</a>

Reviewed by Yusuke Suzuki.

This fixes a gcc issue, a hang, and some failing tests on linux.

The remaining test failures should be fixed by my follow-up libpas
thread suspension patch.

Canonical link: <a href="https://commits.webkit.org/313163@main">https://commits.webkit.org/313163@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b856b82245266fd9e1a856070f3f3bd5c5603401

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162158 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35634 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28748 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171066 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118531 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35738 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35635 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125848 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88709 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165117 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28174 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145668 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106426 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27221 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25738 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18787 "Built successfully") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136921 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23407 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173560 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/22997 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25050 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134147 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35308 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29826 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134148 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36241 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35291 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145203 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97494 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28676 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22031 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194558 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34801 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50149 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34302 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34547 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34450 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->