### PR TITLE
[Site Isolation] Fix editing/selection/drag-in-iframe.html

### DIFF
--- a/LayoutTests/editing/selection/drag-in-iframe.html
+++ b/LayoutTests/editing/selection/drag-in-iframe.html
@@ -7,29 +7,29 @@
     <iframe id="subframe" style="border: 1px solid black;"
         src="data:text/html,<body contenteditable><span id='target'>There</span> should be a caret here --> <br>See it?</body>"></iframe>
     <script>
-        function dragAndDrop()
+        async function dragAndDrop()
         {
             var iframe = document.getElementById("subframe");
             var target = iframe.contentDocument.getElementById("target");
-        
+
             var x1 = iframe.offsetLeft + target.offsetLeft + target.offsetWidth / 2;
             var x2 = iframe.offsetLeft + iframe.offsetWidth - 20;
             var y = iframe.offsetTop + target.offsetTop + target.offsetHeight / 2;
 
             iframe.contentWindow.getSelection().setBaseAndExtent(target, 0, target, 1);
-        
-            eventSender.mouseMoveTo(x1, y);
+
             eventSender.dragMode = false;
-            eventSender.mouseDown();
+            await eventSender.asyncMouseMoveTo(x1, y);
+            await eventSender.asyncMouseDown();
             eventSender.leapForward(1000);
-            eventSender.mouseMoveTo(x2, y);
-        
+            await eventSender.asyncMouseMoveTo(x2, y);
+
             // Dump pixel results before we drop so we can see where the drag caret is painted.
+            // Do not mouseUp afterwards: under Site Isolation notifyDone is async, so a trailing
+            // mouseUp would complete the drop and mutate the DOM before the snapshot is captured.
             testRunner.notifyDone();
-        
-            eventSender.mouseUp();
         }
-        
+
         function test()
         {
             if (!window.testRunner)

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -117,7 +117,6 @@ imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across
 ########################
 accessibility/youtube-embed-accessibility-hierarchy.html [ Failure Timeout ]
 editing/execCommand/delete-no-scroll.html [ Failure ]
-editing/selection/drag-in-iframe.html [ Failure ]
 fast/canvas/webgl/canvas-webgl-page-cache.html [ Failure ]
 fast/events/event-timing-back-forward-cache-duration.html [ Failure ]
 fast/files/file-reader-back-forward-cache.html [ Failure ]


### PR DESCRIPTION
#### fdbdbe0f7a971edae8e1eff89ab31755fd29a768
<pre>
[Site Isolation] Fix editing/selection/drag-in-iframe.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=314678">https://bugs.webkit.org/show_bug.cgi?id=314678</a>
<a href="https://rdar.apple.com/176926106">rdar://176926106</a>

Reviewed by Sihui Liu.

The test wants to snapshot a drag mid-gesture: it calls notifyDone()
before the trailing mouseUp() so the dump captures the drag caret.
Without site isolation that works because notifyDone() is synchronous.
With site isolation it&apos;s async, so the mouseUp() runs first, the drop
completes, and the snapshot reflects post-drop DOM.

I switched the mouse calls to the async eventSender APIs and dropped
the trailing mouseUp() — it was only cleanup, and it&apos;s the actual
failure under site isolation. I also removed the now-passing
expectation.

* LayoutTests/editing/selection/drag-in-iframe.html:
* LayoutTests/platform/mac-site-isolation/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/313203@main">https://commits.webkit.org/313203@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3a27c0df786979d92e946ec131d9ec9ae13d5dfb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162160 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35636 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28750 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171068 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118533 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35740 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35637 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125850 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88712 "Exiting early after 60 failures. 187 tests run.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165119 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28175 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145670 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106428 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27222 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25741 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18789 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136922 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23409 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173562 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25052 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134148 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35310 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29829 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134149 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36261 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35293 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145205 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97496 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28680 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22033 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34803 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34304 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34549 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34452 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->