### PR TITLE
Clearing the Console tab search field does not dismiss the Clear Filters button

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Views/LogContentView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/LogContentView.js
@@ -257,7 +257,7 @@ WI.LogContentView = class LogContentView extends WI.ContentView
 
         if (this._isMessageFilteredOut(messageView.element)) {
             this._immediatelyHiddenMessages.add(messageView);
-            this._showHiddenMessagesBannerIfNeeded();
+            this._updateHiddenMessagesBanner();
         }
 
         this._lastMessageView = messageView;
@@ -531,7 +531,7 @@ WI.LogContentView = class LogContentView extends WI.ContentView
             this._immediatelyHiddenMessages.add(this._lastMessageView);
         }
 
-        this._showHiddenMessagesBannerIfNeeded();
+        this._updateHiddenMessagesBanner();
     }
 
     _handleContextMenuEvent(event)
@@ -887,7 +887,7 @@ WI.LogContentView = class LogContentView extends WI.ContentView
         if (this._currentSearchQuery)
             this.performSearch(this._currentSearchQuery);
 
-        this._showHiddenMessagesBannerIfNeeded();
+        this._updateHiddenMessagesBanner();
 
         this._scopesWithMessages.clear();
         this._showOrHideConditionallyVisibleScopeBarItemsAsNeeded();
@@ -932,15 +932,12 @@ WI.LogContentView = class LogContentView extends WI.ContentView
     _messageSourceBarSelectionDidChange(event)
     {
         this._filterMessageElements(this._allMessageElements());
-
-        this._showHiddenMessagesBannerIfNeeded();
     }
 
     _scopeBarSelectionDidChange(event)
     {
         this._filterMessageElements(this._allMessageElements());
 
-        this._showHiddenMessagesBannerIfNeeded();
         this._showOrHideConditionallyVisibleScopeBarItemsAsNeeded();
     }
 
@@ -956,7 +953,6 @@ WI.LogContentView = class LogContentView extends WI.ContentView
             let classList = messageElement.classList;
             if (visible) {
                 classList.remove(WI.LogContentView.FilteredOutStyleClassName);
-                this._immediatelyHiddenMessages.delete(messageElement.__messageView);
             } else {
                 this._selectedMessages.remove(messageElement);
                 classList.remove(WI.LogContentView.SelectedStyleClassName);
@@ -1198,6 +1194,7 @@ WI.LogContentView = class LogContentView extends WI.ContentView
         if (this._currentSearchQuery === "") {
             this.element.classList.remove(WI.LogContentView.SearchInProgressStyleClassName);
             this.dispatchEventToListeners(WI.ContentView.Event.NumberOfSearchResultsDidChange);
+            this._updateHiddenMessagesBanner();
             return;
         }
 
@@ -1206,6 +1203,7 @@ WI.LogContentView = class LogContentView extends WI.ContentView
             this._findBanner.numberOfResults = 0;
             this.element.classList.remove(WI.LogContentView.SearchInProgressStyleClassName);
             this.dispatchEventToListeners(WI.ContentView.Event.NumberOfSearchResultsDidChange);
+            this._updateHiddenMessagesBanner();
             return;
         }
 
@@ -1239,6 +1237,8 @@ WI.LogContentView = class LogContentView extends WI.ContentView
             this._selectedSearchMatch.highlight.classList.remove(WI.LogContentView.SelectedStyleClassName);
             this._selectedSearchMatch = null;
         }
+
+        this._updateHiddenMessagesBanner();
     }
 
     searchHidden()
@@ -1315,8 +1315,12 @@ WI.LogContentView = class LogContentView extends WI.ContentView
         this._provisionalMessages = [];
     }
 
-    _showHiddenMessagesBannerIfNeeded()
+    _updateHiddenMessagesBanner()
     {
+        for (let messageView of this._immediatelyHiddenMessages)
+            if (!this._isMessageFilteredOut(messageView.element))
+                this._immediatelyHiddenMessages.delete(messageView);
+
         if (!this._immediatelyHiddenMessages.size) {
             if (this._hiddenMessagesBannerElement)
                 this._hiddenMessagesBannerElement.remove();


### PR DESCRIPTION
#### 66231fea23d9ec5263451b700d4b3f31ddaad358
<pre>
Clearing the Console tab search field does not dismiss the Clear Filters button
<a href="https://bugs.webkit.org/show_bug.cgi?id=314204">https://bugs.webkit.org/show_bug.cgi?id=314204</a>
<a href="https://rdar.apple.com/176388155">rdar://176388155</a>

Reviewed by BJ Burg and Devin Rousso.

The banner (&quot;There are unread messages that have been filtered&quot;) stuck around
after clearing the search field because performSearch(&quot;&quot;) never touched
_immediatelyHiddenMessages.

We introduce _updateHiddenMessagesBanner() to centralize banner management.
It reconciles the Set against the current filter state before refreshing the
banner, so each call site doesn&apos;t have to do its own manual cleanup.

Hook it into all three performSearch exit paths (empty query, invalid regex,
valid regex) — all three can change filter state but none of them updated the
Set. The empty-query path is the bug.

The old inline _immediatelyHiddenMessages.delete() in _filterMessageElements
only checked scope visibility, not search, so a message still hidden by search
would drop out of the Set and hide the banner prematurely. The new method
handles removal and checks both dimensions.

Also, drop the now-redundant banner calls in _scopeBarSelectionDidChange and
_messageSourceBarSelectionDidChange, since _filterMessageElements already
calls performSearch which now reconciles.

* Source/WebInspectorUI/UserInterface/Views/LogContentView.js:
(WI.LogContentView.prototype.didAppendConsoleMessageView):
(WI.LogContentView.prototype._previousMessageRepeatCountUpdated):
(WI.LogContentView.prototype._logCleared):
(WI.LogContentView.prototype._messageSourceBarSelectionDidChange):
(WI.LogContentView.prototype._scopeBarSelectionDidChange):
(WI.LogContentView.prototype._filterMessageElements):
(WI.LogContentView.prototype.performSearch):
(WI.LogContentView.prototype._updateHiddenMessagesBanner):
(WI.LogContentView.prototype._showHiddenMessagesBannerIfNeeded): Deleted.

Canonical link: <a href="https://commits.webkit.org/313599@main">https://commits.webkit.org/313599@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e509631b799af46f63650099c7edb3d4bdbd4b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163543 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37027 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30246 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172483 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119992 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c8b80d30-d911-4221-9830-029c52949097) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37358 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37026 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127023 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89551 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/42a54083-5f4d-4c37-ad9c-2d847fe8e7ae) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166502 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29293 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147022 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107577 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e087566c-2ff3-4066-a2f5-ed3a3b96f3f9) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28342 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26973 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20186 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138240 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24741 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174988 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27919 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26404 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135326 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36697 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31075 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135308 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36477 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37482 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146536 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99535 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30613 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23388 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36192 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109338 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35690 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1413 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35940 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35837 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->