### PR TITLE
Iframes with composited layers are pixelated when zooming using CSS zoom

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom-and-transformed-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom-and-transformed-ref.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+
+<style>
+#iframe {
+  border: none;
+  width: calc(128px * 4);
+  height: calc(64px * 4);
+}
+</style>
+
+<p>Text passes if the border around the pink box appears sharp, and the iframes do not scroll.</p>
+<iframe id="iframe" src="resources/leaf.html?scale=4"></iframe>
+<iframe id="iframe" src="resources/leaf.html?scale=4"></iframe>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom-and-transformed.sub-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom-and-transformed.sub-expected.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+
+<style>
+#iframe {
+  border: none;
+  width: calc(128px * 4);
+  height: calc(64px * 4);
+}
+</style>
+
+<p>Text passes if the border around the pink box appears sharp, and the iframes do not scroll.</p>
+<iframe id="iframe" src="resources/leaf.html?scale=4"></iframe>
+<iframe id="iframe" src="resources/leaf.html?scale=4"></iframe>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom-and-transformed.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom-and-transformed.sub.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+
+<title>iframe in an element with CSS zoom and transformed (to trigger composited layer)</title>
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+<link rel="match" href="iframe-zoom-and-transformed-ref.html">
+
+<style>
+.iframe {
+  border: none;
+  width: 128px;
+  height: 64px;
+  transform: translateZ(0);
+  zoom: 4;
+}
+</style>
+
+<p>Text passes if the border around the pink box appears sharp, and the iframes do not scroll.</p>
+<iframe class="iframe" src="resources/leaf.html"></iframe>
+<iframe class="iframe" src="http://{{hosts[alt][]}}:{{ports[http][0]}}/css/css-viewport/zoom/resources/leaf.html"></iframe>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom.sub.html
@@ -22,5 +22,5 @@ iframe {
 </style>
 
 <iframe id="baseline" src="resources/leaf.html"></iframe>
-<iframe id="zoom-same-origin" class="zoom" src="resources/leaf.html" scrolling="no"></iframe>
-<iframe id="zoom-cross-origin" class="zoom" src="http://{{hosts[alt][]}}:{{ports[http][0]}}/css/css-viewport/zoom/resources/leaf.html" scrolling="no"></iframe>
+<iframe id="zoom-same-origin" class="zoom" src="resources/leaf.html"></iframe>
+<iframe id="zoom-cross-origin" class="zoom" src="http://{{hosts[alt][]}}:{{ports[http][0]}}/css/css-viewport/zoom/resources/leaf.html"></iframe>

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -427,7 +427,6 @@ imported/w3c/web-platform-tests/css/css-fonts/font-colorization.html [ ImageOnly
 imported/w3c/web-platform-tests/css/css-position/position-absolute-iframe-print-002.sub.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/rotated-cat-off-top-edge.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom-nested.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom.sub.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-writing-modes/bidi-unset-009.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/browsers/windows/iframe-cross-origin-scaled-print.sub.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/html/canvas/element/manual/unclosed-canvas-2.htm [ ImageOnlyFailure ]

--- a/Source/WebCore/style/StyleResolveForDocument.cpp
+++ b/Source/WebCore/style/StyleResolveForDocument.cpp
@@ -61,11 +61,16 @@ RenderStyle resolveForDocument(const Document& document)
 
     documentStyle.setDisplay(DisplayType::BlockFlow);
     documentStyle.setRTLOrdering(document.visuallyOrdered() ? WebCore::Order::Visual : WebCore::Order::Logical);
-    documentStyle.setZoom(!document.printing() ? renderView->frame().pageZoomFactor() : 1);
-    if (auto frameScaleFactor = protect(renderView->frame())->frameScaleFactor(); frameScaleFactor != 1) {
-        documentStyle.setTransform(Style::Transform { Style::TransformFunction { Style::ScaleTransformFunction::create(frameScaleFactor, frameScaleFactor, Style::TransformFunctionType::Scale) } });
-        documentStyle.setTransformOrigin(Style::TransformOrigin { 0_css_px, 0_css_px, 0_css_px });
-    }
+
+    float zoomLevel = [&] () {
+        if (document.printing())
+            return 1.0f;
+
+        Ref localFrame = renderView->frame();
+        return localFrame->pageZoomFactor() * localFrame->frameScaleFactor();
+    }();
+
+    documentStyle.setZoom(zoomLevel);
 
     // This overrides any -webkit-user-modify inherited from the parent iframe.
     documentStyle.setUserModify(document.inDesignMode() ? UserModify::ReadWrite : UserModify::ReadOnly);


### PR DESCRIPTION
#### 19ec7b336f467c9b783d782cc89141f536baac3d
<pre>
Iframes with composited layers are pixelated when zooming using CSS zoom
<a href="https://rdar.apple.com/168248177">rdar://168248177</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=305594">https://bugs.webkit.org/show_bug.cgi?id=305594</a>

Reviewed by NOBODY (OOPS!).

When an iframe has CSS zoom applied on it, this is reflected in Frame::frameScaleFactor
of the iframe. The frame scale factor then gets applied on the iframe&apos;s Document as a
scale transform. When the frame is rendered in a composited layer, the iframe is rendererd
in its original (non-zoomed) size in the layer, then scaled up by the transform.
This makes the iframe appear blurry, as the iframe is not rendered natively at the
zoomed resolution. Fix this by applying frame scale factor using the Document&apos;s zoom instead.
Frame::frameScaleFactor is SI-safe, so this should work in both SI-enabled and disabled.

Tests: imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom.sub.html
       imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom-and-transformed.sub.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom-and-transformed-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom-and-transformed.sub-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom-and-transformed.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom.sub.html:
    - Remove scrolling=&quot;no&quot; on the iframes. This was added in <a href="https://commits.webkit.org/302097@main">302097@main</a>, but it
      inadvertently hides this bug, as scrolling=&quot;no&quot; iframes don&apos;t get composited.
* LayoutTests/platform/mac-site-isolation/TestExpectations:
* Source/WebCore/style/StyleResolveForDocument.cpp:
(WebCore::Style::resolveForDocument):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19ec7b336f467c9b783d782cc89141f536baac3d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162170 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35646 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28760 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171078 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118543 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/78b99a36-7739-46bd-aef4-eeeed9bc9968) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164039 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35750 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35647 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125859 "Found 26 new test failures: compositing/fixed-with-fixed-layout.html compositing/layer-creation/zoomed-clip-intersection.html compositing/repaint/page-scale-repaint.html fast/dom/Element/scale-page-bounding-client-rect-in-frame.html fast/dom/Element/scale-page-client-rects-in-frame.html fast/dom/iframe-inner-size-scaling.html fast/dom/window-scroll-scaling.html fast/frames/frame-set-rotation-hit.html fast/frames/frame-set-scaling-hit.html fast/repaint/background-scaling.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88720 "1 flakes 32 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/243ee599-4a64-4242-a8f9-1b21a28939c6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165129 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28184 "3 new passes 6 flakes 3 failures") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145666 "Found 4 new API test failures: TestWebKitAPI.CSSViewportUnits.MinimumViewportInsetWithZoom, TestWebKitAPI.CSSViewportUnits.MaximumViewportInsetWithZoom, TestWebKitAPI.CSSViewportUnits.SVGDocument, TestWebKitAPI.CSSViewportUnits.AllSame (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106437 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/90eddf1d-422b-4f1f-aa88-0b0d1ed7c6d5) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27231 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom-and-transformed.sub.html (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25749 "Found 4 new API test failures: TestWebKitAPI.CSSViewportUnits.MinimumViewportInsetWithZoom, TestWebKitAPI.CSSViewportUnits.AllSame, TestWebKitAPI.CSSViewportUnits.MaximumViewportInsetWithZoom, TestWebKitAPI.CSSViewportUnits.SVGDocument (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18799 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136932 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23405 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173572 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20925 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25048 "Found 41 new test failures: compositing/canvas/hidpi-canvas-backing-store-invalidation-2.html compositing/fixed-with-fixed-layout.html compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport.html compositing/layer-creation/zoomed-clip-intersection.html compositing/repaint/page-scale-repaint.html compositing/tiling/tile-cache-zoomed.html fast/dom/Element/scale-page-bounding-client-rect-in-frame.html fast/dom/Element/scale-page-client-rects-in-frame.html fast/dom/iframe-inner-size-scaling.html fast/dom/window-scroll-scaling.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134157 "Found 25 new test failures: compositing/fixed-with-fixed-layout.html compositing/layer-creation/zoomed-clip-intersection.html compositing/repaint/page-scale-repaint.html fast/dom/Element/scale-page-bounding-client-rect-in-frame.html fast/dom/Element/scale-page-client-rects-in-frame.html fast/dom/iframe-inner-size-scaling.html fast/dom/window-scroll-scaling.html fast/frames/frame-set-rotation-hit.html fast/frames/frame-set-scaling-hit.html fast/repaint/background-scaling.html ... (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35320 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29837 "Found 40 new test failures: compositing/canvas/hidpi-canvas-backing-store-invalidation-2.html compositing/fixed-with-fixed-layout.html compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport.html compositing/layer-creation/zoomed-clip-intersection.html compositing/repaint/page-scale-repaint.html compositing/tiling/tile-cache-zoomed.html fast/dom/Element/scale-page-bounding-client-rect-in-frame.html fast/dom/Element/scale-page-client-rects-in-frame.html fast/dom/iframe-inner-size-scaling.html fast/dom/window-scroll-scaling.html ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134158 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35303 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145201 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97506 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28688 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22029 "Found 41 new test failures: compositing/canvas/hidpi-canvas-backing-store-invalidation-2.html compositing/fixed-with-fixed-layout.html compositing/geometry/fixed-position-composited-page-scale-smaller-than-viewport.html compositing/layer-creation/zoomed-clip-intersection.html compositing/repaint/page-scale-repaint.html compositing/tiling/tile-cache-zoomed.html fast/dom/Element/scale-page-bounding-client-rect-in-frame.html fast/dom/Element/scale-page-client-rects-in-frame.html fast/dom/iframe-inner-size-scaling.html fast/dom/window-scroll-scaling.html ... (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34813 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102565 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34314 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34559 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34462 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->