### PR TITLE
Add logging for unfilled frames during scrolling on iOS

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeScrollingPerformanceData.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeScrollingPerformanceData.h
@@ -73,9 +73,7 @@ private:
 
     const CheckedRef<RemoteLayerTreeDrawingAreaProxy> m_drawingArea;
     Vector<ScrollingLogEvent> m_events;
-#if PLATFORM(MAC)
-    uint64_t m_lastUnfilledArea;
-#endif
+    uint64_t m_lastUnfilledArea { 0 };
 };
 
 }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeScrollingPerformanceData.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeScrollingPerformanceData.mm
@@ -35,6 +35,10 @@
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
+#if PLATFORM(IOS_FAMILY)
+#import <UIKit/UIKit.h>
+#endif
+
 namespace WebKit {
 using namespace WebCore;
 
@@ -57,12 +61,10 @@ void RemoteLayerTreeScrollingPerformanceData::didCommitLayerTree(const FloatRect
 void RemoteLayerTreeScrollingPerformanceData::didScroll(const FloatRect& visibleRect)
 {
     auto pixelCount = blankPixelCount(visibleRect);
-#if PLATFORM(MAC)
     if (pixelCount || m_lastUnfilledArea)
         m_lastUnfilledArea = pixelCount;
     else
         return;
-#endif
     appendBlankPixelCount(ScrollingLogEvent::Exposed, pixelCount);
     logData();
 }
@@ -117,6 +119,15 @@ static CALayer *findTileGridContainerLayer(CALayer *layer)
             return foundLayer.autorelease();
     }
 
+#if PLATFORM(IOS_FAMILY)
+    if (auto *view = dynamic_objc_cast<UIView>(layer.delegate)) {
+        for (UIView *subview in view.subviews) {
+            if (RetainPtr foundLayer = findTileGridContainerLayer(subview.layer))
+                return foundLayer.autorelease();
+        }
+    }
+#endif
+
     return nil;
 }
 
@@ -137,6 +148,8 @@ unsigned RemoteLayerTreeScrollingPerformanceData::blankPixelCount(const FloatRec
     Region paintedVisibleTileRegion;
 
     for (CALayer *tileLayer : [tileGridContainer sublayers]) {
+        if (!tileLayer.contents)
+            continue;
         FloatRect tileRect = [tileLayer convertRect:[tileLayer bounds] toLayer:tileGridContainer.get()];
     
         tileRect.intersect(visibleRectExcludingToolbar);
@@ -153,7 +166,6 @@ unsigned RemoteLayerTreeScrollingPerformanceData::blankPixelCount(const FloatRec
 
 void RemoteLayerTreeScrollingPerformanceData::logData()
 {
-#if PLATFORM(MAC)
     for (auto event : m_events) {
         switch (event.eventType) {
         case ScrollingLogEvent::SwitchedScrollingMode: {
@@ -176,7 +188,6 @@ void RemoteLayerTreeScrollingPerformanceData::logData()
         }
     }
     m_events.clear();
-#endif
 }
 
 }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.h
@@ -64,6 +64,8 @@ private:
 
     void didRefreshDisplay() override;
 
+    void didCommitLayerTree(IPC::Connection&, const RemoteLayerTreeTransaction&, const RemoteScrollingCoordinatorTransaction&, const std::optional<MainFrameData>&, const TransactionID&) override;
+
     void windowScreenDidChange(WebCore::PlatformDisplayID) override;
 
     std::optional<WebCore::FramesPerSecond> displayNominalFramesPerSecond() override;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm
@@ -30,6 +30,8 @@
 
 #import "CAFrameRateRangeUtilities.h"
 #import "PageClient.h"
+#import "RemoteLayerTreeCommitBundle.h"
+#import "RemoteLayerTreeScrollingPerformanceData.h"
 #import "RemoteScrollingCoordinatorProxyIOS.h"
 #import "WebPageProxy.h"
 #import "WebPreferences.h"
@@ -447,6 +449,26 @@ UIView *RemoteLayerTreeDrawingAreaProxyIOS::viewWithLayerIDForTesting(WebCore::P
     if (RefPtr node = m_remoteLayerTreeHost->nodeForID(layerID))
         return node->uiView();
     return nil;
+}
+
+void RemoteLayerTreeDrawingAreaProxyIOS::didCommitLayerTree(IPC::Connection&, const RemoteLayerTreeTransaction& transaction, const RemoteScrollingCoordinatorTransaction&, const std::optional<MainFrameData>& mainFrameData, const TransactionID&)
+{
+    if (!mainFrameData)
+        return;
+
+    RefPtr page = this->page();
+    if (!page)
+        return;
+
+    CheckedRef scrollingCoordinatorProxy = *page->scrollingCoordinatorProxy();
+    page->setScrollPerformanceDataCollectionEnabled(scrollingCoordinatorProxy->scrollingPerformanceTestingEnabled());
+
+    if (transaction.createdLayers().size() > 0) {
+        if (auto* scrollPerfData = page->scrollingPerformanceData()) {
+            auto visibleRect = WebCore::FloatRect(transaction.scrollPosition(), mainFrameData->baseLayoutViewportSize);
+            scrollPerfData->didCommitLayerTree(visibleRect);
+        }
+    }
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -12812,9 +12812,7 @@ void WebPageProxy::resetState(ResetStateReason resetStateReason)
 
 #if PLATFORM(COCOA)
     m_scrollingPerformanceData = nullptr;
-#if PLATFORM(MAC)
     m_scrollPerformanceDataCollectionEnabled = false;
-#endif
     internals().firstLayerTreeTransactionIdAfterDidCommitLoad = { };
 #endif
 


### PR DESCRIPTION
#### b302083b4f1df9c8607a593ca905e5a1378c7505
<pre>
Add logging for unfilled frames during scrolling on iOS

<a href="https://bugs.webkit.org/show_bug.cgi?id=314685">https://bugs.webkit.org/show_bug.cgi?id=314685</a>
&lt;<a href="https://rdar.apple.com/176928238">rdar://176928238</a>&gt;

Reviewed by Simon Fraser.

This commit adds logging for unfilled frames during scrolling on iOS. This is calculated from the pixel count of blank tiles in the visible viewport.

Canonical link: <a href="https://commits.webkit.org/313417@main">https://commits.webkit.org/313417@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1f5fc6110c2e5f8524285baceecc9f39e2bf14b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163096 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36575 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/29787 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172035 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119542 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36715 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36577 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/126619 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/89220 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166055 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/28832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/146606 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107194 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27879 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26556 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19734 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137762 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174538 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/26500 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/25983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/134931 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36246 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30659 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134926 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/36958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/146131 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/98863 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24806 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/36958 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/22971 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35742 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108098 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35241 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/990 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35488 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35389 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->