### PR TITLE
SVGGeometryElement.isPointInStroke() ignores 'vector-effect: non-scaling-stroke'

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.isPointInStroke-01-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.isPointInStroke-01-expected.txt
@@ -9,6 +9,6 @@ PASS SVGGeometryElement.prototype.isPointInStroke, 'stroke-miterlimit'.
 PASS SVGGeometryElement.prototype.isPointInStroke, 'stroke-linejoin'.
 PASS SVGGeometryElement.prototype.isPointInStroke, 'stroke-linecap'.
 PASS SVGGeometryElement.prototype.isPointInStroke, 'pathLength'.
-FAIL SVGGeometryElement.prototype.isPointInStroke, 'vector-effect'. assert_false: expected false got true
+PASS SVGGeometryElement.prototype.isPointInStroke, 'vector-effect'.
 PASS SVGGeometryElement.prototype.isPointInStroke, 'visibility' and 'pointer-events' have no effect.
 

--- a/LayoutTests/svg/dom/SVGGeometry-isPointInStroke-expected.txt
+++ b/LayoutTests/svg/dom/SVGGeometry-isPointInStroke-expected.txt
@@ -64,7 +64,7 @@ PASS p10.isPointInStroke({x: 20, y: 90}) is false
 
 Test non-scaling-stroke
 PASS p15.isPointInStroke({}) is true
-PASS p15.isPointInStroke({y: 1}) is true
+PASS p15.isPointInStroke({y: 1}) is false
 PASS p15.isPointInStroke({y: 11}) is false
 PASS successfullyParsed is true
 

--- a/LayoutTests/svg/dom/SVGGeometry-isPointInStroke.xhtml
+++ b/LayoutTests/svg/dom/SVGGeometry-isPointInStroke.xhtml
@@ -119,7 +119,7 @@ function run() {
     debug("");
     debug("Test non-scaling-stroke");
     shouldBe("p15.isPointInStroke({})", "true");
-    shouldBe("p15.isPointInStroke({y: 1})", "true");
+    shouldBe("p15.isPointInStroke({y: 1})", "false");
     shouldBe("p15.isPointInStroke({y: 11})", "false");
     finishJSTest();
 }

--- a/Source/WebCore/rendering/svg/RenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.cpp
@@ -276,6 +276,14 @@ bool RenderSVGShape::isPointInStroke(const FloatPoint& point)
     if (style().stroke().isNone())
         return false;
 
+    if (hasNonScalingStroke() && hasPath()) {
+        AffineTransform nonScalingTransform = nonScalingStrokeTransform();
+        auto& usePath = *nonScalingStrokePath(m_path.get(), nonScalingTransform);
+        return usePath.strokeContains(nonScalingTransform.mapPoint(point), [checkedThis = CheckedRef { *this }](GraphicsContext& context) {
+            SVGRenderSupport::applyStrokeStyleToContext(context, checkedThis->style(), checkedThis.get());
+        });
+    }
+
     return shapeDependentStrokeContains(point, LocalCoordinateSpace);
 }
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp
@@ -364,6 +364,14 @@ bool LegacyRenderSVGShape::isPointInStroke(const FloatPoint& point)
     if (style().stroke().isNone())
         return false;
 
+    if (hasNonScalingStroke() && hasPath()) {
+        AffineTransform nonScalingTransform = nonScalingStrokeTransform();
+        auto& usePath = *nonScalingStrokePath(m_path.get(), nonScalingTransform);
+        return usePath.strokeContains(nonScalingTransform.mapPoint(point), [checkedThis = CheckedRef { *this }](GraphicsContext& context) {
+            SVGRenderSupport::applyStrokeStyleToContext(context, checkedThis->style(), checkedThis.get());
+        });
+    }
+
     return shapeDependentStrokeContains(point, LocalCoordinateSpace);
 }
 


### PR DESCRIPTION
#### 662cd4ef59c3c0cd16b3036dc50ee9ec802973f7
<pre>
SVGGeometryElement.isPointInStroke() ignores &apos;vector-effect: non-scaling-stroke&apos;
<a href="https://bugs.webkit.org/show_bug.cgi?id=314689">https://bugs.webkit.org/show_bug.cgi?id=314689</a>
<a href="https://rdar.apple.com/176931749">rdar://176931749</a>

Reviewed by Rob Buis.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

LegacyRenderSVGShape::isPointInStroke() invoked shapeDependentStrokeContains()
with LocalCoordinateSpace, which is explicitly defined to skip the
non-scaling-stroke transform. As a result, stroke hit-testing used the
shape&apos;s local stroke-width instead of the effective (screen-space) stroke
width, producing &quot;true&quot; for points that lie outside a non-scaling stroke.

Handle non-scaling-stroke directly in isPointInStroke() by transforming
both the path and the test point by the non-scaling-stroke CTM, then
performing a path-based strokeContains() check. This also bypasses the
subclass fast paths in LegacyRenderSVGEllipse / LegacyRenderSVGRect, which
do not account for non-scaling-stroke. Shapes without non-scaling-stroke
continue to use the existing fast paths, so there is no performance impact
on regular hit-testing or on isPointInStroke() for scaling strokes.

NOTE: This patch fixes bug in both Legacy SVG and Layer Based SVG engines.

* LayoutTests/imported/w3c/web-platform-tests/svg/types/scripted/SVGGeometryElement.isPointInStroke-01-expected.txt: Progression
* LayoutTests/svg/dom/SVGGeometry-isPointInStroke.xhtml: Updated (match other browsers)
* LayoutTests/svg/dom/SVGGeometry-isPointInStroke-expected.txt: Rebaselined
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGShape.cpp:
(WebCore::LegacyRenderSVGShape::isPointInStroke):
* Source/WebCore/rendering/svg/RenderSVGShape.cpp:
(WebCore::RenderSVGShape::isPointInStroke):

Canonical link: <a href="https://commits.webkit.org/313967@main">https://commits.webkit.org/313967@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9c166adf86b1c17cdd4db575e6e0a7f522fda74

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163417 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36900 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30116 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172357 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119864 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165286 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37229 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36900 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126908 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89455 "layout-tests (failure)") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166376 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29178 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146904 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107466 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28235 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26854 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20059 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138119 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24627 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174861 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27514 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26283 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135210 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36570 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30954 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135196 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36702 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37355 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146422 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99311 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30502 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23267 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36066 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108958 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35563 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1292 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35811 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35711 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->