### PR TITLE
[Experiment] Use RenderStyle::defaultStyleSingleton() for media query evaluation

### DIFF
--- a/Source/WebCore/css/query/MediaQueryEvaluator.cpp
+++ b/Source/WebCore/css/query/MediaQueryEvaluator.cpp
@@ -25,13 +25,16 @@
 #include "config.h"
 #include "MediaQueryEvaluator.h"
 
+#include "CSSFontSelector.h"
 #include "CSSToLengthConversionData.h"
-#include "Document.h"
+#include "DocumentInlines.h"
 #include "DocumentView.h"
-#include "FontCascade.h"
+#include "FontCascadeInlines.h"
 #include "MediaQuery.h"
 #include "MediaQueryFeatures.h"
+#include "RenderStyle+GettersInlines.h"
 #include "RenderView.h"
+#include "Settings.h"
 #include "StyleFontSizeFunctions.h"
 
 namespace WebCore {
@@ -79,14 +82,40 @@ bool MediaQueryEvaluator::evaluate(const MediaQuery& query) const
         if (!document)
             return m_staticMediaConditionResult;
 
-        CheckedPtr rootElementStyle = m_rootElementStyle;
-        if (!rootElementStyle)
-            return m_staticMediaConditionResult;
+//        /* Former codepath */
+//        CheckedPtr rootElementStyle = m_rootElementStyle;
+//        if (!rootElementStyle)
+//            return m_staticMediaConditionResult;
 
         if (!document->view() || !document->documentElement())
             return EvaluationResult::Unknown;
 
-        FeatureEvaluationContext context { *document, { *rootElementStyle, rootElementStyle.get(), nullptr, document->renderView(), nullptr, CSS::RangeZoomOptions::Unzoomed }, nullptr };
+//        /* Attempt 1 */
+//        document->fontSelector().incrementIsComputingRootStyleFont();
+//        initialStyle.fontCascade().update(&document->fontSelector());
+//        initialStyle.fontCascade().primaryFont();
+//        document->fontSelector().decrementIsComputingRootStyleFont();
+
+//        /* Attempt 2 */
+//        auto& initialStyle = RenderStyle::defaultStyleSingleton();
+
+        /* Attempt 3 */
+        auto initialStyle = RenderStyle::create();
+
+        FontCascadeDescription fontDescription;
+        fontDescription.setOneFamily(WebCore::FontFamily { standardFamily, FontFamilyKind::Generic });
+        fontDescription.setKeywordSizeFromIdentifier(CSSValueMedium);
+
+        auto size = Style::fontSizeForKeyword(CSSValueMedium, false, *document);
+        fontDescription.setSpecifiedSize(size);
+        auto computedFontSize = Style::computedFontSizeFromSpecifiedSize(size, fontDescription.isAbsoluteSize(), false, initialStyle.computedStyle(), *document);
+        fontDescription.setComputedSize(computedFontSize.size, computedFontSize.usedZoomFactor);
+
+        fontDescription.setShouldAllowUserInstalledFonts(document->settings().shouldAllowUserInstalledFonts() ? AllowUserInstalledFonts::Yes : AllowUserInstalledFonts::No);
+        initialStyle.setFontDescription(WTF::move(fontDescription));
+
+
+        FeatureEvaluationContext context { *document, { initialStyle, &initialStyle, nullptr, document->renderView(), nullptr, CSS::RangeZoomOptions::Unzoomed }, nullptr };
         return evaluateCondition(*query.condition, context);
     }();
 


### PR DESCRIPTION
#### 23c68f095fb6aba02064befa442e26e4d429ef7b
<pre>
[Experiment] Use RenderStyle::defaultStyleSingleton() for media query evaluation
<a href="https://bugs.webkit.org/show_bug.cgi?id=314692">https://bugs.webkit.org/show_bug.cgi?id=314692</a>

Reviewed by NOBODY (OOPS!).

WIP. DO NOT REVIEW.

* Source/WebCore/css/MediaQueryMatcher.cpp:
(WebCore::MediaQueryMatcher::documentElementUserAgentStyle const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23c68f095fb6aba02064befa442e26e4d429ef7b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162215 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35691 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28807 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171123 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118588 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164084 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35795 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35692 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125892 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88748 "19 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165174 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28231 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145720 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106470 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27278 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25791 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18844 "Built successfully") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/136980 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23459 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173617 "Built successfully") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/20970 "Found 1 new failure in css/query/MediaQueryEvaluator.cpp") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25102 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134191 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35365 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29879 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134192 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35348 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145255 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97561 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28733 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22083 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34858 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102610 "Found 1 new failure in css/query/MediaQueryEvaluator.cpp") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34359 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34604 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34507 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->