### PR TITLE
REGRESSION(294844@main): platformConvertColorComponents creates a new CGColorTransform on every call

### DIFF
--- a/Source/WebCore/platform/graphics/cg/ColorCG.cpp
+++ b/Source/WebCore/platform/graphics/cg/ColorCG.cpp
@@ -28,6 +28,7 @@
 
 #if USE(CG)
 
+#include "ColorConversion.h"
 #include "ColorSpaceCG.h"
 #include "DestinationColorSpace.h"
 #include <mutex>
@@ -224,17 +225,41 @@ RetainPtr<CGColorRef> cachedCGColorInDestinationStandardRange(const Color& color
 
 ColorComponents<float, 4> platformConvertColorComponents(ColorSpace inputColorSpace, ColorComponents<float, 4> inputColorComponents, const DestinationColorSpace& outputColorSpace)
 {
-    // FIXME: Investigate optimizing this to use the builtin color conversion code for supported color spaces.
-
     auto [cgInputColorSpace, cgCompatibleComponents] = convertToCGCompatibleComponents(inputColorSpace, inputColorComponents);
     if (cgInputColorSpace == outputColorSpace.platformColorSpace())
         return cgCompatibleComponents;
 
+    // Fast path: use built-in conversion for well-known destination color spaces.
+    auto builtin = callWithColorType(inputColorComponents, inputColorSpace, [&](const auto& inputColor) -> std::optional<ColorComponents<float, 4>> {
+        if (outputColorSpace == DestinationColorSpace::SRGB())
+            return asColorComponents(convertColor<SRGBA<float>>(inputColor).resolved());
+        if (outputColorSpace == DestinationColorSpace::LinearSRGB())
+            return asColorComponents(convertColor<LinearSRGBA<float>>(inputColor).resolved());
+#if ENABLE(DESTINATION_COLOR_SPACE_DISPLAY_P3)
+        if (outputColorSpace == DestinationColorSpace::DisplayP3())
+            return asColorComponents(convertColor<DisplayP3<float>>(inputColor).resolved());
+        if (outputColorSpace == DestinationColorSpace::LinearDisplayP3())
+            return asColorComponents(convertColor<LinearDisplayP3<float>>(inputColor).resolved());
+#endif
+        return std::nullopt;
+    });
+    if (builtin)
+        return *builtin;
+
+    // Slow path: fall back to CoreGraphics caching the transform to avoid
+    // recreating the CGColorTransform on every call.
     auto [c1, c2, c3, c4] = cgCompatibleComponents;
     std::array<CGFloat, 4> sourceComponents { c1, c2, c3, c4 };
     std::array<CGFloat, 4> destinationComponents { };
 
-    auto transform = adoptCF(CGColorTransformCreate(protect(outputColorSpace.platformColorSpace()).get(), nullptr));
+    static NeverDestroyed<std::pair<RetainPtr<CGColorSpaceRef>, RetainPtr<CGColorTransformRef>>> cachedTransform;
+    auto& [cachedSpace, transform] = cachedTransform.get();
+    RetainPtr outputColorSpacePlatform = outputColorSpace.platformColorSpace();
+    if (!transform || !CGColorSpaceEqualToColorSpace(cachedSpace.get(), outputColorSpacePlatform.get())) {
+        cachedSpace = WTF::move(outputColorSpacePlatform);
+        transform = adoptCF(CGColorTransformCreate(cachedSpace.get(), nullptr));
+    }
+
     auto result = CGColorTransformConvertColorComponents(transform.get(), cgInputColorSpace, kCGRenderingIntentDefault, sourceComponents.data(), destinationComponents.data());
     ASSERT_UNUSED(result, result);
     // CGColorTransformConvertColorComponents doesn't copy over any alpha component.


### PR DESCRIPTION
#### e80def2354993b9081623dfc419efa216327da92
<pre>
REGRESSION(294844@main): platformConvertColorComponents creates a new CGColorTransform on every call
<a href="https://bugs.webkit.org/show_bug.cgi?id=314694">https://bugs.webkit.org/show_bug.cgi?id=314694</a>
<a href="https://rdar.apple.com/176803517">rdar://176803517</a>

Reviewed by Simon Fraser.

platformConvertColorComponents() was creating and destroying a
CGColorTransformRef on every invocation. Each creation triggers the full
ColorSync transform pipeline, which becomes catastrophic on pages with many
gradient elements rendered to a display with a non-matching color profile.

On Stashweb PR diff pages, this caused 18% CPU in the GPU process, entirely in
ColorSync transform setup/teardown.

Fix by adding two layers of optimization:

1. For well-known destination color spaces (sRGB, Display P3, and their linear
   variants), use WebKit&apos;s built-in color conversion math directly. This is pure
   inline arithmetic with zero framework overhead.

2. For custom ICC profiles that don&apos;t match any known space, cache the
   CGColorTransformRef across calls. In practice there is only one destination
   color space (the display profile), so a single-entry cache is sufficient.

* Source/WebCore/platform/graphics/cg/ColorCG.cpp:
(WebCore::platformConvertColorComponents):

Canonical link: <a href="https://commits.webkit.org/313211@main">https://commits.webkit.org/313211@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f31ae572e647e51becb35ca51fe064fbfdc40e09

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162436 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35912 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29028 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171374 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/118881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164305 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36016 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35914 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126053 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/118881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165395 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28398 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/145919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106631 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27444 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25969 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19074 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23650 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173878 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21191 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25294 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134361 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35586 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30059 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134361 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36266 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35570 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145446 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97825 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28892 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/22278 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35079 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102831 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34581 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34826 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34729 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->