### PR TITLE
[Site Isolation] `http/tests/misc/iframe-beforeunload-dialog-not-matching-ancestor-securityorigin.html` fails

### DIFF
--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -150,6 +150,7 @@
 #include "WindowFeatures.h"
 #include "XMLDocumentParser.h"
 #include <ranges>
+#include <wtf/CallbackAggregator.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Ref.h>
@@ -1992,15 +1993,14 @@ void FrameLoader::loadWithDocumentLoader(DocumentLoader* loader, FrameLoadType t
     cancelPendingAsyncBackForwardNavigation();
 
     if (shouldTreatCurrentLoadAsContinuingLoad()) {
-        continueLoadAfterNavigationPolicy(loader->request(), formSubmission.get(), NavigationPolicyDecision::ContinueLoad, allowNavigationToInvalidURL, shouldRestoreFromBackForwardCache);
+        continueLoadAfterNavigationPolicy(loader->request(), formSubmission.get(), NavigationPolicyDecision::ContinueLoad, allowNavigationToInvalidURL, shouldRestoreFromBackForwardCache, completionHandlerCaller.release());
         return;
     }
 
     auto policyDecisionMode = loader->triggeringAction().isFromNavigationAPI() ? PolicyDecisionMode::Synchronous : PolicyDecisionMode::Asynchronous;
     RELEASE_ASSERT(!isBackForwardLoadType(policyChecker().loadType()) || history().provisionalItem());
     policyChecker().checkNavigationPolicy(ResourceRequest(loader->request()), ResourceResponse { } /* redirectResponse */, loader, WTF::move(formSubmission), [this, protectedThis = Ref { *this }, allowNavigationToInvalidURL, shouldRestoreFromBackForwardCache, completionHandler = completionHandlerCaller.release()] (const ResourceRequest& request, WeakPtr<const FormSubmission>&& weakFormSubmission, NavigationPolicyDecision navigationPolicyDecision) mutable {
-        continueLoadAfterNavigationPolicy(request, RefPtr { weakFormSubmission.get() }.get(), navigationPolicyDecision, allowNavigationToInvalidURL, shouldRestoreFromBackForwardCache);
-        completionHandler();
+        continueLoadAfterNavigationPolicy(request, RefPtr { weakFormSubmission.get() }.get(), navigationPolicyDecision, allowNavigationToInvalidURL, shouldRestoreFromBackForwardCache, WTF::move(completionHandler));
     }, policyDecisionMode, determineNavigationType(type, NavigationHistoryBehavior::Auto));
 }
 
@@ -3911,6 +3911,38 @@ void FrameLoader::scrollToFragmentWithParentBoundary(const URL& url, bool isNewN
     }
 }
 
+bool FrameLoader::dispatchBeforeUnloadOnLocalDescendants(Page& page, FrameIdentifier frameBeingNavigated, NOESCAPE const Function<void(RemoteFrame&)>& onRemoteChild)
+{
+    Ref frame = m_frame.get();
+
+    // Store all references to each subframe in advance since beforeunload's event handler may modify frame
+    Vector<Ref<LocalFrame>, 16> targetFrames;
+    targetFrames.append(frame.copyRef());
+    for (RefPtr child = frame->tree().firstChild(); child; child = child->tree().traverseNext(frame.ptr())) {
+        if (RefPtr localChild = dynamicDowncast<LocalFrame>(*child)) {
+            targetFrames.append(localChild.releaseNonNull());
+            continue;
+        }
+        if (!onRemoteChild)
+            continue;
+        if (RefPtr remoteChild = dynamicDowncast<RemoteFrame>(*child)) {
+            RefPtr parent = child->tree().parent();
+            if (parent && is<LocalFrame>(*parent))
+                onRemoteChild(*remoteChild);
+        }
+    }
+
+    NavigationDisabler navigationDisabler(frame.ptr());
+    UnloadCountIncrementer unloadCountIncrementer(protect(frame->document()).get());
+    for (Ref target : targetFrames) {
+        if (!target->tree().isDescendantOf(frame.ptr()))
+            continue;
+        if (!target->loader().dispatchBeforeUnloadEvent(page.chrome(), this, frameBeingNavigated))
+            return false;
+    }
+    return true;
+}
+
 bool FrameLoader::shouldClose()
 {
     Ref frame = m_frame.get();
@@ -3920,40 +3952,56 @@ bool FrameLoader::shouldClose()
     if (!page->chrome().canRunBeforeUnloadConfirmPanel())
         return true;
 
-    // Store all references to each subframe in advance since beforeunload's event handler may modify frame
-    Vector<Ref<Frame>, 16> targetFrames;
-    targetFrames.append(frame.copyRef());
-    for (RefPtr child = frame->tree().firstChild(); child; child = child->tree().traverseNext(frame.ptr()))
-        targetFrames.append(*child);
-
-    bool shouldClose = false;
-    {
-        NavigationDisabler navigationDisabler(frame.ptr());
-        UnloadCountIncrementer UnloadCountIncrementer(protect(frame->document()).get());
-        size_t i;
-
-        for (i = 0; i < targetFrames.size(); i++) {
-            if (!targetFrames[i]->tree().isDescendantOf(frame.ptr()))
-                continue;
-            if (RefPtr localTargetFrame = dynamicDowncast<LocalFrame>(targetFrames[i])) {
-                if (!localTargetFrame->loader().dispatchBeforeUnloadEvent(page->chrome(), this))
-                    break;
-            } else if (RefPtr remoteTargetFrame = dynamicDowncast<RemoteFrame>(targetFrames[i])) {
-                if (RefPtr document = frame->document())
-                    remoteTargetFrame->client().dispatchCrossOriginBeforeUnloadCheck(document->securityOrigin().data());
-                continue;
-            }
-        }
-
-        if (i == targetFrames.size())
-            shouldClose = true;
-    }
-
+    bool shouldClose = dispatchBeforeUnloadOnLocalDescendants(*page, frame->frameID());
     if (!shouldClose)
         m_submittedFormURL = URL();
 
     m_currentNavigationHasShownBeforeUnloadConfirmPanel = false;
     return shouldClose;
+}
+
+void FrameLoader::shouldClose(CompletionHandler<void(bool)>&& completionHandler)
+{
+    shouldCloseForCrossProcessNavigation(m_frame->frameID(), WTF::move(completionHandler));
+}
+
+void FrameLoader::shouldCloseForCrossProcessNavigation(FrameIdentifier frameBeingNavigated, CompletionHandler<void(bool)>&& completionHandler)
+{
+    Ref frame = m_frame.get();
+    RefPtr page = frame->page();
+    if (!page)
+        return completionHandler(true);
+
+    if (!page->chrome().canRunBeforeUnloadConfirmPanel())
+        return completionHandler(true);
+
+    Vector<Ref<RemoteFrame>> remoteDescendants;
+    bool localShouldClose = dispatchBeforeUnloadOnLocalDescendants(*page, frameBeingNavigated, [&](RemoteFrame& remoteChild) {
+        remoteDescendants.append(remoteChild);
+    });
+
+    if (!localShouldClose) {
+        m_submittedFormURL = URL();
+        m_currentNavigationHasShownBeforeUnloadConfirmPanel = false;
+        return completionHandler(true);
+    }
+
+    if (remoteDescendants.isEmpty()) {
+        m_currentNavigationHasShownBeforeUnloadConfirmPanel = false;
+        return completionHandler(true);
+    }
+
+    Ref aggregator = SuccessCallbackAggregator::create([weakThis = WeakPtr { *this }, completionHandler = WTF::move(completionHandler)](bool result) mutable {
+        if (RefPtr protectedThis = weakThis.get()) {
+            if (!result)
+                protectedThis->m_submittedFormURL = URL();
+            protectedThis->m_currentNavigationHasShownBeforeUnloadConfirmPanel = false;
+        }
+        completionHandler(result);
+    });
+
+    for (Ref remoteFrame : remoteDescendants)
+        remoteFrame->client().dispatchBeforeUnloadInRemoteFrame(frameBeingNavigated, aggregator->chain());
 }
 
 void FrameLoader::dispatchUnloadEvents(UnloadEventPolicy unloadEventPolicy)
@@ -4033,7 +4081,7 @@ static bool NODELETE shouldAskForNavigationConfirmation(Document& document, cons
     return userDidInteractWithPage && (event.defaultPrevented() || !event.returnValue().isEmpty());
 }
 
-bool FrameLoader::dispatchBeforeUnloadEvent(Chrome& chrome, FrameLoader* frameLoaderBeingNavigated)
+bool FrameLoader::dispatchBeforeUnloadEvent(Chrome& chrome, FrameLoader* frameLoaderBeingNavigated, FrameIdentifier frameBeingNavigated)
 {
     RefPtr window = m_frame->document()->window();
     if (!window)
@@ -4042,7 +4090,7 @@ bool FrameLoader::dispatchBeforeUnloadEvent(Chrome& chrome, FrameLoader* frameLo
     RefPtr document = m_frame->document();
     if (!document->bodyOrFrameset())
         return true;
-    
+
     Ref beforeUnloadEvent = BeforeUnloadEvent::create();
 
     {
@@ -4061,36 +4109,37 @@ bool FrameLoader::dispatchBeforeUnloadEvent(Chrome& chrome, FrameLoader* frameLo
 
     // If the navigating FrameLoader has already shown a beforeunload confirmation panel for the current navigation attempt,
     // this frame is not allowed to cause another one to be shown.
-    if (frameLoaderBeingNavigated->m_currentNavigationHasShownBeforeUnloadConfirmPanel) {
+    if (frameLoaderBeingNavigated && frameLoaderBeingNavigated->m_currentNavigationHasShownBeforeUnloadConfirmPanel) {
         document->addConsoleMessage(MessageSource::JS, MessageLevel::Error, "Blocked attempt to show multiple beforeunload confirmation dialogs for the same navigation."_s);
         return true;
     }
 
     // We should only display the beforeunload dialog for an iframe if its SecurityOrigin matches all
-    // ancestor frame SecurityOrigins up through the navigating FrameLoader.
-    if (frameLoaderBeingNavigated != this) {
-        RefPtr parentFrame = dynamicDowncast<LocalFrame>(m_frame->tree().parent());
+    // ancestor frame SecurityOrigins up through the navigating frame.
+    if (m_frame->frameID() != frameBeingNavigated) {
+        RefPtr parentFrame = m_frame->tree().parent();
         while (parentFrame) {
-            RefPtr parentDocument = parentFrame->document();
-            if (!parentDocument)
+            RefPtr parentOrigin = parentFrame->frameDocumentSecurityOrigin();
+            if (!parentOrigin)
                 return true;
-            if (RefPtr document = m_frame->document(); !document || !protect(document->securityOrigin())->isSameOriginDomain(protect(parentDocument->securityOrigin()))) {
+            if (RefPtr document = m_frame->document(); !document || !protect(document->securityOrigin())->isSameOriginDomain(*parentOrigin)) {
                 document->addConsoleMessage(MessageSource::JS, MessageLevel::Error, "Blocked attempt to show beforeunload confirmation dialog on behalf of a frame with different security origin. Protocols, domains, and ports must match."_s);
                 return true;
             }
-            
-            if (&parentFrame->loader() == frameLoaderBeingNavigated)
+
+            if (parentFrame->frameID() == frameBeingNavigated)
                 break;
-            
-            parentFrame = dynamicDowncast<LocalFrame>(parentFrame->tree().parent());
+
+            parentFrame = parentFrame->tree().parent();
         }
-        
-        // The navigatingFrameLoader should always be in our ancestory.
+
+        // The navigating frame should always be in our ancestry.
         ASSERT(parentFrame);
-        ASSERT(&parentFrame->loader() == frameLoaderBeingNavigated);
+        ASSERT(parentFrame->frameID() == frameBeingNavigated);
     }
 
-    frameLoaderBeingNavigated->m_currentNavigationHasShownBeforeUnloadConfirmPanel = true;
+    if (frameLoaderBeingNavigated)
+        frameLoaderBeingNavigated->m_currentNavigationHasShownBeforeUnloadConfirmPanel = true;
 
     String text = document->displayStringModifiedByEncoding(beforeUnloadEvent->returnValue());
     return chrome.runBeforeUnloadConfirmPanel(WTF::move(text), protect(m_frame));
@@ -4132,7 +4181,7 @@ void FrameLoader::executeJavaScriptURL(const URL& url, const NavigationAction& a
     m_quickRedirectComing = false;
 }
 
-void FrameLoader::continueLoadAfterNavigationPolicy(const ResourceRequest& request, const FormSubmission* formSubmission, NavigationPolicyDecision navigationPolicyDecision, AllowNavigationToInvalidURL allowNavigationToInvalidURL, ShouldRestoreFromBackForwardCache shouldRestoreFromBackForwardCache)
+void FrameLoader::continueLoadAfterNavigationPolicy(const ResourceRequest& request, const FormSubmission* formSubmission, NavigationPolicyDecision navigationPolicyDecision, AllowNavigationToInvalidURL allowNavigationToInvalidURL, ShouldRestoreFromBackForwardCache shouldRestoreFromBackForwardCache, CompletionHandler<void()>&& completionHandler)
 {
     // If we loaded an alternate page to replace an unreachableURL, we'll get in here with a
     // nil policyDataSource because loading the alternate page will have passed
@@ -4143,10 +4192,6 @@ void FrameLoader::continueLoadAfterNavigationPolicy(const ResourceRequest& reque
 
     bool urlIsDisallowed = allowNavigationToInvalidURL == AllowNavigationToInvalidURL::No && !request.url().isValid();
 
-    // For Navigation API traversal navigation, dispatch navigate event AFTER beforeunload.
-    bool navigateEventAborted = false;
-    bool shouldCloseResult = true;
-
     if (m_pendingNavigationAPIItem) {
         // Check if this will be a BFCache load - if so, defer navigate event until after restoration
         bool willLoadFromBFCache = false;
@@ -4154,23 +4199,42 @@ void FrameLoader::continueLoadAfterNavigationPolicy(const ResourceRequest& reque
             willLoadFromBFCache = true;
 
         // Only call shouldClose() early for Navigation API traversals
-        shouldCloseResult = shouldClose();
-
-        if (shouldCloseResult && !willLoadFromBFCache) {
-            // For non-BFCache traversals, dispatch navigate event now
-            if (RefPtr window = frame->document()->window()) {
-                if (RefPtr navigation = window->navigation(); navigation->frame()) {
-                    if (navigation->dispatchTraversalNavigateEvent(Ref { *m_pendingNavigationAPIItem }) == Navigation::DispatchResult::Aborted)
-                        navigateEventAborted = true;
+        shouldClose([this, protectedThis = Ref { *this }, request, formSubmission = RefPtr { formSubmission }, navigationPolicyDecision, allowNavigationToInvalidURL, shouldRestoreFromBackForwardCache, urlIsDisallowed, willLoadFromBFCache, completionHandler = WTF::move(completionHandler)](bool shouldCloseResult) mutable {
+            bool navigateEventAborted = false;
+            if (shouldCloseResult && !willLoadFromBFCache) {
+                // For non-BFCache traversals, dispatch navigate event now
+                if (RefPtr window = m_frame->document()->window()) {
+                    if (RefPtr navigation = window->navigation(); navigation->frame()) {
+                        if (navigation->dispatchTraversalNavigateEvent(Ref { *m_pendingNavigationAPIItem }) == Navigation::DispatchResult::Aborted)
+                            navigateEventAborted = true;
+                    }
                 }
-            }
 
-            m_pendingNavigationAPIItem = nullptr;
-        }
-    } else {
-        // For non-Navigation API traversals, use original behavior with short-circuit evaluation
-        shouldCloseResult = (navigationPolicyDecision == NavigationPolicyDecision::ContinueLoad && !urlIsDisallowed) ? shouldClose() : false;
+                m_pendingNavigationAPIItem = nullptr;
+            }
+            continueLoadAfterShouldClose(request, formSubmission.get(), navigationPolicyDecision, allowNavigationToInvalidURL, shouldRestoreFromBackForwardCache, shouldCloseResult, navigateEventAborted, urlIsDisallowed, WTF::move(completionHandler));
+        });
+        return;
     }
+
+    // For non-Navigation API traversals, use original behavior with short-circuit evaluation
+    if (navigationPolicyDecision == NavigationPolicyDecision::ContinueLoad && !urlIsDisallowed) {
+        shouldClose([this, protectedThis = Ref { *this }, request, formSubmission = RefPtr { formSubmission }, navigationPolicyDecision, allowNavigationToInvalidURL, shouldRestoreFromBackForwardCache, urlIsDisallowed, completionHandler = WTF::move(completionHandler)](bool shouldCloseResult) mutable {
+            continueLoadAfterShouldClose(request, formSubmission.get(), navigationPolicyDecision, allowNavigationToInvalidURL, shouldRestoreFromBackForwardCache, shouldCloseResult, false, urlIsDisallowed, WTF::move(completionHandler));
+        });
+        return;
+    }
+
+    continueLoadAfterShouldClose(request, formSubmission, navigationPolicyDecision, allowNavigationToInvalidURL, shouldRestoreFromBackForwardCache, false, false, urlIsDisallowed, WTF::move(completionHandler));
+}
+
+void FrameLoader::continueLoadAfterShouldClose(const ResourceRequest& request, const FormSubmission* formSubmission, NavigationPolicyDecision navigationPolicyDecision, AllowNavigationToInvalidURL allowNavigationToInvalidURL, ShouldRestoreFromBackForwardCache shouldRestoreFromBackForwardCache, bool shouldCloseResult, bool navigateEventAborted, bool urlIsDisallowed, CompletionHandler<void()>&& outerCompletionHandler)
+{
+#if RELEASE_LOG_DISABLED
+    UNUSED_PARAM(allowNavigationToInvalidURL);
+#endif
+    Ref frame = m_frame.get();
+    CompletionHandlerCallingScope completionHandlerCaller(WTF::move(outerCompletionHandler));
 
     bool canContinue = navigationPolicyDecision == NavigationPolicyDecision::ContinueLoad && shouldCloseResult && !navigateEventAborted && !urlIsDisallowed;
     bool isTargetItem = frame->loader().history().provisionalItem() ? frame->loader().history().provisionalItem()->isTargetItem() : false;

--- a/Source/WebCore/loader/FrameLoader.h
+++ b/Source/WebCore/loader/FrameLoader.h
@@ -84,6 +84,7 @@ class NetworkingContext;
 class Node;
 class Page;
 class PolicyChecker;
+class RemoteFrame;
 class ResourceError;
 class ResourceRequest;
 class ResourceResponse;
@@ -302,6 +303,8 @@ public:
     bool quickRedirectComing() const { return m_quickRedirectComing; }
 
     WEBCORE_EXPORT bool shouldClose();
+    WEBCORE_EXPORT void shouldClose(CompletionHandler<void(bool)>&&);
+    WEBCORE_EXPORT void shouldCloseForCrossProcessNavigation(FrameIdentifier frameBeingNavigated, CompletionHandler<void(bool)>&&);
 
     enum class PageDismissalType { None, BeforeUnload, PageHide, Unload };
     PageDismissalType pageDismissalEventBeingDispatched() const { return m_pageDismissalEventBeingDispatched; }
@@ -413,10 +416,12 @@ private:
 
     SubstituteData defaultSubstituteDataForURL(const URL&);
 
-    bool dispatchBeforeUnloadEvent(Chrome&, FrameLoader* frameLoaderBeingNavigated);
+    bool dispatchBeforeUnloadEvent(Chrome&, FrameLoader* frameLoaderBeingNavigated, FrameIdentifier frameBeingNavigated);
+    bool dispatchBeforeUnloadOnLocalDescendants(Page&, FrameIdentifier frameBeingNavigated, NOESCAPE const Function<void(RemoteFrame&)>& onRemoteChild = { });
     void dispatchUnloadEvents(UnloadEventPolicy);
 
-    void continueLoadAfterNavigationPolicy(const ResourceRequest&, const FormSubmission*, NavigationPolicyDecision, AllowNavigationToInvalidURL, ShouldRestoreFromBackForwardCache = ShouldRestoreFromBackForwardCache::Unspecified);
+    void continueLoadAfterNavigationPolicy(const ResourceRequest&, const FormSubmission*, NavigationPolicyDecision, AllowNavigationToInvalidURL, ShouldRestoreFromBackForwardCache = ShouldRestoreFromBackForwardCache::Unspecified, CompletionHandler<void()>&& = [] { });
+    void continueLoadAfterShouldClose(const ResourceRequest&, const FormSubmission*, NavigationPolicyDecision, AllowNavigationToInvalidURL, ShouldRestoreFromBackForwardCache, bool shouldCloseResult, bool navigateEventAborted, bool urlIsDisallowed, CompletionHandler<void()>&&);
     void continueLoadAfterNewWindowPolicy(ResourceRequest&&, RefPtr<const FormSubmission>&&, const AtomString& frameName, const NavigationAction&, ShouldContinuePolicyCheck, AllowNavigationToInvalidURL, NewFrameOpenerPolicy);
     void continueFragmentScrollAfterNavigationPolicy(const ResourceRequest&, const SecurityOrigin* requesterOrigin, bool shouldContinue, NavigationHistoryBehavior);
 

--- a/Source/WebCore/page/RemoteFrameClient.h
+++ b/Source/WebCore/page/RemoteFrameClient.h
@@ -75,6 +75,7 @@ public:
     virtual void findFocusableElementDescendingIntoRemoteFrame(FocusDirection, const FocusEventData&, ShouldFocusElement, CompletionHandler<void(FoundElementInRemoteFrame)>&&) = 0;
     virtual void findFocusableElementContinuingFromFrame(FocusDirection, WebCore::FrameIdentifier, const FocusEventData&, ShouldFocusElement) = 0;
     virtual void dispatchCrossOriginBeforeUnloadCheck(const SecurityOriginData& navigatingFrameOrigin) = 0;
+    virtual void dispatchBeforeUnloadInRemoteFrame(WebCore::FrameIdentifier frameBeingNavigated, CompletionHandler<void(bool)>&&) = 0;
 
     virtual bool isWebRemoteFrameClient() const { return false; }
     virtual ~RemoteFrameClient() { }

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -1015,6 +1015,14 @@ void WebFrameProxy::findFocusableElementContinuingFromFrame(WebCore::FocusDirect
     send(Messages::WebFrame::FindFocusableElementContinuingFromFrame(direction, frameID, focusEventData, shouldFocusElement));
 }
 
+void WebFrameProxy::dispatchBeforeUnloadInRemoteFrame(WebCore::FrameIdentifier frameBeingNavigated, CompletionHandler<void(bool)>&& completionHandler)
+{
+    if (!m_page)
+        return completionHandler(true);
+
+    sendWithAsyncReply(Messages::WebFrame::DispatchBeforeUnloadInRemoteFrame(frameBeingNavigated), WTF::move(completionHandler));
+}
+
 std::optional<SharedPreferencesForWebProcess> WebFrameProxy::sharedPreferencesForWebProcess() const
 {
     return process().sharedPreferencesForWebProcess();

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -280,6 +280,7 @@ public:
     void setAppBadge(const WebCore::SecurityOriginData&, std::optional<uint64_t> badge);
     void findFocusableElementDescendingIntoRemoteFrame(WebCore::FocusDirection, const WebCore::FocusEventData&, WebCore::ShouldFocusElement, CompletionHandler<void(WebCore::FoundElementInRemoteFrame)>&&);
     void findFocusableElementContinuingFromFrame(WebCore::FocusDirection, WebCore::FrameIdentifier, const WebCore::FocusEventData&, WebCore::ShouldFocusElement);
+    void dispatchBeforeUnloadInRemoteFrame(WebCore::FrameIdentifier frameBeingNavigated, CompletionHandler<void(bool)>&&);
 
     std::optional<WebCore::DocumentSecurityPolicy> documentSecurityPolicy() const { return m_documentSecurityPolicy; }
 

--- a/Source/WebKit/UIProcess/WebFrameProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebFrameProxy.messages.in
@@ -29,4 +29,5 @@ messages -> WebFrameProxy {
     [EnabledBy=AppBadgeEnabled] SetAppBadge(WebCore::SecurityOriginData origin, std::optional<uint64_t> badge)
     [EnabledBy=SiteIsolationEnabled] FindFocusableElementDescendingIntoRemoteFrame(enum:uint8_t WebCore::FocusDirection direction, struct WebCore::FocusEventData focusEventData, enum:bool WebCore::ShouldFocusElement shouldFocusElement) -> (enum:bool WebCore::FoundElementInRemoteFrame foundElement)
     [EnabledBy=SiteIsolationEnabled] FindFocusableElementContinuingFromFrame(enum:uint8_t WebCore::FocusDirection direction, WebCore::FrameIdentifier frameIdentifer, struct WebCore::FocusEventData focusEventData, enum:bool WebCore::ShouldFocusElement shouldFocusElement)
+    [EnabledBy=SiteIsolationEnabled] DispatchBeforeUnloadInRemoteFrame(WebCore::FrameIdentifier frameBeingNavigated) -> (bool shouldClose)
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
@@ -289,4 +289,9 @@ void WebRemoteFrameClient::dispatchCrossOriginBeforeUnloadCheck(const WebCore::S
         page->send(Messages::WebPageProxy::DispatchCrossOriginBeforeUnloadCheckForFrame(m_frame->frameID(), navigatingFrameOrigin));
 }
 
+void WebRemoteFrameClient::dispatchBeforeUnloadInRemoteFrame(WebCore::FrameIdentifier frameBeingNavigated, CompletionHandler<void(bool)>&& completionHandler)
+{
+    m_frame->sendWithAsyncReply(Messages::WebFrameProxy::DispatchBeforeUnloadInRemoteFrame(frameBeingNavigated), WTF::move(completionHandler));
+}
+
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h
@@ -70,6 +70,7 @@ private:
     void findFocusableElementDescendingIntoRemoteFrame(WebCore::FocusDirection, const WebCore::FocusEventData&, WebCore::ShouldFocusElement, CompletionHandler<void(WebCore::FoundElementInRemoteFrame)>&&) final;
     void findFocusableElementContinuingFromFrame(WebCore::FocusDirection, WebCore::FrameIdentifier, const WebCore::FocusEventData&, WebCore::ShouldFocusElement) final;
     void dispatchCrossOriginBeforeUnloadCheck(const WebCore::SecurityOriginData& navigatingFrameOrigin) final;
+    void dispatchBeforeUnloadInRemoteFrame(WebCore::FrameIdentifier frameBeingNavigated, CompletionHandler<void(bool)>&&) final;
 
     void broadcastAllFrameTreeSyncDataToOtherProcesses(WebCore::FrameTreeSyncData&) final;
     void broadcastFrameTreeSyncDataToOtherProcesses(const WebCore::FrameTreeSyncSerializationData&) final;

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -1666,6 +1666,14 @@ void WebFrame::findFocusableElementContinuingFromFrame(WebCore::FocusDirection d
     }
 }
 
+void WebFrame::dispatchBeforeUnloadInRemoteFrame(WebCore::FrameIdentifier frameBeingNavigated, CompletionHandler<void(bool)>&& completionHandler)
+{
+    RefPtr localFrame = dynamicDowncast<LocalFrame>(m_coreFrame.get());
+    if (!localFrame)
+        return completionHandler(true);
+    localFrame->loader().shouldCloseForCrossProcessNavigation(frameBeingNavigated, WTF::move(completionHandler));
+}
+
 static RefPtr<Node> NODELETE nodeFromJSHandleIdentifier(JSHandleIdentifier identifier)
 {
     auto* object = WebKitJSHandle::objectForIdentifier(identifier);

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.h
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.h
@@ -314,6 +314,7 @@ private:
 
     void findFocusableElementDescendingIntoRemoteFrame(WebCore::FocusDirection, const WebCore::FocusEventData&, WebCore::ShouldFocusElement, CompletionHandler<void(WebCore::FoundElementInRemoteFrame)>&&);
     void findFocusableElementContinuingFromFrame(WebCore::FocusDirection, WebCore::FrameIdentifier, const WebCore::FocusEventData&, WebCore::ShouldFocusElement);
+    void dispatchBeforeUnloadInRemoteFrame(WebCore::FrameIdentifier frameBeingNavigated, CompletionHandler<void(bool)>&&);
 
     CheckedRef<FrameInspectorTarget> ensureInspectorTarget();
 

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.messages.in
@@ -31,6 +31,7 @@ messages -> WebFrame {
     DestroyProvisionalFrame();
     FindFocusableElementDescendingIntoRemoteFrame(enum:uint8_t WebCore::FocusDirection direction, struct WebCore::FocusEventData focusEventData, enum:bool WebCore::ShouldFocusElement shouldFocusElement) -> (enum:bool WebCore::FoundElementInRemoteFrame foundElement)
     FindFocusableElementContinuingFromFrame(enum:uint8_t WebCore::FocusDirection direction, WebCore::FrameIdentifier frameIdentifer, struct WebCore::FocusEventData focusEventData, enum:bool WebCore::ShouldFocusElement shouldFocusElement)
+    DispatchBeforeUnloadInRemoteFrame(WebCore::FrameIdentifier frameBeingNavigated) -> (bool shouldClose)
     TakeSnapshotOfNode(WebCore::JSHandleIdentifier identifier) -> (std::optional<WebCore::ShareableBitmapHandle> snapshot);
 
     ConnectInspector(Inspector::FrontendChannel::ConnectionType connectionType)


### PR DESCRIPTION
#### 9150cfec10a3f4a8adbcf25b9185067665a6ff86
<pre>
[Site Isolation] `http/tests/misc/iframe-beforeunload-dialog-not-matching-ancestor-securityorigin.html` fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=314696">https://bugs.webkit.org/show_bug.cgi?id=314696</a>
<a href="https://rdar.apple.com/176936614">rdar://176936614</a>

Reviewed by NOBODY (OOPS!).

FrameLoader::shouldClose() excludes remote frames when collecting its descendants, so their
beforeunload handlers never ran.

Add an async FrameLoader::shouldClose(CompletionHandler&lt;void(bool)&gt;&amp;&amp;) that runs local descendants
first, then fans out to remote children with a new dispatchBeforeUnloadInRemoteFrame virtual
implemented as WebRemoteFrameClient → WebFrameProxy → WebFrame IPC. Each target process recursively
handles its own subtree.

Fix the ancestor-origin walk in FrameLoader::dispatchBeforeUnloadEvent to use
frameDocumentSecurityOrigin and identify the navigating frame by FrameIdentifier instead of a
FrameLoader pointer.

Refactor FrameLoader::continueLoadAfterNavigationPolicy to take a completion handler and split into
continueLoadAfterShouldClose so the post-shouldClose tail runs when async results arrive.

* LayoutTests/platform/mac-site-isolation/TestExpectations:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::loadWithDocumentLoader):
(WebCore::FrameLoader::dispatchBeforeUnloadOnLocalDescendants):
(WebCore::FrameLoader::shouldClose):
(WebCore::FrameLoader::shouldCloseForCrossProcessNavigation):
(WebCore::FrameLoader::dispatchBeforeUnloadEvent):
(WebCore::FrameLoader::continueLoadAfterNavigationPolicy):
(WebCore::FrameLoader::continueLoadAfterShouldClose):
* Source/WebCore/loader/FrameLoader.h:
* Source/WebCore/page/RemoteFrameClient.h:
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::dispatchBeforeUnloadInRemoteFrame):
* Source/WebKit/UIProcess/WebFrameProxy.h:
* Source/WebKit/UIProcess/WebFrameProxy.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp:
(WebKit::WebRemoteFrameClient::dispatchBeforeUnloadInRemoteFrame):
* Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::dispatchBeforeUnloadInRemoteFrame):
* Source/WebKit/WebProcess/WebPage/WebFrame.h:
* Source/WebKit/WebProcess/WebPage/WebFrame.messages.in:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9150cfec10a3f4a8adbcf25b9185067665a6ff86

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165104 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38595 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32172 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174146 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122361 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/faaa24d5-8634-46bc-b4fc-308a39ea70c7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166972 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38929 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38596 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128308 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90310 "1 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d9de93ad-4a3b-4128-afeb-f27753b52850) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168063 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30618 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148367 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108833 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f9d3f6da-5ff5-4169-962c-c4ff902e860e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29665 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28288 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21901 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139560 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26065 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176669 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29559 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27770 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136622 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38663 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32424 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-display/display-contents-svg-elements.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136564 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39353 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147861 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101661 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31847 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24728 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37863 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110935 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37260 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2804 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37506 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37404 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->