### PR TITLE
SubtreeScrollbarChangesStateScope can outlive LayoutScope.

### DIFF
--- a/Source/WebCore/rendering/RelayoutScopeForScrollbarChange.cpp
+++ b/Source/WebCore/rendering/RelayoutScopeForScrollbarChange.cpp
@@ -56,6 +56,7 @@ RelayoutScopeForScrollbarChange::~RelayoutScopeForScrollbarChange()
     if (m_renderBlock->style().overflowX() == Overflow::Auto || m_renderBlock->style().overflowY() == Overflow::Auto) {
         if (m_inOverflowRelayout == InOverflowRelayout::No) {
             if (auto& subtreeScrollbarChangesState = m_renderBlock->layoutContext().subtreeScrollbarChangesState(); subtreeScrollbarChangesState && subtreeScrollbarChangesState->isEligibleForScrollbarHandlingByAncestor(m_renderBlock.get())) {
+                ASSERT(m_renderBlock.ptr() != subtreeScrollbarChangesState->subtreeRoot.ptr());
                 subtreeScrollbarChangesState->renderersWithScrollbarChange.add(m_renderBlock);
                 return;
             }

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -539,13 +539,12 @@ void RenderBlock::layout()
 
     // Table cells call layoutBlock directly, so don't add any logic here. Put code into layoutBlock().
     {
-        std::optional<SubtreeScrollbarChangesStateScope> subtreeScrollbarChangesStateScope;
-        if (needsToTrackDescendantScrollbarChanges(*this, layoutContext))
-            subtreeScrollbarChangesStateScope.emplace(layoutContext, *this);
-
-        bool willHandleDescendantScrollbarChanges = subtreeScrollbarChangesStateScope.has_value() || canContainDescendantScrollbarChanges(*this, layoutContext);
         auto scope = LayoutScope { *this };
-        if (willHandleDescendantScrollbarChanges) {
+        if (needsToTrackDescendantScrollbarChanges(*this, layoutContext)) {
+            SubtreeScrollbarChangesStateScope subtreeScrollbarChangesStateScope(layoutContext, *this);
+            SubtreeScrollbarChangesHandler descendantScrollbarChangesHandler(*this);
+            layoutBlock(RelayoutChildren::No);
+        } else if (canContainDescendantScrollbarChanges(*this, layoutContext)) {
             SubtreeScrollbarChangesHandler descendantScrollbarChangesHandler(*this);
             layoutBlock(RelayoutChildren::No);
         } else


### PR DESCRIPTION
#### f9ade7a024fb0e64b2f8898e20d9c580ffd52020
<pre>
SubtreeScrollbarChangesStateScope can outlive LayoutScope.
<a href="https://bugs.webkit.org/show_bug.cgi?id=314822">https://bugs.webkit.org/show_bug.cgi?id=314822</a>
<a href="https://rdar.apple.com/problem/177077505">rdar://problem/177077505</a>

Reviewed by Alan Baradlay.

If LayoutScope is destroyed before SubtreeScrollbarChangesStateScope we
can end up in an odd state. SubtreeScrollbarChangesStateScope is
supposed to be used to track any changes in descendants&apos; scrollbars
during the initial layout of the renderer so after this is done we
should not need to keep it around any longer.

Otherwise, when that renderer&apos;s LayoutScope destructor runs and sets up a
RelayoutScopeForScrollbarChange, it will see the SubtreeScrollbarChangesStateScope
still alive, add the renderer to the list of renderers to process later
(which is already wrong because we only care about its descendants), but
not doing anything with it.

Restructure RenderBlock::layout() so the scrollbar-tracking guards are
nested inside the LayoutScope branch rather than declared alongside it
via std::optional. The three cases (track + handle / handle only /
neither) are now spelled out explicitly, which removes the optional, the
intermediate willHandleDescendantScrollbarChanges flag, and the reliance
on reverse declaration order to get destruction sequencing right. In the
tracking branch, destruction now flows handler -&gt; scrollbar state scope -&gt;
LayoutScope.

Also add an assert in ~RelayoutScopeForScrollbarChange that the block
recording a scrollbar change is not the subtree root itself.

While I have not been able to find any sort of functional issue with
this on trunk, we will need to get this ordering correct to solve a bug
in a follow up patch.

Canonical link: <a href="https://commits.webkit.org/313323@main">https://commits.webkit.org/313323@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b46e5f145e1e80419fc7e421b47224ac946fdc2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162573 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36049 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29181 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171511 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119018 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164442 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36153 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36053 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126167 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88871 "1 flakes 18 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165532 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28523 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146060 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106745 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27569 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26097 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19211 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137274 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23790 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174015 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21328 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25435 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134476 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35723 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30190 "Found 1 new test failure: imported/w3c/web-platform-tests/IndexedDB/interleaved-cursors-small.any.serviceworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134473 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36327 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35707 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145586 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98037 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/29018 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22420 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35217 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102968 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34718 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34963 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34866 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->