### PR TITLE
Shrink-to-fit boxes with do not update their width when a scrollbar is added mid-layout.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/shrink-to-fit-overflow-auto-scrollbar-width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/shrink-to-fit-overflow-auto-scrollbar-width-expected.txt
@@ -1,0 +1,6 @@
+
+
+PASS Float with overflow-y:auto includes scrollbar in shrink-to-fit width
+PASS Inline-block with overflow-y:auto includes scrollbar in shrink-to-fit width
+PASS Abspos with overflow-y:auto includes scrollbar in shrink-to-fit width
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/shrink-to-fit-overflow-auto-scrollbar-width.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-overflow/shrink-to-fit-overflow-auto-scrollbar-width.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<title>Shrink-to-fit blocks with overflow-y:auto should include scrollbar in width</title>
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#scrollbar-sizing">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+.test {
+  height: 26px;
+  overflow-y: auto;
+  border: 2px solid green;
+}
+.scroll {
+  height: 26px;
+  overflow-y: scroll;
+  border: 2px solid green;
+}
+.content {
+  width: 40px;
+  height: 80px;
+}
+.float { float: left; }
+.inline-block { display: inline-block; }
+.abspos-container { position: relative; height: 60px; }
+.abspos { position: absolute; }
+</style>
+
+<div class="test float" id="float-auto"><div class="content"></div></div>
+<div class="scroll float" id="float-scroll"><div class="content"></div></div>
+<div style="clear: both;"></div>
+
+<div class="test inline-block" id="inline-block-auto"><div class="content"></div></div>
+<div class="scroll inline-block" id="inline-block-scroll"><div class="content"></div></div>
+
+<div class="abspos-container">
+  <div class="test abspos" id="abspos-auto"><div class="content"></div></div>
+</div>
+<div class="abspos-container">
+  <div class="scroll abspos" id="abspos-scroll"><div class="content"></div></div>
+</div>
+
+<script>
+test(() => {
+  const auto = document.getElementById("float-auto");
+  const scroll = document.getElementById("float-scroll");
+  assert_equals(auto.offsetWidth, scroll.offsetWidth);
+}, "Float with overflow-y:auto includes scrollbar in shrink-to-fit width");
+
+test(() => {
+  const auto = document.getElementById("inline-block-auto");
+  const scroll = document.getElementById("inline-block-scroll");
+  assert_equals(auto.offsetWidth, scroll.offsetWidth);
+}, "Inline-block with overflow-y:auto includes scrollbar in shrink-to-fit width");
+
+test(() => {
+  const auto = document.getElementById("abspos-auto");
+  const scroll = document.getElementById("abspos-scroll");
+  assert_equals(auto.offsetWidth, scroll.offsetWidth);
+}, "Abspos with overflow-y:auto includes scrollbar in shrink-to-fit width");
+</script>

--- a/LayoutTests/platform/glib/scrollbars/scrollbars-on-positioned-content-expected.txt
+++ b/LayoutTests/platform/glib/scrollbars/scrollbars-on-positioned-content-expected.txt
@@ -6,9 +6,9 @@ layer at (0,0) size 800x600
       RenderBlock {P} at (0,0) size 784x18
         RenderText {#text} at (0,0) size 656x18
           text run at (0,0) width 656: "This test passes if the custom scrollbar paints in the corrext spot, which is at the bottom of the purple div."
-layer at (8,50) size 304x550 clip at (9,51) size 287x533 scrollWidth 302 scrollHeight 1311
-  RenderBlock (positioned) {DIV} at (8,50) size 304x550 [border: (1px solid #FF0000)]
+layer at (8,50) size 319x550 clip at (9,51) size 302x548 scrollHeight 1311
+  RenderBlock (positioned) {DIV} at (8,50) size 319x550 [border: (1px solid #FF0000)]
     RenderBlock {DIV} at (1,412) size 15x900 [bgcolor=#008000]
-layer at (9,51) size 302x411 backgroundClip at (9,51) size 287x411 clip at (10,52) size 286x400 scrollWidth 500
+layer at (9,51) size 302x411 clip at (10,52) size 300x400 scrollWidth 500
   RenderBlock {DIV} at (1,1) size 302x411 [border: (1px solid #0000FF)]
     RenderBlock {DIV} at (1,1) size 500x400 [bgcolor=#800080]

--- a/LayoutTests/platform/mac/scrollbars/scrollbars-on-positioned-content-expected.txt
+++ b/LayoutTests/platform/mac/scrollbars/scrollbars-on-positioned-content-expected.txt
@@ -6,9 +6,9 @@ layer at (0,0) size 800x600
       RenderBlock {P} at (0,0) size 784x18
         RenderText {#text} at (0,0) size 673x18
           text run at (0,0) width 673: "This test passes if the custom scrollbar paints in the corrext spot, which is at the bottom of the purple div."
-layer at (8,50) size 304x550 clip at (9,51) size 287x533 scrollWidth 302 scrollHeight 1311
-  RenderBlock (positioned) {DIV} at (8,50) size 304x550 [border: (1px solid #FF0000)]
+layer at (8,50) size 319x550 clip at (9,51) size 302x548 scrollHeight 1311
+  RenderBlock (positioned) {DIV} at (8,50) size 319x550 [border: (1px solid #FF0000)]
     RenderBlock {DIV} at (1,412) size 15x900 [bgcolor=#008000]
-layer at (9,51) size 302x411 backgroundClip at (9,51) size 287x411 clip at (10,52) size 286x400 scrollWidth 500
+layer at (9,51) size 302x411 clip at (10,52) size 300x400 scrollWidth 500
   RenderBlock {DIV} at (1,1) size 302x411 [border: (1px solid #0000FF)]
     RenderBlock {DIV} at (1,1) size 500x400 [bgcolor=#800080]

--- a/LayoutTests/platform/win/scrollbars/scrollbars-on-positioned-content-expected.txt
+++ b/LayoutTests/platform/win/scrollbars/scrollbars-on-positioned-content-expected.txt
@@ -3,12 +3,12 @@ layer at (0,0) size 800x600
 layer at (0,0) size 800x600
   RenderBlock {HTML} at (0,0) size 800x600
     RenderBody {BODY} at (8,8) size 784x576
-      RenderBlock {P} at (0,0) size 784x20
-        RenderText {#text} at (0,0) size 628x19
-          text run at (0,0) width 628: "This test passes if the custom scrollbar paints in the corrext spot, which is at the bottom of the purple div."
-layer at (8,50) size 304x550 clip at (9,51) size 287x533 scrollWidth 302 scrollHeight 1311
-  RenderBlock (positioned) {DIV} at (8,50) size 304x550 [border: (1px solid #FF0000)]
+      RenderBlock {P} at (0,0) size 784x18
+        RenderText {#text} at (0,0) size 673x18
+          text run at (0,0) width 673: "This test passes if the custom scrollbar paints in the corrext spot, which is at the bottom of the purple div."
+layer at (8,50) size 319x550 clip at (9,51) size 302x548 scrollHeight 1311
+  RenderBlock (positioned) {DIV} at (8,50) size 319x550 [border: (1px solid #FF0000)]
     RenderBlock {DIV} at (1,412) size 15x900 [bgcolor=#008000]
-layer at (9,51) size 302x411 backgroundClip at (9,51) size 287x411 clip at (10,52) size 286x400 scrollWidth 500
+layer at (9,51) size 302x411 clip at (10,52) size 300x400 scrollWidth 500
   RenderBlock {DIV} at (1,1) size 302x411 [border: (1px solid #0000FF)]
     RenderBlock {DIV} at (1,1) size 500x400 [bgcolor=#800080]

--- a/Source/WebCore/rendering/RelayoutScopeForScrollbarChange.cpp
+++ b/Source/WebCore/rendering/RelayoutScopeForScrollbarChange.cpp
@@ -60,10 +60,8 @@ RelayoutScopeForScrollbarChange::~RelayoutScopeForScrollbarChange()
                 subtreeScrollbarChangesState->renderersWithScrollbarChange.add(m_renderBlock);
                 return;
             }
-            m_renderBlock->setNeedsLayout(MarkingBehavior::MarkOnlyThis);
-            auto scope = LayoutScope { m_renderBlock.get(), InOverflowRelayout::Yes };
             m_renderBlock->scrollbarsChanged(scrollbarChanges.contains(ScrollbarChange::AutoHorizontalScrollbarChanged), scrollbarChanges.contains(ScrollbarChange::AutoVerticalScrollBarChanged));
-            m_renderBlock->layoutBlock(RelayoutChildren::Yes);
+            RenderBlock::relayoutRenderBlockForScrollbarChange(m_renderBlock.get());
         }
     }
 

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -520,6 +520,15 @@ std::optional<ScrollbarUpdateScope> RenderBlock::updateScrollInfoAfterLayout()
     return { };
 }
 
+void RenderBlock::relayoutRenderBlockForScrollbarChange(RenderBlock& block)
+{
+    if (block.sizesPreferredLogicalWidthToFitContent())
+        block.setNeedsPreferredWidthsUpdate();
+    block.setNeedsLayout(MarkingBehavior::MarkOnlyThis);
+    auto scope = LayoutScope { block, InOverflowRelayout::Yes };
+    block.layoutBlock(RelayoutChildren::Yes);
+}
+
 static bool needsToTrackDescendantScrollbarChanges(const RenderBlock& renderBlock, const LocalFrameViewLayoutContext& layoutContext)
 {
     auto computedLogicalWidth = renderBlock.style().logicalWidth();

--- a/Source/WebCore/rendering/RenderBlock.h
+++ b/Source/WebCore/rendering/RenderBlock.h
@@ -260,6 +260,8 @@ public:
 
     void layoutOutOfFlowBoxes(RelayoutChildren, bool fixedPositionObjectsOnly = false);
 
+    static void relayoutRenderBlockForScrollbarChange(RenderBlock&);
+
 protected:
     RenderFragmentedFlow* locateEnclosingFragmentedFlow() const override;
     bool establishesIndependentFormattingContextIgnoringDisplayType(const RenderStyle&) const;

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -3145,7 +3145,8 @@ bool RenderBox::sizesPreferredLogicalWidthToFitContent() const
 
     // This code may look a bit strange.  Basically width:intrinsic should clamp the size when testing both
     // min-width and width.  max-width is only clamped if it is also intrinsic.
-    auto& logicalWidth = style().logicalWidth();
+    auto& style = this->style();
+    auto& logicalWidth = style.logicalWidth();
     if (logicalWidth.isIntrinsicKeyword())
         return true;
 
@@ -3193,6 +3194,9 @@ bool RenderBox::sizesPreferredLogicalWidthToFitContent() const
 
     if (isHorizontalWritingMode() != containingBlock()->isHorizontalWritingMode())
         return true;
+
+    if (isOutOfFlowPositioned() && logicalWidth.isAuto() && !shouldComputeLogicalWidthFromAspectRatio())
+        return style.logicalLeft().isAuto() || style.logicalRight().isAuto();
 
     return false;
 }

--- a/Source/WebCore/rendering/SubtreeScrollbarChangesState.cpp
+++ b/Source/WebCore/rendering/SubtreeScrollbarChangesState.cpp
@@ -94,9 +94,7 @@ SubtreeScrollbarChangesHandler::~SubtreeScrollbarChangesHandler()
     if (!isSubtreeRootHandlingScrollbarChanges) {
         while (!descendantsWithScrollbarChange.isEmpty()) {
             CheckedPtr rendererWithScrollbarChange = descendantsWithScrollbarChange.takeFirst();
-            auto scope = LayoutScope { *rendererWithScrollbarChange };
-            rendererWithScrollbarChange->setNeedsLayout(MarkingBehavior::MarkOnlyThis);
-            rendererWithScrollbarChange->layoutBlock(RelayoutChildren::Yes);
+            RenderBlock::relayoutRenderBlockForScrollbarChange(*rendererWithScrollbarChange);
         }
         return;
     }


### PR DESCRIPTION
#### 999b6ea5d83a8c26e38887168ad2b4a354efffe3
<pre>
Shrink-to-fit boxes with do not update their width when a scrollbar is added mid-layout.
<a href="https://bugs.webkit.org/show_bug.cgi?id=314898">https://bugs.webkit.org/show_bug.cgi?id=314898</a>
<a href="https://rdar.apple.com/problem/177172896">rdar://problem/177172896</a>

Reviewed by Alan Baradlay.

When a block sized to fit its content (float, inline-block, out-of-flow with
auto insets, or intrinsic-keyword width) has overflow:auto and its content
overflows, a scrollbar is added mid-layout via updateScrollInfoAfterLayout.
The subsequent self-relayout in RelayoutScopeForScrollbarChange was calling
layoutBlock(RelayoutChildren::Yes) without invalidating preferred widths, so
maxPreferredLogicalWidth() returned its cached value (without the scrollbar
gutter). As a result the block kept the narrower pre-scrollbar width and
its content ended up with a horizontal scrollbar that shrunk the space
for the actual content.

The same issue existed in the !isSubtreeRootHandlingScrollbarChanges path
of SubtreeScrollbarChangesHandler&apos;s destructor, which relaid out deferred
descendants without invalidating their preferred widths.

* LayoutTests/platform/glib/scrollbars/scrollbars-on-positioned-content-expected.txt:
* LayoutTests/platform/mac/scrollbars/scrollbars-on-positioned-content-expected.txt:
* LayoutTests/platform/win/scrollbars/scrollbars-on-positioned-content-expected.txt:
Rebaseline this test because the rendering now matches other engines.

* Source/WebCore/rendering/RenderBlock.cpp:
(WebCore::RenderBlock::relayoutRenderBlockForScrollbarChange):
Extract the relayout-after-scrollbar-change sequence into a shared helper.
When the block sizes to fit content, invalidate preferred widths so the
scrollbar gutter is picked up by the next width computation.

* Source/WebCore/rendering/RenderBox.cpp:
(WebCore::RenderBox::sizesPreferredLogicalWidthToFitContent const):
Report true for out-of-flow boxes with auto width and auto on at least one
inline inset, so the helper invalidates preferred widths for them too.

Canonical link: <a href="https://commits.webkit.org/313390@main">https://commits.webkit.org/313390@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5024192143c3b5f45801089fca8d264bf5a36b2c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162767 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36243 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29424 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171705 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119213 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9c4fd971-9794-41ee-9ae5-ccb3148de60a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164636 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36347 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36247 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126341 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88980 "18 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1958c3e3-e69c-4efd-8257-0598b656f9bb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165726 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28686 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146275 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106918 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9f33efea-f0e4-445e-9c9c-b7718a92cd37) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27732 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26266 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19405 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137440 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24004 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174209 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21701 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25649 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134651 "Passed tests") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35917 "Hash 50241921 for PR 64814 does not build (failure)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30368 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134646 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36361 "Built successfully and passed tests") | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35901 "Hash 50241921 for PR 64814 does not build (failure)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145800 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98313 "Built successfully") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/35901 "Hash 50241921 for PR 64814 does not build (failure)") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22636 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35411 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/103341 "Built successfully") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34912 "Hash 50241921 for PR 64814 does not build (failure)") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35157 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35060 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->