### PR TITLE
CSP form-action directive is not enforced on redirects during cross-frame form submissions

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/form-action/form-action-src-redirect-blocked-original-url-in-report.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/form-action/form-action-src-redirect-blocked-original-url-in-report.sub-expected.txt
@@ -1,0 +1,7 @@
+
+
+Verifies that when CSP form-action blocks a cross-origin redirect, the violation event's blockedURI is the same-origin pre-redirect URL, not the cross-origin redirect destination.
+
+
+PASS Block after cross-origin redirect: blockedURI is the pre-redirect URL
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/form-action/form-action-src-redirect-blocked-original-url-in-report.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/form-action/form-action-src-redirect-blocked-original-url-in-report.sub.html
@@ -1,0 +1,41 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+<meta http-equiv="Content-Security-Policy" content="form-action 'self'">
+<title>form-action-src-redirect-blocked-original-url-in-report</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+</head>
+
+<body>
+  <iframe name="cross_origin_target" id="cross_origin_iframe"></iframe>
+
+  <form id="form_cross_origin"
+        action="/common/redirect.py?location=http://{{domains[www1]}}:{{ports[http][0]}}/content-security-policy/support/postmessage-fail.html"
+        method="post"
+        target="cross_origin_target">
+    <input type="submit" id="submit_cross_origin">
+  </form>
+
+  <p>Verifies that when CSP form-action blocks a cross-origin redirect, the
+  violation event's blockedURI is the same-origin pre-redirect URL, not the
+  cross-origin redirect destination.</p>
+</body>
+
+<script>
+async_test(function(t) {
+    var expectedURL = location.protocol + "//" + location.host + "/common/redirect.py?location=http://{{domains[www1]}}:{{ports[http][0]}}/content-security-policy/support/postmessage-fail.html";
+    var listener = t.step_func(function(e) {
+        if (e.violatedDirective !== 'form-action')
+            return;
+        assert_equals(e.blockedURI, expectedURL, "blockedURI should be the same-origin pre-redirect URL");
+        document.removeEventListener('securitypolicyviolation', listener);
+        t.done();
+    });
+    document.addEventListener('securitypolicyviolation', listener);
+    document.getElementById("form_cross_origin").submit();
+}, "Block after cross-origin redirect: blockedURI is the pre-redirect URL");
+</script>
+
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/form-action/form-action-src-redirect-blocked-target-blank.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/form-action/form-action-src-redirect-blocked-target-blank.sub-expected.txt
@@ -1,6 +1,5 @@
 
-
-Tests that blocking a POST form with a redirect works correctly. If this test passes, a CSP violation will be generated.
+Tests that blocking a POST form with a redirect works correctly when the form uses target="_blank". If this test passes, a CSP violation will be generated.
 
 
 PASS Expecting logs: ["violated-directive=form-action","blocked-uri=http://web-platform.test:8800/common/redirect.py?location=http://www1.web-platform.test:8800/content-security-policy/support/postmessage-fail.html","TEST COMPLETE"]

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/form-action/form-action-src-redirect-blocked-target-blank.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/form-action/form-action-src-redirect-blocked-target-blank.sub.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+    <meta http-equiv="Content-Security-Policy" content="form-action 'self'; script-src 'self' 'unsafe-inline'; connect-src 'self';">
+    <title>form-action-src-redirect-blocked-target-blank</title>
+    <script src="/resources/testharness.js"></script>
+    <script src="/resources/testharnessreport.js"></script>
+    <script src='../support/logTest.sub.js?logs=["violated-directive=form-action","blocked-uri=http://{{hosts[][]}}:{{ports[http][0]}}/common/redirect.py?location=http://{{domains[www1]}}:{{ports[http][0]}}/content-security-policy/support/postmessage-fail.html","TEST COMPLETE"]'></script>
+    <script src="../support/alertAssert.sub.js?alerts=[]"></script>
+    <script>
+        window.addEventListener('securitypolicyviolation', function(e) {
+            log('violated-directive=' + e.violatedDirective);
+            log('blocked-uri=' + e.blockedURI);
+        });
+        window.addEventListener("message", function(event) {
+            alert_assert(event.data);
+        }, false);
+        window.addEventListener('load', function() {
+            setTimeout(function() {
+                document.getElementById('submit').click();
+                log("TEST COMPLETE");
+            }, 0);
+        });
+
+    </script>
+</head>
+
+<body>
+    <form id="form1" action="/common/redirect.py?location=http://{{domains[www1]}}:{{ports[http][0]}}/content-security-policy/support/postmessage-fail.html" method="post" target="_blank" rel="opener">
+        <input type="text" name="fieldname" value="fieldvalue">
+        <input type="submit" id="submit" value="submit">
+    </form>
+    <p>Tests that blocking a POST form with a redirect works correctly when the form uses target="_blank". If this test passes, a CSP violation will be generated.</p>
+    <div id="log"></div>
+</body>
+
+</html>

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/content-security-policy/form-action/form-action-src-redirect-blocked.sub-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/content-security-policy/form-action/form-action-src-redirect-blocked.sub-expected.txt
@@ -1,8 +1,0 @@
-
-
-Tests that blocking a POST form with a redirect works correctly. If this test passes, a CSP violation will be generated.
-
-
-FAIL Expecting logs: ["violated-directive=form-action","blocked-uri=http://web-platform.test:8800/common/redirect.py?location=http://www1.web-platform.test:8800/content-security-policy/support/postmessage-fail.html","TEST COMPLETE"] assert_unreached: Logging timeout, expected logs violated-directive=form-action,blocked-uri=http://web-platform.test:8800/common/redirect.py?location=http://www1.web-platform.test:8800/content-security-policy/support/postmessage-fail.html not sent. Reached unreachable code
-FAIL form-action-src-redirect-blocked assert_unreached: FAIL Reached unreachable code
-

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -645,6 +645,29 @@ void DocumentLoader::redirectReceived(ResourceRequest&& request, const ResourceR
     });
 }
 
+bool DocumentLoader::isFormActionAllowedByRequesterCSP(const URL& postRedirectURL, const ResourceResponse& redirectResponse) const
+{
+    // form-action only applies to form submissions.
+    auto navigationType = m_triggeringAction.type();
+    bool isFormSubmission = (navigationType == NavigationType::FormSubmitted) || (navigationType == NavigationType::FormResubmitted);
+    if (!isFormSubmission)
+        return true;
+
+    const auto& requester = m_triggeringAction.requester();
+    if (!requester)
+        return false;
+
+    // If the initiator document is in this process, use its live CSP object.
+    if (RefPtr initiatorDocument = Document::allDocumentsMap().get(requester->documentIdentifier))
+        return protect(initiatorDocument->contentSecurityPolicy())->allowFormAction(postRedirectURL, std::nullopt, ContentSecurityPolicy::RedirectResponseReceived::Yes, redirectResponse.url());
+
+    // Otherwise, reconstruct CSP from the headers captured at submission time.
+    // FIXME: standalone CSP has no client/document, so securitypolicyviolation events and console messages don't fire on this path.
+    ContentSecurityPolicy initiatorCSP(URL { requester->url }, nullptr, nullptr);
+    initiatorCSP.didReceiveHeaders(requester->policyContainer.contentSecurityPolicyResponseHeaders, String { }, ContentSecurityPolicy::ReportParsingErrors::No);
+    return initiatorCSP.allowFormAction(postRedirectURL, std::nullopt, ContentSecurityPolicy::RedirectResponseReceived::Yes, redirectResponse.url());
+}
+
 void DocumentLoader::willSendRequest(ResourceRequest&& newRequest, const ResourceResponse& redirectResponse, CompletionHandler<void(ResourceRequest&&)>&& completionHandler)
 {
     // Note that there are no asserts here as there are for the other callbacks. This is due to the
@@ -658,7 +681,7 @@ void DocumentLoader::willSendRequest(ResourceRequest&& newRequest, const Resourc
         DOCUMENTLOADER_RELEASE_LOG("willSendRequest: With no provisional document loader");
 
     bool didReceiveRedirectResponse = !redirectResponse.isNull();
-    if (!protect(frameLoader())->checkIfFormActionAllowedByCSP(newRequest.url(), didReceiveRedirectResponse, redirectResponse.url())) {
+    if (didReceiveRedirectResponse && !isFormActionAllowedByRequesterCSP(newRequest.url(), redirectResponse)) {
         DOCUMENTLOADER_RELEASE_LOG("willSendRequest: canceling - form action not allowed by CSP");
         cancelMainResourceLoad(protect(frameLoader())->cancelledError(newRequest));
         return completionHandler(WTF::move(newRequest));

--- a/Source/WebCore/loader/DocumentLoader.h
+++ b/Source/WebCore/loader/DocumentLoader.h
@@ -557,6 +557,8 @@ protected:
 private:
     Document* NODELETE document() const;
 
+    bool isFormActionAllowedByRequesterCSP(const URL& postRedirectURL, const ResourceResponse& redirectResponse) const;
+
     void matchRegistration(const URL&, CompletionHandler<void(std::optional<ServiceWorkerRegistrationData>&&)>&&);
     void unregisterReservedServiceWorkerClient();
 

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -4328,7 +4328,7 @@ void FrameLoader::continueLoadAfterNewWindowPolicy(ResourceRequest&& request,
         mainFrame->document()->setReferrerPolicy(frame->document()->referrerPolicy());
     }
 
-    NavigationAction newAction { protect(frame->document()).releaseNonNull(), request, InitiatedByMainFrame::Unknown, action.isRequestFromClientOrUserInput(), NavigationType::Other, action.shouldOpenExternalURLsPolicy(), nullptr, action.downloadAttribute() };
+    NavigationAction newAction { protect(frame->document()).releaseNonNull(), request, InitiatedByMainFrame::Unknown, action.isRequestFromClientOrUserInput(), action.type(), action.shouldOpenExternalURLsPolicy(), nullptr, action.downloadAttribute() };
     newAction.setShouldReplaceDocumentIfJavaScriptURL(action.shouldReplaceDocumentIfJavaScriptURL());
     mainFrameLoader->loadWithNavigationAction(WTF::move(request), WTF::move(newAction), FrameLoadType::Standard, WTF::move(formSubmission), allowNavigationToInvalidURL, ShouldTreatAsContinuingLoad::No);
 }


### PR DESCRIPTION
#### 6aa8a86bc5dc6365bdf50e7d4e538ee849db43eb
<pre>
CSP form-action directive is not enforced on redirects during cross-frame form submissions
<a href="https://bugs.webkit.org/show_bug.cgi?id=314702">https://bugs.webkit.org/show_bug.cgi?id=314702</a>
<a href="https://rdar.apple.com/176272230">rdar://176272230</a>

Reviewed by NOBODY (OOPS!).

When a form targets a different browsing context, the form-action directive fails to block server-side redirects to disallowed
URLs. The redirect proceeds and the full POST body is sent cross-origin without generating a securitypolicyviolation event.

Check the requester&apos;s CSP form-action directive in DocumentLoader::willSendRequest when a form submission redirect occurs.
The requester&apos;s CSP is available via the NavigationAction&apos;s NavigationRequester, which carries the submitting document&apos;s policy
container regardless of the target frame. Also preserve the navigation type through new window creation in
continueLoadAfterNewWindowPolicy so the check applies to target=&quot;_blank&quot; submissions.

Tests: imported/w3c/web-platform-tests/content-security-policy/form-action/form-action-src-redirect-blocked-original-url-in-report.sub.html
       imported/w3c/web-platform-tests/content-security-policy/form-action/form-action-src-redirect-blocked-target-blank.sub.html

* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/form-action/form-action-src-redirect-blocked-original-url-in-report.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/form-action/form-action-src-redirect-blocked-original-url-in-report.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/form-action/form-action-src-redirect-blocked-target-blank.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/form-action/form-action-src-redirect-blocked-target-blank.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/form-action/form-action-src-redirect-blocked.sub-expected.txt:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/content-security-policy/form-action/form-action-src-redirect-blocked.sub-expected.txt: Removed.
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::isFormActionAllowedByRequesterCSP const):
(WebCore::DocumentLoader::willSendRequest):
* Source/WebCore/loader/DocumentLoader.h:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::continueLoadAfterNewWindowPolicy):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6aa8a86bc5dc6365bdf50e7d4e538ee849db43eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163861 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37345 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30564 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172889 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121112 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/56e51fb7-531b-43c8-8b5e-17bb6972a605) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165730 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37677 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37344 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127284 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89647 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/60394583-a44f-4552-b28f-4e2b1a515ce3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166820 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29572 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147308 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107833 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/60cb8b58-306b-4131-b43b-4670012e889a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28618 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27247 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20654 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138518 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25025 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175411 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28237 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26693 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135592 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37015 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31394 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135567 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37800 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146820 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99937 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30880 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23675 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36511 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109656 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36008 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1787 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36258 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36155 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->