### PR TITLE
[Site Isolation] [ iOS ] http/tests/site-isolation/cross-site-window-open-uses-different-process.html is a constant text failure

### DIFF
--- a/LayoutTests/http/tests/site-isolation/cross-site-window-open-uses-different-process-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/cross-site-window-open-uses-different-process-expected.txt
@@ -1,3 +1,11 @@
+Cross-site window.open uses a different process
 
-PASS Cross-site window.open uses a different process
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS messageType is "processId"
+PASS openerPID is not openedPID
+PASS successfullyParsed is true
+
+TEST COMPLETE
 

--- a/LayoutTests/http/tests/site-isolation/cross-site-window-open-uses-different-process.html
+++ b/LayoutTests/http/tests/site-isolation/cross-site-window-open-uses-different-process.html
@@ -2,36 +2,31 @@
 <!DOCTYPE html>
 <html>
 <head>
-<script src="/resources/testharness.js"></script>
-<script src="/resources/testharnessreport.js"></script>
+<script src="/js-test-resources/js-test.js"></script>
 </head>
 <body>
 <script>
-promise_test(async (t) => {
+    description("Cross-site window.open uses a different process");
+    jsTestIsAsync = true;
+
     if (!window.internals) {
-        assert_unreached("This test requires internals API");
-        return;
-    }
+        testFailed("This test requires the Internals API");
+        finishJSTest();
+    } else {
+        openerPID = internals.processIdentifier;
 
-    const openerPID = internals.processIdentifier;
-
-    // Open a cross-site window (localhost vs 127.0.0.1 are different sites)
-    const openedWindow = window.open("http://localhost:8000/site-isolation/resources/report-process-id.html");
-    t.add_cleanup(() => { if (openedWindow) openedWindow.close(); });
-
-    const event = await new Promise((resolve, reject) => {
-        const timeout = t.step_timeout(() => reject(new Error("Timeout waiting for message")), 5000);
-        window.addEventListener("message", (e) => {
-            clearTimeout(timeout);
-            resolve(e);
+        window.addEventListener("message", (event) => {
+            messageType = event.data.type;
+            openedPID = event.data.pid;
+            shouldBeEqualToString("messageType", "processId");
+            shouldNotBe("openerPID", "openedPID");
+            openedWindow.close();
+            finishJSTest();
         }, { once: true });
-    });
 
-    assert_equals(event.data.type, "processId", "Should receive processId message");
-    const openedPID = event.data.pid;
-
-    assert_not_equals(openerPID, openedPID, "Cross-site window.open should use a different process");
-}, "Cross-site window.open uses a different process");
+        // localhost and 127.0.0.1 are different sites
+        openedWindow = window.open("http://localhost:8000/site-isolation/resources/report-process-id.html");
+    }
 </script>
 </body>
 </html>


### PR DESCRIPTION
#### aafadd2f78962d3e83fa1d693f99e6ca5a179aab
<pre>
[Site Isolation] [ iOS ] http/tests/site-isolation/cross-site-window-open-uses-different-process.html is a constant text failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=314706">https://bugs.webkit.org/show_bug.cgi?id=314706</a>
<a href="https://rdar.apple.com/176902914">rdar://176902914</a>

Reviewed by Ryosuke Niwa, Charlie Wolfe, and Sihui Liu.

This test is timing out because the response from the opened window takes longer
than the 5 second timeout the test sets. If we increase the timeout to 15 seconds,
the test passes. Going back in the history of this test&apos;s runs, it looks like
it was always flaky. It&apos;s possible that a recent change made the test slightly
slower so it now times out consistently instead of flakily. Instead of explicitly
setting a longer timeout duration, we fix this test by rewriting it so that it
finishes when the opener receives the response. If it doesn&apos;t, the test will hit
the default timeout of the TestRunner.

* LayoutTests/http/tests/site-isolation/cross-site-window-open-uses-different-process-expected.txt:
* LayoutTests/http/tests/site-isolation/cross-site-window-open-uses-different-process.html:

Canonical link: <a href="https://commits.webkit.org/313216@main">https://commits.webkit.org/313216@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/677c6fc206c4bbf84f24da0004c98be4cadc32c4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162356 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35832 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28948 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171294 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/118801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35936 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35834 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125992 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/118801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165315 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28333 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145845 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106570 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27380 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25903 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18994 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137083 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23578 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173798 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25222 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134293 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35506 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29991 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134293 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35490 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145374 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97745 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24676 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28833 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22204 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34999 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34501 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34746 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34649 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->