### PR TITLE
Use modern integer hash

### DIFF
--- a/LayoutTests/inspector/animation/lifecycle-css-animation-expected.txt
+++ b/LayoutTests/inspector/animation/lifecycle-css-animation-expected.txt
@@ -17,17 +17,17 @@ keyframes:
   {
     "offset": 0,
     "easing": "cubic-bezier(0.1, 0.2, 0.3, 0.4)",
-    "style": "color: rgb(255, 0, 0);\nopacity: 0;"
+    "style": "opacity: 0;\ncolor: rgb(255, 0, 0);"
   },
   {
     "offset": 0.5,
     "easing": "cubic-bezier(0.1, 0.2, 0.3, 0.4)",
-    "style": "color: rgb(0, 128, 0);\nopacity: 0.5;"
+    "style": "opacity: 0.5;\ncolor: rgb(0, 128, 0);"
   },
   {
     "offset": 1,
     "easing": "cubic-bezier(0.1, 0.2, 0.3, 0.4)",
-    "style": "color: rgb(0, 0, 255);\nopacity: 1;"
+    "style": "opacity: 1;\ncolor: rgb(0, 0, 255);"
   }
 ]
 
@@ -51,17 +51,17 @@ keyframes:
   {
     "offset": 0,
     "easing": "cubic-bezier(0.1, 0.2, 0.3, 0.4)",
-    "style": "color: rgb(255, 0, 0);\nopacity: 0;"
+    "style": "opacity: 0;\ncolor: rgb(255, 0, 0);"
   },
   {
     "offset": 0.5,
     "easing": "cubic-bezier(0.1, 0.2, 0.3, 0.4)",
-    "style": "color: rgb(0, 128, 0);\nopacity: 0.5;"
+    "style": "opacity: 0.5;\ncolor: rgb(0, 128, 0);"
   },
   {
     "offset": 1,
     "easing": "cubic-bezier(0.1, 0.2, 0.3, 0.4)",
-    "style": "color: rgb(0, 0, 255);\nopacity: 1;"
+    "style": "opacity: 1;\ncolor: rgb(0, 0, 255);"
   }
 ]
 

--- a/LayoutTests/media/media-session/actionHandlerInternalMappings-expected.txt
+++ b/LayoutTests/media/media-session/actionHandlerInternalMappings-expected.txt
@@ -21,14 +21,14 @@ Command: StopCommand
 ACTION: seekto
 Command: SeekToPlaybackPositionCommand
 Iterate over all possible actions
-Command: PauseCommand
-Command: PlayCommand
-Command: SkipBackwardCommand
 Command: SkipForwardCommand
-Command: SeekToPlaybackPositionCommand
+Command: SkipBackwardCommand
 Command: PreviousTrackCommand
-Command: NextTrackCommand
+Command: PlayCommand
+Command: SeekToPlaybackPositionCommand
 Command: StopCommand
+Command: PauseCommand
+Command: NextTrackCommand
 Iterate over possible actions after video element src is cleared
 RUN(video.src = "")
 EVENT(loadstart)

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -5398,15 +5398,17 @@ void SpeculativeJIT::compile(Node* node)
             JSValueOperand input(this, node->child1(), ManualOperandSpeculation);
             GPRTemporary result(this, Reuse, input);
             GPRTemporary temp(this);
+            GPRTemporary temp2(this);
 
             GPRReg inputGPR = input.gpr();
             GPRReg resultGPR = result.gpr();
             GPRReg tempGPR = temp.gpr();
+            GPRReg temp2GPR = temp2.gpr();
 
             speculate(node, node->child1());
 
             move(inputGPR, resultGPR);
-            wangsInt64Hash(resultGPR, tempGPR);
+            rapidHashMix64(resultGPR, tempGPR, temp2GPR);
             strictInt32Result(resultGPR, node);
             break;
         }
@@ -5428,11 +5430,15 @@ void SpeculativeJIT::compile(Node* node)
             SpeculateCellOperand input(this, node->child1());
             GPRTemporary result(this);
             std::optional<GPRTemporary> temp;
+            std::optional<GPRTemporary> temp2;
 
             GPRReg tempGPR = InvalidGPRReg;
+            GPRReg temp2GPR = InvalidGPRReg;
             if (node->child1().useKind() == CellUse) {
                 temp.emplace(this);
                 tempGPR = temp->gpr();
+                temp2.emplace(this);
+                temp2GPR = temp2->gpr();
             }
 
             GPRReg inputGPR = input.gpr();
@@ -5447,7 +5453,7 @@ void SpeculativeJIT::compile(Node* node)
                 auto isString = branchIfString(inputGPR);
                 auto isHeapBigInt = branchIfHeapBigInt(inputGPR);
                 move(inputGPR, resultGPR);
-                wangsInt64Hash(resultGPR, tempGPR);
+                rapidHashMix64(resultGPR, tempGPR, temp2GPR);
                 addSlowPathGenerator(slowPathCall(isHeapBigInt, this, operationMapHashHeapBigInt, NeedToSpill, ExceptionCheckRequirement::CheckNotNeeded, resultGPR, TrustedImmPtr(&vm()), inputGPR));
                 done.append(jump());
                 isString.link(this);
@@ -5477,11 +5483,13 @@ void SpeculativeJIT::compile(Node* node)
 
         JSValueOperand input(this, node->child1());
         GPRTemporary temp(this);
+        GPRTemporary temp2(this);
         GPRTemporary result(this);
 
         GPRReg inputGPR = input.gpr();
         GPRReg resultGPR = result.gpr();
         GPRReg tempGPR = temp.gpr();
+        GPRReg temp2GPR = temp2.gpr();
 
         JumpList straightHash;
         JumpList done;
@@ -5498,7 +5506,7 @@ void SpeculativeJIT::compile(Node* node)
 
         straightHash.link(this);
         move(inputGPR, resultGPR);
-        wangsInt64Hash(resultGPR, tempGPR);
+        rapidHashMix64(resultGPR, tempGPR, temp2GPR);
         addSlowPathGenerator(slowPathCall(isHeapBigInt, this, operationMapHashHeapBigInt, NeedToSpill, ExceptionCheckRequirement::CheckNotNeeded, resultGPR, TrustedImmPtr(&vm()), inputGPR));
         done.append(jump());
 

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -15632,47 +15632,21 @@ IGNORE_CLANG_WARNINGS_END
         setBoolean(m_out.phi(Int32, notCellResult, cellResult));
     }
 
-    LValue wangsInt64Hash(LValue input)
+    LValue rapidHashMix64(LValue input)
     {
-        // key += ~(key << 32);
-        LValue key = input;
-        LValue temp = key;
-        temp = m_out.shl(temp, m_out.constInt32(32));
-        temp = m_out.bitNot(temp);
-        key = m_out.add(key, temp);
-        // key ^= (key >> 22);
-        temp = key;
-        temp = m_out.lShr(temp, m_out.constInt32(22));
-        key = m_out.bitXor(key, temp);
-        // key += ~(key << 13);
-        temp = key;
-        temp = m_out.shl(temp, m_out.constInt32(13));
-        temp = m_out.bitNot(temp);
-        key = m_out.add(key, temp);
-        // key ^= (key >> 8);
-        temp = key;
-        temp = m_out.lShr(temp, m_out.constInt32(8));
-        key = m_out.bitXor(key, temp);
-        // key += (key << 3);
-        temp = key;
-        temp = m_out.shl(temp, m_out.constInt32(3));
-        key = m_out.add(key, temp);
-        // key ^= (key >> 15);
-        temp = key;
-        temp = m_out.lShr(temp, m_out.constInt32(15));
-        key = m_out.bitXor(key, temp);
-        // key += ~(key << 27);
-        temp = key;
-        temp = m_out.shl(temp, m_out.constInt32(27));
-        temp = m_out.bitNot(temp);
-        key = m_out.add(key, temp);
-        // key ^= (key >> 31);
-        temp = key;
-        temp = m_out.lShr(temp, m_out.constInt32(31));
-        key = m_out.bitXor(key, temp);
-        key = m_out.castToInt32(key);
-
-        return key;
+        // WYHash / rapidhash "mum" mixer. Must match the C++ rapidHashMix64
+        // in HashMapHelper.h and the DFG AssemblyHelpers implementation so
+        // FTL-inlined hashes agree with the runtime hashers used by
+        // operationMapHash and friends. B3 lowers UMulHigh to umulh on ARM64
+        // and to the mulq rdx:rax sequence on x86-64.
+        auto secret1 = m_out.constInt64(0x2d358dccaa6c78a5ULL);
+        auto secret2 = m_out.constInt64(0x8bb84b93962eacc9ULL);
+        auto a = m_out.bitXor(input, secret1);
+        auto b = m_out.bitXor(input, secret2);
+        auto lo = m_out.mul(a, b);
+        auto hi = m_out.uMulHigh(a, b);
+        auto folded = m_out.bitXor(lo, hi);
+        return m_out.castToInt32(folded);
     }
 
     LValue mapHashString(LValue string, Edge& edge)
@@ -15712,7 +15686,7 @@ IGNORE_CLANG_WARNINGS_END
         case ObjectUse: {
             LValue key = lowJSValue(m_node->child1(), ManualOperandSpeculation);
             speculate(m_node->child1());
-            setInt32(wangsInt64Hash(key));
+            setInt32(rapidHashMix64(key));
             return;
         }
 
@@ -15746,7 +15720,7 @@ IGNORE_CLANG_WARNINGS_END
             m_out.jump(continuation);
 
             m_out.appendTo(notStringNorHeapBigIntCase, continuation);
-            ValueFromBlock notStringResult = m_out.anchor(wangsInt64Hash(value));
+            ValueFromBlock notStringResult = m_out.anchor(rapidHashMix64(value));
             m_out.jump(continuation);
 
             m_out.appendTo(continuation, lastNext);
@@ -15797,7 +15771,7 @@ IGNORE_CLANG_WARNINGS_END
             unsure(slowCase), unsure(continuation));
 
         m_out.appendTo(straightHash, slowCase);
-        ValueFromBlock fastResult = m_out.anchor(wangsInt64Hash(value));
+        ValueFromBlock fastResult = m_out.anchor(rapidHashMix64(value));
         m_out.jump(continuation);
 
         m_out.appendTo(slowCase, continuation);

--- a/Source/JavaScriptCore/ftl/FTLOutput.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOutput.cpp
@@ -165,6 +165,11 @@ LValue Output::mul(LValue left, LValue right)
     return m_block->appendNew<B3::Value>(m_proc, B3::Mul, origin(), left, right);
 }
 
+LValue Output::uMulHigh(LValue left, LValue right)
+{
+    return m_block->appendNew<B3::Value>(m_proc, B3::UMulHigh, origin(), left, right);
+}
+
 LValue Output::div(LValue left, LValue right)
 {
     return m_block->appendNew<B3::Value>(m_proc, B3::Div, origin(), left, right);

--- a/Source/JavaScriptCore/ftl/FTLOutput.h
+++ b/Source/JavaScriptCore/ftl/FTLOutput.h
@@ -157,6 +157,7 @@ public:
     LValue add(LValue, LValue);
     LValue sub(LValue, LValue);
     LValue mul(LValue, LValue);
+    LValue uMulHigh(LValue, LValue);
     LValue div(LValue, LValue);
     LValue chillDiv(LValue, LValue);
     LValue mod(LValue, LValue);

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.cpp
@@ -1242,62 +1242,94 @@ void AssemblyHelpers::emitVirtualCallWithoutMovingGlobalObject(VM& vm, GPRReg ca
 }
 
 #if USE(JSVALUE64)
-void AssemblyHelpers::wangsInt64Hash(GPRReg inputAndResult, GPRReg scratch)
+void AssemblyHelpers::rapidHashMix64(GPRReg inputAndResult, GPRReg scratch1, GPRReg scratch2)
 {
+    // rapidhash "mum" mixer. Keep in sync with WTF intHash and FTL rapidHashMix64 code
+    // as we need to use the same hash function.
+    //
+    //   a = key ^ secret1
+    //   b = key ^ secret2
+    //   product = a * b                  (128-bit)
+    //   result  = lo64(product) ^ hi64(product)
+    //
     GPRReg input = inputAndResult;
+
+    ASSERT(scratch1 != scratch2);
+    ASSERT(scratch1 != input);
+    ASSERT(scratch2 != input);
+
 #if CPU(ARM64)
-    // key += ~(key << 32) => key = key - (key << 32) - 1
-    subLeftShift64(input, input, TrustedImm32(32), input);
-    sub64(TrustedImm32(1), input);
-    // key ^= (key >> 22)
-    xorUnsignedRightShift64(input, input, TrustedImm32(22), input);
-    // key += ~(key << 13) => key = key - (key << 13) - 1
-    subLeftShift64(input, input, TrustedImm32(13), input);
-    sub64(TrustedImm32(1), input);
-    // key ^= (key >> 8)
-    xorUnsignedRightShift64(input, input, TrustedImm32(8), input);
-    // key += (key << 3)
-    addLeftShift64(input, input, TrustedImm32(3), input);
-    // key ^= (key >> 15)
-    xorUnsignedRightShift64(input, input, TrustedImm32(15), input);
-    // key += ~(key << 27) => key = key - (key << 27) - 1
-    subLeftShift64(input, input, TrustedImm32(27), input);
-    sub64(TrustedImm32(1), input);
-    // key ^= (key >> 31)
-    xorUnsignedRightShift64(input, input, TrustedImm32(31), input);
-    UNUSED_PARAM(scratch);
+    // scratch1 = input ^ secret1 = a
+    move(TrustedImm64(static_cast<int64_t>(0x2d358dccaa6c78a5ULL)), scratch1);
+    xor64(input, scratch1);
+    // scratch2 = input ^ secret2 = b
+    move(TrustedImm64(static_cast<int64_t>(0x8bb84b93962eacc9ULL)), scratch2);
+    xor64(input, scratch2);
+    // input is dead as a value now; reuse its register for the hi half.
+    uMulHigh64(scratch1, scratch2, input);  // input = hi64(a * b)
+    mul64(scratch1, scratch2, scratch1);    // scratch1 = lo64(a * b); scratch2 preserved
+    xor64(scratch1, input);                 // input = lo ^ hi = hash
+#elif CPU(X86_64)
+    // x86-64 mulq uses rax and rdx implicitly: rdx:rax = rax * src.
+    // We use scratchRegister, scratch1, and scratch2 to save and restore rax / rdx.
+    GPRReg inputSafe = scratchRegister();
+    move(input, inputSafe); // scratchRegister is never rax / rdx.
+
+    // Whether we need to preserve either rax or rdx.
+    // If they are in scratches, then we do not need to specially save and restore them.
+    bool preserveRax = (scratch1 != X86Registers::eax) && (scratch2 != X86Registers::eax);
+    bool preserveRdx = (scratch1 != X86Registers::edx) && (scratch2 != X86Registers::edx);
+
+    // A scratch is a valid persistent save slot only if it is neither rax nor rdx
+    GPRReg safeScratch1 = (scratch1 != X86Registers::eax && scratch1 != X86Registers::edx) ? scratch1 : InvalidGPRReg;
+    GPRReg safeScratch2 = (scratch2 != X86Registers::eax && scratch2 != X86Registers::edx) ? scratch2 : InvalidGPRReg;
+
+    GPRReg raxSaveSlot = InvalidGPRReg;
+    GPRReg rdxSaveSlot = InvalidGPRReg;
+    if (preserveRax) {
+        raxSaveSlot = (safeScratch1 != InvalidGPRReg) ? safeScratch1 : safeScratch2;
+        ASSERT(raxSaveSlot != InvalidGPRReg);
+    }
+    if (preserveRdx) {
+        if (safeScratch1 != InvalidGPRReg && safeScratch1 != raxSaveSlot)
+            rdxSaveSlot = safeScratch1;
+        else
+            rdxSaveSlot = safeScratch2;
+        ASSERT(rdxSaveSlot != InvalidGPRReg);
+    }
+
+    if (preserveRax)
+        move(X86Registers::eax, raxSaveSlot);
+    if (preserveRdx)
+        move(X86Registers::edx, rdxSaveSlot);
+
+    // rax = input ^ secret1 = a
+    move(TrustedImm64(static_cast<int64_t>(0x2d358dccaa6c78a5ULL)), X86Registers::eax);
+    xor64(inputSafe, X86Registers::eax);
+    // rdx = input ^ secret2 = b
+    move(TrustedImm64(static_cast<int64_t>(0x8bb84b93962eacc9ULL)), X86Registers::edx);
+    xor64(inputSafe, X86Registers::edx);
+
+    // mulq rdx: rdx:rax = rax * rdx = a * b; rax has lo, rdx has hi.
+    m_assembler.mulq_r(X86Registers::edx);
+    xor64(X86Registers::edx, X86Registers::eax);  // rax = lo ^ hi = hash
+
+    move(X86Registers::eax, scratchRegister());
+
+    if (preserveRax)
+        move(raxSaveSlot, X86Registers::eax);
+    if (preserveRdx)
+        move(rdxSaveSlot, X86Registers::edx);
+
+    move(scratchRegister(), inputAndResult);
 #else
-    lshift64(input, TrustedImm32(32), scratch);
-    not64(scratch);
-    add64(scratch, input);
-    // key ^= (key >> 22);
-    urshift64(input, TrustedImm32(22), scratch);
-    xor64(scratch, input);
-    // key += ~(key << 13);
-    lshift64(input, TrustedImm32(13), scratch);
-    not64(scratch);
-    add64(scratch, input);
-    // key ^= (key >> 8);
-    urshift64(input, TrustedImm32(8), scratch);
-    xor64(scratch, input);
-    // key += (key << 3);
-    lshift64(input, TrustedImm32(3), scratch);
-    add64(scratch, input);
-    // key ^= (key >> 15);
-    urshift64(input, TrustedImm32(15), scratch);
-    xor64(scratch, input);
-    // key += ~(key << 27);
-    lshift64(input, TrustedImm32(27), scratch);
-    not64(scratch);
-    add64(scratch, input);
-    // key ^= (key >> 31);
-    urshift64(input, TrustedImm32(31), scratch);
-    xor64(scratch, input);
-#endif // CPU(ARM64)
+    UNUSED_PARAM(scratch1);
+    UNUSED_PARAM(scratch2);
+    RELEASE_ASSERT_NOT_REACHED();
+#endif
 
     // return static_cast<unsigned>(result)
-    void* mask = std::bit_cast<void*>(static_cast<uintptr_t>(UINT_MAX));
-    and64(TrustedImmPtr(mask), inputAndResult);
+    zeroExtend32ToWord(inputAndResult, inputAndResult);
 }
 #endif // USE(JSVALUE64)
 

--- a/Source/JavaScriptCore/jit/AssemblyHelpers.h
+++ b/Source/JavaScriptCore/jit/AssemblyHelpers.h
@@ -2140,7 +2140,7 @@ public:
     }
 
 #if USE(JSVALUE64)
-    void wangsInt64Hash(GPRReg inputAndResult, GPRReg scratch);
+    void rapidHashMix64(GPRReg inputAndResult, GPRReg scratch1, GPRReg scratch2);
 #endif
 
 #if ENABLE(WEBASSEMBLY)

--- a/Source/JavaScriptCore/runtime/HashMapHelper.h
+++ b/Source/JavaScriptCore/runtime/HashMapHelper.h
@@ -32,6 +32,7 @@
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/JSString.h>
 #include <JavaScriptCore/VMTrapsInlines.h>
+#include <wtf/Int128.h>
 
 namespace JSC {
 
@@ -71,17 +72,9 @@ ALWAYS_INLINE JSValue normalizeMapKey(JSValue key)
     return key;
 }
 
-ALWAYS_INLINE uint32_t wangsInt64Hash(uint64_t key)
+ALWAYS_INLINE uint32_t rapidHashMix64(uint64_t key)
 {
-    key += ~(key << 32);
-    key ^= (key >> 22);
-    key += ~(key << 13);
-    key ^= (key >> 8);
-    key += (key << 3);
-    key ^= (key >> 15);
-    key += ~(key << 27);
-    key ^= (key >> 31);
-    return static_cast<unsigned>(key);
+    return intHash(key);
 }
 
 ALWAYS_INLINE uint32_t jsMapHash(JSBigInt* bigInt)
@@ -107,7 +100,7 @@ ALWAYS_INLINE uint32_t jsMapHashImpl(JSGlobalObject* globalObject, VM& vm, JSVal
     if (value.isHeapBigInt())
         return jsMapHash(value.asHeapBigInt());
 
-    return wangsInt64Hash(JSValue::encode(value));
+    return rapidHashMix64(JSValue::encode(value));
 }
 
 ALWAYS_INLINE uint32_t jsMapHash(JSGlobalObject* globalObject, VM& vm, JSValue value)
@@ -137,7 +130,7 @@ ALWAYS_INLINE std::optional<uint32_t> concurrentJSMapHash(JSValue key)
         return key.asHeapBigInt()->concurrentHash();
 
     uint64_t rawValue = JSValue::encode(key);
-    return wangsInt64Hash(rawValue);
+    return rapidHashMix64(rawValue);
 }
 
 static constexpr uint32_t hashMapInitialCapacity = 4;

--- a/Source/JavaScriptCore/runtime/WeakMapImplInlines.h
+++ b/Source/JavaScriptCore/runtime/WeakMapImplInlines.h
@@ -37,7 +37,7 @@ namespace JSC {
 
 ALWAYS_INLINE uint32_t jsWeakMapHash(JSCell* key)
 {
-    return wangsInt64Hash(JSValue::encode(key));
+    return rapidHashMix64(JSValue::encode(key));
 }
 
 ALWAYS_INLINE uint32_t nextCapacityAfterBatchRemoval(uint32_t capacity, uint32_t keyCount)

--- a/Source/WTF/wtf/HashFunctions.h
+++ b/Source/WTF/wtf/HashFunctions.h
@@ -23,62 +23,37 @@
 #include <stdint.h>
 #include <tuple>
 #include <wtf/GetPtr.h>
+#include <wtf/Int128.h>
 #include <wtf/RefPtr.h>
 #include <wtf/StdLibExtras.h>
 
 namespace WTF {
     // integer hash function
 
-    // Thomas Wang's 32 Bit Mix Function: http://www.cris.com/~Ttwang/tech/inthash.htm
-    inline unsigned intHash(uint8_t key8)
-    {
-        unsigned key = key8;
-        key += ~(key << 15);
-        key ^= (key >> 10);
-        key += (key << 3);
-        key ^= (key >> 6);
-        key += ~(key << 11);
-        key ^= (key >> 16);
-        return key;
-    }
-
-    // Thomas Wang's 32 Bit Mix Function: http://www.cris.com/~Ttwang/tech/inthash.htm
-    inline unsigned intHash(uint16_t key16)
-    {
-        unsigned key = key16;
-        key += ~(key << 15);
-        key ^= (key >> 10);
-        key += (key << 3);
-        key ^= (key >> 6);
-        key += ~(key << 11);
-        key ^= (key >> 16);
-        return key;
-    }
-
-    // Thomas Wang's 32 Bit Mix Function: http://www.cris.com/~Ttwang/tech/inthash.htm
-    inline unsigned intHash(uint32_t key) 
-    {
-        key += ~(key << 15);
-        key ^= (key >> 10);
-        key += (key << 3);
-        key ^= (key >> 6);
-        key += ~(key << 11);
-        key ^= (key >> 16);
-        return key;
-    }
-    
-    // Thomas Wang's 64 bit Mix Function: http://www.cris.com/~Ttwang/tech/inthash.htm
+    // rapidhash "mum" mixer.
+    // Keep in sync with AssemblyHelpers::rapidHashMix64 and FTL rapidHashMix64 code as we need to use the same hash function.
     inline unsigned intHash(uint64_t key)
     {
-        key += ~(key << 32);
-        key ^= (key >> 22);
-        key += ~(key << 13);
-        key ^= (key >> 8);
-        key += (key << 3);
-        key ^= (key >> 15);
-        key += ~(key << 27);
-        key ^= (key >> 31);
-        return static_cast<unsigned>(key);
+        constexpr uint64_t secret1 = 0x2d358dccaa6c78a5ULL;
+        constexpr uint64_t secret2 = 0x8bb84b93962eacc9ULL;
+        UInt128 product = static_cast<UInt128>(key ^ secret1) * static_cast<UInt128>(key ^ secret2);
+        uint64_t folded = static_cast<uint64_t>(product) ^ static_cast<uint64_t>(product >> 64);
+        return static_cast<unsigned>(folded);
+    }
+
+    inline unsigned intHash(uint32_t key)
+    {
+        return intHash(static_cast<uint64_t>(key));
+    }
+
+    inline unsigned intHash(uint8_t key8)
+    {
+        return intHash(static_cast<uint32_t>(key8));
+    }
+
+    inline unsigned intHash(uint16_t key16)
+    {
+        return intHash(static_cast<uint32_t>(key16));
     }
 
     // Compound integer hash method: http://opendatastructures.org/versions/edition-0.1d/ods-java/node33.html#SECTION00832000000000000000

--- a/Source/WebCore/Modules/geolocation/Geolocation.h
+++ b/Source/WebCore/Modules/geolocation/Geolocation.h
@@ -41,6 +41,7 @@
 #include <wtf/CheckedRef.h>
 #include <wtf/HashMap.h>
 #include <wtf/HashSet.h>
+#include <wtf/OrderedHashMap.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 
 namespace WebCore {
@@ -114,7 +115,7 @@ private:
         bool NODELETE isEmpty() const;
         void getNotifiersVector(GeoNotifierVector&) const;
     private:
-        typedef HashMap<int, Ref<GeoNotifier>> IdToNotifierMap;
+        typedef WTF::OrderedHashMap<int, Ref<GeoNotifier>> IdToNotifierMap;
         typedef HashMap<Ref<GeoNotifier>, int> NotifierToIdMap;
         IdToNotifierMap m_idToNotifierMap;
         NotifierToIdMap m_notifierToIdMap;

--- a/Tools/TestWebKitAPI/Tests/WTF/HashCountedSet.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/HashCountedSet.cpp
@@ -72,7 +72,7 @@ TEST(WTF_HashCountedSet, DoubleHashCollisions)
     // The "clobber" key here is one that ends up stealing the bucket that the -0 key
     // originally wants to be in. This makes the 0 and -0 keys collide and the test then
     // fails unless the FloatHash::equals() implementation can distinguish them.
-    const double clobberKey = 6;
+    const double clobberKey = 7;
     const double zeroKey = 0;
     const double negativeZeroKey = -zeroKey;
 
@@ -114,7 +114,7 @@ TEST(WTF_HashCountedSet, DoubleHashCollisionsInitialCount)
     // The "clobber" key here is one that ends up stealing the bucket that the -0 key
     // originally wants to be in. This makes the 0 and -0 keys collide and the test then
     // fails unless the FloatHash::equals() implementation can distinguish them.
-    const double clobberKey = 6;
+    const double clobberKey = 7;
     const double zeroKey = 0;
     const double negativeZeroKey = -zeroKey;
 

--- a/Tools/TestWebKitAPI/Tests/WTF/HashMap.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/HashMap.cpp
@@ -101,7 +101,7 @@ TEST(WTF_HashMap, DoubleHashCollisions)
     // The "clobber" key here is one that ends up stealing the bucket that the -0 key
     // originally wants to be in. This makes the 0 and -0 keys collide and the test then
     // fails unless the FloatHash::equals() implementation can distinguish them.
-    const double clobberKey = 6;
+    const double clobberKey = 7;
     const double zeroKey = 0;
     const double negativeZeroKey = -zeroKey;
 

--- a/Tools/TestWebKitAPI/Tests/WTF/RobinHoodHashMap.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/RobinHoodHashMap.cpp
@@ -91,7 +91,7 @@ TEST(WTF_RobinHoodHashMap, DoubleHashCollisions)
     // The "clobber" key here is one that ends up stealing the bucket that the -0 key
     // originally wants to be in. This makes the 0 and -0 keys collide and the test then
     // fails unless the FloatHash::equals() implementation can distinguish them.
-    const double clobberKey = 6;
+    const double clobberKey = 7;
     const double zeroKey = 0;
     const double negativeZeroKey = -zeroKey;
 


### PR DESCRIPTION
#### 310c6dbf3ff6da547cbf9a97b6e0162c80b4f7d2
<pre>
Use modern integer hash
<a href="https://bugs.webkit.org/show_bug.cgi?id=314709">https://bugs.webkit.org/show_bug.cgi?id=314709</a>
<a href="https://rdar.apple.com/176954746">rdar://176954746</a>

Reviewed by Yijia Huang.

We update our integer hash function with modern ones.
We use rapidhash &quot;mum&quot; mixing for that.

* LayoutTests/inspector/animation/lifecycle-css-animation-expected.txt:
* LayoutTests/media/media-session/actionHandlerInternalMappings-expected.txt:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/ftl/FTLOutput.cpp:
(JSC::FTL::Output::uMulHigh):
* Source/JavaScriptCore/ftl/FTLOutput.h:
* Source/JavaScriptCore/jit/AssemblyHelpers.cpp:
(JSC::AssemblyHelpers::rapidHashMix64):
(JSC::AssemblyHelpers::wangsInt64Hash): Deleted.
* Source/JavaScriptCore/jit/AssemblyHelpers.h:
* Source/JavaScriptCore/runtime/HashMapHelper.h:
(JSC::rapidHashMix64):
(JSC::jsMapHashImpl):
(JSC::concurrentJSMapHash):
(JSC::wangsInt64Hash): Deleted.
* Source/JavaScriptCore/runtime/WeakMapImplInlines.h:
(JSC::jsWeakMapHash):
* Source/WTF/wtf/HashFunctions.h:
(WTF::intHash):
* Source/WebCore/Modules/geolocation/Geolocation.h:
* Tools/TestWebKitAPI/Tests/WTF/HashCountedSet.cpp:
(TestWebKitAPI::TEST(WTF_HashCountedSet, DoubleHashCollisions)):
(TestWebKitAPI::TEST(WTF_HashCountedSet, DoubleHashCollisionsInitialCount)):
* Tools/TestWebKitAPI/Tests/WTF/HashMap.cpp:
(TestWebKitAPI::TEST(WTF_HashMap, DoubleHashCollisions)):
* Tools/TestWebKitAPI/Tests/WTF/RobinHoodHashMap.cpp:
(TestWebKitAPI::TEST(WTF_RobinHoodHashMap, DoubleHashCollisions)):

Canonical link: <a href="https://commits.webkit.org/313224@main">https://commits.webkit.org/313224@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e88badfa160c95c10cf4285dfc1ea46d44baaa7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162446 "5 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35922 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29038 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171384 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/118891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164315 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36026 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35926 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126062 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/118891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165405 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28412 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145934 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106640 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25982 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19084 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137161 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23665 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173888 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23285 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21201 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25309 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134375 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35596 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30072 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134375 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35580 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145461 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97835 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24681 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28908 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/22293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194846 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35089 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102841 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/50339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34591 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34836 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34739 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->