### PR TITLE
[MotionMark] Cache repaint container offset to avoid ancestor walk in computeRepaintRects

### DIFF
--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -1254,8 +1254,13 @@ void RenderLayer::recursiveUpdateLayerPositions(OptionSet<UpdateLayerPositionsFl
         flags.add(SubtreeNeedsUpdate);
     }
 
-    if (updateLayerPosition(&flags, mode))
+    if (updateLayerPosition(&flags, mode)) {
         flags.add(SubtreeNeedsUpdate);
+        m_offsetToRepaintContainerValid = false;
+    }
+
+    if (flags.contains(SubtreeNeedsUpdate))
+        m_offsetToRepaintContainerValid = false;
 
 #if ASSERT_ENABLED
     if (mode == Write)
@@ -1515,12 +1520,65 @@ void RenderLayer::computeRepaintRects(const RenderLayerModelObject* repaintConta
 {
     ASSERT(!m_visibleContentStatusDirty);
 
-    if (isSubtreeVisibilityHiddenOrOpacityZero() || !isSelfPaintingLayer())
+    if (isSubtreeVisibilityHiddenOrOpacityZero() || !isSelfPaintingLayer()) {
         clearRepaintRects();
-    else
-        setRepaintRects(renderer().rectsForRepaintingAfterLayout(repaintContainer, RepaintOutlineBounds::Yes));
+        return;
+    }
 
+    if (m_offsetToRepaintContainerValid && m_repaintContainer.get() == repaintContainer) {
+        auto localRects = renderer().localRectsForRepaint(RepaintOutlineBounds::Yes);
+        if (!localRects.clippedOverflowRect.isEmpty()) {
+            if (isTransformed())
+                localRects.transform(currentTransform(), renderer().document().deviceScaleFactor());
+            if (auto* box = renderBox())
+                localRects.moveBy(box->location());
+            localRects.move(m_cachedOffsetToRepaintContainer);
+            if (localRects.outlineBoundsRect)
+                localRects.outlineBoundsRect = LayoutRect(snapRectToDevicePixels(*localRects.outlineBoundsRect, renderer().document().deviceScaleFactor()));
+        } else
+            localRects = { };
+#if ASSERT_ENABLED
+        auto expectedRects = renderer().rectsForRepaintingAfterLayout(repaintContainer, RepaintOutlineBounds::Yes);
+        ASSERT(localRects.clippedOverflowRect == expectedRects.clippedOverflowRect);
+        ASSERT(localRects.outlineBoundsRect == expectedRects.outlineBoundsRect);
+#endif
+        setRepaintRects(localRects);
+        return;
+    }
+
+    setRepaintRects(renderer().rectsForRepaintingAfterLayout(repaintContainer, RepaintOutlineBounds::Yes));
     m_repaintContainer = repaintContainer;
+    m_offsetToRepaintContainerValid = tryToCacheRepaintContainerOffset(repaintContainer);
+}
+
+bool RenderLayer::tryToCacheRepaintContainerOffset(const RenderLayerModelObject* repaintContainer)
+{
+    // The fast-path computes repaint rects by applying the renderer's own transform
+    // and location, then translating by a cached cumulative ancestor offset. This is
+    // only valid when:
+    //  - The renderer has no properties that require special coordinate mapping
+    //    (reflections, writing mode flips, in-flow positioning, widget snapping).
+    //  - Every ancestor up to repaintContainer is a layerless RenderBox in the same
+    //    writing mode — layerless guarantees no transforms, no positioning, no
+    //    overflow clipping, no reflections, no multi-column (see RenderBox::requiresLayer).
+
+    auto* box = renderBox();
+    if (!box)
+        return false;
+
+    if (box->hasReflection() || box->isWritingModeRoot() || box->style().hasInFlowPosition() || box->isRenderWidget())
+        return false;
+
+    LayoutSize offset;
+    for (auto* current = renderer().container(); current && current != repaintContainer; current = current->container()) {
+        auto* ancestor = dynamicDowncast<RenderBox>(*current);
+        if (!ancestor || ancestor->hasLayer() || ancestor->isWritingModeRoot())
+            return false;
+        offset += ancestor->locationOffset();
+    }
+
+    m_cachedOffsetToRepaintContainer = offset;
+    return true;
 }
 
 void RenderLayer::computeRepaintRectsIncludingDescendants()

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -1108,6 +1108,7 @@ private:
 
     void computeRepaintRects(const RenderLayerModelObject* repaintContainer);
     void computeRepaintRectsIncludingDescendants();
+    bool tryToCacheRepaintContainerOffset(const RenderLayerModelObject* repaintContainer);
 
     void compositingStatusChanged(LayoutUpToDate);
 
@@ -1465,6 +1466,7 @@ private:
     bool m_hasNotIsolatedBlendingDescendants : 1;
     bool m_hasNotIsolatedBlendingDescendantsStatusDirty : 1;
     bool m_repaintRectsValid : 1 { false };
+    bool m_offsetToRepaintContainerValid : 1 { false };
 
     bool m_intrinsicallyComposited : 1 { false };
     bool m_alwaysIncludedInZOrderLists : 1 { false };
@@ -1498,6 +1500,10 @@ private:
 
     // Only valid if m_repaintRectsValid is set (std::optional<> not used to avoid padding).
     RenderObject::RepaintRects m_repaintRects;
+
+    // Cached cumulative offset from renderer's parent to the repaint container.
+    // Valid when m_offsetToRepaintContainerValid is set.
+    LayoutSize m_cachedOffsetToRepaintContainer;
 
     // Our current relative or absolute position offset.
     LayoutSize m_offsetForPosition;


### PR DESCRIPTION
#### 54eca247032c78942e2e9153b01e9b2bd263474a
<pre>
[MotionMark] Cache repaint container offset to avoid ancestor walk in computeRepaintRects
<a href="https://bugs.webkit.org/show_bug.cgi?id=314710">https://bugs.webkit.org/show_bug.cgi?id=314710</a>
<a href="https://rdar.apple.com/176948233">rdar://176948233</a>

Reviewed by NOBODY (OOPS!).

computeRepaintRects() calls rectsForRepaintingAfterLayout() which walks
the ancestor chain via computeVisibleRectsInContainer() to map local
repaint rects into the repaint container&apos;s coordinate space. For
workloads with many layers that don&apos;t move between frames (e.g.
MotionMark 1.3 Multiply with ~7K elements), this ancestor walk is
repeated identically every frame.

After the first full computation, cache the cumulative offset from the
renderer to the repaint container. On subsequent frames where the layer
position hasn&apos;t changed, apply the cached offset to localRectsForRepaint()
directly — skipping the full ancestor walk.

Caching is only enabled when the ancestor chain consists entirely of
layerless RenderBox nodes in the same writing mode. A layerless RenderBox
cannot have transforms, positioning, overflow clipping, reflections, or
multi-column (see RenderBox::requiresLayer), so its only contribution to
the coordinate mapping is its locationOffset(). This makes the
correctness argument local to a single predicate rather than an
enumeration of exclusions.

The cache is invalidated in recursiveUpdateLayerPositions() when the
layer moves or any ancestor geometry changes (SubtreeNeedsUpdate). Debug
builds ASSERT that the fast-path result matches the full computation.

* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::recursiveUpdateLayerPositions):
(WebCore::RenderLayer::computeRepaintRects):
(WebCore::RenderLayer::tryToCacheRepaintContainerOffset):
* Source/WebCore/rendering/RenderLayer.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54eca247032c78942e2e9153b01e9b2bd263474a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162245 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35721 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28837 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171153 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118696 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164114 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35825 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35722 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125915 "Failure limit exceed. At least found 466 new test failures: accessibility/add-children-pseudo-element.html accessibility/aria-describedby-on-input.html accessibility/aria-invalid.html accessibility/aria-labelledby-with-descendants.html accessibility/aria-modal-multiple-dialogs.html accessibility/aria-orientation.html accessibility/aria-readonly.html accessibility/aria-required.html accessibility/canvas-accessibilitynodeobject.html accessibility/canvas-fallback-content.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88771 "20 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165204 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28254 "Found 9 new test failures: compositing/repaint/change-notselfpainting-to-scroller.html svg/repaint/foreign-object-repainting-after-modifying-container-transform-repaint-rects.html svg/repaint/foreign-object-repainting-after-modifying-transform-repaint-rects.html svg/repaint/image-repainting-after-modifying-container-transform-repaint-rects.html svg/repaint/image-repainting-after-modifying-transform-repaint-rects.html svg/repaint/shape-repainting-after-modifying-container-transform-repaint-rects.html svg/repaint/shape-repainting-after-modifying-transform-repaint-rects.html svg/repaint/text-repainting-after-modifying-container-transform-repaint-rects.html svg/repaint/text-repainting-after-modifying-transform-repaint-rects.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145748 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106493 "Found 7 new API test failures: WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/surrounding, WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/invalid-sequence, WPE/TestWebKitWebView:/webkit/WebKitWebView/document-focus, WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/reset, WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/cancel-sequence, WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/simple, WPE/TestInputMethodContext:/webkit/WebKitInputMethodContext/sequence (failure)") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27301 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25813 "Found 156 new API test failures: TestWebKitAPI.WKWebExtensionAPIDevTools.InspectedWindowReload, TestWebKitAPI.ElementTargeting.DoNotBeginRepeatedVisibilityAdjustmentIfTargetIsAlreadyHidden, TestWebKitAPI.WebAuthenticationPanel.NfcHardwareBusyRetry, TestWebKitAPI.WKInspectorExtensionHost.RegisterExtension, TestWebKitAPI.WebAuthenticationPanel.MakeCredentialInternalUV, TestWebKitAPI.WKWebExtensionAPIDevTools.MessagePassingToBackground, TestWebKitAPI.FocusWebView.MultipleFrames, TestWebKitAPI.WebAuthenticationPanel.NullPanelHidSuccess, TestWebKitAPI.WKUserContentController.AllowElementUserInfo, TestWebKitAPI.ProcessSwap.SwapOnFormSubmission ... (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18874 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137003 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23487 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173647 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21000 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25130 "Found 9 new test failures: compositing/repaint/change-notselfpainting-to-scroller.html svg/repaint/foreign-object-repainting-after-modifying-container-transform-repaint-rects.html svg/repaint/foreign-object-repainting-after-modifying-transform-repaint-rects.html svg/repaint/image-repainting-after-modifying-container-transform-repaint-rects.html svg/repaint/image-repainting-after-modifying-transform-repaint-rects.html svg/repaint/shape-repainting-after-modifying-container-transform-repaint-rects.html svg/repaint/shape-repainting-after-modifying-transform-repaint-rects.html svg/repaint/text-repainting-after-modifying-container-transform-repaint-rects.html svg/repaint/text-repainting-after-modifying-transform-repaint-rects.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134212 "Failure limit exceed. At least found 472 new test failures: accessibility/add-children-pseudo-element.html accessibility/aria-describedby-on-input.html accessibility/aria-invalid.html accessibility/aria-labelledby-with-descendants.html accessibility/aria-modal-multiple-dialogs.html accessibility/aria-orientation.html accessibility/aria-readonly.html accessibility/aria-required.html accessibility/canvas-accessibilitynodeobject.html accessibility/canvas-fallback-content.html ... (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35395 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29901 "Found 60 new test failures: accessibility/activation-of-input-field-inside-other-element.html accessibility/animated-dropdown.html accessibility/aria-describedby-on-input.html accessibility/aria-disabled.html accessibility/combobox/aria-combobox-control-owns-elements.html accessibility/combobox/aria-combobox-no-owns.html accessibility/combobox/combobox-linked-listbox-destroyed.html accessibility/combobox/mac/aria-combobox-activedescendant.html accessibility/combobox/mac/combobox-activedescendant-notifications.html accessibility/combobox/mac/combobox-inherited-role.html ... (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134213 "Found 13 new API test failures: WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/surrounding, WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/reset, WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/invalid-sequence, WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/simple, WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/cancel-sequence, WebKitGTK/TestInputMethodContext:/webkit/WebKitInputMethodContext/sequence, WebKitGTK/TestInspector:/webkit/WebKitWebInspector/manual-attach-detach, WebKitGTK/TestWebKitWebView:/webkit/WebKitWebView/submit-form, WebKitGTK/TestUIClient:/webkit/WebKitWebView/mouse-target, WebKitGTK/TestUIClient:/webkit/WebKitWebView/javascript-dialogs ... (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35378 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145283 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97602 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28757 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22112 "Found 9 new test failures: compositing/repaint/change-notselfpainting-to-scroller.html svg/repaint/foreign-object-repainting-after-modifying-container-transform-repaint-rects.html svg/repaint/foreign-object-repainting-after-modifying-transform-repaint-rects.html svg/repaint/image-repainting-after-modifying-container-transform-repaint-rects.html svg/repaint/image-repainting-after-modifying-transform-repaint-rects.html svg/repaint/shape-repainting-after-modifying-container-transform-repaint-rects.html svg/repaint/shape-repainting-after-modifying-transform-repaint-rects.html svg/repaint/text-repainting-after-modifying-container-transform-repaint-rects.html svg/repaint/text-repainting-after-modifying-transform-repaint-rects.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34888 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102640 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34389 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34635 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34537 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->