### PR TITLE
[GTK][WPE] Skia Compositor: move painting of platform buffers to SkiaCompositingLayer

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -30,6 +30,7 @@
 #include "CoordinatedAnimatedBackingStoreClient.h"
 #include "CoordinatedImageBackingStore.h"
 #include "CoordinatedPlatformLayerBuffer.h"
+#include "CoordinatedPlatformLayerBufferHolePunch.h"
 #include "CoordinatedTileBuffer.h"
 #include "FilterOperations.h"
 #include "FontCache.h"
@@ -480,12 +481,22 @@ void SkiaCompositingLayer::paintSelf(SkCanvas& canvas, PaintContext& context)
                 canvas.clipRect(SkRect(m_contentsClippingRect.rect()));
         }
 
-        if (m_contentsBuffer)
-            m_contentsBuffer->paintToCanvas(canvas, m_contentsRect, paint);
-        else if (auto* buffer = m_imageBackingStore->buffer()) {
-            if (m_contentsTiling.size.isEmpty())
-                buffer->paintToCanvas(canvas, m_contentsRect, paint);
-            else {
+        sk_sp<SkImage> image;
+
+        if (m_contentsBuffer) {
+            if (is<CoordinatedPlatformLayerBufferHolePunch>(*m_contentsBuffer)) {
+#if USE(GSTREAMER)
+                TransformationMatrix matrix = canvas.getLocalToDevice();
+                downcast<CoordinatedPlatformLayerBufferHolePunch>(*m_contentsBuffer).setHolePunchVideoRectangle(enclosingIntRect(matrix.mapRect(m_contentsRect)));
+#endif
+                paint.setColor(SK_ColorTRANSPARENT);
+                canvas.drawRect(SkRect(m_contentsRect), paint);
+            } else
+                image = m_contentsBuffer->skiaImage();
+        } else if (auto* buffer = m_imageBackingStore->buffer()) {
+            image = buffer->skiaImage();
+            if (!m_contentsTiling.size.isEmpty()) {
+                sk_sp<SkImage> tileImage = std::exchange(image, nullptr);
                 SkAutoCanvasRestore autoRestore(&canvas, true);
                 canvas.clipRect(SkRect(m_contentsRect));
 
@@ -501,10 +512,16 @@ void SkiaCompositingLayer::paintSelf(SkCanvas& canvas, PaintContext& context)
                 for (float y = startY; y < m_contentsRect.maxY(); y += m_contentsTiling.size.height()) {
                     for (float x = startX; x < m_contentsRect.maxX(); x += m_contentsTiling.size.width()) {
                         FloatRect tileRect(x, y, m_contentsTiling.size.width(), m_contentsTiling.size.height());
-                        buffer->paintToCanvas(canvas, tileRect, paint);
+                        canvas.drawImageRect(tileImage, SkRect::MakeSize(SkSize::Make(tileImage->dimensions())), SkRect(tileRect),
+                            SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone), &paint, SkCanvas::kFast_SrcRectConstraint);
                     }
                 }
             }
+        }
+
+        if (image) {
+            canvas.drawImageRect(image, SkRect::MakeSize(SkSize::Make(image->dimensions())), SkRect(m_contentsRect),
+                SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone), &paint, SkCanvas::kFast_SrcRectConstraint);
         }
     }
 

--- a/Source/WebCore/platform/graphics/skia/SkiaUtilities.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaUtilities.cpp
@@ -78,9 +78,9 @@ sk_sp<SkImage> rewrapImageForContext(GrDirectContext* grContext, const SkImage& 
     return SkImages::BorrowTextureFrom(grContext, backendTexture, kTopLeft_GrSurfaceOrigin, image.colorType(), image.alphaType(), image.refColorSpace());
 }
 
-sk_sp<SkImage> borrowBackendTextureAsImage(GrDirectContext* grContext, const GrBackendTexture& backendTexture)
+sk_sp<SkImage> borrowBackendTextureAsImage(GrDirectContext* grContext, const GrBackendTexture& backendTexture, GrSurfaceOrigin origin)
 {
-    return SkImages::BorrowTextureFrom(grContext, backendTexture, kTopLeft_GrSurfaceOrigin, kRGBA_8888_SkColorType, kPremul_SkAlphaType, sRGBColorSpaceSingleton());
+    return SkImages::BorrowTextureFrom(grContext, backendTexture, origin, kRGBA_8888_SkColorType, kPremul_SkAlphaType, sRGBColorSpaceSingleton());
 }
 
 std::optional<unsigned> retrieveGLTextureID(const SkImage& image)

--- a/Source/WebCore/platform/graphics/skia/SkiaUtilities.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaUtilities.h
@@ -65,7 +65,7 @@ sk_sp<SkImage> rewrapImageForContext(GrDirectContext*, const SkImage&);
 
 // Wraps a GrBackendTexture as a non-owning SkImage for the given context,
 // using RGBA8, premultiplied alpha, and sRGB color space.
-sk_sp<SkImage> borrowBackendTextureAsImage(GrDirectContext*, const GrBackendTexture&);
+sk_sp<SkImage> borrowBackendTextureAsImage(GrDirectContext*, const GrBackendTexture&, GrSurfaceOrigin = kTopLeft_GrSurfaceOrigin);
 
 // Extracts the GL texture ID from a GPU-backed SkImage, if available.
 std::optional<unsigned> retrieveGLTextureID(const SkImage&);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBuffer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBuffer.h
@@ -33,7 +33,7 @@
 
 #if USE(SKIA)
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
-#include <skia/core/SkCanvas.h>
+#include <skia/core/SkImage.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #endif
 
@@ -66,7 +66,7 @@ public:
     }
 
 #if USE(SKIA)
-    virtual void paintToCanvas(SkCanvas&, const FloatRect&, const SkPaint&) { }
+    virtual sk_sp<SkImage> skiaImage() { return nullptr; }
 #endif
 
 protected:

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.cpp
@@ -274,7 +274,7 @@ void CoordinatedPlatformLayerBufferDMABuf::paintToTextureMapper(TextureMapper& t
 }
 
 #if USE(SKIA)
-void CoordinatedPlatformLayerBufferDMABuf::paintToCanvas(SkCanvas& canvas, const FloatRect& targetRect, const SkPaint& paint)
+sk_sp<SkImage> CoordinatedPlatformLayerBufferDMABuf::skiaImage()
 {
     waitForContentsIfNeeded();
 
@@ -287,7 +287,9 @@ void CoordinatedPlatformLayerBufferDMABuf::paintToCanvas(SkCanvas& canvas, const
         m_dmabuf->setBuffer(importDMABuf());
 
     if (auto* buffer = m_dmabuf->buffer())
-        buffer->paintToCanvas(canvas, targetRect, paint);
+        return buffer->skiaImage();
+
+    return nullptr;
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.h
@@ -46,7 +46,7 @@ private:
     void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix& modelViewMatrix = TransformationMatrix(), float opacity = 1.0) override;
 
 #if USE(SKIA)
-    void paintToCanvas(SkCanvas&, const FloatRect&, const SkPaint&) override;
+    sk_sp<SkImage> skiaImage() override;
 #endif
 
     std::unique_ptr<CoordinatedPlatformLayerBuffer> importDMABuf() const;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferExternalOES.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferExternalOES.cpp
@@ -41,6 +41,7 @@
 #endif
 
 #if USE(SKIA)
+#include "SkiaUtilities.h"
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkColorSpace.h>
 #include <skia/core/SkImage.h>
@@ -167,23 +168,23 @@ void CoordinatedPlatformLayerBufferExternalOES::paintToTextureMapper(TextureMapp
 }
 
 #if USE(SKIA)
-void CoordinatedPlatformLayerBufferExternalOES::paintToCanvas(SkCanvas& canvas, const FloatRect& targetRect, const SkPaint& paint)
+sk_sp<SkImage> CoordinatedPlatformLayerBufferExternalOES::skiaImage()
 {
     waitForContentsIfNeeded();
 
     if (!m_textureID) {
         // FIXME: support Qualcomm decoder.
-        return;
+        return nullptr;
     }
 
     auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
+    ASSERT(grContext);
     GrGLTextureInfo externalTexture;
     externalTexture.fTarget = GL_TEXTURE_EXTERNAL_OES;
     externalTexture.fID = m_textureID;
     externalTexture.fFormat = GL_RGBA8;
     auto backendTexture = GrBackendTextures::MakeGL(m_size.width(), m_size.height(), skgpu::Mipmapped::kNo, externalTexture);
-    sk_sp<SkImage> image = SkImages::BorrowTextureFrom(grContext, backendTexture, kTopLeft_GrSurfaceOrigin, kRGBA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
-    canvas.drawImageRect(image, SkRect::MakeWH(m_size.width(), m_size.height()), targetRect, SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone), &paint, SkCanvas::kFast_SrcRectConstraint);
+    return SkiaUtilities::borrowBackendTextureAsImage(grContext, backendTexture);
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferExternalOES.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferExternalOES.h
@@ -49,7 +49,7 @@ private:
     void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix& modelViewMatrix = TransformationMatrix(), float opacity = 1.0) override;
 
 #if USE(SKIA)
-    void paintToCanvas(SkCanvas&, const FloatRect&, const SkPaint&) override;
+    sk_sp<SkImage> skiaImage() override;
 #endif
 
     unsigned m_textureID { 0 };

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferHolePunch.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferHolePunch.cpp
@@ -63,29 +63,22 @@ CoordinatedPlatformLayerBufferHolePunch::CoordinatedPlatformLayerBufferHolePunch
 
 CoordinatedPlatformLayerBufferHolePunch::~CoordinatedPlatformLayerBufferHolePunch() = default;
 
+#if USE(GSTREAMER)
+void CoordinatedPlatformLayerBufferHolePunch::setHolePunchVideoRectangle(const IntRect& rect)
+{
+    if (m_videoSink && m_quirksManager)
+        m_quirksManager->setHolePunchVideoRectangle(m_videoSink.get(), rect);
+}
+#endif
+
 void CoordinatedPlatformLayerBufferHolePunch::paintToTextureMapper(TextureMapper& textureMapper, const FloatRect& targetRect, const TransformationMatrix& modelViewMatrix, float)
 {
 #if USE(GSTREAMER)
     if (m_videoSink && m_quirksManager)
-        m_quirksManager->setHolePunchVideoRectangle(m_videoSink.get(), enclosingIntRect(modelViewMatrix.mapRect(targetRect)));
+        setHolePunchVideoRectangle(enclosingIntRect(modelViewMatrix.mapRect(targetRect)));
 #endif
     textureMapper.drawSolidColor(targetRect, modelViewMatrix, Color::transparentBlack, false);
 }
-
-#if USE(SKIA)
-void CoordinatedPlatformLayerBufferHolePunch::paintToCanvas(SkCanvas& canvas, const FloatRect& targetRect, const SkPaint&)
-{
-#if USE(GSTREAMER)
-    if (m_videoSink && m_quirksManager) {
-        TransformationMatrix matrix = canvas.getLocalToDevice();
-        m_quirksManager->setHolePunchVideoRectangle(m_videoSink.get(), enclosingIntRect(matrix.mapRect(targetRect)));
-    }
-#endif
-    SkPaint paint;
-    paint.setColor(SK_ColorTRANSPARENT);
-    canvas.drawRect(SkRect(targetRect), paint);
-}
-#endif
 
 } // namespace WebCore
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferHolePunch.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferHolePunch.h
@@ -46,12 +46,12 @@ public:
 #endif
     virtual ~CoordinatedPlatformLayerBufferHolePunch();
 
+#if USE(GSTREAMER)
+    void setHolePunchVideoRectangle(const IntRect&);
+#endif
+
 private:
     void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix& modelViewMatrix = TransformationMatrix(), float opacity = 1.0) override;
-
-#if USE(SKIA)
-    void paintToCanvas(SkCanvas&, const FloatRect&, const SkPaint&) override;
-#endif
 
 #if USE(GSTREAMER)
     GRefPtr<GstElement> m_videoSink;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.cpp
@@ -154,14 +154,14 @@ void CoordinatedPlatformLayerBufferNativeImage::paintToTextureMapper(TextureMapp
 }
 
 #if USE(SKIA)
-void CoordinatedPlatformLayerBufferNativeImage::paintToCanvas(SkCanvas& canvas, const FloatRect& targetRect, const SkPaint& paint)
+sk_sp<SkImage> CoordinatedPlatformLayerBufferNativeImage::skiaImage()
 {
     waitForContentsIfNeeded();
 
     if (!tryEnsureBuffer(UseSkiaForCompositing::Yes))
-        return;
+        return nullptr;
 
-    m_buffer->paintToCanvas(canvas, targetRect, paint);
+    return m_buffer->skiaImage();
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.h
@@ -44,7 +44,7 @@ private:
     void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix& modelViewMatrix = TransformationMatrix(), float opacity = 1.0) override;
 
 #if USE(SKIA)
-    void paintToCanvas(SkCanvas&, const FloatRect&, const SkPaint&) override;
+    sk_sp<SkImage> skiaImage() override;
 #endif
 
     enum class UseSkiaForCompositing : bool { No, Yes };

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.cpp
@@ -33,6 +33,7 @@
 #include "TextureMapper.h"
 
 #if USE(SKIA)
+#include "SkiaUtilities.h"
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkColorFilter.h>
 #include <skia/core/SkColorSpace.h>
@@ -80,21 +81,21 @@ void CoordinatedPlatformLayerBufferRGB::paintToTextureMapper(TextureMapper& text
 }
 
 #if USE(SKIA)
-void CoordinatedPlatformLayerBufferRGB::paintToCanvas(SkCanvas& canvas, const FloatRect& targetRect, const SkPaint& paint)
+sk_sp<SkImage> CoordinatedPlatformLayerBufferRGB::skiaImage()
 {
     waitForContentsIfNeeded();
 
+    ASSERT(!m_texture || !m_texture->colorConvertFlags().contains(TextureMapperFlags::ShouldConvertTextureBGRAToRGBA));
+
     auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
+    ASSERT(grContext);
     GrGLTextureInfo externalTexture;
     externalTexture.fTarget = GL_TEXTURE_2D;
     externalTexture.fID = m_texture ? m_texture->id() : m_textureID;
     externalTexture.fFormat = GL_RGBA8;
     auto backendTexture = GrBackendTextures::MakeGL(m_size.width(), m_size.height(), skgpu::Mipmapped::kNo, externalTexture);
     auto origin = m_flags.contains(TextureMapperFlags::ShouldFlipTexture) ? kBottomLeft_GrSurfaceOrigin : kTopLeft_GrSurfaceOrigin;
-    sk_sp<SkImage> image = SkImages::BorrowTextureFrom(grContext, backendTexture, origin, kRGBA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
-
-    ASSERT(!m_texture || !m_texture->colorConvertFlags().contains(TextureMapperFlags::ShouldConvertTextureBGRAToRGBA));
-    canvas.drawImageRect(image, SkRect::MakeWH(m_size.width(), m_size.height()), SkRect(targetRect), SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone), &paint, SkCanvas::kFast_SrcRectConstraint);
+    return SkiaUtilities::borrowBackendTextureAsImage(grContext, backendTexture, origin);
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.h
@@ -46,7 +46,7 @@ private:
     void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix& modelViewMatrix = TransformationMatrix(), float opacity = 1.0) override;
 
 #if USE(SKIA)
-    void paintToCanvas(SkCanvas&, const FloatRect&, const SkPaint&) override;
+    sk_sp<SkImage> skiaImage() override;
 #endif
 
     RefPtr<BitmapTexture> m_texture;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.cpp
@@ -295,12 +295,14 @@ void CoordinatedPlatformLayerBufferVideo::paintToTextureMapper(TextureMapper& te
 }
 
 #if USE(SKIA)
-void CoordinatedPlatformLayerBufferVideo::paintToCanvas(SkCanvas& canvas, const FloatRect& targetRect, const SkPaint& paint)
+sk_sp<SkImage> CoordinatedPlatformLayerBufferVideo::skiaImage()
 {
     createBufferFromMappedFrameIfNeeded();
 
     if (m_buffer)
-        m_buffer->paintToCanvas(canvas, targetRect, paint);
+        return m_buffer->skiaImage();
+
+    return nullptr;
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.h
@@ -46,7 +46,7 @@ private:
     void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix& modelViewMatrix = TransformationMatrix(), float opacity = 1.0) override;
 
 #if USE(SKIA)
-    void paintToCanvas(SkCanvas&, const FloatRect&, const SkPaint&) override;
+    sk_sp<SkImage> skiaImage() override;
 #endif
 
     std::unique_ptr<CoordinatedPlatformLayerBuffer> createBufferIfNeeded(bool gstGLEnabled);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferYUV.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferYUV.cpp
@@ -162,7 +162,7 @@ void CoordinatedPlatformLayerBufferYUV::paintToTextureMapper(TextureMapper& text
 }
 
 #if USE(SKIA)
-void CoordinatedPlatformLayerBufferYUV::paintToCanvas(SkCanvas& canvas, const FloatRect& targetRect, const SkPaint& paint)
+sk_sp<SkImage> CoordinatedPlatformLayerBufferYUV::skiaImage()
 {
     waitForContentsIfNeeded();
 
@@ -256,7 +256,7 @@ void CoordinatedPlatformLayerBufferYUV::paintToCanvas(SkCanvas& canvas, const Fl
     }
 
     if (planeConfig == SkYUVAInfo::PlaneConfig::kUnknown)
-        return;
+        return nullptr;
 
     SkYUVColorSpace yuvaColorSpace = [&] {
         switch (m_yuvToRgbColorSpace) {
@@ -275,7 +275,7 @@ void CoordinatedPlatformLayerBufferYUV::paintToCanvas(SkCanvas& canvas, const Fl
     SkYUVAInfo info(SkISize::Make(m_size.width(), m_size.height()), planeConfig, subsampling, yuvaColorSpace);
     GrYUVABackendTextures yuvaBackendTextures(info, backendTextures.data(), kTopLeft_GrSurfaceOrigin);
     if (!yuvaBackendTextures.isValid())
-        return;
+        return nullptr;
 
     sk_sp<SkColorSpace> colorSpace = [&] {
         switch (m_transferFunction) {
@@ -288,8 +288,8 @@ void CoordinatedPlatformLayerBufferYUV::paintToCanvas(SkCanvas& canvas, const Fl
     }();
 
     auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
-    auto image = SkImages::TextureFromYUVATextures(grContext, yuvaBackendTextures, colorSpace);
-    canvas.drawImageRect(image, SkRect::MakeWH(m_size.width(), m_size.height()), targetRect, SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone), &paint, SkCanvas::kFast_SrcRectConstraint);
+    ASSERT(grContext);
+    return SkImages::TextureFromYUVATextures(grContext, yuvaBackendTextures, colorSpace);
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferYUV.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferYUV.h
@@ -47,7 +47,7 @@ private:
     void paintToTextureMapper(TextureMapper&, const FloatRect&, const TransformationMatrix& modelViewMatrix = TransformationMatrix(), float opacity = 1.0) override;
 
 #if USE(SKIA)
-    void paintToCanvas(SkCanvas&, const FloatRect&, const SkPaint&) override;
+    sk_sp<SkImage> skiaImage() override;
 #endif
 
     Format m_format { Format::AYUV };


### PR DESCRIPTION
#### a2209c6caff2acd54ae61f0213ddfe258c30f4e0
<pre>
[GTK][WPE] Skia Compositor: move painting of platform buffers to SkiaCompositingLayer
<a href="https://bugs.webkit.org/show_bug.cgi?id=314711">https://bugs.webkit.org/show_bug.cgi?id=314711</a>

Reviewed by Nikolas Zimmermann.

All CoordinatedPlatformLayerBuffer implementations now paint the same
way by calling SkCanvas::drawImageRect(), the only difference is how the
SkImage is created in each case. So, we can call
SkCanvas::drawImageRect() in SkiaCompositingLayer and the platform
buffers only need to provide the image to paint. The only exception is
CoordinatedPlatformLayerBufferHolePunch that we can handle differently
by setting the hole puch rect and painting with transparent color from
SkiaCompositingLayer too. This will allow us to implement batched
painting.

* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
(WebCore::SkiaCompositingLayer::paintSelf):
* Source/WebCore/platform/graphics/skia/SkiaUtilities.cpp:
(WebCore::SkiaUtilities::borrowBackendTextureAsImage):
* Source/WebCore/platform/graphics/skia/SkiaUtilities.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBuffer.h:
(WebCore::CoordinatedPlatformLayerBuffer::skiaImage):
(WebCore::CoordinatedPlatformLayerBuffer::paintToCanvas): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.cpp:
(WebCore::CoordinatedPlatformLayerBufferDMABuf::skiaImage):
(WebCore::CoordinatedPlatformLayerBufferDMABuf::paintToCanvas): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferDMABuf.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferExternalOES.cpp:
(WebCore::CoordinatedPlatformLayerBufferExternalOES::skiaImage):
(WebCore::CoordinatedPlatformLayerBufferExternalOES::paintToCanvas): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferExternalOES.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferHolePunch.cpp:
(WebCore::CoordinatedPlatformLayerBufferHolePunch::setHolePunchVideoRectangle):
(WebCore::CoordinatedPlatformLayerBufferHolePunch::paintToTextureMapper):
(WebCore::CoordinatedPlatformLayerBufferHolePunch::paintToCanvas): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferHolePunch.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.cpp:
(WebCore::CoordinatedPlatformLayerBufferNativeImage::skiaImage):
(WebCore::CoordinatedPlatformLayerBufferNativeImage::paintToCanvas): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.cpp:
(WebCore::CoordinatedPlatformLayerBufferRGB::skiaImage):
(WebCore::CoordinatedPlatformLayerBufferRGB::paintToCanvas): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.cpp:
(WebCore::CoordinatedPlatformLayerBufferVideo::skiaImage):
(WebCore::CoordinatedPlatformLayerBufferVideo::paintToCanvas): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferYUV.cpp:
(WebCore::CoordinatedPlatformLayerBufferYUV::skiaImage):
(WebCore::CoordinatedPlatformLayerBufferYUV::paintToCanvas): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferYUV.h:

Canonical link: <a href="https://commits.webkit.org/313149@main">https://commits.webkit.org/313149@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/14dd536fb7f49adfca7db60f29e184c6c8221d8c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162251 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35727 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28843 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171159 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/118628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164120 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35831 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35728 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/125920 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/118628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165210 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28261 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/145754 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106498 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18880 "Built successfully") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137010 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23493 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173653 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21006 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25136 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134214 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35401 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/29907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/134215 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35384 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145289 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97608 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24641 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28763 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22118 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34894 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102646 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34395 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34641 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34543 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->