### PR TITLE
[GStreamer][MSE] ended event may not always fire when the duration change

### DIFF
--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -5564,8 +5564,6 @@ ipc/empty-svgfilterrenderer-expression-crash.html [ Skip ]
 
 webkit.org/b/314373 media/media-source/media-source-real-webm-fastseek.html [ Failure ]
 webkit.org/b/314373 media/media-source/media-source-real-webm-remove.html [ Failure ]
-# test timeout, skip it for now
-webkit.org/b/314643 media/media-source/media-source-duration-truncation-ended.html [ Skip ]
 
 webkit.org/b/314491 imported/w3c/web-platform-tests/html/infrastructure/safe-passing-of-structured-data/messagechannel.any.serviceworker.html [ Crash ]
 # End: Common failures between GTK and WPE.

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -419,7 +419,7 @@ protected:
     GRefPtr<GstElement> m_pipeline;
     IntSize m_size;
 
-    MediaPlayer::ReadyState m_readyState { MediaPlayer::ReadyState::HaveNothing };
+    mutable MediaPlayer::ReadyState m_readyState { MediaPlayer::ReadyState::HaveNothing };
     mutable MediaPlayer::NetworkState m_networkState { MediaPlayer::NetworkState::Empty };
 
     mutable Lock m_sampleMutex;

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp
@@ -415,7 +415,18 @@ void MediaPlayerPrivateGStreamerMSE::propagateReadyStateToPlayer()
 
 void MediaPlayerPrivateGStreamerMSE::mediaSourceHasRetrievedAllData()
 {
+    GST_DEBUG_OBJECT(pipeline(), "MediaSource has retrieved all data");
     setNetworkState(MediaPlayer::NetworkState::Loaded);
+
+    RefPtr mediaSourcePrivate = m_mediaSourcePrivate;
+    if (!mediaSourcePrivate)
+        return;
+
+    if (!mediaSourcePrivate->isEnded())
+        return;
+
+    GST_DEBUG_OBJECT(pipeline(), "MediaSource is ended");
+    timeChanged(MediaTime::invalidTime());
 }
 
 void MediaPlayerPrivateGStreamerMSE::didPreroll()
@@ -655,15 +666,19 @@ MediaTime MediaPlayerPrivateGStreamerMSE::maxTimeSeekable() const
 
 bool MediaPlayerPrivateGStreamerMSE::timeIsProgressing() const
 {
-    if (!m_mediaSourcePrivate)
-        return false;
-
-    bool isPaused = paused();
     const auto currentTime = this->currentTime();
-    bool hasFutureTime = m_mediaSourcePrivate->hasFutureTime(currentTime);
-    bool isProgressing = !isPaused && hasFutureTime;
-    GST_DEBUG_OBJECT(pipeline(), "Is paused: %s, has future time for %f: %s, time is progressing: %s", boolForPrinting(isPaused), currentTime.toDouble(), boolForPrinting(hasFutureTime), boolForPrinting(isProgressing));
-    return isProgressing;
+    auto result = !paused() && currentTime.isValid() && currentTime != m_cachedCurrentTime;
+    if (m_cachedCurrentTime.isValid() && !result) {
+        auto oldReadyState = m_readyState;
+        m_readyState = MediaPlayer::ReadyState::HaveMetadata;
+        RefPtr player = m_player.get();
+        if (player && oldReadyState != m_readyState)
+            player->readyStateChanged();
+    }
+
+    m_cachedCurrentTime = currentTime;
+    GST_DEBUG_OBJECT(pipeline(), "Time is progressing: %s", boolForPrinting(result));
+    return result;
 }
 
 void MediaPlayerPrivateGStreamerMSE::notifyActiveSourceBuffersChanged()

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h
@@ -139,6 +139,8 @@ private:
     MediaPlayer::NetworkState m_mediaSourceNetworkState = MediaPlayer::NetworkState::Empty;
 
     bool m_playbackStateChangedNotificationPending { false };
+
+    mutable MediaTime m_cachedCurrentTime { MediaTime::invalidTime() };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### f7d7155963895fc0b341dd4a232e7fffca55e3a2
<pre>
[GStreamer][MSE] ended event may not always fire when the duration change
<a href="https://bugs.webkit.org/show_bug.cgi?id=314643">https://bugs.webkit.org/show_bug.cgi?id=314643</a>

Reviewed by NOBODY (OOPS!).

WIP

* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.cpp:
(WebCore::MediaPlayerPrivateGStreamerMSE::mediaSourceHasRetrievedAllData):
(WebCore::MediaPlayerPrivateGStreamerMSE::timeIsProgressing const):
* Source/WebCore/platform/graphics/gstreamer/mse/MediaPlayerPrivateGStreamerMSE.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f7d7155963895fc0b341dd4a232e7fffca55e3a2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162247 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35723 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28839 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171155 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118695 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164116 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35827 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35724 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125918 "Found 51 new test failures: fast/canvas/webgl/texImage2D-mse-in-dom-flipY-true.html http/tests/media/media-source/media-source-video-fit-fill.html http/tests/media/media-source/mediasource-rvfc.html imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-temporary-clear-encrypted.https.html imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-temporary-encrypted-clear.https.html imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-temporary-events.https.html imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-temporary-multikey.https.html imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-temporary-setMediaKeys-after-update.https.html imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-temporary-setMediaKeys-onencrypted.https.html imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-temporary-waitingforkey.https.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88770 "17 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165206 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28256 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145753 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106496 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27303 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25814 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18876 "Built successfully") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137005 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23492 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173649 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21002 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25135 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134211 "Found 54 new test failures: fast/canvas/webgl/texImage2D-mse-flipY-false.html fast/canvas/webgl/texImage2D-mse-flipY-true.html fast/canvas/webgl/texImage2D-mse-in-dom-flipY-true.html http/tests/media/media-source/media-source-video-fit-fill.html http/tests/media/media-source/mediasource-rvfc.html imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-temporary-clear-encrypted.https.html imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-temporary-encrypted-clear-sources.https.html imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-temporary-encrypted-clear.https.html imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-temporary-events.https.html imported/w3c/web-platform-tests/encrypted-media/clearkey-mp4-playback-temporary-multikey.https.html ... (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35397 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29902 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134212 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35380 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145288 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97604 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28756 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22117 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34890 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102642 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34391 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34637 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34539 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->