### PR TITLE
[WebXR Layers] Enable texture array support for projection layer

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrProjectionLayer_textureType.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrProjectionLayer_textureType.https-expected.txt
@@ -1,0 +1,6 @@
+
+PASS createProjectionLayer with textureType 'texture-array' requires WebGL2 - webgl
+PASS createProjectionLayer with textureType 'texture-array' requires WebGL2 - webgl2
+PASS createProjectionLayer succeeds with the default textureType - webgl
+PASS createProjectionLayer succeeds with the default textureType - webgl2
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrProjectionLayer_textureType.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrProjectionLayer_textureType.https.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/webxr_util.js"></script>
+<script src="../resources/webxr_test_constants.js"></script>
+
+<script>
+
+  function testTextureArrayCreation(session, deviceController, t, { gl }) {
+    const binding = new XRWebGLBinding(session, gl);
+    t.step(() => {
+      if (gl instanceof WebGL2RenderingContext) {
+        const layer = binding.createProjectionLayer({ textureType: 'texture-array' });
+        assert_true(layer instanceof XRProjectionLayer, "createProjectionLayer with textureType 'texture-array' must succeed on WebGL2.");
+      } else {
+        assert_throws_dom('InvalidStateError', () => binding.createProjectionLayer({ textureType: 'texture-array' }),
+          "createProjectionLayer with textureType 'texture-array' must throw InvalidStateError on WebGL.");
+      }
+    });
+    return Promise.resolve();
+  }
+
+  function testTextureCreation(session, deviceController, t, { gl }) {
+    const binding = new XRWebGLBinding(session, gl);
+    t.step(() => {
+      // depthFormat: 0 disables the depth swapchain so the test does not depend on the WEBGL_depth_texture extension for non WebGL2 contexts.
+      const layer = binding.createProjectionLayer({ depthFormat: 0 });
+      assert_true(layer instanceof XRProjectionLayer, "createProjectionLayer with the default textureType must succeed.");
+    });
+    return Promise.resolve();
+  }
+
+  xr_session_promise_test("createProjectionLayer with textureType 'texture-array' requires WebGL2",
+    testTextureArrayCreation, TRACKED_IMMERSIVE_DEVICE, 'immersive-vr', { requiredFeatures: ['layers'] });
+
+  xr_session_promise_test("createProjectionLayer succeeds with the default textureType",
+    testTextureCreation, TRACKED_IMMERSIVE_DEVICE, 'immersive-vr', { requiredFeatures: ['layers'] });
+
+</script>

--- a/Source/WebCore/Modules/webxr/WebGLOpaqueTexture.cpp
+++ b/Source/WebCore/Modules/webxr/WebGLOpaqueTexture.cpp
@@ -32,14 +32,16 @@
 
 namespace WebCore {
 
-RefPtr<WebGLOpaqueTexture> WebGLOpaqueTexture::create(WebGLRenderingContextBase& context, PlatformGLObject object)
+RefPtr<WebGLOpaqueTexture> WebGLOpaqueTexture::create(WebGLRenderingContextBase& context, PlatformGLObject object, GCGLenum target)
 {
-    return adoptRef(*new WebGLOpaqueTexture { context, object });
+    return adoptRef(*new WebGLOpaqueTexture { context, object, target });
 }
 
-WebGLOpaqueTexture::WebGLOpaqueTexture(WebGLRenderingContextBase& context, PlatformGLObject object)
+WebGLOpaqueTexture::WebGLOpaqueTexture(WebGLRenderingContextBase& context, PlatformGLObject object, GCGLenum target)
     : WebGLTexture(context, object)
 {
+    // Opaque textures bypass the normal bindTexture path, so m_target would stay 0. Set it directly so WebGL validation knows the correct target type.
+    didBind(target);
 }
 
 void WebGLOpaqueTexture::deleteObjectImpl(const AbstractLocker&, GraphicsContextGL*, PlatformGLObject)

--- a/Source/WebCore/Modules/webxr/WebGLOpaqueTexture.h
+++ b/Source/WebCore/Modules/webxr/WebGLOpaqueTexture.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(WEBXR_LAYERS)
 
+#include "GraphicsTypesGL.h"
 #include "WebGLTexture.h"
 #include <wtf/RefPtr.h>
 #include <wtf/Vector.h>
@@ -37,10 +38,10 @@ class WebGLOpaqueTexture final : public WebGLTexture {
 public:
     virtual ~WebGLOpaqueTexture();
 
-    static RefPtr<WebGLOpaqueTexture> create(WebGLRenderingContextBase&, PlatformGLObject);
+    static RefPtr<WebGLOpaqueTexture> create(WebGLRenderingContextBase&, PlatformGLObject, GCGLenum target);
 
 private:
-    WebGLOpaqueTexture(WebGLRenderingContextBase&, PlatformGLObject);
+    WebGLOpaqueTexture(WebGLRenderingContextBase&, PlatformGLObject, GCGLenum target);
     void deleteObjectImpl(const AbstractLocker&, GraphicsContextGL*, PlatformGLObject) override;
 };
 

--- a/Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.cpp
@@ -50,10 +50,47 @@ WebXRWebGLSwapchain::WebXRWebGLSwapchain(WebGLRenderingContextBase& context, Swa
         m_framebufferForClearing = m_context->createFramebuffer();
 }
 
-void WebXRWebGLSwapchain::clearCurrentTexture(GraphicsContextGL& gl)
+void WebXRWebGLSwapchain::clearTextureLayers(GraphicsContextGL& gl, uint32_t layerCount, NOESCAPE const BindAttachmentFunction& bindAttachment)
 {
     ASSERT(m_context);
+    ASSERT(m_framebufferForClearing);
+    ASSERT(layerCount >= 1);
 
+    GCGLenum clearMask = 0;
+    if (m_targetFlags.contains(SwapchainTargetFlags::Color))
+        clearMask |= GL::COLOR_BUFFER_BIT;
+    if (m_targetFlags.contains(SwapchainTargetFlags::Depth))
+        clearMask |= GL::DEPTH_BUFFER_BIT;
+    if (m_targetFlags.contains(SwapchainTargetFlags::Stencil))
+        clearMask |= GL::STENCIL_BUFFER_BIT;
+
+    GCGLenum attachment = GL::COLOR_ATTACHMENT0;
+    if (m_targetFlags.contains(SwapchainTargetFlags::Depth) && m_targetFlags.contains(SwapchainTargetFlags::Stencil))
+        attachment = GL::DEPTH_STENCIL_ATTACHMENT;
+    else if (m_targetFlags.contains(SwapchainTargetFlags::Depth))
+        attachment = GL::DEPTH_ATTACHMENT;
+    else if (m_targetFlags.contains(SwapchainTargetFlags::Stencil))
+        attachment = GL::STENCIL_ATTACHMENT;
+    else
+        ASSERT(m_targetFlags.contains(SwapchainTargetFlags::Color));
+
+    ScopedWebGLRestoreFramebuffer restoreFramebuffer { *m_context };
+    ScopedDisableRasterizerDiscard disableRasterizerDiscard { *m_context };
+    ScopedEnableBackbuffer enableBackBuffer { *m_context };
+    ScopedDisableScissorTest disableScissorTest { *m_context };
+    ScopedClearColorAndMask zeroClear { *m_context, 0.f, 0.f, 0.f, 0.f, true, true, true, true };
+    ScopedClearDepthAndMask zeroDepth { *m_context, 1.0f, true, m_targetFlags.contains(SwapchainTargetFlags::Depth) };
+    ScopedClearStencilAndMask zeroStencil { *m_context, 0, 0xFFFFFFFF, m_targetFlags.contains(SwapchainTargetFlags::Stencil) };
+
+    gl.bindFramebuffer(GL::FRAMEBUFFER, m_framebufferForClearing->object());
+    for (GCGLint layer = 0; layer < static_cast<GCGLint>(layerCount); ++layer) {
+        bindAttachment(attachment, layer);
+        gl.clear(clearMask);
+    }
+}
+
+void WebXRWebGLSwapchain::clearCurrentTexture(GraphicsContextGL& gl)
+{
     if (!m_framebufferForClearing)
         return;
 
@@ -61,39 +98,44 @@ void WebXRWebGLSwapchain::clearCurrentTexture(GraphicsContextGL& gl)
     if (!texture)
         return;
 
-    auto computeClearMask = [](const SwapchainTargets& targets) {
-        GCGLenum clearMask = 0;
-        if (targets.contains(SwapchainTargetFlags::Color))
-            clearMask |= GL::COLOR_BUFFER_BIT;
-        if (targets.contains(SwapchainTargetFlags::Depth))
-            clearMask |= GL::DEPTH_BUFFER_BIT;
-        if (targets.contains(SwapchainTargetFlags::Stencil))
-            clearMask |= GL::STENCIL_BUFFER_BIT;
-        return clearMask;
-    };
+    clearTextureLayers(gl, 1, [&](GCGLenum attachment, GCGLint) {
+        gl.framebufferTexture2D(GL::FRAMEBUFFER, attachment, GL::TEXTURE_2D, texture, 0);
+    });
+}
 
-    auto computeAttachment = [](const SwapchainTargets& target) {
-        if (target.contains(SwapchainTargetFlags::Color))
-            return GL::COLOR_ATTACHMENT0;
-        if (target.contains(SwapchainTargetFlags::Depth) && target.contains(SwapchainTargetFlags::Stencil))
-            return GL::DEPTH_STENCIL_ATTACHMENT;
-        if (target.contains(SwapchainTargetFlags::Depth))
-            return GL::DEPTH_ATTACHMENT;
-        ASSERT(target.contains(SwapchainTargetFlags::Stencil));
-        return GL::STENCIL_ATTACHMENT;
-    };
+static IntSize toIntSize(const auto& size)
+{
+    return IntSize(size[0], size[1]);
+}
 
-    ScopedWebGLRestoreFramebuffer restoreFramebuffer { *m_context };
-    ScopedDisableRasterizerDiscard disableRasterizerDiscard { *m_context };
-    ScopedEnableBackbuffer enableBackBuffer { *m_context };
-    ScopedDisableScissorTest disableScissorTest { *m_context };
-    ScopedClearColorAndMask zeroClear { *m_context, 0.f, 0.f, 0.f, 0.f, true, true, true, true, };
-    ScopedClearDepthAndMask zeroDepth { *m_context, 1.0f, true, m_targetFlags.contains(SwapchainTargetFlags::Depth) };
-    ScopedClearStencilAndMask zeroStencil { *m_context, 0, 0xFFFFFFFF, m_targetFlags.contains(SwapchainTargetFlags::Stencil) };
-    GCGLenum clearMask = computeClearMask(m_targetFlags);
-    gl.bindFramebuffer(GL::FRAMEBUFFER, m_framebufferForClearing->object());
-    gl.framebufferTexture2D(GL::FRAMEBUFFER, computeAttachment(m_targetFlags), GL::TEXTURE_2D, texture, 0);
-    gl.clear(clearMask);
+static IntSize calcImagePhysicalSize(const IntSize& leftPhysicalSize, const IntSize& rightPhysicalSize)
+{
+    if (rightPhysicalSize.isEmpty())
+        return leftPhysicalSize;
+    RELEASE_ASSERT(leftPhysicalSize.height() == rightPhysicalSize.height(), "Only side-by-side shared framebuffer layout is supported");
+    return { leftPhysicalSize.width() + rightPhysicalSize.width(), leftPhysicalSize.height() };
+}
+
+void WebXRWebGLSwapchain::setupExternalImage(const PlatformXR::FrameData::LayerSetupData& data)
+{
+    auto leftPhysicalSize = toIntSize(data.physicalSize[0]);
+    auto rightPhysicalSize = toIntSize(data.physicalSize[1]);
+
+    m_texSize = calcImagePhysicalSize(leftPhysicalSize, rightPhysicalSize);
+}
+
+void WebXRWebGLSwapchain::signalEndFrame(GraphicsContextGL& gl, PlatformXR::DeviceLayer& layerData)
+{
+#if PLATFORM(GTK) || PLATFORM(WPE)
+    if (auto sync = gl.createExternalSync({ })) {
+        layerData.fenceFD = gl.exportExternalSync(sync);
+        gl.deleteExternalSync(sync);
+        return;
+    }
+#else
+    UNUSED_PARAM(layerData);
+#endif
+    gl.finish();
 }
 
 RefPtr<WebGLRenderingContextBase> WebXRWebGLSwapchain::context()
@@ -128,26 +170,6 @@ PlatformGLObject WebXRWebGLSharedImageSwapchain::currentTexture()
 
     RELEASE_ASSERT(m_displayImagesSets.size() > m_currentImageIndex);
     return m_displayImagesSets[m_currentImageIndex].colorBuffer.tex;
-}
-
-static IntSize calcImagePhysicalSize(const IntSize& leftPhysicalSize, const IntSize& rightPhysicalSize)
-{
-    if (rightPhysicalSize.isEmpty())
-        return leftPhysicalSize;
-    RELEASE_ASSERT(leftPhysicalSize.height() == rightPhysicalSize.height(), "Only side-by-side shared framebuffer layout is supported");
-    return { leftPhysicalSize.width() + rightPhysicalSize.width(), leftPhysicalSize.height() };
-}
-
-static IntSize toIntSize(const auto& size)
-{
-    return IntSize(size[0], size[1]);
-}
-
-void WebXRWebGLSharedImageSwapchain::setupExternalImage(GraphicsContextGL&, const PlatformXR::FrameData::LayerSetupData& data)
-{
-    auto leftPhysicalSize = toIntSize(data.physicalSize[0]);
-    auto rightPhysicalSize = toIntSize(data.physicalSize[1]);
-    m_texSize = calcImagePhysicalSize(leftPhysicalSize, rightPhysicalSize);
 }
 
 const WebXRExternalImages* WebXRWebGLSharedImageSwapchain::reusableTextures(const PlatformXR::FrameData::ExternalTextureData& textureData) const
@@ -241,7 +263,8 @@ void WebXRWebGLSharedImageSwapchain::bindCompositorTexturesForDisplay(GraphicsCo
 #else
     constexpr auto kColorFormat = GL::RGBA8;
 #endif
-    // FIXME: add support for texture arrays.
+    // DMABuf does not support sharing texture arrays so this is always 0.
+    // FIXME: eventually check for other texture sharing mechanisms that might support texture arrays sharing.
     GCGLint layer = 0;
     createAndBindCompositorTexture(gl, m_displayImagesSets[m_currentImageIndex].colorBuffer, kColorFormat, WTF::move(colorTextureSource), layer);
     ASSERT(m_displayImagesSets[m_currentImageIndex].colorBuffer.tex);
@@ -263,7 +286,7 @@ void WebXRWebGLSharedImageSwapchain::startFrame(PlatformXR::FrameData::LayerData
         return;
 
     if (data.layerSetup)
-        setupExternalImage(*gl, *data.layerSetup);
+        setupExternalImage(*data.layerSetup);
 
     bindCompositorTexturesForDisplay(*gl, data);
 
@@ -278,17 +301,7 @@ void WebXRWebGLSharedImageSwapchain::endFrame(PlatformXR::DeviceLayer& layerData
         return;
 
     ASSERT(gl->checkFramebufferStatus(GL::FRAMEBUFFER) == GL::FRAMEBUFFER_COMPLETE);
-
-#if PLATFORM(GTK) || PLATFORM(WPE)
-    if (auto sync = gl->createExternalSync({ })) {
-        layerData.fenceFD = gl->exportExternalSync(sync);
-        gl->deleteExternalSync(sync);
-        return;
-    }
-#else
-    UNUSED_PARAM(layerData);
-#endif
-    gl->finish();
+    signalEndFrame(*gl, layerData);
 }
 
 void WebXRExternalImage::destroyImage(GraphicsContextGL& gl)
@@ -367,17 +380,37 @@ void WebXRWebGLStaticImageSwapchain::bindCompositorTexturesForDisplay(GraphicsCo
 
     releaseDisplayImagesAtIndex(m_currentImageIndex);
 
-    // FIXME: add support for texture arrays.
-    GCGLenum target = GL::TEXTURE_2D;
+    GCGLenum target = m_imageAttributes.textureType;
     PlatformGLObject texture = gl.createTexture();
     gl.bindTexture(target, texture);
 
-    if (m_context->isWebGL2())
+    if (m_imageAttributes.textureType == GL::TEXTURE_2D_ARRAY)
+        gl.texStorage3D(target, 1, m_imageAttributes.internalFormat, m_texSize.width(), m_texSize.height(), m_imageAttributes.arrayLength);
+    else if (m_context->isWebGL2())
         gl.texStorage2D(target, 1, m_imageAttributes.internalFormat, m_texSize.width(), m_texSize.height());
     else
         gl.texImage2D(target, 0, m_imageAttributes.internalFormat, m_texSize.width(), m_texSize.height(), 0, m_imageAttributes.format, GL::UNSIGNED_INT, { });
 
     m_textures[m_currentImageIndex] = texture;
+}
+
+void WebXRWebGLStaticImageSwapchain::clearCurrentTexture(GraphicsContextGL& gl)
+{
+    if (m_imageAttributes.textureType != GL::TEXTURE_2D_ARRAY) {
+        WebXRWebGLSwapchain::clearCurrentTexture(gl);
+        return;
+    }
+
+    if (!m_framebufferForClearing)
+        return;
+
+    auto texture = currentTexture();
+    if (!texture)
+        return;
+
+    clearTextureLayers(gl, m_imageAttributes.arrayLength, [&](GCGLenum attachment, GCGLint layer) {
+        gl.framebufferTextureLayer(GL::FRAMEBUFFER, attachment, texture, 0, layer);
+    });
 }
 
 void WebXRWebGLStaticImageSwapchain::startFrame(PlatformXR::FrameData::LayerData& data)
@@ -404,6 +437,203 @@ bool WebXRWebGLStaticImageSwapchain::allTexturesAreBound() const
     });
 }
 
+WTF_MAKE_TZONE_ALLOCATED_IMPL(WebXRWebGLTextureArraySwapchain);
+
+std::unique_ptr<WebXRWebGLTextureArraySwapchain> WebXRWebGLTextureArraySwapchain::create(WebGLRenderingContextBase& context, SwapchainTargets targets, GCGLenum internalFormat, bool clearOnAccess, size_t imageCount, uint32_t arrayLength)
+{
+    ASSERT(arrayLength);
+    return std::unique_ptr<WebXRWebGLTextureArraySwapchain>(new WebXRWebGLTextureArraySwapchain(context, targets, internalFormat, clearOnAccess, imageCount, arrayLength));
+}
+
+WebXRWebGLTextureArraySwapchain::WebXRWebGLTextureArraySwapchain(WebGLRenderingContextBase& context, SwapchainTargets targets, GCGLenum internalFormat, bool clearOnAccess, size_t imageCount, uint32_t arrayLength)
+    : WebXRWebGLSwapchain(context, targets, clearOnAccess, imageCount)
+    , m_arrayLength(arrayLength)
+    , m_internalFormat(internalFormat)
+{
+}
+
+WebXRWebGLTextureArraySwapchain::~WebXRWebGLTextureArraySwapchain()
+{
+    for (size_t i = 0; i < m_textureSets.size(); ++i)
+        releaseTexturesAtIndex(i);
+    m_textureSets.clear();
+
+    if (RefPtr gl = m_context->graphicsContextGL()) {
+        if (m_blitReadFBO)
+            gl->deleteFramebuffer(m_blitReadFBO);
+        if (m_blitDrawFBO)
+            gl->deleteFramebuffer(m_blitDrawFBO);
+    }
+}
+
+void WebXRWebGLTextureArraySwapchain::TextureSet::release(GraphicsContextGL& gl)
+{
+    if (arrayTexture) {
+        gl.deleteTexture(arrayTexture);
+        arrayTexture = 0;
+    }
+    sharedImage.release(gl);
+}
+
+void WebXRWebGLTextureArraySwapchain::TextureSet::leakObject()
+{
+    arrayTexture = 0;
+    sharedImage.leakObject();
+}
+
+PlatformGLObject WebXRWebGLTextureArraySwapchain::currentTexture()
+{
+    if (m_textureSets.isEmpty())
+        return 0;
+    RELEASE_ASSERT(m_textureSets.size() > m_currentImageIndex);
+    return m_textureSets[m_currentImageIndex].arrayTexture;
+}
+
+void WebXRWebGLTextureArraySwapchain::releaseTexturesAtIndex(size_t index)
+{
+    if (index >= m_textureSets.size())
+        return;
+
+    if (RefPtr gl = m_context->graphicsContextGL())
+        m_textureSets[index].release(*gl);
+    else
+        m_textureSets[index].leakObject();
+}
+
+const WebXRExternalImages* WebXRWebGLTextureArraySwapchain::reusableTextures(const PlatformXR::FrameData::ExternalTextureData& textureData) const
+{
+    if (textureData.colorTexture)
+        return nullptr;
+
+    auto reusableTextureIndex = textureData.reusableTextureIndex;
+    if (reusableTextureIndex >= m_textureSets.size() || !m_textureSets[reusableTextureIndex]) {
+        RELEASE_LOG_FAULT(XR, "Unable to find reusable texture at index: %" PRIu64, reusableTextureIndex);
+        ASSERT_NOT_REACHED();
+        return nullptr;
+    }
+
+    return &m_textureSets[reusableTextureIndex].sharedImage;
+}
+
+void WebXRWebGLTextureArraySwapchain::bindCompositorTexturesForDisplay(GraphicsContextGL& gl, PlatformXR::FrameData::LayerData& layerData)
+{
+    m_currentImageIndex = layerData.textureData ? layerData.textureData->reusableTextureIndex : 0;
+    if (m_textureSets.size() <= m_currentImageIndex)
+        m_textureSets.resizeToFit(m_currentImageIndex + 1);
+
+    if (!layerData.textureData) {
+        m_currentImageIndex = 0;
+        return;
+    }
+
+    auto& currentSet = m_textureSets[m_currentImageIndex];
+
+    // If the shared image is already bound (reusable), only create the array texture if needed.
+    auto* reusable = reusableTextures(*(layerData.textureData));
+    if (!reusable) {
+        // New frame data: release old textures and bind the new shared image.
+        releaseTexturesAtIndex(m_currentImageIndex);
+
+        if (!layerData.textureData->colorTexture)
+            return;
+
+        IntSize texSize = layerData.layerSetup ? toIntSize(layerData.layerSetup->physicalSize[0]) : IntSize(32, 32);
+        auto colorTextureSource = makeExternalImageSource(layerData.textureData->colorTexture, texSize);
+#if PLATFORM(COCOA)
+        constexpr auto kColorFormat = GL::BGRA_EXT;
+#else
+        constexpr auto kColorFormat = GL::RGBA8;
+#endif
+        // DMABuf does not support sharing texture arrays so this is always 0.
+        // FIXME: eventually check for other texture sharing mechanisms that might support texture arrays sharing.
+        GCGLint layer = 0;
+        createAndBindCompositorTexture(gl, currentSet.sharedImage.colorBuffer, kColorFormat, WTF::move(colorTextureSource), layer);
+        if (!currentSet.sharedImage.colorBuffer.tex)
+            return;
+    }
+
+    // Create the GL_TEXTURE_2D_ARRAY that the WebXR app will render into.
+    if (!currentSet.arrayTexture) {
+        // Each array layer has the per-eye width; the shared texture holds all layers side-by-side.
+        auto sliceWidth = m_texSize.width() / static_cast<int>(m_arrayLength);
+        currentSet.arrayTexture = gl.createTexture();
+        gl.bindTexture(GL::TEXTURE_2D_ARRAY, currentSet.arrayTexture);
+        gl.texStorage3D(GL::TEXTURE_2D_ARRAY, 1, m_internalFormat, sliceWidth, m_texSize.height(), m_arrayLength);
+    }
+}
+
+void WebXRWebGLTextureArraySwapchain::blitTextureArrayToSharedImage(GraphicsContextGL& gl)
+{
+    auto& currentSet = m_textureSets[m_currentImageIndex];
+    if (!currentSet.arrayTexture || !currentSet.sharedImage.colorBuffer.tex)
+        return;
+
+    if (!m_blitReadFBO)
+        m_blitReadFBO = gl.createFramebuffer();
+    if (!m_blitDrawFBO)
+        m_blitDrawFBO = gl.createFramebuffer();
+
+    auto sliceWidth = m_texSize.width() / static_cast<int>(m_arrayLength);
+    auto height = m_texSize.height();
+
+    gl.bindFramebuffer(GL::READ_FRAMEBUFFER, m_blitReadFBO);
+    gl.bindFramebuffer(GL::DRAW_FRAMEBUFFER, m_blitDrawFBO);
+    gl.framebufferTexture2D(GL::DRAW_FRAMEBUFFER, GL::COLOR_ATTACHMENT0, GL::TEXTURE_2D, currentSet.sharedImage.colorBuffer.tex, 0);
+
+    for (uint32_t layer = 0; layer < m_arrayLength; ++layer) {
+        gl.framebufferTextureLayer(GL::READ_FRAMEBUFFER, GL::COLOR_ATTACHMENT0, currentSet.arrayTexture, 0, static_cast<GCGLint>(layer));
+        auto dstX = static_cast<GCGLint>(layer) * sliceWidth;
+        gl.blitFramebuffer(0, 0, sliceWidth, height, dstX, 0, dstX + sliceWidth, height, GL::COLOR_BUFFER_BIT, GL::NEAREST);
+    }
+
+    gl.bindFramebuffer(GL::FRAMEBUFFER, 0);
+}
+
+void WebXRWebGLTextureArraySwapchain::clearCurrentTexture(GraphicsContextGL& gl)
+{
+    if (!m_framebufferForClearing)
+        return;
+
+    auto texture = currentTexture();
+    if (!texture)
+        return;
+
+    clearTextureLayers(gl, m_arrayLength, [&](GCGLenum attachment, GCGLint layer) {
+        gl.framebufferTextureLayer(GL::FRAMEBUFFER, attachment, texture, 0, layer);
+    });
+}
+
+void WebXRWebGLTextureArraySwapchain::startFrame(PlatformXR::FrameData::LayerData& data)
+{
+    RefPtr gl = m_context->graphicsContextGL();
+    if (!gl)
+        return;
+
+    if (data.layerSetup)
+        setupExternalImage(*data.layerSetup);
+
+    bindCompositorTexturesForDisplay(*gl, data);
+
+    if (m_clearOnAccess)
+        clearCurrentTexture(*gl);
+}
+
+void WebXRWebGLTextureArraySwapchain::endFrame(PlatformXR::DeviceLayer& layerData)
+{
+    RefPtr gl = m_context->graphicsContextGL();
+    if (!gl)
+        return;
+
+    blitTextureArrayToSharedImage(*gl);
+    signalEndFrame(*gl, layerData);
+}
+
+bool WebXRWebGLTextureArraySwapchain::allTexturesAreBound() const
+{
+    return m_textureSets.size() == m_imageCount && std::all_of(m_textureSets.begin(), m_textureSets.end(), [](const auto& set) {
+        return set.arrayTexture && set.sharedImage;
+    });
+}
 
 } // namespace WebCore
 

--- a/Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.h
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.h
@@ -31,6 +31,7 @@
 #include "GraphicsTypesGL.h"
 #include "PlatformXR.h"
 #include "WebXRSwapchain.h"
+#include <wtf/Function.h>
 #include <wtf/Ref.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/Vector.h>
@@ -82,16 +83,24 @@ public:
 
     RefPtr<WebGLRenderingContextBase> context();
 
-    IntSize size() const { return m_texSize; }
+    virtual IntSize size() const { return m_texSize; }
 
     virtual void startFrame(PlatformXR::FrameData::LayerData&) = 0;
     virtual void endFrame(PlatformXR::DeviceLayer&) = 0;
 
     virtual bool allTexturesAreBound() const = 0;
 
+    virtual GCGLenum textureTarget() const { return GraphicsContextGL::TEXTURE_2D; }
+
 protected:
     WebXRWebGLSwapchain(WebGLRenderingContextBase&, SwapchainTargets, bool clearOnAccess, size_t imageCount);
-    void clearCurrentTexture(GraphicsContextGL&);
+    virtual void clearCurrentTexture(GraphicsContextGL&);
+
+    using BindAttachmentFunction = Function<void(GCGLenum attachment, GCGLint layer)>;
+    void clearTextureLayers(GraphicsContextGL&, uint32_t layerCount, NOESCAPE const BindAttachmentFunction&);
+
+    void setupExternalImage(const PlatformXR::FrameData::LayerSetupData&);
+    void signalEndFrame(GraphicsContextGL&, PlatformXR::DeviceLayer&);
 
     PlatformXR::LayerHandle m_handle;
     RefPtr<WebGLRenderingContextBase> m_context;
@@ -120,7 +129,6 @@ public:
 
 private:
     WebXRWebGLSharedImageSwapchain(WebGLRenderingContextBase&, SwapchainTargets, GCGLenum format, IntSize initialSize, bool clearOnAccess, size_t imageCount);
-    void setupExternalImage(GraphicsContextGL&, const PlatformXR::FrameData::LayerSetupData&);
 
     const WebXRExternalImages* reusableTextures(const PlatformXR::FrameData::ExternalTextureData&) const;
     void releaseTexturesAtIndex(size_t index);
@@ -147,6 +155,8 @@ public:
         bool clearOnAccess { false };
         SwapchainTargets targets;
         size_t imageCount { 0 };
+        uint32_t arrayLength { 1 };
+        GCGLenum textureType { GraphicsContextGL::TEXTURE_2D };
     };
     static std::unique_ptr<WebXRWebGLStaticImageSwapchain> create(WebGLRenderingContextBase&, StaticImageAttributes);
     ~WebXRWebGLStaticImageSwapchain() override;
@@ -158,16 +168,64 @@ public:
 
     bool allTexturesAreBound() const override;
 
+    GCGLenum textureTarget() const override { return m_imageAttributes.textureType; }
+
 private:
     WebXRWebGLStaticImageSwapchain(WebGLRenderingContextBase&, StaticImageAttributes);
     void bindCompositorTexturesForDisplay(GraphicsContextGL&, PlatformXR::FrameData::LayerData&);
     void releaseDisplayImagesAtIndex(size_t);
+    void clearCurrentTexture(GraphicsContextGL&) override;
 
     StaticImageAttributes m_imageAttributes;
 #if USE(OPENXR)
     WTF::UnixFileDescriptor m_fenceFD;
 #endif
     Vector<PlatformGLObject> m_textures;
+};
+
+// Swapchain that renders internally into a GL_TEXTURE_2D_ARRAY and blits each array slice into the corresponding
+// horizontal region of a side-by-side shared texture exported to the UIProcess. Used whenever texture arrays
+// cannot be shared directly (like with DMABuf) so this approach keeps the existing sharing mechanism intact.
+class WebXRWebGLTextureArraySwapchain final : public WebXRWebGLSwapchain {
+    WTF_MAKE_TZONE_ALLOCATED(WebXRWebGLTextureArraySwapchain);
+    WTF_MAKE_NONCOPYABLE(WebXRWebGLTextureArraySwapchain);
+public:
+    static std::unique_ptr<WebXRWebGLTextureArraySwapchain> create(WebGLRenderingContextBase&, SwapchainTargets, GCGLenum internalFormat, bool clearOnAccess, size_t imageCount, uint32_t arrayLength);
+    ~WebXRWebGLTextureArraySwapchain() override;
+
+    PlatformGLObject currentTexture() override;
+
+    void startFrame(PlatformXR::FrameData::LayerData&) override;
+    void endFrame(PlatformXR::DeviceLayer&) override;
+
+    bool allTexturesAreBound() const override;
+
+    GCGLenum textureTarget() const override { return GraphicsContextGL::TEXTURE_2D_ARRAY; }
+    uint32_t arrayLength() const { return m_arrayLength; }
+
+private:
+    struct TextureSet {
+        PlatformGLObject arrayTexture { 0 };
+        WebXRExternalImages sharedImage;
+
+        explicit operator bool() const { return arrayTexture && sharedImage; }
+        void release(GraphicsContextGL&);
+        void leakObject();
+    };
+
+    WebXRWebGLTextureArraySwapchain(WebGLRenderingContextBase&, SwapchainTargets, GCGLenum internalFormat, bool clearOnAccess, size_t imageCount, uint32_t arrayLength);
+
+    void clearCurrentTexture(GraphicsContextGL&) override;
+    void bindCompositorTexturesForDisplay(GraphicsContextGL&, PlatformXR::FrameData::LayerData&);
+    void blitTextureArrayToSharedImage(GraphicsContextGL&);
+    void releaseTexturesAtIndex(size_t);
+    const WebXRExternalImages* reusableTextures(const PlatformXR::FrameData::ExternalTextureData&) const;
+
+    uint32_t m_arrayLength;
+    GCGLenum m_internalFormat;
+    Vector<TextureSet> m_textureSets;
+    PlatformGLObject m_blitReadFBO { 0 };
+    PlatformGLObject m_blitDrawFBO { 0 };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webxr/XRWebGLBinding.cpp
+++ b/Source/WebCore/Modules/webxr/XRWebGLBinding.cpp
@@ -209,6 +209,11 @@ ExceptionOr<Ref<XRProjectionLayer>> XRWebGLBinding::createProjectionLayer(Script
             if (baseContext->isContextLost())
                 return Exception { ExceptionCode::InvalidStateError, "Cannot create a projection layer with a lost WebGL context"_s };
 
+            if (init.textureType == XRTextureType::TextureArray) {
+                if (!baseContext->isWebGL2())
+                    return Exception { ExceptionCode::InvalidStateError, "Texture array is only supported on WebGL2 contexts."_s };
+            }
+
             // The following two checks are really part of the allocate textures algorithm, but we need to fail early for the projection layer case
             // as the allocation happens lazily when getViewSubImage() is called.
             if (!colorFormatIsSupportedForProjectionLayer(init.colorFormat))
@@ -343,6 +348,17 @@ ExceptionOr<void> XRWebGLBinding::validateCompositionLayerInitParameters(const X
 
     // The following checks are really part of the allocate textures algorithm, but we prefer to early fail here
     // as the allocation happens lazily when getSubImage() is called.
+    if (init.textureType == XRTextureType::TextureArray) {
+        bool isWebGL2Context = WTF::switchOn(m_context,
+            [](const Ref<WebGL2RenderingContext>&) { return true; },
+            [](const Ref<WebGLRenderingContext>&) { return false; },
+            [](std::monostate) {
+                return false;
+            });
+        if (!isWebGL2Context)
+            return Exception { ExceptionCode::InvalidStateError, "Texture array is only supported on WebGL 2.0 contexts."_s };
+    }
+
     if (init.mipLevels < 1)
         return Exception { ExceptionCode::InvalidStateError, "Mip levels lower than 1 are invalid."_s };
     if (init.mipLevels > 1) {
@@ -430,11 +446,13 @@ bool XRWebGLBinding::validateXRWebGLSubImageCreation(const XRCompositionLayer& l
     return true;
 }
 
-IntRect XRWebGLBinding::rectForView(const XRProjectionLayer& layer, const WebXRView& view) const
+IntRect XRWebGLBinding::rectForView(const XRProjectionLayer& layer, const XRTextureType textureType, const WebXRView& view) const
 {
-    // If the layer is not side-by-side return the full texture size adjusted by the viewport scale.
-    if (layer.textureArrayLength() > 1)
-        return { 0, 0, static_cast<int>(layer.textureWidth() * view.requestedViewportScale()), static_cast<int>(layer.textureHeight() * view.requestedViewportScale()) };
+    // For texture arrays each slice is textureWidth/arrayLength wide; the viewport covers one full slice.
+    if (textureType == XRTextureType::TextureArray) {
+        int perEyeWidth = static_cast<int>(layer.textureWidth()) / static_cast<int>(layer.textureArrayLength());
+        return { 0, 0, static_cast<int>(perEyeWidth * view.requestedViewportScale()), static_cast<int>(layer.textureHeight() * view.requestedViewportScale()) };
+    }
 
     // Otherwise the layer is side-by-side, so the viewports should be distributed across the texture width.
     int viewportWidth = layer.textureWidth() / m_session->views().size();
@@ -450,29 +468,26 @@ ExceptionOr<Vector<RefPtr<WebGLOpaqueTexture>>> XRWebGLBinding::allocateColorTex
                 return Exception { ExceptionCode::InvalidStateError, "Cannot create a projection layer with a lost WebGL context"_s };
 
             Vector<RefPtr<WebGLOpaqueTexture>> textures;
+            auto& backing = static_cast<XRWebGLLayerBacking&>(layer.backing());
             switch (layer.layout()) {
-            case XRLayerLayout::Default:
             case XRLayerLayout::Mono:
                 return Exception { ExceptionCode::NotSupportedError, "Mono layout not implemented."_s };
+            case XRLayerLayout::Default:
             case XRLayerLayout::Stereo:
-                if (textureType == XRTextureType::TextureArray)
-                    return Exception { ExceptionCode::NotSupportedError, "Texture arrays not implemented."_s };
                 for (auto& view : m_session->views()) {
                     if (!view.active)
                         continue;
-                    textures.append(static_cast<XRWebGLLayerBacking&>(layer.backing()).currentColorTexture());
+                    textures.append(backing.currentColorTexture());
                 }
                 break;
-            case XRLayerLayout::StereoLeftRight: {
-                if (textureType == XRTextureType::TextureArray)
-                    return Exception { ExceptionCode::NotSupportedError, "Texture arrays not implemented."_s };
-                textures.append(static_cast<XRWebGLLayerBacking&>(layer.backing()).currentColorTexture());
+            case XRLayerLayout::StereoLeftRight:
+                textures.append(backing.currentColorTexture());
                 break;
-            }
             case XRLayerLayout::StereoTopBottom:
                 return Exception { ExceptionCode::NotSupportedError, "Stereo top bottom not implemented."_s };
             };
 
+            UNUSED_PARAM(textureType);
             UNUSED_PARAM(textureFormat);
             UNUSED_PARAM(scaleFactor);
 
@@ -501,29 +516,26 @@ ExceptionOr<Vector<RefPtr<WebGLOpaqueTexture>>> XRWebGLBinding::allocateDepthTex
             if (baseContext->isWebGL1() && !baseContext->extensionIsEnabled("WEBGL_depth_texture"_s))
                 return textures;
 
+            auto& depthBacking = static_cast<XRWebGLLayerBacking&>(layer.backing());
             switch (layer.layout()) {
-            case XRLayerLayout::Default:
             case XRLayerLayout::Mono:
                 return Exception { ExceptionCode::NotSupportedError, "Mono layout not implemented."_s };
+            case XRLayerLayout::Default:
             case XRLayerLayout::Stereo:
-                if (textureType == XRTextureType::TextureArray)
-                    return Exception { ExceptionCode::NotSupportedError, "Texture arrays not implemented."_s };
                 for (auto& view : m_session->views()) {
                     if (!view.active)
                         continue;
-                    textures.append(static_cast<XRWebGLLayerBacking&>(layer.backing()).currentDepthTexture());
+                    textures.append(depthBacking.currentDepthTexture());
                 }
                 break;
-            case XRLayerLayout::StereoLeftRight: {
-                if (textureType == XRTextureType::TextureArray)
-                    return Exception { ExceptionCode::NotSupportedError, "Texture arrays not implemented."_s };
-                textures.append(static_cast<XRWebGLLayerBacking&>(layer.backing()).currentDepthTexture());
+            case XRLayerLayout::StereoLeftRight:
+                textures.append(depthBacking.currentDepthTexture());
                 break;
-            }
             case XRLayerLayout::StereoTopBottom:
                 return Exception { ExceptionCode::NotSupportedError, "Stereo top bottom not implemented."_s };
             };
 
+            UNUSED_PARAM(textureType);
             UNUSED_PARAM(textureFormat);
             UNUSED_PARAM(scaleFactor);
 
@@ -752,8 +764,14 @@ ExceptionOr<Ref<XRWebGLSubImage>> XRWebGLBinding::getViewSubImage(XRProjectionLa
         return Exception { ExceptionCode::InvalidStateError, "Cannot get view subimage."_s };
 
     // FIXME: if getViewSubImage() was called previously with the same binding, layer and view, the UA MAY return the same XRWebGLSubImage object as was returned previously.
-    Ref viewport = WebXRViewport::create(rectForView(layer, view));
-    return XRWebGLSubImage::create(WTF::move(viewport), layer);
+    Ref viewport = WebXRViewport::create(rectForView(layer, textureType, view));
+    auto subImageResult = XRWebGLSubImage::create(WTF::move(viewport), layer);
+    if (subImageResult.hasException())
+        return subImageResult.releaseException();
+
+    Ref subImage = subImageResult.releaseReturnValue();
+    subImage->setImageIndex(textureType == XRTextureType::TextureArray && view.eye() == XREye::Right ? 1 : 0);
+    return subImage;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webxr/XRWebGLBinding.h
+++ b/Source/WebCore/Modules/webxr/XRWebGLBinding.h
@@ -102,7 +102,7 @@ private:
     ExceptionOr<Vector<RefPtr<WebGLOpaqueTexture>>> allocateDepthTexturesForLayer(XRCompositionLayer&, XRTextureType, const XRLayerInit&);
     bool validateXRWebGLSubImageCreation(const XRCompositionLayer&, const WebXRFrame&) const;
 
-    IntRect rectForView(const XRProjectionLayer&, const WebXRView&) const;
+    IntRect rectForView(const XRProjectionLayer&, const XRTextureType, const WebXRView&) const;
 
     const Ref<WebXRSession> m_session;
     WebXRWebGLRenderingContext m_context;

--- a/Source/WebCore/Modules/webxr/XRWebGLCylinderLayerBacking.cpp
+++ b/Source/WebCore/Modules/webxr/XRWebGLCylinderLayerBacking.cpp
@@ -42,12 +42,12 @@ ExceptionOr<Ref<XRWebGLCylinderLayerBacking>> XRWebGLCylinderLayerBacking::creat
     auto swapchains = XRWebGLLayerBacking::createCompositionLayerSwapchains(session, context, PlatformXR::CompositionLayerType::Cylinder, init);
     if (swapchains.hasException())
         return swapchains.releaseException();
-    auto [handle, colorSwapchain, depthSwapchain] = swapchains.releaseReturnValue();
-    return adoptRef(*new XRWebGLCylinderLayerBacking(handle, WTF::move(colorSwapchain), WTF::move(depthSwapchain), init));
+    auto [handle, colorSwapchain, depthSwapchain, arrayLength] = swapchains.releaseReturnValue();
+    return adoptRef(*new XRWebGLCylinderLayerBacking(handle, WTF::move(colorSwapchain), WTF::move(depthSwapchain), arrayLength, init));
 }
 
-XRWebGLCylinderLayerBacking::XRWebGLCylinderLayerBacking(PlatformXR::LayerHandle handle, std::unique_ptr<WebXRWebGLSwapchain>&& colorSwapchain, std::unique_ptr<WebXRWebGLSwapchain>&& depthSwapchain, const XRCylinderLayerInit& init)
-    : XRWebGLLayerBacking(handle, WTF::move(colorSwapchain), WTF::move(depthSwapchain))
+XRWebGLCylinderLayerBacking::XRWebGLCylinderLayerBacking(PlatformXR::LayerHandle handle, std::unique_ptr<WebXRWebGLSwapchain>&& colorSwapchain, std::unique_ptr<WebXRWebGLSwapchain>&& depthSwapchain, uint32_t colorTextureArrayLength, const XRCylinderLayerInit& init)
+    : XRWebGLLayerBacking(handle, WTF::move(colorSwapchain), WTF::move(depthSwapchain), colorTextureArrayLength)
     , m_init(init)
 {
 }

--- a/Source/WebCore/Modules/webxr/XRWebGLCylinderLayerBacking.h
+++ b/Source/WebCore/Modules/webxr/XRWebGLCylinderLayerBacking.h
@@ -45,7 +45,7 @@ public:
     static ExceptionOr<Ref<XRWebGLCylinderLayerBacking>> create(WebXRSession&, WebGLRenderingContextBase&, const XRCylinderLayerInit&);
 
 private:
-    XRWebGLCylinderLayerBacking(PlatformXR::LayerHandle, std::unique_ptr<WebXRWebGLSwapchain>&& colorSwapchain, std::unique_ptr<WebXRWebGLSwapchain>&& depthSwapchain, const XRCylinderLayerInit&);
+    XRWebGLCylinderLayerBacking(PlatformXR::LayerHandle, std::unique_ptr<WebXRWebGLSwapchain>&& colorSwapchain, std::unique_ptr<WebXRWebGLSwapchain>&& depthSwapchain, uint32_t colorTextureArrayLength, const XRCylinderLayerInit&);
 
     XRCylinderLayerInit m_init;
 };

--- a/Source/WebCore/Modules/webxr/XRWebGLEquirectLayerBacking.cpp
+++ b/Source/WebCore/Modules/webxr/XRWebGLEquirectLayerBacking.cpp
@@ -42,12 +42,12 @@ ExceptionOr<Ref<XRWebGLEquirectLayerBacking>> XRWebGLEquirectLayerBacking::creat
     auto swapchains = XRWebGLLayerBacking::createCompositionLayerSwapchains(session, context, PlatformXR::CompositionLayerType::Equirect, init);
     if (swapchains.hasException())
         return swapchains.releaseException();
-    auto [handle, colorSwapchain, depthSwapchain] = swapchains.releaseReturnValue();
-    return adoptRef(*new XRWebGLEquirectLayerBacking(handle, WTF::move(colorSwapchain), WTF::move(depthSwapchain), init));
+    auto [handle, colorSwapchain, depthSwapchain, arrayLength] = swapchains.releaseReturnValue();
+    return adoptRef(*new XRWebGLEquirectLayerBacking(handle, WTF::move(colorSwapchain), WTF::move(depthSwapchain), arrayLength, init));
 }
 
-XRWebGLEquirectLayerBacking::XRWebGLEquirectLayerBacking(PlatformXR::LayerHandle handle, std::unique_ptr<WebXRWebGLSwapchain>&& colorSwapchain, std::unique_ptr<WebXRWebGLSwapchain>&& depthSwapchain, const XREquirectLayerInit& init)
-    : XRWebGLLayerBacking(handle, WTF::move(colorSwapchain), WTF::move(depthSwapchain))
+XRWebGLEquirectLayerBacking::XRWebGLEquirectLayerBacking(PlatformXR::LayerHandle handle, std::unique_ptr<WebXRWebGLSwapchain>&& colorSwapchain, std::unique_ptr<WebXRWebGLSwapchain>&& depthSwapchain, uint32_t colorTextureArrayLength, const XREquirectLayerInit& init)
+    : XRWebGLLayerBacking(handle, WTF::move(colorSwapchain), WTF::move(depthSwapchain), colorTextureArrayLength)
     , m_init(init)
 {
 };

--- a/Source/WebCore/Modules/webxr/XRWebGLEquirectLayerBacking.h
+++ b/Source/WebCore/Modules/webxr/XRWebGLEquirectLayerBacking.h
@@ -45,7 +45,7 @@ public:
     static ExceptionOr<Ref<XRWebGLEquirectLayerBacking>> create(WebXRSession&, WebGLRenderingContextBase&, const XREquirectLayerInit&);
 
 private:
-    XRWebGLEquirectLayerBacking(PlatformXR::LayerHandle, std::unique_ptr<WebXRWebGLSwapchain>&& colorSwapchain, std::unique_ptr<WebXRWebGLSwapchain>&& depthSwapchain, const XREquirectLayerInit&);
+    XRWebGLEquirectLayerBacking(PlatformXR::LayerHandle, std::unique_ptr<WebXRWebGLSwapchain>&& colorSwapchain, std::unique_ptr<WebXRWebGLSwapchain>&& depthSwapchain, uint32_t colorTextureArrayLength, const XREquirectLayerInit&);
 
     XREquirectLayerInit m_init;
 };

--- a/Source/WebCore/Modules/webxr/XRWebGLLayerBacking.cpp
+++ b/Source/WebCore/Modules/webxr/XRWebGLLayerBacking.cpp
@@ -39,6 +39,7 @@
 #include "XRLayerInit.h"
 #include "XRLayerLayout.h"
 #include "XRProjectionLayerInit.h"
+#include "XRTextureType.h"
 
 #include <wtf/TZoneMallocInlines.h>
 
@@ -48,9 +49,10 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(XRWebGLLayerBacking);
 
 using GL = GraphicsContextGL;
 
-XRWebGLLayerBacking::XRWebGLLayerBacking(PlatformXR::LayerHandle handle, std::unique_ptr<WebXRWebGLSwapchain>&& colorSwapchain, std::unique_ptr<WebXRWebGLSwapchain>&& depthSwapchain)
+XRWebGLLayerBacking::XRWebGLLayerBacking(PlatformXR::LayerHandle handle, std::unique_ptr<WebXRWebGLSwapchain>&& colorSwapchain, std::unique_ptr<WebXRWebGLSwapchain>&& depthSwapchain, uint32_t colorTextureArrayLength)
     : m_colorSwapchain(WTF::move(colorSwapchain))
     , m_depthSwapchain(WTF::move(depthSwapchain))
+    , m_colorTextureArrayLength(colorTextureArrayLength)
 {
     setHandle(handle);
 }
@@ -67,8 +69,7 @@ uint32_t XRWebGLLayerBacking::colorTextureHeight() const
 
 uint32_t XRWebGLLayerBacking::colorTextureArrayLength() const
 {
-    // FIXME: Support texture arrays for multiview.
-    return 1;
+    return m_colorTextureArrayLength;
 };
 
 std::optional<uint32_t> XRWebGLLayerBacking::depthTextureWidth() const
@@ -116,14 +117,14 @@ void XRWebGLLayerBacking::endFrame(PlatformXR::DeviceLayer& layerData)
 RefPtr<WebGLOpaqueTexture> XRWebGLLayerBacking::currentColorTexture() const
 {
     if (auto texture = m_colorSwapchain->currentTexture())
-        return WebGLOpaqueTexture::create(*m_colorSwapchain->context(), texture);
+        return WebGLOpaqueTexture::create(*m_colorSwapchain->context(), texture, m_colorSwapchain->textureTarget());
     return nullptr;
 }
 
 RefPtr<WebGLOpaqueTexture> XRWebGLLayerBacking::currentDepthTexture() const
 {
     if (auto texture = m_depthSwapchain->currentTexture())
-        return WebGLOpaqueTexture::create(*m_depthSwapchain->context(), texture);
+        return WebGLOpaqueTexture::create(*m_depthSwapchain->context(), texture, m_depthSwapchain->textureTarget());
     return nullptr;
 }
 
@@ -144,6 +145,11 @@ static std::pair<IntSize, PlatformXR::LayerLayout> computeNonProjectionLayerSize
     };
 }
 
+static uint32_t computeArrayLength(bool useTextureArray, uint32_t textureArrayLength)
+{
+    return useTextureArray ? textureArrayLength : 1;
+}
+
 ExceptionOr<XRWebGLLayerBacking::XRLayerSwapchains> XRWebGLLayerBacking::createCompositionLayerSwapchains(WebXRSession& session, WebGLRenderingContextBase& context, PlatformXR::CompositionLayerType layerType, const XRLayerInit& init)
 {
     auto device = session.device();
@@ -156,7 +162,11 @@ ExceptionOr<XRWebGLLayerBacking::XRLayerSwapchains> XRWebGLLayerBacking::createC
     if (!layerInfo)
         return Exception { ExceptionCode::OperationError, "Unable to create a composition layer."_s };
 
-    return createColorAndDepthSwapchains(context, layerInfo->handle, init.colorFormat, init.depthFormat, layerSize, init.clearOnAccess, layerInfo->numImages);
+    bool useTextureArray = init.textureType == XRTextureType::TextureArray;
+    GCGLenum colorTextureType = useTextureArray ? GL::TEXTURE_2D_ARRAY : GL::TEXTURE_2D;
+    uint32_t arrayLength = computeArrayLength(useTextureArray, static_cast<uint32_t>(session.views().size()));
+
+    return XRWebGLLayerBacking::createColorAndDepthSwapchains(context, layerInfo->handle, init.colorFormat, init.depthFormat, layerSize, init.clearOnAccess, layerInfo->numImages, arrayLength, colorTextureType);
 }
 
 ExceptionOr<XRWebGLLayerBacking::XRLayerSwapchains> XRWebGLLayerBacking::createProjectionLayerSwapchains(WebXRSession& session, WebGLRenderingContextBase& context, const XRProjectionLayerInit& init)
@@ -174,29 +184,37 @@ ExceptionOr<XRWebGLLayerBacking::XRLayerSwapchains> XRWebGLLayerBacking::createP
     if (!layerInfo)
         return Exception { ExceptionCode::OperationError, "Unable to create a projection layer."_s };
 
-    return createColorAndDepthSwapchains(context, layerInfo->handle, init.colorFormat, init.depthFormat, size, init.clearOnAccess, layerInfo->numImages);
+    bool useTextureArray = init.textureType == XRTextureType::TextureArray;
+    GCGLenum colorTextureType = useTextureArray ? GL::TEXTURE_2D_ARRAY : GL::TEXTURE_2D;
+    uint32_t arrayLength = computeArrayLength(useTextureArray, static_cast<uint32_t>(session.views().size()));
+
+    return XRWebGLLayerBacking::createColorAndDepthSwapchains(context, layerInfo->handle, init.colorFormat, init.depthFormat, size, init.clearOnAccess, layerInfo->numImages, arrayLength, colorTextureType);
 }
 
-ExceptionOr<XRWebGLLayerBacking::XRLayerSwapchains> XRWebGLLayerBacking::createColorAndDepthSwapchains(WebGLRenderingContextBase& context, PlatformXR::LayerHandle handle, GCGLenum colorFormat, std::optional<GCGLenum> depthFormat, IntSize size, bool clearOnAccess, size_t numImages)
+ExceptionOr<XRWebGLLayerBacking::XRLayerSwapchains> XRWebGLLayerBacking::createColorAndDepthSwapchains(WebGLRenderingContextBase& context, PlatformXR::LayerHandle handle, GCGLenum colorFormat, std::optional<GCGLenum> depthFormat, IntSize size, bool clearOnAccess, size_t numImages, uint32_t arrayLength, GCGLenum colorTextureType)
 {
-    auto colorSwapchain = WebXRWebGLSharedImageSwapchain::create(context, WebXRSwapchain::SwapchainTargetFlags::Color, colorFormat, size, clearOnAccess, numImages);
+    std::unique_ptr<WebXRWebGLSwapchain> colorSwapchain;
+    std::unique_ptr<WebXRWebGLSwapchain> depthSwapchain;
+
+    bool useTextureArray = colorTextureType == GL::TEXTURE_2D_ARRAY;
+    if (useTextureArray) {
+        auto colorFormats = swapchainFormatsForLayerFormat(colorFormat);
+        colorSwapchain = WebXRWebGLTextureArraySwapchain::create(context, WebXRSwapchain::SwapchainTargetFlags::Color, colorFormats.internalFormat, clearOnAccess, numImages, arrayLength);
+    } else
+        colorSwapchain = WebXRWebGLSharedImageSwapchain::create(context, WebXRSwapchain::SwapchainTargetFlags::Color, colorFormat, size, clearOnAccess, numImages);
+
     if (!colorSwapchain)
         return Exception { ExceptionCode::OperationError, "Failed to create a WebGL swapchain."_s };
 
-    std::unique_ptr<WebXRWebGLSwapchain> depthSwapchain;
-    if (depthFormat && *depthFormat)
-        depthSwapchain = createDepthSwapchain(context, *depthFormat, size, clearOnAccess, numImages);
+    if (depthFormat && *depthFormat) {
+        IntSize depthSize = useTextureArray ? IntSize(size.width() / static_cast<int>(arrayLength), size.height()) : size;
+        depthSwapchain = createDepthSwapchain(context, *depthFormat, depthSize, clearOnAccess, numImages, arrayLength, colorTextureType);
+    }
 
-    return XRLayerSwapchains { handle, WTF::move(colorSwapchain), WTF::move(depthSwapchain) };
+    return XRLayerSwapchains { handle, WTF::move(colorSwapchain), WTF::move(depthSwapchain), arrayLength };
 }
 
-// Based on https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/xr/xr_webgl_binding.cc
-struct SwapchainFormats {
-    GCGLenum format { 0 };
-    GCGLenum internalFormat { 0 };
-};
-
-static SwapchainFormats swapchainFormatsForLayerFormat(GCGLenum layerFormat)
+SwapchainFormats swapchainFormatsForLayerFormat(GCGLenum layerFormat)
 {
     switch (layerFormat) {
     case GL::RGBA:
@@ -229,7 +247,7 @@ static SwapchainFormats swapchainFormatsForLayerFormat(GCGLenum layerFormat)
     };
 }
 
-std::unique_ptr<WebXRWebGLSwapchain> XRWebGLLayerBacking::createDepthSwapchain(WebGLRenderingContextBase& context, GCGLenum depthFormat, IntSize size, bool clearOnAccess, size_t imageCount)
+std::unique_ptr<WebXRWebGLSwapchain> XRWebGLLayerBacking::createDepthSwapchain(WebGLRenderingContextBase& context, GCGLenum depthFormat, IntSize size, bool clearOnAccess, size_t imageCount, uint32_t arrayLength, GCGLenum textureType)
 {
     ASSERT(depthFormat);
 
@@ -254,6 +272,8 @@ std::unique_ptr<WebXRWebGLSwapchain> XRWebGLLayerBacking::createDepthSwapchain(W
         .clearOnAccess = clearOnAccess,
         .targets = targets,
         .imageCount = imageCount,
+        .arrayLength = arrayLength,
+        .textureType = textureType,
     };
     return WebXRWebGLStaticImageSwapchain::create(context, attributes);
 }

--- a/Source/WebCore/Modules/webxr/XRWebGLLayerBacking.h
+++ b/Source/WebCore/Modules/webxr/XRWebGLLayerBacking.h
@@ -43,6 +43,13 @@ enum class CompositionLayerType : uint8_t;
 
 namespace WebCore {
 
+// Based on https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/modules/xr/xr_webgl_binding.cc
+struct SwapchainFormats {
+    GCGLenum format { 0 };
+    GCGLenum internalFormat { 0 };
+};
+SwapchainFormats swapchainFormatsForLayerFormat(GCGLenum layerFormat);
+
 class WebGLOpaqueTexture;
 class WebGLRenderingContextBase;
 class WebXROpaqueFramebuffer;
@@ -75,23 +82,25 @@ public:
     bool allColorTexturesAreBound() const final;
 
 protected:
-    XRWebGLLayerBacking(PlatformXR::LayerHandle, std::unique_ptr<WebXRWebGLSwapchain>&& colorSwapchain, std::unique_ptr<WebXRWebGLSwapchain>&& depthSwapchain);
+    XRWebGLLayerBacking(PlatformXR::LayerHandle, std::unique_ptr<WebXRWebGLSwapchain>&& colorSwapchain, std::unique_ptr<WebXRWebGLSwapchain>&& depthSwapchain, uint32_t colorTextureArrayLength);
 
     struct XRLayerSwapchains {
         PlatformXR::LayerHandle handle;
         std::unique_ptr<WebXRWebGLSwapchain> colorSwapchain;
         std::unique_ptr<WebXRWebGLSwapchain> depthSwapchain;
+        uint32_t colorTextureArrayLength { 1 };
     };
 
     static ExceptionOr<XRLayerSwapchains> createCompositionLayerSwapchains(WebXRSession&, WebGLRenderingContextBase&, PlatformXR::CompositionLayerType, const XRLayerInit&);
     static ExceptionOr<XRLayerSwapchains> createProjectionLayerSwapchains(WebXRSession&, WebGLRenderingContextBase&, const XRProjectionLayerInit&);
 
 private:
-    static ExceptionOr<XRLayerSwapchains> createColorAndDepthSwapchains(WebGLRenderingContextBase&, PlatformXR::LayerHandle, GCGLenum colorFormat, std::optional<GCGLenum> depthFormat, IntSize, bool clearOnAccess, size_t numImages);
-    static std::unique_ptr<WebXRWebGLSwapchain> createDepthSwapchain(WebGLRenderingContextBase&, GCGLenum depthFormat, IntSize, bool clearOnAccess, size_t imageCount);
+    static ExceptionOr<XRLayerSwapchains> createColorAndDepthSwapchains(WebGLRenderingContextBase&, PlatformXR::LayerHandle, GCGLenum colorFormat, std::optional<GCGLenum> depthFormat, IntSize, bool clearOnAccess, size_t numImages, uint32_t arrayLength, GCGLenum colorTextureType);
+    static std::unique_ptr<WebXRWebGLSwapchain> createDepthSwapchain(WebGLRenderingContextBase&, GCGLenum depthFormat, IntSize, bool clearOnAccess, size_t imageCount, uint32_t arrayLength, GCGLenum textureType);
 
     std::unique_ptr<WebXRWebGLSwapchain> m_colorSwapchain;
     std::unique_ptr<WebXRWebGLSwapchain> m_depthSwapchain;
+    uint32_t m_colorTextureArrayLength { 1 };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webxr/XRWebGLProjectionLayerBacking.cpp
+++ b/Source/WebCore/Modules/webxr/XRWebGLProjectionLayerBacking.cpp
@@ -42,12 +42,12 @@ ExceptionOr<Ref<XRWebGLProjectionLayerBacking>> XRWebGLProjectionLayerBacking::c
     auto swapchains = XRWebGLLayerBacking::createProjectionLayerSwapchains(session, context, init);
     if (swapchains.hasException())
         return swapchains.releaseException();
-    auto [handle, colorSwapchain, depthSwapchain] = swapchains.releaseReturnValue();
-    return adoptRef(*new XRWebGLProjectionLayerBacking(handle, WTF::move(colorSwapchain), WTF::move(depthSwapchain)));
+    auto [handle, colorSwapchain, depthSwapchain, arrayLength] = swapchains.releaseReturnValue();
+    return adoptRef(*new XRWebGLProjectionLayerBacking(handle, WTF::move(colorSwapchain), WTF::move(depthSwapchain), arrayLength));
 }
 
-XRWebGLProjectionLayerBacking::XRWebGLProjectionLayerBacking(PlatformXR::LayerHandle handle, std::unique_ptr<WebXRWebGLSwapchain>&& colorSwapchain, std::unique_ptr<WebXRWebGLSwapchain>&& depthSwapchain)
-    : XRWebGLLayerBacking(handle, WTF::move(colorSwapchain), WTF::move(depthSwapchain))
+XRWebGLProjectionLayerBacking::XRWebGLProjectionLayerBacking(PlatformXR::LayerHandle handle, std::unique_ptr<WebXRWebGLSwapchain>&& colorSwapchain, std::unique_ptr<WebXRWebGLSwapchain>&& depthSwapchain, uint32_t colorTextureArrayLength)
+    : XRWebGLLayerBacking(handle, WTF::move(colorSwapchain), WTF::move(depthSwapchain), colorTextureArrayLength)
 {
 };
 

--- a/Source/WebCore/Modules/webxr/XRWebGLProjectionLayerBacking.h
+++ b/Source/WebCore/Modules/webxr/XRWebGLProjectionLayerBacking.h
@@ -46,7 +46,7 @@ public:
     static ExceptionOr<Ref<XRWebGLProjectionLayerBacking>> create(WebXRSession&, WebGLRenderingContextBase&, const XRProjectionLayerInit&);
 
 private:
-    XRWebGLProjectionLayerBacking(PlatformXR::LayerHandle, std::unique_ptr<WebXRWebGLSwapchain>&& colorSwapchain, std::unique_ptr<WebXRWebGLSwapchain>&& depthSwapchain);
+    XRWebGLProjectionLayerBacking(PlatformXR::LayerHandle, std::unique_ptr<WebXRWebGLSwapchain>&& colorSwapchain, std::unique_ptr<WebXRWebGLSwapchain>&& depthSwapchain, uint32_t colorTextureArrayLength);
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webxr/XRWebGLQuadLayerBacking.cpp
+++ b/Source/WebCore/Modules/webxr/XRWebGLQuadLayerBacking.cpp
@@ -42,12 +42,12 @@ ExceptionOr<Ref<XRWebGLQuadLayerBacking>> XRWebGLQuadLayerBacking::create(WebXRS
     auto swapchains = XRWebGLLayerBacking::createCompositionLayerSwapchains(session, context, PlatformXR::CompositionLayerType::Quad, init);
     if (swapchains.hasException())
         return swapchains.releaseException();
-    auto [handle, colorSwapchain, depthSwapchain] = swapchains.releaseReturnValue();
-    return adoptRef(*new XRWebGLQuadLayerBacking(handle, WTF::move(colorSwapchain), WTF::move(depthSwapchain), init));
+    auto [handle, colorSwapchain, depthSwapchain, arrayLength] = swapchains.releaseReturnValue();
+    return adoptRef(*new XRWebGLQuadLayerBacking(handle, WTF::move(colorSwapchain), WTF::move(depthSwapchain), arrayLength, init));
 }
 
-XRWebGLQuadLayerBacking::XRWebGLQuadLayerBacking(PlatformXR::LayerHandle handle, std::unique_ptr<WebXRWebGLSwapchain>&& colorSwapchain, std::unique_ptr<WebXRWebGLSwapchain>&& depthSwapchain, const XRQuadLayerInit& init)
-    : XRWebGLLayerBacking(handle, WTF::move(colorSwapchain), WTF::move(depthSwapchain))
+XRWebGLQuadLayerBacking::XRWebGLQuadLayerBacking(PlatformXR::LayerHandle handle, std::unique_ptr<WebXRWebGLSwapchain>&& colorSwapchain, std::unique_ptr<WebXRWebGLSwapchain>&& depthSwapchain, uint32_t colorTextureArrayLength, const XRQuadLayerInit& init)
+    : XRWebGLLayerBacking(handle, WTF::move(colorSwapchain), WTF::move(depthSwapchain), colorTextureArrayLength)
     , m_init(init)
 {
 }

--- a/Source/WebCore/Modules/webxr/XRWebGLQuadLayerBacking.h
+++ b/Source/WebCore/Modules/webxr/XRWebGLQuadLayerBacking.h
@@ -45,7 +45,7 @@ public:
     static ExceptionOr<Ref<XRWebGLQuadLayerBacking>> create(WebXRSession&, WebGLRenderingContextBase&, const XRQuadLayerInit&);
 
 private:
-    XRWebGLQuadLayerBacking(PlatformXR::LayerHandle, std::unique_ptr<WebXRWebGLSwapchain>&& colorSwapchain, std::unique_ptr<WebXRWebGLSwapchain>&& depthSwapchain, const XRQuadLayerInit&);
+    XRWebGLQuadLayerBacking(PlatformXR::LayerHandle, std::unique_ptr<WebXRWebGLSwapchain>&& colorSwapchain, std::unique_ptr<WebXRWebGLSwapchain>&& depthSwapchain, uint32_t colorTextureArrayLength, const XRQuadLayerInit&);
 
     XRQuadLayerInit m_init;
 };


### PR DESCRIPTION
#### d158677d4a0286d4927090bbd206fc111c17f62f
<pre>
[WebXR Layers] Enable texture array support for projection layer
<a href="https://bugs.webkit.org/show_bug.cgi?id=314547">https://bugs.webkit.org/show_bug.cgi?id=314547</a>

Reviewed by Dan Glastonbury.

The WebXR Layers API allows author to specify a XRTextureType in the
layer init parameters. By default it&apos;s a regular WebGL texture but
authors can decide to use a texture array instead. Texture arrays would
eventually be very useful in combination with the multiview extension to
improve the performance of stereo rendering.

In WPE and GTK ports the current texture sharing mechanisms
(DMABuf/GBM/AndroidHardwareBuffer) don&apos;t allow natively sharing a
texture array. That&apos;s why we were forced to create a new type of
swapchain which provides a valid texture array to JavaScript but that
blits the multiple layers of a single texture array in a larger side by
side single texture that would be used to share the rendered content
with the UI process.

We&apos;re already working on a new way to share textures between processes
using Vulkan. Vulkan natively supports sharing texture arrays since the
VkImageCreateInfor structure used to create VkImages already contain an
attribute to specify the number of array layers. In theory we could get
rid of this extra blit (and higher memory allocation) with Vulkan.
Leaving the door open to further changes that could also accomodate
other texture sharing mechanisms in other ports.

Test: imported/w3c/web-platform-tests/webxr/layers/xrProjectionLayer_textureType.https.html

* LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrProjectionLayer_textureType.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrProjectionLayer_textureType.https.html: Added.
* Source/WebCore/Modules/webxr/WebGLOpaqueTexture.cpp:
(WebCore::WebGLOpaqueTexture::create):
(WebCore::WebGLOpaqueTexture::WebGLOpaqueTexture):
* Source/WebCore/Modules/webxr/WebGLOpaqueTexture.h:
* Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.cpp:
(WebCore::WebXRWebGLSwapchain::clearTextureLayers):
(WebCore::WebXRWebGLSwapchain::clearCurrentTexture):
(WebCore::toIntSize):
(WebCore::calcImagePhysicalSize):
(WebCore::WebXRWebGLSwapchain::setupExternalImage):
(WebCore::WebXRWebGLSwapchain::signalEndFrame):
(WebCore::WebXRWebGLSharedImageSwapchain::bindCompositorTexturesForDisplay):
(WebCore::WebXRWebGLSharedImageSwapchain::startFrame):
(WebCore::WebXRWebGLSharedImageSwapchain::endFrame):
(WebCore::WebXRWebGLStaticImageSwapchain::bindCompositorTexturesForDisplay):
(WebCore::WebXRWebGLStaticImageSwapchain::clearCurrentTexture):
(WebCore::WebXRWebGLTextureArraySwapchain::create):
(WebCore::WebXRWebGLTextureArraySwapchain::WebXRWebGLTextureArraySwapchain):
(WebCore::WebXRWebGLTextureArraySwapchain::~WebXRWebGLTextureArraySwapchain):
(WebCore::WebXRWebGLTextureArraySwapchain::TextureSet::release):
(WebCore::WebXRWebGLTextureArraySwapchain::TextureSet::leakObject):
(WebCore::WebXRWebGLTextureArraySwapchain::currentTexture):
(WebCore::WebXRWebGLTextureArraySwapchain::releaseTexturesAtIndex):
(WebCore::WebXRWebGLTextureArraySwapchain::reusableTextures const):
(WebCore::WebXRWebGLTextureArraySwapchain::bindCompositorTexturesForDisplay):
(WebCore::WebXRWebGLTextureArraySwapchain::blitTextureArrayToSharedImage):
(WebCore::WebXRWebGLTextureArraySwapchain::clearCurrentTexture):
(WebCore::WebXRWebGLTextureArraySwapchain::startFrame):
(WebCore::WebXRWebGLTextureArraySwapchain::endFrame):
(WebCore::WebXRWebGLTextureArraySwapchain::allTexturesAreBound const):
(WebCore::WebXRWebGLSharedImageSwapchain::setupExternalImage): Deleted.
* Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.h:
(WebCore::WebXRWebGLSwapchain::size const):
(WebCore::WebXRWebGLSwapchain::textureTarget const):
* Source/WebCore/Modules/webxr/XRWebGLBinding.cpp:
(WebCore::XRWebGLBinding::createProjectionLayer):
(WebCore::XRWebGLBinding::validateCompositionLayerInitParameters const):
(WebCore::XRWebGLBinding::rectForView const):
(WebCore::XRWebGLBinding::allocateColorTexturesForProjectionLayer):
(WebCore::XRWebGLBinding::allocateDepthTexturesForProjectionLayer):
(WebCore::XRWebGLBinding::getViewSubImage):
* Source/WebCore/Modules/webxr/XRWebGLBinding.h:
* Source/WebCore/Modules/webxr/XRWebGLCylinderLayerBacking.cpp:
(WebCore::XRWebGLCylinderLayerBacking::create):
(WebCore::XRWebGLCylinderLayerBacking::XRWebGLCylinderLayerBacking):
* Source/WebCore/Modules/webxr/XRWebGLCylinderLayerBacking.h:
* Source/WebCore/Modules/webxr/XRWebGLEquirectLayerBacking.cpp:
(WebCore::XRWebGLEquirectLayerBacking::create):
(WebCore::XRWebGLEquirectLayerBacking::XRWebGLEquirectLayerBacking):
* Source/WebCore/Modules/webxr/XRWebGLEquirectLayerBacking.h:
* Source/WebCore/Modules/webxr/XRWebGLLayerBacking.cpp:
(WebCore::XRWebGLLayerBacking::XRWebGLLayerBacking):
(WebCore::XRWebGLLayerBacking::colorTextureArrayLength const):
(WebCore::XRWebGLLayerBacking::currentColorTexture const):
(WebCore::XRWebGLLayerBacking::currentDepthTexture const):
(WebCore::computeArrayLength):
(WebCore::XRWebGLLayerBacking::createCompositionLayerSwapchains):
(WebCore::XRWebGLLayerBacking::createProjectionLayerSwapchains):
(WebCore::XRWebGLLayerBacking::createColorAndDepthSwapchains):
(WebCore::swapchainFormatsForLayerFormat):
(WebCore::XRWebGLLayerBacking::createDepthSwapchain):
(): Deleted.
* Source/WebCore/Modules/webxr/XRWebGLLayerBacking.h:
* Source/WebCore/Modules/webxr/XRWebGLProjectionLayerBacking.cpp:
(WebCore::XRWebGLProjectionLayerBacking::create):
(WebCore::XRWebGLProjectionLayerBacking::XRWebGLProjectionLayerBacking):
* Source/WebCore/Modules/webxr/XRWebGLProjectionLayerBacking.h:
* Source/WebCore/Modules/webxr/XRWebGLQuadLayerBacking.cpp:
(WebCore::XRWebGLQuadLayerBacking::create):
(WebCore::XRWebGLQuadLayerBacking::XRWebGLQuadLayerBacking):
* Source/WebCore/Modules/webxr/XRWebGLQuadLayerBacking.h:

Canonical link: <a href="https://commits.webkit.org/313477@main">https://commits.webkit.org/313477@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dcd2eae386a0192cfaf5d0b1c3e1f889ea98f8c7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163250 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36731 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29948 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172189 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119697 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165119 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37059 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36732 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/126765 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/89362 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166209 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/29039 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146763 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107332 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19891 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24487 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174692 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/26941 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26142 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/135071 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36401 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30815 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135063 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36404 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37187 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146282 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99112 "Built successfully") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/30368 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/23126 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35897 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108347 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35396 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1151 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35643 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35543 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->