### PR TITLE
[WPE][GTK] Atlas textures use spec-violating glTexImage2D(internal=GL_RGBA, format=GL_BGRA), render black on strict GLES drivers

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaReplayAtlas.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaReplayAtlas.cpp
@@ -28,13 +28,14 @@
 
 #if USE(SKIA)
 
+#include "ColorSpaceSkia.h"
 #include "PlatformDisplay.h"
 #include "SkiaGPUAtlas.h"
-#include "SkiaUtilities.h"
 #include <wtf/TZoneMallocInlines.h>
 
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/gpu/ganesh/GrDirectContext.h>
+#include <skia/gpu/ganesh/SkImageGanesh.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 namespace WebCore {
@@ -61,7 +62,7 @@ std::unique_ptr<SkiaReplayAtlas> SkiaReplayAtlas::create(const SkiaGPUAtlas& gpu
     // The underlying GL texture was created on the main thread context but is
     // shareable via GL context sharing. However, the Skia SkImage wrapper is
     // context-specific and must be rewrapped for each worker's GrDirectContext.
-    auto rewrapped = SkiaUtilities::borrowBackendTextureAsImage(grContext, gpuAtlas.backendTexture());
+    auto rewrapped = SkImages::BorrowTextureFrom(grContext, gpuAtlas.backendTexture(), kTopLeft_GrSurfaceOrigin, kBGRA_8888_SkColorType, kPremul_SkAlphaType, sRGBColorSpaceSingleton());
     if (!rewrapped)
         return nullptr;
 

--- a/Source/WebCore/platform/graphics/skia/SkiaUtilities.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaUtilities.cpp
@@ -58,7 +58,8 @@ GrBackendTexture createBackendTexture(const BitmapTexture& texture)
     GrGLTextureInfo externalTexture;
     externalTexture.fTarget = GL_TEXTURE_2D;
     externalTexture.fID = texture.id();
-    externalTexture.fFormat = GL_RGBA8;
+    // EXT_texture_format_BGRA8888 (unsized form, matches BitmapTexture::textureFormat).
+    externalTexture.fFormat = texture.flags().contains(BitmapTexture::Flags::UseBGRALayout) ? GL_BGRA : GL_RGBA8;
     return GrBackendTextures::MakeGL(texture.size().width(), texture.size().height(), skgpu::Mipmapped::kNo, externalTexture);
 }
 
@@ -76,11 +77,6 @@ sk_sp<SkImage> rewrapImageForContext(GrDirectContext* grContext, const SkImage& 
     if (!SkImages::GetBackendTextureFromImage(&image, &backendTexture, false))
         return nullptr;
     return SkImages::BorrowTextureFrom(grContext, backendTexture, kTopLeft_GrSurfaceOrigin, image.colorType(), image.alphaType(), image.refColorSpace());
-}
-
-sk_sp<SkImage> borrowBackendTextureAsImage(GrDirectContext* grContext, const GrBackendTexture& backendTexture, GrSurfaceOrigin origin)
-{
-    return SkImages::BorrowTextureFrom(grContext, backendTexture, origin, kRGBA_8888_SkColorType, kPremul_SkAlphaType, sRGBColorSpaceSingleton());
 }
 
 std::optional<unsigned> retrieveGLTextureID(const SkImage& image)

--- a/Source/WebCore/platform/graphics/skia/SkiaUtilities.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaUtilities.h
@@ -63,10 +63,6 @@ sk_sp<SkSurface> createSurface(GrDirectContext*, const BitmapTexture&, const SkS
 // original image's color type, alpha type, and color space.
 sk_sp<SkImage> rewrapImageForContext(GrDirectContext*, const SkImage&);
 
-// Wraps a GrBackendTexture as a non-owning SkImage for the given context,
-// using RGBA8, premultiplied alpha, and sRGB color space.
-sk_sp<SkImage> borrowBackendTextureAsImage(GrDirectContext*, const GrBackendTexture&, GrSurfaceOrigin = kTopLeft_GrSurfaceOrigin);
-
 // Extracts the GL texture ID from a GPU-backed SkImage, if available.
 std::optional<unsigned> retrieveGLTextureID(const SkImage&);
 

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
@@ -161,7 +161,9 @@ void BitmapTexture::createTexture()
 void BitmapTexture::allocateTexture()
 {
     createTexture();
-    glTexImage2D(m_renderTarget, 0, GL_RGBA, m_size.width(), m_size.height(), 0, textureFormat(), s_pixelDataType, nullptr);
+    // EXT_texture_format_BGRA8888 mandates internalFormat == format.
+    // https://registry.khronos.org/OpenGL/extensions/EXT/EXT_texture_format_BGRA8888.txt
+    glTexImage2D(m_renderTarget, 0, textureFormat(), m_size.width(), m_size.height(), 0, textureFormat(), s_pixelDataType, nullptr);
 }
 
 size_t BitmapTexture::sizeInBytes() const
@@ -297,7 +299,7 @@ void BitmapTexture::reset(const IntSize& size, OptionSet<Flags> flags)
 #endif
 
     glBindTexture(m_renderTarget, m_id);
-    glTexImage2D(m_renderTarget, 0, GL_RGBA, m_size.width(), m_size.height(), 0, textureFormat(), s_pixelDataType, nullptr);
+    glTexImage2D(m_renderTarget, 0, textureFormat(), m_size.width(), m_size.height(), 0, textureFormat(), s_pixelDataType, nullptr);
     glBindTexture(m_renderTarget, boundTexture);
 }
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferExternalOES.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferExternalOES.cpp
@@ -41,7 +41,7 @@
 #endif
 
 #if USE(SKIA)
-#include "SkiaUtilities.h"
+#include "ColorSpaceSkia.h"
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkColorSpace.h>
 #include <skia/core/SkImage.h>
@@ -184,7 +184,7 @@ sk_sp<SkImage> CoordinatedPlatformLayerBufferExternalOES::skiaImage()
     externalTexture.fID = m_textureID;
     externalTexture.fFormat = GL_RGBA8;
     auto backendTexture = GrBackendTextures::MakeGL(m_size.width(), m_size.height(), skgpu::Mipmapped::kNo, externalTexture);
-    return SkiaUtilities::borrowBackendTextureAsImage(grContext, backendTexture);
+    return SkImages::BorrowTextureFrom(grContext, backendTexture, kTopLeft_GrSurfaceOrigin, kRGBA_8888_SkColorType, kPremul_SkAlphaType, sRGBColorSpaceSingleton());
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.cpp
@@ -33,7 +33,7 @@
 #include "TextureMapper.h"
 
 #if USE(SKIA)
-#include "SkiaUtilities.h"
+#include "ColorSpaceSkia.h"
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkColorFilter.h>
 #include <skia/core/SkColorSpace.h>
@@ -95,7 +95,7 @@ sk_sp<SkImage> CoordinatedPlatformLayerBufferRGB::skiaImage()
     externalTexture.fFormat = GL_RGBA8;
     auto backendTexture = GrBackendTextures::MakeGL(m_size.width(), m_size.height(), skgpu::Mipmapped::kNo, externalTexture);
     auto origin = m_flags.contains(TextureMapperFlags::ShouldFlipTexture) ? kBottomLeft_GrSurfaceOrigin : kTopLeft_GrSurfaceOrigin;
-    return SkiaUtilities::borrowBackendTextureAsImage(grContext, backendTexture, origin);
+    return SkImages::BorrowTextureFrom(grContext, backendTexture, origin, kRGBA_8888_SkColorType, kPremul_SkAlphaType, sRGBColorSpaceSingleton());
 }
 #endif
 


### PR DESCRIPTION
#### b47541a2e00178526fb3e5827f8d17260dac09eb
<pre>
[WPE][GTK] Atlas textures use spec-violating glTexImage2D(internal=GL_RGBA, format=GL_BGRA), render black on strict GLES drivers
<a href="https://bugs.webkit.org/show_bug.cgi?id=314719">https://bugs.webkit.org/show_bug.cgi?id=314719</a>

Reviewed by Nikolas Zimmermann.

SkiaGPUAtlas allocates BitmapTextures with UseBGRALayout, intended to give
them GL_BGRA storage. BitmapTexture uploaded them via
glTexImage2D(internal=GL_RGBA, format=GL_BGRA), which is undefined per
EXT_texture_format_BGRA8888 — the spec mandates internalFormat == format.
Mesa accepts it (TextureMapper&apos;s shaders swizzle BGRA→RGBA at sample time);
Adreno rejects every upload with GL_INVALID_OPERATION, leaving the atlas
texture undefined and rendering solid-black photos after a scroll burst.

Pass textureFormat() for both internalFormat and format in glTexImage2D so
UseBGRALayout textures upload as internal=format=GL_BGRA. On the Skia side,
declare fFormat=GL_BGRA on the GrBackendTexture for UseBGRALayout textures.
Tile textures (createBuffer) don&apos;t have UseBGRALayout, so they remain
GL_RGBA — no-op.

Drop the helper borrowBackendTextureAsImage and inline SkImages::BorrowTextureFrom
at each call site with the SkColorType matching that site&apos;s backend texture.

* Source/WebCore/platform/graphics/skia/SkiaReplayAtlas.cpp:
(WebCore::SkiaReplayAtlas::create): Inline SkImages::BorrowTextureFrom with
kBGRA_8888_SkColorType (atlas has UseBGRALayout).
* Source/WebCore/platform/graphics/skia/SkiaUtilities.cpp:
(WebCore::SkiaUtilities::createBackendTexture): Declare fFormat=GL_BGRA for
UseBGRALayout textures.
(WebCore::SkiaUtilities::borrowBackendTextureAsImage): Deleted.
* Source/WebCore/platform/graphics/skia/SkiaUtilities.h: Drop
borrowBackendTextureAsImage declaration.
* Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp:
(WebCore::BitmapTexture::allocateTexture): Use textureFormat() for both internalFormat and format.
(WebCore::BitmapTexture::reset): Same.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferExternalOES.cpp:
(WebCore::CoordinatedPlatformLayerBufferExternalOES::skiaImage): Inline
SkImages::BorrowTextureFrom with kRGBA_8888_SkColorType (backend is GL_RGBA8).
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.cpp:
(WebCore::CoordinatedPlatformLayerBufferRGB::skiaImage): Inline

SkImages::BorrowTextureFrom with kRGBA_8888_SkColorType (backend is GL_RGBA8).
Canonical link: <a href="https://commits.webkit.org/313395@main">https://commits.webkit.org/313395@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c350e31e4233d5fe17db358ee8507de3b9090c30

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162580 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36056 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29190 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171518 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119025 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164449 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36160 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36060 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126172 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88875 "17 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165539 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28532 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146072 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106750 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27578 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26101 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19218 "Built successfully") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137283 "Found 2 new API test failures: TestWebKitAPI.WKAttachmentTestsIOS.PasteRichTextCopiedFromNotes, TestWebKitAPI.PasteHTML.PasteDarkTextOnWhiteBackgroundIntoDarkModeEditor (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23802 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174022 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21335 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25447 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134482 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35730 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30195 "Found 1 new test failure: imported/w3c/web-platform-tests/IndexedDB/interleaved-cursors-small.any.serviceworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134479 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36363 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35714 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145598 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98050 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/29024 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22432 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35224 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102975 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34725 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34970 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34873 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->