### PR TITLE
[iOS] Fixed headers in web apps may be obscured during top scroll stretch

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -3393,6 +3393,9 @@ WebCore::CocoaColor *sampledFixedPositionContentColor(const WebCore::FixedContai
         if (![_scrollView _wk_isScrolledBeyondTopExtent])
             return 0;
 
+        if (![_scrollView refreshControl])
+            return 0;
+
         auto topFixedColor = _fixedContainerEdges.predominantColor(WebCore::BoxSide::Top);
         if (!topFixedColor.isVisible())
             return 0;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SampledPageTopColor.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SampledPageTopColor.mm
@@ -494,6 +494,8 @@ TEST(SampledPageTopColor, MainDocumentChange)
 TEST(SampledPageTopColor, TopColorExtensionWhenRubberBanding)
 {
     RetainPtr webView = createWebViewWithSampledPageTopColorMaxDifference(5);
+    RetainPtr refreshControl = adoptNS([[UIRefreshControl alloc] init]);
+    [[webView scrollView] setRefreshControl:refreshControl];
 
     auto insets = UIEdgeInsetsMake(75, 0, 0, 0);
     auto insetSize = UIEdgeInsetsInsetRect([webView bounds], insets).size;
@@ -526,7 +528,9 @@ TEST(SampledPageTopColor, TopColorExtensionWhenRubberBanding)
     EXPECT_EQ(colorExtensionViewHeight(), 100.f);
 }
 
-TEST(SampledPageTopColor, TopColorExtensionGrowsDuringRubberBandingWithoutSampledPageTopColor)
+enum class NeedsRefreshControl : bool { No, Yes };
+
+static RetainPtr<TestWKWebView> webViewForColorExtensionGrowthTests(NeedsRefreshControl needsRefreshControl)
 {
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
 
@@ -534,13 +538,25 @@ TEST(SampledPageTopColor, TopColorExtensionGrowsDuringRubberBandingWithoutSample
     auto insetSize = UIEdgeInsetsInsetRect([webView bounds], insets).size;
     [webView _setObscuredInsets:insets];
     RetainPtr scrollView = [webView scrollView];
+
     [scrollView setContentInsetAdjustmentBehavior:UIScrollViewContentInsetAdjustmentNever];
     [scrollView setContentInset:insets];
-    [webView _overrideLayoutParametersWithMinimumLayoutSize:insetSize minimumUnobscuredSizeOverride:insetSize maximumUnobscuredSizeOverride:insetSize];
 
+    if (needsRefreshControl == NeedsRefreshControl::Yes) {
+        RetainPtr refreshControl = adoptNS([[UIRefreshControl alloc] init]);
+        [scrollView setRefreshControl:refreshControl];
+    }
+
+    [webView _overrideLayoutParametersWithMinimumLayoutSize:insetSize minimumUnobscuredSizeOverride:insetSize maximumUnobscuredSizeOverride:insetSize];
     [webView synchronouslyLoadTestPageNamed:@"top-fixed-element"];
     [webView waitForNextPresentationUpdate];
 
+    return webView;
+}
+
+TEST(SampledPageTopColor, TopColorExtensionGrowsDuringRubberBandingWithoutSampledPageTopColor)
+{
+    RetainPtr webView = webViewForColorExtensionGrowthTests(NeedsRefreshControl::Yes);
     RetainPtr topColorExtension = [webView _colorExtensionViewForTesting:UIRectEdgeTop];
     EXPECT_NOT_NULL(topColorExtension.get());
 
@@ -557,7 +573,7 @@ TEST(SampledPageTopColor, TopColorExtensionGrowsDuringRubberBandingWithoutSample
         EXPECT_IN_RANGE(components[2], 0.27, 0.28);
     }
 
-    [scrollView setContentOffset:CGPointMake(0, -100) animated:NO];
+    [[webView scrollView] setContentOffset:CGPointMake(0, -100) animated:NO];
     [webView waitForNextPresentationUpdate];
 
     EXPECT_EQ(colorExtensionViewHeight(), 100.f);
@@ -572,18 +588,8 @@ TEST(SampledPageTopColor, TopColorExtensionGrowsDuringRubberBandingWithoutSample
 
 TEST(SampledPageTopColor, TopColorExtensionHeightIncreasesWithRubberBandAmount)
 {
-    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600)]);
-
-    auto insets = UIEdgeInsetsMake(75, 0, 0, 0);
-    auto insetSize = UIEdgeInsetsInsetRect([webView bounds], insets).size;
-    [webView _setObscuredInsets:insets];
+    RetainPtr webView = webViewForColorExtensionGrowthTests(NeedsRefreshControl::Yes);
     RetainPtr scrollView = [webView scrollView];
-    [scrollView setContentInsetAdjustmentBehavior:UIScrollViewContentInsetAdjustmentNever];
-    [scrollView setContentInset:insets];
-    [webView _overrideLayoutParametersWithMinimumLayoutSize:insetSize minimumUnobscuredSizeOverride:insetSize maximumUnobscuredSizeOverride:insetSize];
-
-    [webView synchronouslyLoadTestPageNamed:@"top-fixed-element"];
-    [webView waitForNextPresentationUpdate];
 
     RetainPtr topColorExtension = [webView _colorExtensionViewForTesting:UIRectEdgeTop];
 
@@ -600,6 +606,32 @@ TEST(SampledPageTopColor, TopColorExtensionHeightIncreasesWithRubberBandAmount)
     [scrollView setContentOffset:CGPointMake(0, -150) animated:NO];
     [webView waitForNextPresentationUpdate];
     EXPECT_EQ(colorExtensionViewHeight(), 150.f);
+
+    [scrollView setContentOffset:CGPointMake(0, -75) animated:NO];
+    [webView waitForNextPresentationUpdate];
+    EXPECT_EQ(colorExtensionViewHeight(), 75.f);
+}
+
+TEST(SampledPageTopColor, TopColorExtensionHeightDoesNotIncreaseWithoutRefreshControl)
+{
+    RetainPtr webView = webViewForColorExtensionGrowthTests(NeedsRefreshControl::No);
+    RetainPtr scrollView = [webView scrollView];
+
+    RetainPtr topColorExtension = [webView _colorExtensionViewForTesting:UIRectEdgeTop];
+
+    auto colorExtensionViewHeight = [topColorExtension] {
+        return CGRectGetHeight([topColorExtension bounds]);
+    };
+
+    EXPECT_EQ(colorExtensionViewHeight(), 75.f);
+
+    [scrollView setContentOffset:CGPointMake(0, -100) animated:NO];
+    [webView waitForNextPresentationUpdate];
+    EXPECT_EQ(colorExtensionViewHeight(), 75.f);
+
+    [scrollView setContentOffset:CGPointMake(0, -150) animated:NO];
+    [webView waitForNextPresentationUpdate];
+    EXPECT_EQ(colorExtensionViewHeight(), 75.f);
 
     [scrollView setContentOffset:CGPointMake(0, -75) animated:NO];
     [webView waitForNextPresentationUpdate];


### PR DESCRIPTION
#### 7aa2c5c2159457a055b3de29283644fff1b7cb35
<pre>
[iOS] Fixed headers in web apps may be obscured during top scroll stretch
<a href="https://bugs.webkit.org/show_bug.cgi?id=314720">https://bugs.webkit.org/show_bug.cgi?id=314720</a>
<a href="https://rdar.apple.com/175917998">rdar://175917998</a>

Reviewed by Abrar Rahman Protyasha and Wenson Hsieh.

When a WKWebView with no refresh control loads a page with a fixed top
header, the header remains at the top of the view during top scroll
stretching. By contrast, when a WKWebView does have a refresh control,
the entirety of the page shifts down during top scroll stretching, including
any fixed top headers.

If a color extension is created for a web view as a result of its top fixed
header, and that web view does not have a refresh control, the color extension
still grows regardless, and thus covers the fixed top header.

Resolve this issue by not adding the scroll stretch amount to color extension
height in `_obscuredInsetsForFixedColorExtension` if the scroll view does not
have a refresh control.

Add a new API test for this behavior, and refactor a few tests to reduce
code duplication between those tests and the new one. Add a refresh
control to the web view in SampledPageTopColor.TopColorExtensionWhenRubberBanding
so that the test continues to demonstrate color extension growth during
rubberbanding.

Test: SampledPageTopColor.TopColorExtensionHeightDoesNotIncreaseWithoutRefreshControl

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(-[WKWebView _obscuredInsetsForFixedColorExtension]):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SampledPageTopColor.mm:
(TestWebKitAPI::TEST(SampledPageTopColor, TopColorExtensionWhenRubberBanding)):
(TestWebKitAPI::webViewForColorExtensionGrowthTests):
(TestWebKitAPI::TEST(SampledPageTopColor, TopColorExtensionGrowsDuringRubberBandingWithoutSampledPageTopColor)):
(TestWebKitAPI::TEST(SampledPageTopColor, TopColorExtensionHeightIncreasesWithRubberBandAmount)):
(TestWebKitAPI::TEST(SampledPageTopColor, TopColorExtensionHeightDoesNotIncreaseWithoutRefreshControl)):

Canonical link: <a href="https://commits.webkit.org/313186@main">https://commits.webkit.org/313186@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/056ad8f03dbcc27d358448ef7a0b09d53d9c6d20

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162292 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35768 "Hash 056ad8f0 for PR 64835 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28884 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171200 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/118737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164161 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35872 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35769 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125949 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/118737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d8100b27-5295-409b-9f65-f43149b0c3e5) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165251 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Passed webkitperl tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28289 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145791 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106527 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27336 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25855 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18921 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137039 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23527 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173694 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21047 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25171 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134245 "Passed tests") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35442 "Hash 056ad8f0 for PR 64835 does not build (failure)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29943 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134246 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35425 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145323 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97675 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24662 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28790 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22152 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34935 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102687 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34436 "Built successfully") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34682 "Hash 056ad8f0 for PR 64835 does not build (failure)") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34584 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->