### PR TITLE
Adopt ReducedResolutionSeconds more widely

### DIFF
--- a/Source/WTF/wtf/ReducedResolutionSeconds.h
+++ b/Source/WTF/wtf/ReducedResolutionSeconds.h
@@ -51,13 +51,6 @@ public:
     double milliseconds() const { return std::round(m_value * 1000000.0) / 1000.0; }
     double microseconds() const { return std::round(m_value * 1000000.0); }
 
-    // Returns the raw value as Seconds without microsecond rounding. Callers should prefer
-    // seconds() / milliseconds() / microseconds(), which preserve the microsecond-rounded
-    // invariant; this accessor exists only for boundaries that need bit-equivalence with a
-    // plain Seconds (e.g. for storage in a Seconds-typed field) and are expected to migrate
-    // to ReducedResolutionSeconds over time.
-    Seconds deprecatedNonRoundedSeconds() const { return Seconds { m_value }; }
-
     void dump(PrintStream& out) const { out.print(milliseconds(), " ms"); }
 
     friend struct MarkableTraits<ReducedResolutionSeconds>;

--- a/Source/WebCore/animation/AnimationTimelinesController.cpp
+++ b/Source/WebCore/animation/AnimationTimelinesController.cpp
@@ -281,7 +281,7 @@ std::optional<Seconds> AnimationTimelinesController::timeUntilNextTickForAnimati
 {
     if (!m_cachedCurrentTime)
         return std::nullopt;
-    return m_frameRateAligner.timeUntilNextUpdateForFrameRate(frameRate, ReducedResolutionSeconds::fromSeconds(*m_cachedCurrentTime));
+    return m_frameRateAligner.timeUntilNextUpdateForFrameRate(frameRate, *m_cachedCurrentTime);
 };
 
 void AnimationTimelinesController::suspendAnimations()
@@ -290,7 +290,7 @@ void AnimationTimelinesController::suspendAnimations()
         return;
 
     if (!m_cachedCurrentTime)
-        m_cachedCurrentTime = liveCurrentTime().deprecatedNonRoundedSeconds();
+        m_cachedCurrentTime = liveCurrentTime();
 
     m_cachedCurrentTimeClearanceTimer.stop();
 
@@ -318,13 +318,13 @@ ReducedResolutionSeconds AnimationTimelinesController::liveCurrentTime() const
     return protect(document().window())->nowTimestamp();
 }
 
-std::optional<Seconds> AnimationTimelinesController::currentTime(UseCachedCurrentTime useCachedCurrentTime)
+std::optional<ReducedResolutionSeconds> AnimationTimelinesController::currentTime(UseCachedCurrentTime useCachedCurrentTime)
 {
     if (!m_document->window())
         return std::nullopt;
 
     if (useCachedCurrentTime == UseCachedCurrentTime::No && !m_isSuspended)
-        return liveCurrentTime().deprecatedNonRoundedSeconds();
+        return liveCurrentTime();
 
     if (!m_cachedCurrentTime)
         cacheCurrentTime(liveCurrentTime());
@@ -334,7 +334,7 @@ std::optional<Seconds> AnimationTimelinesController::currentTime(UseCachedCurren
 
 void AnimationTimelinesController::cacheCurrentTime(ReducedResolutionSeconds newCurrentTime)
 {
-    if (m_cachedCurrentTime == newCurrentTime.deprecatedNonRoundedSeconds())
+    if (m_cachedCurrentTime == newCurrentTime)
         return;
 
     m_cachedCurrentTimeClearanceTimer.stop();
@@ -347,7 +347,7 @@ void AnimationTimelinesController::cacheCurrentTime(ReducedResolutionSeconds new
         processPendingAnimations();
     }
 
-    m_cachedCurrentTime = newCurrentTime.deprecatedNonRoundedSeconds();
+    m_cachedCurrentTime = newCurrentTime;
 
     // As we've advanced to a new current time, we want all animations created during this run
     // loop to have this newly-cached current time as their start time. To that end, we schedule

--- a/Source/WebCore/animation/AnimationTimelinesController.h
+++ b/Source/WebCore/animation/AnimationTimelinesController.h
@@ -65,7 +65,7 @@ public:
     void updateStaleScrollTimelines();
     void addPendingAnimation(WebAnimation&);
 
-    std::optional<Seconds> currentTime(UseCachedCurrentTime = UseCachedCurrentTime::Yes);
+    std::optional<ReducedResolutionSeconds> currentTime(UseCachedCurrentTime = UseCachedCurrentTime::Yes);
     std::optional<FramesPerSecond> maximumAnimationFrameRate() const { return m_frameRateAligner.maximumFrameRate(); }
     std::optional<Seconds> timeUntilNextTickForAnimationsWithFrameRate(FramesPerSecond) const;
 
@@ -103,7 +103,7 @@ private:
     TaskCancellationGroup m_pendingAnimationsProcessingTaskCancellationGroup;
     WeakRef<Document, WeakPtrImplWithEventTargetData> m_document;
     FrameRateAligner m_frameRateAligner;
-    Markable<Seconds> m_cachedCurrentTime;
+    Markable<ReducedResolutionSeconds> m_cachedCurrentTime;
     bool m_isSuspended { false };
 };
 

--- a/Source/WebCore/animation/DocumentTimeline.cpp
+++ b/Source/WebCore/animation/DocumentTimeline.cpp
@@ -544,8 +544,7 @@ Ref<AcceleratedTimeline> DocumentTimeline::createAcceleratedRepresentation() con
     ASSERT(m_document->window());
     ASSERT(m_document->settings().threadedTimeBasedAnimationsEnabled());
     Ref window = *m_document->window();
-    auto monotonicOriginTime = MonotonicTime::fromRawSeconds(m_originTime.seconds());
-    auto convertedOriginTime = m_originTime - window->performance().relativeTimeFromTimeOriginInReducedResolutionSeconds(monotonicOriginTime);
+    auto convertedOriginTime = window->performance().monotonicTimeFromOriginRelative(m_originTime).secondsSinceEpoch();
     return AcceleratedTimeline::create(m_acceleratedTimelineIdentifier, convertedOriginTime);
 }
 #endif

--- a/Source/WebCore/animation/WebAnimationTime.cpp
+++ b/Source/WebCore/animation/WebAnimationTime.cpp
@@ -31,6 +31,7 @@
 #include "CSSUnits.h"
 #include "LayoutUnit.h"
 #include "WebAnimationUtilities.h"
+#include <wtf/ReducedResolutionSeconds.h>
 
 namespace WebCore {
 
@@ -48,6 +49,12 @@ WebAnimationTime::WebAnimationTime(std::optional<Seconds> time, std::optional<do
 }
 
 WebAnimationTime::WebAnimationTime(const Seconds& value)
+    : m_type(Type::Time)
+    , m_value(value.seconds())
+{
+}
+
+WebAnimationTime::WebAnimationTime(const ReducedResolutionSeconds& value)
     : m_type(Type::Time)
     , m_value(value.seconds())
 {

--- a/Source/WebCore/animation/WebAnimationTime.h
+++ b/Source/WebCore/animation/WebAnimationTime.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/CSSNumericValue.h>
+#include <wtf/Forward.h>
 #include <wtf/Seconds.h>
 
 namespace WebCore {
@@ -36,6 +37,7 @@ public:
     WEBCORE_EXPORT WebAnimationTime(std::optional<Seconds>, std::optional<double>);
 
     WEBCORE_EXPORT WebAnimationTime(const Seconds&);
+    WEBCORE_EXPORT WebAnimationTime(const ReducedResolutionSeconds&);
     WebAnimationTime(const CSSNumberish&);
 
     static WebAnimationTime NODELETE fromMilliseconds(double);

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -2673,7 +2673,7 @@ void LocalDOMWindow::queueEventTimingCandidateForDispatch(PerformanceEventTiming
 PerformanceEventTimingCandidate LocalDOMWindow::initializeEventTiming(Event& event, EventType type)
 {
     auto startTime = performance().relativeTimeFromTimeOriginInReducedResolutionSeconds(event.timeStamp());
-    auto processingStart = performance().nowInReducedResolutionSeconds().deprecatedNonRoundedSeconds();
+    auto processingStart = performance().nowInReducedResolutionSeconds();
     LOG_WITH_STREAM(PerformanceTimeline, stream << "Initializing event timing entry (type=" << event.type() << "; tstamp=" << startTime << ") at t=" << processingStart);
     if (startTime > processingStart)
         startTime = processingStart;
@@ -2701,7 +2701,7 @@ PerformanceEventTimingCandidate LocalDOMWindow::initializeEventTiming(Event& eve
 void LocalDOMWindow::markEndOfProcessingForEventTiming(PerformanceEventTimingCandidate& entry, const Event& event, EventType type)
 {
     // Maps to "Finalize event timing" in the spec.
-    auto processingEnd = performance().nowInReducedResolutionSeconds().deprecatedNonRoundedSeconds();
+    auto processingEnd = performance().nowInReducedResolutionSeconds();
     entry.processingEnd = processingEnd;
     entry.target = event.target();
 
@@ -2771,7 +2771,7 @@ void LocalDOMWindow::markEndOfProcessingForEventTiming(PerformanceEventTimingCan
 void LocalDOMWindow::finalizeAndQueueEventTimingEntries()
 {
     // Maps to "Dispatch pending Event Timing entries" in the spec.
-    auto renderingTime = performance().nowInReducedResolutionSeconds().deprecatedNonRoundedSeconds();
+    auto renderingTime = performance().nowInReducedResolutionSeconds();
     if (m_pendingPointerDown && !m_pendingPointerDown->duration)
         m_pendingPointerDown->duration = std::max(renderingTime - m_pendingPointerDown->startTime, Seconds::fromMilliseconds(1));
 

--- a/Source/WebCore/page/LocalDOMWindow.h
+++ b/Source/WebCore/page/LocalDOMWindow.h
@@ -456,7 +456,7 @@ private:
     bool m_contextMenuTriggered { false };
 
     // Workaround for https://webkit.org/b/301443 causing very old timestamps to be produced:
-    Seconds m_lastInputEventStartTime;
+    ReducedResolutionSeconds m_lastInputEventStartTime;
 
     struct PendingKeyDownState {
         PerformanceEventTimingCandidate keyDown;

--- a/Source/WebCore/page/Performance.cpp
+++ b/Source/WebCore/page/Performance.cpp
@@ -186,9 +186,14 @@ Seconds Performance::timeResolution()
     return timePrecision;
 }
 
-Seconds Performance::relativeTimeFromTimeOriginInReducedResolutionSeconds(MonotonicTime timestamp) const
+ReducedResolutionSeconds Performance::relativeTimeFromTimeOriginInReducedResolutionSeconds(MonotonicTime timestamp) const
 {
-    return reduceTimeResolution(timestamp - m_timeOrigin);
+    return ReducedResolutionSeconds::fromSeconds(reduceTimeResolution(timestamp - m_timeOrigin));
+}
+
+MonotonicTime Performance::monotonicTimeFromOriginRelative(Seconds offset) const
+{
+    return m_timeOrigin + offset;
 }
 
 DOMHighResTimeStamp Performance::relativeTimeFromTimeOriginInReducedResolution(MonotonicTime timestamp) const

--- a/Source/WebCore/page/Performance.h
+++ b/Source/WebCore/page/Performance.h
@@ -89,6 +89,7 @@ public:
 
     DOMHighResTimeStamp now() const;
     DOMHighResTimeStamp timeOrigin() const;
+    MonotonicTime monotonicTimeFromOriginRelative(Seconds offset) const;
     ReducedResolutionSeconds nowInReducedResolutionSeconds() const;
 
     PerformanceNavigation& navigation();
@@ -131,7 +132,7 @@ public:
     static Seconds NODELETE timeResolution();
     static Seconds reduceTimeResolution(Seconds);
 
-    Seconds relativeTimeFromTimeOriginInReducedResolutionSeconds(MonotonicTime) const;
+    ReducedResolutionSeconds relativeTimeFromTimeOriginInReducedResolutionSeconds(MonotonicTime) const;
     DOMHighResTimeStamp relativeTimeFromTimeOriginInReducedResolution(MonotonicTime) const;
     MonotonicTime NODELETE monotonicTimeFromRelativeTime(DOMHighResTimeStamp) const;
 

--- a/Source/WebCore/page/PerformanceEventTiming.h
+++ b/Source/WebCore/page/PerformanceEventTiming.h
@@ -30,6 +30,7 @@
 #include "EventTarget.h"
 #include "EventTimingInteractionID.h"
 #include "PerformanceEntry.h"
+#include <wtf/ReducedResolutionSeconds.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -61,8 +62,8 @@ private:
 
     bool m_isFirst;
     bool m_cancelable;
-    Seconds m_processingStart;
-    Seconds m_processingEnd;
+    ReducedResolutionSeconds m_processingStart;
+    ReducedResolutionSeconds m_processingEnd;
     EventTimingInteractionID m_interactionID;
     WeakPtr<EventTarget, EventTarget::WeakPtrImplType> m_target;
 };

--- a/Source/WebCore/page/PerformanceEventTimingCandidate.h
+++ b/Source/WebCore/page/PerformanceEventTimingCandidate.h
@@ -27,6 +27,7 @@
 
 #include <WebCore/EventTarget.h>
 #include <WebCore/EventTimingInteractionID.h>
+#include <wtf/ReducedResolutionSeconds.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -36,9 +37,9 @@ enum class EventType : uint16_t;
 struct PerformanceEventTimingCandidate {
     EventType type { };
     bool cancelable { false };
-    Seconds startTime;
-    Seconds processingStart;
-    Seconds processingEnd;
+    ReducedResolutionSeconds startTime;
+    ReducedResolutionSeconds processingStart;
+    ReducedResolutionSeconds processingEnd;
     Seconds duration;
     WeakPtr<EventTarget, EventTarget::WeakPtrImplType> target;
     EventTimingInteractionID interactionID;


### PR DESCRIPTION
#### e6f4d3c2b495bc5e69b451e2ea0981075176f0fe
<pre>
Adopt ReducedResolutionSeconds more widely
<a href="https://bugs.webkit.org/show_bug.cgi?id=314722">https://bugs.webkit.org/show_bug.cgi?id=314722</a>

Reviewed by Ryosuke Niwa.

313153@main left seven call sites using deprecatedNonRoundedSeconds(), each
of which silently dropped the microsecond-rounded invariant before the value
reached the JS DOMHighResTimeStamp boundary. This patch migrates those
(animation current-time cache + event-timing entries) and deletes the escape
hatch.

Two changes are more than mechanical:

Performance::relativeTimeFromTimeOriginInReducedResolutionSeconds now
returns ReducedResolutionSeconds rather than Seconds. This removed a redundant
ReducedResolutionSeconds::fromSeconds round-trip at the event-timing call site,
and as a side effect its DOMHighResTimeStamp sibling
(relativeTimeFromTimeOriginInReducedResolution) now produces
microsecond-rounded output for IdleDeadline, Event.timeStamp, AudioContext,
HTMLVideoElement frame metadata, and LargestContentfulPaint.

DocumentTimeline::createAcceleratedRepresentation needs &quot;m_timeOrigin +
m_originTime&quot; in monotonic-clock-epoch seconds, to tell the remote layer
tree where the timeline&apos;s zero point sits. The old code computed this
obliquely, by feeding m_originTime&apos;s bits through reduceTimeResolution as
if they were a MonotonicTime and backing out the result; the arithmetic
happens to cancel and yield the right answer — but only when m_originTime
is smaller than the reduce-resolution precision step. Any JS-constructed
DocumentTimeline({originTime: N}) with N ≥ 1ms had its threaded animations
mistimed by roughly N. Added a narrow
Performance::monotonicTimeFromOriginRelative(Seconds) helper that performs
the addition directly, fixing both the arcane code and the latent bug.

Canonical link: <a href="https://commits.webkit.org/313462@main">https://commits.webkit.org/313462@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/879c68f0a3df81943c20afeee9357d1183644d1f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162279 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35755 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28871 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171187 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118724 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0d20cbec-5127-49b3-af61-0ac7ad39631b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164148 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35859 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35756 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125939 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88777 "17 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ec3a297f-3d80-43df-ac23-a4fd62386bb8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165238 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28284 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145781 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106517 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a07fd2f8-05c1-4930-8a09-56bb8878a564) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27331 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25844 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18908 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/154339 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137034 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23517 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173681 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23118 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21034 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25160 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134237 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35429 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29931 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134238 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35412 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145313 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97652 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24829 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28783 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22142 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194679 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34922 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102674 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50227 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34423 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/170 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34669 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34571 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->