### PR TITLE
[Site Isolation] Enable MultiProcessBackForwardCache automatically when Site Isolation is active

### DIFF
--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1338,8 +1338,11 @@ Ref<WebPageProxy> WebProcessPool::createWebPage(PageClient& pageClient, Ref<API:
 
     RefPtr relatedPage = pageConfiguration->relatedPage();
     bool siteIsolationEnabled = protect(pageConfiguration->preferences())->siteIsolationEnabled();
-    if (siteIsolationEnabled)
-        protect(pageConfiguration->preferences())->setUseUIProcessForBackForwardItemLoading(true);
+    if (siteIsolationEnabled) {
+        Ref<WebPreferences> preferences = pageConfiguration->preferences();
+        preferences->setUseUIProcessForBackForwardItemLoading(true);
+        preferences->setMultiProcessBackForwardCacheEnabled(true);
+    }
     RefPtr preferredBrowsingContextGroup = pageConfiguration->preferredBrowsingContextGroup();
     RefPtr preferredFrameProcess = preferredBrowsingContextGroup ? preferredBrowsingContextGroup->processForSite(pageConfiguration->openedSite()) : nullptr;
     if (auto& openerInfo = pageConfiguration->openerInfo(); openerInfo && siteIsolationEnabled) {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -273,6 +273,16 @@ static void enableSiteIsolation(WKWebViewConfiguration *configuration)
     enableFeature(configuration, @"SiteIsolationEnabled");
 }
 
+// WKPreferences._usesPageCache is macOS-only, so disable BFCache via the
+// cross-platform _WKProcessPoolConfiguration.pageCacheEnabled property
+// instead (sets the process pool's BFCache capacity to 0).
+static RetainPtr<WKProcessPool> processPoolWithBackForwardCacheDisabled()
+{
+    RetainPtr poolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    poolConfiguration.get().pageCacheEnabled = NO;
+    return adoptNS([[WKProcessPool alloc] _initWithConfiguration:poolConfiguration.get()]);
+}
+
 static std::pair<RetainPtr<TestWKWebView>, RetainPtr<TestNavigationDelegate>> siteIsolatedViewAndDelegate(RetainPtr<WKWebViewConfiguration> configuration, CGRect rect, bool enable)
 {
     RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
@@ -318,6 +328,9 @@ static std::pair<RetainPtr<TestWKWebView>, RetainPtr<TestNavigationDelegate>> si
         RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
         processPoolConfiguration.get().usesWebProcessCache = YES;
         processPoolConfiguration.get().prewarmsProcessesAutomatically = YES;
+        // These tests assert WebProcessCache process-reuse semantics; disable BFCache so it
+        // does not compete with WebProcessCache for the cached processes' lifetime.
+        processPoolConfiguration.get().pageCacheEnabled = NO;
         RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
         [configuration setProcessPool:processPool.get()];
     }
@@ -1210,7 +1223,11 @@ TEST(SiteIsolation, PostMessageWithMessagePorts)
         { "/example2"_s, { example2HTML } },
         { "/webkit2"_s, { webkit2HTML } }
     }, HTTPServer::Protocol::HttpsProxy);
-    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server);
+    // This test exercises MessagePort delivery across site-isolated processes, not BFCache.
+    // Disable BFCache so the same-site navigation does not cache the page holding the port.
+    auto *configuration = server.httpsProxyConfiguration();
+    configuration.processPool = processPoolWithBackForwardCacheDisabled().get();
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
     [navigationDelegate waitForDidFinishNavigation];
@@ -1796,7 +1813,11 @@ TEST(SiteIsolation, IframeRedirectCrossSite)
     checkFrameTreesInProcesses(webView.get(), {
         { "https://example.com"_s,
             { { "https://example.com"_s } }
-        }
+        },
+        // example1 is BFCached on the same-site nav to example2; the apple.com
+        // iframe process stays alive as a suspended cached iframe and surfaces
+        // here as a remote tree (remote main with one remote child).
+        { RemoteFrame, { { RemoteFrame } } }
     });
 }
 
@@ -1915,11 +1936,15 @@ TEST(SiteIsolation, NavigationWithIFrames)
 
     [webView goBack];
     [navigationDelegate waitForDidFinishNavigation];
-    [navigationDelegate waitForDidFinishLoadInSubframe];
-    checkFrameTreesInProcesses(webView.get(), {
+    Vector<ExpectedFrameTree> expectedAfterGoBack = {
         { "https://domain1.com"_s, { { RemoteFrame } } },
         { RemoteFrame, { { "https://domain2.com"_s } } }
-    });
+    };
+    // BFCache restore does not fire didFinishLoad in the subframe, so spin
+    // until the cross-process tree is fully reconstructed.
+    while (!frameTreesMatch(frameTrees(webView.get()).get(), Vector<ExpectedFrameTree> { expectedAfterGoBack }))
+        TestWebKitAPI::Util::spinRunLoop();
+    checkFrameTreesInProcesses(webView.get(), WTF::move(expectedAfterGoBack));
 }
 
 TEST(SiteIsolation, RemoveFrames)
@@ -2495,7 +2520,13 @@ TEST(SiteIsolation, ShutDownFrameProcessesAfterNavigation)
         { "/apple"_s, { "hello"_s } }
     }, HTTPServer::Protocol::HttpsProxy);
 
-    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server);
+    // The test verifies that the iframe process is torn down on cross-site
+    // navigation. With BFCache the iframe page would be kept alive as a
+    // suspended cached iframe, so disable BFCache to keep the original
+    // shutdown semantics under test.
+    auto *configuration = server.httpsProxyConfiguration();
+    configuration.processPool = processPoolWithBackForwardCacheDisabled().get();
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
     [navigationDelegate waitForDidFinishNavigation];
@@ -2509,6 +2540,35 @@ TEST(SiteIsolation, ShutDownFrameProcessesAfterNavigation)
     [navigationDelegate waitForDidFinishNavigation];
     checkFrameTreesInProcesses(webView.get(), { { "https://apple.com"_s } });
 
+    while (processStillRunning(iframePID))
+        Util::spinRunLoop();
+}
+
+TEST(SiteIsolation, ShutDownFrameProcessesAfterNavigationBFCacheEnabled)
+{
+    HTTPServer server({
+        { "/example"_s, { "<iframe src='https://webkit.org/webkit'></iframe>"_s } },
+        { "/webkit"_s, { "hello"_s } },
+        { "/apple"_s, { "hello"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    // With BFCache enabled (the default when Site Isolation is active), the
+    // suspended iframe process is kept alive until the BFCache entry is
+    // evicted. Verify that clearing the cache releases the process.
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    pid_t iframePID = findFramePID(frameTrees(webView.get()).get(), FrameType::Remote);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://apple.com/apple"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // BFCache keeps the iframe process alive after navigation.
+    EXPECT_TRUE(processStillRunning(iframePID));
+
+    // Evicting the BFCache entry must release the suspended iframe process.
+    [webView _clearBackForwardCache];
     while (processStillRunning(iframePID))
         Util::spinRunLoop();
 }
@@ -3432,7 +3492,10 @@ TEST(SiteIsolation, DrawAfterNavigateToDomainAgain)
     [webView evaluateJavaScript:@"window.location = 'https://c.com/c'" completionHandler:nil];
     [navigationDelegate waitForDidFinishNavigation];
     checkFrameTreesInProcesses(webView.get(), {
-        { "https://c.com"_s }
+        { "https://c.com"_s },
+        // a.com is BFCached; the b.com iframe process stays alive as a
+        // suspended cached iframe and surfaces here as a remote tree.
+        { RemoteFrame }
     });
 
     [webView evaluateJavaScript:@"window.location = 'https://a.com/a'" completionHandler:nil];
@@ -4157,21 +4220,20 @@ TEST(SiteIsolation, GoBackToPageWithIframe)
     auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server);
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
-    [navigationDelegate waitForDidFinishNavigation];
+    [navigationDelegate waitForDidFinishNavigationAndLoadInSubframe];
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://b.com/b"]]];
     [navigationDelegate waitForDidFinishNavigation];
 
     [webView goBack];
     [navigationDelegate waitForDidFinishNavigation];
-    [navigationDelegate waitForDidFinishLoadInSubframe];
-    checkFrameTreesInProcesses(webView.get(), {
-        { "https://a.com"_s,
-            { { RemoteFrame } }
-        }, { RemoteFrame,
-            { { "https://frame.com"_s } }
-        },
-    });
+    Vector<ExpectedFrameTree> expectedAfterGoBack = {
+        { "https://a.com"_s, { { RemoteFrame } } },
+        { RemoteFrame, { { "https://frame.com"_s } } },
+    };
+    while (!frameTreesMatch(frameTrees(webView.get()).get(), Vector<ExpectedFrameTree> { expectedAfterGoBack }))
+        TestWebKitAPI::Util::spinRunLoop();
+    checkFrameTreesInProcesses(webView.get(), WTF::move(expectedAfterGoBack));
 }
 
 TEST(SiteIsolation, GoBackToPageWithIframeBFCache)
@@ -4193,9 +4255,7 @@ TEST(SiteIsolation, GoBackToPageWithIframeBFCache)
         { "/b"_s, { ""_s } },
         { "/frame"_s, { ""_s } }
     }, HTTPServer::Protocol::HttpsProxy);
-    auto *configuration = server.httpsProxyConfiguration();
-    enableFeature(configuration, @"MultiProcessBackForwardCacheEnabled");
-    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(server);
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
     [navigationDelegate waitForDidFinishNavigationAndLoadInSubframe];
@@ -4878,6 +4938,10 @@ TEST(SiteIsolation, ProcessReuse)
 
     RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
     processPoolConfiguration.get().usesWebProcessCache = YES;
+    // The test is about WebProcessCache-driven process reuse; turning off
+    // BFCache keeps cached WebPages from inflating countWebPages and
+    // confusing the reuse assertions.
+    processPoolConfiguration.get().pageCacheEnabled = NO;
     RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
     RetainPtr webViewConfiguration = server.httpsProxyConfiguration();
     [webViewConfiguration setProcessPool:processPool.get()];
@@ -4897,6 +4961,47 @@ TEST(SiteIsolation, ProcessReuse)
     [navigationDelegate waitForDidFinishNavigation];
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://apple.com/example"]]];
     [navigationDelegate waitForDidFinishNavigation];
+    EXPECT_EQ(countWebPages(webView), 2u);
+}
+
+TEST(SiteIsolation, ProcessReuseWithBFCache)
+{
+    HTTPServer server({
+        { "/example"_s, { "<iframe src='https://webkit.org/iframe' id='onlyiframe'></iframe>"_s } },
+        { "/iframe"_s, { "hi"_s } },
+        { "/iframe_with_alert"_s, { "<script>alert('loaded')</script>"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    // Same as ProcessReuse but with BFCache enabled. BFCache keeps suspended
+    // WebPages alive during back/forward navigation, so countWebPages can
+    // temporarily exceed 2. After evicting the BFCache the count must drop
+    // back to 2, confirming that WebProcessCache reuse still works correctly.
+    RetainPtr processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    processPoolConfiguration.get().usesWebProcessCache = YES;
+    RetainPtr processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+    RetainPtr webViewConfiguration = server.httpsProxyConfiguration();
+    [webViewConfiguration setProcessPool:processPool.get()];
+
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(webViewConfiguration.get());
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [webView objectByEvaluatingJavaScript:@"var frame = document.getElementById('onlyiframe'); frame.parentNode.removeChild(frame);1"];
+    [webView evaluateJavaScript:@"var iframe = document.createElement('iframe');iframe.src = 'https://webkit.org/iframe_with_alert';document.body.appendChild(iframe)" completionHandler:nil];
+    EXPECT_WK_STREQ([webView _test_waitForAlert], "loaded");
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.org/example"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://webkit.org/example"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://apple.com/example"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // Evict BFCache entries so that suspended pages from prior navigations
+    // are released before checking the final WebPage count.
+    [webView _clearBackForwardCache];
+    while (countWebPages(webView) != 2u)
+        Util::spinRunLoop();
     EXPECT_EQ(countWebPages(webView), 2u);
 }
 
@@ -8761,7 +8866,6 @@ TEST(SiteIsolation, MultiProcessBFCacheIframeProcessSurvival)
     }, HTTPServer::Protocol::HttpsProxy);
 
     auto *configuration = server.httpsProxyConfiguration();
-    enableFeature(configuration, @"MultiProcessBackForwardCacheEnabled");
     auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
@@ -8837,7 +8941,6 @@ TEST(SiteIsolation, MultiProcessBFCacheOpenerSkipsBFCache)
     }, HTTPServer::Protocol::HttpsProxy);
 
     auto *configuration = server.httpsProxyConfiguration();
-    enableFeature(configuration, @"MultiProcessBackForwardCacheEnabled");
     auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
 
     RetainPtr uiDelegate = adoptNS([TestUIDelegate new]);
@@ -8972,7 +9075,6 @@ TEST(SiteIsolation, MultiProcessBFCacheSameSiteCaching)
     }, HTTPServer::Protocol::HttpsProxy);
 
     auto *configuration = server.httpsProxyConfiguration();
-    enableFeature(configuration, @"MultiProcessBackForwardCacheEnabled");
     auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a1"]]];
@@ -9003,7 +9105,6 @@ TEST(SiteIsolation, MultiProcessBFCacheSameSiteWithCrossSiteIframe)
     }, HTTPServer::Protocol::HttpsProxy);
 
     auto *configuration = server.httpsProxyConfiguration();
-    enableFeature(configuration, @"MultiProcessBackForwardCacheEnabled");
     auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a1"]]];
@@ -9052,7 +9153,6 @@ TEST(SiteIsolation, MultiProcessBFCacheSameSiteWithCrossSiteIframeMultipleCycles
     }, HTTPServer::Protocol::HttpsProxy);
 
     auto *configuration = server.httpsProxyConfiguration();
-    enableFeature(configuration, @"MultiProcessBackForwardCacheEnabled");
     auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a1"]]];
@@ -9113,7 +9213,6 @@ TEST(SiteIsolation, MultiProcessBFCacheSameSiteWithDifferentCrossSiteIframes)
     }, HTTPServer::Protocol::HttpsProxy);
 
     auto *configuration = server.httpsProxyConfiguration();
-    enableFeature(configuration, @"MultiProcessBackForwardCacheEnabled");
     auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a1"]]];
@@ -9186,7 +9285,6 @@ TEST(SiteIsolation, MultiProcessBFCacheGoForwardSimple)
     }, HTTPServer::Protocol::HttpsProxy);
 
     auto *configuration = server.httpsProxyConfiguration();
-    enableFeature(configuration, @"MultiProcessBackForwardCacheEnabled");
     auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
@@ -9227,7 +9325,6 @@ TEST(SiteIsolation, MultiProcessBFCacheGoForward)
     }, HTTPServer::Protocol::HttpsProxy);
 
     auto *configuration = server.httpsProxyConfiguration();
-    enableFeature(configuration, @"MultiProcessBackForwardCacheEnabled");
     auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
 
     // Step 1: Load A (a.com) with cross-site iframe (b.com).
@@ -9282,7 +9379,6 @@ TEST(SiteIsolation, MultiProcessBFCacheSameSiteNavAfterRestore)
     }, HTTPServer::Protocol::HttpsProxy);
 
     auto *configuration = server.httpsProxyConfiguration();
-    enableFeature(configuration, @"MultiProcessBackForwardCacheEnabled");
     auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
 
     [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a1"]]];


### PR DESCRIPTION
#### c69c4853e6d259a70cbadd69628a6b73f1383bc2
<pre>
[Site Isolation] Enable MultiProcessBackForwardCache automatically when Site Isolation is active
<a href="https://bugs.webkit.org/show_bug.cgi?id=314699">https://bugs.webkit.org/show_bug.cgi?id=314699</a>
<a href="https://rdar.apple.com/176944362">rdar://176944362</a>

Reviewed by Sihui Liu.

The MultiProcessBackForwardCacheEnabled preference has been off-by-default and required to be
toggled on independently from SiteIsolationEnabled. In practice the two features are meant to be
used together: under Site Isolation, BFCache relies on the UIProcess coordination this flag
unlocks (BackForwardCache::addIfCacheable refuses any SI page when the flag is off, per the guard
from bug 313657).

Flip the preference on automatically at page creation time whenever SiteIsolationEnabled is on,
mirroring the existing pattern for UseUIProcessForBackForwardItemLoading in WebProcessPool.

Drop the now-redundant `enableFeature(configuration, @&quot;MultiProcessBackForwardCacheEnabled&quot;)`
calls from the SiteIsolation.mm API tests (including GoBackToPageWithIframeBFCache) — every
affected test goes through siteIsolatedViewAndDelegate, which sets up SI, so the preference is
auto-enabled by the new code path.

Adjust SiteIsolation.mm tests whose pre-conditions changed because of the auto-enable:
- DrawAfterNavigateToDomainAgain, IframeRedirectCrossSite: extend the expected frame trees to
  include the cached iframe-process tree that now stays alive through the cross-site nav.
- NavigationWithIFrames: replace waitForDidFinishLoadInSubframe (which doesn&apos;t fire on BFCache
  restore) with a frameTreesMatch spin pattern.
- ShutDownFrameProcessesAfterNavigation, GoBackToPageWithIframe, ProcessReuse: turn BFCache off
  via the process pool config (pageCacheEnabled = NO) — the assertions in these tests are about
  pre-BFCache semantics (process teardown, reload-style goBack tree, WebProcessCache reuse
  counted via WebPages) that BFCache deliberately changes.
- siteIsolatedViewWithSharedProcess: disable BFCache on the WebProcessCache process pool
  (EnableProcessCache::Yes) for the same reason — those tests assert process-reuse semantics that
  BFCache would otherwise perturb.
- PostMessageWithMessagePorts: disable BFCache; the test exercises MessagePort delivery across
  site-isolated processes, not BFCache, and the same-site navigation must not cache the page
  holding the port.

Covered by existing SiteIsolation.MultiProcessBFCache* tests plus the adjusted tests above.

* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::createWebPage):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(siteIsolatedViewWithSharedProcess):
(TEST(SiteIsolation, PostMessageWithMessagePorts)):
(TEST(SiteIsolation, IframeRedirectCrossSite)):
(TEST(SiteIsolation, NavigationWithIFrames)):
(TEST(SiteIsolation, ShutDownFrameProcessesAfterNavigation)):
(TEST(SiteIsolation, DrawAfterNavigateToDomainAgain)):
(TEST(SiteIsolation, GoBackToPageWithIframe)):
(TEST(SiteIsolation, GoBackToPageWithIframeBFCache)):
(TEST(SiteIsolation, ProcessReuse)):

Canonical link: <a href="https://commits.webkit.org/314514@main">https://commits.webkit.org/314514@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2e84cde03bbdbc5151c76a201ba63cd486059802

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166350 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39840 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33421 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175398 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/510bb673-e195-402f-9de5-48cfe1a84b0f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168216 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40266 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39848 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129310 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123605 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1eeff499-8508-4846-88d8-2d18fa927390) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169309 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/31690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/149466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109835 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cf5450ca-eed2-4725-87f8-6558fe14905e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30668 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23538 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140637 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27163 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177930 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/30832 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28869 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/137663 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39910 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/33513 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137584 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37062 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40598 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148960 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103250 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32874 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/25826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39108 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/112183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38505 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3912 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38750 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38648 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->