### PR TITLE
REGRESSION(312949@main): Further fixes for Linux builds with PCH enabled

### DIFF
--- a/Source/JavaScriptCore/JavaScriptCoreJITPrefix.h
+++ b/Source/JavaScriptCore/JavaScriptCoreJITPrefix.h
@@ -29,6 +29,12 @@
 
 #include <wtf/Platform.h>
 
+#if !OS(DARWIN)
+// On non-Apple, PCH chaining is not used; include the base prefix directly so
+// this PCH is self-contained and all required types and macros are available.
+#include "JavaScriptCorePrefix.h"
+#endif
+
 #ifdef __cplusplus
 #undef new
 #undef delete

--- a/Source/WebCore/WebCoreDOMAndRenderingPrefix.h
+++ b/Source/WebCore/WebCoreDOMAndRenderingPrefix.h
@@ -23,10 +23,21 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* Chained on top of WebCorePrefix.h; do not include that file here -- the
-   base PCH supplies it. Anchors below are headers that >=80% of the
-   dom/html/page/rendering/accessibility/animation/style TUs include and that
-   are not already in the base PCH closure. */
+/* On Apple, chained on top of WebCorePrefix.h (base PCH supplies Platform.h).
+   On non-Apple, compiled as a standalone PCH — include Platform.h directly so
+   macros like CPU() are available to all dom/html/page/rendering TUs. */
+
+#if defined(HAVE_CONFIG_H) && HAVE_CONFIG_H && defined(BUILDING_WITH_CMAKE)
+#include "cmakeconfig.h"
+#endif
+
+#include <wtf/Platform.h>
+
+#if !OS(DARWIN)
+// On non-Apple, PCH chaining is not used; include the base prefix directly so
+// this PCH is self-contained and all required types and macros are available.
+#include "WebCorePrefix.h"
+#endif
 
 #ifdef __cplusplus
 #undef new

--- a/Source/WebCore/WebCoreInspectorPrefix.h
+++ b/Source/WebCore/WebCoreInspectorPrefix.h
@@ -23,9 +23,22 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* Chained on top of WebCorePrefix.h; do not include that file here -- the
-   base PCH supplies it. Anchors below are headers that >=80% of inspector/
-   TUs include and that are not already in the base PCH closure. */
+/* On Apple, chained on top of WebCorePrefix.h (base PCH supplies Platform.h
+   and cmakeconfig.h). On non-Apple, compiled as a standalone PCH — include
+   WebCorePrefix.h directly so cmakeconfig.h is processed before Platform.h
+   pulls in PlatformEnable.h defaults, and ENABLE() macros are correct. */
+
+#if defined(HAVE_CONFIG_H) && HAVE_CONFIG_H && defined(BUILDING_WITH_CMAKE)
+#include "cmakeconfig.h"
+#endif
+
+#include <wtf/Platform.h>
+
+#if !OS(DARWIN)
+// On non-Apple, PCH chaining is not used; include the base prefix directly so
+// this PCH is self-contained and all required types and macros are available.
+#include "WebCorePrefix.h"
+#endif
 
 #ifdef __cplusplus
 #undef new

--- a/Source/WebCore/WebCoreJSBindingsPrefix.h
+++ b/Source/WebCore/WebCoreJSBindingsPrefix.h
@@ -29,6 +29,12 @@
 
 #include <wtf/Platform.h>
 
+#if !OS(DARWIN)
+// On non-Apple, PCH chaining is not used; include the base prefix directly so
+// this PCH is self-contained and all required types and macros are available.
+#include "WebCorePrefix.h"
+#endif
+
 #ifdef __cplusplus
 #undef new
 #undef delete

--- a/Source/WebKit/UIProcess/API/glib/APIContentRuleListStoreGLib.cpp
+++ b/Source/WebKit/UIProcess/API/glib/APIContentRuleListStoreGLib.cpp
@@ -29,10 +29,10 @@
 namespace API {
 
 #if ENABLE(CONTENT_EXTENSIONS)
-String ContentRuleListStore::defaultStorePath()
+WTF::String ContentRuleListStore::defaultStorePath()
 {
     ASSERT_NOT_REACHED();
-    return String();
+    return WTF::String();
 }
 #endif
 

--- a/Source/WebKit/WebKitMessageReceiversPrefix.h
+++ b/Source/WebKit/WebKitMessageReceiversPrefix.h
@@ -23,10 +23,15 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* Chained on top of WebKitPrefix.h; do not include that file here -- the
-   base PCH supplies it. Anchors below are headers that >=80% of generated
-   DerivedSources message-receiver/serializer TUs include and that are not
-   already in the base PCH closure. */
+/* On Apple, chained on top of WebKitPrefix.h (base PCH supplies Platform.h).
+   On non-Apple, compiled as a standalone PCH — include Platform.h directly so
+   macros like CPU() are available to all message-receiver TUs. */
+
+#if defined(HAVE_CONFIG_H) && HAVE_CONFIG_H && defined(BUILDING_WITH_CMAKE)
+#include "cmakeconfig.h"
+#endif
+
+#include <wtf/Platform.h>
 
 #ifdef __cplusplus
 #undef new

--- a/Source/WebKit/WebKitUIProcessPrefix.h
+++ b/Source/WebKit/WebKitUIProcessPrefix.h
@@ -23,9 +23,15 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* Chained on top of WebKitPrefix.h; do not include that file here -- the
-   base PCH supplies it. Anchors below are headers that >=80% of UIProcess/
-   TUs include and that are not already in the base PCH closure. */
+/* On Apple, chained on top of WebKitPrefix.h (base PCH supplies Platform.h).
+   On non-Apple, compiled as a standalone PCH — include Platform.h directly so
+   macros like CPU() are available to all UIProcess TUs. */
+
+#if defined(HAVE_CONFIG_H) && HAVE_CONFIG_H && defined(BUILDING_WITH_CMAKE)
+#include "cmakeconfig.h"
+#endif
+
+#include <wtf/Platform.h>
 
 #ifdef __cplusplus
 #undef new

--- a/Source/WebKit/WebKitWebProcessPrefix.h
+++ b/Source/WebKit/WebKitWebProcessPrefix.h
@@ -23,9 +23,15 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* Chained on top of WebKitPrefix.h; do not include that file here -- the
-   base PCH supplies it. Anchors below are headers that >=80% of WebProcess/
-   TUs include and that are not already in the base PCH closure. */
+/* On Apple, chained on top of WebKitPrefix.h (base PCH supplies Platform.h).
+   On non-Apple, compiled as a standalone PCH — include Platform.h directly so
+   macros like CPU() are available to all WebProcess TUs. */
+
+#if defined(HAVE_CONFIG_H) && HAVE_CONFIG_H && defined(BUILDING_WITH_CMAKE)
+#include "cmakeconfig.h"
+#endif
+
+#include <wtf/Platform.h>
 
 #ifdef __cplusplus
 #undef new

--- a/Source/cmake/WebKitMacros.cmake
+++ b/Source/cmake/WebKitMacros.cmake
@@ -210,16 +210,23 @@ function(WEBKIT_ADD_PREFIX_HEADER_WITH_PARENT _target _base_target _header _pare
         string(JOIN "," _lang_genex ${ARGN})
         target_precompile_headers(${_target} PRIVATE
             "$<$<COMPILE_LANGUAGE:${_lang_genex}>:${CMAKE_CURRENT_SOURCE_DIR}/${_header}>")
-        get_target_property(_base_bin_dir ${_base_target} BINARY_DIR)
-        get_target_property(_chain_bin_dir ${_target} BINARY_DIR)
-        foreach (_lang ${ARGN})
-            _WEBKIT_PCH_PATHS_FOR_LANGUAGE(${_lang} _src_ext _stub_ext _pch_stem)
-            set(_base_pch "${_base_bin_dir}/CMakeFiles/${_base_target}.dir/${_pch_stem}.pch")
-            set(_chain_stub "${_chain_bin_dir}/CMakeFiles/${_target}.dir/${_pch_stem}.${_stub_ext}")
-            set_source_files_properties(${_chain_stub} PROPERTIES
-                COMPILE_OPTIONS "-Xclang;-include-pch;-Xclang;${_base_pch}"
-                OBJECT_DEPENDS "${_base_pch}")
-        endforeach ()
+        if (APPLE)
+            # On Apple, chain the child PCH on top of the parent PCH so the child only stores
+            # the delta. The chain mechanism works correctly on Apple/Darwin clang.
+            get_target_property(_base_bin_dir ${_base_target} BINARY_DIR)
+            get_target_property(_chain_bin_dir ${_target} BINARY_DIR)
+            foreach (_lang ${ARGN})
+                _WEBKIT_PCH_PATHS_FOR_LANGUAGE(${_lang} _src_ext _stub_ext _pch_stem)
+                set(_base_pch "${_base_bin_dir}/CMakeFiles/${_base_target}.dir/${_pch_stem}.pch")
+                set(_chain_stub "${_chain_bin_dir}/CMakeFiles/${_target}.dir/${_pch_stem}.${_stub_ext}")
+                set_source_files_properties(${_chain_stub} PROPERTIES
+                    COMPILE_OPTIONS "-Xclang;-include-pch;-Xclang;${_base_pch}"
+                    OBJECT_DEPENDS "${_base_pch}")
+            endforeach ()
+        endif ()
+        # On non-Apple, the child PCH is compiled without the parent PCH loaded so it is
+        # self-contained. Each child prefix header must include <wtf/Platform.h> directly
+        # so macros like CPU() end up in the child PCH and are available to its TUs.
         _WEBKIT_ADD_PCH_OBJECT(${_target} PREFIX_NO_CODEGEN PREFIX_LANGUAGES ${ARGN})
     else ()
         WEBKIT_ADD_PREFIX_HEADER(${_target} ${_parent_header} PREFIX_LANGUAGES ${ARGN})


### PR DESCRIPTION
#### 7457ffd4adc1a0c71e55468bb5353304851190ad
<pre>
REGRESSION(<a href="https://commits.webkit.org/312949@main">312949@main</a>): Further fixes for Linux builds with PCH enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=314726">https://bugs.webkit.org/show_bug.cgi?id=314726</a>

Reviewed by NOBODY (OOPS!).

On non-Apple platforms, child PCH stubs are compiled standalone (not chained on the
parent), so cmakeconfig.h must run before Platform.h pulls in PlatformEnable.h defaults.
Add missing prefix headers where they are needed for non-Apple builds.

* Source/JavaScriptCore/JavaScriptCoreJITPrefix.h:
* Source/WebCore/WebCoreDOMAndRenderingPrefix.h:
* Source/WebCore/WebCoreInspectorPrefix.h:
* Source/WebCore/WebCoreJSBindingsPrefix.h:
* Source/WebKit/UIProcess/API/glib/APIContentRuleListStoreGLib.cpp:
(API::ContentRuleListStore::defaultStorePath):
* Source/WebKit/WebKitMessageReceiversPrefix.h:
* Source/WebKit/WebKitUIProcessPrefix.h:
* Source/WebKit/WebKitWebProcessPrefix.h:
* Source/cmake/WebKitMacros.cmake:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7457ffd4adc1a0c71e55468bb5353304851190ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162289 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35765 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28881 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171197 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118734 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164158 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35869 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35773 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125948 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88779 "17 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165248 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28288 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145790 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106526 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27335 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25857 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18918 "Built successfully") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137038 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23526 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173691 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23128 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21044 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25170 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134247 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35439 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29945 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134248 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35422 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145322 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97670 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28789 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22151 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194689 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34932 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102684 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50235 "Found 1 new JSC stress test failure: stress/regexp-dot-star-enclosure-contains-capturing-terms-out-of-stack.js.bytecode-cache (failure)") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34446 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34679 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34589 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->