### PR TITLE
Correct URL parsing for sendBeacon() and the Media Session API

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/beacon/beacon-url-encoding-euc-kr.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/beacon/beacon-url-encoding-euc-kr.https-expected.txt
@@ -1,0 +1,3 @@
+
+PASS beacon-url-encoding-euc-kr
+

--- a/LayoutTests/imported/w3c/web-platform-tests/beacon/beacon-url-encoding-euc-kr.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/beacon/beacon-url-encoding-euc-kr.https.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<meta charset="euc-kr">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  // This file is actually ascii, because otherwise text editors would have hard time.
+
+  promise_test(async (t) => {
+    // "icon" in Korean language
+    const iconKorean = "\uc544\uc744\ucf58";
+    const id = crypto.randomUUID();
+
+    assert_true(navigator.sendBeacon(
+        `/beacon/resources/url-echo.py?cmd=store&id=${id}&icon=${iconKorean}`, "x"));
+
+    // Poll the echo endpoint until the beacon is received. The stored value
+    // is the raw query string sendBeacon() sent.
+    const statUrl = `/beacon/resources/url-echo.py?cmd=stat&id=${id}`;
+    for (let i = 0; i < 30; i++) {
+      const response = await fetch(statUrl);
+      const text = await response.text();
+      if (text) {
+        assert_equals(text, `cmd=store&id=${id}&icon=%EC%95%84%EC%9D%84%EC%BD%98`, "URL encoded with utf-8");
+        return;
+      }
+      await new Promise(resolve => t.step_timeout(resolve, 200));
+    }
+    assert_unreached("sendBeacon was not received");
+  });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/beacon/resources/url-echo.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/beacon/resources/url-echo.py
@@ -1,0 +1,18 @@
+def main(request, response):
+    """Helper handler for testing the URL encoding used by sendBeacon().
+
+    The 'store' command stashes the request's raw (percent-encoded) query
+    string keyed by the 'id' UUID query parameter. The 'stat' command takes
+    that stashed string back out.
+    """
+    cmd = request.GET.first(b"cmd")
+    id = request.GET.first(b"id")
+
+    if cmd == b"store":
+        request.server.stash.put(id, request.url_parts.query)
+    elif cmd == b"stat":
+        stored = request.server.stash.take(id)
+        response.headers.set(b"Content-Type", b"text/plain")
+        response.content = stored.encode("ascii") if stored is not None else b""
+    else:
+        response.status = 400

--- a/LayoutTests/imported/w3c/web-platform-tests/mediasession/artwork-url-encoding-euc-kr-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediasession/artwork-url-encoding-euc-kr-expected.txt
@@ -1,0 +1,3 @@
+
+PASS artwork-url-encoding-euc-kr
+

--- a/LayoutTests/imported/w3c/web-platform-tests/mediasession/artwork-url-encoding-euc-kr.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/mediasession/artwork-url-encoding-euc-kr.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<meta charset="euc-kr">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+  // This file is actually ascii, because otherwise text editors would have hard time.
+
+  test(() => {
+    // "icon" in Korean language
+    const iconKorean = "\uc544\uc744\ucf58";
+    const metadata = new MediaMetadata({ artwork: [{ src: `?icon=${iconKorean}` }] });
+
+    assert_equals(new URL(metadata.artwork[0].src).search, "?icon=%EC%95%84%EC%9D%84%EC%BD%98", "artwork src encoded with utf-8");
+  });
+</script>

--- a/Source/WebCore/Modules/beacon/NavigatorBeacon.cpp
+++ b/Source/WebCore/Modules/beacon/NavigatorBeacon.cpp
@@ -111,7 +111,7 @@ void NavigatorBeacon::logError(const ResourceError& error)
 
 ExceptionOr<bool> NavigatorBeacon::sendBeacon(Document& document, const String& url, std::optional<FetchBody::Init>&& body)
 {
-    URL parsedURL = document.encodingParseURL(url);
+    URL parsedURL = document.parseURL(url);
 
     // Set parsedURL to the result of the URL parser steps with url and base. If the algorithm returns an error, or if
     // parsedURL's scheme is not "http" or "https", throw a "TypeError" exception and terminate these steps.

--- a/Source/WebCore/Modules/cookie-store/CookieStore.cpp
+++ b/Source/WebCore/Modules/cookie-store/CookieStore.cpp
@@ -264,7 +264,7 @@ void CookieStore::getShared(GetType getType, CookieStoreGetOptions&& options, Re
 
     auto url = context->cookieURL();
     if (!options.url.isNull()) {
-        auto parsed = context->encodingParseURL(options.url);
+        auto parsed = context->parseURL(options.url);
         if (context->isDocument() && !equalIgnoringFragmentIdentifier(parsed, url)) {
             promise->reject(Exception { ExceptionCode::TypeError, "URL must match the document URL"_s });
             return;

--- a/Source/WebCore/Modules/mediasession/MediaMetadata.cpp
+++ b/Source/WebCore/Modules/mediasession/MediaMetadata.cpp
@@ -73,7 +73,7 @@ void ArtworkImageLoader::requestImageResource()
     RefPtr document = m_document.get();
     options.contentSecurityPolicyImposition = document->isInUserAgentShadowTree() ? ContentSecurityPolicyImposition::SkipPolicyCheck : ContentSecurityPolicyImposition::DoPolicyCheck;
 
-    CachedResourceRequest request(ResourceRequest(document->encodingParseURL(m_src)), options);
+    CachedResourceRequest request(ResourceRequest(document->parseURL(m_src)), options);
     request.setInitiatorType(AtomString { document->documentURI() });
     m_cachedImage = protect(document->cachedResourceLoader())->requestImage(WTF::move(request)).value_or(nullptr);
 
@@ -168,7 +168,7 @@ ExceptionOr<void> MediaMetadata::setArtwork(ScriptExecutionContext& context, Vec
     Vector<MediaImage> resolvedArtwork;
     resolvedArtwork.reserveInitialCapacity(artwork.size());
     for (auto& image : artwork) {
-        auto resolvedSrc = context.encodingParseURL(image.src);
+        auto resolvedSrc = context.parseURL(image.src);
         if (!resolvedSrc.isValid())
             return Exception { ExceptionCode::TypeError };
         resolvedArtwork.append(MediaImage { resolvedSrc.string(), image.sizes, image.type });


### PR DESCRIPTION
#### 6c8a7108b8e408f9acacf0623df1452441dd5114
<pre>
Correct URL parsing for sendBeacon() and the Media Session API
<a href="https://bugs.webkit.org/show_bug.cgi?id=314732">https://bugs.webkit.org/show_bug.cgi?id=314732</a>

Reviewed by Youenn Fablet.

This also changes the call for the Cookie Store API, but this does not
impact anything as we never look at the query of that URL. And
therefore that can not be tested.

Tests: imported/w3c/web-platform-tests/beacon/beacon-url-encoding-euc-kr.https.html
       imported/w3c/web-platform-tests/mediasession/artwork-url-encoding-euc-kr.html

Upstream: <a href="https://github.com/web-platform-tests/wpt/pull/59851">https://github.com/web-platform-tests/wpt/pull/59851</a>
Canonical link: <a href="https://commits.webkit.org/313403@main">https://commits.webkit.org/313403@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e0919ad3aadc0d554bb02b2b54d365e0941d6de9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162294 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35770 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28886 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171202 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118739 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/01f0e120-a1ef-4252-b459-dc7b1a182380) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164163 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35874 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35771 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125950 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88783 "18 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/27b5df81-a454-4b90-bccb-560dd65f08b0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165253 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28293 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145795 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106528 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b7dddbcb-d691-41bf-a410-5025a49fb279) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27340 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25858 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18923 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137043 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23530 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173696 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21049 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25174 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134248 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35444 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29946 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134249 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35427 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145326 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97677 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24796 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28794 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22914 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34937 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102689 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34438 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34684 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34586 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->