### PR TITLE
[JSC] Do not allocate promise reaction when it is initial `then` calls and one handler attachment

### DIFF
--- a/JSTests/stress/promise-inline-child-reaction.js
+++ b/JSTests/stress/promise-inline-child-reaction.js
@@ -1,0 +1,122 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${expected}, got ${actual}`);
+}
+
+// defer() returns a {promise, resolve, reject} capability without touching the
+// constructor's internal machinery beyond what users can observe.
+function defer() {
+    let resolve, reject;
+    let p = new Promise((res, rej) => { resolve = res; reject = rej; });
+    return { promise: p, resolve, reject };
+}
+
+async function main() {
+    // .then(f) single-fulfill handler: takes the inline-child path.
+    {
+        let counter = 0;
+        let d = defer();
+        let q = d.promise.then(v => { counter++; return v + 1; });
+        d.resolve(10);
+        shouldBe(await q, 11);
+        shouldBe(counter, 1);
+    }
+
+    // .catch(f) single-reject handler: inline-childReject path.
+    {
+        let caught = null;
+        let d = defer();
+        let q = d.promise.catch(e => { caught = e; return "handled-" + e; });
+        d.reject("oops");
+        shouldBe(await q, "handled-oops");
+        shouldBe(caught, "oops");
+    }
+
+    // Multi-consumer on same pending promise: second .then triggers spill of
+    // the first inline-child into a JSSlimPromiseReaction.
+    {
+        let d = defer();
+        let a = d.promise.then(v => v * 2);
+        let b = d.promise.then(v => v * 3);
+        let c = d.promise.then(v => v * 4);
+        d.resolve(5);
+        shouldBe(await a, 10);
+        shouldBe(await b, 15);
+        shouldBe(await c, 20);
+    }
+
+    // Two-handler .then(f, g): falls through to JSFullPromiseReaction (not inline).
+    {
+        let d = defer();
+        let q = d.promise.then(x => x + "!", e => "err-" + e);
+        d.resolve("r");
+        shouldBe(await q, "r!");
+    }
+
+    // Deep chain: promise.then(f).then(g).then(h) — each step is inline-child
+    // on its parent at the time it's attached (parent pending, no existing
+    // reactions). As each parent settles, a new microtask resolves the child.
+    {
+        let p = Promise.resolve(1);
+        let r = p.then(x => x + 1).then(x => x * 10).then(x => x - 3);
+        shouldBe(await r, 17);
+    }
+
+    // Resolving to an already-fulfilled promise goes through the settled branch
+    // of performPromiseThen — no inline-child path.
+    {
+        let r = Promise.resolve(42);
+        shouldBe(await r.then(v => v + 1), 43);
+        shouldBe(await r.then(v => v * 2), 84);
+    }
+
+    // Resolving to an already-rejected promise: settled-rejected branch.
+    {
+        let r = Promise.reject("bad");
+        r.catch(() => {}); // already handle to avoid unhandled rejection
+        try { await r.then(v => "never"); } catch (e) { shouldBe(e, "bad"); }
+    }
+
+    // .then() with no callable handlers — reuses the existing inline-internal-microtask
+    // form via PromiseResolveWithoutHandlerJob. The resulting promise should mirror.
+    {
+        let p = Promise.resolve("mirror");
+        let q = p.then();
+        shouldBe(await q, "mirror");
+    }
+
+    // Settling a promise that has an inline-child reaction installed: verify the
+    // child promise is correctly resolved from the microtask path.
+    {
+        let d = defer();
+        let c = d.promise.then(v => "child:" + v);
+        d.resolve("parent");
+        shouldBe(await c, "child:parent");
+    }
+
+    // Settling a promise whose inline-child is ChildReject (only onRejected supplied)
+    // when parent FULFILLS: the child promise should resolve with the parent's value
+    // (pass-through).
+    {
+        let d = defer();
+        let c = d.promise.then(undefined, e => "caught:" + e);
+        d.resolve("ok");
+        shouldBe(await c, "ok");
+    }
+
+    // Settling a promise whose inline-child is ChildFulfill when parent REJECTS:
+    // child should propagate rejection.
+    {
+        let d = defer();
+        let c = d.promise.then(v => "fulfilled:" + v);
+        c.catch(() => {}); // avoid unhandled-rejection noise
+        d.reject("boom");
+        try { await c; throw new Error("should have thrown"); }
+        catch (e) { shouldBe(e, "boom"); }
+    }
+}
+
+main().then(
+    () => {},
+    $vm.abort
+);

--- a/JSTests/stress/promise-packed-layout-gc-stress.js
+++ b/JSTests/stress/promise-packed-layout-gc-stress.js
@@ -1,0 +1,72 @@
+// Exercise JSPromise under GC pressure to validate the new packed layout's
+// visitChildren / write-barrier discipline. Allocates many promises, awaits
+// them at various stages, and forces edenGC / fullGC between phases so the
+// concurrent collector has a chance to scan promises that hold inline-handler
+// payloads (a JSPromise* in m_packed) and inline-microtask contexts (in m_slot).
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`expected ${expected}, got ${actual}`);
+}
+
+function defer() {
+    let resolve, reject;
+    let p = new Promise((res, rej) => { resolve = res; reject = rej; });
+    return { promise: p, resolve, reject };
+}
+
+async function stressOne(i) {
+    // Inline-microtask reaction (await on a freshly-pending promise). Force a
+    // GC after attaching the await — the pending promise has its inline-microtask
+    // context cell in m_slot and must be traced.
+    let a = defer();
+    let aPromise = a.promise.then(v => v); // re-await via .then to attach a reaction first
+    edenGC();
+    a.resolve(i);
+    shouldBe(await aPromise, i);
+
+    // Inline-child reaction (.then on pending). Force GC while the inline
+    // FulfillHandler holds the result-promise pointer in m_packed and the
+    // handler in m_slot.
+    let b = defer();
+    let c = b.promise.then(v => v + 1);
+    edenGC();
+    b.resolve(i * 2);
+    shouldBe(await c, i * 2 + 1);
+
+    // Inline-child reaction followed by spill (second consumer creates a
+    // JSSlimPromiseReaction). GC at both states.
+    let d = defer();
+    let e1 = d.promise.then(v => v + 1);
+    edenGC();
+    let e2 = d.promise.then(v => v + 2);
+    edenGC();
+    d.resolve(i * 3);
+    shouldBe(await e1, i * 3 + 1);
+    shouldBe(await e2, i * 3 + 2);
+
+    // Rejection with settlement value that's a fresh object (cell settlement
+    // value lives in m_slot after settlement).
+    let f = Promise.reject({ err: "e" + i });
+    edenGC();
+    try { await f; } catch (err) { shouldBe(err.err, "e" + i); }
+
+    // Chain of 4 where each step uses inline-child. GC mid-chain.
+    let g = Promise.resolve(i).then(x => x + 1).then(x => x * 2).then(x => { edenGC(); return x - i; });
+    shouldBe(await g, (i + 1) * 2 - i);
+
+    // Periodic full GC to exercise the slow path and unreachable-promise sweeping.
+    if ((i % 32) === 0)
+        fullGC();
+}
+
+async function main() {
+    const N = 200;
+    for (let i = 0; i < N; i++)
+        await stressOne(i);
+}
+
+main().then(
+    () => {},
+    $vm.abort
+);

--- a/Source/JavaScriptCore/b3/B3AbstractHeapRepository.cpp
+++ b/Source/JavaScriptCore/b3/B3AbstractHeapRepository.cpp
@@ -47,6 +47,7 @@
 #include "JSGlobalObject.h"
 #include "JSGlobalProxy.h"
 #include "JSMap.h"
+#include "JSPromise.h"
 #include "JSPropertyNameEnumerator.h"
 #include "JSSet.h"
 #include "JSWeakMap.h"

--- a/Source/JavaScriptCore/b3/B3AbstractHeapRepository.h
+++ b/Source/JavaScriptCore/b3/B3AbstractHeapRepository.h
@@ -180,6 +180,8 @@ namespace JSC::B3 {
     macro(SpecialPropertyCache_cachedToStringTagValue, SpecialPropertyCache::offsetOfCache(CachedSpecialPropertyKey::ToStringTag) + SpecialPropertyCacheEntry::offsetOfValue(), Mutability::Mutable) \
     macro(JSMap_storage, (JSMap::offsetOfStorage()), Mutability::Mutable) \
     macro(JSSet_storage, (JSSet::offsetOfStorage()), Mutability::Mutable) \
+    macro(JSPromise_packed, JSPromise::offsetOfPacked(), Mutability::Mutable) \
+    macro(JSPromise_slot, JSPromise::offsetOfSlot(), Mutability::Mutable) \
     macro(VM_heap_barrierThreshold, VM::offsetOfHeapBarrierThreshold(), Mutability::Mutable) \
     macro(VM_heap_mutatorShouldBeFenced, VM::offsetOfHeapMutatorShouldBeFenced(), Mutability::Mutable) \
     macro(VM_exception, VM::exceptionOffset(), Mutability::Mutable) \

--- a/Source/JavaScriptCore/builtins/BuiltinNames.h
+++ b/Source/JavaScriptCore/builtins/BuiltinNames.h
@@ -78,6 +78,8 @@ namespace JSC {
     macro(resolvePromise) \
     macro(rejectPromise) \
     macro(fulfillPromise) \
+    macro(markPromiseAsHandled) \
+    macro(isPromiseStatePending) \
     macro(resolvePromiseWithFirstResolvingFunctionCallCheck) \
     macro(rejectPromiseWithFirstResolvingFunctionCallCheck) \
     macro(fulfillPromiseWithFirstResolvingFunctionCallCheck) \

--- a/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.cpp
+++ b/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.cpp
@@ -82,18 +82,6 @@ BytecodeIntrinsicRegistry::BytecodeIntrinsicRegistry(VM& vm)
     m_ModuleSatisfy.set(m_vm, jsNumber(static_cast<unsigned>(JSModuleLoader::Status::Satisfy)));
     m_ModuleLink.set(m_vm, jsNumber(static_cast<unsigned>(JSModuleLoader::Status::Link)));
     m_ModuleReady.set(m_vm, jsNumber(static_cast<unsigned>(JSModuleLoader::Status::Ready)));
-    m_promiseRejectionReject.set(m_vm, jsNumber(static_cast<unsigned>(JSPromiseRejectionOperation::Reject)));
-    m_promiseRejectionHandle.set(m_vm, jsNumber(static_cast<unsigned>(JSPromiseRejectionOperation::Handle)));
-    m_promiseStatePending.set(m_vm, jsNumber(static_cast<int32_t>(JSPromise::Status::Pending)));
-    m_promiseStateFulfilled.set(m_vm, jsNumber(static_cast<int32_t>(JSPromise::Status::Fulfilled)));
-    m_promiseStateRejected.set(m_vm, jsNumber(static_cast<int32_t>(JSPromise::Status::Rejected)));
-    m_promiseStateMask.set(m_vm, jsNumber(JSPromise::stateMask));
-    m_promiseFlagsIsHandled.set(m_vm, jsNumber(JSPromise::isHandledFlag));
-    m_promiseFlagsIsFirstResolvingFunctionCalled.set(m_vm, jsNumber(JSPromise::isFirstResolvingFunctionCalledFlag));
-    // FIXME: Clean up JSInternalObjectImpl field registry.
-    // https://bugs.webkit.org/show_bug.cgi?id=201894
-    m_promiseFieldFlags.set(m_vm, jsNumber(static_cast<unsigned>(JSPromise::Field::Flags)));
-    m_promiseFieldReactionsOrResult.set(m_vm, jsNumber(static_cast<unsigned>(JSPromise::Field::ReactionsOrResult)));
     m_generatorFieldState.set(m_vm, jsNumber(static_cast<unsigned>(JSGenerator::Field::State)));
     m_generatorFieldNext.set(m_vm, jsNumber(static_cast<unsigned>(JSGenerator::Field::Next)));
     m_generatorFieldThis.set(m_vm, jsNumber(static_cast<unsigned>(JSGenerator::Field::This)));

--- a/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h
+++ b/Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h
@@ -48,7 +48,6 @@ enum class LinkTimeConstant : int32_t;
     macro(getByIdDirectPrivate) \
     macro(getByValWithThis) \
     macro(getPrototypeOf) \
-    macro(getPromiseInternalField) \
     macro(getGeneratorInternalField) \
     macro(getIteratorHelperInternalField) \
     macro(getAsyncDisposableStackInternalField) \
@@ -98,7 +97,6 @@ enum class LinkTimeConstant : int32_t;
     macro(putByValDirect) \
     macro(putByValWithThisSloppy) \
     macro(putByValWithThisStrict) \
-    macro(putPromiseInternalField) \
     macro(putGeneratorInternalField) \
     macro(putAsyncDisposableStackInternalField) \
     macro(putAsyncGeneratorInternalField) \
@@ -144,16 +142,6 @@ enum class LinkTimeConstant : int32_t;
     macro(ModuleSatisfy) \
     macro(ModuleLink) \
     macro(ModuleReady) \
-    macro(promiseRejectionReject) \
-    macro(promiseRejectionHandle) \
-    macro(promiseStatePending) \
-    macro(promiseStateFulfilled) \
-    macro(promiseStateRejected) \
-    macro(promiseStateMask) \
-    macro(promiseFlagsIsHandled) \
-    macro(promiseFlagsIsFirstResolvingFunctionCalled) \
-    macro(promiseFieldFlags) \
-    macro(promiseFieldReactionsOrResult) \
     macro(proxyFieldTarget) \
     macro(proxyFieldHandler) \
     macro(generatorFieldState) \

--- a/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
+++ b/Source/JavaScriptCore/bytecode/LinkTimeConstant.h
@@ -58,6 +58,8 @@ class JSGlobalObject;
     v(resolvePromise, nullptr) \
     v(rejectPromise, nullptr) \
     v(fulfillPromise, nullptr) \
+    v(markPromiseAsHandled, nullptr) \
+    v(isPromiseStatePending, nullptr) \
     v(resolvePromiseWithFirstResolvingFunctionCallCheck, nullptr) \
     v(rejectPromiseWithFirstResolvingFunctionCallCheck, nullptr) \
     v(fulfillPromiseWithFirstResolvingFunctionCallCheck, nullptr) \

--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -1548,17 +1548,6 @@ RegisterID* BytecodeIntrinsicNode::emit_intrinsic_getPrototypeOf(BytecodeGenerat
     return generator.emitGetPrototypeOf(generator.finalDestination(dst), value.get());
 }
 
-static JSPromise::Field NODELETE promiseInternalFieldIndex(BytecodeIntrinsicNode* node)
-{
-    ASSERT(node->entry().type() == BytecodeIntrinsicRegistry::Type::Emitter);
-    if (node->entry().emitter() == &BytecodeIntrinsicNode::emit_intrinsic_promiseFieldFlags)
-        return JSPromise::Field::Flags;
-    if (node->entry().emitter() == &BytecodeIntrinsicNode::emit_intrinsic_promiseFieldReactionsOrResult)
-        return JSPromise::Field::ReactionsOrResult;
-    RELEASE_ASSERT_NOT_REACHED();
-    return JSPromise::Field::Flags;
-}
-
 static JSGenerator::Field NODELETE generatorInternalFieldIndex(BytecodeIntrinsicNode* node)
 {
     ASSERT(node->entry().type() == BytecodeIntrinsicRegistry::Type::Emitter);
@@ -1739,19 +1728,6 @@ static JSRegExpStringIterator::Field NODELETE regExpStringIteratorInternalFieldI
         return JSRegExpStringIterator::Field::Flags;
     RELEASE_ASSERT_NOT_REACHED();
     return JSRegExpStringIterator::Field::RegExp;
-}
-
-RegisterID* BytecodeIntrinsicNode::emit_intrinsic_getPromiseInternalField(BytecodeGenerator& generator, RegisterID* dst)
-{
-    ArgumentListNode* node = m_args->m_listNode;
-    RefPtr<RegisterID> base = generator.emitNode(node);
-    node = node->m_next;
-    RELEASE_ASSERT(node->m_expr->isBytecodeIntrinsicNode());
-    unsigned index = static_cast<unsigned>(promiseInternalFieldIndex(static_cast<BytecodeIntrinsicNode*>(node->m_expr)));
-    ASSERT(index < JSPromise::numberOfInternalFields);
-    ASSERT(!node->m_next);
-
-    return generator.emitGetInternalField(generator.finalDestination(dst), base.get(), index);
 }
 
 RegisterID* BytecodeIntrinsicNode::emit_intrinsic_getGeneratorInternalField(BytecodeGenerator& generator, RegisterID* dst)
@@ -2016,22 +1992,6 @@ RegisterID* BytecodeIntrinsicNode::emit_intrinsic_putByValDirect(BytecodeGenerat
     ASSERT(!node->m_next);
 
     return generator.move(dst, generator.emitDirectPutByVal(base.get(), index.get(), value.get()));
-}
-
-RegisterID* BytecodeIntrinsicNode::emit_intrinsic_putPromiseInternalField(BytecodeGenerator& generator, RegisterID* dst)
-{
-    ArgumentListNode* node = m_args->m_listNode;
-    RefPtr<RegisterID> base = generator.emitNode(node);
-    node = node->m_next;
-    RELEASE_ASSERT(node->m_expr->isBytecodeIntrinsicNode());
-    unsigned index = static_cast<unsigned>(promiseInternalFieldIndex(static_cast<BytecodeIntrinsicNode*>(node->m_expr)));
-    ASSERT(index < JSPromise::numberOfInternalFields);
-    node = node->m_next;
-    RefPtr<RegisterID> value = generator.emitNode(node);
-
-    ASSERT(!node->m_next);
-
-    return generator.move(dst, generator.emitPutInternalField(base.get(), index, value.get()));
 }
 
 RegisterID* BytecodeIntrinsicNode::emit_intrinsic_putGeneratorInternalField(BytecodeGenerator& generator, RegisterID* dst)

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -4065,6 +4065,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
     case NewInternalFieldObject:
     case NewObject:
     case MaterializeNewInternalFieldObject:
+    case NewPromise:
         ASSERT(!!node->structure().get());
         setForNode(node, node->structure());
         break;
@@ -4161,6 +4162,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
     case PhantomNewArrayWithSpread:
     case PhantomNewArrayBuffer:
     case PhantomNewInternalFieldObject:
+    case PhantomNewPromise:
     case PhantomNewRegExp:
     case BottomValue: {
         clearForNode(node);

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -7414,7 +7414,7 @@ void ByteCodeParser::parseBlock(unsigned limit)
                 }
                 if (promiseConstructor) {
                     addToGraph(Phantom, callee);
-                    Node* promise = addToGraph(NewInternalFieldObject, OpInfo(m_graph.registerStructure(globalObject->promiseStructure())));
+                    Node* promise = addToGraph(NewPromise, OpInfo(m_graph.registerStructure(globalObject->promiseStructure())));
                     set(VirtualRegister(bytecode.m_dst), promise);
                     alreadyEmitted = true;
                 }
@@ -7449,7 +7449,7 @@ void ByteCodeParser::parseBlock(unsigned limit)
                                 m_graph.freeze(globalObject);
                                 m_graph.watchpoints().addLazily(globalObject->structureCacheClearedWatchpointSet());
 
-                                Node* promise = addToGraph(NewInternalFieldObject, OpInfo(m_graph.registerStructure(structure)));
+                                Node* promise = addToGraph(NewPromise, OpInfo(m_graph.registerStructure(structure)));
                                 set(VirtualRegister(bytecode.m_dst), promise);
                                 // The callee is still live up to this point.
                                 addToGraph(Phantom, callee);
@@ -7485,7 +7485,7 @@ void ByteCodeParser::parseBlock(unsigned limit)
         case op_new_promise: {
             auto bytecode = currentInstruction->as<OpNewPromise>();
             JSGlobalObject* globalObject = m_graph.globalObjectFor(currentNodeOrigin().semantic);
-            Node* promise = addToGraph(NewInternalFieldObject, OpInfo(m_graph.registerStructure(globalObject->promiseStructure())));
+            Node* promise = addToGraph(NewPromise, OpInfo(m_graph.registerStructure(globalObject->promiseStructure())));
             set(bytecode.m_dst, promise);
             NEXT_OPCODE(op_new_promise);
         }

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -2226,6 +2226,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
 
     case NewObject:
     case NewInternalFieldObject:
+    case NewPromise:
     case NewRegExp:
     case NewStringObject:
     case NewMap:
@@ -2238,6 +2239,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
     case PhantomNewAsyncGeneratorFunction:
     case PhantomNewInternalFieldObject:
     case MaterializeNewInternalFieldObject:
+    case PhantomNewPromise:
     case PhantomCreateActivation:
     case MaterializeCreateActivation:
     case PhantomNewRegExp:

--- a/Source/JavaScriptCore/dfg/DFGClobbersExitState.cpp
+++ b/Source/JavaScriptCore/dfg/DFGClobbersExitState.cpp
@@ -57,6 +57,7 @@ bool clobbersExitState(Graph& graph, Node* node)
     case Arrayify:
     case NewObject:
     case NewInternalFieldObject:
+    case NewPromise:
     case NewRegExp:
     case NewMap:
     case NewSet:
@@ -69,6 +70,7 @@ bool clobbersExitState(Graph& graph, Node* node)
     case PhantomNewAsyncGeneratorFunction:
     case PhantomNewAsyncFunction:
     case PhantomNewInternalFieldObject:
+    case PhantomNewPromise:
     case MaterializeNewInternalFieldObject:
     case PhantomCreateActivation:
     case MaterializeCreateActivation:

--- a/Source/JavaScriptCore/dfg/DFGCloneHelper.h
+++ b/Source/JavaScriptCore/dfg/DFGCloneHelper.h
@@ -294,6 +294,7 @@ BasicBlock* CloneHelper::cloneBlock(BasicBlock* const block, const CustomizeSucc
     CLONE_STATUS(NewArrayWithSpread, Common) \
     CLONE_STATUS(NewFunction, Common) \
     CLONE_STATUS(NewInternalFieldObject, Common) \
+    CLONE_STATUS(NewPromise, Common) \
     CLONE_STATUS(NewMap, Common) \
     CLONE_STATUS(NewObject, Common) \
     CLONE_STATUS(NewRegExp, Common) \

--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -1004,7 +1004,7 @@ private:
                 JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);
                 if (JSValue base = m_state.forNode(node->child1()).m_value) {
                     if (base == globalObject->promiseConstructor()) {
-                        node->convertToNewInternalFieldObject(m_graph.registerStructure(globalObject->promiseStructure()));
+                        node->convertToNewPromise(m_graph.registerStructure(globalObject->promiseStructure()));
                         changed = true;
                         break;
                     }
@@ -1017,7 +1017,7 @@ private:
                                     && structure->realm() == globalObject) {
                                     m_graph.freeze(rareData);
                                     m_graph.watchpoints().addLazily(rareData->allocationProfileWatchpointSet());
-                                    node->convertToNewInternalFieldObject(m_graph.registerStructure(structure));
+                                    node->convertToNewPromise(m_graph.registerStructure(structure));
                                     changed = true;
                                     break;
                                 }
@@ -1994,21 +1994,11 @@ private:
                 JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);
                 if (JSValue constructor = m_state.forNode(node->child1()).m_value) {
                     if (constructor == globalObject->promiseConstructor()) {
-                        auto convertToFulfilledPromise = [&](Node* node) {
-                            auto* promise = m_insertionSet.insertNode(indexInBlock, SpecPromiseObject, NewInternalFieldObject, node->origin, OpInfo(m_graph.registerStructure(globalObject->promiseStructure())));
-                            m_insertionSet.insertNode(indexInBlock, SpecNone, ExitOK, node->origin);
-                            m_insertionSet.insertNode(indexInBlock, SpecNone, PutInternalField, node->origin, OpInfo(static_cast<uint32_t>(JSPromise::Field::Flags)), Edge(promise, KnownCellUse), Edge(m_insertionSet.insertConstant(indexInBlock, node->origin, jsNumber(JSPromise::isFirstResolvingFunctionCalledFlag | static_cast<int32_t>(JSPromise::Status::Fulfilled)))));
-                            m_insertionSet.insertNode(indexInBlock, SpecNone, ExitOK, node->origin);
-                            m_insertionSet.insertNode(indexInBlock, SpecNone, PutInternalField, node->origin, OpInfo(static_cast<uint32_t>(JSPromise::Field::ReactionsOrResult)), Edge(promise, KnownCellUse), node->child2());
-                            m_insertionSet.insertNode(indexInBlock, SpecNone, ExitOK, node->origin);
-                            node->convertToIdentityOn(promise);
-                        };
-
                         auto& argument = m_state.forNode(node->child2());
                         if (argument.isType(~SpecObject)) {
                             m_interpreter.execute(indexInBlock); // Push CFA over this node after we get the state before.
                             alreadyHandled = true; // Don't allow the default constant folder to do things to this.
-                            convertToFulfilledPromise(node);
+                            node->convertToNewResolvedPromise(node->child2());
                             changed = true;
                             break;
                         }
@@ -2034,7 +2024,7 @@ private:
                                     if (m_graph.watchConditions(conditionSet)) {
                                         m_interpreter.execute(indexInBlock); // Push CFA over this node after we get the state before.
                                         alreadyHandled = true; // Don't allow the default constant folder to do things to this.
-                                        convertToFulfilledPromise(node);
+                                        node->convertToNewResolvedPromise(node->child2());
                                         changed = true;
                                         break;
                                     }
@@ -2059,7 +2049,7 @@ private:
                                     m_interpreter.execute(indexInBlock);
                                     alreadyHandled = true;
 
-                                    auto* resultPromise = m_insertionSet.insertNode(indexInBlock, SpecPromiseObject, NewInternalFieldObject, node->origin, OpInfo(m_graph.registerStructure(globalObject->promiseStructure())));
+                                    auto* resultPromise = m_insertionSet.insertNode(indexInBlock, SpecPromiseObject, NewPromise, node->origin, OpInfo(m_graph.registerStructure(globalObject->promiseStructure())));
                                     m_insertionSet.insertNode(indexInBlock, SpecNone, ExitOK, node->origin);
 
                                     unsigned firstChild = m_graph.m_varArgChildren.size();
@@ -2107,6 +2097,7 @@ private:
             case PhantomNewAsyncGeneratorFunction:
             case PhantomNewAsyncFunction:
             case PhantomNewInternalFieldObject:
+            case PhantomNewPromise:
             case PhantomCreateActivation:
             case PhantomDirectArguments:
             case PhantomClonedArguments:

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -223,6 +223,7 @@ bool doesGC(Graph& graph, Node* node)
     case PhantomNewAsyncFunction:
     case PhantomNewAsyncGeneratorFunction:
     case PhantomNewInternalFieldObject:
+    case PhantomNewPromise:
     case PhantomCreateActivation:
     case PhantomDirectArguments:
     case PhantomCreateRest:
@@ -417,6 +418,7 @@ bool doesGC(Graph& graph, Node* node)
     case NewArray:
     case NewArrayWithSpread:
     case NewInternalFieldObject:
+    case NewPromise:
     case Spread:
     case NewButterflyWithSize:
     case ArraySortCompact:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -2776,6 +2776,7 @@ private:
         case PhantomNewAsyncGeneratorFunction:
         case PhantomNewAsyncFunction:
         case PhantomNewInternalFieldObject:
+        case PhantomNewPromise:
         case PhantomCreateActivation:
         case PhantomDirectArguments:
         case PhantomCreateRest:
@@ -3619,6 +3620,7 @@ private:
         case ProfileControlFlow:
         case NewObject:
         case NewInternalFieldObject:
+        case NewPromise:
         case NewRegExp:
         case NewMap:
         case NewSet:

--- a/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
@@ -874,6 +874,7 @@ bool LoopUnrollingPhase::LoopData::isMaterialNode(Graph& graph, Node* node)
     case PhantomNewAsyncGeneratorFunction:
     case PhantomNewAsyncFunction:
     case PhantomNewInternalFieldObject:
+    case PhantomNewPromise:
     case PhantomCreateActivation:
     case PhantomDirectArguments:
     case PhantomCreateRest:

--- a/Source/JavaScriptCore/dfg/DFGMayExit.cpp
+++ b/Source/JavaScriptCore/dfg/DFGMayExit.cpp
@@ -73,6 +73,7 @@ ExitMode mayExitImpl(Graph& graph, Node* node, StateType& state)
     case PhantomNewObject:
     case PhantomNewArrayWithButterfly:
     case PhantomNewInternalFieldObject:
+    case PhantomNewPromise:
     case PhantomNewButterflyWithSize:
     case PutStack:
     case KillStack:
@@ -201,6 +202,7 @@ ExitMode mayExitImpl(Graph& graph, Node* node, StateType& state)
     case NewBoundFunction:
     case NewStringObject:
     case NewInternalFieldObject:
+    case NewPromise:
     case NewRegExp:
     case NewMap:
     case NewSet:

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -912,6 +912,33 @@ public:
         m_opInfo2 = OpInfoWrapper();
     }
 
+    void convertToNewPromise(RegisteredStructure structure)
+    {
+        ASSERT(m_op == CreatePromise);
+        setOpAndDefaultFlags(NewPromise);
+        children.reset();
+        m_opInfo = structure;
+        m_opInfo2 = OpInfoWrapper();
+    }
+
+    void convertToPhantomNewPromise()
+    {
+        ASSERT(m_op == NewPromise);
+        setOpAndDefaultFlags(PhantomNewPromise);
+        m_opInfo = OpInfoWrapper();
+        m_opInfo2 = OpInfoWrapper();
+        children = AdjacencyList();
+    }
+
+    void convertToNewResolvedPromise(Edge argument)
+    {
+        ASSERT(m_op == PromiseResolve);
+        setOpAndDefaultFlags(NewResolvedPromise);
+        children = AdjacencyList(AdjacencyList::Fixed, argument);
+        m_opInfo = OpInfoWrapper();
+        m_opInfo2 = OpInfoWrapper();
+    }
+
     void NODELETE convertToNewArrayBuffer(FrozenValue* immutableButterfly);
     void NODELETE convertToNewArrayWithSize();
     void NODELETE convertToNewArrayWithButterfly(Graph&, Node* butterfly);
@@ -2402,6 +2429,7 @@ public:
         case MaterializeNewInternalFieldObject:
         case NewObject:
         case NewInternalFieldObject:
+        case NewPromise:
         case NewStringObject:
         case NewRegExpUntyped:
         case NewMap:
@@ -2610,6 +2638,7 @@ public:
         case PhantomNewAsyncFunction:
         case PhantomNewAsyncGeneratorFunction:
         case PhantomNewInternalFieldObject:
+        case PhantomNewPromise:
         case PhantomCreateActivation:
         case PhantomNewRegExp:
             return true;

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -428,6 +428,7 @@ namespace JSC { namespace DFG {
     macro(ArraySortCompact, NodeResultJS | NodeMustGenerate) \
     macro(ArraySortCommit, NodeMustGenerate) \
     macro(NewInternalFieldObject, NodeResultJS) \
+    macro(NewPromise, NodeResultJS) \
     macro(NewTypedArray, NodeResultJS | NodeMustGenerate) \
     macro(NewTypedArrayBuffer, NodeResultJS | NodeMustGenerate) \
     macro(NewRegExp, NodeResultJS) \
@@ -455,6 +456,7 @@ namespace JSC { namespace DFG {
     macro(PhantomNewAsyncGeneratorFunction, NodeResultJS | NodeMustGenerate) \
     macro(PhantomNewInternalFieldObject, NodeResultJS | NodeMustGenerate) \
     macro(MaterializeNewInternalFieldObject, NodeResultJS | NodeHasVarArgs) \
+    macro(PhantomNewPromise, NodeResultJS | NodeMustGenerate) \
     macro(PhantomCreateActivation, NodeResultJS | NodeMustGenerate) \
     macro(MaterializeCreateActivation, NodeResultJS | NodeHasVarArgs) \
     macro(PhantomNewRegExp, NodeResultJS | NodeMustGenerate) \

--- a/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp
@@ -146,7 +146,7 @@ public:
     // once it is escaped if it still has pointers to it in order to
     // replace any use of those pointers by the corresponding
     // materialization
-    enum class Kind { Escaped, Array, ArrayButterfly, Object, Activation, Function, GeneratorFunction, AsyncFunction, AsyncGeneratorFunction, InternalFieldObject, RegExpObject };
+    enum class Kind { Escaped, Array, ArrayButterfly, Object, Activation, Function, GeneratorFunction, AsyncFunction, AsyncGeneratorFunction, InternalFieldObject, RegExpObject, Promise };
 
     using Fields = UncheckedKeyHashMap<PromotedLocationDescriptor, Node*>;
 
@@ -304,6 +304,11 @@ public:
     bool NODELETE isRegExpObjectAllocation() const
     {
         return m_kind == Kind::RegExpObject;
+    }
+
+    bool NODELETE isPromiseAllocation() const
+    {
+        return m_kind == Kind::Promise;
     }
 
     friend bool NODELETE operator==(const Allocation&, const Allocation&) = default;
@@ -1152,10 +1157,6 @@ private:
             case JSAsyncGeneratorType:
                 target = handleInternalFieldClass<JSAsyncGenerator>(node, writes);
                 break;
-            case JSPromiseType:
-                ASSERT(node->structure()->classInfoForCells() == JSPromise::info());
-                target = handleInternalFieldClass<JSPromise>(node, writes);
-                break;
             default:
                 DFG_CRASH(m_graph, node, "Bad structure");
             }
@@ -1167,6 +1168,13 @@ private:
 
             writes.add(RegExpObjectRegExpPLoc, LazyNode(node->cellOperand()));
             writes.add(RegExpObjectLastIndexPLoc, LazyNode(node->child1().node()));
+            break;
+        }
+
+        case NewPromise: {
+            ASSERT(node->structure()->classInfoForCells() == JSPromise::info());
+            target = &m_heap.newAllocation(node, Allocation::Kind::Promise);
+            writes.add(StructurePLoc, LazyNode(m_graph.freeze(node->structure().get())));
             break;
         }
 
@@ -1922,6 +1930,13 @@ escapeChildren:
                 OpInfo(allocation.identifier()->structure()), OpInfo(data), 0, 0);
         }
 
+        case Allocation::Kind::Promise: {
+            return m_graph.addNode(
+                allocation.identifier()->prediction(), NewPromise,
+                where->origin.withSemantic(allocation.identifier()->origin.semantic),
+                OpInfo(allocation.identifier()->structure()));
+        }
+
         case Allocation::Kind::Activation: {
             ObjectMaterializationData* data = m_graph.m_objectMaterializationData.add();
             FrozenValue* symbolTable = allocation.identifier()->cellOperand();
@@ -2358,6 +2373,10 @@ escapeChildren:
                         node->convertToPhantomNewInternalFieldObject();
                         break;
 
+                    case NewPromise:
+                        node->convertToPhantomNewPromise();
+                        break;
+
                     case CreateActivation:
                         node->convertToPhantomCreateActivation();
                         break;
@@ -2696,14 +2715,20 @@ escapeChildren:
         case NewAsyncFunction: {
             Vector<PromotedHeapLocation> locations = m_locationsForAllocation.get(escapee);
             ASSERT(locations.size() == 2);
-                
+
             PromotedHeapLocation executable(FunctionExecutablePLoc, allocation.identifier());
             ASSERT_UNUSED(executable, locations.contains(executable));
-                
+
             PromotedHeapLocation activation(FunctionActivationPLoc, allocation.identifier());
             ASSERT(locations.contains(activation));
 
             node->child1() = Edge(resolve(block, activation), KnownCellUse);
+            break;
+        }
+
+        case NewPromise: {
+            ASSERT(m_locationsForAllocation.get(escapee).size() == 1);
+            ASSERT(m_locationsForAllocation.get(escapee)[0] == PromotedHeapLocation(StructurePLoc, allocation.identifier()));
             break;
         }
 

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1388,6 +1388,7 @@ private:
             break;
 
         case NewInternalFieldObject:
+        case NewPromise:
             setPrediction(speculationFromStructure(m_currentNode->structure().get()));
             break;
             
@@ -1673,6 +1674,7 @@ private:
         case PhantomNewArrayWithSpread:
         case PhantomNewArrayBuffer:
         case PhantomNewInternalFieldObject:
+        case PhantomNewPromise:
         case PhantomClonedArguments:
         case PhantomNewRegExp:
         case GetMyArgumentByVal:

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -673,6 +673,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case NewArrayBuffer:
     case NewArrayWithSpread:
     case NewInternalFieldObject:
+    case NewPromise:
     case Spread:
     case NewRegExp:
     case NewMap:
@@ -755,6 +756,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case PhantomNewAsyncGeneratorFunction:
     case PhantomNewAsyncFunction:
     case PhantomNewInternalFieldObject:
+    case PhantomNewPromise:
     case PhantomCreateActivation:
     case PhantomNewRegExp:
     case PutHint:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -16037,52 +16037,6 @@ void SpeculativeJIT::compileCreateThis(Node* node)
     cellResult(resultGPR, node);
 }
 
-void SpeculativeJIT::compileCreatePromise(Node* node)
-{
-    JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);
-
-    SpeculateCellOperand callee(this, node->child1());
-    GPRTemporary result(this);
-    GPRTemporary structure(this);
-    GPRTemporary scratch1(this);
-    GPRTemporary scratch2(this);
-
-    GPRReg calleeGPR = callee.gpr();
-    GPRReg resultGPR = result.gpr();
-    GPRReg structureGPR = structure.gpr();
-    GPRReg scratch1GPR = scratch1.gpr();
-    GPRReg scratch2GPR = scratch2.gpr();
-    // Rare data is only used to access the allocator & structure
-    // We can avoid using an additional GPR this way
-    GPRReg rareDataGPR = structureGPR;
-
-    move(TrustedImmPtr(m_graph.registerStructure(globalObject->promiseStructure())), structureGPR);
-    auto fastPromisePath = branchLinkableConstant(Equal, calleeGPR, LinkableConstant(*this, globalObject->promiseConstructor()));
-
-    JumpList slowCases;
-
-    slowCases.append(branchIfNotFunction(calleeGPR));
-    loadPtr(Address(calleeGPR, JSFunction::offsetOfExecutableOrRareData()), rareDataGPR);
-    slowCases.append(branchTestPtr(Zero, rareDataGPR, TrustedImm32(JSFunction::rareDataTag)));
-    load32(Address(rareDataGPR, FunctionRareData::offsetOfInternalFunctionAllocationProfile() + InternalFunctionAllocationProfile::offsetOfStructureID() - JSFunction::rareDataTag), structureGPR);
-    slowCases.append(branchTest32(Zero, structureGPR));
-    emitNonNullDecodeZeroExtendedStructureID(structureGPR, structureGPR);
-    move(TrustedImmPtr(JSPromise::info()), scratch1GPR);
-    slowCases.append(branchPtr(NotEqual, scratch1GPR, Address(structureGPR, Structure::classInfoOffset())));
-    loadLinkableConstant(LinkableConstant::globalObject(*this, node), scratch1GPR);
-    slowCases.append(branchPtr(NotEqual, scratch1GPR, Address(structureGPR, Structure::realmOffset())));
-
-    fastPromisePath.link(this);
-    auto butterfly = TrustedImmPtr(nullptr);
-    emitAllocateJSObjectWithKnownSize<JSPromise>(resultGPR, structureGPR, butterfly, scratch1GPR, scratch2GPR, slowCases, sizeof(JSPromise), SlowAllocationResult::UndefinedBehavior);
-    storeTrustedValue(jsNumber(static_cast<int32_t>(JSPromise::Status::Pending)), Address(resultGPR, JSInternalFieldObjectImpl<>::offsetOfInternalField(static_cast<unsigned>(JSPromise::Field::Flags))));
-    storeTrustedValue(JSValue(), Address(resultGPR, JSInternalFieldObjectImpl<>::offsetOfInternalField(static_cast<unsigned>(JSPromise::Field::ReactionsOrResult))));
-    mutatorFence(vm());
-
-    addSlowPathGenerator(slowPathCall(slowCases, this, operationCreatePromise, resultGPR, LinkableConstant::globalObject(*this, node), calleeGPR));
-
-    cellResult(resultGPR, node);
-}
 
 
 template<typename JSClass, typename Operation>
@@ -16228,11 +16182,6 @@ void SpeculativeJIT::compileNewInternalFieldObject(Node* node)
     case JSAsyncGeneratorType:
         compileNewInternalFieldObjectImpl<JSAsyncGenerator>(node, operationNewAsyncGenerator);
         break;
-    case JSPromiseType: {
-        ASSERT(node->structure()->classInfoForCells() == JSPromise::info());
-        compileNewInternalFieldObjectImpl<JSPromise>(node, operationNewPromise);
-        break;
-    }
     default:
         DFG_CRASH(m_graph, node, "Bad structure");
     }
@@ -18367,45 +18316,6 @@ void SpeculativeJIT::compileFulfillPromiseFirstResolving(Node* node)
     flushRegisters();
     callOperation(operationFulfillPromiseFirstResolving, LinkableConstant::globalObject(*this, node), promiseGPR, argumentRegs);
     noResult(node);
-}
-
-void SpeculativeJIT::compileNewResolvedPromise(Node* node)
-{
-    JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);
-    if (!(m_state.forNode(node->child1()).m_type & SpecObject)) {
-        JSValueOperand argument(this, node->child1());
-        JSValueRegs argumentRegs = argument.jsValueRegs();
-
-        GPRTemporary result(this);
-        GPRTemporary scratch1(this);
-        GPRTemporary scratch2(this);
-        GPRReg resultGPR = result.gpr();
-        GPRReg scratch1GPR = scratch1.gpr();
-        GPRReg scratch2GPR = scratch2.gpr();
-
-        JumpList slowCases;
-
-        auto structure = m_graph.registerStructure(globalObject->promiseStructure());
-        auto butterfly = TrustedImmPtr(nullptr);
-        emitAllocateJSObjectWithKnownSize<JSPromise>(resultGPR, TrustedImmPtr(structure), butterfly, scratch1GPR, scratch2GPR, slowCases, sizeof(JSPromise), SlowAllocationResult::UndefinedBehavior);
-        storeTrustedValue(jsNumber(static_cast<int32_t>(JSPromise::Status::Fulfilled)), Address(resultGPR, JSInternalFieldObjectImpl<>::offsetOfInternalField(static_cast<unsigned>(JSPromise::Field::Flags))));
-        storeValue(argumentRegs, Address(resultGPR, JSInternalFieldObjectImpl<>::offsetOfInternalField(static_cast<unsigned>(JSPromise::Field::ReactionsOrResult))));
-        mutatorFence(vm());
-
-        addSlowPathGenerator(slowPathCall(slowCases, this, operationNewResolvedPromise, resultGPR, LinkableConstant::globalObject(*this, node), argumentRegs));
-
-        cellResult(resultGPR, node);
-        return;
-    }
-
-    JSValueOperand argument(this, node->child1());
-    JSValueRegs argumentRegs = argument.jsValueRegs();
-
-    flushRegisters();
-    GPRFlushedCallResult result(this);
-    GPRReg resultGPR = result.gpr();
-    callOperation(operationNewResolvedPromise, resultGPR, LinkableConstant::globalObject(*this, node), argumentRegs);
-    cellResult(resultGPR, node);
 }
 
 void SpeculativeJIT::compileNewRejectedPromise(Node* node)

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1785,6 +1785,7 @@ public:
     void compileCreateAsyncGenerator(Node*);
     void compileNewObject(Node*);
     void compileNewInternalFieldObject(Node*);
+    void compileNewPromise(Node*);
     void compileToPrimitive(Node*);
     void compileToPropertyKey(Node*);
     void compileToPropertyKeyOrNumber(Node*);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -3343,6 +3343,11 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case NewPromise: {
+        compileNewPromise(node);
+        break;
+    }
+
     case GetCallee: {
         compileGetCallee(node);
         break;
@@ -4488,6 +4493,7 @@ void SpeculativeJIT::compile(Node* node)
     case PhantomNewAsyncGeneratorFunction:
     case PhantomCreateActivation:
     case PhantomNewInternalFieldObject:
+    case PhantomNewPromise:
     case PhantomNewRegExp:
     case PutHint:
     case CheckStructureImmediate:
@@ -5545,6 +5551,39 @@ void SpeculativeJIT::compileMapIteratorNext(Node* node)
     JSValueRegs resultRegs = result.regs();
     callOperationWithoutExceptionCheck(node->child1().useKind() == MapIteratorObjectUse ? operationMapIteratorNext : operationSetIteratorNext, resultRegs, TrustedImmPtr(&vm()), mapIteratorGPR);
     jsValueResult(resultRegs, node);
+}
+
+void SpeculativeJIT::compileCreatePromise(Node* node)
+{
+    SpeculateCellOperand callee(this, node->child1());
+    GPRReg calleeGPR = callee.gpr();
+
+    flushRegisters();
+    GPRFlushedCallResult result(this);
+    GPRReg resultGPR = result.gpr();
+    callOperation(operationCreatePromise, resultGPR, LinkableConstant::globalObject(*this, node), calleeGPR);
+    cellResult(resultGPR, node);
+}
+
+void SpeculativeJIT::compileNewPromise(Node* node)
+{
+    flushRegisters();
+    GPRFlushedCallResult result(this);
+    GPRReg resultGPR = result.gpr();
+    callOperation(operationNewPromise, resultGPR, TrustedImmPtr(&vm()), TrustedImmPtr(m_graph.freezeStrong(node->structure().get())));
+    cellResult(resultGPR, node);
+}
+
+void SpeculativeJIT::compileNewResolvedPromise(Node* node)
+{
+    JSValueOperand argument(this, node->child1());
+    JSValueRegs argumentRegs = argument.jsValueRegs();
+
+    flushRegisters();
+    GPRFlushedCallResult result(this);
+    GPRReg resultGPR = result.gpr();
+    callOperation(operationNewResolvedPromise, resultGPR, LinkableConstant::globalObject(*this, node), argumentRegs);
+    cellResult(resultGPR, node);
 }
 
 #endif

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -42,6 +42,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 #include "HasOwnPropertyCache.h"
 #include "JSMap.h"
 #include "JSMapIterator.h"
+#include "JSPromise.h"
 #include "JSSet.h"
 #include "JSSetIterator.h"
 #include "MegamorphicCache.h"
@@ -4714,6 +4715,11 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case NewPromise: {
+        compileNewPromise(node);
+        break;
+    }
+
     case GetCallee: {
         compileGetCallee(node);
         break;
@@ -6678,6 +6684,7 @@ void SpeculativeJIT::compile(Node* node)
     case PhantomNewAsyncFunction:
     case PhantomNewAsyncGeneratorFunction:
     case PhantomNewInternalFieldObject:
+    case PhantomNewPromise:
     case PhantomCreateActivation:
     case PhantomNewRegExp:
     case GetMyArgumentByVal:
@@ -8706,6 +8713,122 @@ void SpeculativeJIT::compileMapIteratorNext(Node* node)
 
     doneCases.link(this);
     jsValueResult(scratchGPR4, node);
+}
+
+// JSPromise inline allocation. The packed-pointer-and-flags layout assumed
+// here (flags in the high 16 bits of the 64-bit slot) only holds on
+// CPU(ADDRESS64) builds with CompactPointerTuple's 48-bit pointer encoding.
+// JSVALUE32_64 builds keep their definitions in DFGSpeculativeJIT32_64.cpp.
+static_assert(CompactPointerTuple<JSCell*, uint16_t>::maxNumberOfBitsInPointer == 48,
+    "JSPromise JIT initialization assumes a 48-bit pointer / 16-bit type packing");
+
+void SpeculativeJIT::compileCreatePromise(Node* node)
+{
+    JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);
+
+    SpeculateCellOperand callee(this, node->child1());
+    GPRTemporary result(this);
+    GPRTemporary structure(this);
+    GPRTemporary scratch1(this);
+    GPRTemporary scratch2(this);
+
+    GPRReg calleeGPR = callee.gpr();
+    GPRReg resultGPR = result.gpr();
+    GPRReg structureGPR = structure.gpr();
+    GPRReg scratch1GPR = scratch1.gpr();
+    GPRReg scratch2GPR = scratch2.gpr();
+    // Rare data is only used to access the allocator & structure
+    // We can avoid using an additional GPR this way
+    GPRReg rareDataGPR = structureGPR;
+
+    move(TrustedImmPtr(m_graph.registerStructure(globalObject->promiseStructure())), structureGPR);
+    auto fastPromisePath = branchLinkableConstant(Equal, calleeGPR, LinkableConstant(*this, globalObject->promiseConstructor()));
+
+    JumpList slowCases;
+
+    slowCases.append(branchIfNotFunction(calleeGPR));
+    loadPtr(Address(calleeGPR, JSFunction::offsetOfExecutableOrRareData()), rareDataGPR);
+    slowCases.append(branchTestPtr(Zero, rareDataGPR, TrustedImm32(JSFunction::rareDataTag)));
+    load32(Address(rareDataGPR, FunctionRareData::offsetOfInternalFunctionAllocationProfile() + InternalFunctionAllocationProfile::offsetOfStructureID() - JSFunction::rareDataTag), structureGPR);
+    slowCases.append(branchTest32(Zero, structureGPR));
+    emitNonNullDecodeZeroExtendedStructureID(structureGPR, structureGPR);
+    move(TrustedImmPtr(JSPromise::info()), scratch1GPR);
+    slowCases.append(branchPtr(NotEqual, scratch1GPR, Address(structureGPR, Structure::classInfoOffset())));
+    loadLinkableConstant(LinkableConstant::globalObject(*this, node), scratch1GPR);
+    slowCases.append(branchPtr(NotEqual, scratch1GPR, Address(structureGPR, Structure::realmOffset())));
+
+    fastPromisePath.link(this);
+    auto butterfly = TrustedImmPtr(nullptr);
+    emitAllocateJSObjectWithKnownSize<JSPromise>(resultGPR, structureGPR, butterfly, scratch1GPR, scratch2GPR, slowCases, sizeof(JSPromise), SlowAllocationResult::UndefinedBehavior);
+    store64(TrustedImm64(0), Address(resultGPR, JSPromise::offsetOfPacked()));
+    storeTrustedValue(JSValue(), Address(resultGPR, JSPromise::offsetOfSlot()));
+    mutatorFence(vm());
+
+    addSlowPathGenerator(slowPathCall(slowCases, this, operationCreatePromise, resultGPR, LinkableConstant::globalObject(*this, node), calleeGPR));
+
+    cellResult(resultGPR, node);
+}
+
+void SpeculativeJIT::compileNewPromise(Node* node)
+{
+    GPRTemporary result(this);
+    GPRTemporary scratch1(this);
+    GPRTemporary scratch2(this);
+
+    GPRReg resultGPR = result.gpr();
+    GPRReg scratch1GPR = scratch1.gpr();
+    GPRReg scratch2GPR = scratch2.gpr();
+
+    JumpList slowCases;
+    FrozenValue* structure = m_graph.freezeStrong(node->structure().get());
+    auto butterfly = TrustedImmPtr(nullptr);
+    emitAllocateJSObjectWithKnownSize<JSPromise>(resultGPR, TrustedImmPtr(structure), butterfly, scratch1GPR, scratch2GPR, slowCases, sizeof(JSPromise), SlowAllocationResult::UndefinedBehavior);
+    store64(TrustedImm64(0), Address(resultGPR, JSPromise::offsetOfPacked()));
+    storeTrustedValue(JSValue(), Address(resultGPR, JSPromise::offsetOfSlot()));
+    mutatorFence(vm());
+
+    addSlowPathGenerator(slowPathCall(slowCases, this, operationNewPromise, resultGPR, TrustedImmPtr(&vm()), TrustedImmPtr(structure)));
+    cellResult(resultGPR, node);
+}
+
+void SpeculativeJIT::compileNewResolvedPromise(Node* node)
+{
+    JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);
+    if (!(m_state.forNode(node->child1()).m_type & SpecObject)) {
+        JSValueOperand argument(this, node->child1());
+
+        GPRTemporary result(this);
+        GPRTemporary scratch1(this);
+        GPRTemporary scratch2(this);
+
+        JSValueRegs argumentRegs = argument.jsValueRegs();
+        GPRReg resultGPR = result.gpr();
+        GPRReg scratch1GPR = scratch1.gpr();
+        GPRReg scratch2GPR = scratch2.gpr();
+
+        JumpList slowCases;
+
+        auto structure = m_graph.registerStructure(globalObject->promiseStructure());
+        auto butterfly = TrustedImmPtr(nullptr);
+        emitAllocateJSObjectWithKnownSize<JSPromise>(resultGPR, TrustedImmPtr(structure), butterfly, scratch1GPR, scratch2GPR, slowCases, sizeof(JSPromise), SlowAllocationResult::UndefinedBehavior);
+        store64(TrustedImm64((static_cast<uint64_t>(JSPromise::Status::Fulfilled) | JSPromise::isFirstResolvingFunctionCalledFlag) << CompactPointerTuple<JSCell*, uint16_t>::maxNumberOfBitsInPointer), Address(resultGPR, JSPromise::offsetOfPacked()));
+        storeValue(argumentRegs, Address(resultGPR, JSPromise::offsetOfSlot()));
+        mutatorFence(vm());
+
+        addSlowPathGenerator(slowPathCall(slowCases, this, operationNewResolvedPromise, resultGPR, LinkableConstant::globalObject(*this, node), argumentRegs));
+
+        cellResult(resultGPR, node);
+        return;
+    }
+
+    JSValueOperand argument(this, node->child1());
+    JSValueRegs argumentRegs = argument.jsValueRegs();
+
+    flushRegisters();
+    GPRFlushedCallResult result(this);
+    GPRReg resultGPR = result.gpr();
+    callOperation(operationNewResolvedPromise, resultGPR, LinkableConstant::globalObject(*this, node), argumentRegs);
+    cellResult(resultGPR, node);
 }
 
 #endif

--- a/Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp
@@ -406,6 +406,7 @@ private:
             case NewArrayWithSizeAndStructure:
             case NewArrayBuffer:
             case NewInternalFieldObject:
+            case NewPromise:
             case NewTypedArray:
             case NewTypedArrayBuffer:
             case NewRegExp:

--- a/Source/JavaScriptCore/dfg/DFGValidate.cpp
+++ b/Source/JavaScriptCore/dfg/DFGValidate.cpp
@@ -694,6 +694,7 @@ private:
                 case PhantomNewAsyncGeneratorFunction:
                 case PhantomCreateActivation:
                 case PhantomNewRegExp:
+                case PhantomNewPromise:
                 case GetMyArgumentByVal:
                 case GetMyArgumentByValOutOfBounds:
                 case PutHint:
@@ -918,6 +919,7 @@ private:
                 case PhantomCreateRest:
                 case PhantomClonedArguments:
                 case PhantomNewRegExp:
+                case PhantomNewPromise:
                 case MovHint:
                 case Upsilon:
                 case ForwardVarargs:

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -81,6 +81,7 @@ inline CapabilityLevel canCompile(Node* node)
     case NewArray:
     case NewArrayWithSpread:
     case NewInternalFieldObject:
+    case NewPromise:
     case Spread:
     case NewArrayBuffer:
     case NewTypedArray:
@@ -361,6 +362,7 @@ inline CapabilityLevel canCompile(Node* node)
     case PhantomNewAsyncGeneratorFunction:
     case PhantomNewAsyncFunction:
     case PhantomNewInternalFieldObject:
+    case PhantomNewPromise:
     case PhantomCreateActivation:
     case PhantomNewRegExp:
     case PutHint:

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -1245,6 +1245,9 @@ private:
         case NewInternalFieldObject:
             compileNewInternalFieldObject();
             break;
+        case NewPromise:
+            compileNewPromise();
+            break;
         case NewStringObject:
             compileNewStringObject();
             break;
@@ -1994,6 +1997,7 @@ private:
         case PhantomNewAsyncGeneratorFunction:
         case PhantomNewAsyncFunction:
         case PhantomNewInternalFieldObject:
+        case PhantomNewPromise:
         case PhantomCreateActivation:
         case PhantomDirectArguments:
         case PhantomCreateRest:
@@ -9629,13 +9633,31 @@ IGNORE_CLANG_WARNINGS_END
         case JSAsyncGeneratorType:
             compileNewInternalFieldObjectImpl<JSAsyncGenerator>(operationNewAsyncGenerator);
             break;
-        case JSPromiseType:
-            ASSERT(m_node->structure()->classInfoForCells() == JSPromise::info());
-            compileNewInternalFieldObjectImpl<JSPromise>(operationNewPromise);
-            break;
         default:
             DFG_CRASH(m_graph, m_node, "Bad structure");
         }
+    }
+
+    void compileNewPromise()
+    {
+        ASSERT(m_node->structure()->classInfoForCells() == JSPromise::info());
+        LBasicBlock slowCase = m_out.newBlock();
+        LBasicBlock continuation = m_out.newBlock();
+        LBasicBlock lastNext = m_out.insertNewBlocksBefore(slowCase);
+
+        LValue object = allocateObject<JSPromise>(m_node->structure(), m_out.intPtrZero, slowCase);
+        m_out.store64(m_out.int64Zero, object, m_heaps.JSPromise_packed);
+        m_out.store64(m_out.constInt64(JSValue::encode(JSValue())), object, m_heaps.JSPromise_slot);
+        mutatorFence();
+        ValueFromBlock fastResult = m_out.anchor(object);
+        m_out.jump(continuation);
+
+        m_out.appendTo(slowCase, continuation);
+        ValueFromBlock slowResult = m_out.anchor(vmCall(pointerType(), operationNewPromise, m_vmValue, frozenPointer(m_graph.freezeStrong(m_node->structure().get()))));
+        m_out.jump(continuation);
+
+        m_out.appendTo(continuation, lastNext);
+        setJSValue(m_out.phi(pointerType(), fastResult, slowResult));
     }
 
     void compileNewStringObject()
@@ -10085,8 +10107,8 @@ IGNORE_CLANG_WARNINGS_END
 
         m_out.appendTo(fastAllocationCase, slowCase);
         LValue promise = allocateObject<JSPromise>(m_out.phi(pointerType(), promiseStructure, derivedStructure), m_out.intPtrZero, slowCase);
-        m_out.store64(m_out.constInt64(JSValue::encode(jsNumber(static_cast<int32_t>(JSPromise::Status::Pending)))), promise, m_heaps.JSInternalFieldObjectImpl_internalFields[static_cast<unsigned>(JSPromise::Field::Flags)]);
-        m_out.store64(m_out.constInt64(JSValue::encode(JSValue())), promise, m_heaps.JSInternalFieldObjectImpl_internalFields[static_cast<unsigned>(JSPromise::Field::ReactionsOrResult)]);
+        m_out.store64(m_out.int64Zero, promise, m_heaps.JSPromise_packed);
+        m_out.store64(m_out.constInt64(JSValue::encode(JSValue())), promise, m_heaps.JSPromise_slot);
         mutatorFence();
         ValueFromBlock fastResult = m_out.anchor(promise);
         m_out.jump(continuation);
@@ -18701,10 +18723,6 @@ IGNORE_CLANG_WARNINGS_END
         case JSAsyncGeneratorType:
             compileMaterializeNewInternalFieldObjectImpl<JSAsyncGenerator>(operationNewAsyncGenerator);
             break;
-        case JSPromiseType:
-            ASSERT(m_node->structure()->classInfoForCells() == JSPromise::info());
-            compileMaterializeNewInternalFieldObjectImpl<JSPromise>(operationNewPromise);
-            break;
         default:
             DFG_CRASH(m_graph, m_node, "Bad structure");
         }
@@ -21059,8 +21077,9 @@ IGNORE_CLANG_WARNINGS_END
 
             LValue structure = weakStructure(m_graph.registerStructure(globalObject->promiseStructure()));
             LValue promise = allocateObject<JSPromise>(structure, m_out.intPtrZero, slowCase);
-            m_out.store64(m_out.constInt64(JSValue::encode(jsNumber(static_cast<int32_t>(JSPromise::Status::Fulfilled)))), promise, m_heaps.JSInternalFieldObjectImpl_internalFields[static_cast<unsigned>(JSPromise::Field::Flags)]);
-            m_out.store64(argument, promise, m_heaps.JSInternalFieldObjectImpl_internalFields[static_cast<unsigned>(JSPromise::Field::ReactionsOrResult)]);
+            static_assert(CompactPointerTuple<JSCell*, uint16_t>::maxNumberOfBitsInPointer == 48, "JSPromise FTL initialization assumes a 48-bit pointer / 16-bit type packing");
+            m_out.store64(m_out.constInt64((static_cast<uint64_t>(JSPromise::Status::Fulfilled) | JSPromise::isFirstResolvingFunctionCalledFlag) << CompactPointerTuple<JSCell*, uint16_t>::maxNumberOfBitsInPointer), promise, m_heaps.JSPromise_packed);
+            m_out.store64(argument, promise, m_heaps.JSPromise_slot);
             mutatorFence();
             ValueFromBlock fastResult = m_out.anchor(promise);
             m_out.jump(continuation);

--- a/Source/JavaScriptCore/ftl/FTLOperations.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOperations.cpp
@@ -164,6 +164,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationPopulateObjectInOSR, void, (JSGlobalO
     case PhantomSpread:
     case PhantomNewArrayWithSpread:
     case PhantomNewArrayBuffer:
+    case PhantomNewPromise:
         // Those are completely handled by operationMaterializeObjectInOSR
         break;
 
@@ -226,10 +227,6 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationPopulateObjectInOSR, void, (JSGlobalO
             break;
         case JSAsyncGeneratorType:
             materialize(uncheckedDowncast<JSAsyncGenerator>(target));
-            break;
-        case JSPromiseType:
-            ASSERT(target->classInfo() == JSPromise::info());
-            materialize(uncheckedDowncast<JSPromise>(target));
             break;
         default:
             RELEASE_ASSERT_NOT_REACHED();
@@ -525,13 +522,24 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMaterializeObjectInOSR, HeapCell*, (J
             return create.operator()<JSGenerator>();
         case JSAsyncGeneratorType:
             return create.operator()<JSAsyncGenerator>();
-        case JSPromiseType:
-            ASSERT(structure->classInfoForCells() == JSPromise::info());
-            return create.operator()<JSPromise>();
         default:
             RELEASE_ASSERT_NOT_REACHED();
             return nullptr;
         }
+    }
+
+    case PhantomNewPromise: {
+        Structure* structure = nullptr;
+        for (unsigned i = materialization->properties().size(); i--;) {
+            const ExitPropertyValue& property = materialization->properties()[i];
+            if (property.location() == PromotedLocationDescriptor(StructurePLoc)) {
+                RELEASE_ASSERT(JSValue::decode(values[i]).asCell()->inherits<Structure>());
+                structure = uncheckedDowncast<Structure>(JSValue::decode(values[i]));
+            }
+        }
+        RELEASE_ASSERT(structure);
+        ASSERT(structure->classInfoForCells() == JSPromise::info());
+        return JSPromise::create(vm, structure);
     }
 
     case PhantomCreateRest:

--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -454,16 +454,9 @@ void Interpreter::getAsyncStackTrace(JSCell* owner, Vector<StackFrame>& results,
     VM& vm = this->vm();
 
     auto getContextValueFromPromise = [&](JSPromise* promise) -> JSValue {
-        if (promise && promise->status() == JSPromise::Status::Pending) {
-            if (promise->hasInlineReaction())
-                return promise->inlineReactionContext();
-            JSValue reactionsValue = promise->internalField(JSPromise::Field::ReactionsOrResult).get();
-            if (reactionsValue) {
-                if (JSValue context = JSPromiseReaction::tryGetContext(reactionsValue))
-                    return context;
-            }
-        }
-        return JSValue();
+        if (!promise)
+            return { };
+        return promise->asyncStackTraceContext();
     };
 
     auto getParentGenerator = [&](JSGenerator* gen) -> JSGenerator* {

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -358,6 +358,8 @@ static JSC_DECLARE_HOST_FUNCTION(disableSuperSampler);
 static JSC_DECLARE_HOST_FUNCTION(resolvePromise);
 static JSC_DECLARE_HOST_FUNCTION(rejectPromise);
 static JSC_DECLARE_HOST_FUNCTION(fulfillPromise);
+static JSC_DECLARE_HOST_FUNCTION(markPromiseAsHandledHostFunction);
+static JSC_DECLARE_HOST_FUNCTION(isPromiseStatePending);
 static JSC_DECLARE_HOST_FUNCTION(resolvePromiseWithFirstResolvingFunctionCallCheck);
 static JSC_DECLARE_HOST_FUNCTION(rejectPromiseWithFirstResolvingFunctionCallCheck);
 static JSC_DECLARE_HOST_FUNCTION(fulfillPromiseWithFirstResolvingFunctionCallCheck);
@@ -764,6 +766,19 @@ JSC_DEFINE_HOST_FUNCTION(fulfillPromise, (JSGlobalObject* globalObject, CallFram
     JSValue argument = callFrame->uncheckedArgument(1);
     promise->fulfillPromise(globalObject->vm(), globalObject, argument);
     return encodedJSUndefined();
+}
+
+JSC_DEFINE_HOST_FUNCTION(markPromiseAsHandledHostFunction, (JSGlobalObject*, CallFrame* callFrame))
+{
+    auto* promise = dynamicDowncast<JSPromise>(callFrame->uncheckedArgument(0));
+    promise->markAsHandled();
+    return encodedJSUndefined();
+}
+
+JSC_DEFINE_HOST_FUNCTION(isPromiseStatePending, (JSGlobalObject*, CallFrame* callFrame))
+{
+    auto* promise = dynamicDowncast<JSPromise>(callFrame->uncheckedArgument(0));
+    return JSValue::encode(jsBoolean(promise->status() == JSPromise::Status::Pending));
 }
 
 JSC_DEFINE_HOST_FUNCTION(resolvePromiseWithFirstResolvingFunctionCallCheck, (JSGlobalObject* globalObject, CallFrame* callFrame))
@@ -1969,6 +1984,12 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::fulfillPromise)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, init.owner, 2, "fulfillPromise"_s, fulfillPromise, ImplementationVisibility::Private));
+        });
+    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::markPromiseAsHandled)].initLater([] (const Initializer<JSCell>& init) {
+            init.set(JSFunction::create(init.vm, init.owner, 1, "markPromiseAsHandled"_s, markPromiseAsHandledHostFunction, ImplementationVisibility::Private));
+        });
+    m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::isPromiseStatePending)].initLater([] (const Initializer<JSCell>& init) {
+            init.set(JSFunction::create(init.vm, init.owner, 1, "isPromiseStatePending"_s, isPromiseStatePending, ImplementationVisibility::Private));
         });
     m_linkTimeConstants[static_cast<unsigned>(LinkTimeConstant::resolvePromiseWithFirstResolvingFunctionCallCheck)].initLater([] (const Initializer<JSCell>& init) {
             init.set(JSFunction::create(init.vm, init.owner, 2, "resolvePromiseWithFirstResolvingFunctionCallCheck"_s, resolvePromiseWithFirstResolvingFunctionCallCheck, ImplementationVisibility::Private, ResolvePromiseWithFirstResolvingFunctionCallCheckIntrinsic));

--- a/Source/JavaScriptCore/runtime/JSPromise.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromise.cpp
@@ -32,7 +32,6 @@
 #include "GlobalObjectMethodTable.h"
 #include "JSCInlines.h"
 #include "JSFunctionWithFields.h"
-#include "JSInternalFieldObjectImplInlines.h"
 #include "JSMicrotask.h"
 #include "JSPromiseCombinatorsContext.h"
 #include "JSPromiseCombinatorsGlobalContext.h"
@@ -69,20 +68,15 @@ JSPromise::JSPromise(VM& vm, Structure* structure)
 {
 }
 
-void JSPromise::finishCreation(VM& vm)
-{
-    Base::finishCreation(vm);
-    auto values = initialValues();
-    for (unsigned index = 0; index < values.size(); ++index)
-        Base::internalField(index).set(vm, this, values[index]);
-}
-
 template<typename Visitor>
 void JSPromise::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
     auto* thisObject = uncheckedDowncast<JSPromise>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
+    if (JSCell* payload = thisObject->m_packed.pointer())
+        visitor.appendUnbarriered(payload);
+    visitor.append(thisObject->m_slot);
 }
 
 DEFINE_VISIT_CHILDREN(JSPromise);
@@ -173,40 +167,36 @@ JSPromise* JSPromise::rejectedPromise(JSGlobalObject* globalObject, JSValue valu
 
 void JSPromise::resolve(JSGlobalObject* globalObject, VM& vm, JSValue value)
 {
-    int32_t flags = this->flags();
     ASSERT(!value.inherits<Exception>());
-    if (!(flags & isFirstResolvingFunctionCalledFlag)) {
-        internalField(Field::Flags).setWithoutWriteBarrier(jsNumber(static_cast<int32_t>(flags | isFirstResolvingFunctionCalledFlag)));
+    if (!isFirstResolvingFunctionCalled()) {
+        setFlags(flags() | isFirstResolvingFunctionCalledFlag);
         resolvePromise(globalObject, vm, value);
     }
 }
 
 void JSPromise::reject(VM& vm, JSGlobalObject* globalObject, JSValue value)
 {
-    int32_t flags = this->flags();
     ASSERT(!value.inherits<Exception>());
-    if (!(flags & isFirstResolvingFunctionCalledFlag)) {
-        internalField(Field::Flags).setWithoutWriteBarrier(jsNumber(static_cast<int32_t>(flags | isFirstResolvingFunctionCalledFlag)));
+    if (!isFirstResolvingFunctionCalled()) {
+        setFlags(flags() | isFirstResolvingFunctionCalledFlag);
         rejectPromise(vm, globalObject, value);
     }
 }
 
 void JSPromise::fulfill(VM& vm, JSGlobalObject* globalObject, JSValue value)
 {
-    int32_t flags = this->flags();
     ASSERT(!value.inherits<Exception>());
-    if (!(flags & isFirstResolvingFunctionCalledFlag)) {
-        internalField(Field::Flags).setWithoutWriteBarrier(jsNumber(static_cast<int32_t>(flags | isFirstResolvingFunctionCalledFlag)));
+    if (!isFirstResolvingFunctionCalled()) {
+        setFlags(flags() | isFirstResolvingFunctionCalledFlag);
         fulfillPromise(vm, globalObject, value);
     }
 }
 
 void JSPromise::pipeFrom(VM& vm, JSPromise* from)
 {
-    int32_t flags = this->flags();
-    if (flags & isFirstResolvingFunctionCalledFlag)
+    if (isFirstResolvingFunctionCalled())
         return;
-    internalField(Field::Flags).setWithoutWriteBarrier(jsNumber(static_cast<int32_t>(flags | isFirstResolvingFunctionCalledFlag)));
+    setFlags(flags() | isFirstResolvingFunctionCalledFlag);
 
     JSGlobalObject* globalObject = this->realm();
     from->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::PromiseFulfillWithoutHandlerJob, this, jsUndefined());
@@ -220,7 +210,7 @@ void JSPromise::performPromiseThenExported(VM& vm, JSGlobalObject* globalObject,
 void JSPromise::rejectAsHandled(VM& vm, JSGlobalObject* lexicalGlobalObject, JSValue value)
 {
     // Setting isHandledFlag before calling reject since this removes round-trip between JSC and PromiseRejectionTracker, and it does not show an user-observable behavior.
-    if (!(flags() & isFirstResolvingFunctionCalledFlag)) {
+    if (!isFirstResolvingFunctionCalled()) {
         markAsHandled();
         reject(vm, lexicalGlobalObject, value);
     }
@@ -247,24 +237,88 @@ JSPromise* JSPromise::rejectWithCaughtException(JSGlobalObject* globalObject, Th
     return this;
 }
 
+void JSPromise::setInlineMicrotaskReaction(VM& vm, InternalMicrotask task, JSValue context)
+{
+    ASSERT(status() == Status::Pending);
+    ASSERT(inlineReactionKind() == InlineReactionKind::None);
+    ASSERT(!payloadCell());
+    ASSERT(task != InternalMicrotask::None);
+    // The inline reaction always implies markAsHandled; fold both into one flag update.
+    uint16_t newFlags = flags()
+        | isHandledFlag
+        | (static_cast<uint16_t>(InlineReactionKind::InternalMicrotask) << inlineReactionKindShift)
+        | (static_cast<uint16_t>(task) << inlineReactionMicrotaskShift);
+    setSlot(vm, context);
+    setFlags(newFlags);
+}
+
+void JSPromise::setInlineHandlerReaction(VM& vm, InlineReactionKind kind, JSPromise* resultPromise, JSValue handler)
+{
+    ASSERT(status() == Status::Pending);
+    ASSERT(inlineReactionKind() == InlineReactionKind::None);
+    ASSERT(!payloadCell());
+    ASSERT(kind == InlineReactionKind::FulfillHandler || kind == InlineReactionKind::RejectHandler);
+    ASSERT(resultPromise);
+    uint16_t newFlags = flags()
+        | isHandledFlag
+        | (static_cast<uint16_t>(kind) << inlineReactionKindShift);
+    setSlot(vm, handler);
+    setPackedCell(vm, newFlags, resultPromise);
+}
+
 JSPromiseReaction* JSPromise::spillInlineReaction(VM& vm)
 {
-    ASSERT(hasInlineReaction());
-    InternalMicrotask task = inlineReactionMicrotask();
-    JSValue context = inlineReactionContext();
-    auto* reaction = JSSlimPromiseReaction::create(vm, jsUndefined(), task, context, nullptr);
-    clearInlineReaction();
-    setReactionsOrResult(vm, reaction);
+    auto kind = inlineReactionKind();
+    ASSERT(kind != InlineReactionKind::None);
+    JSSlimPromiseReaction* reaction = nullptr;
+    switch (kind) {
+    case InlineReactionKind::InternalMicrotask: {
+        InternalMicrotask task = inlineReactionMicrotask();
+        JSValue context = m_slot.get();
+        reaction = JSSlimPromiseReaction::create(vm, jsUndefined(), task, context, nullptr);
+        break;
+    }
+    case InlineReactionKind::FulfillHandler:
+    case InlineReactionKind::RejectHandler: {
+        JSPromise* resultPromise = uncheckedDowncast<JSPromise>(payloadCell());
+        JSValue handler = m_slot.get();
+        bool isFulfill = kind == InlineReactionKind::FulfillHandler;
+        reaction = JSSlimPromiseReaction::create(vm, resultPromise, handler, isFulfill, nullptr);
+        break;
+    }
+    case InlineReactionKind::None:
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+    clearSlot();
+    uint16_t newFlags = flags() & ~(inlineReactionKindMask | inlineReactionMicrotaskMask);
+    setPackedCell(vm, newFlags, reaction);
     return reaction;
 }
 
 JSPromiseReaction* JSPromise::reactionHead(VM& vm)
 {
     ASSERT(status() == Status::Pending);
-    if (hasInlineReaction()) [[unlikely]]
+    if (inlineReactionKind() != InlineReactionKind::None) [[unlikely]]
         return spillInlineReaction(vm);
-    JSValue reactionsOrResult = this->reactionsOrResult();
-    return reactionsOrResult ? uncheckedDowncast<JSPromiseReaction>(reactionsOrResult) : nullptr;
+    return uncheckedDowncast<JSPromiseReaction>(payloadCell());
+}
+
+JSValue JSPromise::asyncStackTraceContext() const
+{
+    if (status() != Status::Pending)
+        return { };
+    switch (inlineReactionKind()) {
+    case InlineReactionKind::None: {
+        auto* head = uncheckedDowncast<JSPromiseReaction>(payloadCell());
+        return head ? JSPromiseReaction::tryGetContext(head) : JSValue();
+    }
+    case InlineReactionKind::InternalMicrotask:
+        return m_slot.get();
+    case InlineReactionKind::FulfillHandler:
+    case InlineReactionKind::RejectHandler:
+        return { };
+    }
+    return { };
 }
 
 void JSPromise::performPromiseThen(VM& vm, JSGlobalObject* globalObject, JSValue onFulfilled, JSValue onRejected, JSValue promiseOrCapability)
@@ -272,39 +326,48 @@ void JSPromise::performPromiseThen(VM& vm, JSGlobalObject* globalObject, JSValue
     bool fulfilledCallable = onFulfilled.isCallable();
     bool rejectedCallable = onRejected.isCallable();
 
-    JSValue reactionsOrResult = this->reactionsOrResult();
     switch (status()) {
     case JSPromise::Status::Pending: {
+        bool onlyFulfill = fulfilledCallable && !rejectedCallable;
+        bool onlyReject = !fulfilledCallable && rejectedCallable;
+        if (inlineReactionKind() == InlineReactionKind::None && !payloadCell()) {
+            if ((onlyFulfill || onlyReject) && promiseOrCapability.inherits<JSPromise>()) [[likely]] {
+                auto* resultPromise = uncheckedDowncast<JSPromise>(promiseOrCapability);
+                setInlineHandlerReaction(vm, onlyFulfill ? InlineReactionKind::FulfillHandler : InlineReactionKind::RejectHandler, resultPromise, onlyFulfill ? onFulfilled : onRejected);
+                break;
+            }
+        }
         JSPromiseReaction* existing = reactionHead(vm);
         JSPromiseReaction* reaction;
-        if (fulfilledCallable && !rejectedCallable)
+        if (onlyFulfill)
             reaction = JSSlimPromiseReaction::create(vm, promiseOrCapability, onFulfilled, true, existing);
-        else if (!fulfilledCallable && rejectedCallable)
+        else if (onlyReject)
             reaction = JSSlimPromiseReaction::create(vm, promiseOrCapability, onRejected, false, existing);
         else if (fulfilledCallable) {
             ASSERT(rejectedCallable);
             reaction = JSFullPromiseReaction::create(vm, promiseOrCapability, onFulfilled, onRejected, jsUndefined(), existing);
         } else
             reaction = JSSlimPromiseReaction::create(vm, promiseOrCapability, InternalMicrotask::PromiseResolveWithoutHandlerJob, jsUndefined(), existing);
-        setReactionsOrResult(vm, reaction);
-        markAsHandled();
+        setPackedCell(vm, flags() | isHandledFlag, reaction);
         break;
     }
     case JSPromise::Status::Rejected: {
+        JSValue settled = settlementValue();
         if (!isHandled())
             globalObject->globalObjectMethodTable()->promiseRejectionTracker(globalObject, this, JSPromiseRejectionOperation::Handle);
         if (rejectedCallable)
-            globalObject->queueMicrotask(vm, InternalMicrotask::PromiseReactionJob, static_cast<uint8_t>(Status::Rejected), promiseOrCapability, onRejected, reactionsOrResult);
+            globalObject->queueMicrotask(vm, InternalMicrotask::PromiseReactionJob, static_cast<uint8_t>(Status::Rejected), promiseOrCapability, onRejected, settled);
         else
-            globalObject->queueMicrotask(vm, InternalMicrotask::PromiseResolveWithoutHandlerJob, static_cast<uint8_t>(Status::Rejected), promiseOrCapability, reactionsOrResult, jsUndefined());
+            globalObject->queueMicrotask(vm, InternalMicrotask::PromiseResolveWithoutHandlerJob, static_cast<uint8_t>(Status::Rejected), promiseOrCapability, settled, jsUndefined());
         markAsHandled();
         break;
     }
     case JSPromise::Status::Fulfilled: {
+        JSValue settled = settlementValue();
         if (fulfilledCallable)
-            globalObject->queueMicrotask(vm, InternalMicrotask::PromiseReactionJob, static_cast<uint8_t>(Status::Fulfilled), promiseOrCapability, onFulfilled, reactionsOrResult);
+            globalObject->queueMicrotask(vm, InternalMicrotask::PromiseReactionJob, static_cast<uint8_t>(Status::Fulfilled), promiseOrCapability, onFulfilled, settled);
         else
-            globalObject->queueMicrotask(vm, InternalMicrotask::PromiseResolveWithoutHandlerJob, static_cast<uint8_t>(Status::Fulfilled), promiseOrCapability, reactionsOrResult, jsUndefined());
+            globalObject->queueMicrotask(vm, InternalMicrotask::PromiseResolveWithoutHandlerJob, static_cast<uint8_t>(Status::Fulfilled), promiseOrCapability, settled, jsUndefined());
         break;
     }
     }
@@ -312,31 +375,28 @@ void JSPromise::performPromiseThen(VM& vm, JSGlobalObject* globalObject, JSValue
 
 void JSPromise::performPromiseThenWithInternalMicrotask(VM& vm, JSGlobalObject* globalObject, InternalMicrotask task, JSValue promise, JSValue context)
 {
-    JSValue reactionsOrResult = this->reactionsOrResult();
     switch (status()) {
     case JSPromise::Status::Pending: {
-        if (promise.isUndefined() && !reactionsOrResult) [[likely]] {
-            // setInlineReaction always stores a non-empty cell into ReactionsOrResult,
-            // so an empty ReactionsOrResult implies no inline reaction.
-            ASSERT(!hasInlineReaction());
-            setInlineReaction(vm, task, context);
+        if (promise.isUndefined() && inlineReactionKind() == InlineReactionKind::None && !payloadCell()) [[likely]] {
+            setInlineMicrotaskReaction(vm, task, context);
             break;
         }
         JSPromiseReaction* existing = reactionHead(vm);
         auto* reaction = JSSlimPromiseReaction::create(vm, promise, task, context, existing);
-        setReactionsOrResult(vm, reaction);
-        markAsHandled();
+        setPackedCell(vm, flags() | isHandledFlag, reaction);
         break;
     }
     case JSPromise::Status::Rejected: {
+        JSValue settled = settlementValue();
         if (!isHandled())
             globalObject->globalObjectMethodTable()->promiseRejectionTracker(globalObject, this, JSPromiseRejectionOperation::Handle);
-        globalObject->queueMicrotask(vm, task, static_cast<uint8_t>(Status::Rejected), promise, reactionsOrResult, context);
+        globalObject->queueMicrotask(vm, task, static_cast<uint8_t>(Status::Rejected), promise, settled, context);
         markAsHandled();
         break;
     }
     case JSPromise::Status::Fulfilled: {
-        globalObject->queueMicrotask(vm, task, static_cast<uint8_t>(Status::Fulfilled), promise, reactionsOrResult, context);
+        JSValue settled = settlementValue();
+        globalObject->queueMicrotask(vm, task, static_cast<uint8_t>(Status::Fulfilled), promise, settled, context);
         break;
     }
     }
@@ -365,53 +425,91 @@ bool isDefinitelyNonThenable(JSObject* object, JSGlobalObject* globalObject)
     return true;
 }
 
-ALWAYS_INLINE void JSPromise::settleInlineReaction(VM& vm, JSGlobalObject* globalObject, Status status, JSValue argument, int32_t flags)
+ALWAYS_INLINE void JSPromise::settleInlineInternalMicrotask(VM& vm, JSGlobalObject* globalObject, Status newStatus, JSValue argument, uint16_t flagsSnapshot)
 {
-    ASSERT(flags & hasInlineReactionFlag);
-    // setInlineReaction always sets isHandledFlag, so no rejection tracker call needed.
-    ASSERT(flags & isHandledFlag);
-    InternalMicrotask task = static_cast<InternalMicrotask>((flags & inlineReactionMicrotaskMask) >> inlineReactionMicrotaskShift);
-    JSValue context = reactionsOrResult();
-    internalField(Field::Flags).setWithoutWriteBarrier(jsNumber((flags & ~(hasInlineReactionFlag | inlineReactionMicrotaskMask)) | static_cast<int32_t>(status)));
-    internalField(Field::ReactionsOrResult).set(vm, this, argument);
-    globalObject->queueMicrotask(vm, task, static_cast<uint8_t>(status), jsUndefined(), argument, context);
+    ASSERT((flagsSnapshot & inlineReactionKindMask) == (static_cast<uint16_t>(InlineReactionKind::InternalMicrotask) << inlineReactionKindShift));
+    ASSERT(flagsSnapshot & isHandledFlag);
+    InternalMicrotask task = static_cast<InternalMicrotask>((flagsSnapshot & inlineReactionMicrotaskMask) >> inlineReactionMicrotaskShift);
+    JSValue context = m_slot.get();
+    uint16_t settledFlags = (flagsSnapshot & ~(inlineReactionKindMask | inlineReactionMicrotaskMask)) | static_cast<uint16_t>(newStatus);
+    setSlot(vm, argument);
+    setPackedCell(vm, settledFlags, nullptr);
+    globalObject->queueMicrotask(vm, task, static_cast<uint8_t>(newStatus), jsUndefined(), argument, context);
+}
+
+ALWAYS_INLINE void JSPromise::settleInlineHandler(VM& vm, JSGlobalObject* globalObject, Status newStatus, JSValue argument, uint16_t flagsSnapshot)
+{
+    ASSERT(flagsSnapshot & isHandledFlag);
+    InlineReactionKind kind = static_cast<InlineReactionKind>((flagsSnapshot & inlineReactionKindMask) >> inlineReactionKindShift);
+    ASSERT(kind == InlineReactionKind::FulfillHandler || kind == InlineReactionKind::RejectHandler);
+    bool settledIsFulfilled = newStatus == Status::Fulfilled;
+    bool handlerIsFulfill = kind == InlineReactionKind::FulfillHandler;
+    JSPromise* resultPromise = uncheckedDowncast<JSPromise>(payloadCell());
+    JSValue handler = m_slot.get();
+    uint16_t settledFlags = (flagsSnapshot & ~(inlineReactionKindMask | inlineReactionMicrotaskMask)) | static_cast<uint16_t>(newStatus);
+    setSlot(vm, argument);
+    setPackedCell(vm, settledFlags, nullptr);
+    if (settledIsFulfilled == handlerIsFulfill)
+        globalObject->queueMicrotask(vm, InternalMicrotask::PromiseReactionJob, static_cast<uint8_t>(newStatus), resultPromise, handler, argument);
+    else
+        globalObject->queueMicrotask(vm, InternalMicrotask::PromiseResolveWithoutHandlerJob, static_cast<uint8_t>(newStatus), resultPromise, argument, jsUndefined());
 }
 
 void JSPromise::rejectPromise(VM& vm, JSGlobalObject* globalObject, JSValue argument)
 {
     ASSERT(status() == Status::Pending);
-    int32_t flags = this->flags();
+    uint16_t currentFlags = flags();
+    auto kind = static_cast<InlineReactionKind>((currentFlags & inlineReactionKindMask) >> inlineReactionKindShift);
+    switch (kind) {
+    case InlineReactionKind::InternalMicrotask:
+        return settleInlineInternalMicrotask(vm, globalObject, Status::Rejected, argument, currentFlags);
 
-    if (flags & hasInlineReactionFlag)
-        return settleInlineReaction(vm, globalObject, Status::Rejected, argument, flags);
+    case InlineReactionKind::FulfillHandler:
+    case InlineReactionKind::RejectHandler:
+        return settleInlineHandler(vm, globalObject, Status::Rejected, argument, currentFlags);
 
-    JSValue reactions = this->reactionsOrResult();
-    internalField(Field::Flags).setWithoutWriteBarrier(jsNumber(static_cast<int32_t>(flags | static_cast<uint32_t>(Status::Rejected))));
-    internalField(Field::ReactionsOrResult).set(vm, this, argument);
+    case InlineReactionKind::None: {
+        JSPromiseReaction* reactions = uncheckedDowncast<JSPromiseReaction>(payloadCell());
+        uint16_t settledFlags = currentFlags | static_cast<uint16_t>(Status::Rejected);
+        setSlot(vm, argument);
+        setPackedCell(vm, settledFlags, nullptr);
 
-    if (!isHandled())
-        globalObject->globalObjectMethodTable()->promiseRejectionTracker(globalObject, this, JSPromiseRejectionOperation::Reject);
+        if (!isHandled())
+            globalObject->globalObjectMethodTable()->promiseRejectionTracker(globalObject, this, JSPromiseRejectionOperation::Reject);
 
-    if (!reactions)
+        if (!reactions)
+            return;
+        triggerPromiseReactions(vm, globalObject, Status::Rejected, reactions, argument);
         return;
-    triggerPromiseReactions(vm, globalObject, Status::Rejected, uncheckedDowncast<JSPromiseReaction>(reactions), argument);
+    }
+    }
 }
 
 void JSPromise::fulfillPromise(VM& vm, JSGlobalObject* globalObject, JSValue argument)
 {
     ASSERT(status() == Status::Pending);
-    int32_t flags = this->flags();
+    uint16_t currentFlags = flags();
+    auto kind = static_cast<InlineReactionKind>((currentFlags & inlineReactionKindMask) >> inlineReactionKindShift);
+    switch (kind) {
+    case InlineReactionKind::InternalMicrotask:
+        return settleInlineInternalMicrotask(vm, globalObject, Status::Fulfilled, argument, currentFlags);
 
-    if (flags & hasInlineReactionFlag)
-        return settleInlineReaction(vm, globalObject, Status::Fulfilled, argument, flags);
+    case InlineReactionKind::FulfillHandler:
+    case InlineReactionKind::RejectHandler:
+        return settleInlineHandler(vm, globalObject, Status::Fulfilled, argument, currentFlags);
 
-    JSValue reactions = this->reactionsOrResult();
-    internalField(Field::Flags).setWithoutWriteBarrier(jsNumber(static_cast<int32_t>(flags | static_cast<uint32_t>(Status::Fulfilled))));
-    internalField(Field::ReactionsOrResult).set(vm, this, argument);
+    case InlineReactionKind::None: {
+        JSPromiseReaction* reactions = uncheckedDowncast<JSPromiseReaction>(payloadCell());
+        uint16_t settledFlags = currentFlags | static_cast<uint16_t>(Status::Fulfilled);
+        setSlot(vm, argument);
+        setPackedCell(vm, settledFlags, nullptr);
 
-    if (!reactions)
+        if (!reactions)
+            return;
+        triggerPromiseReactions(vm, globalObject, Status::Fulfilled, reactions, argument);
         return;
-    triggerPromiseReactions(vm, globalObject, Status::Fulfilled, uncheckedDowncast<JSPromiseReaction>(reactions), argument);
+    }
+    }
 }
 
 void JSPromise::resolvePromise(JSGlobalObject* globalObject, VM& vm, JSValue resolution)

--- a/Source/JavaScriptCore/runtime/JSPromise.h
+++ b/Source/JavaScriptCore/runtime/JSPromise.h
@@ -25,15 +25,23 @@
 
 #pragma once
 
-#include <JavaScriptCore/JSInternalFieldObjectImpl.h>
+#include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/Microtask.h>
+#include <wtf/CompactPointerTuple.h>
 
 namespace JSC {
 
 class JSPromiseConstructor;
-class JSPromise : public JSInternalFieldObjectImpl<2> {
+class JSPromiseReaction;
+
+// JSPromise stores its state in two machine words:
+//   m_packed: CompactPointerTuple<JSCell*, uint16_t>
+//       Lower 48 bits: payload cell pointer (may be null)
+//       Upper 16 bits: flags (see Flags layout below)
+//   m_slot: JSValue (as WriteBarrier<Unknown>)
+class JSPromise : public JSNonFinalObject {
 public:
-    using Base = JSInternalFieldObjectImpl<2>;
+    using Base = JSNonFinalObject;
 
     template<typename CellType, SubspaceAccess mode>
     static GCClient::IsoSubspace* subspaceFor(VM& vm)
@@ -45,64 +53,65 @@ public:
     static JSPromise* createWithInitialValues(VM&, Structure*);
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
+    static size_t allocationSize(Checked<size_t> inlineCapacity)
+    {
+        ASSERT_UNUSED(inlineCapacity, !inlineCapacity);
+        return sizeof(JSPromise);
+    }
+
     DECLARE_EXPORT_INFO;
 
-    enum class Status : int32_t {
+    // Flags layout (upper 16 bits of m_packed):
+    //   bits 0-1:   Status
+    //   bit 2:      isHandled
+    //   bit 3:      isFirstResolvingFunctionCalled
+    //   bits 4-5:   InlineReactionKind (4 values, 2 bits)
+    //   bits 6-13:  InternalMicrotask (only when kind == InternalMicrotask)
+    //   bits 14-15: reserved
+
+    enum class Status : uint16_t {
         Pending = 0, // Making this as 0, so that, we can change the status from Pending to others without masking.
         Fulfilled = 1,
         Rejected = 2,
     };
-    static constexpr int32_t isHandledFlag = 4;
-    static constexpr int32_t isFirstResolvingFunctionCalledFlag = 8;
-    static constexpr int32_t stateMask = 0b11;
 
-    // For pending promises with exactly one internal-microtask reaction whose result
-    // promise is undefined (the common await / async-generator-resume case), we avoid
-    // allocating a JSSlimPromiseReaction by storing the InternalMicrotask in the upper
-    // bits of Flags and the reaction's context in ReactionsOrResult.
-    static constexpr int32_t hasInlineReactionFlag = 16;
-    static constexpr int32_t inlineReactionMicrotaskShift = 5;
-    static constexpr int32_t inlineReactionMicrotaskMask = 0xff << inlineReactionMicrotaskShift;
-
-    enum class Field : unsigned {
-        Flags = 0,
-        // Pending + hasInlineReactionFlag: the inline reaction's context cell.
-        // Pending otherwise: head of the JSPromiseReaction chain (or empty).
-        // Fulfilled / Rejected: the settlement value.
-        ReactionsOrResult = 1,
+    enum class InlineReactionKind : uint8_t {
+        None = 0,
+        InternalMicrotask = 1,
+        FulfillHandler = 2,
+        RejectHandler = 3,
     };
-    static_assert(numberOfInternalFields == 2);
 
-    static std::array<JSValue, numberOfInternalFields> initialValues()
+    static constexpr uint16_t stateMask                          = 0b0000000000000011;
+    static constexpr uint16_t isHandledFlag                      = 0b0000000000000100;
+    static constexpr uint16_t isFirstResolvingFunctionCalledFlag = 0b0000000000001000;
+    static constexpr uint16_t inlineReactionKindMask             = 0b0000000000110000;
+    static constexpr uint16_t inlineReactionMicrotaskMask        = 0b0011111111000000;
+    static constexpr unsigned inlineReactionKindShift = 4;
+    static constexpr unsigned inlineReactionMicrotaskShift = 6;
+
+    static constexpr ptrdiff_t offsetOfPacked() { return OBJECT_OFFSETOF(JSPromise, m_packed); }
+    static constexpr ptrdiff_t offsetOfSlot() { return OBJECT_OFFSETOF(JSPromise, m_slot); }
+
+    inline uint16_t flags() const { return m_packed.type(); }
+
+    inline Status status() const { return static_cast<Status>(flags() & stateMask); }
+    inline bool isHandled() const { return flags() & isHandledFlag; }
+
+    // Value accessors — meaningful only after settlement.
+    inline JSValue settlementValue() const
     {
-        return { {
-            jsNumber(static_cast<int32_t>(Status::Pending)),
-            JSValue(),
-        } };
+        ASSERT(status() != Status::Pending);
+        return m_slot.get();
     }
-
-    const WriteBarrier<Unknown>& internalField(Field field) const { return Base::internalField(static_cast<uint32_t>(field)); }
-    WriteBarrier<Unknown>& internalField(Field field) { return Base::internalField(static_cast<uint32_t>(field)); }
-
-    inline Status status() const
-    {
-        JSValue value = internalField(Field::Flags).get();
-        int32_t flags = value.asInt32AsAnyInt();
-        return static_cast<Status>(flags & stateMask);
-    }
-
-    inline bool isHandled() const
-    {
-        return flags() & isHandledFlag;
-    }
-
     inline JSValue result() const
     {
-        Status status = this->status();
-        if (status == Status::Pending)
+        if (status() == Status::Pending)
             return jsUndefined();
-        return internalField(Field::ReactionsOrResult).get();
+        return m_slot.get();
     }
+
+    JSValue asyncStackTraceContext() const;
 
     JS_EXPORT_PRIVATE static JSPromise* resolvedPromise(JSGlobalObject*, JSValue);
     JS_EXPORT_PRIVATE static JSPromise* rejectedPromise(JSGlobalObject*, JSValue);
@@ -120,22 +129,8 @@ public:
 
     JS_EXPORT_PRIVATE JSPromise* rejectWithCaughtException(JSGlobalObject*, ThrowScope&);
 
-    JSValue reactionsOrResult() const { return internalField(Field::ReactionsOrResult).get(); };
-    void setReactionsOrResult(VM& vm, JSValue value) { internalField(Field::ReactionsOrResult).set(vm, this, value); };
-
-    bool hasInlineReaction() const { return flags() & hasInlineReactionFlag; }
-    JSValue inlineReactionContext() const
-    {
-        ASSERT(hasInlineReaction());
-        return reactionsOrResult();
-    }
-
     // https://webidl.spec.whatwg.org/#mark-a-promise-as-handled
-    void markAsHandled()
-    {
-        int32_t flags = this->flags();
-        internalField(Field::Flags).setWithoutWriteBarrier(jsNumber(flags | isHandledFlag));
-    }
+    void markAsHandled() { m_packed.setType(flags() | isHandledFlag); }
 
     struct DeferredData {
         WTF_FORBID_HEAP_ALLOCATION;
@@ -173,43 +168,70 @@ public:
     static JSObject* promiseReject(JSGlobalObject*, JSObject* constructor, JSValue);
 
     JS_EXPORT_PRIVATE JSObject* then(JSGlobalObject*, JSValue onFulfilled, JSValue onRejected);
+
 protected:
     JSPromise(VM&, Structure*);
-    void finishCreation(VM&);
 
-    inline int32_t flags() const
-    {
-        JSValue value = internalField(Field::Flags).get();
-        return value.asInt32AsAnyInt();
-    }
+    DECLARE_DEFAULT_FINISH_CREATION;
 
 private:
-    InternalMicrotask inlineReactionMicrotask() const
+    inline bool isFirstResolvingFunctionCalled() const { return flags() & isFirstResolvingFunctionCalledFlag; }
+
+    inline InlineReactionKind inlineReactionKind() const
     {
-        ASSERT(hasInlineReaction());
-        return static_cast<InternalMicrotask>((flags() & inlineReactionMicrotaskMask) >> inlineReactionMicrotaskShift);
+        return static_cast<InlineReactionKind>((flags() & inlineReactionKindMask) >> inlineReactionKindShift);
     }
-    void setInlineReaction(VM& vm, InternalMicrotask task, JSValue context)
+    inline bool hasInlineReaction() const { return inlineReactionKind() != InlineReactionKind::None; }
+    inline bool hasInlineHandlerReaction() const
     {
-        ASSERT(status() == Status::Pending);
-        ASSERT(!reactionsOrResult());
-        ASSERT(task != InternalMicrotask::None);
-        int32_t flags = this->flags();
-        ASSERT(!(flags & hasInlineReactionFlag));
-        // The inline reaction always implies markAsHandled, so set both bits in one write.
-        internalField(Field::Flags).setWithoutWriteBarrier(jsNumber(flags | hasInlineReactionFlag | isHandledFlag | (static_cast<int32_t>(task) << inlineReactionMicrotaskShift)));
-        setReactionsOrResult(vm, context);
+        auto kind = inlineReactionKind();
+        return kind == InlineReactionKind::FulfillHandler || kind == InlineReactionKind::RejectHandler;
     }
-    void clearInlineReaction()
+
+    // Pending-state accessors. The caller is responsible for checking state.
+    inline JSValue inlineReactionContext() const
     {
-        int32_t flags = this->flags();
-        ASSERT(flags & hasInlineReactionFlag);
-        internalField(Field::Flags).setWithoutWriteBarrier(jsNumber(flags & ~(hasInlineReactionFlag | inlineReactionMicrotaskMask)));
+        ASSERT(inlineReactionKind() == InlineReactionKind::InternalMicrotask);
+        return m_slot.get();
     }
+    inline JSValue inlineHandlerHandler() const
+    {
+        ASSERT(hasInlineHandlerReaction());
+        return m_slot.get();
+    }
+    inline JSPromise* inlineHandlerResultPromise() const
+    {
+        ASSERT(hasInlineHandlerReaction());
+        return uncheckedDowncast<JSPromise>(payloadCell());
+    }
+    inline JSCell* payloadCell() const { return m_packed.pointer(); }
+
+    void setFlags(uint16_t newFlags) { m_packed.setType(newFlags); }
+    void setPackedCell(VM& vm, uint16_t newFlags, JSCell* cell)
+    {
+        m_packed = CompactPointerTuple<JSCell*, uint16_t> { cell, newFlags };
+        if (cell)
+            vm.writeBarrier(this, cell);
+    }
+    void setSlot(VM& vm, JSValue value) { m_slot.set(vm, this, value); }
+    void clearSlot() { m_slot.clear(); }
+
+    void setInlineMicrotaskReaction(VM&, InternalMicrotask, JSValue context);
+    void setInlineHandlerReaction(VM&, InlineReactionKind, JSPromise* resultPromise, JSValue handler);
     JSPromiseReaction* spillInlineReaction(VM&);
     JSPromiseReaction* reactionHead(VM&);
-    void settleInlineReaction(VM&, JSGlobalObject*, Status, JSValue argument, int32_t flags);
+    void settleInlineInternalMicrotask(VM&, JSGlobalObject*, Status, JSValue argument, uint16_t flags);
+    void settleInlineHandler(VM&, JSGlobalObject*, Status, JSValue argument, uint16_t flags);
     static void triggerPromiseReactions(VM&, JSGlobalObject*, JSPromise::Status, JSPromiseReaction* head, JSValue argument);
+
+    InternalMicrotask inlineReactionMicrotask() const
+    {
+        ASSERT(inlineReactionKind() == InlineReactionKind::InternalMicrotask);
+        return static_cast<InternalMicrotask>((flags() & inlineReactionMicrotaskMask) >> inlineReactionMicrotaskShift);
+    }
+
+    CompactPointerTuple<JSCell*, uint16_t> m_packed;
+    WriteBarrier<Unknown> m_slot;
 };
 
 static constexpr PropertyOffset promiseCapabilityResolvePropertyOffset = 0;

--- a/Source/WebCore/Modules/streams/StreamInternals.js
+++ b/Source/WebCore/Modules/streams/StreamInternals.js
@@ -26,14 +26,6 @@
 
 // @internal
 
-function markPromiseAsHandled(promise)
-{
-    "use strict";
-
-    @assert(@isPromise(promise));
-    @putPromiseInternalField(promise, @promiseFieldFlags, @getPromiseInternalField(promise, @promiseFieldFlags) | @promiseFlagsIsHandled);
-}
-
 function shieldingPromiseResolve(result)
 {
     "use strict";

--- a/Source/WebCore/Modules/streams/WritableStreamInternals.js
+++ b/Source/WebCore/Modules/streams/WritableStreamInternals.js
@@ -508,7 +508,7 @@ function writableStreamDefaultWriterEnsureClosedPromiseRejected(writer, error)
     let closedPromiseCapability = @getByIdDirectPrivate(writer, "closedPromise");
     let closedPromise = closedPromiseCapability.promise;
 
-    if ((@getPromiseInternalField(closedPromise, @promiseFieldFlags) & @promiseStateMask) !== @promiseStatePending) {
+    if (!@isPromiseStatePending(closedPromise)) {
         closedPromiseCapability = @newPromiseCapability(@Promise);
         closedPromise = closedPromiseCapability.promise;
         @putByIdDirectPrivate(writer, "closedPromise", closedPromiseCapability);
@@ -523,7 +523,7 @@ function writableStreamDefaultWriterEnsureReadyPromiseRejected(writer, error)
     let readyPromiseCapability = @getByIdDirectPrivate(writer, "readyPromise");
     let readyPromise = readyPromiseCapability.promise;
 
-    if ((@getPromiseInternalField(readyPromise, @promiseFieldFlags) & @promiseStateMask) !== @promiseStatePending) {
+    if (!@isPromiseStatePending(readyPromise)) {
         readyPromiseCapability = @newPromiseCapability(@Promise);
         readyPromise = readyPromiseCapability.promise;
         @putByIdDirectPrivate(writer, "readyPromise", readyPromiseCapability);


### PR DESCRIPTION
#### 3f9955f695b6fd08fe816d37aaea66e8e67429fe
<pre>
[JSC] Do not allocate promise reaction when it is initial `then` calls and one handler attachment
<a href="https://bugs.webkit.org/show_bug.cgi?id=314733">https://bugs.webkit.org/show_bug.cgi?id=314733</a>
<a href="https://rdar.apple.com/176981580">rdar://176981580</a>

Reviewed by Yijia Huang.

This patch changes JSPromise layout so that we can avoid promise
reaction cell allocation when it is initial `then` calls and one
handler attachment. This is by-far common case: most of promise
use is having one `then(function () { ... })` fulfill handler and
it is rare that one promise is having multiple reactions. We
optimize this pattern so one reaction case is efficiently packed
without allocating a new promise reaction cell. This is achievable
since we now moved all JSPromise modification code from builtin JS
code to C++, so any new careful handling does not require builtin
JS interaction including JIT code. So,

1. We change JSPromise from JSInternalFieldObjectImpl to normal JS
   object. We also add NewPromise / PhantomNewPromise DFG nodes to
   keep its efficiency. This model is aligned to JSFunction for
   example. So then, we are fine to have much more complicated fields
   beyond JSValue fields.
2. We add CompactPointerTuple field in JSPromise to have cell and flags
   in one field. This allows us to fold optimized fulfill / reject handlers
   placed inside JSPromise instead of allocating a reaction cell.

Tests: JSTests/stress/promise-inline-child-reaction.js
       JSTests/stress/promise-packed-layout-gc-stress.js

* JSTests/stress/promise-inline-child-reaction.js: Added.
(shouldBe):
(defer):
(async main):
(main.then):
* JSTests/stress/promise-packed-layout-gc-stress.js: Added.
(shouldBe):
(defer):
(async stressOne):
(async main):
(main.then):
* Source/JavaScriptCore/b3/B3AbstractHeapRepository.cpp:
* Source/JavaScriptCore/b3/B3AbstractHeapRepository.h:
* Source/JavaScriptCore/builtins/BuiltinNames.h:
* Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.cpp:
(JSC::BytecodeIntrinsicRegistry::BytecodeIntrinsicRegistry):
* Source/JavaScriptCore/bytecode/BytecodeIntrinsicRegistry.h:
* Source/JavaScriptCore/bytecode/LinkTimeConstant.h:
* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::promiseInternalFieldIndex): Deleted.
(JSC::BytecodeIntrinsicNode::emit_intrinsic_getPromiseInternalField): Deleted.
(JSC::BytecodeIntrinsicNode::emit_intrinsic_putPromiseInternalField): Deleted.
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::parseBlock):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGClobbersExitState.cpp:
(JSC::DFG::clobbersExitState):
* Source/JavaScriptCore/dfg/DFGCloneHelper.h:
* Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp:
(JSC::DFG::ConstantFoldingPhase::foldConstants):
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp:
(JSC::DFG::LoopUnrollingPhase::LoopData::isMaterialNode):
* Source/JavaScriptCore/dfg/DFGMayExit.cpp:
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::convertToNewPromise):
(JSC::DFG::Node::convertToPhantomNewPromise):
(JSC::DFG::Node::convertToNewResolvedPromise):
(JSC::DFG::Node::hasStructure):
(JSC::DFG::Node::isPhantomAllocation):
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGObjectAllocationSinkingPhase.cpp:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
(JSC::DFG::SpeculativeJIT::compileCreatePromise):
(JSC::DFG::SpeculativeJIT::compileNewPromise):
(JSC::DFG::SpeculativeJIT::compileNewResolvedPromise):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
(JSC::DFG::SpeculativeJIT::compileCreatePromise):
(JSC::DFG::SpeculativeJIT::compileNewPromise):
(JSC::DFG::SpeculativeJIT::compileNewResolvedPromise):
* Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp:
* Source/JavaScriptCore/dfg/DFGValidate.cpp:
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileNewInternalFieldObject):
(JSC::FTL::DFG::LowerDFGToB3::compileNewPromise):
(JSC::FTL::DFG::LowerDFGToB3::compileCreatePromise):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/ftl/FTLOperations.cpp:
(JSC::FTL::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::Interpreter::getAsyncStackTrace):
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSGlobalObject::init):
* Source/JavaScriptCore/runtime/JSPromise.cpp:
(JSC::JSPromise::visitChildrenImpl):
(JSC::JSPromise::resolve):
(JSC::JSPromise::reject):
(JSC::JSPromise::fulfill):
(JSC::JSPromise::pipeFrom):
(JSC::JSPromise::rejectAsHandled):
(JSC::JSPromise::setInlineMicrotaskReaction):
(JSC::JSPromise::setInlineHandlerReaction):
(JSC::JSPromise::spillInlineReaction):
(JSC::JSPromise::reactionHead):
(JSC::JSPromise::asyncStackTraceContext const):
(JSC::JSPromise::performPromiseThen):
(JSC::JSPromise::performPromiseThenWithInternalMicrotask):
(JSC::JSPromise::settleInlineInternalMicrotask):
(JSC::JSPromise::settleInlineHandler):
(JSC::JSPromise::rejectPromise):
(JSC::JSPromise::fulfillPromise):
(JSC::JSPromise::finishCreation):
(JSC::JSPromise::settleInlineReaction): Deleted.
* Source/JavaScriptCore/runtime/JSPromise.h:
(JSC::JSPromise::allocationSize):
(JSC::JSPromise::offsetOfPacked):
(JSC::JSPromise::offsetOfSlot):
(JSC::JSPromise::flags const):
(JSC::JSPromise::status const):
(JSC::JSPromise::isHandled const):
(JSC::JSPromise::settlementValue const):
(JSC::JSPromise::result const):
(JSC::JSPromise::markAsHandled):
(JSC::JSPromise::isFirstResolvingFunctionCalled const):
(JSC::JSPromise::inlineReactionKind const):
(JSC::JSPromise::hasInlineReaction const):
(JSC::JSPromise::hasInlineHandlerReaction const):
(JSC::JSPromise::inlineReactionContext const):
(JSC::JSPromise::inlineHandlerHandler const):
(JSC::JSPromise::inlineHandlerResultPromise const):
(JSC::JSPromise::payloadCell const):
(JSC::JSPromise::setFlags):
(JSC::JSPromise::setPackedCell):
(JSC::JSPromise::setSlot):
(JSC::JSPromise::clearSlot):
(JSC::JSPromise::inlineReactionMicrotask const):
(JSC::JSPromise::initialValues): Deleted.
(JSC::JSPromise::internalField const): Deleted.
(JSC::JSPromise::internalField): Deleted.
(JSC::JSPromise::reactionsOrResult const): Deleted.
(JSC::JSPromise::setReactionsOrResult): Deleted.
(JSC::JSPromise::setInlineReaction): Deleted.
(JSC::JSPromise::clearInlineReaction): Deleted.
* Source/WebCore/Modules/streams/StreamInternals.js:
(markPromiseAsHandled):
* Source/WebCore/Modules/streams/WritableStreamInternals.js:
(writableStreamDefaultWriterEnsureClosedPromiseRejected):
(writableStreamDefaultWriterEnsureReadyPromiseRejected):

Canonical link: <a href="https://commits.webkit.org/313220@main">https://commits.webkit.org/313220@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/20cb978577ed7778174bcc5082f0ebe62c46d830

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162447 "7 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35923 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29039 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171385 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/118892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164316 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36027 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35927 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126064 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/118892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165406 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28406 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145932 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106642 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27452 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25979 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19085 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137155 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23663 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173889 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23286 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21202 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25307 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134370 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35597 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30069 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134370 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35581 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145459 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97836 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24678 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28903 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/22291 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194847 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35090 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102842 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/50342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34592 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34837 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34740 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->