### PR TITLE
ANGLE: Fix crash from stale texture views during size transitions

### DIFF
--- a/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/TextureMtl.mm
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/TextureMtl.mm
@@ -154,27 +154,6 @@ GLuint GetImageCubeFaceIndexOrZeroFrom(const gl::ImageIndex &index)
     return 0;
 }
 
-// Given texture type, get texture type of one image for a glTexImage call.
-// For example, for texture 2d, one image is also texture 2d.
-// for texture cube, one image is texture 2d.
-gl::TextureType GetTextureImageType(gl::TextureType texType)
-{
-    switch (texType)
-    {
-        case gl::TextureType::CubeMap:
-            return gl::TextureType::_2D;
-        case gl::TextureType::_2D:
-        case gl::TextureType::_2DArray:
-        case gl::TextureType::_2DMultisample:
-        case gl::TextureType::_3D:
-        case gl::TextureType::Rectangle:
-            return texType;
-        default:
-            UNREACHABLE();
-            return gl::TextureType::InvalidEnum;
-    }
-}
-
 // D24X8 by default writes depth data to high 24 bits of 32 bit integers. However, Metal separate
 // depth stencil blitting expects depth data to be in low 24 bits of the data.
 void WriteDepthStencilToDepth24(const uint8_t *srcPtr, uint8_t *dstPtr)
@@ -1030,7 +1009,7 @@ angle::Result TextureMtl::ensureNativeStorageCreated(const gl::Context *context,
 
                 // Invalidate texture image definition at this index so that we can make it a
                 // view of the native texture at this index later.
-                imageToTransfer = nullptr;
+                mTexImageDefs[face][imageMipLevel] = {};
             }
         }
     }
@@ -1713,7 +1692,20 @@ angle::Result TextureMtl::generateMipmap(const gl::Context *context)
 {
     ANGLE_TRY(ensureNativeStorageCreated(context, false));
 
+    int numCubeFaces = static_cast<int>(mNativeTextureStorage->cubeFaces());
+    for (int face = 0; face < numCubeFaces; ++face)
+    {
+        const GLuint mips = mNativeTextureStorage->mipmapLevels();
+        for (mtl::MipmapNativeLevel mip = mtl::kZeroNativeMipLevel; mip.get() < mips; ++mip)
+        {
+            GLuint level = mNativeTextureStorage->getGLLevel(mip);
+            // Recreate views conservatively. All views should point to mNativeTextureStorage.
+            mTexImageDefs[face][level] = {};
+        }
+    }
+    
     ContextMtl *contextMtl = mtl::GetImpl(context);
+    contextMtl->invalidateCurrentTextures();
     if (!mViewFromBaseToMaxLevel)
     {
         return angle::Result::Continue;
@@ -2079,22 +2071,29 @@ angle::Result TextureMtl::redefineImage(const gl::Context *context,
                                         const mtl::Format &mtlFormat,
                                         const gl::Extents &size)
 {
-    bool imageWithinNativeStorageLevels = false;
-    if (mNativeTextureStorage && mNativeTextureStorage->isGLLevelSupported(index.getLevelIndex()))
+    GLuint cubeFaceOrZero        = GetImageCubeFaceIndexOrZeroFrom(index);
+    GLuint glLevel               = index.getLevelIndex();
+    ImageDefinitionMtl &imageDef = mTexImageDefs[cubeFaceOrZero][glLevel];
+
+    if (mNativeTextureStorage && mNativeTextureStorage->isGLLevelSupported(glLevel))
     {
-        imageWithinNativeStorageLevels = true;
-        GLuint glLevel                 = index.getLevelIndex();
-        // Calculate the expected size for the index we are defining. If the size is different
-        // from the given size, or the format is different, we are redefining the image so we
-        // must release it.
+        // mNativeTextureStorage stores the complete mipmap chain when present.
         ASSERT(mNativeTextureStorage->textureType() == mtl::GetTextureType(index.getType()));
-        if (mNativeTextureStorage->getFormat() != mtlFormat ||
-            size != mNativeTextureStorage->size(glLevel))
+        if (mNativeTextureStorage->getFormat() == mtlFormat && size == mNativeTextureStorage->size(glLevel))
         {
-            // Keep other images
-            deallocateNativeStorage(/*keepImages=*/true);
+            return angle::Result::Continue;
         }
+        // The redefinition makes the mipmap chain incomplete. Move the mipmaps to
+        // detached views.
+        deallocateNativeStorage(/*keepImages=*/true);
     }
+
+    // The detached view might be not match format or size, currently we do not reuse these.
+    imageDef = {};
+
+    ContextMtl *contextMtl = mtl::GetImpl(context);
+    // Tell context to rebind textures
+    contextMtl->invalidateCurrentTextures();
 
     // Early-out on empty textures, don't create a zero-sized storage.
     if (size.empty())
@@ -2102,55 +2101,38 @@ angle::Result TextureMtl::redefineImage(const gl::Context *context,
         return angle::Result::Continue;
     }
 
-    ContextMtl *contextMtl = mtl::GetImpl(context);
-    ImageDefinitionMtl &imageDef = getImageDefinition(index);
-
-    // If native texture still exists, it means the size hasn't been changed, no need to create new
-    // image
-    if (mNativeTextureStorage && imageDef.image && imageWithinNativeStorageLevels)
+    mtl::TextureRef image;
+    bool allowFormatView =
+        mtlFormat.hasDepthAndStencilBits() ||
+        needsFormatViewForPixelLocalStorage(
+            contextMtl->getDisplay()->getNativePixelLocalStorageOptions(), mtlFormat);
+    // Create image to hold texture's data at this level & slice:
+    switch (index.getType())
     {
-        ASSERT(imageDef.image->textureType() ==
-                   mtl::GetTextureType(GetTextureImageType(index.getType())) &&
-               imageDef.formatID == mNativeTextureStorage->getFormat().intendedFormatId &&
-               imageDef.image->sizeAt0() == size);
-    }
-    else
-    {
-        imageDef.formatID    = mtlFormat.intendedFormatId;
-        bool allowFormatView =
-            mtlFormat.hasDepthAndStencilBits() ||
-            needsFormatViewForPixelLocalStorage(
-                contextMtl->getDisplay()->getNativePixelLocalStorageOptions(), mtlFormat);
-        // Create image to hold texture's data at this level & slice:
-        switch (index.getType())
-        {
-            case gl::TextureType::_2D:
-            case gl::TextureType::CubeMap:
-                ANGLE_TRY(mtl::Texture::Make2DTexture(
-                    contextMtl, mtlFormat, size.width, size.height, 1,
-                    /** renderTargetOnly */ false, allowFormatView, &imageDef.image));
-                break;
-            case gl::TextureType::_3D:
-                ANGLE_TRY(mtl::Texture::Make3DTexture(
-                    contextMtl, mtlFormat, size.width, size.height, size.depth, 1,
-                    /** renderTargetOnly */ false, allowFormatView, &imageDef.image));
-                break;
-            case gl::TextureType::_2DArray:
-                ANGLE_TRY(mtl::Texture::Make2DArrayTexture(
-                    contextMtl, mtlFormat, size.width, size.height, 1, size.depth,
-                    /** renderTargetOnly */ false, allowFormatView, &imageDef.image));
-                break;
-            default:
-                UNREACHABLE();
-        }
-
-        // Make sure emulated channels are properly initialized in this newly allocated texture.
-        ANGLE_TRY(checkForEmulatedChannels(context, mtlFormat, imageDef.image));
+        case gl::TextureType::_2D:
+        case gl::TextureType::CubeMap:
+            ANGLE_TRY(mtl::Texture::Make2DTexture(
+                contextMtl, mtlFormat, size.width, size.height, 1,
+                /** renderTargetOnly */ false, allowFormatView, &image));
+            break;
+        case gl::TextureType::_3D:
+            ANGLE_TRY(mtl::Texture::Make3DTexture(
+                contextMtl, mtlFormat, size.width, size.height, size.depth, 1,
+                /** renderTargetOnly */ false, allowFormatView, &image));
+            break;
+        case gl::TextureType::_2DArray:
+            ANGLE_TRY(mtl::Texture::Make2DArrayTexture(
+                contextMtl, mtlFormat, size.width, size.height, 1, size.depth,
+                /** renderTargetOnly */ false, allowFormatView, &image));
+            break;
+        default:
+            UNREACHABLE();
     }
 
-    // Tell context to rebind textures
-    contextMtl->invalidateCurrentTextures();
+    // Make sure emulated channels are properly initialized in this newly allocated texture.
+    ANGLE_TRY(checkForEmulatedChannels(context, mtlFormat, image));
 
+    imageDef = {image, mtlFormat.intendedFormatId};
     return angle::Result::Continue;
 }
 

--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/MipmapTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/MipmapTest.cpp
@@ -2528,6 +2528,80 @@ TEST_P(MipmapTestES3, MismatchingLevelFormats)
     glUniform1f(lodLoc, 2);
     drawQuad(verify, essl3_shaders::PositionAttrib(), 0.5f);
     EXPECT_PIXEL_COLOR_EQ(0, 0, GLColor::green);
+
+// Verifies texture uploads work correctly after size transitions that change mipmap dimensions.
+TEST_P(MipmapTest, UploadAfterSizeTransition)
+{
+    GLTexture texture;
+    glBindTexture(GL_TEXTURE_2D, texture);
+
+    std::vector<GLColor> redData(128 * 128, GLColor::red);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 128, 128, 0, GL_RGBA, GL_UNSIGNED_BYTE,
+                 redData.data());
+    glGenerateMipmap(GL_TEXTURE_2D);
+    ASSERT_GL_NO_ERROR();
+
+    std::vector<GLColor> greenData(256 * 256, GLColor::green);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 256, 256, 0, GL_RGBA, GL_UNSIGNED_BYTE,
+                 greenData.data());
+    glGenerateMipmap(GL_TEXTURE_2D);
+    ASSERT_GL_NO_ERROR();
+
+    std::vector<GLColor> blueData(128 * 128, GLColor::blue);
+    glTexImage2D(GL_TEXTURE_2D, 1, GL_RGBA, 128, 128, 0, GL_RGBA, GL_UNSIGNED_BYTE,
+                 blueData.data());
+    ASSERT_GL_NO_ERROR();
+
+    GLFramebuffer fbo;
+    glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texture, 0);
+    EXPECT_GL_NO_ERROR();
+    EXPECT_PIXEL_COLOR_EQ(128, 128, GLColor::green);
+
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texture, 1);
+    EXPECT_GL_NO_ERROR();
+    EXPECT_PIXEL_COLOR_EQ(64, 64, GLColor::blue);
+}
+
+// Verifies old generated mipmap data doesn't persist after base level size changes.
+TEST_P(MipmapTest, GeneratedMipmapsInvalidatedAfterSizeChange)
+{
+    GLTexture texture;
+    glBindTexture(GL_TEXTURE_2D, texture);
+
+    std::vector<GLColor> redData(128 * 128, GLColor::red);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 128, 128, 0, GL_RGBA, GL_UNSIGNED_BYTE,
+                 redData.data());
+    glGenerateMipmap(GL_TEXTURE_2D);
+    ASSERT_GL_NO_ERROR();
+
+    GLFramebuffer fbo;
+    glBindFramebuffer(GL_FRAMEBUFFER, fbo);
+
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texture, 0);
+    EXPECT_GL_NO_ERROR();
+    EXPECT_PIXEL_COLOR_EQ(64, 64, GLColor::red);
+
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texture, 1);
+    EXPECT_GL_NO_ERROR();
+    EXPECT_PIXEL_COLOR_EQ(32, 32, GLColor::red);
+
+    std::vector<GLColor> greenData(256 * 256, GLColor::green);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, 256, 256, 0, GL_RGBA, GL_UNSIGNED_BYTE,
+                 greenData.data());
+    ASSERT_GL_NO_ERROR();
+
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texture, 0);
+    EXPECT_GL_NO_ERROR();
+    EXPECT_PIXEL_COLOR_EQ(128, 128, GLColor::green);
+
+    glGenerateMipmap(GL_TEXTURE_2D);
+    ASSERT_GL_NO_ERROR();
+
+    glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, texture, 1);
+    EXPECT_GL_NO_ERROR();
+    EXPECT_PIXEL_COLOR_EQ(64, 64, GLColor::green);
 }
 
 // Use this to select which configurations (e.g. which renderer, which GLES major version) these


### PR DESCRIPTION
#### baeadcd1b8cb6fdc06e7a2e5fae5ad0cd04d290f
<pre>
ANGLE: Fix crash from stale texture views during size transitions
<a href="https://bugs.webkit.org/show_bug.cgi?id=304282">https://bugs.webkit.org/show_bug.cgi?id=304282</a>
<a href="https://rdar.apple.com/165836916">rdar://165836916</a>

Reviewed by Kimmo Kinnunen.

When texture base level size changes (e.g., 128x128 → 256x256), native storage
is recreated but old mipmap views with wrong dimensions can remain in
mTexImageDefs. Uploading to these stale views causes Metal validation failure:
&quot;(origin.x + size.width)(128) must be &lt;= width(64).&quot;

Clear mTexImageDefs entries in generateMipmap() and redefineImage() to ensure
views are always recreated with correct dimensions from current storage.

* Source/ThirdParty/ANGLE/src/libANGLE/renderer/metal/TextureMtl.mm:
(rx::TextureMtl::ensureNativeStorageCreated):
(rx::TextureMtl::generateMipmap):
(rx::TextureMtl::redefineImage):
* Source/ThirdParty/ANGLE/src/tests/gl_tests/MipmapTest.cpp:

Originally-landed-as: 305413.191@safari-7624-branch (0391090cef9a). <a href="https://rdar.apple.com/173969233">rdar://173969233</a>
Canonical link: <a href="https://commits.webkit.org/313293@main">https://commits.webkit.org/313293@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/134d4d36af4df5d50f970c3bf7f4cb3b433a9ae3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162341 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35817 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28933 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171279 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118786 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35921 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35819 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125983 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88793 "17 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/37e7ffc1-fcb5-48d2-911d-ef5419cf06a4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165300 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28322 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145835 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106561 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0b2d3800-d411-4b54-babd-63adf013cabf) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27369 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25892 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18979 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137072 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23568 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173783 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25212 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134283 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35491 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29980 "Found 5 new test failures: http/tests/site-isolation/inspector/console/message-from-iframe.html http/tests/site-isolation/inspector/debugger/provisional-frame-target-pausing.html http/tests/site-isolation/inspector/target/target-cross-origin-page-navigation.html http/tests/site-isolation/inspector/target/target.html http/tests/site-isolation/inspector/worker/worker-in-cross-origin-iframe.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134284 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36306 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35475 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145364 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97730 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28826 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22194 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34984 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34486 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34731 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34634 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->