### PR TITLE
Remove WebKitBuffer.asUTF8String

### DIFF
--- a/Source/WebCore/page/WebKitBuffer.h
+++ b/Source/WebCore/page/WebKitBuffer.h
@@ -36,7 +36,6 @@ class WEBCORE_EXPORT WebKitBuffer : public RefCounted<WebKitBuffer> {
 public:
     virtual ~WebKitBuffer();
 
-    virtual ExceptionOr<String> asUTF8String() const = 0;
     virtual ExceptionOr<String> asUTF16String() const = 0;
     virtual String asLatin1String() const = 0;
 

--- a/Source/WebCore/page/WebKitBuffer.idl
+++ b/Source/WebCore/page/WebKitBuffer.idl
@@ -27,7 +27,6 @@
     LegacyNoInterfaceObject,
     SkipVTableValidation,
 ] interface WebKitBuffer {
-    DOMString asUTF8String();
     DOMString asUTF16String();
     DOMString asLatin1String();
 };

--- a/Source/WebKit/WebProcess/UserContent/SharedMemoryJSBuffer.cpp
+++ b/Source/WebKit/WebProcess/UserContent/SharedMemoryJSBuffer.cpp
@@ -42,13 +42,6 @@ SharedMemoryJSBuffer::SharedMemoryJSBuffer(Ref<WebCore::SharedMemory>&& sharedMe
 {
 }
 
-WebCore::ExceptionOr<String> SharedMemoryJSBuffer::asUTF8String() const
-{
-    if (charactersAreAllASCII(m_sharedMemory->span()))
-        return asLatin1String();
-    return String::fromUTF8(m_sharedMemory->span());
-}
-
 WebCore::ExceptionOr<String> SharedMemoryJSBuffer::asUTF16String() const
 {
     if (m_sharedMemory->size() % sizeof(char16_t))

--- a/Source/WebKit/WebProcess/UserContent/SharedMemoryJSBuffer.h
+++ b/Source/WebKit/WebProcess/UserContent/SharedMemoryJSBuffer.h
@@ -41,7 +41,6 @@ public:
 private:
     SharedMemoryJSBuffer(Ref<WebCore::SharedMemory>&&);
 
-    WebCore::ExceptionOr<String> asUTF8String() const final;
     WebCore::ExceptionOr<String> asUTF16String() const final;
     String asLatin1String() const final;
 


### PR DESCRIPTION
#### 8cd68b84dc1d8920588049b0ca3f3aa74317b656
<pre>
Remove WebKitBuffer.asUTF8String
<a href="https://bugs.webkit.org/show_bug.cgi?id=314739">https://bugs.webkit.org/show_bug.cgi?id=314739</a>
<a href="https://rdar.apple.com/176990134">rdar://176990134</a>

Reviewed by Ben Nham.

It is not necessary.  Using it removes the efficiency gains offered by WebKitBuffer
because we need to read the entire buffer and check for ASCII-ness.  If UTF-8 decoding
is desired, an application can use TextDecoder instead.

* Source/WebCore/page/WebKitBuffer.h:
* Source/WebCore/page/WebKitBuffer.idl:
* Source/WebKit/WebProcess/UserContent/SharedMemoryJSBuffer.cpp:
(WebKit::SharedMemoryJSBuffer::asUTF8String const): Deleted.
* Source/WebKit/WebProcess/UserContent/SharedMemoryJSBuffer.h:

Canonical link: <a href="https://commits.webkit.org/313264@main">https://commits.webkit.org/313264@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eb1b5dccf1fe22d66805d3489460de11da1b0dd6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162326 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35802 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28918 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171234 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118771 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/73d86200-c784-448a-8d37-34b2875c983e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164195 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35906 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35804 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125974 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88787 "1 flakes 18 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bdc7f491-052d-4dda-bdb1-f3e7a1da1e65) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165285 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28316 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145825 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106552 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/72b3d15e-e028-49a8-9db4-4ebc6251aa16) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27363 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25881 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18963 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137066 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23558 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173728 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21081 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25202 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134273 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35476 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29969 "Found 5 new test failures: http/tests/site-isolation/inspector/console/message-from-iframe.html http/tests/site-isolation/inspector/debugger/provisional-frame-target-pausing.html http/tests/site-isolation/inspector/target/target-cross-origin-page-navigation.html http/tests/site-isolation/inspector/target/target.html http/tests/site-isolation/inspector/worker/worker-in-cross-origin-iframe.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134274 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35460 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145354 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97720 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24715 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28816 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22184 "Found 1 new test failure: accessibility/mac/value-change/value-change-user-info-textarea.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34969 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102721 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34471 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34716 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34619 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->