### PR TITLE
WebCore/platform: Use nullptr instead of 0 for pointer initialization

### DIFF
--- a/Source/WebCore/platform/ContextMenuItem.h
+++ b/Source/WebCore/platform/ContextMenuItem.h
@@ -193,7 +193,7 @@ enum class ContextMenuItemType : uint8_t {
 class ContextMenuItem {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(ContextMenuItem, WEBCORE_EXPORT);
 public:
-    WEBCORE_EXPORT ContextMenuItem(ContextMenuItemType, ContextMenuAction, const String&, ContextMenu* subMenu = 0);
+    WEBCORE_EXPORT ContextMenuItem(ContextMenuItemType, ContextMenuAction, const String&, ContextMenu* subMenu = nullptr);
     WEBCORE_EXPORT ContextMenuItem(ContextMenuItemType, ContextMenuAction, const String&, bool enabled, bool checked, unsigned indentationLevel = 0);
 
     WEBCORE_EXPORT ~ContextMenuItem();

--- a/Source/WebCore/platform/graphics/ComplexTextController.h
+++ b/Source/WebCore/platform/graphics/ComplexTextController.h
@@ -59,7 +59,7 @@ enum class GlyphIterationStyle : bool { IncludePartialGlyphs, ByWholeGlyphs };
 class ComplexTextController {
     WTF_MAKE_TZONE_ALLOCATED(ComplexTextController);
 public:
-    ComplexTextController(const FontCascade&, const TextRun&, bool mayUseNaturalWritingDirection = false, SingleThreadWeakHashSet<const Font>* fallbackFonts = 0, bool forTextEmphasis = false);
+    ComplexTextController(const FontCascade&, const TextRun&, bool mayUseNaturalWritingDirection = false, SingleThreadWeakHashSet<const Font>* fallbackFonts = nullptr, bool forTextEmphasis = false);
 
     static std::pair<float, float> enclosingGlyphBoundsForTextRun(const FontCascade&, const TextRun&);
     static Vector<float> glyphAdvancesForTextRun(const FontCascade&, const TextRun&);

--- a/Source/WebCore/platform/graphics/WidthIterator.h
+++ b/Source/WebCore/platform/graphics/WidthIterator.h
@@ -51,7 +51,7 @@ using CharactersTreatedAsSpace = Vector<OriginalAdvancesForCharacterTreatedAsSpa
 struct WidthIterator {
     WTF_MAKE_TZONE_ALLOCATED(WidthIterator);
 public:
-    WidthIterator(const FontCascade&, const TextRun&, SingleThreadWeakHashSet<const Font>* fallbackFonts = 0, bool accountForGlyphBounds = false, bool forTextEmphasis = false);
+    WidthIterator(const FontCascade&, const TextRun&, SingleThreadWeakHashSet<const Font>* fallbackFonts = nullptr, bool accountForGlyphBounds = false, bool forTextEmphasis = false);
 
     void advance(unsigned to, GlyphBuffer&);
     bool advanceOneCharacter(float& width, GlyphBuffer&);

--- a/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
+++ b/Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp
@@ -2176,7 +2176,7 @@ GCGLsizeiptr GraphicsContextGLANGLE::getVertexAttribOffset(GCGLuint index, GCGLe
     if (!makeContextCurrent())
         return 0;
 
-    GLvoid* pointer = 0;
+    GLvoid* pointer = nullptr;
     GL_GetVertexAttribPointervRobustANGLE(index, pname, 1, nullptr, &pointer);
     return static_cast<GCGLsizeiptr>(reinterpret_cast<intptr_t>(pointer));
 }

--- a/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.mm
@@ -96,7 +96,7 @@ RefPtr<Uint8Array> CDMSessionAVFoundationObjC::generateKeyRequest(const String& 
     RetainPtr certificateData = toNSData(certificate->span());
     RetainPtr assetString = keyID.createNSString();
     RetainPtr<NSData> assetID = [assetString dataUsingEncoding:NSUTF8StringEncoding];
-    NSError* nsError = 0;
+    NSError* nsError = nullptr;
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     RetainPtr<NSData> keyRequest = [m_request streamingContentKeyRequestDataForApp:certificateData.get() contentIdentifier:assetID.get() options:nil error:&nsError];
 ALLOW_DEPRECATED_DECLARATIONS_END

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h
@@ -398,7 +398,7 @@ private:
     void computePixelAlignment(float contentsScale, const FloatPoint& positionRelativeToBase,
         FloatPoint& position, FloatPoint3D& anchorPoint, FloatSize& alignmentOffset) const;
 
-    TransformationMatrix layerTransform(const FloatPoint& position, const TransformationMatrix* customTransform = 0) const;
+    TransformationMatrix layerTransform(const FloatPoint& position, const TransformationMatrix* customTransform = nullptr) const;
     TransformationMatrix transformByApplyingAnchorPoint(const TransformationMatrix&) const;
 
     enum ComputeVisibleRectFlag { RespectAnimatingTransforms = 1 << 0 };

--- a/Source/WebCore/platform/graphics/opentype/OpenTypeVerticalData.cpp
+++ b/Source/WebCore/platform/graphics/opentype/OpenTypeVerticalData.cpp
@@ -354,7 +354,7 @@ struct GSUBTable : TableBase {
         const FeatureList* features = featureList(buffer);
         if (!features)
             return 0;
-        const FeatureTable* feature = 0;
+        const FeatureTable* feature = nullptr;
         if (langSys)
             feature = langSys->feature(featureTag, features, buffer);
         if (!feature) {

--- a/Source/WebCore/platform/graphics/transforms/TransformationMatrix.h
+++ b/Source/WebCore/platform/graphics/transforms/TransformationMatrix.h
@@ -203,9 +203,9 @@ public:
     // Maps a point on the z=0 plane into a point on the plane with with the transform applied, by
     // extending a ray perpendicular to the source plane and computing the local x,y position of
     // the point where that ray intersects with the destination plane.
-    FloatPoint NODELETE projectPoint(const FloatPoint&, bool* clamped = 0) const;
+    FloatPoint NODELETE projectPoint(const FloatPoint&, bool* clamped = nullptr) const;
     // Projects the four corners of the quad.
-    FloatQuad NODELETE projectQuad(const FloatQuad&,  bool* clamped = 0) const;
+    FloatQuad NODELETE projectQuad(const FloatQuad&,  bool* clamped = nullptr) const;
     // Projects the four corners of the quad and takes a bounding box,
     // while sanitizing values created when the w component is negative.
     LayoutRect clampedBoundsOfProjectedQuad(const FloatQuad&) const;

--- a/Source/WebCore/platform/graphics/win/FontCacheWin.cpp
+++ b/Source/WebCore/platform/graphics/win/FontCacheWin.cpp
@@ -288,7 +288,7 @@ RefPtr<Font> FontCache::systemFallbackForCharacterCluster(const FontDescription&
     }
 
     String familyName;
-    const Vector<String>* linkedFonts = 0;
+    const Vector<String>* linkedFonts = nullptr;
     unsigned linkedFontIndex = 0;
     while (hfont) {
         SelectObject(hdc, hfont);

--- a/Source/WebCore/platform/graphics/win/GraphicsContextWin.cpp
+++ b/Source/WebCore/platform/graphics/win/GraphicsContextWin.cpp
@@ -56,7 +56,7 @@ HDC GraphicsContext::getWindowsContext(const IntRect& dstRect, bool supportAlpha
     // Create a bitmap DC in which to draw.
     BitmapInfo bitmapInfo = BitmapInfo::create(dstRect.size());
 
-    void* pixels = 0;
+    void* pixels = nullptr;
     HBITMAP bitmap = ::CreateDIBSection(nullptr, &bitmapInfo, DIB_RGB_COLORS, &pixels, 0, 0);
     if (!bitmap)
         return 0;

--- a/Source/WebCore/platform/graphics/win/cairo/GraphicsContextWinCairo.cpp
+++ b/Source/WebCore/platform/graphics/win/cairo/GraphicsContextWinCairo.cpp
@@ -42,7 +42,7 @@ static RefPtr<cairo_t> createCairoContextWithHDC(HDC hdc)
     // Put the HDC In advanced mode so it will honor affine transforms.
     SetGraphicsMode(hdc, GM_ADVANCED);
 
-    cairo_surface_t* surface = 0;
+    cairo_surface_t* surface = nullptr;
 
     HBITMAP bitmap = static_cast<HBITMAP>(GetCurrentObject(hdc, OBJ_BITMAP));
 

--- a/Source/WebCore/platform/image-decoders/jpeg/JPEGImageDecoder.cpp
+++ b/Source/WebCore/platform/image-decoders/jpeg/JPEGImageDecoder.cpp
@@ -276,7 +276,7 @@ public:
         // Allocate and initialize JPEG decompression object.
         jpeg_create_decompress(&m_info);
 
-        decoder_source_mgr* src = 0;
+        decoder_source_mgr* src = nullptr;
         if (!m_info.src) {
             src = (decoder_source_mgr*)fastCalloc(sizeof(decoder_source_mgr), 1);
             if (!src) {

--- a/Source/WebCore/platform/ios/wak/WebCoreThreadRun.cpp
+++ b/Source/WebCore/platform/ios/wak/WebCoreThreadRun.cpp
@@ -148,7 +148,7 @@ static void _WebThreadRun(void (^block)(void), bool synchronous)
     ASSERT(runSource());
     ASSERT(runQueue);
 
-    WebThreadBlockState* state = 0;
+    WebThreadBlockState* state = nullptr;
     if (synchronous)
         state = new WebThreadBlockState;
 

--- a/Source/WebCore/platform/win/ClipboardUtilitiesWin.h
+++ b/Source/WebCore/platform/win/ClipboardUtilitiesWin.h
@@ -68,8 +68,8 @@ RefPtr<DocumentFragment> fragmentFromHTML(Document*, IDataObject*);
 RefPtr<DocumentFragment> fragmentFromHTML(Document*, const DragDataMap*);
 Ref<DocumentFragment> fragmentFromCFHTML(Document*, const String& cfhtml);
 
-String getURL(IDataObject*, DragData::FilenameConversionPolicy, String* title = 0);
-String getURL(const DragDataMap*, DragData::FilenameConversionPolicy, String* title = 0);
+String getURL(IDataObject*, DragData::FilenameConversionPolicy, String* title = nullptr);
+String getURL(const DragDataMap*, DragData::FilenameConversionPolicy, String* title = nullptr);
 String getPlainText(IDataObject*);
 String getPlainText(const DragDataMap*);
 String getTextHTML(IDataObject*);

--- a/Source/WebCore/platform/win/cairo/DragImageWinCairo.cpp
+++ b/Source/WebCore/platform/win/cairo/DragImageWinCairo.cpp
@@ -159,7 +159,7 @@ DragImageRef createDragImageFromImage(Image* img, ImageOrientation, GraphicsClie
     if (!workingDC)
         return 0;
 
-    GraphicsContextCairo* drawContext = 0;
+    GraphicsContextCairo* drawContext = nullptr;
     auto hbmp = allocImage(workingDC.get(), IntSize(img->size()), &drawContext);
     if (!hbmp || !drawContext)
         return 0;


### PR DESCRIPTION
#### a1f9b136e8a596e37cb85ca437959a406433ab27
<pre>
WebCore/platform: Use nullptr instead of 0 for pointer initialization
<a href="https://bugs.webkit.org/show_bug.cgi?id=314740">https://bugs.webkit.org/show_bug.cgi?id=314740</a>
<a href="https://rdar.apple.com/176990368">rdar://176990368</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/platform/ContextMenuItem.h:
* Source/WebCore/platform/graphics/ComplexTextController.h:
* Source/WebCore/platform/graphics/WidthIterator.h:
* Source/WebCore/platform/graphics/angle/GraphicsContextGLANGLE.cpp:
(WebCore::GraphicsContextGLANGLE::getVertexAttribOffset):
* Source/WebCore/platform/graphics/avfoundation/objc/CDMSessionAVFoundationObjC.mm:
(WebCore::CDMSessionAVFoundationObjC::generateKeyRequest):
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.h:
* Source/WebCore/platform/graphics/opentype/OpenTypeVerticalData.cpp:
(WebCore::OpenType::GSUBTable::feature const):
* Source/WebCore/platform/graphics/transforms/TransformationMatrix.h:
* Source/WebCore/platform/graphics/win/FontCacheWin.cpp:
(WebCore::FontCache::systemFallbackForCharacterCluster):
* Source/WebCore/platform/graphics/win/GraphicsContextWin.cpp:
(WebCore::GraphicsContext::getWindowsContext):
* Source/WebCore/platform/graphics/win/cairo/GraphicsContextWinCairo.cpp:
(WebCore::createCairoContextWithHDC):
* Source/WebCore/platform/image-decoders/jpeg/JPEGImageDecoder.cpp:
(WebCore::JPEGImageReader::JPEGImageReader):
* Source/WebCore/platform/ios/wak/WebCoreThreadRun.cpp:
* Source/WebCore/platform/win/ClipboardUtilitiesWin.h:
* Source/WebCore/platform/win/cairo/DragImageWinCairo.cpp:
(WebCore::createDragImageFromImage):

Canonical link: <a href="https://commits.webkit.org/313189@main">https://commits.webkit.org/313189@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8fbd6aa5fdd4b97aa7a770733fcaec62bc87bfb5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162336 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35812 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28928 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings); Compiled WebKit (warnings)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171273 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/118781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164205 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35916 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35814 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125978 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/118781 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165295 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28323 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145834 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106556 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18974 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137073 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23567 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173782 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21091 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25211 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134280 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35486 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/29976 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134281 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36253 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35470 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145363 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97725 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28827 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/22193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34979 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102731 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34481 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34726 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34629 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->