### PR TITLE
MobileMiniBrowser is not able to launch the WebContentEnhancedSecurity extension

### DIFF
--- a/Tools/MobileMiniBrowser/MobileMiniBrowser.xcodeproj/project.pbxproj
+++ b/Tools/MobileMiniBrowser/MobileMiniBrowser.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		DD403C5828500FE300D899FC /* WebKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = CD1DAFC11D70E12D00017CF0 /* WebKit.framework */; };
 		DDC9E8CC2A91DEDE00B015C1 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD954C942A90280800C6843C /* UIKit.framework */; };
 		DDC9E8CD2A91E0F400B015C1 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DD954C942A90280800C6843C /* UIKit.framework */; };
+		E37DD4942FB4F8180069AF09 /* WebContentEnhancedSecurityExtension.appex in CopyFiles */ = {isa = PBXBuildFile; fileRef = E37DD4932FB4F8180069AF09 /* WebContentEnhancedSecurityExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		E3EE46DB2DF3473D009ED72B /* GPUExtension.appex in CopyFiles */ = {isa = PBXBuildFile; fileRef = E3EE46DA2DF3473D009ED72B /* GPUExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		E3EE46DD2DF3475B009ED72B /* NetworkingExtension.appex in CopyFiles */ = {isa = PBXBuildFile; fileRef = E3EE46DC2DF3475B009ED72B /* NetworkingExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		E3EE46DF2DF34770009ED72B /* WebContentExtension.appex in CopyFiles */ = {isa = PBXBuildFile; fileRef = E3EE46DE2DF34770009ED72B /* WebContentExtension.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
@@ -111,6 +112,7 @@
 			files = (
 				E3EE46DB2DF3473D009ED72B /* GPUExtension.appex in CopyFiles */,
 				E3EE46DD2DF3475B009ED72B /* NetworkingExtension.appex in CopyFiles */,
+				E37DD4942FB4F8180069AF09 /* WebContentEnhancedSecurityExtension.appex in CopyFiles */,
 				E3EE46DF2DF34770009ED72B /* WebContentExtension.appex in CopyFiles */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -147,10 +149,11 @@
 		CDC279282935417100151088 /* test.mp4 */ = {isa = PBXFileReference; lastKnownFileType = file; path = test.mp4; sourceTree = "<group>"; };
 		CDC279292935417100151088 /* looping2s.html */ = {isa = PBXFileReference; lastKnownFileType = text.html; path = looping2s.html; sourceTree = "<group>"; };
 		DD954C942A90280800C6843C /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
+		E37DD4932FB4F8180069AF09 /* WebContentEnhancedSecurityExtension.appex */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.extensionkit-extension"; name = WebContentEnhancedSecurityExtension.appex; path = WebContentEnhancedSecurityExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 		E3C8BD852BBF286D00181A2E /* MobileMiniBrowser.entitlements */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.entitlements; path = MobileMiniBrowser.entitlements; sourceTree = "<group>"; };
-		E3EE46DA2DF3473D009ED72B /* GPUExtension.appex */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.extensionkit-extension"; name = GPUExtension.appex; path = "GPUExtension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
-		E3EE46DC2DF3475B009ED72B /* NetworkingExtension.appex */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.extensionkit-extension"; name = NetworkingExtension.appex; path = "NetworkingExtension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
-		E3EE46DE2DF34770009ED72B /* WebContentExtension.appex */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.extensionkit-extension"; name = WebContentExtension.appex; path = "WebContentExtension.appex"; sourceTree = BUILT_PRODUCTS_DIR; };
+		E3EE46DA2DF3473D009ED72B /* GPUExtension.appex */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.extensionkit-extension"; path = GPUExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		E3EE46DC2DF3475B009ED72B /* NetworkingExtension.appex */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.extensionkit-extension"; path = NetworkingExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		E3EE46DE2DF34770009ED72B /* WebContentExtension.appex */ = {isa = PBXFileReference; lastKnownFileType = "wrapper.extensionkit-extension"; path = WebContentExtension.appex; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -186,6 +189,7 @@
 		CD1DAF891D709E3600017CF0 = {
 			isa = PBXGroup;
 			children = (
+				E37DD4932FB4F8180069AF09 /* WebContentEnhancedSecurityExtension.appex */,
 				E3EE46DE2DF34770009ED72B /* WebContentExtension.appex */,
 				E3EE46DC2DF3475B009ED72B /* NetworkingExtension.appex */,
 				E3EE46DA2DF3473D009ED72B /* GPUExtension.appex */,
@@ -475,9 +479,7 @@
 		};
 		DD2A1D0A2888D1D300342472 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			platformFilters = (
-				ios,
-			);
+			platformFilter = ios;
 			target = CD1DAF911D709E3600017CF0 /* MobileMiniBrowser */;
 			targetProxy = DD2A1D092888D1D300342472 /* PBXContainerItemProxy */;
 		};


### PR DESCRIPTION
#### 9b27aecad20007c8eb0559359eb51ee576786dc5
<pre>
MobileMiniBrowser is not able to launch the WebContentEnhancedSecurity extension
<a href="https://bugs.webkit.org/show_bug.cgi?id=314743">https://bugs.webkit.org/show_bug.cgi?id=314743</a>
<a href="https://rdar.apple.com/176993203">rdar://176993203</a>

Reviewed by Sihui Liu.

The extension needs to be copied into the app&apos;s bundle.

* Tools/MobileMiniBrowser/MobileMiniBrowser.xcodeproj/project.pbxproj:

Canonical link: <a href="https://commits.webkit.org/313194@main">https://commits.webkit.org/313194@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ecaa2b0b5705459a390d4e3ec0b7dfb9b3fc6356

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162345 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35821 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28937 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171283 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/118790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164214 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35925 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35823 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125986 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/118790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165304 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28325 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/145839 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106564 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25894 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18983 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137075 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23572 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173787 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25216 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134291 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35495 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29982 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134285 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35479 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145368 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97734 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24665 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28828 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22198 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34988 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34490 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34735 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34638 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->