### PR TITLE
testRunner.getApplicationManifestThen should return whether fetch was successful

### DIFF
--- a/LayoutTests/applicationmanifest/developer-warnings.html
+++ b/LayoutTests/applicationmanifest/developer-warnings.html
@@ -3,9 +3,10 @@
 if (window.testRunner) {
     testRunner.dumpAsText();
     testRunner.waitUntilDone();
-    testRunner.getApplicationManifestThen(function() {
+    (async () => {
+        await testRunner.getApplicationManifest();
         alert("Pass");
         testRunner.notifyDone();
-    });
+    })();
 }
 </script>

--- a/LayoutTests/applicationmanifest/multiple-links-expected.txt
+++ b/LayoutTests/applicationmanifest/multiple-links-expected.txt
@@ -1,4 +1,1 @@
-urlscheme://2 - willSendRequest <NSURLRequest URL urlscheme://2, main document URL multiple-links.html, http method GET> redirectResponse (null)
-multiple-links.html - didFinishLoading
-urlscheme://2 - didFailLoadingWithError: <NSError domain NSURLErrorDomain, code -1002, failing URL "urlscheme://2">
-
+manifest fetch success: false

--- a/LayoutTests/applicationmanifest/multiple-links.html
+++ b/LayoutTests/applicationmanifest/multiple-links.html
@@ -1,6 +1,5 @@
 <script>
 if (window.testRunner) {
-    testRunner.dumpResourceLoadCallbacks();
     testRunner.dumpAsText();
     testRunner.waitUntilDone();
 }
@@ -9,8 +8,11 @@ if (window.testRunner) {
 <link rel="manifest" href="urlscheme://2">
 <script>
 if (window.testRunner) {
-    testRunner.getApplicationManifestThen(function() {
+    (async () => {
+        const success = await testRunner.getApplicationManifest();
+        outputdiv.innerHTML = `manifest fetch success: ${success}`;
         testRunner.notifyDone();
-    });
+    })();
 }
 </script>
+<div id=outputdiv></div>

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/manifest-src-allowed-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/manifest-src-allowed-expected.txt
@@ -1,2 +1,2 @@
-ALERT: Pass
+ALERT: manifest fetch success: true
 

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/manifest-src-allowed.html
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/manifest-src-allowed.html
@@ -4,9 +4,10 @@
     if (window.testRunner) {
         testRunner.dumpAsText();
         testRunner.waitUntilDone();
-        testRunner.getApplicationManifestThen(function() {
-            alert("Pass");
+        (async () => {
+            const success = await testRunner.getApplicationManifest();
+            alert("manifest fetch success: " + success);
             testRunner.notifyDone();
-        });
+        })();
     }
 </script>

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/manifest-src-blocked-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/manifest-src-blocked-expected.txt
@@ -1,3 +1,3 @@
 CONSOLE MESSAGE: Refused to load http://127.0.0.1:8000/security/contentSecurityPolicy/manifest.test/manifest.json because it does not appear in the manifest-src directive of the Content Security Policy.
-ALERT: Pass
+ALERT: manifest fetch success: false
 

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/manifest-src-blocked.html
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/manifest-src-blocked.html
@@ -8,9 +8,10 @@
 <link rel="manifest" href="manifest.test/manifest.json">
 <script>
     if (window.testRunner) {
-        testRunner.getApplicationManifestThen(function() {
-            alert("Pass");
+        (async () => {
+            const success = await testRunner.getApplicationManifest();
+            alert("manifest fetch success: " + success);
             testRunner.notifyDone();
-        });
+        })();
     }
 </script>

--- a/LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked-cross-origin.sub-expected.txt
+++ b/LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked-cross-origin.sub-expected.txt
@@ -1,3 +1,1 @@
-http://localhost:8800/WebKit/content-security-policy/sandbox-manifest-blocked-cross-origin.sub.html - didFinishLoading
-http://not-web-platform.test:8800/WebKit/content-security-policy/manifest.json - didFailLoadingWithError: <NSError domain , code 0, failing URL "http://not-web-platform.test:8800/WebKit/content-security-policy/manifest.json">
-
+Fetched manifest: http://not-web-platform.test:8800/WebKit/content-security-policy/manifest.json, success: false

--- a/LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked-cross-origin.sub.html
+++ b/LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked-cross-origin.sub.html
@@ -6,11 +6,12 @@
 </head>
 <script>
     testRunner?.dumpAsText();
-    testRunner?.dumpResourceLoadCallbacks();
     testRunner?.waitUntilDone();
-    testRunner?.getApplicationManifestThen(() => {
+    (async () => {
+        const success = await testRunner.getApplicationManifest();
         const elem = document.querySelector("link");
-        console.log(`Fetched manifest: ${elem.href}`);
+        outputdiv.innerHTML = `Fetched manifest: ${elem.href}, success: ${success}`;
         testRunner.notifyDone();
-    });
+    })();
 </script>
+<div id=outputdiv></div>

--- a/LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked-expected.txt
+++ b/LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked-expected.txt
@@ -1,3 +1,3 @@
 http://localhost:8800/WebKit/content-security-policy/sandbox-manifest-blocked.html - didFinishLoading
 http://localhost:8800/WebKit/content-security-policy/manifest.json - didFailLoadingWithError: <NSError domain , code 0, failing URL "http://localhost:8800/WebKit/content-security-policy/manifest.json">
-
+Fetched manifest: http://localhost:8800/WebKit/content-security-policy/manifest.json, success: false

--- a/LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked.html
+++ b/LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked.html
@@ -5,9 +5,11 @@
     testRunner?.dumpAsText();
     testRunner?.dumpResourceLoadCallbacks();
     testRunner?.waitUntilDone();
-    testRunner?.getApplicationManifestThen(() => {
+    (async () => {
+        const success = await testRunner.getApplicationManifest();
         const elem = document.querySelector("link");
-        console.log(`Fetched manifest: ${elem.href}`);
+        outputdiv.innerHTML = `Fetched manifest: ${elem.href}, success: ${success}`;
         testRunner.notifyDone();
-    });
+    })();
 </script>
+<div id=outputdiv></div>

--- a/Source/WebKit/UIProcess/API/C/WKPage.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPage.cpp
@@ -3206,11 +3206,11 @@ void WKPageGetApplicationManifest(WKPageRef pageRef, void* context, WKPageGetApp
     CRASH_IF_SUSPENDED;
 #if ENABLE(APPLICATION_MANIFEST)
     protect(toImpl(pageRef))->getApplicationManifest([function, context](const std::optional<WebCore::ApplicationManifest>& manifest) {
-        function(context);
+        function(context, !!manifest);
     });
 #else
     UNUSED_PARAM(pageRef);
-    function(context);
+    function(context, false);
 #endif
 }
 

--- a/Source/WebKit/UIProcess/API/C/WKPagePrivate.h
+++ b/Source/WebKit/UIProcess/API/C/WKPagePrivate.h
@@ -175,7 +175,7 @@ WK_EXPORT void WKPageSetUseDarkAppearanceForTesting(WKPageRef pageRef, bool useD
 WK_EXPORT WKProcessID WKPageGetProcessIdentifier(WKPageRef page);
 WK_EXPORT WKProcessID WKPageGetGPUProcessIdentifier(WKPageRef page);
 
-typedef void (*WKPageGetApplicationManifestFunction)(void* functionContext);
+typedef void (*WKPageGetApplicationManifestFunction)(void* functionContext, bool success);
 WK_EXPORT void WKPageGetApplicationManifest(WKPageRef page, void* context, WKPageGetApplicationManifestFunction block);
 
 typedef void (*WKPageDumpPrivateClickMeasurementFunction)(WKStringRef privateClickMeasurementRepresentation, void* functionContext);

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -2008,7 +2008,7 @@ if (window.testRunner) {
     testRunner.findString = (target, options) => post(['FindString', target, options]);
     testRunner.runUIScript = (script, callback) => post(['RunUIScript', script, createHandle(callback)]);
     testRunner.runUIScriptImmediately = (script, callback) => post(['RunUIScriptImmediately', script, createHandle(callback)]);
-    testRunner.getApplicationManifestThen = async (callback) => { await post(['GetApplicationManifest']); callback() }; // NOLINT
+    testRunner.getApplicationManifest = () => post(['GetApplicationManifest']);
     testRunner.scrollDuringEnterFullscreen = () => post(['ScrollDuringEnterFullscreen']);
     testRunner.waitBeforeFinishingFullscreenExit = () => post(['WaitBeforeFinishingFullscreenExit']);
     testRunner.finishFullscreenExit = () => post(['FinishFullscreenExit']);
@@ -2570,8 +2570,12 @@ void TestController::didReceiveScriptMessage(WKScriptMessageRef message, Complet
         return completionHandler(nullptr);
     }
 
-    if (WKStringIsEqualToUTF8CString(command, "GetApplicationManifest"))
-        return WKPageGetApplicationManifest(mainWebView()->page(), completionHandler.leak(), adoptAndCallCompletionHandler);
+    if (WKStringIsEqualToUTF8CString(command, "GetApplicationManifest")) {
+        return WKPageGetApplicationManifest(mainWebView()->page(), completionHandler.leak(), [] (void* context, bool success) {
+            auto completionHandler = WTF::adopt(static_cast<CompletionHandler<void(WKTypeRef)>::Impl*>(context));
+            completionHandler(adoptWK(WKBooleanCreate(success)).get());
+        });
+    }
 
     if (WKStringIsEqualToUTF8CString(command, "IndicateFindMatch")) {
         auto index = static_cast<uint32_t>(WKDoubleGetValue(static_cast<WKDoubleRef>(argument)));


### PR DESCRIPTION
#### 6ada7c61fd44a8919473d8e7a12875b8f4790298
<pre>
testRunner.getApplicationManifestThen should return whether fetch was successful
<a href="https://bugs.webkit.org/show_bug.cgi?id=314744">https://bugs.webkit.org/show_bug.cgi?id=314744</a>
<a href="https://rdar.apple.com/176994174">rdar://176994174</a>

Reviewed by Chris Dumez.

This is breaking off a piece of <a href="https://github.com/WebKit/WebKit/pull/64581">https://github.com/WebKit/WebKit/pull/64581</a> into its own smaller PR.
Some of the tests for application manifest fetching used testRunner.dumpResourceLoadCallbacks as a way
of indicating whether the fetch was successful or hit an error.  This works with injected bundle load
callbacks, but doesn&apos;t work in a non-flaky way with UI process callbacks because it hits cases where
NetworkResourceLoader::didRetrieveCacheEntry fails a load sometimes, resulting in non-deterministic
calls to the _WKResourceLoadDelegate.  Rather than doing some invasive changes in behavior that could
affect actual loading, for this test-only behavior I just expose whether the fetch was successful and
log that in the test ouptut.  The tests continue to test the success or failure of the load, but now
the test output is deterministic even when the load delegate callbacks will be moved to the UI process.

* LayoutTests/applicationmanifest/developer-warnings.html:
* LayoutTests/applicationmanifest/multiple-links-expected.txt:
* LayoutTests/applicationmanifest/multiple-links.html:
* LayoutTests/http/tests/security/contentSecurityPolicy/manifest-src-allowed-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/manifest-src-allowed.html:
* LayoutTests/http/tests/security/contentSecurityPolicy/manifest-src-blocked-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/manifest-src-blocked.html:
* LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked-cross-origin.sub-expected.txt:
* LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked-cross-origin.sub.html:
* LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked-expected.txt:
* LayoutTests/http/wpt/content-security-policy/sandbox-manifest-blocked.html:
* Source/WebKit/UIProcess/API/C/WKPage.cpp:
(WKPageGetApplicationManifest):
* Source/WebKit/UIProcess/API/C/WKPagePrivate.h:
* Tools/WebKitTestRunner/TestController.cpp:

Canonical link: <a href="https://commits.webkit.org/313332@main">https://commits.webkit.org/313332@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54c92aef87e0239155ba9fa2f772e10fe5b4c149

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162351 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35827 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28943 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171289 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118796 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164220 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35931 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35829 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125989 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88795 "18 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165310 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28327 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145842 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106567 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27374 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25900 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/18989 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137077 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23575 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173793 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21106 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25219 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134287 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35501 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29988 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134288 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35485 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145371 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97740 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24750 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28830 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22201 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/34994 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102746 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34496 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34741 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34644 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->