### PR TITLE
Deque takeFirst()/takeLast() description is confusing

### DIFF
--- a/Source/WTF/wtf/Deque.h
+++ b/Source/WTF/wtf/Deque.h
@@ -67,6 +67,7 @@ public:
     size_t size() const { return (m_end - m_start) & m_capacityMask; }
     bool isEmpty() const { return m_start == m_end; }
 
+    // Iteration.
     iterator begin() LIFETIME_BOUND { return iterator(this, m_start); }
     iterator end() LIFETIME_BOUND { return iterator(this, m_end); }
     const_iterator begin() const LIFETIME_BOUND { return const_iterator(this, m_start); }
@@ -75,46 +76,44 @@ public:
     reverse_iterator rend() LIFETIME_BOUND { return reverse_iterator(begin()); }
     const_reverse_iterator rbegin() const LIFETIME_BOUND { return const_reverse_iterator(end()); }
     const_reverse_iterator rend() const LIFETIME_BOUND { return const_reverse_iterator(begin()); }
-    
-    template<typename U> bool contains(const U&) const;
 
+    // Accessing and/or removing the first item.
     T& first() LIFETIME_BOUND { return m_buffer.capacitySpan()[m_start]; }
     const T& first() const LIFETIME_BOUND { return m_buffer.capacitySpan()[m_start]; }
+    void removeFirst();
     T takeFirst();
+    // Returns a default-constructed T if the callback always returns false.
+    template<std::predicate<T&> Predicate>
+    T takeFirst(NOESCAPE const Predicate&);
 
+    // Accessing and/or removing the last item.
     T& last() LIFETIME_BOUND { return m_buffer.capacitySpan()[(m_end - 1) & m_capacityMask]; }
     const T& last() const LIFETIME_BOUND { return m_buffer.capacitySpan()[(m_end - 1) & m_capacityMask]; }
+    void removeLast();
     T takeLast();
+    // Returns a default-constructed T if the callback always returns false.
+    template<std::predicate<T&> Predicate>
+    T takeLast(NOESCAPE const Predicate&);
 
+    // Removal.
+    void remove(iterator&);
+    void remove(const_iterator&);
+    template<std::predicate<T&> Predicate> size_t removeAllMatching(const Predicate&);
+    template<std::predicate<T&> Predicate> bool removeFirstMatching(const Predicate&);
+    void clear();
+
+    // Insertion.
     void append(T&& value) { append<T>(std::forward<T>(value)); }
     template<typename U> void append(U&&);
     template<typename U> void prepend(U&&);
-    void removeFirst();
-    void removeLast();
-    void remove(iterator&);
-    void remove(const_iterator&);
-    
-    template<std::predicate<T&> Predicate> size_t removeAllMatching(const Predicate&);
-    template<std::predicate<T&> Predicate> bool removeFirstMatching(const Predicate&);
-
     // This is a priority enqueue. The callback is given a value, and if it returns true, then this
     // will put the appended value before that value. It will keep bubbling until the callback returns
     // false or the value ends up at the head of the queue.
     template<typename U, std::predicate<T&> Predicate>
     void appendAndBubble(U&&, const Predicate&);
-    
-    // Remove and return the first element for which the callback returns true. Returns a null version of
-    // T if it the callback always returns false.
-    template<std::predicate<T&> Predicate>
-    T takeFirst(NOESCAPE const Predicate&);
 
-    // Remove and return the last element for which the callback returns true. Returns a null version of
-    // T if it the callback always returns false.
-    template<std::predicate<T&> Predicate>
-    T takeLast(NOESCAPE const Predicate&);
-
-    void clear();
-
+    // Search.
+    template<typename U> bool contains(const U&) const;
     template<std::predicate<T&> Predicate> iterator findIf(NOESCAPE const Predicate&) LIFETIME_BOUND;
     template<std::predicate<const T&> Predicate> const_iterator findIf(NOESCAPE const Predicate&) const LIFETIME_BOUND;
     template<std::predicate<const T&> Predicate> bool containsIf(NOESCAPE const Predicate& predicate) const LIFETIME_BOUND


### PR DESCRIPTION
This is probably easier to review with side-by-side or before/after views rather than via unified diff.

#### 852ee0f0430a6ce5b8590e97911bb768db24615d
<pre>
Deque takeFirst()/takeLast() description is confusing
<a href="https://bugs.webkit.org/show_bug.cgi?id=314688">https://bugs.webkit.org/show_bug.cgi?id=314688</a>
<a href="https://rdar.apple.com/176932881">rdar://176932881</a>

Reviewed by NOBODY (OOPS!).

Clarify what is meant by &quot;null version of T&quot;.
While we&apos;re here, organize the methods into sections with category titles
so that the interface is easier to navigate and understand.

* Source/WTF/wtf/Deque.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/690d19c6076ad65133f40180d6e8606cb9e4b72c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162615 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36091 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29229 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171553 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119061 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36195 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36095 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126211 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88890 "17 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c3930c5b-8694-4b2a-917c-6faece37d895) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165574 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28561 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146108 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106789 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27607 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26133 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19253 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137313 "Found 1 new API test failure: TestWebKitAPI.PasteHTML.PasteDarkTextOnWhiteBackgroundIntoDarkModeEditor (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23838 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174057 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23454 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21370 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25483 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134520 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35765 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30230 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134516 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35749 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145634 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98101 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/29055 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22468 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195016 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35259 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/103010 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50416 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34760 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35005 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34908 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->