### PR TITLE
FileSystemHandle IndexedDB storage

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-IndexedDB-deferred-deserialization.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-IndexedDB-deferred-deserialization.https.any-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Reading request.result after the record is deleted still produces a usable handle.
+PASS Reading request.result after the database is closed still produces a usable handle.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-IndexedDB-deferred-deserialization.https.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-IndexedDB-deferred-deserialization.https.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-IndexedDB-deferred-deserialization.https.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-IndexedDB-deferred-deserialization.https.any.js
@@ -1,0 +1,59 @@
+// META: script=resources/test-helpers.js
+// META: script=resources/sandboxed-fs-test-helpers.js
+// META: script=resources/messaging-helpers.js
+// META: script=/IndexedDB/resources/support-promises.js
+
+'use strict';
+
+// Regression test: deserializing a FileSystemHandle out of an IndexedDB result must
+// still work after the originating record has been deleted, since `request.result`
+// is only materialized when JS first reads it.
+
+directory_test(async (t, root_dir) => {
+  const handle = await createFileWithContents('file', 'contents', root_dir);
+
+  const db = await createDatabase(t, db => {
+    db.createObjectStore('store');
+  });
+
+  let tx = db.transaction('store', 'readwrite');
+  await promiseForRequest(t, tx.objectStore('store').put(handle, 'key'));
+  await promiseForTransaction(t, tx);
+
+  tx = db.transaction('store', 'readwrite');
+  const store = tx.objectStore('store');
+  const getRequest = store.get('key');
+  await requestWatcher(t, getRequest).wait_for('success');
+
+  await promiseForRequest(t, store.delete('key'));
+  await promiseForTransaction(t, tx);
+
+  const retrieved = getRequest.result;
+  assert_true(await handle.isSameEntry(retrieved));
+  const file = await retrieved.getFile();
+  assert_equals(await file.text(), 'contents');
+}, 'Reading request.result after the record is deleted still produces a usable handle.');
+
+directory_test(async (t, root_dir) => {
+  const handle = await createFileWithContents('file', 'contents', root_dir);
+
+  const db = await createDatabase(t, db => {
+    db.createObjectStore('store');
+  });
+
+  const tx = db.transaction('store', 'readwrite');
+  await promiseForRequest(t, tx.objectStore('store').put(handle, 'key'));
+  await promiseForTransaction(t, tx);
+
+  const readTx = db.transaction('store', 'readonly');
+  const getRequest = readTx.objectStore('store').get('key');
+  await requestWatcher(t, getRequest).wait_for('success');
+  await promiseForTransaction(t, readTx);
+
+  db.close();
+
+  const retrieved = getRequest.result;
+  assert_true(await handle.isSameEntry(retrieved));
+  const file = await retrieved.getFile();
+  assert_equals(await file.text(), 'contents');
+}, 'Reading request.result after the database is closed still produces a usable handle.');

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-IndexedDB-deferred-deserialization.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-IndexedDB-deferred-deserialization.https.any.worker-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Reading request.result after the record is deleted still produces a usable handle.
+PASS Reading request.result after the database is closed still produces a usable handle.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-IndexedDB-deferred-deserialization.https.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-IndexedDB-deferred-deserialization.https.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-IndexedDB.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-IndexedDB.https.any-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL Store handle in IndexedDB and read from pending transaction. promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL Store handle in IndexedDB and read from new transaction. promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL Store handles and blobs in IndexedDB. promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL Store handle in IndexedDB and read using a cursor. promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL Store handle in IndexedDB using inline keys. promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL Store and retrieve the root directory from IndexedDB. promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
+PASS Store handle in IndexedDB and read from pending transaction.
+PASS Store handle in IndexedDB and read from new transaction.
+PASS Store handles and blobs in IndexedDB.
+PASS Store handle in IndexedDB and read using a cursor.
+PASS Store handle in IndexedDB using inline keys.
+PASS Store and retrieve the root directory from IndexedDB.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-IndexedDB.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-IndexedDB.https.any.worker-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL Store handle in IndexedDB and read from pending transaction. promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL Store handle in IndexedDB and read from new transaction. promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL Store handles and blobs in IndexedDB. promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL Store handle in IndexedDB and read using a cursor. promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL Store handle in IndexedDB using inline keys. promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
-FAIL Store and retrieve the root directory from IndexedDB. promise_test: Unhandled rejection with value: object "DataCloneError: The object can not be cloned."
+PASS Store handle in IndexedDB and read from pending transaction.
+PASS Store handle in IndexedDB and read from new transaction.
+PASS Store handles and blobs in IndexedDB.
+PASS Store handle in IndexedDB and read using a cursor.
+PASS Store handle in IndexedDB using inline keys.
+PASS Store and retrieve the root directory from IndexedDB.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/w3c-import.log
@@ -14,6 +14,7 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-IndexedDB-deferred-deserialization.https.any.js
 /LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-IndexedDB.https.any.js
 /LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-buckets.https.any.js
 /LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-getUniqueId.https.any.js

--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -432,6 +432,8 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/filesystem/FileSystemHandleIdentifier.h
     Modules/filesystem/FileSystemHandleInfo.h
     Modules/filesystem/FileSystemHandleKind.h
+    Modules/filesystem/FileSystemHandleRecord.h
+    Modules/filesystem/FileSystemHandleStorageKeepAlive.h
     Modules/filesystem/FileSystemStorageConnection.h
     Modules/filesystem/FileSystemSyncAccessHandleIdentifier.h
     Modules/filesystem/FileSystemWritableFileStreamIdentifier.h

--- a/Source/WebCore/Modules/filesystem/FileSystemHandleRecord.h
+++ b/Source/WebCore/Modules/filesystem/FileSystemHandleRecord.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/FileSystemHandleGlobalIdentifier.h>
+#include <WebCore/FileSystemHandleKind.h>
+#include <wtf/text/WTFString.h>
+
+namespace WebCore {
+
+struct FileSystemHandleRecord {
+    FileSystemHandleGlobalIdentifier identifier;
+    FileSystemHandleKind kind;
+    String path;
+    String name;
+
+    FileSystemHandleRecord isolatedCopy() const & { return { identifier, kind, path.isolatedCopy(), name.isolatedCopy() }; }
+    FileSystemHandleRecord isolatedCopy() && { return { identifier, kind, WTF::move(path).isolatedCopy(), WTF::move(name).isolatedCopy() }; }
+};
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/filesystem/FileSystemHandleStorageKeepAlive.cpp
+++ b/Source/WebCore/Modules/filesystem/FileSystemHandleStorageKeepAlive.cpp
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "FileSystemHandleStorageKeepAlive.h"
+
+#include "FileSystemStorageConnection.h"
+#include <wtf/CrossThreadCopier.h>
+
+namespace WebCore {
+
+Ref<FileSystemHandleStorageKeepAlive> FileSystemHandleStorageKeepAlive::create(ClientOrigin&& origin, Vector<FileSystemHandleGlobalIdentifier>&& globalIdentifiers, Ref<FileSystemStorageConnection>&& connection)
+{
+    return adoptRef(*new FileSystemHandleStorageKeepAlive(WTF::move(origin), WTF::move(globalIdentifiers), WTF::move(connection)));
+}
+
+FileSystemHandleStorageKeepAlive::FileSystemHandleStorageKeepAlive(ClientOrigin&& origin, Vector<FileSystemHandleGlobalIdentifier>&& globalIdentifiers, Ref<FileSystemStorageConnection>&& connection)
+    : m_origin(crossThreadCopy(WTF::move(origin)))
+    , m_globalIdentifiers(WTF::move(globalIdentifiers))
+    , m_connection(WTF::move(connection))
+{
+}
+
+FileSystemHandleStorageKeepAlive::~FileSystemHandleStorageKeepAlive()
+{
+    if (m_globalIdentifiers.isEmpty())
+        return;
+    if (RefPtr connection = m_connection)
+        connection->removeGlobalIdentifierReferences(ClientOrigin { m_origin }, WTF::move(m_globalIdentifiers));
+}
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/filesystem/FileSystemHandleStorageKeepAlive.h
+++ b/Source/WebCore/Modules/filesystem/FileSystemHandleStorageKeepAlive.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/ClientOrigin.h>
+#include <WebCore/FileSystemHandleGlobalIdentifier.h>
+#include <wtf/RefPtr.h>
+#include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/Vector.h>
+
+namespace WebCore {
+
+class FileSystemStorageConnection;
+
+class FileSystemHandleStorageKeepAlive : public ThreadSafeRefCounted<FileSystemHandleStorageKeepAlive> {
+public:
+    WEBCORE_EXPORT static Ref<FileSystemHandleStorageKeepAlive> create(ClientOrigin&&, Vector<FileSystemHandleGlobalIdentifier>&&, Ref<FileSystemStorageConnection>&&);
+    WEBCORE_EXPORT ~FileSystemHandleStorageKeepAlive();
+
+private:
+    FileSystemHandleStorageKeepAlive(ClientOrigin&&, Vector<FileSystemHandleGlobalIdentifier>&&, Ref<FileSystemStorageConnection>&&);
+
+    ClientOrigin m_origin;
+    Vector<FileSystemHandleGlobalIdentifier> m_globalIdentifiers;
+    RefPtr<FileSystemStorageConnection> m_connection;
+};
+
+} // namespace WebCore

--- a/Source/WebCore/Modules/filesystem/FileSystemStorageConnection.h
+++ b/Source/WebCore/Modules/filesystem/FileSystemStorageConnection.h
@@ -118,6 +118,8 @@ public:
     FileSystemHandleKeepAlive(const FileSystemHandleKeepAlive&) = delete;
     FileSystemHandleKeepAlive& operator=(const FileSystemHandleKeepAlive&) = delete;
 
+    Markable<FileSystemHandleGlobalIdentifier> globalIdentifier() const { return m_globalIdentifier; }
+
 private:
     Markable<FileSystemHandleGlobalIdentifier> m_globalIdentifier;
     ClientOrigin m_origin;

--- a/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBTransaction.cpp
@@ -926,7 +926,7 @@ void IDBTransaction::iterateCursorOnServer(IDBClient::TransactionOperation& oper
 
     if (data.keyData.isNull() && data.primaryKeyData.isNull()) {
         if (auto getResult = cursor->iterateWithPrefetchedRecords(data.count, m_lastWriteOperationID)) {
-            auto result = IDBResultData::iterateCursorSuccess(operation.identifier(), getResult.value());
+            auto result = IDBResultData::iterateCursorSuccess(operation.identifier(), getResult.value(), { });
             m_database->connectionProxy().iterateCursor(operation, { data.keyData, data.primaryKeyData, data.count, IndexedDB::CursorIterateOption::DoNotReply });
             operationCompletedOnServer(result, operation);
             return;

--- a/Source/WebCore/Modules/indexeddb/IDBValue.cpp
+++ b/Source/WebCore/Modules/indexeddb/IDBValue.cpp
@@ -26,6 +26,8 @@
 #include "config.h"
 #include "IDBValue.h"
 
+#include "FileSystemHandleRecord.h"
+#include "FileSystemHandleStorageKeepAlive.h"
 #include "SerializedScriptValue.h"
 #include <wtf/CrossThreadTask.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -39,6 +41,7 @@ IDBValue::IDBValue() = default;
 IDBValue::IDBValue(const SerializedScriptValue& scriptValue)
     : m_data(ThreadSafeDataBuffer::copyData(scriptValue.wireBytes()))
     , m_blobURLs(scriptValue.blobURLs())
+    , m_fileSystemHandleGlobalIdentifiers(scriptValue.fileSystemHandleGlobalIdentifiers())
 {
 }
 
@@ -51,31 +54,59 @@ IDBValue::IDBValue(const SerializedScriptValue& scriptValue, const Vector<String
     : m_data(ThreadSafeDataBuffer::copyData(scriptValue.wireBytes()))
     , m_blobURLs(blobURLs)
     , m_blobFilePaths(blobFilePaths)
+    , m_fileSystemHandleGlobalIdentifiers(scriptValue.fileSystemHandleGlobalIdentifiers())
 {
     ASSERT(m_data.data());
 }
 
-IDBValue::IDBValue(const ThreadSafeDataBuffer& value, Vector<String>&& blobURLs, Vector<String>&& blobFilePaths)
+IDBValue::IDBValue(const ThreadSafeDataBuffer& value, Vector<String>&& blobURLs, Vector<String>&& blobFilePaths, Vector<FileSystemHandleGlobalIdentifier>&& fileSystemHandleGlobalIdentifiers)
     : m_data(value)
     , m_blobURLs(WTF::move(blobURLs))
     , m_blobFilePaths(WTF::move(blobFilePaths))
+    , m_fileSystemHandleGlobalIdentifiers(WTF::move(fileSystemHandleGlobalIdentifiers))
 {
 }
 
-IDBValue::IDBValue(const ThreadSafeDataBuffer& value, const Vector<String>& blobURLs, const Vector<String>& blobFilePaths)
+IDBValue::IDBValue(const ThreadSafeDataBuffer& value, const Vector<String>& blobURLs, const Vector<String>& blobFilePaths, const Vector<FileSystemHandleGlobalIdentifier>& fileSystemHandleGlobalIdentifiers)
     : m_data(value)
     , m_blobURLs(blobURLs)
     , m_blobFilePaths(blobFilePaths)
+    , m_fileSystemHandleGlobalIdentifiers(fileSystemHandleGlobalIdentifiers)
 {
+}
+
+IDBValue::IDBValue(const IDBValue&) = default;
+IDBValue::IDBValue(IDBValue&&) = default;
+IDBValue& IDBValue::operator=(const IDBValue&) = default;
+IDBValue& IDBValue::operator=(IDBValue&&) = default;
+IDBValue::~IDBValue() = default;
+
+void IDBValue::attachStorageKeepAlive(RefPtr<FileSystemHandleStorageKeepAlive>&& keepAlive) const
+{
+    ASSERT(!m_storageKeepAlive);
+    m_storageKeepAlive = WTF::move(keepAlive);
+}
+
+const Vector<FileSystemHandleRecord>& IDBValue::fileSystemHandleRecords() const
+{
+    return m_fileSystemHandleRecords;
+}
+
+void IDBValue::setFileSystemHandleRecords(Vector<FileSystemHandleRecord>&& records) const
+{
+    m_fileSystemHandleRecords = WTF::move(records);
 }
 
 void IDBValue::setAsIsolatedCopy(const IDBValue& other)
 {
-    ASSERT(m_blobURLs.isEmpty() && m_blobFilePaths.isEmpty());
+    ASSERT(m_blobURLs.isEmpty() && m_blobFilePaths.isEmpty() && m_fileSystemHandleGlobalIdentifiers.isEmpty() && m_fileSystemHandleRecords.isEmpty() && !m_storageKeepAlive);
 
     m_data = other.m_data;
     m_blobURLs = crossThreadCopy(other.m_blobURLs);
     m_blobFilePaths = crossThreadCopy(other.m_blobFilePaths);
+    m_fileSystemHandleGlobalIdentifiers = other.m_fileSystemHandleGlobalIdentifiers;
+    m_fileSystemHandleRecords = crossThreadCopy(other.m_fileSystemHandleRecords);
+    m_storageKeepAlive = other.m_storageKeepAlive;
 }
 
 IDBValue IDBValue::isolatedCopy() const
@@ -94,6 +125,8 @@ size_t IDBValue::size() const
 
     for (auto& path : m_blobFilePaths)
         totalSize += path.sizeInBytes();
+
+    totalSize += m_fileSystemHandleGlobalIdentifiers.size() * sizeof(FileSystemHandleGlobalIdentifier);
 
     totalSize += m_data.size();
 

--- a/Source/WebCore/Modules/indexeddb/IDBValue.h
+++ b/Source/WebCore/Modules/indexeddb/IDBValue.h
@@ -25,13 +25,17 @@
 
 #pragma once
 
+#include <WebCore/FileSystemHandleGlobalIdentifier.h>
 #include <WebCore/ThreadSafeDataBuffer.h>
+#include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
 
+class FileSystemHandleStorageKeepAlive;
 class SerializedScriptValue;
+struct FileSystemHandleRecord;
 
 class IDBValue {
     WTF_MAKE_TZONE_ALLOCATED_EXPORT(IDBValue, WEBCORE_EXPORT);
@@ -40,8 +44,14 @@ public:
     IDBValue(const SerializedScriptValue&);
     WEBCORE_EXPORT IDBValue(const ThreadSafeDataBuffer&);
     IDBValue(const SerializedScriptValue&, const Vector<String>& blobURLs, const Vector<String>& blobFilePaths);
-    WEBCORE_EXPORT IDBValue(const ThreadSafeDataBuffer&, Vector<String>&& blobURLs, Vector<String>&& blobFilePaths);
-    IDBValue(const ThreadSafeDataBuffer&, const Vector<String>& blobURLs, const Vector<String>& blobFilePaths);
+    WEBCORE_EXPORT IDBValue(const ThreadSafeDataBuffer&, Vector<String>&& blobURLs, Vector<String>&& blobFilePaths, Vector<FileSystemHandleGlobalIdentifier>&& fileSystemHandleGlobalIdentifiers = { });
+    IDBValue(const ThreadSafeDataBuffer&, const Vector<String>& blobURLs, const Vector<String>& blobFilePaths, const Vector<FileSystemHandleGlobalIdentifier>& fileSystemHandleGlobalIdentifiers = { });
+
+    WEBCORE_EXPORT IDBValue(const IDBValue&);
+    WEBCORE_EXPORT IDBValue(IDBValue&&);
+    WEBCORE_EXPORT IDBValue& operator=(const IDBValue&);
+    WEBCORE_EXPORT IDBValue& operator=(IDBValue&&);
+    WEBCORE_EXPORT ~IDBValue();
 
     void setAsIsolatedCopy(const IDBValue&);
     WEBCORE_EXPORT IDBValue isolatedCopy() const;
@@ -49,12 +59,21 @@ public:
     const ThreadSafeDataBuffer& data() const LIFETIME_BOUND { return m_data; }
     const Vector<String>& blobURLs() const LIFETIME_BOUND { return m_blobURLs; }
     const Vector<String>& blobFilePaths() const LIFETIME_BOUND { return m_blobFilePaths; }
+    const Vector<FileSystemHandleGlobalIdentifier>& fileSystemHandleGlobalIdentifiers() const LIFETIME_BOUND { return m_fileSystemHandleGlobalIdentifiers; }
+
+    WEBCORE_EXPORT const Vector<FileSystemHandleRecord>& fileSystemHandleRecords() const LIFETIME_BOUND;
+    WEBCORE_EXPORT void setFileSystemHandleRecords(Vector<FileSystemHandleRecord>&&) const;
+
+    WEBCORE_EXPORT void attachStorageKeepAlive(RefPtr<FileSystemHandleStorageKeepAlive>&&) const;
 
     size_t NODELETE size() const;
 private:
     ThreadSafeDataBuffer m_data;
     Vector<String> m_blobURLs;
     Vector<String> m_blobFilePaths;
+    Vector<FileSystemHandleGlobalIdentifier> m_fileSystemHandleGlobalIdentifiers;
+    mutable Vector<FileSystemHandleRecord> m_fileSystemHandleRecords;
+    mutable RefPtr<FileSystemHandleStorageKeepAlive> m_storageKeepAlive;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.cpp
@@ -80,6 +80,7 @@ static const uint64_t maxGeneratorValue = 0x20000000000000;
 #define INDEX_INFO_TABLE_SCHEMA_SUFFIX " (id INTEGER NOT NULL ON CONFLICT FAIL, name TEXT NOT NULL ON CONFLICT FAIL, objectStoreID INTEGER NOT NULL ON CONFLICT FAIL, keyPath BLOB NOT NULL ON CONFLICT FAIL, isUnique INTEGER NOT NULL ON CONFLICT FAIL, multiEntry INTEGER NOT NULL ON CONFLICT FAIL)"_s;
 #define BLOB_RECORDS_TABLE_SCHEMA_SUFFIX " (objectStoreRow INTEGER NOT NULL ON CONFLICT FAIL, blobURL TEXT NOT NULL ON CONFLICT FAIL)"_s;
 #define BLOB_FILES_TABLE_SCHEMA_SUFFIX " (blobURL TEXT NOT NULL ON CONFLICT FAIL UNIQUE ON CONFLICT FAIL, fileName TEXT NOT NULL ON CONFLICT FAIL UNIQUE ON CONFLICT FAIL)"_s;
+#define FILE_SYSTEM_HANDLE_RECORDS_TABLE_SCHEMA_SUFFIX " (objectStoreRow INTEGER NOT NULL ON CONFLICT FAIL, globalIdentifier BLOB NOT NULL ON CONFLICT FAIL, kind INTEGER NOT NULL ON CONFLICT FAIL, path TEXT NOT NULL ON CONFLICT FAIL, name TEXT NOT NULL ON CONFLICT FAIL)"_s;
 
 static int idbKeyCollate(std::span<const uint8_t> aBuffer, std::span<const uint8_t> bBuffer)
 {
@@ -223,6 +224,16 @@ static ASCIILiteral blobFilesTableSchemaAlternate()
     return TABLE_SCHEMA_PREFIX "\"BlobFiles\"" BLOB_FILES_TABLE_SCHEMA_SUFFIX;
 }
 
+static ASCIILiteral fileSystemHandleRecordsTableSchema()
+{
+    return TABLE_SCHEMA_PREFIX "FileSystemHandleRecords" FILE_SYSTEM_HANDLE_RECORDS_TABLE_SCHEMA_SUFFIX;
+}
+
+static ASCIILiteral fileSystemHandleRecordsTableSchemaAlternate()
+{
+    return TABLE_SCHEMA_PREFIX "\"FileSystemHandleRecords\"" FILE_SYSTEM_HANDLE_RECORDS_TABLE_SCHEMA_SUFFIX;
+}
+
 static String createV1ObjectStoreInfoSchema(ASCIILiteral tableName)
 {
     return makeString("CREATE TABLE "_s, tableName, " (id INTEGER PRIMARY KEY NOT NULL ON CONFLICT FAIL UNIQUE ON CONFLICT FAIL, name TEXT NOT NULL ON CONFLICT FAIL UNIQUE ON CONFLICT FAIL, keyPath BLOB NOT NULL ON CONFLICT FAIL, autoInc INTEGER NOT NULL ON CONFLICT FAIL, maxIndexID INTEGER NOT NULL ON CONFLICT FAIL)"_s);
@@ -323,6 +334,24 @@ IDBError SQLiteIDBBackingStore::ensureValidBlobTables()
     }
 
     RELEASE_ASSERT(filesTableStatement == blobFilesTableSchema() || filesTableStatement == blobFilesTableSchemaAlternate());
+    return IDBError { };
+}
+
+IDBError SQLiteIDBBackingStore::ensureValidFileSystemHandleRecordsTable()
+{
+    CheckedPtr sqliteDB = m_sqliteDB.get();
+    ASSERT(sqliteDB);
+    ASSERT(sqliteDB->isOpen());
+
+    String tableStatement = sqliteDB->tableSQL("FileSystemHandleRecords"_s);
+    if (tableStatement.isEmpty()) {
+        if (!sqliteDB->executeCommand(fileSystemHandleRecordsTableSchema()))
+            return IDBError { ExceptionCode::UnknownError, makeString("Error creating FileSystemHandleRecords table ("_s, sqliteDB->lastError(), ") - "_s, unsafeSpan(sqliteDB->lastErrorMsg())) };
+
+        tableStatement = fileSystemHandleRecordsTableSchema();
+    }
+
+    RELEASE_ASSERT(tableStatement == fileSystemHandleRecordsTableSchema() || tableStatement == fileSystemHandleRecordsTableSchemaAlternate());
     return IDBError { };
 }
 
@@ -1006,6 +1035,12 @@ IDBError SQLiteIDBBackingStore::getOrEstablishDatabaseInfo(IDBDatabaseInfo& info
         return error;
     }
 
+    error = ensureValidFileSystemHandleRecordsTable();
+    if (!error.isNull()) {
+        closeSQLiteDB();
+        return error;
+    }
+
     auto result = extractExistingDatabaseInfo();
     if (!result) {
         ASSERT(!result.error().isNull());
@@ -1022,6 +1057,7 @@ IDBError SQLiteIDBBackingStore::getOrEstablishDatabaseInfo(IDBDatabaseInfo& info
 
     m_databaseInfo = WTF::move(databaseInfo);
     info = *m_databaseInfo;
+
     return IDBError { };
 }
 
@@ -1201,6 +1237,9 @@ IDBError SQLiteIDBBackingStore::deleteObjectStore(const IDBResourceIdentifier& t
         return IDBError { ExceptionCode::UnknownError, "Attempt to delete an object store in a non-version-change transaction"_s };
     }
 
+    if (auto fsHandleError = deleteFileSystemHandleRecordsForObjectStore(objectStoreIdentifier); !fsHandleError.isNull())
+        return fsHandleError;
+
     // Delete the ObjectStore record
     {
         auto sql = cachedStatement(SQL::DeleteObjectStoreInfo, "DELETE FROM ObjectStoreInfo WHERE id = ?;"_s);
@@ -1337,6 +1376,9 @@ IDBError SQLiteIDBBackingStore::clearObjectStore(const IDBResourceIdentifier& tr
         LOG_ERROR("Attempt to clear an object store in a read-only transaction");
         return IDBError { ExceptionCode::UnknownError, "Attempt to clear an object store in a read-only transaction"_s };
     }
+
+    if (auto fsHandleError = deleteFileSystemHandleRecordsForObjectStore(objectStoreID); !fsHandleError.isNull())
+        return fsHandleError;
 
     {
         auto sql = cachedStatement(SQL::ClearObjectStoreRecords, "DELETE FROM Records WHERE objectStoreID = ?;"_s);
@@ -1725,6 +1767,9 @@ IDBError SQLiteIDBBackingStore::deleteRecord(SQLiteIDBTransaction& transaction, 
     if (!error.isNull())
         return error;
 
+    if (auto fsHandleError = deleteFileSystemHandleRecordsForObjectStoreRecord(recordID); !fsHandleError.isNull())
+        return fsHandleError;
+
     // Delete record from object store
     {
         auto sql = cachedStatement(SQL::DeleteObjectStoreRecord, "DELETE FROM Records WHERE objectStoreID = ? AND key = CAST(? AS TEXT);"_s);
@@ -1964,6 +2009,9 @@ IDBError SQLiteIDBBackingStore::addRecord(const IDBResourceIdentifier& transacti
         transaction->addBlobFile(blobFiles[i], storedFilename);
     }
 
+    if (auto fsHandleError = addFileSystemHandleRecordsForObjectStoreRecord(recordID, value.fileSystemHandleRecords()); !fsHandleError.isNull())
+        return fsHandleError;
+
     transaction->notifyCursorsOfChanges(objectStoreInfo.identifier());
 
     return error;
@@ -2025,6 +2073,118 @@ IDBError SQLiteIDBBackingStore::getBlobRecordsForObjectStoreRecord(int64_t objec
         blobFilePaths.append(FileSystem::pathByAppendingComponent(m_databaseDirectory, fileName));
     }
     return IDBError { };
+}
+
+IDBError SQLiteIDBBackingStore::addFileSystemHandleRecordsForObjectStoreRecord(int64_t recordID, const Vector<FileSystemHandleRecord>& records)
+{
+    for (auto& record : records) {
+        auto sql = cachedStatement(SQL::AddFileSystemHandleRecord, "INSERT INTO FileSystemHandleRecords VALUES (?, ?, ?, ?, ?);"_s);
+        CheckedPtr statement = sql.get();
+        auto rawIdentifier = record.identifier.toRawValue();
+        if (!statement
+            || statement->bindInt64(1, recordID) != SQLITE_OK
+            || statement->bindBlob(2, rawIdentifier.span()) != SQLITE_OK
+            || statement->bindInt(3, static_cast<int>(record.kind)) != SQLITE_OK
+            || statement->bindText(4, record.path) != SQLITE_OK
+            || statement->bindText(5, record.name) != SQLITE_OK
+            || statement->step() != SQLITE_DONE) {
+            CheckedRef sqliteDB = *m_sqliteDB;
+            LOG_ERROR("Could not insert FileSystemHandleRecord (%i) - %s", sqliteDB->lastError(), sqliteDB->lastErrorMsg());
+            return IDBError { ExceptionCode::UnknownError, "Failed to record FileSystemHandle in database"_s };
+        }
+    }
+
+    return IDBError { };
+}
+
+IDBError SQLiteIDBBackingStore::deleteFileSystemHandleRecordsForObjectStoreRecord(int64_t recordID)
+{
+    auto sql = cachedStatement(SQL::DeleteFileSystemHandleRecordsByObjectStoreRow, "DELETE FROM FileSystemHandleRecords WHERE objectStoreRow = ?;"_s);
+    CheckedPtr statement = sql.get();
+    if (!statement
+        || statement->bindInt64(1, recordID) != SQLITE_OK
+        || statement->step() != SQLITE_DONE) {
+        CheckedRef sqliteDB = *m_sqliteDB;
+        LOG_ERROR("Could not delete FileSystemHandleRecords (%i) - %s", sqliteDB->lastError(), sqliteDB->lastErrorMsg());
+        return IDBError { ExceptionCode::UnknownError, "Failed to delete FileSystemHandleRecords"_s };
+    }
+    return IDBError { };
+}
+
+IDBError SQLiteIDBBackingStore::deleteFileSystemHandleRecordsForObjectStore(IDBObjectStoreIdentifier objectStoreID)
+{
+    auto sql = cachedStatement(SQL::DeleteFileSystemHandleRecordsByObjectStoreID, "DELETE FROM FileSystemHandleRecords WHERE objectStoreRow IN (SELECT recordID FROM Records WHERE objectStoreID = ?);"_s);
+    CheckedPtr statement = sql.get();
+    if (!statement
+        || statement->bindInt64(1, objectStoreID.toRawValue()) != SQLITE_OK
+        || statement->step() != SQLITE_DONE) {
+        CheckedRef sqliteDB = *m_sqliteDB;
+        LOG_ERROR("Could not delete FileSystemHandleRecords for object store (%i) - %s", sqliteDB->lastError(), sqliteDB->lastErrorMsg());
+        return IDBError { ExceptionCode::UnknownError, "Failed to delete FileSystemHandleRecords"_s };
+    }
+    return IDBError { };
+}
+
+IDBError SQLiteIDBBackingStore::getFileSystemHandleRecordsForObjectStoreRecord(int64_t recordID, Vector<FileSystemHandleRecord>& records)
+{
+    auto sql = cachedStatement(SQL::GetFileSystemHandleRecordsByObjectStoreRow, "SELECT globalIdentifier, kind, path, name FROM FileSystemHandleRecords WHERE objectStoreRow = ? ORDER BY rowid;"_s);
+    CheckedPtr statement = sql.get();
+    if (!statement
+        || statement->bindInt64(1, recordID) != SQLITE_OK) {
+        CheckedRef sqliteDB = *m_sqliteDB;
+        LOG_ERROR("Could not prepare statement to fetch FileSystemHandleRecords (%i) - %s", sqliteDB->lastError(), sqliteDB->lastErrorMsg());
+        return IDBError { ExceptionCode::UnknownError, "Failed to look up FileSystemHandleRecords"_s };
+    }
+
+    int result = statement->step();
+    while (result == SQLITE_ROW) {
+        auto blob = statement->columnBlob(0);
+        auto kindInt = statement->columnInt(1);
+        auto path = statement->columnText(2);
+        auto name = statement->columnText(3);
+        if (blob.size() != 16) {
+            LOG_ERROR("FileSystemHandleRecords row has invalid identifier blob size %zu", blob.size());
+            return IDBError { ExceptionCode::UnknownError, "FileSystemHandleRecords row corrupt"_s };
+        }
+        auto uuid = WTF::UUID(blob.span());
+        if (!uuid) {
+            LOG_ERROR("FileSystemHandleRecords row has empty UUID");
+            return IDBError { ExceptionCode::UnknownError, "FileSystemHandleRecords row corrupt"_s };
+        }
+        if (kindInt != static_cast<int>(FileSystemHandleKind::File) && kindInt != static_cast<int>(FileSystemHandleKind::Directory)) {
+            LOG_ERROR("FileSystemHandleRecords row has invalid kind %d", kindInt);
+            return IDBError { ExceptionCode::UnknownError, "FileSystemHandleRecords row corrupt"_s };
+        }
+        records.append(FileSystemHandleRecord {
+            FileSystemHandleGlobalIdentifier { uuid },
+            static_cast<FileSystemHandleKind>(kindInt),
+            WTF::move(path),
+            WTF::move(name),
+        });
+        result = statement->step();
+    }
+
+    if (result != SQLITE_DONE) {
+        CheckedRef sqliteDB = *m_sqliteDB;
+        LOG_ERROR("Could not fetch FileSystemHandleRecords (%i) - %s", sqliteDB->lastError(), sqliteDB->lastErrorMsg());
+        return IDBError { ExceptionCode::UnknownError, "Failed to look up FileSystemHandleRecords"_s };
+    }
+
+    return IDBError { };
+}
+
+Expected<IDBValue, IDBError> SQLiteIDBBackingStore::buildIDBValueForRecord(int64_t recordID, const ThreadSafeDataBuffer& data, Vector<String>&& blobURLs, Vector<String>&& blobFilePaths)
+{
+    Vector<FileSystemHandleRecord> fileSystemHandleRecords;
+    if (auto error = getFileSystemHandleRecordsForObjectStoreRecord(recordID, fileSystemHandleRecords); !error.isNull())
+        return makeUnexpected(WTF::move(error));
+
+    Vector<FileSystemHandleGlobalIdentifier> handleGlobalIdentifiers = fileSystemHandleRecords.map([](auto& record) {
+        return record.identifier;
+    });
+    IDBValue value { data, WTF::move(blobURLs), WTF::move(blobFilePaths), WTF::move(handleGlobalIdentifiers) };
+    value.setFileSystemHandleRecords(WTF::move(fileSystemHandleRecords));
+    return value;
 }
 
 IDBError SQLiteIDBBackingStore::getRecord(const IDBResourceIdentifier& transactionIdentifier, IDBObjectStoreIdentifier objectStoreID, const IDBKeyRangeData& keyRange, IDBGetRecordDataType type, IDBGetResult& resultValue)
@@ -2148,7 +2308,10 @@ IDBError SQLiteIDBBackingStore::getRecord(const IDBResourceIdentifier& transacti
     if (!error.isNull())
         return error;
 
-    resultValue = { keyData, { valueResultBuffer, WTF::move(blobURLs), WTF::move(blobFilePaths) }, objectStoreInfo->keyPath() };
+    auto valueResult = buildIDBValueForRecord(recordID, valueResultBuffer, WTF::move(blobURLs), WTF::move(blobFilePaths));
+    if (!valueResult)
+        return WTF::move(valueResult.error());
+    resultValue = { keyData, WTF::move(*valueResult), objectStoreInfo->keyPath() };
     return IDBError { };
 }
 
@@ -2285,7 +2448,10 @@ IDBError SQLiteIDBBackingStore::getAllObjectStoreRecords(const IDBResourceIdenti
             if (!error.isNull())
                 return error;
 
-            result.addValue({ valueResultBuffer, WTF::move(blobURLs), WTF::move(blobFilePaths) });
+            auto valueResult = buildIDBValueForRecord(recordID, valueResultBuffer, WTF::move(blobURLs), WTF::move(blobFilePaths));
+            if (!valueResult)
+                return WTF::move(valueResult.error());
+            result.addValue(WTF::move(*valueResult));
         }
 
         ++returnedResults;
@@ -2463,7 +2629,10 @@ IDBError SQLiteIDBBackingStore::uncheckedGetIndexRecordForOneKey(IDBIndexIdentif
         RELEASE_LOG_ERROR(IndexedDB, "%p - SQLiteIDBBackingStore::uncheckedGetIndexRecordForOneKey: object store cannot be found in database", this);
         return IDBError { ExceptionCode::UnknownError, "Object store cannot be found in the database"_s };
     }
-    getResult = { objectStoreKey, objectStoreKey, { ThreadSafeDataBuffer::create(WTF::move(valueVector)), WTF::move(blobURLs), WTF::move(blobFilePaths) }, objectStoreInfo->keyPath() };
+    auto valueResult = buildIDBValueForRecord(recordID, ThreadSafeDataBuffer::create(WTF::move(valueVector)), WTF::move(blobURLs), WTF::move(blobFilePaths));
+    if (!valueResult)
+        return WTF::move(valueResult.error());
+    getResult = { objectStoreKey, objectStoreKey, WTF::move(*valueResult), objectStoreInfo->keyPath() };
     return IDBError { };
 }
 
@@ -2947,6 +3116,7 @@ void SQLiteIDBBackingStore::forEachObjectStoreRecord(const IDBResourceIdentifier
 #undef INDEX_INFO_TABLE_SCHEMA_SUFFIX
 #undef BLOB_RECORDS_TABLE_SCHEMA_SUFFIX
 #undef BLOB_FILES_TABLE_SCHEMA_SUFFIX
+#undef FILE_SYSTEM_HANDLE_RECORDS_TABLE_SCHEMA_SUFFIX
 
 } // namespace IDBServer
 } // namespace WebCore

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.h
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBBackingStore.h
@@ -26,6 +26,9 @@
 #pragma once
 
 #include <JavaScriptCore/Strong.h>
+#include <WebCore/FileSystemHandleGlobalIdentifier.h>
+#include <WebCore/FileSystemHandleKind.h>
+#include <WebCore/FileSystemHandleRecord.h>
 #include <WebCore/IDBBackingStore.h>
 #include <WebCore/IDBDatabaseIdentifier.h>
 #include <WebCore/IDBDatabaseInfo.h>
@@ -100,6 +103,8 @@ public:
     void unregisterCursor(SQLiteIDBCursor&);
 
     IDBError getBlobRecordsForObjectStoreRecord(int64_t objectStoreRecord, Vector<String>& blobURLs, Vector<String>& blobFilePaths);
+    IDBError getFileSystemHandleRecordsForObjectStoreRecord(int64_t objectStoreRecord, Vector<FileSystemHandleRecord>& records);
+    Expected<IDBValue, IDBError> buildIDBValueForRecord(int64_t objectStoreRecord, const ThreadSafeDataBuffer&, Vector<String>&& blobURLs, Vector<String>&& blobFilePaths);
 
     WEBCORE_EXPORT static uint64_t databasesSizeForDirectory(const String& directory);
     const String& databaseDirectory() const LIFETIME_BOUND { return m_databaseDirectory; };
@@ -117,6 +122,7 @@ protected:
     IDBError ensureValidIndexRecordsIndex();
     IDBError ensureValidIndexRecordsRecordIndex();
     IDBError ensureValidBlobTables();
+    IDBError ensureValidFileSystemHandleRecordsTable();
     std::optional<IsSchemaUpgraded> ensureValidObjectStoreInfoTable();
     std::unique_ptr<IDBDatabaseInfo> createAndPopulateInitialDatabaseInfo();
     Expected<std::unique_ptr<IDBDatabaseInfo>, IDBError> extractExistingDatabaseInfo();
@@ -144,6 +150,10 @@ private:
     IDBError uncheckedGetIndexRecordForOneKey(IDBIndexIdentifier, IDBObjectStoreIdentifier, IndexedDB::IndexRecordType, const IDBKeyData&, IDBGetResult&);
 
     IDBError deleteUnusedBlobFileRecords(SQLiteIDBTransaction&);
+
+    IDBError addFileSystemHandleRecordsForObjectStoreRecord(int64_t recordID, const Vector<FileSystemHandleRecord>&);
+    IDBError deleteFileSystemHandleRecordsForObjectStoreRecord(int64_t recordID);
+    IDBError deleteFileSystemHandleRecordsForObjectStore(IDBObjectStoreIdentifier);
 
     IDBError getAllObjectStoreRecords(const IDBResourceIdentifier& transactionIdentifier, const IDBGetAllRecordsData&, IDBGetAllResult& outValue);
     IDBError getAllIndexRecords(const IDBResourceIdentifier& transactionIdentifier, const IDBGetAllRecordsData&, IDBGetAllResult& outValue);
@@ -187,6 +197,10 @@ private:
         BlobFilenameForBlobURL,
         AddBlobFilename,
         GetBlobURL,
+        AddFileSystemHandleRecord,
+        DeleteFileSystemHandleRecordsByObjectStoreRow,
+        DeleteFileSystemHandleRecordsByObjectStoreID,
+        GetFileSystemHandleRecordsByObjectStoreRow,
         GetKeyGeneratorValue,
         SetKeyGeneratorValue,
         GetObjectStoreRecords,

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteIDBCursor.cpp
@@ -540,8 +540,15 @@ SQLiteIDBCursor::FetchResult SQLiteIDBCursor::internalFetchNextRecord(SQLiteCurs
             return FetchResult::Failure;
         }
 
-        if (m_cursorType == IndexedDB::CursorType::KeyAndValue)
-            record.record.value = { ThreadSafeDataBuffer::create(WTF::move(keyData)), blobURLs, blobFilePaths };
+        if (m_cursorType == IndexedDB::CursorType::KeyAndValue) {
+            auto valueResult = m_transaction->backingStore().buildIDBValueForRecord(record.rowID, ThreadSafeDataBuffer::create(WTF::move(keyData)), WTF::move(blobURLs), WTF::move(blobFilePaths));
+            if (!valueResult) {
+                LOG_ERROR("Unable to fetch FileSystemHandle records from database while advancing cursor");
+                markAsErrored(record);
+                return FetchResult::Failure;
+            }
+            record.record.value = WTF::move(*valueResult);
+        }
     } else {
         if (!deserializeIDBKeyData(keyData.span(), record.record.primaryKey)) {
             LOG_ERROR("Unable to deserialize value data from database while advancing index cursor");
@@ -575,7 +582,13 @@ SQLiteIDBCursor::FetchResult SQLiteIDBCursor::internalFetchNextRecord(SQLiteCurs
                 return FetchResult::Failure;
             }
 
-            record.record.value = { ThreadSafeDataBuffer::create(cachedObjectStoreStatement->columnBlob(1)), WTF::move(blobURLs), WTF::move(blobFilePaths) };
+            auto valueResult = m_transaction->backingStore().buildIDBValueForRecord(recordsRowID, ThreadSafeDataBuffer::create(cachedObjectStoreStatement->columnBlob(1)), WTF::move(blobURLs), WTF::move(blobFilePaths));
+            if (!valueResult) {
+                LOG_ERROR("Unable to fetch FileSystemHandle records from database while advancing cursor");
+                markAsErrored(record);
+                return FetchResult::Failure;
+            }
+            record.record.value = WTF::move(*valueResult);
         } else if (result == SQLITE_DONE) {
             // This indicates that the record we're trying to retrieve has been removed from the object store.
             // Skip over it.

--- a/Source/WebCore/Modules/indexeddb/server/SQLiteMemoryIDBBackingStore.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/SQLiteMemoryIDBBackingStore.cpp
@@ -132,6 +132,12 @@ IDBError SQLiteMemoryIDBBackingStore::getOrEstablishDatabaseInfo(IDBDatabaseInfo
         return error;
     }
 
+    error = ensureValidFileSystemHandleRecordsTable();
+    if (!error.isNull()) {
+        closeSQLiteDB();
+        return error;
+    }
+
     auto result = extractExistingDatabaseInfo();
     if (!result) {
         ASSERT(!result.error().isNull());

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabase.h
@@ -42,19 +42,14 @@
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
-namespace IDBServer {
-class UniqueIDBDatabase;
-}
-}
 
-namespace WebCore {
-
-struct ClientOrigin;
 class IDBError;
 class IDBGetAllResult;
-struct IDBGetRecordData;
 class IDBRequestData;
 class IDBTransactionInfo;
+
+struct ClientOrigin;
+struct IDBGetRecordData;
 
 enum class IDBGetRecordDataType : bool;
 
@@ -65,6 +60,7 @@ enum class IndexRecordType : bool;
 namespace IDBServer {
 
 class IDBConnectionToClient;
+class UniqueIDBDatabase;
 class UniqueIDBDatabaseConnection;
 class UniqueIDBDatabaseManager;
 

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.cpp
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.cpp
@@ -38,6 +38,13 @@
 namespace WebCore {
 namespace IDBServer {
 
+static ClientOrigin clientOrigin(UniqueIDBDatabaseConnection& databaseConnection)
+{
+    if (CheckedPtr database = databaseConnection.database())
+        return database->identifier().origin();
+    return { };
+}
+
 Ref<UniqueIDBDatabaseTransaction> UniqueIDBDatabaseTransaction::create(UniqueIDBDatabaseConnection& connection, const IDBTransactionInfo& info)
 {
     return adoptRef(*new UniqueIDBDatabaseTransaction(connection, info));
@@ -340,11 +347,11 @@ void UniqueIDBDatabaseTransaction::putOrAdd(const IDBRequestData& requestData, c
 
     ASSERT(!isReadOnly());
     ASSERT(m_transactionInfo.identifier() == requestData.transactionIdentifier());
-    
+
     CheckedPtr database = this->database();
     if (!database)
         return;
-    
+
     database->putOrAdd(requestData, keyData, value, indexKeys, overwriteMode, [weakThis = WeakPtr { *this }, requestData](auto& error, const IDBKeyData& key) {
         LOG(IndexedDB, "UniqueIDBDatabaseTransaction::putOrAdd (callback)");
 
@@ -389,7 +396,7 @@ void UniqueIDBDatabaseTransaction::getRecord(const IDBRequestData& requestData, 
         protectedThis->m_requestResults.append(error);
 
         if (error.isNull())
-            protect(databaseConnection->connectionToClient())->didGetRecord(IDBResultData::getRecordSuccess(requestData.requestIdentifier(), result));
+            protect(databaseConnection->connectionToClient())->didGetRecord(IDBResultData::getRecordSuccess(requestData.requestIdentifier(), result, clientOrigin(*databaseConnection)));
         else
             protect(databaseConnection->connectionToClient())->didGetRecord(IDBResultData::error(requestData.requestIdentifier(), error));
     });
@@ -419,7 +426,7 @@ void UniqueIDBDatabaseTransaction::getAllRecords(const IDBRequestData& requestDa
         protectedThis->m_requestResults.append(error);
 
         if (error.isNull())
-            protect(databaseConnection->connectionToClient())->didGetAllRecords(IDBResultData::getAllRecordsSuccess(requestData.requestIdentifier(), result));
+            protect(databaseConnection->connectionToClient())->didGetAllRecords(IDBResultData::getAllRecordsSuccess(requestData.requestIdentifier(), result, clientOrigin(*databaseConnection)));
         else
             protect(databaseConnection->connectionToClient())->didGetAllRecords(IDBResultData::error(requestData.requestIdentifier(), error));
     });
@@ -509,7 +516,7 @@ void UniqueIDBDatabaseTransaction::openCursor(const IDBRequestData& requestData,
         protectedThis->m_requestResults.append(error);
 
         if (error.isNull())
-            protect(databaseConnection->connectionToClient())->didOpenCursor(IDBResultData::openCursorSuccess(requestData.requestIdentifier(), result));
+            protect(databaseConnection->connectionToClient())->didOpenCursor(IDBResultData::openCursorSuccess(requestData.requestIdentifier(), result, clientOrigin(*databaseConnection)));
         else
             protect(databaseConnection->connectionToClient())->didOpenCursor(IDBResultData::error(requestData.requestIdentifier(), error));
     });
@@ -542,7 +549,7 @@ void UniqueIDBDatabaseTransaction::iterateCursor(const IDBRequestData& requestDa
         protectedThis->m_requestResults.append(error);
 
         if (error.isNull())
-            protect(databaseConnection->connectionToClient())->didIterateCursor(IDBResultData::iterateCursorSuccess(requestData.requestIdentifier(), result));
+            protect(databaseConnection->connectionToClient())->didIterateCursor(IDBResultData::iterateCursorSuccess(requestData.requestIdentifier(), result, clientOrigin(*databaseConnection)));
         else
             protect(databaseConnection->connectionToClient())->didIterateCursor(IDBResultData::error(requestData.requestIdentifier(), error));
     });

--- a/Source/WebCore/Modules/indexeddb/shared/IDBResultData.cpp
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBResultData.cpp
@@ -29,6 +29,7 @@
 #include "UniqueIDBDatabase.h"
 #include "UniqueIDBDatabaseConnection.h"
 #include "UniqueIDBDatabaseTransaction.h"
+#include <wtf/CrossThreadCopier.h>
 
 namespace WebCore {
 
@@ -52,6 +53,8 @@ IDBResultData::IDBResultData(const IDBResultData& other)
     , m_databaseConnectionIdentifier(other.m_databaseConnectionIdentifier)
     , m_resultInteger(other.m_resultInteger)
 {
+    if (other.m_clientOrigin)
+        m_clientOrigin = makeUniqueWithoutFastMallocCheck<ClientOrigin>(*other.m_clientOrigin);
     if (other.m_databaseInfo)
         m_databaseInfo = makeUnique<IDBDatabaseInfo>(*other.m_databaseInfo);
     if (other.m_transactionInfo)
@@ -81,6 +84,8 @@ void IDBResultData::isolatedCopy(const IDBResultData& source, IDBResultData& des
     destination.m_error = source.m_error.isolatedCopy();
     destination.m_databaseConnectionIdentifier = source.m_databaseConnectionIdentifier;
     destination.m_resultInteger = source.m_resultInteger;
+    if (source.m_clientOrigin)
+        destination.m_clientOrigin = makeUniqueWithoutFastMallocCheck<ClientOrigin>(crossThreadCopy(*source.m_clientOrigin));
 
     if (source.m_databaseInfo)
         destination.m_databaseInfo = makeUnique<IDBDatabaseInfo>(*source.m_databaseInfo, IDBDatabaseInfo::IsolatedCopy);
@@ -171,17 +176,19 @@ IDBResultData IDBResultData::putOrAddSuccess(const IDBResourceIdentifier& reques
     return result;
 }
 
-IDBResultData IDBResultData::getRecordSuccess(const IDBResourceIdentifier& requestIdentifier, const IDBGetResult& getResult)
+IDBResultData IDBResultData::getRecordSuccess(const IDBResourceIdentifier& requestIdentifier, const IDBGetResult& getResult, ClientOrigin&& origin)
 {
     IDBResultData result { IDBResultType::GetRecordSuccess, requestIdentifier };
     result.m_getResult = makeUnique<IDBGetResult>(getResult);
+    result.setClientOrigin(WTF::move(origin));
     return result;
 }
 
-IDBResultData IDBResultData::getAllRecordsSuccess(const IDBResourceIdentifier& requestIdentifier, const IDBGetAllResult& getAllResult)
+IDBResultData IDBResultData::getAllRecordsSuccess(const IDBResourceIdentifier& requestIdentifier, const IDBGetAllResult& getAllResult, ClientOrigin&& origin)
 {
     IDBResultData result { IDBResultType::GetAllRecordsSuccess, requestIdentifier };
     result.m_getAllResult = makeUnique<IDBGetAllResult>(getAllResult);
+    result.setClientOrigin(WTF::move(origin));
     return result;
 }
 
@@ -197,17 +204,19 @@ IDBResultData IDBResultData::deleteRecordSuccess(const IDBResourceIdentifier& re
     return { IDBResultType::DeleteRecordSuccess, requestIdentifier };
 }
 
-IDBResultData IDBResultData::openCursorSuccess(const IDBResourceIdentifier& requestIdentifier, const IDBGetResult& getResult)
+IDBResultData IDBResultData::openCursorSuccess(const IDBResourceIdentifier& requestIdentifier, const IDBGetResult& getResult, ClientOrigin&& origin)
 {
     IDBResultData result { IDBResultType::OpenCursorSuccess, requestIdentifier };
     result.m_getResult = makeUnique<IDBGetResult>(getResult);
+    result.setClientOrigin(WTF::move(origin));
     return result;
 }
 
-IDBResultData IDBResultData::iterateCursorSuccess(const IDBResourceIdentifier& requestIdentifier, const IDBGetResult& getResult)
+IDBResultData IDBResultData::iterateCursorSuccess(const IDBResourceIdentifier& requestIdentifier, const IDBGetResult& getResult, ClientOrigin&& origin)
 {
     IDBResultData result { IDBResultType::IterateCursorSuccess, requestIdentifier };
     result.m_getResult = makeUnique<IDBGetResult>(getResult);
+    result.setClientOrigin(WTF::move(origin));
     return result;
 }
 
@@ -233,6 +242,19 @@ const IDBGetAllResult& IDBResultData::getAllResult() const
 {
     RELEASE_ASSERT(m_getAllResult);
     return *m_getAllResult;
+}
+
+const ClientOrigin* IDBResultData::clientOrigin() const
+{
+    return m_clientOrigin.get();
+}
+
+void IDBResultData::setClientOrigin(ClientOrigin&& origin)
+{
+    // Skip default-constructed origins (database gone by result time).
+    if (origin.topOrigin.isNull())
+        return;
+    m_clientOrigin = makeUniqueWithoutFastMallocCheck<ClientOrigin>(WTF::move(origin));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/indexeddb/shared/IDBResultData.h
+++ b/Source/WebCore/Modules/indexeddb/shared/IDBResultData.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/ClientOrigin.h>
 #include <WebCore/IDBDatabaseConnectionIdentifier.h>
 #include <WebCore/IDBDatabaseInfo.h>
 #include <WebCore/IDBError.h>
@@ -80,12 +81,12 @@ public:
     static IDBResultData deleteIndexSuccess(const IDBResourceIdentifier&);
     static IDBResultData renameIndexSuccess(const IDBResourceIdentifier&);
     static IDBResultData putOrAddSuccess(const IDBResourceIdentifier&, const IDBKeyData&);
-    static IDBResultData getRecordSuccess(const IDBResourceIdentifier&, const IDBGetResult&);
-    static IDBResultData getAllRecordsSuccess(const IDBResourceIdentifier&, const IDBGetAllResult&);
+    static IDBResultData getRecordSuccess(const IDBResourceIdentifier&, const IDBGetResult&, ClientOrigin&&);
+    static IDBResultData getAllRecordsSuccess(const IDBResourceIdentifier&, const IDBGetAllResult&, ClientOrigin&&);
     static IDBResultData getCountSuccess(const IDBResourceIdentifier&, uint64_t count);
     static IDBResultData deleteRecordSuccess(const IDBResourceIdentifier&);
-    static IDBResultData openCursorSuccess(const IDBResourceIdentifier&, const IDBGetResult&);
-    static IDBResultData iterateCursorSuccess(const IDBResourceIdentifier&, const IDBGetResult&);
+    static IDBResultData openCursorSuccess(const IDBResourceIdentifier&, const IDBGetResult&, ClientOrigin&&);
+    static IDBResultData iterateCursorSuccess(const IDBResourceIdentifier&, const IDBGetResult&, ClientOrigin&&);
 
     WEBCORE_EXPORT IDBResultData(const IDBResultData&);
     IDBResultData(IDBResultData&&) = default;
@@ -110,6 +111,12 @@ public:
     WEBCORE_EXPORT const IDBGetResult& NODELETE getResult() const;
     WEBCORE_EXPORT const IDBGetAllResult& NODELETE getAllResult() const;
 
+    // NetworkProcess-internal: set by UniqueIDBDatabaseTransaction before delegate dispatch so
+    // IDBStorageConnectionToClient can route per-origin work without a side map. Never encoded
+    // for IPC; stays empty on the WebProcess side.
+    WEBCORE_EXPORT const ClientOrigin* clientOrigin() const LIFETIME_BOUND;
+    void setClientOrigin(ClientOrigin&&);
+
     WEBCORE_EXPORT IDBResultData();
 
 private:
@@ -131,6 +138,7 @@ private:
     std::unique_ptr<IDBGetResult> m_getResult;
     std::unique_ptr<IDBGetAllResult> m_getAllResult;
     uint64_t m_resultInteger { 0 };
+    std::unique_ptr<ClientOrigin> m_clientOrigin;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webxr/WebXRRay.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRRay.cpp
@@ -34,6 +34,7 @@
 #include "DOMPointReadOnly.h"
 #include "WebXRRigidTransform.h"
 #include "XRRayDirectionInit.h"
+#include <JavaScriptCore/GenericTypedArrayViewInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -140,6 +140,7 @@ Modules/fetch/WindowOrWorkerGlobalScopeFetch.cpp
 Modules/filesystem/FileSystemDirectoryHandle.cpp
 Modules/filesystem/FileSystemFileHandle.cpp
 Modules/filesystem/FileSystemHandle.cpp
+Modules/filesystem/FileSystemHandleStorageKeepAlive.cpp
 Modules/filesystem/FileSystemStorageConnection.cpp
 Modules/filesystem/FileSystemSyncAccessHandle.cpp
 Modules/filesystem/FileSystemWritableFileStream.cpp

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -2422,8 +2422,7 @@ private:
 #endif
 
             auto serializeFileSystemHandle = [&](FileSystemHandle& handle) {
-                // FIXME: Add support for storage.
-                if (m_forStorage == SerializationForStorage::Yes || handle.isClosed()) {
+                if (handle.isClosed()) {
                     code = SerializationReturnCode::DataCloneError;
                     return true;
                 }
@@ -7103,6 +7102,17 @@ Vector<String> SerializedScriptValue::blobURLs() const
     return m_internals->blobHandles.map([](auto& handle) {
         return handle.url().string().isolatedCopy();
     });
+}
+
+Vector<FileSystemHandleGlobalIdentifier> SerializedScriptValue::fileSystemHandleGlobalIdentifiers() const
+{
+    Vector<FileSystemHandleGlobalIdentifier> result;
+    result.reserveInitialCapacity(m_internals->fileSystemHandleKeepAlives.size());
+    for (auto& keepAlive : m_internals->fileSystemHandleKeepAlives) {
+        if (auto identifier = keepAlive.globalIdentifier())
+            result.append(*identifier);
+    }
+    return result;
 }
 
 void SerializedScriptValue::writeBlobsToDiskForIndexedDB(bool isEphemeral, CompletionHandler<void(IDBValue&&)>&& completionHandler)

--- a/Source/WebCore/bindings/js/SerializedScriptValue.h
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.h
@@ -28,6 +28,7 @@
 
 #include <JavaScriptCore/Forward.h>
 #include <JavaScriptCore/JSCJSValue.h>
+#include <WebCore/FileSystemHandleGlobalIdentifier.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/text/WTFString.h>
 
@@ -114,6 +115,7 @@ public:
 
     Vector<String> blobURLs() const;
     WEBCORE_EXPORT Vector<URLKeepingBlobAlive> blobHandles() const;
+    Vector<FileSystemHandleGlobalIdentifier> fileSystemHandleGlobalIdentifiers() const;
     void writeBlobsToDiskForIndexedDB(bool isEphemeral, CompletionHandler<void(IDBValue&&)>&&);
     IDBValue writeBlobsToDiskForIndexedDBSynchronously(bool isEphemeral, JSC::VM&);
     WEBCORE_EXPORT static Ref<SerializedScriptValue> createFromWireBytes(Vector<uint8_t>&&);

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.cpp
@@ -311,4 +311,50 @@ Expected<WebCore::FileSystemHandleIdentifier, FileSystemStorageError> FileSystem
     return newIdentifier;
 }
 
+std::optional<WebCore::FileSystemHandleRecord> FileSystemStorageManager::lookupHandle(WebCore::FileSystemHandleGlobalIdentifier globalIdentifier)
+{
+    ASSERT(!RunLoop::isMain());
+
+    auto it = m_globalIdentifierRegistry.find(globalIdentifier);
+    if (it == m_globalIdentifierRegistry.end())
+        return std::nullopt;
+
+    auto& entry = it->value;
+    return WebCore::FileSystemHandleRecord { globalIdentifier, entry.kind, entry.path, entry.name };
+}
+
+std::optional<Vector<WebCore::FileSystemHandleRecord>> FileSystemStorageManager::lookupHandles(std::span<const WebCore::FileSystemHandleGlobalIdentifier> identifiers)
+{
+    ASSERT(!RunLoop::isMain());
+
+    Vector<WebCore::FileSystemHandleRecord> records;
+    records.reserveInitialCapacity(identifiers.size());
+    for (auto& identifier : identifiers) {
+        auto record = lookupHandle(identifier);
+        if (!record)
+            return std::nullopt;
+        records.append(WTF::move(*record));
+    }
+    return records;
+}
+
+void FileSystemStorageManager::registerPersistedHandle(WebCore::FileSystemHandleGlobalIdentifier globalIdentifier, WebCore::FileSystemHandleKind kind, String&& path, String&& name)
+{
+    ASSERT(!RunLoop::isMain());
+
+    m_globalIdentifierRegistry.ensure(globalIdentifier, [&] {
+        return GlobalIdentifierEntry { kind, WTF::move(path), WTF::move(name), CheckedUint32 { 0 } };
+    });
+}
+
+void FileSystemStorageManager::registerPersistedHandlesAndAddReferences(const Vector<WebCore::FileSystemHandleRecord>& records)
+{
+    ASSERT(!RunLoop::isMain());
+
+    for (auto& record : records) {
+        registerPersistedHandle(record.identifier, record.kind, String { record.path }, String { record.name });
+        addGlobalIdentifierReference(record.identifier);
+    }
+}
+
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/FileSystemStorageManager.h
@@ -30,6 +30,7 @@
 #include <WebCore/FileSystemHandleGlobalIdentifier.h>
 #include <WebCore/FileSystemHandleIdentifier.h>
 #include <WebCore/FileSystemHandleKind.h>
+#include <WebCore/FileSystemHandleRecord.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
 
@@ -65,6 +66,11 @@ public:
     void addGlobalIdentifierReference(WebCore::FileSystemHandleGlobalIdentifier);
     void removeGlobalIdentifierReferences(std::span<const WebCore::FileSystemHandleGlobalIdentifier>);
     Expected<WebCore::FileSystemHandleIdentifier, FileSystemStorageError> resolveGlobalIdentifier(IPC::Connection::UniqueID, WebCore::FileSystemHandleGlobalIdentifier);
+
+    std::optional<WebCore::FileSystemHandleRecord> lookupHandle(WebCore::FileSystemHandleGlobalIdentifier);
+    std::optional<Vector<WebCore::FileSystemHandleRecord>> lookupHandles(std::span<const WebCore::FileSystemHandleGlobalIdentifier>);
+    void registerPersistedHandle(WebCore::FileSystemHandleGlobalIdentifier, WebCore::FileSystemHandleKind, String&& path, String&& name);
+    void registerPersistedHandlesAndAddReferences(const Vector<WebCore::FileSystemHandleRecord>&);
 
     enum class LockType : bool { Exclusive, Shared };
     bool acquireLockForFile(const String& path, LockType);

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageConnectionToClient.cpp
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageConnectionToClient.cpp
@@ -26,8 +26,11 @@
 #include "config.h"
 #include "IDBStorageConnectionToClient.h"
 
+#include "NetworkStorageManager.h"
 #include "WebIDBConnectionToServerMessages.h"
 #include "WebIDBResult.h"
+#include <WebCore/IDBGetAllResult.h>
+#include <WebCore/IDBGetResult.h>
 #include <WebCore/IDBRequestData.h>
 #include <WebCore/IDBResultData.h>
 #include <WebCore/UniqueIDBDatabaseConnection.h>
@@ -37,10 +40,11 @@ namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(IDBStorageConnectionToClient);
 
-IDBStorageConnectionToClient::IDBStorageConnectionToClient(IPC::Connection::UniqueID connection, WebCore::IDBConnectionIdentifier identifier)
+IDBStorageConnectionToClient::IDBStorageConnectionToClient(IPC::Connection::UniqueID connection, WebCore::IDBConnectionIdentifier identifier, NetworkStorageManager& networkStorageManager)
     : m_connection(connection)
     , m_identifier(identifier)
     , m_connectionToClient(WebCore::IDBServer::IDBConnectionToClient::create(*this))
+    , m_networkStorageManager(networkStorageManager)
 {
 }
 
@@ -119,14 +123,52 @@ void IDBStorageConnectionToClient::didPutOrAdd(const WebCore::IDBResultData& res
     IPC::Connection::send(m_connection, Messages::WebIDBConnectionToServer::DidPutOrAdd(resultData), 0);
 }
 
+template<typename RegisterFn>
+static WebIDBResult prepareResultImpl(const WebCore::IDBResultData& resultData, RefPtr<NetworkStorageManager>&& networkStorageManager, NOESCAPE RegisterFn&& registerRecords)
+{
+    WebIDBResult result { resultData };
+    if (!networkStorageManager)
+        return result;
+    if (resultData.type() == WebCore::IDBResultType::Error || !resultData.clientOrigin())
+        return result;
+    auto& origin = *resultData.clientOrigin();
+    registerRecords(*networkStorageManager, origin);
+    result.setClientOrigin(WebCore::ClientOrigin { origin });
+    return result;
+}
+
+WebIDBResult IDBStorageConnectionToClient::prepareGetResult(const WebCore::IDBResultData& resultData)
+{
+    return prepareResultImpl(resultData, m_networkStorageManager.get(), [&](auto& networkStorageManager, auto& origin) {
+        networkStorageManager.registerFileSystemHandleRecordsForOrigin(origin, resultData.getResult().value().fileSystemHandleRecords());
+    });
+}
+
+WebIDBResult IDBStorageConnectionToClient::prepareGetAllResult(const WebCore::IDBResultData& resultData)
+{
+    return prepareResultImpl(resultData, m_networkStorageManager.get(), [&](auto& networkStorageManager, auto& origin) {
+        for (auto& value : resultData.getAllResult().values())
+            networkStorageManager.registerFileSystemHandleRecordsForOrigin(origin, value.fileSystemHandleRecords());
+    });
+}
+
+WebIDBResult IDBStorageConnectionToClient::prepareCursorResult(const WebCore::IDBResultData& resultData)
+{
+    return prepareResultImpl(resultData, m_networkStorageManager.get(), [&](auto& networkStorageManager, auto& origin) {
+        networkStorageManager.registerFileSystemHandleRecordsForOrigin(origin, resultData.getResult().value().fileSystemHandleRecords());
+        for (auto& cursorRecord : resultData.getResult().prefetchedRecords())
+            networkStorageManager.registerFileSystemHandleRecordsForOrigin(origin, cursorRecord.value.fileSystemHandleRecords());
+    });
+}
+
 void IDBStorageConnectionToClient::didGetRecord(const WebCore::IDBResultData& resultData)
 {
-    IPC::Connection::send(m_connection, Messages::WebIDBConnectionToServer::DidGetRecord(resultData), 0);
+    IPC::Connection::send(m_connection, Messages::WebIDBConnectionToServer::DidGetRecord(prepareGetResult(resultData)), 0);
 }
 
 void IDBStorageConnectionToClient::didGetAllRecords(const WebCore::IDBResultData& resultData)
 {
-    IPC::Connection::send(m_connection, Messages::WebIDBConnectionToServer::DidGetAllRecords(resultData), 0);
+    IPC::Connection::send(m_connection, Messages::WebIDBConnectionToServer::DidGetAllRecords(prepareGetAllResult(resultData)), 0);
 }
 
 void IDBStorageConnectionToClient::didGetCount(const WebCore::IDBResultData& resultData)
@@ -141,12 +183,12 @@ void IDBStorageConnectionToClient::didDeleteRecord(const WebCore::IDBResultData&
 
 void IDBStorageConnectionToClient::didOpenCursor(const WebCore::IDBResultData& resultData)
 {
-    IPC::Connection::send(m_connection, Messages::WebIDBConnectionToServer::DidOpenCursor(resultData), 0);
+    IPC::Connection::send(m_connection, Messages::WebIDBConnectionToServer::DidOpenCursor(prepareCursorResult(resultData)), 0);
 }
 
 void IDBStorageConnectionToClient::didIterateCursor(const WebCore::IDBResultData& resultData)
 {
-    IPC::Connection::send(m_connection, Messages::WebIDBConnectionToServer::DidIterateCursor(resultData), 0);
+    IPC::Connection::send(m_connection, Messages::WebIDBConnectionToServer::DidIterateCursor(prepareCursorResult(resultData)), 0);
 }
 
 void IDBStorageConnectionToClient::didGetAllDatabaseNamesAndVersions(const WebCore::IDBResourceIdentifier& requestIdentifier, Vector<WebCore::IDBDatabaseNameAndVersion>&& databases)

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageConnectionToClient.h
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageConnectionToClient.h
@@ -29,14 +29,18 @@
 #include <WebCore/IDBConnectionToClient.h>
 #include <WebCore/IDBConnectionToClientDelegate.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakPtr.h>
 
 namespace WebKit {
+
+class NetworkStorageManager;
+class WebIDBResult;
 
 class IDBStorageConnectionToClient final : public WebCore::IDBServer::IDBConnectionToClientDelegate {
     WTF_MAKE_TZONE_ALLOCATED(IDBStorageConnectionToClient);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(IDBStorageConnectionToClient);
 public:
-    IDBStorageConnectionToClient(IPC::Connection::UniqueID, WebCore::IDBConnectionIdentifier);
+    IDBStorageConnectionToClient(IPC::Connection::UniqueID, WebCore::IDBConnectionIdentifier, NetworkStorageManager&);
     ~IDBStorageConnectionToClient();
 
     std::optional<WebCore::IDBConnectionIdentifier> identifier() const final { return m_identifier; }
@@ -70,9 +74,14 @@ private:
     void generateIndexKeyForRecord(const WebCore::IDBResourceIdentifier& requestIdentifier, const WebCore::IDBIndexInfo&, const std::optional<WebCore::IDBKeyPath>&, const WebCore::IDBKeyData&, const WebCore::IDBValue&, std::optional<int64_t> recordID);
     void didCloseFromServer(WebCore::IDBServer::UniqueIDBDatabaseConnection&, const WebCore::IDBError&) final;
 
+    WebIDBResult prepareGetResult(const WebCore::IDBResultData&);
+    WebIDBResult prepareGetAllResult(const WebCore::IDBResultData&);
+    WebIDBResult prepareCursorResult(const WebCore::IDBResultData&);
+
     IPC::Connection::UniqueID m_connection;
     WebCore::IDBConnectionIdentifier m_identifier;
     const Ref<WebCore::IDBServer::IDBConnectionToClient> m_connectionToClient;
+    ThreadSafeWeakPtr<NetworkStorageManager> m_networkStorageManager;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.cpp
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.cpp
@@ -42,13 +42,13 @@ IDBStorageRegistry::~IDBStorageRegistry() = default;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(IDBStorageRegistry);
 
-WebCore::IDBServer::IDBConnectionToClient* IDBStorageRegistry::ensureConnectionToClient(IPC::Connection& ipcConnection, const WebCore::IDBResourceIdentifier& requestIdentifier)
+WebCore::IDBServer::IDBConnectionToClient* IDBStorageRegistry::ensureConnectionToClient(IPC::Connection& ipcConnection, const WebCore::IDBResourceIdentifier& requestIdentifier, NetworkStorageManager& networkStorageManager)
 {
     MESSAGE_CHECK_WITH_RETURN_VALUE(requestIdentifier.connectionIdentifier(), ipcConnection, nullptr);
     auto identifier = *requestIdentifier.connectionIdentifier();
     auto addResult = m_connectionsToClient.add(identifier, nullptr);
     if (addResult.isNewEntry)
-        addResult.iterator->value = makeUnique<IDBStorageConnectionToClient>(ipcConnection.uniqueID(), identifier);
+        addResult.iterator->value = makeUnique<IDBStorageConnectionToClient>(ipcConnection.uniqueID(), identifier, networkStorageManager);
 
     MESSAGE_CHECK_WITH_RETURN_VALUE(addResult.iterator->value->ipcConnection() == ipcConnection.uniqueID(), ipcConnection, nullptr);
     return &addResult.iterator->value->connectionToClient();

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.h
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.h
@@ -42,6 +42,7 @@ class UniqueIDBDatabaseTransaction;
 namespace WebKit {
 
 class IDBStorageConnectionToClient;
+class NetworkStorageManager;
 
 class IDBStorageRegistry : public CanMakeThreadSafeCheckedPtr<IDBStorageRegistry> {
     WTF_MAKE_TZONE_ALLOCATED(IDBStorageRegistry);
@@ -49,7 +50,7 @@ class IDBStorageRegistry : public CanMakeThreadSafeCheckedPtr<IDBStorageRegistry
 public:
     IDBStorageRegistry();
     ~IDBStorageRegistry();
-    WebCore::IDBServer::IDBConnectionToClient* ensureConnectionToClient(IPC::Connection&, const WebCore::IDBResourceIdentifier&);
+    WebCore::IDBServer::IDBConnectionToClient* ensureConnectionToClient(IPC::Connection&, const WebCore::IDBResourceIdentifier&, NetworkStorageManager&);
     void removeConnectionToClient(IPC::Connection::UniqueID);
     void registerConnection(WebCore::IDBServer::UniqueIDBDatabaseConnection&);
     void unregisterConnection(WebCore::IDBServer::UniqueIDBDatabaseConnection&);

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -54,6 +54,7 @@
 #include "UnifiedOriginStorageLevel.h"
 #include "WebsiteDataType.h"
 #include <WebCore/DOMCacheEngine.h>
+#include <WebCore/FileSystemHandleRecord.h>
 #include <WebCore/IDBRequestData.h>
 #include <WebCore/SWRegistrationDatabase.h>
 #include <WebCore/SecurityOriginData.h>
@@ -1980,17 +1981,32 @@ void NetworkStorageManager::clear(IPC::Connection& connection, StorageAreaIdenti
     writeOriginToFileIfNecessary(storageArea->origin(), ShouldUpdateOriginAccessTime::Yes, storageArea.get());
 }
 
+IDBStorageManager& NetworkStorageManager::idbStorageManagerForOrigin(const WebCore::ClientOrigin& origin, ShouldWriteOriginFile shouldWriteOriginFile, ShouldUpdateOriginAccessTime shouldUpdateOriginAccessTime)
+{
+    return originStorageManager(origin, shouldWriteOriginFile, shouldUpdateOriginAccessTime)->idbStorageManager(*m_idbStorageRegistry, useSQLiteMemoryBackingStore());
+}
+
+void NetworkStorageManager::registerFileSystemHandleRecordsForOrigin(const WebCore::ClientOrigin& origin, const Vector<WebCore::FileSystemHandleRecord>& records)
+{
+    assertIsCurrent(workQueue());
+    if (records.isEmpty() || !m_fileSystemStorageHandleRegistry)
+        return;
+
+    Ref fileSystemStorageManager = originStorageManager(origin)->fileSystemStorageManager(*protect(m_fileSystemStorageHandleRegistry));
+    fileSystemStorageManager->registerPersistedHandlesAndAddReferences(records);
+}
+
 void NetworkStorageManager::openDatabase(IPC::Connection& connection, const WebCore::IDBOpenRequestData& requestData)
 {
     auto origin = requestData.databaseIdentifier().origin();
     MESSAGE_CHECK(isSiteAllowedForConnection(connection.uniqueID(), WebCore::RegistrableDomain { origin.topOrigin }), connection);
     MESSAGE_CHECK(requestData.requestIdentifier().connectionIdentifier(), connection);
 
-    RefPtr connectionToClient = m_idbStorageRegistry->ensureConnectionToClient(connection, requestData.requestIdentifier());
+    RefPtr connectionToClient = m_idbStorageRegistry->ensureConnectionToClient(connection, requestData.requestIdentifier(), *this);
     if (!connectionToClient)
         return;
 
-    protect(originStorageManager(origin)->idbStorageManager(*m_idbStorageRegistry, useSQLiteMemoryBackingStore()))->openDatabase(*connectionToClient, requestData);
+    protect(idbStorageManagerForOrigin(origin))->openDatabase(*connectionToClient, requestData);
 }
 
 void NetworkStorageManager::openDBRequestCancelled(IPC::Connection& connection, const WebCore::IDBOpenRequestData& requestData)
@@ -1998,7 +2014,7 @@ void NetworkStorageManager::openDBRequestCancelled(IPC::Connection& connection, 
     auto origin = requestData.databaseIdentifier().origin();
     MESSAGE_CHECK(isSiteAllowedForConnection(connection.uniqueID(), WebCore::RegistrableDomain { origin.topOrigin }), connection);
 
-    protect(originStorageManager(origin)->idbStorageManager(*m_idbStorageRegistry, useSQLiteMemoryBackingStore()))->openDBRequestCancelled(requestData);
+    protect(idbStorageManagerForOrigin(origin))->openDBRequestCancelled(requestData);
 }
 
 void NetworkStorageManager::deleteDatabase(IPC::Connection& connection, const WebCore::IDBOpenRequestData& requestData)
@@ -2007,11 +2023,11 @@ void NetworkStorageManager::deleteDatabase(IPC::Connection& connection, const We
     MESSAGE_CHECK(isSiteAllowedForConnection(connection.uniqueID(), WebCore::RegistrableDomain { origin.topOrigin }), connection);
     MESSAGE_CHECK(requestData.requestIdentifier().connectionIdentifier(), connection);
 
-    RefPtr connectionToClient = m_idbStorageRegistry->ensureConnectionToClient(connection, requestData.requestIdentifier());
+    RefPtr connectionToClient = m_idbStorageRegistry->ensureConnectionToClient(connection, requestData.requestIdentifier(), *this);
     if (!connectionToClient)
         return;
 
-    protect(originStorageManager(origin)->idbStorageManager(*m_idbStorageRegistry, useSQLiteMemoryBackingStore()))->deleteDatabase(*connectionToClient, requestData);
+    protect(idbStorageManagerForOrigin(origin))->deleteDatabase(*connectionToClient, requestData);
 }
 
 void NetworkStorageManager::establishTransaction(IPC::Connection& ipcConnection, WebCore::IDBDatabaseConnectionIdentifier databaseConnectionIdentifier, const WebCore::IDBTransactionInfo& transactionInfo)
@@ -2040,7 +2056,7 @@ void NetworkStorageManager::databaseConnectionClosed(IPC::Connection& ipcConnect
     }
 
     if (databaseIdentifier.isValid())
-        protect(originStorageManager(databaseIdentifier.origin())->idbStorageManager(*m_idbStorageRegistry, useSQLiteMemoryBackingStore()))->tryCloseDatabase(databaseIdentifier);
+        protect(idbStorageManagerForOrigin(databaseIdentifier.origin()))->tryCloseDatabase(databaseIdentifier);
 }
 
 void NetworkStorageManager::abortOpenAndUpgradeNeeded(IPC::Connection& ipcConnection, WebCore::IDBDatabaseConnectionIdentifier databaseConnectionIdentifier, const std::optional<WebCore::IDBResourceIdentifier>& transactionIdentifier)
@@ -2188,6 +2204,32 @@ void NetworkStorageManager::putOrAdd(IPC::Connection& connection, const WebCore:
         }
     }
 
+    if (!value.fileSystemHandleGlobalIdentifiers().isEmpty()) {
+        // Storing wire bytes that reference UUIDs without registering trios in the FSM would
+        // produce records that can never resolve on read. Drop the put if the registry has been
+        // torn down (close()) or anything else fails the lookup, matching the surrounding
+        // blob-paths checks; the WebProcess transaction request is left unanswered.
+        if (!m_fileSystemStorageHandleRegistry) {
+            RELEASE_LOG_FAULT(IndexedDB, "NetworkStorageManager::putOrAdd: FileSystemHandle storage registry is unavailable");
+            return;
+        }
+        RefPtr databaseConnection = transaction->databaseConnection();
+        CheckedPtr database = databaseConnection ? databaseConnection->database() : nullptr;
+        if (!database)
+            return;
+        auto& origin = database->identifier().origin();
+        Ref fileSystemStorageManager = originStorageManager(origin)->fileSystemStorageManager(*protect(m_fileSystemStorageHandleRegistry));
+        auto records = fileSystemStorageManager->lookupHandles(value.fileSystemHandleGlobalIdentifiers().span());
+        if (!records) {
+            // Reachable only via a misbehaving WebProcess: a non-malicious caller has a live
+            // FileSystemHandle keeping the FSM entry alive, and the storage queue is single-
+            // threaded so a release for the same UUID can't interleave.
+            RELEASE_LOG_FAULT(IndexedDB, "NetworkStorageManager::putOrAdd: FileSystemHandle UUID is not registered");
+            return;
+        }
+        value.setFileSystemHandleRecords(WTF::move(*records));
+    }
+
     transaction->putOrAdd(requestData, keyData, value, indexKeys, overwriteMode);
 }
 
@@ -2232,11 +2274,11 @@ void NetworkStorageManager::getAllDatabaseNamesAndVersions(IPC::Connection& conn
     MESSAGE_CHECK(isSiteAllowedForConnection(connection.uniqueID(), WebCore::RegistrableDomain { origin.topOrigin }), connection);
     MESSAGE_CHECK(requestIdentifier.connectionIdentifier(), connection);
 
-    RefPtr connectionToClient = m_idbStorageRegistry->ensureConnectionToClient(connection, requestIdentifier);
+    RefPtr connectionToClient = m_idbStorageRegistry->ensureConnectionToClient(connection, requestIdentifier, *this);
     if (!connectionToClient)
         return;
 
-    auto result = protect(originStorageManager(origin)->idbStorageManager(*m_idbStorageRegistry, useSQLiteMemoryBackingStore()))->getAllDatabaseNamesAndVersions();
+    auto result = protect(idbStorageManagerForOrigin(origin))->getAllDatabaseNamesAndVersions();
     connectionToClient->didGetAllDatabaseNamesAndVersions(requestIdentifier, WTF::move(result));
 }
 

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -83,6 +83,7 @@ class IDBTransactionInfo;
 class IDBValue;
 class ServiceWorkerRegistrationKey;
 struct ClientOrigin;
+struct FileSystemHandleRecord;
 struct IDBGetAllRecordsData;
 struct IDBGetRecordData;
 struct IDBGetAllRecordsData;
@@ -164,6 +165,8 @@ public:
     const String& customIDBStoragePath() const LIFETIME_BOUND { return m_customIDBStoragePathNormalizedMainThread; }
 
     void queryCacheStorage(WebCore::ClientOrigin&&, WebCore::RetrieveRecordsOptions&&, String&&, CompletionHandler<void(std::optional<WebCore::DOMCacheEngine::Record>&&)>&&);
+
+    void registerFileSystemHandleRecordsForOrigin(const WebCore::ClientOrigin&, const Vector<WebCore::FileSystemHandleRecord>&);
 
 private:
     NetworkStorageManager(NetworkProcess&, PAL::SessionID, Markable<WTF::UUID>, std::optional<IPC::Connection::UniqueID>, const String& path, const String& customLocalStoragePath, const String& customIDBStoragePath, const String& customCacheStoragePath, const String& customServiceWorkerStoragePath, uint64_t defaultOriginQuota, std::optional<double> originQuotaRatio, std::optional<double> totalQuotaRatio, std::optional<uint64_t> standardVolumeCapacity, std::optional<uint64_t> volumeCapacityOverride, UnifiedOriginStorageLevel, bool storageSiteValidationEnabled, TimeBasedEvictionMode, Seconds timeBasedEvictionThreshold, std::optional<Seconds> lastModificationTimeUpdateIntervalOverride, std::optional<Seconds> timeBasedEvictionIntervalOverride);
@@ -257,6 +260,8 @@ private:
     void openCursor(IPC::Connection&, const WebCore::IDBRequestData&, const WebCore::IDBCursorInfo&);
     void iterateCursor(IPC::Connection&, const WebCore::IDBRequestData&, const WebCore::IDBIterateCursorData&);
     void getAllDatabaseNamesAndVersions(IPC::Connection&, const WebCore::IDBResourceIdentifier&, const WebCore::ClientOrigin&);
+
+    IDBStorageManager& idbStorageManagerForOrigin(const WebCore::ClientOrigin&, ShouldWriteOriginFile = ShouldWriteOriginFile::Yes, ShouldUpdateOriginAccessTime = ShouldUpdateOriginAccessTime::No);
 
     // Message handlers for CacheStorage.
     void cacheStorageOpenCache(IPC::Connection&, const WebCore::ClientOrigin&, const String& cacheName, WebCore::DOMCacheEngine::CacheIdentifierCallback&&);

--- a/Source/WebKit/Shared/Databases/IndexedDB/WebIDBResult.h
+++ b/Source/WebKit/Shared/Databases/IndexedDB/WebIDBResult.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "SandboxExtension.h"
+#include <WebCore/ClientOrigin.h>
 #include <WebCore/IDBResultData.h>
 #include <wtf/Noncopyable.h>
 
@@ -48,17 +49,27 @@ public:
         , m_handles(WTF::move(handles))
     {
     }
-    
+
+    WebIDBResult(const WebCore::IDBResultData& resultData, Vector<SandboxExtension::Handle>&& handles, std::optional<WebCore::ClientOrigin>&& clientOrigin)
+        : m_resultData(resultData)
+        , m_handles(WTF::move(handles))
+        , m_clientOrigin(WTF::move(clientOrigin))
+    {
+    }
+
     WebIDBResult(WebIDBResult&&) = default;
     WebIDBResult& operator=(WebIDBResult&&) = default;
 
     const WebCore::IDBResultData& resultData() const LIFETIME_BOUND { return m_resultData; }
     const Vector<SandboxExtension::Handle>& handles() const LIFETIME_BOUND { return m_handles; }
+    const std::optional<WebCore::ClientOrigin>& clientOrigin() const LIFETIME_BOUND { return m_clientOrigin; }
+    void setClientOrigin(WebCore::ClientOrigin&& origin) { m_clientOrigin = WTF::move(origin); }
 
 private:
     friend struct IPC::ArgumentCoder<WebIDBResult>;
     WebCore::IDBResultData m_resultData;
     Vector<SandboxExtension::Handle> m_handles;
+    std::optional<WebCore::ClientOrigin> m_clientOrigin;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/Shared/Databases/IndexedDB/WebIDBResult.serialization.in
+++ b/Source/WebKit/Shared/Databases/IndexedDB/WebIDBResult.serialization.in
@@ -23,4 +23,5 @@
 [RValue] class WebKit::WebIDBResult {
     WebCore::IDBResultData m_resultData;
     Vector<WebKit::SandboxExtensionHandle> m_handles
+    std::optional<WebCore::ClientOrigin> m_clientOrigin
 }

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -559,6 +559,7 @@ class WebCore::IDBValue {
     WebCore::ThreadSafeDataBuffer data()
     Vector<String> blobURLs()
     Vector<String> blobFilePaths()
+    Vector<WebCore::FileSystemHandleGlobalIdentifier> fileSystemHandleGlobalIdentifiers()
 };
 
 class WebCore::IDBOpenRequestData {
@@ -604,6 +605,7 @@ struct WebCore::IDBDatabaseNameAndVersion {
     std::unique_ptr<WebCore::IDBGetResult> m_getResult;
     std::unique_ptr<WebCore::IDBGetAllResult> m_getAllResult;
     uint64_t m_resultInteger;
+    [NotSerialized] std::unique_ptr<WebCore::ClientOrigin> m_clientOrigin;
 }
 
 class WebCore::IDBKeyData {

--- a/Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.cpp
+++ b/Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.cpp
@@ -30,8 +30,10 @@
 #include "NetworkConnectionToWebProcessMessages.h"
 #include "NetworkProcessConnection.h"
 #include "NetworkStorageManagerMessages.h"
+#include "WebFileSystemStorageConnection.h"
 #include "WebIDBResult.h"
 #include "WebProcess.h"
+#include <WebCore/FileSystemHandleStorageKeepAlive.h>
 #include <WebCore/IDBConnectionToServer.h>
 #include <WebCore/IDBCursorInfo.h>
 #include <WebCore/IDBError.h>
@@ -275,11 +277,17 @@ void WebIDBConnectionToServer::didPutOrAdd(const IDBResultData& result)
 
 void WebIDBConnectionToServer::didGetRecord(const WebIDBResult& result)
 {
+    if (result.clientOrigin())
+        attachStorageKeepAliveIfNeeded(result, result.resultData().getResult().value());
     m_connectionToServer->didGetRecord(result.resultData());
 }
 
 void WebIDBConnectionToServer::didGetAllRecords(const WebIDBResult& result)
 {
+    if (result.clientOrigin()) {
+        for (auto& value : result.resultData().getAllResult().values())
+            attachStorageKeepAliveIfNeeded(result, value);
+    }
     m_connectionToServer->didGetAllRecords(result.resultData());
 }
 
@@ -295,12 +303,32 @@ void WebIDBConnectionToServer::didDeleteRecord(const IDBResultData& result)
 
 void WebIDBConnectionToServer::didOpenCursor(const WebIDBResult& result)
 {
+    if (result.clientOrigin()) {
+        attachStorageKeepAliveIfNeeded(result, result.resultData().getResult().value());
+        for (auto& cursorRecord : result.resultData().getResult().prefetchedRecords())
+            attachStorageKeepAliveIfNeeded(result, cursorRecord.value);
+    }
     m_connectionToServer->didOpenCursor(result.resultData());
 }
 
 void WebIDBConnectionToServer::didIterateCursor(const WebIDBResult& result)
 {
+    if (result.clientOrigin()) {
+        attachStorageKeepAliveIfNeeded(result, result.resultData().getResult().value());
+        for (auto& cursorRecord : result.resultData().getResult().prefetchedRecords())
+            attachStorageKeepAliveIfNeeded(result, cursorRecord.value);
+    }
     m_connectionToServer->didIterateCursor(result.resultData());
+}
+
+void WebIDBConnectionToServer::attachStorageKeepAliveIfNeeded(const WebIDBResult& result, const IDBValue& value)
+{
+    if (value.fileSystemHandleGlobalIdentifiers().isEmpty() || !result.clientOrigin())
+        return;
+    value.attachStorageKeepAlive(FileSystemHandleStorageKeepAlive::create(
+        ClientOrigin { *result.clientOrigin() },
+        Vector { value.fileSystemHandleGlobalIdentifiers() },
+        Ref { WebProcess::singleton().fileSystemStorageConnection() }));
 }
 
 void WebIDBConnectionToServer::fireVersionChangeEvent(IDBDatabaseConnectionIdentifier uniqueDatabaseConnectionIdentifier, const IDBResourceIdentifier& requestIdentifier, uint64_t requestedVersion)

--- a/Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.h
+++ b/Source/WebKit/WebProcess/Databases/IndexedDB/WebIDBConnectionToServer.h
@@ -113,6 +113,8 @@ private:
     void notifyOpenDBRequestBlocked(const WebCore::IDBResourceIdentifier& requestIdentifier, uint64_t oldVersion, uint64_t newVersion);
     void didGetAllDatabaseNamesAndVersions(const WebCore::IDBResourceIdentifier&, Vector<WebCore::IDBDatabaseNameAndVersion>&&);
 
+    void attachStorageKeepAliveIfNeeded(const WebIDBResult&, const WebCore::IDBValue&);
+
     const RefPtr<WebCore::IDBClient::IDBConnectionToServer> m_connectionToServer;
 };
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFileSystemStorageConnection.cpp
@@ -223,6 +223,8 @@ void WebFileSystemStorageConnection::addGlobalIdentifierReference(WebCore::Clien
 
 void WebFileSystemStorageConnection::removeGlobalIdentifierReferences(WebCore::ClientOrigin&& origin, Vector<WebCore::FileSystemHandleGlobalIdentifier>&& globalIdentifiers)
 {
+    if (globalIdentifiers.isEmpty())
+        return;
     if (RefPtr connection = m_connection)
         connection->send(Messages::NetworkStorageManager::RemoveGlobalIdentifierReferences(WTF::move(origin), WTF::move(globalIdentifiers)), 0);
 }


### PR DESCRIPTION
#### da007ac59f0dfd9b4de7f11349ea6ae278f29d88
<pre>
FileSystemHandle IndexedDB storage
<a href="https://bugs.webkit.org/show_bug.cgi?id=313320">https://bugs.webkit.org/show_bug.cgi?id=313320</a>
<a href="https://rdar.apple.com/176102643">rdar://176102643</a>

Reviewed by Sihui Liu.

Allow FileSystemFileHandle and FileSystemDirectoryHandle to be stored in IndexedDB.
The wire form is just the FileSystemHandle global identifier; the (kind, path,
name) trio is resolved on the NetworkProcess side from the per-origin
FileSystemStorageManager.

Architecture:

* SQLiteIDBBackingStore gains a FileSystemHandleRecords table that stores
  (global identifier, kind, path, name) alongside the existing Records /
  BlobRecords tables. The backing store knows nothing about
  FileSystemStorageManager.

* NetworkStorageManager is the orchestrator. On putOrAdd it resolves global
  identifiers via FileSystemStorageManager::lookupHandles and stashes the
  resolved records on the IDBValue (NetworkProcess-internal, not encoded for
  IPC) so SQLiteIDBBackingStore::addRecord can read them back without an extra
  parameter threaded through five putOrAdd layers. On result delivery
  IDBStorageConnectionToClient registers persisted handles and bumps
  per-identifier refs via
  FileSystemStorageManager::registerPersistedHandlesAndAddReferences.

* Origin flows on IDBResultData (NetworkProcess-internal, [NotSerialized]):
  IDBResultData::getRecordSuccess / getAllRecordsSuccess / openCursorSuccess /
  iterateCursorSuccess each take the originating origin, supplied by
  UniqueIDBDatabaseTransaction from its database identifier.
  IDBStorageConnectionToClient reads it off the result and copies it onto
  WebIDBResult.clientOrigin (one-way IPC, NetworkProcess→WebProcess) before
  sending.

* WebProcess attaches a FileSystemHandleStorageKeepAlive — a thread-safe
  refcounted object — to each IDBValue that carries global identifiers. The
  keep-alive holds an FSM ref over IPC for the lifetime of the IDBValue and
  releases it via a batched RemoveGlobalIdentifierReferences IPC on destruction.
  This fixes the async-deserialization race where JS could await an IDB result,
  delete the record, then read request.result and find the FSM entry gone.

* WebCore IDB layer (delegate, transaction, IDBValue) stays oblivious to
  FileSystemStorageManager. Per-identifier iteration lives in
  FileSystemStorageManager via lookupHandles /
  registerPersistedHandlesAndAddReferences / removeGlobalIdentifierReferences
  batch methods.

Canonical link: <a href="https://commits.webkit.org/314229@main">https://commits.webkit.org/314229@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d8945e228eaac343416485c87efe711d0504a9d8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165473 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38963 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32544 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174515 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122728 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2992e78d-daba-4aa2-b510-a05395f841c9) 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/167339 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39299 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38967 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128589 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90515 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cdbfeacd-6278-4c25-84f6-f81baca29987) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168432 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30900 "Found 2 new test failures: fast/events/touch/ios/touch-event-regions-layer-tree/mousemove-mouseup.html fast/forms/ios/drag-range-track.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148662 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109114 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5aa57700-fef7-43dc-a523-04450d586431) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29946 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-images/gradients-with-border.html imported/w3c/web-platform-tests/css/css-images/multiple-position-color-stop-linear.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28578 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22590 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139841 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26360 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177039 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29948 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28065 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136914 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39032 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32716 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-display/display-contents-svg-elements.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136850 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36892 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39720 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148156 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102106 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32121 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25023 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38230 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111304 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37627 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3103 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37873 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37771 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->