### PR TITLE
NEW TESTS(312463@main): [macOS iOS] 2 failing tests in TestWebKitAPI.WKWebExtensionAPI (314126)

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIScripting.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIScripting.mm
@@ -429,12 +429,7 @@ TEST(WKWebExtensionAPIScripting, ExecuteScriptWithDocumentIds)
     [manager run];
 }
 
-// FIXME when webkit.org/b/314126 is resolved.
-#if PLATFORM(MAC)
-TEST(WKWebExtensionAPIScripting, DISABLED_ExecuteScriptWithUserGesture)
-#else
 TEST(WKWebExtensionAPIScripting, ExecuteScriptWithUserGesture)
-#endif
 {
     TestWebKitAPI::HTTPServer server({
         { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } },
@@ -442,6 +437,11 @@ TEST(WKWebExtensionAPIScripting, ExecuteScriptWithUserGesture)
 
     auto *backgroundScript = Util::constructScript(@[
         @"browser.action.setPopup({ popup: '' })",
+
+        @"browser.tabs.onUpdated.addListener((tabId, changeInfo) => {",
+        @"  if (changeInfo.status === 'complete')",
+        @"    browser.test.sendMessage('Page Ready')",
+        @"})",
 
         @"browser.action.onClicked.addListener(async (tab) => {",
         @"  browser.test.assertTrue(navigator.userActivation.isActive, 'User gesture should be active at the scripting.executeScript call site')",
@@ -463,9 +463,11 @@ TEST(WKWebExtensionAPIScripting, ExecuteScriptWithUserGesture)
 
     auto manager = Util::loadExtension(scriptingActionManifest, @{ @"background.js": backgroundScript });
 
+    [manager runUntilTestMessage:@"Background Ready"];
+
     [manager.get().defaultTab.webView loadRequest:server.requestWithLocalhost()];
 
-    [manager runUntilTestMessage:@"Background Ready"];
+    [manager runUntilTestMessage:@"Page Ready"];
 
     [manager.get().context performActionForTab:manager.get().defaultTab];
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPITabs.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPITabs.mm
@@ -2565,8 +2565,7 @@ TEST(WKWebExtensionAPITabs, PortPostMessageWithoutUserGesture)
     [manager run];
 }
 
-// FIXME when webkit.org/b/314126 is resolved.
-TEST(WKWebExtensionAPITabs, DISABLED_PortPostMessageGestureFromContentScriptIsNotPropagated)
+TEST(WKWebExtensionAPITabs, PortPostMessageGestureFromContentScriptIsNotPropagated)
 {
     // Gestures from content scripts are intentionally not propagated to extension pages,
     // even when the content script sends a port message inside a user gesture.
@@ -2585,7 +2584,6 @@ TEST(WKWebExtensionAPITabs, DISABLED_PortPostMessageGestureFromContentScriptIsNo
             @"type": @"module",
             @"persistent": @NO,
         },
-        @"action": @{ },
         @"content_scripts": @[ @{
             @"js": @[ @"content.js" ],
             @"matches": @[ @"*://localhost/*" ],
@@ -2593,10 +2591,12 @@ TEST(WKWebExtensionAPITabs, DISABLED_PortPostMessageGestureFromContentScriptIsNo
     };
 
     auto *backgroundScript = Util::constructScript(@[
-        @"browser.action.setPopup({ popup: '' })",
+        @"browser.test.onMessage.addListener(async (message) => {",
+        @"  if (message !== 'Connect')",
+        @"    return",
 
-        @"browser.action.onClicked.addListener(async (tab) => {",
-        @"  const port = browser.tabs.connect(tab.id, { name: 'gesturePort' })",
+        @"  const [currentTab] = await browser.tabs.query({ active: true, currentWindow: true })",
+        @"  const port = browser.tabs.connect(currentTab.id, { name: 'gesturePort' })",
         @"  port.onMessage.addListener((message) => {",
         @"    if (message !== 'check-gesture')",
         @"      return",
@@ -2630,7 +2630,7 @@ TEST(WKWebExtensionAPITabs, DISABLED_PortPostMessageGestureFromContentScriptIsNo
     [manager runUntilTestMessage:@"Background Ready"];
     [manager runUntilTestMessage:@"Content Ready"];
 
-    [manager.get().context performActionForTab:manager.get().defaultTab];
+    [manager sendTestMessage:@"Connect"];
 
     [manager run];
 }


### PR DESCRIPTION
#### 9a9c868ef9d268d0ef5571f93cb620deaed05875
<pre>
NEW TESTS(312463@main): [macOS iOS] 2 failing tests in TestWebKitAPI.WKWebExtensionAPI (314126)
<a href="https://bugs.webkit.org/show_bug.cgi?id=314126">https://bugs.webkit.org/show_bug.cgi?id=314126</a>
<a href="https://rdar.apple.com/176303192">rdar://176303192</a>

Reviewed by Timothy Hatcher.

A couple issues were going wrong here:
1) PortPostMessageGestureFromContentScriptIsNotPropagated was a constant failure because a user
gesture was always active, but not because of it being propagated from the content script. The gesture
was active because browser.action.onClicked carries one. To fix that, use browser.test instead to
send the message to signal the background page and content script are ready.

2) For ExecuteScriptWithUserGesture, it&apos;s possible that performActionForTab runs before the page has
fully loaded. To fix that, use browser.tabs.onUpdated to send a &apos;Page Ready&apos; message before continuing
on with the test.

Testing:
- Verified PortPostMessageGestureFromContentScriptIsNotPropagated passes (previously 100% failure)
- Verified ExecuteScriptWithUserGesture passes with 50 iterations (previously at least one failure)

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIScripting.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIScripting, ExecuteScriptWithUserGesture)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPITabs.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, PortPostMessageGestureFromContentScriptIsNotPropagated)):
(TestWebKitAPI::TEST(WKWebExtensionAPITabs, DISABLED_PortPostMessageGestureFromContentScriptIsNotPropagated)): Deleted.

Canonical link: <a href="https://commits.webkit.org/313262@main">https://commits.webkit.org/313262@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a70e1e356b460418e9e4f5c1828a5915f85b4fad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162366 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35842 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28958 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171304 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118811 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164235 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35946 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35844 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/125998 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88799 "1 flakes 17 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165325 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28339 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145850 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106576 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27386 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25910 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19004 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137089 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23583 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173808 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25227 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134299 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35516 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/29998 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134299 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35500 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145379 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97755 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24704 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28838 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22210 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35009 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34511 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34756 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34659 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->