### PR TITLE
[GLIB] Non-unified build fixes for May 13th 2026

### DIFF
--- a/Source/JavaScriptCore/API/JSCallbackObjectFunctions.h
+++ b/Source/JavaScriptCore/API/JSCallbackObjectFunctions.h
@@ -42,6 +42,8 @@
 
 namespace JSC {
 
+inline PreferredPrimitiveType toPreferredPrimitiveType(JSGlobalObject*, JSValue);
+
 template <class Parent>
 inline JSCallbackObject<Parent>* JSCallbackObject<Parent>::asCallbackObject(JSValue value)
 {

--- a/Source/JavaScriptCore/b3/air/AirLivenessAdapter.h
+++ b/Source/JavaScriptCore/b3/air/AirLivenessAdapter.h
@@ -35,6 +35,7 @@
 #include "AirTmpInlines.h"
 #include <wtf/ForbidHeapAllocation.h>
 #include <wtf/IndexMap.h>
+#include <wtf/ListDump.h>
 #include <wtf/SequesteredMalloc.h>
 #include <wtf/TZoneMalloc.h>
 

--- a/Source/JavaScriptCore/dfg/DFGLazyJSValue.h
+++ b/Source/JavaScriptCore/dfg/DFGLazyJSValue.h
@@ -30,6 +30,7 @@
 #include "DFGCommon.h"
 #include "DFGFrozenValue.h"
 #include "GPRInfo.h"
+#include "SpeculatedType.h"
 #include <wtf/text/StringImpl.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/dfg/DFGRegisteredStructureSet.h
+++ b/Source/JavaScriptCore/dfg/DFGRegisteredStructureSet.h
@@ -30,6 +30,7 @@
 #if ENABLE(DFG_JIT)
 
 #include "DFGRegisteredStructure.h"
+#include "SpeculatedType.h"
 #include <JavaScriptCore/ArrayProfile.h>
 #include <JavaScriptCore/StructureSet.h>
 #include <wtf/TinyPtrSet.h>

--- a/Source/JavaScriptCore/ftl/FTLOSRExit.h
+++ b/Source/JavaScriptCore/ftl/FTLOSRExit.h
@@ -44,6 +44,7 @@
 #include "Reg.h"
 #include "ValueProfile.h"
 #include "VirtualRegister.h"
+#include <wtf/Bag.h>
 #include <wtf/FixedVector.h>
 
 namespace JSC {

--- a/Source/JavaScriptCore/inspector/ConsoleMessage.cpp
+++ b/Source/JavaScriptCore/inspector/ConsoleMessage.cpp
@@ -35,6 +35,7 @@
 #include "InjectedScript.h"
 #include "InjectedScriptManager.h"
 #include "InspectorFrontendDispatchers.h"
+#include "JSCellInlines.h"
 #include "JSGlobalObject.h"
 #include "JSString.h"
 #include "ScriptArguments.h"

--- a/Source/JavaScriptCore/llint/LLIntThunks.cpp
+++ b/Source/JavaScriptCore/llint/LLIntThunks.cpp
@@ -28,6 +28,7 @@
 
 #include "Gate.h"
 #include "InPlaceInterpreter.h"
+#include "JITOperations.h"
 #include "JSCConfig.h"
 #include "JSCJSValueInlines.h"
 #include "JSInterfaceJIT.h"

--- a/Source/JavaScriptCore/parser/SourceProviderCacheItem.h
+++ b/Source/JavaScriptCore/parser/SourceProviderCacheItem.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <JavaScriptCore/ConstructorKind.h>
 #include <JavaScriptCore/ImplementationVisibility.h>
 #include <JavaScriptCore/ParserModes.h>
 #include <JavaScriptCore/ParserTokens.h>

--- a/Source/JavaScriptCore/runtime/FunctionConstructor.h
+++ b/Source/JavaScriptCore/runtime/FunctionConstructor.h
@@ -30,6 +30,7 @@ class TextPosition;
 namespace JSC {
 
 class FunctionPrototype;
+class SourceOrigin;
 enum class SourceTaintedOrigin : uint8_t;
 
 class FunctionConstructor final : public InternalFunction {

--- a/Source/JavaScriptCore/runtime/JSStringInlines.h
+++ b/Source/JavaScriptCore/runtime/JSStringInlines.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <JavaScriptCore/ExceptionHelpers.h>
 #include <JavaScriptCore/GetVM.h>
 #include <JavaScriptCore/HeapCellInlines.h>
 #include <JavaScriptCore/JSGlobalObject.h>

--- a/Source/JavaScriptCore/runtime/Symbol.h
+++ b/Source/JavaScriptCore/runtime/Symbol.h
@@ -27,7 +27,9 @@
 #pragma once
 
 #include <JavaScriptCore/ErrorType.h>
+#include <JavaScriptCore/JSCell.h>
 #include <JavaScriptCore/PrivateName.h>
+#include <JavaScriptCore/VM.h>
 #include <wtf/Expected.h>
 
 namespace JSC {

--- a/Source/WebCore/Modules/filesystem/FileSystemStorageConnection.cpp
+++ b/Source/WebCore/Modules/filesystem/FileSystemStorageConnection.cpp
@@ -32,6 +32,7 @@
 #include "Exception.h"
 #include "FileSystemWritableFileStream.h"
 #include "StorageConnection.h"
+#include "WorkerFileSystemStorageConnection.h"
 #include "WorkerGlobalScope.h"
 
 namespace WebCore {

--- a/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.h
+++ b/Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.h
@@ -32,6 +32,7 @@
 #include "EventTargetInterfaces.h"
 #include "JSDOMPromiseDeferredForward.h"
 #include "RTCRtpSFrameTransformer.h"
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/WeakPtr.h>
 
 namespace JSC {

--- a/Source/WebCore/Modules/mediastream/RTCRtpScriptTransform.cpp
+++ b/Source/WebCore/Modules/mediastream/RTCRtpScriptTransform.cpp
@@ -35,6 +35,7 @@
 #include "MessageChannel.h"
 #include "RTCRtpScriptTransformer.h"
 #include "RTCRtpTransformBackend.h"
+#include "ScriptExecutionContext.h"
 #include "Worker.h"
 #include <JavaScriptCore/HeapCellInlines.h>
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/Modules/reporting/ReportingObserver.h
+++ b/Source/WebCore/Modules/reporting/ReportingObserver.h
@@ -28,7 +28,9 @@
 #include "ActiveDOMObject.h"
 #include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/Vector.h>
 #include <wtf/WeakPtr.h>
+#include <wtf/text/AtomString.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/Modules/webaudio/AudioWorkletNode.h
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletNode.h
@@ -39,6 +39,10 @@ namespace JSC {
 class JSGlobalObject;
 } // namespace JSC
 
+namespace WTF {
+class Thread;
+}
+
 namespace WebCore {
 
 class AudioParamMap;
@@ -92,7 +96,7 @@ private:
     Lock m_processLock;
     RefPtr<AudioWorkletProcessor> m_processor; // Should only be used on the rendering thread.
     MemoryCompactLookupOnlyRobinHoodHashMap<String, std::unique_ptr<AudioFloatArray>> m_paramValuesMap;
-    RefPtr<Thread> m_workletThread;
+    RefPtr<WTF::Thread> m_workletThread;
 
     // Keeps the reference of AudioBus objects from AudioNodeInput and AudioNodeOutput in order
     // to pass them to AudioWorkletProcessor.

--- a/Source/WebCore/Modules/webtransport/DatagramSink.h
+++ b/Source/WebCore/Modules/webtransport/DatagramSink.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "WritableStreamSink.h"
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/webtransport/WebTransportSendStreamSink.h
+++ b/Source/WebCore/Modules/webtransport/WebTransportSendStreamSink.h
@@ -27,6 +27,7 @@
 
 #include "WritableStreamSink.h"
 #include <wtf/Ref.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/webxr/WebXRSystem.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRSystem.cpp
@@ -51,7 +51,7 @@
 #include "WebXRSession.h"
 #include "XRReferenceSpaceType.h"
 #include "XRSessionInit.h"
-#include <JavaScriptCore/JSCJSValue.h>
+#include <JavaScriptCore/JSCJSValuePropertyInlines.h>
 #include <JavaScriptCore/JSGlobalObject.h>
 #include <JavaScriptCore/JSString.h>
 #include <wtf/Scope.h>

--- a/Source/WebCore/Modules/webxr/WebXRViewerPose.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRViewerPose.cpp
@@ -28,6 +28,7 @@
 
 #if ENABLE(WEBXR)
 
+#include <JavaScriptCore/WeakInlines.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {

--- a/Source/WebCore/Modules/webxr/XRWebGLLayerBacking.cpp
+++ b/Source/WebCore/Modules/webxr/XRWebGLLayerBacking.cpp
@@ -36,6 +36,8 @@
 #include "WebXROpaqueFramebuffer.h"
 #include "WebXRSession.h"
 #include "WebXRWebGLSwapchain.h"
+#include "XRLayerInit.h"
+#include "XRLayerLayout.h"
 #include "XRProjectionLayerInit.h"
 
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebCore/Modules/webxr/XRWebGLLayerBacking.h
+++ b/Source/WebCore/Modules/webxr/XRWebGLLayerBacking.h
@@ -27,6 +27,7 @@
 
 #if ENABLE(WEBXR_LAYERS)
 
+#include "ExceptionOr.h"
 #include "GraphicsTypesGL.h"
 #include "IntSize.h"
 #include "XRLayerBacking.h"

--- a/Source/WebCore/accessibility/AXCoreObject.cpp
+++ b/Source/WebCore/accessibility/AXCoreObject.cpp
@@ -33,6 +33,7 @@
 #include "AXLoggerBase.h"
 #include "AXObjectCache.h"
 #include "AXSearchManager.h"
+#include "AXTextMarker.h"
 #include "AXTreeStoreInlines.h"
 #include "AXUtilities.h"
 #include "DocumentView.h"

--- a/Source/WebCore/accessibility/AXObjectTypes.h
+++ b/Source/WebCore/accessibility/AXObjectTypes.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "Node.h"
 #include <optional>
 #include <wtf/ProcessID.h>
 #include <wtf/RefPtr.h>
@@ -32,7 +33,6 @@
 namespace WebCore {
 
 class ContainerNode;
-class Node;
 
 enum class AccessibilityMode : uint8_t {
     Off = 0,

--- a/Source/WebCore/accessibility/AXSearchManager.h
+++ b/Source/WebCore/accessibility/AXSearchManager.h
@@ -25,6 +25,7 @@
 #pragma once
 
 #include <WebCore/AXCoreObject.h>
+#include <WebCore/AXTextMarker.h>
 #include <WebCore/AccessibilityRemoteToken.h>
 #include <WebCore/FrameIdentifier.h>
 #include <wtf/HashMap.h>

--- a/Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp
@@ -32,6 +32,7 @@
 #include "Element.h"
 #include "HTMLSelectElement.h"
 #include "Range.h"
+#include "RenderView.h"
 #include "TextIterator.h"
 
 namespace WebCore {

--- a/Source/WebCore/animation/AnimationPlaybackEvent.cpp
+++ b/Source/WebCore/animation/AnimationPlaybackEvent.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "AnimationPlaybackEvent.h"
 
+#include "WebAnimation.h"
 #include "WebAnimationUtilities.h"
 #include <wtf/TZoneMallocInlines.h>
 

--- a/Source/WebCore/bindings/js/JSDOMWindowProperties.cpp
+++ b/Source/WebCore/bindings/js/JSDOMWindowProperties.cpp
@@ -35,6 +35,7 @@
 #include "JSHTMLCollection.h"
 #include "LocalFrame.h"
 #include "WebCoreJSClientData.h"
+#include <JavaScriptCore/JSObjectInlines.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/bindings/js/JSWindowProxy.cpp
+++ b/Source/WebCore/bindings/js/JSWindowProxy.cpp
@@ -41,6 +41,7 @@
 #include <JavaScriptCore/Debugger.h>
 #include <JavaScriptCore/JSObject.h>
 #include <JavaScriptCore/StrongInlines.h>
+#include <JavaScriptCore/StructureInlines.h>
 #include <wtf/text/MakeString.h>
 
 #if PLATFORM(COCOA)

--- a/Source/WebCore/bindings/js/SerializedScriptValue.h
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.h
@@ -29,6 +29,7 @@
 #include <JavaScriptCore/Forward.h>
 #include <JavaScriptCore/JSCJSValue.h>
 #include <wtf/ThreadSafeRefCounted.h>
+#include <wtf/text/WTFString.h>
 
 typedef const struct OpaqueJSContext* JSContextRef;
 typedef const struct OpaqueJSValue* JSValueRef;

--- a/Source/WebCore/bridge/runtime_object.cpp
+++ b/Source/WebCore/bridge/runtime_object.cpp
@@ -31,6 +31,7 @@
 #include "runtime_method.h"
 #include <JavaScriptCore/Error.h>
 #include <JavaScriptCore/JSCJSValueInlines.h>
+#include <JavaScriptCore/StructureInlinesLight.h>
 
 using namespace WebCore;
 

--- a/Source/WebCore/css/CSSCrossfadeValue.cpp
+++ b/Source/WebCore/css/CSSCrossfadeValue.cpp
@@ -27,6 +27,7 @@
 #include "config.h"
 #include "CSSCrossfadeValue.h"
 
+#include "CSSPrimitiveNumericTypes+Serialization.h"
 #include "StyleBuilderState.h"
 #include "StyleCrossfadeImage.h"
 #include "StylePrimitiveNumericTypes+Conversions.h"

--- a/Source/WebCore/css/CSSCursorImageValue.cpp
+++ b/Source/WebCore/css/CSSCursorImageValue.cpp
@@ -24,6 +24,7 @@
 #include "CSSCursorImageValue.h"
 
 #include "CSSImageValue.h"
+#include "CSSPrimitiveNumericTypes+Serialization.h"
 #include "StyleBuilderState.h"
 #include "StyleCursorImage.h"
 #include "StylePrimitiveNumericTypes+Conversions.h"

--- a/Source/WebCore/css/CSSFontVariationValue.h
+++ b/Source/WebCore/css/CSSFontVariationValue.h
@@ -28,6 +28,7 @@
 
 #include "CSSValue.h"
 #include "FontTaggedSettings.h"
+#include <wtf/Function.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/dom/BroadcastChannel.h
+++ b/Source/WebCore/dom/BroadcastChannel.h
@@ -32,6 +32,7 @@
 #include <WebCore/EventTargetInterfaces.h>
 #include <wtf/Forward.h>
 #include <wtf/RefCounted.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 
 namespace JSC {
 class JSGlobalObject;

--- a/Source/WebCore/dom/UserActionElementSet.h
+++ b/Source/WebCore/dom/UserActionElementSet.h
@@ -28,7 +28,9 @@
 #pragma once
 
 #include <wtf/Forward.h>
+#include <wtf/HashMap.h>
 #include <wtf/OptionSet.h>
+#include <wtf/OptionSetHash.h>
 #include <wtf/Ref.h>
 #include <wtf/WeakHashMap.h>
 

--- a/Source/WebCore/html/ImageDocument.cpp
+++ b/Source/WebCore/html/ImageDocument.cpp
@@ -54,6 +54,7 @@
 #include "RenderElement.h"
 #include "Settings.h"
 #include "UserScriptTypes.h"
+#include <pal/text/TextEncoding.h>
 #include <wtf/MathExtras.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>

--- a/Source/WebCore/html/RadioNodeList.h
+++ b/Source/WebCore/html/RadioNodeList.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "LiveNodeList.h"
+#include <wtf/text/AtomString.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/inspector/PageDebugger.cpp
+++ b/Source/WebCore/inspector/PageDebugger.cpp
@@ -27,6 +27,7 @@
 #include "config.h"
 #include "PageDebugger.h"
 
+#include "ActiveDOMObject.h"
 #include "CommonVM.h"
 #include "Document.h"
 #include "InspectorFrontendClient.h"

--- a/Source/WebCore/loader/ResourceMonitorThrottler.h
+++ b/Source/WebCore/loader/ResourceMonitorThrottler.h
@@ -30,6 +30,7 @@
 #include <wtf/HashMap.h>
 #include <wtf/PriorityQueue.h>
 #include <wtf/Vector.h>
+#include <wtf/text/StringHash.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {

--- a/Source/WebCore/loader/ResourceTimingInformation.h
+++ b/Source/WebCore/loader/ResourceTimingInformation.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <wtf/HashMap.h>
 #include <wtf/WeakHashMap.h>
 #include <wtf/text/WTFString.h>
 

--- a/Source/WebCore/page/EventSource.cpp
+++ b/Source/WebCore/page/EventSource.cpp
@@ -33,6 +33,7 @@
 #include "config.h"
 #include "EventSource.h"
 
+#include "Blob.h"
 #include "CachedResourceRequestInitiatorTypes.h"
 #include "ContentSecurityPolicy.h"
 #include "ContextDestructionObserverInlines.h"

--- a/Source/WebCore/page/UndoManager.h
+++ b/Source/WebCore/page/UndoManager.h
@@ -27,6 +27,7 @@
 
 #include <WebCore/EventTarget.h>
 
+#include <wtf/HashSet.h>
 #include <wtf/Ref.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/RefPtr.h>

--- a/Source/WebCore/page/UserAgentStringData.h
+++ b/Source/WebCore/page/UserAgentStringData.h
@@ -27,6 +27,7 @@
 #include <optional>
 #include <wtf/Forward.h>
 #include <wtf/RefCounted.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 struct UserAgentStringData : public RefCounted<UserAgentStringData> {

--- a/Source/WebCore/page/UserAgentStringParser.cpp
+++ b/Source/WebCore/page/UserAgentStringParser.cpp
@@ -34,7 +34,6 @@
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringCommon.h>
 #include <wtf/text/StringImpl.h>
-#include <wtf/text/WTFString.h>
 
 /*
  * GRAMMAR:

--- a/Source/WebCore/page/UserAgentStringParser.h
+++ b/Source/WebCore/page/UserAgentStringParser.h
@@ -27,6 +27,8 @@
 #include <wtf/Forward.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/Variant.h>
+#include <wtf/Vector.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 struct UserAgentStringData;

--- a/Source/WebCore/page/UserStyleSheet.cpp
+++ b/Source/WebCore/page/UserStyleSheet.cpp
@@ -32,6 +32,7 @@
 #include <wtf/NeverDestroyed.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/text/MakeString.h>
+#include <wtf/text/StringHash.h>
 
 #if PLATFORM(COCOA)
 #include <wtf/cocoa/RuntimeApplicationChecksCocoa.h>

--- a/Source/WebCore/platform/graphics/MediaSourcePrivateClient.h
+++ b/Source/WebCore/platform/graphics/MediaSourcePrivateClient.h
@@ -35,6 +35,10 @@
 #include <wtf/ThreadSafeWeakPtr.h>
 
 namespace WebCore {
+struct SeekTarget;
+} // namespace WebCore
+
+namespace WebCore {
 
 class MediaSourcePrivate;
 

--- a/Source/WebCore/platform/graphics/NativeImageSource.h
+++ b/Source/WebCore/platform/graphics/NativeImageSource.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include "DestinationColorSpace.h"
 #include "ImageSource.h"
 
 namespace WebCore {

--- a/Source/WebCore/platform/graphics/Pattern.h
+++ b/Source/WebCore/platform/graphics/Pattern.h
@@ -32,6 +32,7 @@
 
 #include <wtf/Ref.h>
 #include <wtf/RefCounted.h>
+#include <wtf/ThreadSafeRefCounted.h>
 
 #if USE(CG)
 typedef struct CGPattern* CGPatternRef;

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -102,6 +102,10 @@
 #include <gst/webrtc/webrtc-enumtypes.h>
 #endif
 
+#if USE(GSTREAMER_GL)
+#include <gst/gl/gl.h>
+#endif
+
 #if USE(GSTREAMER_FULL) && GST_CHECK_VERSION(1, 18, 0) && !GST_CHECK_VERSION(1, 20, 0)
 #define IS_GST_FULL_1_18 1
 #include <gst/gstinitstaticplugins.h>

--- a/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp
@@ -41,6 +41,7 @@
 #include "Logging.h"
 #include "MediaPlayerPrivateGStreamer.h"
 #include "MediaPlayerPrivateGStreamerMSE.h"
+#include "MediaSourcePrivateClient.h"
 #include "MediaSourceTrackGStreamer.h"
 #include "NotImplemented.h"
 #include "SourceBufferPrivateGStreamer.h"

--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
@@ -26,6 +26,7 @@
 
 #if ENABLE(VIDEO) && ENABLE(MEDIA_SOURCE) && USE(GSTREAMER)
 
+#include "MediaPlayerPrivateGStreamerMSE.h"
 #include "MediaSourcePrivateClient.h"
 #include "MediaSourceTrackGStreamer.h"
 #include "VideoTrackPrivateGStreamer.h"

--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.h
@@ -27,6 +27,7 @@
 
 #include "GStreamerCommon.h"
 #include <wtf/Forward.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 
 namespace WebCore {
 class MediaPlayerPrivateGStreamerMSE;
@@ -55,7 +56,7 @@ GType webkit_media_src_get_type(void);
 
 void webKitMediaSrcEmitStreams(WebKitMediaSrc*, const Vector<RefPtr<WebCore::MediaSourceTrackGStreamer>>&);
 
-void webKitMediaSrcFlush(WebKitMediaSrc*, TrackID);
+void webKitMediaSrcFlush(WebKitMediaSrc*, WebCore::TrackID);
 
 void webKitMediaSrcSetPlayer(WebKitMediaSrc*, ThreadSafeWeakPtr<WebCore::MediaPlayerPrivateGStreamerMSE>&&);
 

--- a/Source/WebCore/platform/graphics/vulkan/VulkanTypes.cpp
+++ b/Source/WebCore/platform/graphics/vulkan/VulkanTypes.cpp
@@ -37,6 +37,7 @@
 #include <sys/sysmacros.h>
 #include <wtf/Scope.h>
 #include <wtf/text/CStringView.h>
+#include <wtf/text/StringBuilder.h>
 
 #if USE(GBM)
 #include "DRMDeviceManager.h"

--- a/Source/WebCore/platform/graphics/vulkan/VulkanTypes.h
+++ b/Source/WebCore/platform/graphics/vulkan/VulkanTypes.h
@@ -34,6 +34,7 @@
 #include <expected>
 #include <volk.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/text/WTFString.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/platform/graphics/vulkan/VulkanUtilities.cpp
+++ b/Source/WebCore/platform/graphics/vulkan/VulkanUtilities.cpp
@@ -33,6 +33,7 @@
 #include <wtf/StdLibExtras.h>
 #include <wtf/Vector.h>
 #include <wtf/text/ASCIILiteral.h>
+#include <wtf/text/CStringView.h>
 #include <wtf/text/MakeString.h>
 #include <wtf/text/StringBuilder.h>
 

--- a/Source/WebCore/rendering/RenderLayerModelObject.cpp
+++ b/Source/WebCore/rendering/RenderLayerModelObject.cpp
@@ -34,6 +34,7 @@
 #include "ReferencedSVGResources.h"
 #include "RenderDescendantIterator.h"
 #include "RenderElementInlines.h"
+#include "RenderElementStyleInlines.h"
 #include "RenderLayer.h"
 #include "RenderLayerBacking.h"
 #include "RenderLayerCompositor.h"

--- a/Source/WebCore/rendering/svg/RenderSVGTextPath.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGTextPath.cpp
@@ -25,6 +25,7 @@
 #include "FloatQuad.h"
 #include "RenderBlock.h"
 #include "RenderBoxModelObjectInlines.h"
+#include "RenderElementStyleInlines.h"
 #include "RenderLayer.h"
 #include "RenderObjectInlines.h"
 #include "RenderSVGInlineInlines.h"

--- a/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilder.cpp
@@ -35,6 +35,7 @@
 #include "LegacyRenderSVGContainer.h"
 #include "LegacyRenderSVGRoot.h"
 #include "LocalFrame.h"
+#include "NodeInlines.h"
 #include "LocalFrameViewInlines.h"
 #include "LocalFrameViewLayoutContext.h"
 #include "RenderBlockFlowInlines.h"

--- a/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
+++ b/Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp
@@ -25,6 +25,7 @@
 #include "RenderTreeBuilderFirstLetter.h"
 
 #include "FontCascade.h"
+#include "NodeInlines.h"
 #include "RenderBlock.h"
 #include "RenderButton.h"
 #include "RenderInline.h"

--- a/Source/WebCore/style/StyleSheetContentsCache.h
+++ b/Source/WebCore/style/StyleSheetContentsCache.h
@@ -28,6 +28,7 @@
 #include "CSSParserContext.h"
 #include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
+#include <wtf/text/StringHash.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {

--- a/Source/WebCore/workers/WorkerThread.cpp
+++ b/Source/WebCore/workers/WorkerThread.cpp
@@ -30,6 +30,7 @@
 #include "AdvancedPrivacyProtections.h"
 #include "IDBConnectionProxy.h"
 #include "JSDOMExceptionHandling.h"
+#include "JSDOMGlobalObject.h"
 #include "ScriptSourceCode.h"
 #include "SecurityOrigin.h"
 #include "SocketProvider.h"

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheBlobStorage.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheBlobStorage.cpp
@@ -33,6 +33,7 @@
 #include <wtf/Locker.h>
 #include <wtf/RunLoop.h>
 #include <wtf/SHA1.h>
+#include <wtf/TZoneMallocInlines.h>
 
 #if !OS(WINDOWS)
 #include <sys/stat.h>

--- a/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.h
+++ b/Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.h
@@ -28,6 +28,7 @@
 #include <WebCore/ClientOrigin.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/HashMap.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 
 namespace WTF {
 class WorkQueue;

--- a/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
+++ b/Source/WebKit/Shared/TextExtractionToStringConversion.cpp
@@ -30,6 +30,7 @@
 #include <WebCore/TextExtractionTypes.h>
 #include <wtf/EnumSet.h>
 #include <wtf/JSONValues.h>
+#include <wtf/RunLoop.h>
 #include <wtf/Scope.h>
 #include <wtf/TZoneMallocInlines.h>
 #include <unicode/ubrk.h>

--- a/Source/WebKit/UIProcess/Gamepad/wpe/PlatformGamepadWPE.cpp
+++ b/Source/WebKit/UIProcess/Gamepad/wpe/PlatformGamepadWPE.cpp
@@ -29,6 +29,7 @@
 #include "GamepadProviderWPE.h"
 
 #if ENABLE(GAMEPAD) && ENABLE(WPE_PLATFORM)
+#include <WebCore/SharedGamepadValue.h>
 #include <wpe/wpe-platform.h>
 #include <wtf/TZoneMallocInlines.h>
 

--- a/Source/WebKit/UIProcess/WebBackForwardCacheEntry.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardCacheEntry.cpp
@@ -30,6 +30,7 @@
 #include "SuspendedPageProxy.h"
 #include "WebBackForwardCache.h"
 #include "WebBackForwardListFrameItem.h"
+#include "WebBackForwardListItem.h"
 #include "WebProcessMessages.h"
 #include "WebProcessProxy.h"
 #include <wtf/TZoneMallocInlines.h>

--- a/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxyTesting.cpp
@@ -28,6 +28,7 @@
 
 #include "Connection.h"
 #include "MessageSenderInlines.h"
+#include "NetworkProcessMessages.h"
 #include "WebBackForwardList.h"
 #include "WebFrameProxy.h"
 #include "WebPageMessages.h"

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.h
@@ -36,6 +36,10 @@
 #include <wtf/CrossThreadQueue.h>
 #include <wtf/MediaTime.h>
 
+namespace WTF {
+class Thread;
+}
+
 #if PLATFORM(COCOA)
 #include "SharedCARingBuffer.h"
 #endif
@@ -104,7 +108,7 @@ private:
     String m_sceneIdentifier;
 #endif
 
-    RefPtr<Thread> m_renderThread;
+    RefPtr<WTF::Thread> m_renderThread;
     RefPtr<WebCore::SharedMemory> m_frameCount;
     uint32_t m_lastFrameCount { 0 };
     std::atomic<bool> m_shouldStopThread { false };


### PR DESCRIPTION
#### b2bd22edb4d592b538979af83a17c74378b2b923
<pre>
[GLIB] Non-unified build fixes for May 13th 2026
<a href="https://bugs.webkit.org/show_bug.cgi?id=314749">https://bugs.webkit.org/show_bug.cgi?id=314749</a>

Unreviewed build fix.

* Source/JavaScriptCore/API/JSCallbackObjectFunctions.h:
* Source/JavaScriptCore/b3/air/AirLivenessAdapter.h:
* Source/JavaScriptCore/dfg/DFGLazyJSValue.h:
* Source/JavaScriptCore/dfg/DFGRegisteredStructureSet.h:
* Source/JavaScriptCore/ftl/FTLOSRExit.h:
* Source/JavaScriptCore/inspector/ConsoleMessage.cpp:
* Source/JavaScriptCore/llint/LLIntThunks.cpp:
* Source/JavaScriptCore/parser/SourceProviderCacheItem.h:
* Source/JavaScriptCore/runtime/FunctionConstructor.h:
* Source/JavaScriptCore/runtime/JSStringInlines.h:
* Source/JavaScriptCore/runtime/Symbol.h:
* Source/WebCore/Modules/filesystem/FileSystemStorageConnection.cpp:
* Source/WebCore/Modules/mediastream/RTCRtpSFrameTransform.h:
* Source/WebCore/Modules/mediastream/RTCRtpScriptTransform.cpp:
* Source/WebCore/Modules/reporting/ReportingObserver.h:
* Source/WebCore/Modules/webaudio/AudioWorkletNode.h:
* Source/WebCore/Modules/webtransport/DatagramSink.h:
* Source/WebCore/Modules/webtransport/WebTransportSendStreamSink.h:
* Source/WebCore/Modules/webxr/WebXRSystem.cpp:
* Source/WebCore/Modules/webxr/WebXRViewerPose.cpp:
* Source/WebCore/Modules/webxr/XRWebGLLayerBacking.cpp:
* Source/WebCore/Modules/webxr/XRWebGLLayerBacking.h:
* Source/WebCore/accessibility/AXCoreObject.cpp:
* Source/WebCore/accessibility/AXObjectTypes.h:
* Source/WebCore/accessibility/AXSearchManager.h:
* Source/WebCore/accessibility/atspi/AXObjectCacheAtspi.cpp:
* Source/WebCore/animation/AnimationPlaybackEvent.cpp:
* Source/WebCore/bindings/js/JSDOMWindowProperties.cpp:
* Source/WebCore/bindings/js/JSWindowProxy.cpp:
* Source/WebCore/bindings/js/SerializedScriptValue.h:
* Source/WebCore/bridge/runtime_object.cpp:
* Source/WebCore/css/CSSCrossfadeValue.cpp:
* Source/WebCore/css/CSSCursorImageValue.cpp:
* Source/WebCore/css/CSSFontVariationValue.h:
* Source/WebCore/dom/BroadcastChannel.h:
* Source/WebCore/dom/UserActionElementSet.h:
* Source/WebCore/html/ImageDocument.cpp:
* Source/WebCore/html/RadioNodeList.h:
* Source/WebCore/inspector/PageDebugger.cpp:
* Source/WebCore/loader/ResourceMonitorThrottler.h:
* Source/WebCore/loader/ResourceTimingInformation.h:
* Source/WebCore/page/EventSource.cpp:
* Source/WebCore/page/UndoManager.h:
* Source/WebCore/page/UserAgentStringData.h:
* Source/WebCore/page/UserAgentStringParser.cpp:
* Source/WebCore/page/UserAgentStringParser.h:
* Source/WebCore/page/UserStyleSheet.cpp:
* Source/WebCore/platform/graphics/MediaSourcePrivateClient.h:
* Source/WebCore/platform/graphics/NativeImageSource.h:
* Source/WebCore/platform/graphics/Pattern.h:
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
* Source/WebCore/platform/graphics/gstreamer/mse/MediaSourcePrivateGStreamer.cpp:
* Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp:
* Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.h:
* Source/WebCore/platform/graphics/vulkan/VulkanTypes.cpp:
* Source/WebCore/platform/graphics/vulkan/VulkanTypes.h:
* Source/WebCore/platform/graphics/vulkan/VulkanUtilities.cpp:
* Source/WebCore/rendering/RenderLayerModelObject.cpp:
* Source/WebCore/rendering/svg/RenderSVGTextPath.cpp:
* Source/WebCore/rendering/updating/RenderTreeBuilder.cpp:
* Source/WebCore/rendering/updating/RenderTreeBuilderFirstLetter.cpp:
* Source/WebCore/style/StyleSheetContentsCache.h:
* Source/WebCore/workers/WorkerThread.cpp:
* Source/WebKit/NetworkProcess/cache/NetworkCacheBlobStorage.cpp:
* Source/WebKit/NetworkProcess/storage/BackgroundFetchStoreImpl.h:
* Source/WebKit/Shared/TextExtractionToStringConversion.cpp:
* Source/WebKit/UIProcess/Gamepad/wpe/PlatformGamepadWPE.cpp:
* Source/WebKit/UIProcess/WebBackForwardCacheEntry.cpp:
* Source/WebKit/UIProcess/WebPageProxyTesting.cpp:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioDestinationProxy.h:

Canonical link: <a href="https://commits.webkit.org/313222@main">https://commits.webkit.org/313222@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/531b87e03349d2d260a42e52b2183f5e4c632952

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162473 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35949 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29065 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171411 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/118918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164342 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36053 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35953 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/126091 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/118918 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165432 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28435 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/145959 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106669 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27481 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19111 "Built successfully") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23689 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173915 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23312 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21228 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25333 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/134405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35623 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30099 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134398 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35607 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145485 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97866 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24680 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28932 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/22318 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194873 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35116 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102868 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/50360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34618 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34863 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34766 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->