### PR TITLE
[threaded-animations] account for velocity for a transform-related animation to be high impact

### DIFF
--- a/LayoutTests/webanimations/threaded-animations/ios/display-link-opts-into-high-frame-rate-with-high-impact-animations.html
+++ b/LayoutTests/webanimations/threaded-animations/ios/display-link-opts-into-high-frame-rate-with-high-impact-animations.html
@@ -20,39 +20,36 @@
 
 <script>
 
-const assertLowImpactOpacityAnimation = async () => {
-    const acceleratedAnimations = internals.acceleratedAnimationsForElement(target);
-    assert_equals(acceleratedAnimations.length, 1);
-    assert_equals(acceleratedAnimations[0].property, "opacity");
-    assert_false(acceleratedAnimations[0].hasHighImpact, "Animating 'opacity' does not have a high impact");
-    assert_false(await UIHelper.displayLinkWantsHighFrameRate(), "Animating 'opacity' does not yield high frame rate display link updates");
-};
-
 promise_test(async t => {
-    const duration = 1000 * 1000;
+    const highImpactDistance = 120;
+    const lowImpactDistance = highImpactDistance / 2;
+    const timing = { duration: 1000, iterations: 100 };
 
     // First, start an opacity animation, which is not considered high-impact and
     // should not result in high frame rate display link updates.
-    const opacityAnimation = target.animate({ opacity: 0.5 }, duration);
+    const opacityAnimation = target.animate({ opacity: 0.5 }, timing);
     await animationAcceleration(opacityAnimation);
-    await assertLowImpactOpacityAnimation();
+    await threadedAnimationsCommit();
+    assert_false(await UIHelper.displayLinkWantsHighFrameRate(), "Animating 'opacity' does not yield high frame rate display link updates");
 
-    // Now, add a translate animation, which is considered high-impact and should
-    // result in high frame rate display link updates.
-    const translateAnimation = target.animate({ translate: "1000px" }, duration);
+    // Add a translate animation, which will not be considered high-impact
+    // when traveling around 60pt/s.
+    const translateAnimation = target.animate({ translate: `${lowImpactDistance}px` }, timing);
     await animationAcceleration(translateAnimation);
-    const acceleratedAnimations = internals.acceleratedAnimationsForElement(target);
-    assert_equals(acceleratedAnimations.length, 2);
-    assert_equals(acceleratedAnimations[1].property, "translate");
-    assert_true(acceleratedAnimations[1].hasHighImpact, "Animating 'translate' has a high impact");
-    assert_true(await UIHelper.displayLinkWantsHighFrameRate(), "Animating 'translate' yields high frame rate display link updates");
+    await threadedAnimationsCommit();
+    assert_false(await UIHelper.displayLinkWantsHighFrameRate(), "Adding a 'translate' animation around 60pt/s does not yield high frame rate display link updates");
+
+    // Change the translate animation to travel around 120pt/s, which will be considered high-impact.
+    translateAnimation.effect.setKeyframes({ translate: `${highImpactDistance}px` });
+    await threadedAnimationsCommit();
+    assert_true(await UIHelper.displayLinkWantsHighFrameRate(), "Changing the 'translate' animation to animate around 120pt/s yields high frame rate display link updates");
 
     // Finally, terminate that translate animation, which means only the opacity
     // animation is running in the remote layer tree, which should result in the
     // display link updates to return to a non-high frame rate.
     translateAnimation.finish();
     await threadedAnimationsCommit();
-    await assertLowImpactOpacityAnimation();
+    assert_false(await UIHelper.displayLinkWantsHighFrameRate(), "Removing the 'translate' animation and having only an 'opacity' animation does not yield high frame rate display link updates");
 }, "Display link opts into high frame rate updates only when high-impact animations are running");
 
 </script>

--- a/Source/WebCore/platform/animation/AcceleratedEffect.cpp
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.cpp
@@ -590,14 +590,6 @@ bool AcceleratedEffect::animatesTransformRelatedProperty() const
     return m_animatedProperties.containsAny(transformRelatedAcceleratedProperties);
 }
 
-bool AcceleratedEffect::hasHighImpact() const
-{
-    // FIXME: This is just an initial implementation. A logical next step would be to
-    // compute the distance traveled over time and only mark effects with distance traveled
-    // over a certain threshold (over 60px, 90px, 120px per second?) as high impact.
-    return animatesTransformRelatedProperty();
-}
-
 const KeyframeInterpolation::Keyframe& AcceleratedEffect::keyframeAtIndex(size_t index) const
 {
     ASSERT(index < m_keyframes.size());

--- a/Source/WebCore/platform/animation/AcceleratedEffect.h
+++ b/Source/WebCore/platform/animation/AcceleratedEffect.h
@@ -107,7 +107,6 @@ public:
     const OptionSet<AcceleratedEffectProperty> composedProperties() const;
 
     bool NODELETE animatesTransformRelatedProperty() const;
-    WEBCORE_EXPORT bool NODELETE hasHighImpact() const;
 
 private:
     AcceleratedEffect(const KeyframeEffect&, const IntRect&, const OptionSet<AcceleratedEffectProperty>&);

--- a/Source/WebCore/platform/graphics/GraphicsLayer.h
+++ b/Source/WebCore/platform/graphics/GraphicsLayer.h
@@ -377,7 +377,6 @@ public:
         String property;
         double speed;
         bool isThreaded;
-        bool hasHighImpact;
     };
     virtual Vector<AcceleratedAnimationForTesting> acceleratedAnimationsForTesting() const { return { }; }
 

--- a/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
+++ b/Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp
@@ -5306,8 +5306,7 @@ Vector<GraphicsLayer::AcceleratedAnimationForTesting> GraphicsLayerCA::accelerat
             animations.append({
                 .property = acceleratedEffectPropertyIDAsString(property),
                 .speed = effect.playbackRate(),
-                .isThreaded = true,
-                .hasHighImpact = effect.hasHighImpact()
+                .isThreaded = true
             });
         }
     };
@@ -5327,15 +5326,13 @@ Vector<GraphicsLayer::AcceleratedAnimationForTesting> GraphicsLayerCA::accelerat
             animations.append({
                 .property = animatedPropertyIDAsString(animation.m_property),
                 .speed = caAnimation->speed(),
-                .isThreaded = false,
-                .hasHighImpact = false
+                .isThreaded = false
             });
         } else {
             animations.append({
                 .property = animatedPropertyIDAsString(animation.m_property),
                 .speed = (animation.m_playState == PlayState::Playing || animation.m_playState == PlayState::PlayPending) ? 1.0 : 0.0,
-                .isThreaded = false,
-                .hasHighImpact = false
+                .isThreaded = false
             });
         }
     }

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -1516,7 +1516,7 @@ Vector<Internals::AcceleratedAnimation> Internals::acceleratedAnimationsForEleme
 
     Vector<Internals::AcceleratedAnimation> animations;
     for (const auto& acceleratedAnimation : timelinesController->acceleratedAnimationsForElement(element))
-        animations.append({ acceleratedAnimation.property, acceleratedAnimation.speed, acceleratedAnimation.isThreaded, acceleratedAnimation.hasHighImpact });
+        animations.append({ acceleratedAnimation.property, acceleratedAnimation.speed, acceleratedAnimation.isThreaded });
     return animations;
 }
 

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -339,7 +339,6 @@ public:
         String property;
         double speed;
         bool isThreaded;
-        bool hasHighImpact;
     };
     struct ScrollingNodeID {
         uint64_t nodeIdentifier;

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -337,7 +337,6 @@ enum AV1ConfigurationRange {
     required DOMString property;
     required double speed;
     required boolean isThreaded;
-    required boolean hasHighImpact;
 };
 
 [

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.h
@@ -43,6 +43,11 @@ OBJC_CLASS CAPresentationModifierGroup;
 OBJC_CLASS CAPresentationModifier;
 #endif
 
+namespace WebCore {
+class FloatRect;
+class TransformationMatrix;
+}
+
 namespace WebKit {
 
 using RemoteAnimations = Vector<Ref<RemoteAnimation>>;
@@ -62,12 +67,12 @@ public:
     void applyEffects() const;
 #endif
 
-    void applyEffectsFromMainThread(PlatformLayer*, bool backdropRootIsOpaque) const;
+    void applyEffectsFromMainThread(PlatformLayer*, bool backdropRootIsOpaque);
 
     bool isDependentOnScrollingNodeWithID(WebCore::ScrollingNodeID) const;
     bool hasTimeBasedAnimations() const { return m_hasTimeBasedAnimations; }
     bool hasProgressBasedAnimations() const { return m_hasProgressBasedAnimations; }
-
+    bool hasHighImpact() const;
     void clear(PlatformLayer*);
 
     Ref<JSON::Object> toJSONForTesting() const;
@@ -76,7 +81,9 @@ private:
     explicit RemoteAnimationStack(RemoteAnimations&&, WebCore::AcceleratedEffectValues&&, WebCore::FloatRect);
 
     WebCore::AcceleratedEffectValues computeValues() const;
-
+#if PLATFORM(IOS_FAMILY)
+    void updateAnimatedBounds(const WebCore::TransformationMatrix&);
+#endif
 #if PLATFORM(MAC)
     const WebCore::FilterOperations* longestFilterList() const;
 #endif
@@ -92,6 +99,10 @@ private:
     RemoteAnimations m_animations;
     WebCore::AcceleratedEffectValues m_baseValues;
     WebCore::FloatRect m_bounds;
+
+#if PLATFORM(IOS_FAMILY)
+    Vector<std::pair<MonotonicTime, WebCore::FloatRect>> m_animatedBounds;
+#endif
 
 #if PLATFORM(MAC)
     RetainPtr<CAPresentationModifierGroup> m_presentationModifierGroup;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.mm
@@ -30,6 +30,8 @@
 
 #import "RemoteAnimationUtilities.h"
 #import "RemoteProgressBasedTimeline.h"
+#import <WebCore/FloatRect.h>
+#import <WebCore/TransformationMatrix.h>
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
 #import <wtf/TZoneMallocInlines.h>
 
@@ -198,7 +200,7 @@ void RemoteAnimationStack::applyEffects() const
 }
 #endif
 
-void RemoteAnimationStack::applyEffectsFromMainThread(PlatformLayer *layer, bool backdropRootIsOpaque) const
+void RemoteAnimationStack::applyEffectsFromMainThread(PlatformLayer *layer, bool backdropRootIsOpaque)
 {
     auto computedValues = computeValues();
 
@@ -211,6 +213,9 @@ void RemoteAnimationStack::applyEffectsFromMainThread(PlatformLayer *layer, bool
     if (m_affectedLayerProperties.contains(LayerProperty::Transform)) {
         auto computedTransform = computedValues.computedTransformationMatrix(m_bounds);
         [layer setTransform:computedTransform];
+#if PLATFORM(IOS_FAMILY)
+        updateAnimatedBounds(computedTransform);
+#endif
     }
 }
 
@@ -250,6 +255,59 @@ bool RemoteAnimationStack::isDependentOnScrollingNodeWithID(WebCore::ScrollingNo
         RefPtr progressBasedTimeline = dynamicDowncast<RemoteProgressBasedTimeline>(animation->timeline());
         return progressBasedTimeline && progressBasedTimeline->source() == scrollingNodeID;
     });
+}
+
+#if PLATFORM(IOS_FAMILY)
+void RemoteAnimationStack::updateAnimatedBounds(const WebCore::TransformationMatrix& transform)
+{
+    ASSERT(m_affectedLayerProperties.contains(LayerProperty::Transform));
+
+    // FIXME: We may want to cache whether we have some time-dependent animations at all.
+    if (!isTimeDependent()) {
+        m_animatedBounds.clear();
+        return;
+    }
+
+    auto now = MonotonicTime::now();
+
+    // Prune all items recorded over a second ago.
+    auto pruneDelay = 100_ms;
+    while (!m_animatedBounds.isEmpty() && now - m_animatedBounds[0].first > pruneDelay)
+        m_animatedBounds.removeAt(0);
+
+    m_animatedBounds.append({ now, transform.mapRect(m_bounds) });
+}
+#endif
+
+bool RemoteAnimationStack::hasHighImpact() const
+{
+#if PLATFORM(IOS_FAMILY)
+    auto size = m_animatedBounds.size();
+    if (size < 2)
+        return false;
+
+    ASSERT(m_affectedLayerProperties.contains(LayerProperty::Transform));
+
+    auto& a = m_animatedBounds[size - 2];
+    auto& b = m_animatedBounds[size - 1];
+    auto elapsedTime = b.first - a.first;
+
+    // We want to determine if we're traveling at more than 90pt / seconds.
+    auto minDelta = 90 * elapsedTime.seconds();
+    auto& aBounds = a.second;
+    auto& bBounds = b.second;
+
+    if (std::abs(aBounds.x() - bBounds.x()) >= minDelta)
+        return true;
+    if (std::abs(aBounds.y() - bBounds.y()) >= minDelta)
+        return true;
+    if (std::abs(aBounds.maxX() - bBounds.maxX()) >= minDelta)
+        return true;
+    if (std::abs(aBounds.maxY() - bBounds.maxY()) >= minDelta)
+        return true;
+#endif
+
+    return false;
 }
 
 Ref<JSON::Object> RemoteAnimationStack::toJSONForTesting() const

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h
@@ -155,9 +155,9 @@ public:
 
 #if ENABLE(THREADED_ANIMATIONS)
     void setAcceleratedEffectsAndBaseValues(const WebCore::AcceleratedEffects&, const WebCore::AcceleratedEffectValues&, RemoteLayerTreeHost&);
-    const RemoteAnimationStack* animationStack() const { return m_animationStack.get(); }
+    RemoteAnimationStack* animationStack() const { return m_animationStack.get(); }
     RefPtr<RemoteAnimationStack> takeAnimationStack() { return std::exchange(m_animationStack, nullptr); }
-    bool hasHighImpactMonotonicAnimations() const { return m_hasHighImpactMonotonicAnimations; }
+    bool hasHighImpactMonotonicAnimations() const;
 #endif
 
     bool backdropRootIsOpaque() const { return m_backdropRootIsOpaque; }
@@ -223,7 +223,6 @@ private:
 
 #if ENABLE(THREADED_ANIMATIONS)
     RefPtr<RemoteAnimationStack> m_animationStack;
-    bool m_hasHighImpactMonotonicAnimations { false };
 #endif
     bool m_backdropRootIsOpaque { false };
 };

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm
@@ -416,6 +416,11 @@ void RemoteLayerTreeNode::removeFromHostingNode()
 }
 
 #if ENABLE(THREADED_ANIMATIONS)
+bool RemoteLayerTreeNode::hasHighImpactMonotonicAnimations() const
+{
+    return m_animationStack && m_animationStack->hasHighImpact();
+}
+
 void RemoteLayerTreeNode::setAcceleratedEffectsAndBaseValues(const WebCore::AcceleratedEffects& effects, const WebCore::AcceleratedEffectValues& baseValues, RemoteLayerTreeHost& host)
 {
     ASSERT(isUIThread());
@@ -425,8 +430,6 @@ void RemoteLayerTreeNode::setAcceleratedEffectsAndBaseValues(const WebCore::Acce
         animationStack->clear(layer.get());
     host.animationsWereRemovedFromNode(*this);
 
-    m_hasHighImpactMonotonicAnimations = false;
-
     if (effects.isEmpty())
         return;
 
@@ -434,8 +437,6 @@ void RemoteLayerTreeNode::setAcceleratedEffectsAndBaseValues(const WebCore::Acce
         TimelineID timelineID { effect->timelineIdentifier(), m_layerID.processIdentifier() };
         RefPtr timeline = host.timeline(timelineID);
         RELEASE_ASSERT(timeline, "Remote layer tree animations should have a pre-registered timeline.");
-        if (!m_hasHighImpactMonotonicAnimations && timeline->isMonotonic())
-            m_hasHighImpactMonotonicAnimations = effect->hasHighImpact();
         return RemoteAnimation::create(Ref { effect }.get(), *timeline);
     }), baseValues.clone(), layer.get().bounds);
     m_animationStack = animationStack.copyRef();

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.h
@@ -45,7 +45,6 @@ public:
 
     void scheduleDisplayRefreshCallbacksForMonotonicAnimations();
     void pauseDisplayRefreshCallbacksForMonotonicAnimations();
-    void highImpactMonotonicAnimationsWereRemoved();
 
     UIView *viewWithLayerIDForTesting(WebCore::PlatformLayerIdentifier) const;
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm
@@ -362,8 +362,11 @@ void RemoteLayerTreeDrawingAreaProxyIOS::didRefreshDisplay()
         RefPtr page = this->page();
         if (!page)
             return;
+        CheckedPtr scrollingCoordinatorProxy = page->scrollingCoordinatorProxy();
         if (auto displayID = page->displayID())
-            protect(page->scrollingCoordinatorProxy())->displayDidRefresh(*displayID);
+            scrollingCoordinatorProxy->displayDidRefresh(*displayID);
+        m_hasHighImpactMonotonicAnimations = scrollingCoordinatorProxy->hasHighImpactMonotonicAnimations();
+        scheduleDisplayLinkAndSetFrameRate();
     }
 }
 
@@ -382,20 +385,7 @@ void RemoteLayerTreeDrawingAreaProxyIOS::pauseDisplayRefreshCallbacks()
 void RemoteLayerTreeDrawingAreaProxyIOS::scheduleDisplayRefreshCallbacksForMonotonicAnimations()
 {
     m_needsDisplayRefreshCallbacksForMonotonicAnimations = true;
-    if (!m_hasHighImpactMonotonicAnimations) {
-        if (RefPtr page = this->page())
-            m_hasHighImpactMonotonicAnimations = protect(page->scrollingCoordinatorProxy())->hasHighImpactMonotonicAnimations();
-    }
     scheduleDisplayLinkAndSetFrameRate();
-}
-
-void RemoteLayerTreeDrawingAreaProxyIOS::highImpactMonotonicAnimationsWereRemoved()
-{
-    if (!m_hasHighImpactMonotonicAnimations)
-        return;
-
-    if (RefPtr page = this->page())
-        m_hasHighImpactMonotonicAnimations = protect(page->scrollingCoordinatorProxy())->hasHighImpactMonotonicAnimations();
 }
 
 void RemoteLayerTreeDrawingAreaProxyIOS::pauseDisplayRefreshCallbacksForMonotonicAnimations()

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
@@ -796,8 +796,6 @@ void RemoteScrollingCoordinatorProxyIOS::animationsWereRemovedFromNode(RemoteLay
     m_animatedNodeLayerIDs.remove(node.layerID());
     if (m_animatedNodeLayerIDs.isEmpty() || !m_monotonicTimelineRegistry || m_monotonicTimelineRegistry->isEmpty())
         protect(drawingAreaIOS())->pauseDisplayRefreshCallbacksForMonotonicAnimations();
-    else if (node.hasHighImpactMonotonicAnimations())
-        protect(drawingAreaIOS())->highImpactMonotonicAnimationsWereRemoved();
 }
 
 void RemoteScrollingCoordinatorProxyIOS::updateTimelinesRegistration(WebCore::ProcessIdentifier processIdentifier, const WebCore::AcceleratedTimelinesUpdate& timelinesUpdate, MonotonicTime now)


### PR DESCRIPTION
#### fc692f40e489f97345f79cc82e282a113c875011
<pre>
[threaded-animations] account for velocity for a transform-related animation to be high impact
<a href="https://bugs.webkit.org/show_bug.cgi?id=307776">https://bugs.webkit.org/show_bug.cgi?id=307776</a>
<a href="https://rdar.apple.com/170304142">rdar://170304142</a>

Reviewed by NOBODY (OOPS!).

Adopt a new strategy where we determine whether an animation stack has a high impact
by comparing the transformed bounds of the stack&apos;s target frame by frame, opting into
higher frame rate updates in that situation.

* LayoutTests/webanimations/threaded-animations/ios/display-link-opts-into-high-frame-rate-with-high-impact-animations.html:
* Source/WebCore/platform/animation/AcceleratedEffect.cpp:
(WebCore::AcceleratedEffect::hasHighImpact const): Deleted.
* Source/WebCore/platform/animation/AcceleratedEffect.h:
* Source/WebCore/platform/graphics/GraphicsLayer.h:
* Source/WebCore/platform/graphics/ca/GraphicsLayerCA.cpp:
(WebCore::GraphicsLayerCA::ensureStructuralLayer):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::acceleratedAnimationsForElement):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.mm:
(WebKit::RemoteAnimationStack::applyEffectsFromMainThread):
(WebKit::RemoteAnimationStack::updateAnimatedBounds):
(WebKit::RemoteAnimationStack::hasHighImpact const):
(WebKit::RemoteAnimationStack::applyEffectsFromMainThread const): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteLayerTreeNode.mm:
(WebKit::RemoteLayerTreeNode::hasHighImpactMonotonicAnimations const):
(WebKit::RemoteLayerTreeNode::setAcceleratedEffectsAndBaseValues):
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm:
(WebKit::RemoteLayerTreeDrawingAreaProxyIOS::didRefreshDisplay):
(WebKit::RemoteLayerTreeDrawingAreaProxyIOS::scheduleDisplayRefreshCallbacksForMonotonicAnimations):
(WebKit::RemoteLayerTreeDrawingAreaProxyIOS::highImpactMonotonicAnimationsWereRemoved): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm:
(WebKit::RemoteScrollingCoordinatorProxyIOS::animationsWereRemovedFromNode):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/173ca0ff62f048b0cc988e7d6d29c750bc9af091

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163721 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37205 "Hash 173ca0ff for PR 64867 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30424 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172661 "Hash 173ca0ff for PR 64867 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/120365 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165590 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37536 "Hash 173ca0ff for PR 64867 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37204 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/172661 "Hash 173ca0ff for PR 64867 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89631 "layout-tests (failure)") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166680 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/37536 "Hash 173ca0ff for PR 64867 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147188 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/172661 "Hash 173ca0ff for PR 64867 does not build (failure)") | | ⏳ 🛠 vision-apple 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/37536 "Hash 173ca0ff for PR 64867 does not build (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27130 "Passed tests") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20364 "Hash 173ca0ff for PR 64867 does not build (failure)") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/37536 "Hash 173ca0ff for PR 64867 does not build (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24905 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175166 "Hash 173ca0ff for PR 64867 does not build (failure)") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28097 "Failed to build and analyze WebKit") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26573 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/175166 "Hash 173ca0ff for PR 64867 does not build (failure)") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36875 "Hash 173ca0ff for PR 64867 does not build (failure)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31235 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/175166 "Hash 173ca0ff for PR 64867 does not build (failure)") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37660 "Hash 173ca0ff for PR 64867 does not build (failure)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146700 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99756 "Hash 173ca0ff for PR 64867 does not build (failure)") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/37660 "Hash 173ca0ff for PR 64867 does not build (failure)") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23554 "Passed tests") | | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36371 "Hash 173ca0ff for PR 64867 does not build (failure)") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109516 "Built successfully") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35868 "Hash 173ca0ff for PR 64867 does not build (failure)") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1584 "Passed tests") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36118 "Hash 173ca0ff for PR 64867 does not build (failure)") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36015 "Hash 173ca0ff for PR 64867 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->