### PR TITLE
REGRESSION(310826@main): Confirming composition results in beep and initiates a search on google.com

### DIFF
--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -5609,9 +5609,6 @@ void WebViewImpl::interpretKeyEvent(NSEvent *event, void(^completionHandler)(BOO
                 hasInsertText = true;
         }
 
-        if (hasInsertText)
-            handled = NO;
-
         LOG(TextInput, "... handleEventByInputMethod%s handled", handled ? "" : " not");
         if (handled) {
             capturedBlock(YES, WTF::move(commands));

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -356,8 +356,9 @@ bool WebPage::handleEditingKeyboardEvent(KeyboardEvent& event)
             haveTextInsertionCommands = true;
     }
     // If there are no text insertion commands, default keydown handler is the right time to execute the commands.
-    // Keypress (Char event) handler is the latest opportunity to execute.
-    if (!haveTextInsertionCommands || platformEvent->type() == PlatformEvent::Type::Char) {
+    // Keypress (Char event) handler is the latest opportunity to execute. When the input method handled the
+    // keydown, no keypress will be dispatched, so text insertion commands must be executed here.
+    if (!haveTextInsertionCommands || platformEvent->type() == PlatformEvent::Type::Char || event.handledByInputMethod()) {
         eventWasHandled = executeKeypressCommandsInternal(commands, &event);
         commands.clear();
     }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/WKWebViewMacEditingTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/WKWebViewMacEditingTests.mm
@@ -335,6 +335,42 @@ TEST(WKWebViewMacEditingTests, KeyDownInsertAccentedCharacterOnce)
         [webView stringByEvaluatingJavaScript:@"logs.map((event) => event.type).join(',')"].UTF8String);
 }
 
+TEST(WKWebViewMacEditingTests, KeyDownForInputMethodCommitUsesCompositionKeyCode)
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    for (_WKFeature *feature in WKPreferences._features) {
+        NSString *key = feature.key;
+        if ([key isEqualToString:@"InputMethodUsesCorrectKeyEventOrder"])
+            [[configuration preferences] _setEnabled:YES forFeature:feature];
+    }
+
+    RetainPtr webView = adoptNS([[TestWebViewWithMockTextInputContext alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    [webView _web_superInputContext].actions = [@[
+        [[[MockTextInputContextAction alloc] initWithMarkedText:@"\u3093" selectedRange:NSMakeRange(0, 1) replacementRange:NSMakeRange(NSNotFound, 0)] autorelease],
+        [[[MockTextInputContextAction alloc] initWithInsertText:@"\u3093" replacementRange:NSMakeRange(NSNotFound, 0)] autorelease],
+    ].mutableCopy autorelease];
+    [webView synchronouslyLoadHTMLString:@"<input type='text' id='q'>"];
+    // When the input method commits a composition via insertText:, keydown
+    // must fire with CompositionEventKeyCode (229), not the real key's
+    // windowsVirtualKeyCode. Otherwise:
+    //  - Sites like google.com submit search on keydown when they see
+    //    event.keyCode === 13, treating the Enter-to-commit as a real Enter.
+    //  - The key event would be reported as unhandled, re-sent to the
+    //    responder chain, and trigger an unhandled-keyDown: alert sound.
+    [webView stringByEvaluatingJavaScript:@"window.keyCodes = [];"
+        "document.addEventListener('keydown', (event) => window.keyCodes.push(event.keyCode), true);"
+        "document.getElementById('q').focus();"];
+    [webView waitForNextPresentationUpdate];
+    [webView removeFromSuperview];
+    [webView typeCharacter:'n'];
+    Util::runFor(1_s);
+    [webView typeCharacter:'\r'];
+    Util::runFor(1_s);
+
+    EXPECT_STREQ(@"\u3093".UTF8String, [webView stringByEvaluatingJavaScript:@"document.getElementById('q').value"].UTF8String);
+    EXPECT_STREQ("229,229", [webView stringByEvaluatingJavaScript:@"window.keyCodes.join(',')"].UTF8String);
+}
+
 TEST(WKWebViewMacEditingTests, DoNotCrashWhenInterpretingKeyEventWhileDeallocatingView)
 {
     __block bool isDone = false;


### PR DESCRIPTION
#### 300105f8996dbbd074b3ca9b2d3a3aaaa9d00c40
<pre>
REGRESSION(310826@main): Confirming composition results in beep and initiates a search on google.com
<a href="https://bugs.webkit.org/show_bug.cgi?id=314752">https://bugs.webkit.org/show_bug.cgi?id=314752</a>
<a href="https://rdar.apple.com/176851109">rdar://176851109</a>

Reviewed by Abrar Rahman Protyasha and Wenson Hsieh.

310826@main turned on InputMethodUsesCorrectKeyEventOrder by default and, as part of the dead-key
double-insertion fix, kept pre-existing logic in WebViewImpl::interpretKeyEvent that forced
handled = NO whenever the IME&apos;s collected commands contained an insertText: This forcing was wrong
once the preference became the default path for all IMEs, not just docs.google.com&apos;s Devanagari flow.

When a Japanese IME commits a composition (Enter/Space confirm), it calls insertText: with the final
text and returns handled=YES. With the force:
  - UIProcess sent handledByInputMethod=false to the web process.
  - In EventHandler::internalKeyEvent, the handledByInputMethod branch was skipped, so:
    * The keydown&apos;s windowsVirtualKeyCode was not replaced with CompositionEventKeyCode (229).
    * setIsDefaultEventHandlerIgnored was not called.

This resulted in two user-visible bugs:
  a. A deep when confirming candidates - the Enter keydown path went through the composing branch in
     internalKeyEvent which returned keydownResult (false) regardless of whether keypress handled the
     commands. The web process reported handled=false, so WebViewImpl::doneWithKeyEvent re-sent the
     event via [NSApp sendEvent:], and the unhandled keyDown: walked up the first responder chain,
     resulted in a beep sound in some apps.
  b. google.com search submit - JS keydown listeners saw the real Enter keyCode (13) instead of 229,
     so scripts in google.com that looked for keyCode of 13 on keydown which initiates google search
     was erroneously triggered.

This PR fixes the root cause with two code changes at UIProcess/WebProcess boundary:
  1. Source/WebKit/UIProcess/mac/WebViewImpl.mm - removed the branch for setting handled = NO when
     hasInsertText is true; The IME&apos;s handled=YES now flows through, so NativeWebKeyboardEvent has
     handledByInputMethod=true whenever the IME says it handled the event. The if (!hasInsertText)
     guard on appending additionalCommands remains (so that it still protects the original dead-key
     double-insertion case in the handled=NO branch).
  2. Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm - handleEditingKeyboardEvent now executes
     queued commands when event.handledByInputMethod() is true, not just when there are no text
     insertion commands orthe event is Char. This is required because with handledByInputMethod=YES,
     internalKeyEvent returns without dispatching keypress, so the insertText: command must execute
     during didDispatchInputMethodKeydown or else the final text would never be inserted.

Test: TestWebKitAPI.WKWebViewMacEditingTests.KeyDownForInputMethodCommitUsesCompositionKeyCode

* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::interpretKeyEvent):
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::handleEditingKeyboardEvent):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/WKWebViewMacEditingTests.mm:
(TestWebKitAPI::TEST(WKWebViewMacEditingTests, KeyDownForInputMethodCommitUsesCompositionKeyCode)):

Canonical link: <a href="https://commits.webkit.org/313212@main">https://commits.webkit.org/313212@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/89f65ea73ca8d7000cd66b3725894f7e508d1c1d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162398 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35874 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/28990 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171336 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/118843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164267 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35978 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35876 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126020 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/118843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165357 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28360 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145879 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106598 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27407 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19036 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137110 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23610 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173840 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21153 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25254 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134327 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35548 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30026 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134327 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35532 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145406 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97787 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24674 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28858 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22237 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35041 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102793 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34543 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34788 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34691 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->