### PR TITLE
[WGSL] shader,validation,expression,binary,short_circuiting_and_or:* is failing

### DIFF
--- a/LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/binary/short_circuiting_and_or-expected.txt
+++ b/LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/binary/short_circuiting_and_or-expected.txt
@@ -811,326 +811,70 @@ PASS :invalid_types:op="%7C%7C";type="sampler";control=true
 PASS :invalid_types:op="%7C%7C";type="sampler";control=false
 PASS :invalid_types:op="%7C%7C";type="struct";control=true
 PASS :invalid_types:op="%7C%7C";type="struct";control=false
-FAIL :invalid_rhs_const:op="%26%26";rhs="overflow";short_circuit=true assert_unreached:
-  - (in subcase: ) VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    8:22: error: value 2147483648 cannot be represented as 'i32'
-
-    ---- shader ----
-
-    const thirty_one = 31u;
-    const zero_i32 = 0i;
-    const one_f32 = 1.0f;
-
-    @compute @workgroup_size(1)
-    fn main() {
-      let foo = false && i32(1<<thirty_one) < 0;
-    }
-
-      at (elided: below max severity)
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
-    8:21: value 2147483648 cannot be represented as 'i32'
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:466:44
- Reached unreachable code
+PASS :invalid_rhs_const:op="%26%26";rhs="overflow";short_circuit=true
 PASS :invalid_rhs_const:op="%26%26";rhs="overflow";short_circuit=false
-FAIL :invalid_rhs_const:op="%26%26";rhs="div_zero_i32";short_circuit=true assert_unreached:
-  - (in subcase: ) VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    8:25: error: invalid division by zero
-
-    ---- shader ----
-
-    const thirty_one = 31u;
-    const zero_i32 = 0i;
-    const one_f32 = 1.0f;
-
-    @compute @workgroup_size(1)
-    fn main() {
-      let foo = false && (1 / zero_i32) == 0;
-    }
-
-      at (elided: below max severity)
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
-    8:24: invalid division by zero
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:466:44
- Reached unreachable code
+PASS :invalid_rhs_const:op="%26%26";rhs="div_zero_i32";short_circuit=true
 PASS :invalid_rhs_const:op="%26%26";rhs="div_zero_i32";short_circuit=false
-FAIL :invalid_rhs_const:op="%26%26";rhs="div_zero_f32";short_circuit=true assert_unreached:
-  - (in subcase: ) VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    8:31: error: value Infinity cannot be represented as 'f32'
-
-    ---- shader ----
-
-    const thirty_one = 31u;
-    const zero_i32 = 0i;
-    const one_f32 = 1.0f;
-
-    @compute @workgroup_size(1)
-    fn main() {
-      let foo = false && (one_f32 / 0) == 0;
-    }
-
-      at (elided: below max severity)
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
-    8:30: value Infinity cannot be represented as 'f32'
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:466:44
- Reached unreachable code
+PASS :invalid_rhs_const:op="%26%26";rhs="div_zero_f32";short_circuit=true
 PASS :invalid_rhs_const:op="%26%26";rhs="div_zero_f32";short_circuit=false
-FAIL :invalid_rhs_const:op="%26%26";rhs="builtin";short_circuit=true assert_unreached:
-  - (in subcase: ) VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    8:22: error: value NaN cannot be represented as 'f32'
-
-    ---- shader ----
-
-    const thirty_one = 31u;
-    const zero_i32 = 0i;
-    const one_f32 = 1.0f;
-
-    @compute @workgroup_size(1)
-    fn main() {
-      let foo = false && sqrt(-one_f32) == 0;
-    }
-
-      at (elided: below max severity)
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
-    8:21: value NaN cannot be represented as 'f32'
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:466:44
- Reached unreachable code
+PASS :invalid_rhs_const:op="%26%26";rhs="builtin";short_circuit=true
 PASS :invalid_rhs_const:op="%26%26";rhs="builtin";short_circuit=false
-FAIL :invalid_rhs_const:op="%7C%7C";rhs="overflow";short_circuit=true assert_unreached:
-  - (in subcase: ) VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    8:21: error: value 2147483648 cannot be represented as 'i32'
-
-    ---- shader ----
-
-    const thirty_one = 31u;
-    const zero_i32 = 0i;
-    const one_f32 = 1.0f;
-
-    @compute @workgroup_size(1)
-    fn main() {
-      let foo = true || i32(1<<thirty_one) < 0;
-    }
-
-      at (elided: below max severity)
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
-    8:20: value 2147483648 cannot be represented as 'i32'
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:466:44
- Reached unreachable code
+PASS :invalid_rhs_const:op="%7C%7C";rhs="overflow";short_circuit=true
 PASS :invalid_rhs_const:op="%7C%7C";rhs="overflow";short_circuit=false
-FAIL :invalid_rhs_const:op="%7C%7C";rhs="div_zero_i32";short_circuit=true assert_unreached:
-  - (in subcase: ) VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    8:24: error: invalid division by zero
-
-    ---- shader ----
-
-    const thirty_one = 31u;
-    const zero_i32 = 0i;
-    const one_f32 = 1.0f;
-
-    @compute @workgroup_size(1)
-    fn main() {
-      let foo = true || (1 / zero_i32) == 0;
-    }
-
-      at (elided: below max severity)
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
-    8:23: invalid division by zero
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:466:44
- Reached unreachable code
+PASS :invalid_rhs_const:op="%7C%7C";rhs="div_zero_i32";short_circuit=true
 PASS :invalid_rhs_const:op="%7C%7C";rhs="div_zero_i32";short_circuit=false
-FAIL :invalid_rhs_const:op="%7C%7C";rhs="div_zero_f32";short_circuit=true assert_unreached:
-  - (in subcase: ) VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    8:30: error: value Infinity cannot be represented as 'f32'
-
-    ---- shader ----
-
-    const thirty_one = 31u;
-    const zero_i32 = 0i;
-    const one_f32 = 1.0f;
-
-    @compute @workgroup_size(1)
-    fn main() {
-      let foo = true || (one_f32 / 0) == 0;
-    }
-
-      at (elided: below max severity)
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
-    8:29: value Infinity cannot be represented as 'f32'
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:466:44
- Reached unreachable code
+PASS :invalid_rhs_const:op="%7C%7C";rhs="div_zero_f32";short_circuit=true
 PASS :invalid_rhs_const:op="%7C%7C";rhs="div_zero_f32";short_circuit=false
-FAIL :invalid_rhs_const:op="%7C%7C";rhs="builtin";short_circuit=true assert_unreached:
-  - (in subcase: ) VALIDATION FAILED: Unexpected compilationInfo 'error' message.
-    8:21: error: value NaN cannot be represented as 'f32'
-
-    ---- shader ----
-
-    const thirty_one = 31u;
-    const zero_i32 = 0i;
-    const one_f32 = 1.0f;
-
-    @compute @workgroup_size(1)
-    fn main() {
-      let foo = true || sqrt(-one_f32) == 0;
-    }
-
-      at (elided: below max severity)
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: 1 error generated while compiling the shader:
-    8:20: value NaN cannot be represented as 'f32'
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:466:44
- Reached unreachable code
+PASS :invalid_rhs_const:op="%7C%7C";rhs="builtin";short_circuit=true
 PASS :invalid_rhs_const:op="%7C%7C";rhs="builtin";short_circuit=false
-FAIL :invalid_rhs_fn_override:op="%26%26";rhs="overflow";short_circuit=true assert_unreached:
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:466:44
- Reached unreachable code
+PASS :invalid_rhs_fn_override:op="%26%26";rhs="overflow";short_circuit=true
 PASS :invalid_rhs_fn_override:op="%26%26";rhs="overflow";short_circuit=false
-FAIL :invalid_rhs_fn_override:op="%26%26";rhs="div_zero_i32";short_circuit=true assert_unreached:
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:466:44
- Reached unreachable code
+PASS :invalid_rhs_fn_override:op="%26%26";rhs="div_zero_i32";short_circuit=true
 PASS :invalid_rhs_fn_override:op="%26%26";rhs="div_zero_i32";short_circuit=false
-FAIL :invalid_rhs_fn_override:op="%26%26";rhs="div_zero_f32";short_circuit=true assert_unreached:
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:466:44
- Reached unreachable code
+PASS :invalid_rhs_fn_override:op="%26%26";rhs="div_zero_f32";short_circuit=true
 PASS :invalid_rhs_fn_override:op="%26%26";rhs="div_zero_f32";short_circuit=false
-FAIL :invalid_rhs_fn_override:op="%26%26";rhs="builtin";short_circuit=true assert_unreached:
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:466:44
- Reached unreachable code
+PASS :invalid_rhs_fn_override:op="%26%26";rhs="builtin";short_circuit=true
 PASS :invalid_rhs_fn_override:op="%26%26";rhs="builtin";short_circuit=false
-FAIL :invalid_rhs_fn_override:op="%7C%7C";rhs="overflow";short_circuit=true assert_unreached:
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:466:44
- Reached unreachable code
+PASS :invalid_rhs_fn_override:op="%7C%7C";rhs="overflow";short_circuit=true
 PASS :invalid_rhs_fn_override:op="%7C%7C";rhs="overflow";short_circuit=false
-FAIL :invalid_rhs_fn_override:op="%7C%7C";rhs="div_zero_i32";short_circuit=true assert_unreached:
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:466:44
- Reached unreachable code
+PASS :invalid_rhs_fn_override:op="%7C%7C";rhs="div_zero_i32";short_circuit=true
 PASS :invalid_rhs_fn_override:op="%7C%7C";rhs="div_zero_i32";short_circuit=false
-FAIL :invalid_rhs_fn_override:op="%7C%7C";rhs="div_zero_f32";short_circuit=true assert_unreached:
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:466:44
- Reached unreachable code
+PASS :invalid_rhs_fn_override:op="%7C%7C";rhs="div_zero_f32";short_circuit=true
 PASS :invalid_rhs_fn_override:op="%7C%7C";rhs="div_zero_f32";short_circuit=false
-FAIL :invalid_rhs_fn_override:op="%7C%7C";rhs="builtin";short_circuit=true assert_unreached:
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:466:44
- Reached unreachable code
+PASS :invalid_rhs_fn_override:op="%7C%7C";rhs="builtin";short_circuit=true
 PASS :invalid_rhs_fn_override:op="%7C%7C";rhs="builtin";short_circuit=false
-FAIL :invalid_rhs_override:op="%26%26";rhs="overflow";short_circuit=true assert_unreached:
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:466:44
- Reached unreachable code
+PASS :invalid_rhs_override:op="%26%26";rhs="overflow";short_circuit=true
 PASS :invalid_rhs_override:op="%26%26";rhs="overflow";short_circuit=false
-FAIL :invalid_rhs_override:op="%26%26";rhs="div_zero_i32";short_circuit=true assert_unreached:
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:466:44
- Reached unreachable code
+PASS :invalid_rhs_override:op="%26%26";rhs="div_zero_i32";short_circuit=true
 PASS :invalid_rhs_override:op="%26%26";rhs="div_zero_i32";short_circuit=false
-FAIL :invalid_rhs_override:op="%26%26";rhs="div_zero_f32";short_circuit=true assert_unreached:
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:466:44
- Reached unreachable code
+PASS :invalid_rhs_override:op="%26%26";rhs="div_zero_f32";short_circuit=true
 PASS :invalid_rhs_override:op="%26%26";rhs="div_zero_f32";short_circuit=false
-FAIL :invalid_rhs_override:op="%26%26";rhs="builtin";short_circuit=true assert_unreached:
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:466:44
- Reached unreachable code
+PASS :invalid_rhs_override:op="%26%26";rhs="builtin";short_circuit=true
 PASS :invalid_rhs_override:op="%26%26";rhs="builtin";short_circuit=false
-FAIL :invalid_rhs_override:op="%7C%7C";rhs="overflow";short_circuit=true assert_unreached:
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:466:44
- Reached unreachable code
+PASS :invalid_rhs_override:op="%7C%7C";rhs="overflow";short_circuit=true
 PASS :invalid_rhs_override:op="%7C%7C";rhs="overflow";short_circuit=false
-FAIL :invalid_rhs_override:op="%7C%7C";rhs="div_zero_i32";short_circuit=true assert_unreached:
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:466:44
- Reached unreachable code
+PASS :invalid_rhs_override:op="%7C%7C";rhs="div_zero_i32";short_circuit=true
 PASS :invalid_rhs_override:op="%7C%7C";rhs="div_zero_i32";short_circuit=false
-FAIL :invalid_rhs_override:op="%7C%7C";rhs="div_zero_f32";short_circuit=true assert_unreached:
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:466:44
- Reached unreachable code
+PASS :invalid_rhs_override:op="%7C%7C";rhs="div_zero_f32";short_circuit=true
 PASS :invalid_rhs_override:op="%7C%7C";rhs="div_zero_f32";short_circuit=false
-FAIL :invalid_rhs_override:op="%7C%7C";rhs="builtin";short_circuit=true assert_unreached:
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:466:44
- Reached unreachable code
+PASS :invalid_rhs_override:op="%7C%7C";rhs="builtin";short_circuit=true
 PASS :invalid_rhs_override:op="%7C%7C";rhs="builtin";short_circuit=false
-FAIL :nested_invalid_rhs_override:op_a="%26%26";op_b="%26%26";cond_a_val=false;cond_b_val=false assert_unreached:
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:466:44
- Reached unreachable code
-FAIL :nested_invalid_rhs_override:op_a="%26%26";op_b="%26%26";cond_a_val=false;cond_b_val=true assert_unreached:
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:466:44
- Reached unreachable code
-FAIL :nested_invalid_rhs_override:op_a="%26%26";op_b="%26%26";cond_a_val=true;cond_b_val=false assert_unreached:
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:466:44
- Reached unreachable code
+PASS :nested_invalid_rhs_override:op_a="%26%26";op_b="%26%26";cond_a_val=false;cond_b_val=false
+PASS :nested_invalid_rhs_override:op_a="%26%26";op_b="%26%26";cond_a_val=false;cond_b_val=true
+PASS :nested_invalid_rhs_override:op_a="%26%26";op_b="%26%26";cond_a_val=true;cond_b_val=false
 PASS :nested_invalid_rhs_override:op_a="%26%26";op_b="%26%26";cond_a_val=true;cond_b_val=true
 PASS :nested_invalid_rhs_override:op_a="%26%26";op_b="%7C%7C";cond_a_val=false;cond_b_val=false
 PASS :nested_invalid_rhs_override:op_a="%26%26";op_b="%7C%7C";cond_a_val=false;cond_b_val=true
 PASS :nested_invalid_rhs_override:op_a="%26%26";op_b="%7C%7C";cond_a_val=true;cond_b_val=false
-FAIL :nested_invalid_rhs_override:op_a="%26%26";op_b="%7C%7C";cond_a_val=true;cond_b_val=true assert_unreached:
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:466:44
- Reached unreachable code
-FAIL :nested_invalid_rhs_override:op_a="%7C%7C";op_b="%26%26";cond_a_val=false;cond_b_val=false assert_unreached:
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:466:44
- Reached unreachable code
+PASS :nested_invalid_rhs_override:op_a="%26%26";op_b="%7C%7C";cond_a_val=true;cond_b_val=true
+PASS :nested_invalid_rhs_override:op_a="%7C%7C";op_b="%26%26";cond_a_val=false;cond_b_val=false
 PASS :nested_invalid_rhs_override:op_a="%7C%7C";op_b="%26%26";cond_a_val=false;cond_b_val=true
 PASS :nested_invalid_rhs_override:op_a="%7C%7C";op_b="%26%26";cond_a_val=true;cond_b_val=false
 PASS :nested_invalid_rhs_override:op_a="%7C%7C";op_b="%26%26";cond_a_val=true;cond_b_val=true
 PASS :nested_invalid_rhs_override:op_a="%7C%7C";op_b="%7C%7C";cond_a_val=false;cond_b_val=false
-FAIL :nested_invalid_rhs_override:op_a="%7C%7C";op_b="%7C%7C";cond_a_val=false;cond_b_val=true assert_unreached:
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:466:44
- Reached unreachable code
-FAIL :nested_invalid_rhs_override:op_a="%7C%7C";op_b="%7C%7C";cond_a_val=true;cond_b_val=false assert_unreached:
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:466:44
- Reached unreachable code
-FAIL :nested_invalid_rhs_override:op_a="%7C%7C";op_b="%7C%7C";cond_a_val=true;cond_b_val=true assert_unreached:
-  - (in subcase: ) INFO: subcase ran
-  - EXCEPTION: Error: Unexpected validation error occurred: Failed to evaluate override value
-    attemptEndTestScope@http://127.0.0.1:8000/webgpu/webgpu/util/device_pool.js:466:44
- Reached unreachable code
+PASS :nested_invalid_rhs_override:op_a="%7C%7C";op_b="%7C%7C";cond_a_val=false;cond_b_val=true
+PASS :nested_invalid_rhs_override:op_a="%7C%7C";op_b="%7C%7C";cond_a_val=true;cond_b_val=false
+PASS :nested_invalid_rhs_override:op_a="%7C%7C";op_b="%7C%7C";cond_a_val=true;cond_b_val=true
 PASS :invalid_array_count_on_rhs:op="%26%26";rhs="negative";control=true
 PASS :invalid_array_count_on_rhs:op="%26%26";rhs="negative";control=false
 PASS :invalid_array_count_on_rhs:op="%26%26";rhs="sqrt_neg1";control=true

--- a/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
+++ b/Source/WebGPU/WGSL/GlobalVariableRewriter.cpp
@@ -172,6 +172,7 @@ private:
     HashSet<AST::Expression*> m_doNotUnpack;
     CheckedUint32 m_combinedFunctionVariablesSize;
     bool m_isTopLevelExpression { true };
+    bool m_suppressOverrideValidation { false };
 };
 
 std::optional<Error> RewriteGlobalVariables::run()
@@ -596,7 +597,20 @@ Packing RewriteGlobalVariables::getPacking(AST::IndexAccessExpression& expressio
 Packing RewriteGlobalVariables::getPacking(AST::BinaryExpression& expression)
 {
     pack(Packing::Unpacked, expression.leftExpression());
+
+    if (expression.operation() == AST::BinaryOperation::ShortCircuitAnd || expression.operation() == AST::BinaryOperation::ShortCircuitOr) {
+        auto leftEval = expression.leftExpression().maybeEvaluation().value_or(Evaluation::Runtime);
+        if (leftEval == Evaluation::Override) {
+            SetForScope suppressScope(m_suppressOverrideValidation, true);
+            pack(Packing::Unpacked, expression.rightExpression());
+            return Packing::Unpacked;
+        }
+    }
+
     pack(Packing::Unpacked, expression.rightExpression());
+
+    if (m_suppressOverrideValidation)
+        return Packing::Unpacked;
 
     auto operation = toASCIILiteral(expression.operation());
     if (auto* overload = m_shaderModule.lookupOverload(operation)) {
@@ -719,20 +733,22 @@ Packing RewriteGlobalVariables::getPacking(AST::CallExpression& call)
     for (auto& argument : call.arguments())
         pack(Packing::Unpacked, argument);
 
-    if (auto validate = call.validationFunction()) {
-        m_shaderModule.addOverrideValidation([&shaderModule = m_shaderModule, &call, validate](auto& overrideValues) -> std::optional<Error> {
-            unsigned argumentCount = call.arguments().size();
-            FixedVector<std::optional<ConstantValue>> validationArguments(argumentCount);
-            for (unsigned i = 0; i < argumentCount; ++i) {
-                if (auto value = evaluate(shaderModule, call.arguments()[i], overrideValues))
-                    validationArguments[i] = { *value };
-            }
+    if (!m_suppressOverrideValidation) {
+        if (auto validate = call.validationFunction()) {
+            m_shaderModule.addOverrideValidation([&shaderModule = m_shaderModule, &call, validate](auto& overrideValues) -> std::optional<Error> {
+                unsigned argumentCount = call.arguments().size();
+                FixedVector<std::optional<ConstantValue>> validationArguments(argumentCount);
+                for (unsigned i = 0; i < argumentCount; ++i) {
+                    if (auto value = evaluate(shaderModule, call.arguments()[i], overrideValues))
+                        validationArguments[i] = { *value };
+                }
 
-            if (auto error = validate(WTF::move(validationArguments)))
-                return Error(*error, call.span());
+                if (auto error = validate(WTF::move(validationArguments)))
+                    return Error(*error, call.span());
 
-            return std::nullopt;
-        });
+                return std::nullopt;
+            });
+        }
     }
 
     return Packing::Unpacked;

--- a/Source/WebGPU/WGSL/TypeCheck.cpp
+++ b/Source/WebGPU/WGSL/TypeCheck.cpp
@@ -263,6 +263,7 @@ private:
     std::optional<Evaluation> m_currentEvaluation { std::nullopt };
     Evaluation m_maxEvaluation { Evaluation::Runtime };
     DiscardResult m_discardResult { DiscardResult::No };
+    bool m_suppressConstantErrors { false };
 
     TypeStore& m_types;
     Vector<BreakTarget> m_breakTargetStack;
@@ -1345,6 +1346,30 @@ Result<void> TypeChecker::visit(AST::BinaryExpression& binary)
 
 Result<void> TypeChecker::binaryExpression(const SourceSpan& span, AST::Expression* expression, AST::BinaryOperation operation, AST::Expression& leftExpression, AST::Expression& rightExpression)
 {
+    if (operation == AST::BinaryOperation::ShortCircuitAnd || operation == AST::BinaryOperation::ShortCircuitOr) {
+        UNWRAP(lhsType, infer(leftExpression, m_maxEvaluation));
+        if (lhsType == m_types.boolType()) {
+            if (auto lhsValue = leftExpression.constantValue()) {
+                bool lhsBool = std::get<bool>(*lhsValue);
+                bool shortCircuits = (operation == AST::BinaryOperation::ShortCircuitAnd && !lhsBool)
+                    || (operation == AST::BinaryOperation::ShortCircuitOr && lhsBool);
+                if (shortCircuits) {
+                    auto suppressScope = SetForScope(m_suppressConstantErrors, true);
+                    UNWRAP(rhsType, infer(rightExpression, m_maxEvaluation));
+                    if (auto* reference = std::get_if<Types::Reference>(rhsType))
+                        rhsType = reference->element;
+                    if (rhsType != m_types.boolType())
+                        TYPE_ERROR(span, "no matching overload for operator "_s, toASCIILiteral(operation), '(', *lhsType, ", "_s, *rhsType, ')');
+                    inferred(m_types.boolType());
+                    evaluated(leftExpression.evaluation());
+                    if (expression)
+                        expression->setConstantValue(operation == AST::BinaryOperation::ShortCircuitAnd ? false : true);
+                    return { };
+                }
+            }
+        }
+    }
+
     CHECK(chooseOverload("operator"_s, span, expression, toASCIILiteral(operation), ReferenceWrapperVector<AST::Expression, 2> { leftExpression, rightExpression }, { }));
 
     ASCIILiteral operationName;
@@ -2155,8 +2180,10 @@ Result<const Type*> TypeChecker::chooseOverload(ASCIILiteral kind, const SourceS
         }
 
         auto constantFunction = overload->constantFunction;
-        if (!constantFunction && m_maxEvaluation < Evaluation::Runtime) [[unlikely]]
-            TYPE_ERROR(span, "cannot call function from "_s, evaluationToString(m_maxEvaluation), " context"_s);
+        if (!constantFunction && m_maxEvaluation < Evaluation::Runtime) [[unlikely]] {
+            if (!m_suppressConstantErrors)
+                TYPE_ERROR(span, "cannot call function from "_s, evaluationToString(m_maxEvaluation), " context"_s);
+        }
 
         if (!constantFunction)
             evaluation = Evaluation::Runtime;
@@ -2164,9 +2191,10 @@ Result<const Type*> TypeChecker::chooseOverload(ASCIILiteral kind, const SourceS
 
         if (isConstant && constantFunction) {
             auto result = constantFunction(selectedOverload->result, WTF::move(arguments));
-            if (!result) [[unlikely]]
-                TYPE_ERROR(span, result.error());
-            if (expression)
+            if (!result) [[unlikely]] {
+                if (!m_suppressConstantErrors)
+                    TYPE_ERROR(span, result.error());
+            } else if (expression)
                 CHECK(setConstantValue(*expression, selectedOverload->result, WTF::move(*result)));
         } else if (auto* validate = overload->validationFunction) {
             if (auto error = validate(WTF::move(validationArguments)))
@@ -2521,6 +2549,10 @@ Result<void> TypeChecker::convertValue(const SourceSpan& span, const Type* type,
     }
 
     if (!convertValueImpl(span, type, *value)) [[unlikely]] {
+        if (m_suppressConstantErrors) {
+            value = std::nullopt;
+            return { };
+        }
         StringPrintStream valueString;
         value->dump(valueString);
         TYPE_ERROR(span, "value "_s, valueString.toString(), " cannot be represented as '"_s, *type, '\'');

--- a/Source/WebGPU/WGSL/WGSL.cpp
+++ b/Source/WebGPU/WGSL/WGSL.cpp
@@ -224,8 +224,28 @@ std::optional<ConstantValue> evaluate(const ShaderModule& module, const AST::Exp
     switch (expression.kind()) {
     case AST::NodeKind::BinaryExpression: {
         auto& binary = uncheckedDowncast<AST::BinaryExpression>(expression);
-        auto operation = toASCIILiteral(binary.operation());
-        result = call(operation, ReferenceWrapperVector<const AST::Expression, 2> { binary.leftExpression(), binary.rightExpression() });
+        if (binary.operation() == AST::BinaryOperation::ShortCircuitAnd) {
+            auto lhsValue = evaluate(module, binary.leftExpression(), overrideValues);
+            if (lhsValue && !std::get<bool>(*lhsValue))
+                result = false;
+            else {
+                auto rhsValue = evaluate(module, binary.rightExpression(), overrideValues);
+                if (lhsValue && rhsValue)
+                    result = std::get<bool>(*lhsValue) && std::get<bool>(*rhsValue);
+            }
+        } else if (binary.operation() == AST::BinaryOperation::ShortCircuitOr) {
+            auto lhsValue = evaluate(module, binary.leftExpression(), overrideValues);
+            if (lhsValue && std::get<bool>(*lhsValue))
+                result = true;
+            else {
+                auto rhsValue = evaluate(module, binary.rightExpression(), overrideValues);
+                if (lhsValue && rhsValue)
+                    result = std::get<bool>(*lhsValue) || std::get<bool>(*rhsValue);
+            }
+        } else {
+            auto operation = toASCIILiteral(binary.operation());
+            result = call(operation, ReferenceWrapperVector<const AST::Expression, 2> { binary.leftExpression(), binary.rightExpression() });
+        }
         break;
     }
 


### PR DESCRIPTION
#### 52b6ed6716579e2a2de6caadf23e556820f9858d
<pre>
[WGSL] shader,validation,expression,binary,short_circuiting_and_or:* is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=314762">https://bugs.webkit.org/show_bug.cgi?id=314762</a>
<a href="https://rdar.apple.com/177012957">rdar://177012957</a>

Reviewed by Mike Wyrzykowski.

Add support for short-circuiting logical operators at constant and
override evaluation times.

* LayoutTests/http/tests/webgpu/webgpu/shader/validation/expression/binary/short_circuiting_and_or-expected.txt:
* Source/WebGPU/WGSL/GlobalVariableRewriter.cpp:
(WGSL::RewriteGlobalVariables::getPacking):
* Source/WebGPU/WGSL/TypeCheck.cpp:
(WGSL::TypeChecker::binaryExpression):
(WGSL::TypeChecker::convertValue):
* Source/WebGPU/WGSL/WGSL.cpp:
(WGSL::evaluate):

Canonical link: <a href="https://commits.webkit.org/313467@main">https://commits.webkit.org/313467@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/efa6a52b45dd7decd7e2818aadeb10269f39e3bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163145 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36626 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29843 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172084 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119592 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/015979b6-7e09-4fa5-bf0e-25269507a585) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36954 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36626 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126665 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89268 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2f979388-3c70-42eb-b656-376bfcb6386e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166104 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28938 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146666 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107235 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/676f84ec-8f66-421c-b5c5-a381fa5c434d) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26614 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19784 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137877 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24390 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174587 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/26744 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26045 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134976 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36296 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30717 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134968 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36401 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37082 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146185 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98939 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30270 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23029 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35792 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108153 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35291 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1052 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35538 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35438 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->