### PR TITLE
[CMake] Some Linux builds with precompiled headers enabled are broken

### DIFF
--- a/Source/JavaScriptCore/JavaScriptCoreJITPrefix.h
+++ b/Source/JavaScriptCore/JavaScriptCoreJITPrefix.h
@@ -23,11 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#if defined(HAVE_CONFIG_H) && HAVE_CONFIG_H && defined(BUILDING_WITH_CMAKE)
-#include "cmakeconfig.h"
-#endif
-
-#include <wtf/Platform.h>
+#include "JavaScriptCorePrefix.h"
 
 #ifdef __cplusplus
 #undef new

--- a/Source/JavaScriptCore/JavaScriptCorePrefix.h
+++ b/Source/JavaScriptCore/JavaScriptCorePrefix.h
@@ -23,6 +23,8 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#pragma once
+
 #if defined(HAVE_CONFIG_H) && HAVE_CONFIG_H && defined(BUILDING_WITH_CMAKE)
 #include "cmakeconfig.h"
 #endif

--- a/Source/ThirdParty/libwebrtc/CMakeLists.txt
+++ b/Source/ThirdParty/libwebrtc/CMakeLists.txt
@@ -1819,7 +1819,9 @@ if (WTF_CPU_X86_64 OR WTF_CPU_X86)
         Source/webrtc/modules/audio_processing/aec3/vector_math_avx2.cc
         Source/webrtc/modules/audio_processing/agc2/rnn_vad/vector_math_avx2.cc
     )
-    set_source_files_properties(${webrtc_avx_SOURCES} PROPERTIES COMPILE_OPTIONS "-mavx2;-mfma")
+    set_source_files_properties(${webrtc_avx_SOURCES} PROPERTIES
+        COMPILE_OPTIONS "-mavx2;-mfma"
+        SKIP_PRECOMPILE_HEADERS ON)
     list(APPEND webrtc_SOURCES ${webrtc_avx_SOURCES})
     add_definitions(-DWEBRTC_ENABLE_AVX2)
 endif()
@@ -2009,7 +2011,9 @@ if (WTF_CPU_ARM)
         Source/webrtc/modules/audio_processing/aec3/suppression_filter.cc
         Source/webrtc/modules/audio_processing/aec3/suppression_gain.cc
     )
-    set_source_files_properties(${webrtc_neon_SOURCES} PROPERTIES COMPILE_OPTIONS "-mfpu=neon;-mfloat-abi=hard")
+    set_source_files_properties(${webrtc_neon_SOURCES} PROPERTIES
+        COMPILE_OPTIONS "-mfpu=neon;-mfloat-abi=hard"
+        SKIP_PRECOMPILE_HEADERS ON)
 endif ()
 
 if (WTF_CPU_MIPS)

--- a/Source/WebCore/WebCoreDOMAndRenderingPrefix.h
+++ b/Source/WebCore/WebCoreDOMAndRenderingPrefix.h
@@ -23,10 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* Chained on top of WebCorePrefix.h; do not include that file here -- the
-   base PCH supplies it. Anchors below are headers that >=80% of the
-   dom/html/page/rendering/accessibility/animation/style TUs include and that
-   are not already in the base PCH closure. */
+#include "WebCorePrefix.h"
 
 #ifdef __cplusplus
 #undef new

--- a/Source/WebCore/WebCoreInspectorPrefix.h
+++ b/Source/WebCore/WebCoreInspectorPrefix.h
@@ -23,9 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* Chained on top of WebCorePrefix.h; do not include that file here -- the
-   base PCH supplies it. Anchors below are headers that >=80% of inspector/
-   TUs include and that are not already in the base PCH closure. */
+#include "WebCorePrefix.h"
 
 #ifdef __cplusplus
 #undef new

--- a/Source/WebCore/WebCoreJSBindingsPrefix.h
+++ b/Source/WebCore/WebCoreJSBindingsPrefix.h
@@ -23,11 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-#if defined(HAVE_CONFIG_H) && HAVE_CONFIG_H && defined(BUILDING_WITH_CMAKE)
-#include "cmakeconfig.h"
-#endif
-
-#include <wtf/Platform.h>
+#include "WebCorePrefix.h"
 
 #ifdef __cplusplus
 #undef new

--- a/Source/WebCore/WebCorePrefix.h
+++ b/Source/WebCore/WebCorePrefix.h
@@ -18,6 +18,8 @@
  *
  */
 
+#pragma once
+
 /* This prefix file should contain only:
  *    1) files to precompile for faster builds
  *    2) in one case at least: OS-X-specific performance bug workarounds

--- a/Source/WebKit/UIProcess/API/glib/APIContentRuleListStoreGLib.cpp
+++ b/Source/WebKit/UIProcess/API/glib/APIContentRuleListStoreGLib.cpp
@@ -29,10 +29,10 @@
 namespace API {
 
 #if ENABLE(CONTENT_EXTENSIONS)
-String ContentRuleListStore::defaultStorePath()
+WTF::String ContentRuleListStore::defaultStorePath()
 {
     ASSERT_NOT_REACHED();
-    return String();
+    return { };
 }
 #endif
 

--- a/Source/WebKit/WebKitMessageReceiversPrefix.h
+++ b/Source/WebKit/WebKitMessageReceiversPrefix.h
@@ -23,10 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* Chained on top of WebKitPrefix.h; do not include that file here -- the
-   base PCH supplies it. Anchors below are headers that >=80% of generated
-   DerivedSources message-receiver/serializer TUs include and that are not
-   already in the base PCH closure. */
+#include "WebKitPrefix.h"
 
 #ifdef __cplusplus
 #undef new

--- a/Source/WebKit/WebKitPrefix.h
+++ b/Source/WebKit/WebKitPrefix.h
@@ -24,6 +24,8 @@
  * THE POSSIBILITY OF SUCH DAMAGE.
  */
 
+#pragma once
+
 #if defined(HAVE_CONFIG_H) && HAVE_CONFIG_H && defined(BUILDING_WITH_CMAKE)
 #include "cmakeconfig.h"
 #endif

--- a/Source/WebKit/WebKitUIProcessPrefix.h
+++ b/Source/WebKit/WebKitUIProcessPrefix.h
@@ -23,9 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* Chained on top of WebKitPrefix.h; do not include that file here -- the
-   base PCH supplies it. Anchors below are headers that >=80% of UIProcess/
-   TUs include and that are not already in the base PCH closure. */
+#include "WebKitPrefix.h"
 
 #ifdef __cplusplus
 #undef new

--- a/Source/WebKit/WebKitWebProcessPrefix.h
+++ b/Source/WebKit/WebKitWebProcessPrefix.h
@@ -23,9 +23,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 
-/* Chained on top of WebKitPrefix.h; do not include that file here -- the
-   base PCH supplies it. Anchors below are headers that >=80% of WebProcess/
-   TUs include and that are not already in the base PCH closure. */
+#include "WebKitPrefix.h"
 
 #ifdef __cplusplus
 #undef new

--- a/Source/cmake/WebKitMacros.cmake
+++ b/Source/cmake/WebKitMacros.cmake
@@ -210,16 +210,21 @@ function(WEBKIT_ADD_PREFIX_HEADER_WITH_PARENT _target _base_target _header _pare
         string(JOIN "," _lang_genex ${ARGN})
         target_precompile_headers(${_target} PRIVATE
             "$<$<COMPILE_LANGUAGE:${_lang_genex}>:${CMAKE_CURRENT_SOURCE_DIR}/${_header}>")
-        get_target_property(_base_bin_dir ${_base_target} BINARY_DIR)
-        get_target_property(_chain_bin_dir ${_target} BINARY_DIR)
-        foreach (_lang ${ARGN})
-            _WEBKIT_PCH_PATHS_FOR_LANGUAGE(${_lang} _src_ext _stub_ext _pch_stem)
-            set(_base_pch "${_base_bin_dir}/CMakeFiles/${_base_target}.dir/${_pch_stem}.pch")
-            set(_chain_stub "${_chain_bin_dir}/CMakeFiles/${_target}.dir/${_pch_stem}.${_stub_ext}")
-            set_source_files_properties(${_chain_stub} PROPERTIES
-                COMPILE_OPTIONS "-Xclang;-include-pch;-Xclang;${_base_pch}"
-                OBJECT_DEPENDS "${_base_pch}")
-        endforeach ()
+        if (APPLE)
+            # FIXME: Upstream clang does not appear to propagate parent-PCH state to consumers
+            # of the child PCH (webkit.org/b/314763). Until that is root-caused, build the child
+            # prefix as a standalone PCH on non-Apple clang; the child header #includes its parent.
+            get_target_property(_base_bin_dir ${_base_target} BINARY_DIR)
+            get_target_property(_chain_bin_dir ${_target} BINARY_DIR)
+            foreach (_lang ${ARGN})
+                _WEBKIT_PCH_PATHS_FOR_LANGUAGE(${_lang} _src_ext _stub_ext _pch_stem)
+                set(_base_pch "${_base_bin_dir}/CMakeFiles/${_base_target}.dir/${_pch_stem}.pch")
+                set(_chain_stub "${_chain_bin_dir}/CMakeFiles/${_target}.dir/${_pch_stem}.${_stub_ext}")
+                set_source_files_properties(${_chain_stub} PROPERTIES
+                    COMPILE_OPTIONS "-Xclang;-include-pch;-Xclang;${_base_pch}"
+                    OBJECT_DEPENDS "${_base_pch}")
+            endforeach ()
+        endif ()
         _WEBKIT_ADD_PCH_OBJECT(${_target} PREFIX_NO_CODEGEN PREFIX_LANGUAGES ${ARGN})
     else ()
         WEBKIT_ADD_PREFIX_HEADER(${_target} ${_parent_header} PREFIX_LANGUAGES ${ARGN})


### PR DESCRIPTION
#### 99f0b44bc5cec7e8e2c46fada62bc0167dc7f6b2
<pre>
[CMake] Some Linux builds with precompiled headers enabled are broken
<a href="https://bugs.webkit.org/show_bug.cgi?id=314763">https://bugs.webkit.org/show_bug.cgi?id=314763</a>
<a href="https://rdar.apple.com/177014051">rdar://177014051</a>

Reviewed by Claudio Saavedra.

In some versions of clang on Linux, when a child PCH is built with
-Xclang -include-pch &lt;parent&gt;.pch, consumers of the child PCH see the
parent&apos;s #pragma once / include-guard state but not any of its defined
symbols. So the symbols are not present and also cannot be made present
with an #include statement.

I am inferring this explanation by experimental observation.

Workaround: Only do -include-pch in Apple clang, where we know it works.
Add an explicit #include in the child prefix header to catch the platforms
that don&apos;t do  -include-pch.

Also fix two issues exposed by enabling PCH on Linux clang:

* Source/JavaScriptCore/JavaScriptCoreJITPrefix.h:
* Source/JavaScriptCore/JavaScriptCorePrefix.h:
* Source/WebCore/WebCoreDOMAndRenderingPrefix.h:
* Source/WebCore/WebCoreInspectorPrefix.h:
* Source/WebCore/WebCoreJSBindingsPrefix.h:
* Source/WebCore/WebCorePrefix.h:
* Source/WebKit/WebKitMessageReceiversPrefix.h:
* Source/WebKit/WebKitPrefix.h:
* Source/WebKit/WebKitUIProcessPrefix.h:
* Source/WebKit/WebKitWebProcessPrefix.h:
Child prefix headers #include their parent; parent prefix headers gain

* Source/cmake/WebKitMacros.cmake:
(WEBKIT_ADD_PREFIX_HEADER_WITH_PARENT): Only inject the parent
-include-pch on Apple platforms.

* Source/ThirdParty/libwebrtc/CMakeLists.txt:
Set SKIP_PRECOMPILE_HEADERS on the AVX2/FMA and NEON source groups
because the compilation flags don&apos;t match.

* Source/WebKit/UIProcess/API/glib/APIContentRuleListStoreGLib.cpp:
Resolve pre-existing ambiguity in the name &apos;String&apos;.

Canonical link: <a href="https://commits.webkit.org/313333@main">https://commits.webkit.org/313333@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6222f8ff125425c20fa55ddd017c9bfcf2b09b0f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162841 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36318 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/29475 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171779 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/119287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164710 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36422 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36321 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/126403 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/119287 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165800 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/28751 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/146322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/106980 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/19479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/24051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174283 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/23680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/21806 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/25696 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/134712 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/35991 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/134707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/35976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/145847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/98396 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24751 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/35976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/22683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195242 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35485 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/103525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/50593 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/34986 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/35231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/35134 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->