### PR TITLE
[Site Isolation] Fix http/tests/ssl/media-stream/get-user-media-secure-connection.html test failure

### DIFF
--- a/LayoutTests/http/tests/ssl/media-stream/resources/get-user-media-frame.html
+++ b/LayoutTests/http/tests/ssl/media-stream/resources/get-user-media-frame.html
@@ -38,7 +38,7 @@
                 if (window.testRunner)
                     testRunner.notifyDone();
                 if (stream)
-                    stream.srcObject.getTracks().forEach(t => t.stop());
+                    stream.getTracks().forEach(t => t.stop());
             }
 
             debug(`URL: ${window.location.href}`);

--- a/LayoutTests/platform/ios-site-isolation/TestExpectations
+++ b/LayoutTests/platform/ios-site-isolation/TestExpectations
@@ -222,7 +222,6 @@ http/tests/security/xss-DENIED-window-open-javascript-url-with-spaces.html [ Fai
 http/tests/security/xss-DENIED-window-open-javascript-url.html [ Failure ]
 http/tests/ssl/applepay/page-cache-active-apple-pay-session.html [ Failure ]
 http/tests/ssl/applepay/page-cache-inactive-apple-pay-session.html [ Failure ]
-http/tests/ssl/media-stream/get-user-media-secure-connection.html [ Failure ]
 http/tests/webrtc/audioSessionInFrames.html [ Failure ]
 http/tests/workers/service/client-added-to-clients-when-restored-from-page-cache.html [ Failure ]
 http/tests/workers/service/client-removed-from-clients-while-in-page-cache.html [ Failure ]

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -224,7 +224,6 @@ webkit.org/b/311836 http/tests/site-isolation/inspector/page/set-emulated-media-
 http/tests/site-isolation/inspector/worker/worker-in-cross-origin-iframe.html [ Pass ]
 http/tests/ssl/applepay/page-cache-active-apple-pay-session.html [ Failure ]
 http/tests/ssl/applepay/page-cache-inactive-apple-pay-session.html [ Failure ]
-http/tests/ssl/media-stream/get-user-media-secure-connection.html [ Failure ]
 http/tests/storageAccess/grant-storage-access-under-opener-at-popup-user-gesture-ephemeral.https.html [ Failure ]
 http/tests/storageAccess/grant-storage-access-under-opener-at-popup-user-gesture.https.html [ Failure ]
 http/tests/storageAccess/request-and-grant-access-cross-origin-sandboxed-iframe-from-prevalent-domain-with-user-interaction-and-access-from-right-frame.https.html [ Failure ]


### PR DESCRIPTION
#### 6a2779a9df5bce87b67eaf43e78395de472983e2
<pre>
[Site Isolation] Fix http/tests/ssl/media-stream/get-user-media-secure-connection.html test failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=314756">https://bugs.webkit.org/show_bug.cgi?id=314756</a>
<a href="https://rdar.apple.com/177009411">rdar://177009411</a>

Reviewed by Ryosuke Niwa.

The track-stopping cleanup added in 298547@main reads
stream.srcObject.getTracks(), but `stream` here is the MediaStream returned
from navigator.mediaDevices.getUserMedia() and MediaStream has no srcObject
property (that belongs to HTMLMediaElement).

The thrown TypeError was masked without site isolation because it fired after
testRunner.notifyDone() had already dumped output, but under site isolation
extra cross-process IPC lets the promise&apos;s .catch run first, producing an extra FAIL line.

* LayoutTests/http/tests/ssl/media-stream/resources/get-user-media-frame.html:
* LayoutTests/platform/ios-site-isolation/TestExpectations:
* LayoutTests/platform/mac-site-isolation/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/313278@main">https://commits.webkit.org/313278@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2c898496e9e315b42c67fe53d439a86aeda615c7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162410 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35886 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29119 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171348 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118855 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/945b74b2-d189-46a6-870d-8967e46ac196) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/35990 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35888 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126032 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88811 "1 flakes 18 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165369 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28372 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146001 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106610 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27419 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25947 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19048 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137122 "Found 1 new API test failure: TestWebKitAPI.WKAttachmentTestsIOS.PasteRichTextCopiedFromNotes (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23731 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173852 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25376 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134339 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35560 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30037 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134339 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36298 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35544 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145527 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97799 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28868 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22360 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35053 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34555 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34800 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34703 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->