### PR TITLE
[JSC][Temporal] Add duration rounding, calendar field resolution, and date-time difference algorithms

### DIFF
--- a/Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp
+++ b/Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp
@@ -27,15 +27,19 @@
 #include "TemporalCoreTest.h"
 
 #include "CalendarArithmetic.h"
+#include "CalendarFields.h"
 #include "CalendarICUBridge.h"
+#include "DurationArithmetic.h"
 #include "ISO8601.h"
 #include "ISOArithmetic.h"
 #include "InstantCore.h"
 #include "JSCTimeZone.h"
+#include "PlainDateTimeCore.h"
 #include "Rounding.h"
 #include "TemporalCoreTypes.h"
 #include "TemporalEnums.h"
 #include "TimeZoneICUBridge.h"
+#include "ZonedDateTimeCore.h"
 #include <stdio.h>
 #include <wtf/Int128.h>
 
@@ -278,6 +282,105 @@ static void testMaximumRoundingIncrement()
 }
 
 // ---------------------------------------------------------------------------
+// DurationArithmetic tests — mirrors temporal_rs src/builtins/core/duration.rs
+// ---------------------------------------------------------------------------
+
+static void testTimeDurationFromComponents()
+{
+    // temporal_rs: TimeDuration::from_components
+    // 1h = 3600000000000 ns
+    Int128 h1 = timeDurationFromComponents(1, 0, 0, 0, 0, 0);
+    TCHECK_EQ(h1, Int128(3600000000000LL), "timeDuration: 1h");
+
+    // 1m = 60000000000 ns
+    Int128 m1 = timeDurationFromComponents(0, 1, 0, 0, 0, 0);
+    TCHECK_EQ(m1, Int128(60000000000LL), "timeDuration: 1m");
+
+    // 1s = 1000000000 ns
+    Int128 s1 = timeDurationFromComponents(0, 0, 1, 0, 0, 0);
+    TCHECK_EQ(s1, Int128(1000000000LL), "timeDuration: 1s");
+
+    // 1ms = 1000000 ns
+    Int128 ms1 = timeDurationFromComponents(0, 0, 0, 1, 0, 0);
+    TCHECK_EQ(ms1, Int128(1000000LL), "timeDuration: 1ms");
+
+    // 1µs = 1000 ns
+    Int128 us1 = timeDurationFromComponents(0, 0, 0, 0, 1, 0);
+    TCHECK_EQ(us1, Int128(1000LL), "timeDuration: 1µs");
+
+    // 1ns
+    Int128 ns1 = timeDurationFromComponents(0, 0, 0, 0, 0, 1);
+    TCHECK_EQ(ns1, Int128(1LL), "timeDuration: 1ns");
+
+    // Combined: 1h2m3s = 3723000000000 ns
+    Int128 combined = timeDurationFromComponents(1, 2, 3, 0, 0, 0);
+    TCHECK_EQ(combined, Int128(3723000000000LL), "timeDuration: 1h2m3s");
+
+    // 25h = 90000000000000 ns
+    Int128 h25 = timeDurationFromComponents(25, 0, 0, 0, 0, 0);
+    TCHECK_EQ(h25, Int128(90000000000000LL), "timeDuration: 25h");
+}
+
+static void testDurationSign()
+{
+    // temporal_rs: Duration::sign
+    ISO8601::Duration pos(1, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+    TCHECK_EQ(durationSign(pos), 1, "durationSign: positive");
+
+    ISO8601::Duration neg(-1, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+    TCHECK_EQ(durationSign(neg), -1, "durationSign: negative");
+
+    ISO8601::Duration zero;
+    TCHECK_EQ(durationSign(zero), 0, "durationSign: zero");
+
+    // Mixed field signs -> should not occur in valid durations, but sign uses first nonzero
+    ISO8601::Duration negHours(0, 0, 0, 0, -5, 0, 0, 0, 0, 0);
+    TCHECK_EQ(durationSign(negHours), -1, "durationSign: negative hours");
+}
+
+static void testLargestSubduration()
+{
+    // temporal_rs: Duration::default_largest_unit
+    ISO8601::Duration d1(1, 0, 0, 0, 0, 0, 0, 0, 0, 0);
+    TCHECK_EQ(largestSubduration(d1), TemporalUnit::Year, "largestSub: years");
+
+    ISO8601::Duration d2(0, 2, 0, 0, 0, 0, 0, 0, 0, 0);
+    TCHECK_EQ(largestSubduration(d2), TemporalUnit::Month, "largestSub: months");
+
+    ISO8601::Duration d3(0, 0, 0, 0, 3, 0, 0, 0, 0, 0);
+    TCHECK_EQ(largestSubduration(d3), TemporalUnit::Hour, "largestSub: hours");
+
+    ISO8601::Duration d4(0, 0, 0, 0, 0, 0, 0, 0, 0, 5);
+    TCHECK_EQ(largestSubduration(d4), TemporalUnit::Nanosecond, "largestSub: nanoseconds");
+
+    // Zero duration -> Nanosecond (first nonzero not found, returns last)
+    ISO8601::Duration d5;
+    TCHECK_EQ(largestSubduration(d5), TemporalUnit::Nanosecond, "largestSub: zero");
+}
+
+static void testAdjustDateDurationRecord()
+{
+    // temporal_rs: AdjustDateDurationRecord
+    ISO8601::Duration base(2, 3, 1, 5, 0, 0, 0, 0, 0, 0);
+
+    // Override days only
+    auto r1 = adjustDateDurationRecord(base, 10.0, std::nullopt, std::nullopt);
+    TCHECK_TRUE(r1.has_value(), "adjustDateDur: days override ok");
+    TCHECK_EQ(static_cast<int64_t>(r1->years()), 2LL, "adjustDateDur: years preserved");
+    TCHECK_EQ(static_cast<int64_t>(r1->months()), 3LL, "adjustDateDur: months preserved");
+    TCHECK_EQ(static_cast<int64_t>(r1->days()), 10LL, "adjustDateDur: days overridden");
+
+    // Override weeks
+    auto r2 = adjustDateDurationRecord(base, 5.0, 2.0, std::nullopt);
+    TCHECK_TRUE(r2.has_value(), "adjustDateDur: weeks override ok");
+    TCHECK_EQ(static_cast<int64_t>(r2->weeks()), 2LL, "adjustDateDur: weeks overridden");
+
+    // Mixed signs -> invalid, should error
+    auto r3 = adjustDateDurationRecord(base, -10.0, std::nullopt, std::nullopt);
+    TCHECK_TRUE(!r3.has_value(), "adjustDateDur: mixed sign rejected");
+}
+
+// ---------------------------------------------------------------------------
 // CalendarArithmetic tests — mirrors temporal_rs src/builtins/core/calendar.rs
 // ---------------------------------------------------------------------------
 
@@ -470,9 +573,8 @@ static void testNegativeRounding()
 
 static void testRoundAsIfPositive()
 {
-    // roundNumberToIncrementAsIfPositive always uses getUnsignedRoundingMode(mode, false).
-    // For negative x=-107, increment=10: C++ quotient=-10, r1=-11, r2=-10.
-    // Trunc->Zero->r1*inc = -110; Expand->Infinity->r2*inc = -100.
+    // roundNumberToIncrementAsIfPositive treats negative x as positive for rounding direction.
+    // x=-107 inc=10: Trunc→-110 (toward -∞ when treated positive), Expand→-100.
     TCHECK_EQ(roundNumberToIncrementAsIfPositive(Int128(-107), Int128(10), RoundingMode::Trunc), Int128(-110), "asIfPos: -107 Trunc=-110");
     TCHECK_EQ(roundNumberToIncrementAsIfPositive(Int128(-107), Int128(10), RoundingMode::Expand), Int128(-100), "asIfPos: -107 Expand=-100");
     TCHECK_EQ(roundNumberToIncrementAsIfPositive(Int128(-107), Int128(10), RoundingMode::Ceil), Int128(-100), "asIfPos: -107 Ceil=-100");
@@ -506,6 +608,30 @@ static void testNegateRoundingMode()
 }
 
 // ---------------------------------------------------------------------------
+// Duration balancing — mirrors temporal_rs balance tests
+// ---------------------------------------------------------------------------
+
+static void testDurationBalancing()
+{
+    // temporal_rs: balance_days_up_to_both_years_and_months
+    // 2020-01-01 + 11M = 2020-12-01, then + 396D = 2022-01-01
+    auto r = isoDateAdd({ 2020, 1, 1 }, ISO8601::Duration(0, 11, 0, 396, 0, 0, 0, 0, 0, 0), TemporalOverflow::Constrain);
+    TCHECK_TRUE(r.has_value(), "balance: 11m+396d from 2020-01-01 ok");
+    TCHECK_EQ(r->year(), 2022, "balance: 11m+396d year=2022");
+    TCHECK_EQ(r->month(), 1u, "balance: 11m+396d month=1");
+
+    // temporal_rs: negative balance
+    // -60h = -3d (using timeDurationFromComponents)
+    Int128 neg60h = timeDurationFromComponents(-60, 0, 0, 0, 0, 0);
+    TCHECK_EQ(neg60h, Int128(-216000000000000LL), "balance: -60h in ns");
+
+    // Subsecond balancing: -999ms + -999999µs + -999999999ns = -2.998998999s
+    Int128 negMs = timeDurationFromComponents(0, 0, 0, -999, -999999, -999999999);
+    // Total = -999*1e6 - 999999*1e3 - 999999999 = -999000000 - 999999000 - 999999999 = -2998998999 ns
+    TCHECK_EQ(negMs, Int128(-2998998999LL), "balance: -999ms-999999µs-999999999ns");
+}
+
+// ---------------------------------------------------------------------------
 // isoDateAdd boundary/error cases
 // ---------------------------------------------------------------------------
 
@@ -533,7 +659,8 @@ static void testISODateAddBoundaries()
 }
 
 // ---------------------------------------------------------------------------
-// Negative number rounding — mirrors temporal_rs src/rounding.rs tests
+// New tests — ISOArithmetic, DurationArithmetic, Rounding, Instant, Calendar,
+// TimeZone, PlainDateTime
 // ---------------------------------------------------------------------------
 
 static void testBalanceISOYearMonth()
@@ -587,6 +714,144 @@ static void testApplyUnsignedRoundingMode()
     TCHECK_EQ(applyUnsignedRoundingMode(3.5, 3.0, 4.0, UnsignedRoundingMode::HalfEven), 4.0, "applyURM: 3.5 HalfEven->4");
 }
 
+static void testNegateDuration()
+{
+    ISO8601::Duration d(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
+    auto neg = negateDuration(d);
+    TCHECK_EQ(static_cast<int64_t>(neg.years()), -1LL, "negate: years");
+    TCHECK_EQ(static_cast<int64_t>(neg.months()), -2LL, "negate: months");
+    TCHECK_EQ(static_cast<int64_t>(neg.days()), -4LL, "negate: days");
+    TCHECK_EQ(static_cast<int64_t>(neg.hours()), -5LL, "negate: hours");
+    // Double negation = identity
+    auto back = negateDuration(neg);
+    TCHECK_EQ(static_cast<int64_t>(back.years()), 1LL, "negate: double neg years");
+    // Zero unchanged
+    ISO8601::Duration zero;
+    auto negZero = negateDuration(zero);
+    TCHECK_EQ(durationSign(negZero), 0, "negate: zero");
+}
+
+static void testAbsDuration()
+{
+    // Positive unchanged
+    ISO8601::Duration pos(1, 2, 0, 4, 0, 0, 0, 0, 0, 0);
+    auto absPos = absDuration(pos);
+    TCHECK_EQ(static_cast<int64_t>(absPos.years()), 1LL, "abs: pos years");
+    TCHECK_EQ(static_cast<int64_t>(absPos.days()), 4LL, "abs: pos days");
+    // Negative -> positive
+    ISO8601::Duration neg(-1, -2, 0, -4, 0, 0, 0, 0, 0, 0);
+    auto absNeg = absDuration(neg);
+    TCHECK_EQ(static_cast<int64_t>(absNeg.years()), 1LL, "abs: neg years");
+    TCHECK_EQ(static_cast<int64_t>(absNeg.months()), 2LL, "abs: neg months");
+    TCHECK_EQ(static_cast<int64_t>(absNeg.days()), 4LL, "abs: neg days");
+    TCHECK_EQ(durationSign(absNeg), 1, "abs: sign positive");
+    // Zero unchanged
+    ISO8601::Duration zero;
+    auto absZero = absDuration(zero);
+    TCHECK_EQ(durationSign(absZero), 0, "abs: zero");
+}
+
+static void testGetUTCEpochNanoseconds()
+{
+    // Unix epoch = 0
+    auto r0 = getUTCEpochNanoseconds({ 1970, 1, 1 }, { 0, 0, 0, 0, 0, 0 });
+    TCHECK_EQ(r0, Int128(0LL), "utcEpoch: 1970-01-01 00:00:00 = 0");
+    // 1 day = 86400000000000 ns
+    auto r1 = getUTCEpochNanoseconds({ 1970, 1, 2 }, { 0, 0, 0, 0, 0, 0 });
+    TCHECK_EQ(r1, Int128(86400000000000LL), "utcEpoch: 1970-01-02 = 1 day");
+    // 1 second
+    auto r2 = getUTCEpochNanoseconds({ 1970, 1, 1 }, { 0, 0, 1, 0, 0, 0 });
+    TCHECK_EQ(r2, Int128(1000000000LL), "utcEpoch: 1970-01-01 00:00:01 = 1s");
+    // 2001-09-09T01:46:40Z = 1000000000 seconds = 1e18 ns
+    auto r3 = getUTCEpochNanoseconds({ 2001, 9, 9 }, { 1, 46, 40, 0, 0, 0 });
+    TCHECK_EQ(r3, Int128(1000000000LL) * Int128(1000000000LL), "utcEpoch: unix billion");
+    // Negative: 1969-12-31 = -1 day
+    auto r4 = getUTCEpochNanoseconds({ 1969, 12, 31 }, { 0, 0, 0, 0, 0, 0 });
+    TCHECK_EQ(r4, Int128(-86400000000000LL), "utcEpoch: 1969-12-31 = -1day");
+}
+
+static void testSplitTimeDuration()
+{
+    // 25 hours = 90000000000000 ns -> 1 overflow day, 1h remainder
+    auto [days1, rem1] = splitTimeDuration(Int128(90000000000000LL));
+    TCHECK_EQ(days1, 1LL, "split: 25h = 1 overflow day");
+    TCHECK_EQ(rem1, Int128(3600000000000LL), "split: 25h remainder = 1h");
+    // Exact 1 day
+    auto [days2, rem2] = splitTimeDuration(Int128(86400000000000LL));
+    TCHECK_EQ(days2, 1LL, "split: 1day overflow");
+    TCHECK_EQ(rem2, Int128(0LL), "split: 1day remainder=0");
+    // Less than 1 day — no overflow
+    auto [days3, rem3] = splitTimeDuration(Int128(3600000000000LL));
+    TCHECK_EQ(days3, 0LL, "split: 1h no overflow");
+    TCHECK_EQ(rem3, Int128(3600000000000LL), "split: 1h remainder");
+    // Negative: -25h -> floor(-25/24) = -2, remainder = 23h = 82800000000000 ns
+    auto [days4, rem4] = splitTimeDuration(Int128(-90000000000000LL));
+    TCHECK_EQ(days4, -2LL, "split: -25h overflow=-2 (floor)");
+    TCHECK_EQ(rem4, Int128(82800000000000LL), "split: -25h remainder=23h");
+}
+
+static void testPlainTimeFromSubdayNs()
+{
+    // 0 -> midnight
+    auto t0 = plainTimeFromSubdayNs(Int128(0));
+    TCHECK_EQ(t0.hour(), 0u, "ptFromNs: midnight hour");
+    TCHECK_EQ(t0.nanosecond(), 0u, "ptFromNs: midnight ns");
+    // 1 hour = 3600000000000 ns -> 01:00:00
+    auto t1 = plainTimeFromSubdayNs(Int128(3600000000000LL));
+    TCHECK_EQ(t1.hour(), 1u, "ptFromNs: 1h hour");
+    TCHECK_EQ(t1.minute(), 0u, "ptFromNs: 1h minute");
+    // 1 ns -> 00:00:00.000000001
+    auto t2 = plainTimeFromSubdayNs(Int128(1));
+    TCHECK_EQ(t2.nanosecond(), 1u, "ptFromNs: 1ns");
+    // 13:00:00 = 46800000000000 ns
+    auto t3 = plainTimeFromSubdayNs(Int128(46800000000000LL));
+    TCHECK_EQ(t3.hour(), 13u, "ptFromNs: 13h hour");
+}
+
+static void testAdd24HourDaysToTimeDuration()
+{
+    // Add 1 day (86400000000000 ns) to 1h (3600000000000 ns) = 90000000000000 ns
+    auto r1 = add24HourDaysToTimeDuration(Int128(3600000000000LL), 1.0);
+    TCHECK_TRUE(r1.has_value(), "add24h: 1h+1d ok");
+    TCHECK_EQ(*r1, Int128(90000000000000LL), "add24h: 1h+1d = 25h");
+    // Add 0 days -> unchanged
+    auto r2 = add24HourDaysToTimeDuration(Int128(3600000000000LL), 0.0);
+    TCHECK_TRUE(r2.has_value(), "add24h: +0d ok");
+    TCHECK_EQ(*r2, Int128(3600000000000LL), "add24h: +0d unchanged");
+    // Negative days: 25h - 1d = 1h
+    auto r3 = add24HourDaysToTimeDuration(Int128(90000000000000LL), -1.0);
+    TCHECK_TRUE(r3.has_value(), "add24h: -1d ok");
+    TCHECK_EQ(*r3, Int128(3600000000000LL), "add24h: 25h-1d = 1h");
+}
+
+static void testTemporalDurationFromInternal()
+{
+    // 4 days as time nanoseconds -> largestUnit=Day yields 4 days, 0 hours
+    Int128 fourDays = Int128(4LL) * Int128(86400000000000LL);
+    auto internal = ISO8601::InternalDuration::combineDateAndTimeDuration(ISO8601::Duration(), fourDays);
+    auto result = temporalDurationFromInternal(internal, TemporalUnit::Day);
+    TCHECK_EQ(static_cast<int64_t>(result.days()), 4LL, "fromInternal: 4d days");
+    TCHECK_EQ(static_cast<int64_t>(result.hours()), 0LL, "fromInternal: 4d hours=0");
+    // largestUnit=Hour: 4 days = 96 hours, 0 days
+    auto result2 = temporalDurationFromInternal(internal, TemporalUnit::Hour);
+    TCHECK_EQ(static_cast<int64_t>(result2.hours()), 96LL, "fromInternal: 96h");
+    TCHECK_EQ(static_cast<int64_t>(result2.days()), 0LL, "fromInternal: 96h days=0");
+}
+
+static void testCompareISODateTime()
+{
+    ISO8601::PlainDate d1 { 2019, 1, 8 }, d2 { 2021, 9, 7 };
+    ISO8601::PlainTime t1 { 8, 22, 36, 0, 0, 0 }, t2 { 12, 39, 40, 0, 0, 0 };
+    // Equal
+    TCHECK_EQ(compareISODateTime(d1, t1, d1, t1), 0, "compareIDT: equal");
+    // Different date — earlier vs later
+    TCHECK_EQ(compareISODateTime(d1, t1, d2, t2), -1, "compareIDT: earlier");
+    TCHECK_EQ(compareISODateTime(d2, t2, d1, t1), 1, "compareIDT: later");
+    // Same date, different time
+    ISO8601::PlainTime earlyT { 8, 22, 35, 0, 0, 0 };
+    TCHECK_EQ(compareISODateTime(d1, earlyT, d1, t1), -1, "compareIDT: earlier time");
+}
+
 static void testMaximumInstantIncrement()
 {
     TCHECK_EQ(maximumInstantIncrement(TemporalUnit::Hour), 24.0, "maxInstInc: Hour=24");
@@ -594,6 +859,146 @@ static void testMaximumInstantIncrement()
     TCHECK_EQ(maximumInstantIncrement(TemporalUnit::Second), 86400.0, "maxInstInc: Second=86400");
     TCHECK_EQ(maximumInstantIncrement(TemporalUnit::Millisecond), 8.64e7, "maxInstInc: Ms");
     TCHECK_EQ(maximumInstantIncrement(TemporalUnit::Microsecond), 8.64e10, "maxInstInc: µs");
+}
+
+static void testToDateDurationRecordWithoutTime()
+{
+    // Strip time fields, keep date fields
+    ISO8601::Duration d(1, 2, 0, 4, 5, 6, 7, 8, 9, 10);
+    auto r = toDateDurationRecordWithoutTime(d);
+    TCHECK_TRUE(r.has_value(), "stripTime: ok");
+    TCHECK_EQ(static_cast<int64_t>(r->years()), 1LL, "stripTime: years");
+    TCHECK_EQ(static_cast<int64_t>(r->months()), 2LL, "stripTime: months");
+    TCHECK_EQ(static_cast<int64_t>(r->days()), 4LL, "stripTime: days");
+    TCHECK_EQ(static_cast<int64_t>(r->hours()), 0LL, "stripTime: hours=0");
+    TCHECK_EQ(static_cast<int64_t>(r->minutes()), 0LL, "stripTime: minutes=0");
+}
+
+// ---------------------------------------------------------------------------
+// totalSeconds / totalSubseconds — internal balance helpers
+// ---------------------------------------------------------------------------
+
+static void testTotalSecondsAndSubseconds()
+{
+    // temporal_rs: internal balance helpers
+    // 1h30m = 5400s
+    ISO8601::Duration d1(0, 0, 0, 0, 1, 30, 0, 0, 0, 0);
+    TCHECK_EQ(totalSeconds(d1), 5400LL, "totalSec: 1h30m=5400s");
+
+    // 1d2h = 26*3600 = 93600s
+    ISO8601::Duration d2(0, 0, 0, 1, 2, 0, 0, 0, 0, 0);
+    TCHECK_EQ(totalSeconds(d2), 93600LL, "totalSec: 1d2h=93600s");
+
+    // 0 duration -> 0s
+    ISO8601::Duration z;
+    TCHECK_EQ(totalSeconds(z), 0LL, "totalSec: zero");
+
+    // 999ms + 999999µs + 999999999ns = 999*1e6 + 999999*1e3 + 999999999 = 2998998999 ns
+    ISO8601::Duration d3(0, 0, 0, 0, 0, 0, 0, 999, 999999, 999999999);
+    Int128 expected = Int128(2998998999LL);
+    TCHECK_EQ(totalSubseconds(d3), expected, "totalSub: max subseconds");
+
+    // 1s = 0 subseconds (only ms/µs/ns contribute)
+    ISO8601::Duration d4(0, 0, 0, 0, 0, 0, 1, 0, 0, 0);
+    TCHECK_EQ(totalSubseconds(d4), Int128(0LL), "totalSub: 1s=0 subseconds");
+}
+
+// ---------------------------------------------------------------------------
+// totalTimeDuration — fractional unit conversion
+// ---------------------------------------------------------------------------
+
+static void testTotalTimeDuration()
+{
+    // temporal_rs: internal nanosecond-to-unit conversion
+    // 3600000000000 ns = 1 hour
+    TCHECK_EQ(totalTimeDuration(Int128(3600000000000LL), TemporalUnit::Hour), 1.0, "totalTD: 1h");
+    // 86400000000000 ns = 1 day
+    TCHECK_EQ(totalTimeDuration(Int128(86400000000000LL), TemporalUnit::Day), 1.0, "totalTD: 1day");
+    // 1000000000 ns = 1 second
+    TCHECK_EQ(totalTimeDuration(Int128(1000000000LL), TemporalUnit::Second), 1.0, "totalTD: 1s");
+    // 90000000000000 ns (25h) in hours = 25.0
+    TCHECK_EQ(totalTimeDuration(Int128(90000000000000LL), TemporalUnit::Hour), 25.0, "totalTD: 25h");
+    // 1000000 ns = 1 ms
+    TCHECK_EQ(totalTimeDuration(Int128(1000000LL), TemporalUnit::Millisecond), 1.0, "totalTD: 1ms");
+}
+
+// ---------------------------------------------------------------------------
+// balanceDuration — redistribute time fields
+// ---------------------------------------------------------------------------
+
+static void testBalanceDuration()
+{
+    // temporal_rs: Duration::balance — redistributes seconds/minutes/hours
+    // 90min -> 1h30m when largestUnit=Hour
+    ISO8601::Duration d1(0, 0, 0, 0, 0, 90, 0, 0, 0, 0);
+    balanceDuration(d1, TemporalUnit::Hour);
+    TCHECK_EQ(static_cast<int64_t>(d1.hours()), 1LL, "balance: 90m -> 1h");
+    TCHECK_EQ(static_cast<int64_t>(d1.minutes()), 30LL, "balance: 90m -> 30m");
+
+    // 3600s -> 1h when largestUnit=Hour
+    ISO8601::Duration d2(0, 0, 0, 0, 0, 0, 3600, 0, 0, 0);
+    balanceDuration(d2, TemporalUnit::Hour);
+    TCHECK_EQ(static_cast<int64_t>(d2.hours()), 1LL, "balance: 3600s -> 1h");
+    TCHECK_EQ(static_cast<int64_t>(d2.seconds()), 0LL, "balance: 3600s -> 0s");
+
+    // 2000ms -> 2s when largestUnit=Second (ms overflow folds into seconds)
+    ISO8601::Duration d3(0, 0, 0, 0, 0, 0, 0, 2000, 0, 0);
+    balanceDuration(d3, TemporalUnit::Second);
+    TCHECK_EQ(static_cast<int64_t>(d3.seconds()), 2LL, "balance: 2000ms -> 2s");
+    TCHECK_EQ(static_cast<int64_t>(d3.milliseconds()), 0LL, "balance: 2000ms -> 0ms");
+
+    // 500ms with largestUnit=Millisecond -> unchanged
+    ISO8601::Duration d4(0, 0, 0, 0, 0, 0, 0, 500, 0, 0);
+    balanceDuration(d4, TemporalUnit::Millisecond);
+    TCHECK_EQ(static_cast<int64_t>(d4.milliseconds()), 500LL, "balance: 500ms unchanged");
+}
+
+// ---------------------------------------------------------------------------
+// toInternalDuration / toInternalDurationRecordWith24HourDays
+// ---------------------------------------------------------------------------
+
+static void testToInternalDuration()
+{
+    // temporal_rs: internal conversion helpers
+    // P1DT2H -> InternalDuration with time portion = 2h in ns, date = 1 day (NOT folded)
+    ISO8601::Duration d(0, 0, 0, 1, 2, 0, 0, 0, 0, 0);
+    auto internal = toInternalDuration(d);
+    TCHECK_EQ(static_cast<int64_t>(internal.dateDuration().days()), 1LL, "toInternal: days=1");
+    TCHECK_EQ(internal.time(), Int128(7200000000000LL), "toInternal: time=2h ns");
+
+    // toInternalDurationRecordWith24HourDays: folds days into time
+    auto r = toInternalDurationRecordWith24HourDays(d);
+    TCHECK_TRUE(r.has_value(), "toInternal24h: ok");
+    // days folded into time: 1d + 2h = 26h = 93600000000000 ns, date part = 0 days
+    TCHECK_EQ(static_cast<int64_t>(r->dateDuration().days()), 0LL, "toInternal24h: days=0");
+    TCHECK_EQ(r->time(), Int128(93600000000000LL), "toInternal24h: time=26h");
+}
+
+// ---------------------------------------------------------------------------
+// diffISODateTime — unrounded internal duration between datetimes
+// ---------------------------------------------------------------------------
+
+static void testDiffISODateTime()
+{
+    // temporal_rs: IsoDateTime::diff (unrounded portion)
+    ISO8601::PlainDate d1 { 2019, 1, 8 }, d2 { 2021, 9, 7 };
+    ISO8601::PlainTime t1 { 8, 22, 36, 0, 0, 0 }, t2 { 12, 39, 40, 0, 0, 0 };
+
+    // 2019-01-08T08:22:36 until 2021-09-07T12:39:40, largestUnit=Day
+    auto r = diffISODateTime(d1, t1, d2, t2, TemporalUnit::Day);
+    // 973 days + 4h 17m 4s
+    TCHECK_EQ(static_cast<int64_t>(r.dateDuration().days()), 973LL, "diffIDT: days=973");
+    Int128 expected4h17m4s = timeDurationFromComponents(4, 17, 4, 0, 0, 0);
+    TCHECK_EQ(r.time(), expected4h17m4s, "diffIDT: time=4h17m4s");
+
+    // Same datetime -> zero
+    auto r2 = diffISODateTime(d1, t1, d1, t1, TemporalUnit::Day);
+    TCHECK_EQ(static_cast<int64_t>(r2.dateDuration().days()), 0LL, "diffIDT: same=0 days");
+    TCHECK_EQ(r2.time(), Int128(0LL), "diffIDT: same=0 time");
+
+    // Negative: later until earlier
+    auto r3 = diffISODateTime(d2, t2, d1, t1, TemporalUnit::Day);
+    TCHECK_EQ(static_cast<int64_t>(r3.dateDuration().days()), -973LL, "diffIDT: neg days");
 }
 
 // ---------------------------------------------------------------------------
@@ -758,6 +1163,37 @@ static void testISOEpochDayLimits()
     // 275760-09-14 = abs(days) = MAX_DAYS_BASE + 1 -> out of range
     auto rMax14 = isoDateAdd({ 275760, 9, 14 }, ISO8601::Duration(0, 0, 0, 0, 0, 0, 0, 0, 0, 0), TemporalOverflow::Reject);
     TCHECK_TRUE(!rMax14.has_value(), "epochDays: 275760-09-14 is out of range");
+
+    // temporal_rs: test_month_limits
+    // 1970-01-01 = epoch day 0
+    auto rEpoch = getUTCEpochNanoseconds({ 1970, 1, 1 }, { 0, 0, 0, 0, 0, 0 });
+    TCHECK_EQ(rEpoch, Int128(0LL), "epochDays: 1970-01-01 epoch ns = 0");
+
+    // 1969-12-31 = epoch day -1
+    auto rPrev = getUTCEpochNanoseconds({ 1969, 12, 31 }, { 0, 0, 0, 0, 0, 0 });
+    TCHECK_EQ(rPrev, Int128(-86400000000000LL), "epochDays: 1969-12-31 epoch ns = -1 day");
+
+    // temporal_rs: iso_date_to_epoch_days_limits — exact day counts
+    // -271821-04-20: abs(epochDays) = 100_000_000 exactly
+    auto rD20 = getUTCEpochNanoseconds({ -271821, 4, 20 }, { 0, 0, 0, 0, 0, 0 });
+    Int128 nsPerDay = Int128(86400000000000LL);
+    Int128 days20 = (rD20 < Int128(0LL) ? -rD20 : rD20) / nsPerDay;
+    TCHECK_EQ(days20, Int128(100000000LL), "epochDays: -271821-04-20 = abs 1e8 days");
+
+    // -271821-04-19: abs(epochDays) = 100_000_001
+    auto rD19 = getUTCEpochNanoseconds({ -271821, 4, 19 }, { 0, 0, 0, 0, 0, 0 });
+    Int128 days19 = (rD19 < Int128(0LL) ? -rD19 : rD19) / nsPerDay;
+    TCHECK_EQ(days19, Int128(100000001LL), "epochDays: -271821-04-19 = abs 1e8+1 days");
+
+    // 275760-09-13: abs(epochDays) = 100_000_000 exactly
+    auto rD13 = getUTCEpochNanoseconds({ 275760, 9, 13 }, { 0, 0, 0, 0, 0, 0 });
+    Int128 days13 = (rD13 < Int128(0LL) ? -rD13 : rD13) / nsPerDay;
+    TCHECK_EQ(days13, Int128(100000000LL), "epochDays: 275760-09-13 = abs 1e8 days");
+
+    // 275760-09-14: abs(epochDays) = 100_000_001
+    auto rD14 = getUTCEpochNanoseconds({ 275760, 9, 14 }, { 0, 0, 0, 0, 0, 0 });
+    Int128 days14 = (rD14 < Int128(0LL) ? -rD14 : rD14) / nsPerDay;
+    TCHECK_EQ(days14, Int128(100000001LL), "epochDays: 275760-09-14 = abs 1e8+1 days");
 }
 
 // ---------------------------------------------------------------------------
@@ -796,8 +1232,7 @@ static void testRoundingExactMultiples()
     TCHECK_EQ(roundNumberToIncrementInt128(Int128(-100), Int128(10), RoundingMode::HalfEven), Int128(-100), "exact: -100 HalfEven=-100");
 
     // temporal_rs: x=-14, inc=3 (non-exact, between -15 and -12, closer to -15)
-    // -14 / 3: floor = -5 -> -15; ceil = -4 -> -12; remainder = (-14) mod 3 = 1 (one away from -15)
-    // midpoint of 3 = 1.5, so 1 < 1.5 -> closer to floor (-15)
+    // -14 / 3: remainder=1 < midpoint 1.5 → rounds toward floor (-15) for all Half* modes
     TCHECK_EQ(roundNumberToIncrementInt128(Int128(-14), Int128(3), RoundingMode::Ceil), Int128(-12), "14/3: Ceil=-12");
     TCHECK_EQ(roundNumberToIncrementInt128(Int128(-14), Int128(3), RoundingMode::Floor), Int128(-15), "14/3: Floor=-15");
     TCHECK_EQ(roundNumberToIncrementInt128(Int128(-14), Int128(3), RoundingMode::Expand), Int128(-15), "14/3: Expand=-15");
@@ -882,9 +1317,7 @@ static void testNewDateLimits()
 
 static void testDateRoundingIncrement()
 {
-    // temporal_rs: rounding_increment_observed — date since with rounding increments
-    // 2021-09-07 since 2019-01-08, smallest=Year, inc=4, HalfExpand -> 4 years
-    // Actual diff ≈ 2.66 years -> rounds to 4 (nearest multiple of 4)
+    // temporal_rs: rounding_increment_observed — diff ≈ 2.66 years, inc=4 HalfExpand → 4 years.
     {
         auto diff = diffISODate({ 2019, 1, 8 }, { 2021, 9, 7 }, TemporalUnit::Year);
         // 2y 7m 29d ≈ 2.66y, rounded to inc=4 -> 4
@@ -902,10 +1335,7 @@ static void testDateRoundingIncrement()
         TCHECK_EQ(static_cast<int64_t>(roundedMonths), 30LL, "dateRoundInc: months inc=10 HalfExpand=30");
     }
 
-    // smallest=Week, inc=12, HalfExpand -> 144 weeks
-    // temporal_rs: rounding_increment_observed — Week case
-    // 2019-01-08 to 2021-09-07 = 973 days = 139 weeks + 0 days
-    // 139 / 12 = 11.583... -> HalfExpand -> 12 -> 144 weeks
+    // temporal_rs: rounding_increment_observed — Week case: 973 days = 139 weeks, inc=12 HalfExpand → 144 weeks.
     {
         auto diff = diffISODate({ 2019, 1, 8 }, { 2021, 9, 7 }, TemporalUnit::Week);
         // 973 days = 139 weeks exactly (973 = 139 * 7)
@@ -925,8 +1355,633 @@ static void testDateRoundingIncrement()
     }
 }
 
-// Note: testInvalidDateStrings and testCriticalUnknownAnnotation use
-// ISO8601::parseCalendarDateTime — confirmed JS_EXPORT_PRIVATE in ISO8601.h.
+// ---------------------------------------------------------------------------
+// plain_date_time.rs: limits, add/subtract overflow, since conflicting signs,
+//                     round basic
+// ---------------------------------------------------------------------------
+
+static void testPlainDateTimeLimits()
+{
+    // temporal_rs: plain_date_time_limits
+    // -271821-04-19 at midnight -> just outside limit (same as date limit check)
+    auto rErr1 = isoDateAdd({ -271821, 4, 19 }, ISO8601::Duration(0, 0, 0, 0, 0, 0, 0, 0, 0, 0), TemporalOverflow::Reject);
+    TCHECK_TRUE(rErr1.has_value(), "pdtLimits: -271821-04-19 date valid");
+    // That date itself is the boundary; with time=noon it's out of range for datetime
+    // but pure date operations still work. Verify the border-crossing behavior:
+    // -271821-04-20T00:00:00 is valid (date is within limits)
+    auto rOk1 = regulateISODate(-271821, 4, 20, TemporalOverflow::Reject);
+    TCHECK_TRUE(rOk1.has_value(), "pdtLimits: -271821-04-20 ok");
+
+    // 275760-09-14 -> invalid
+    auto rErr2 = regulateISODate(275760, 9, 14, TemporalOverflow::Reject);
+    TCHECK_TRUE(rErr2.has_value(), "pdtLimits: 275760-09-14 date fields valid");
+    // date-only regulation doesn't check epoch limits; isoDateAdd does
+    auto rOver = isoDateAdd({ 275760, 9, 14 }, ISO8601::Duration(0, 0, 0, 0, 0, 0, 0, 0, 0, 0), TemporalOverflow::Reject);
+    TCHECK_TRUE(!rOver.has_value(), "pdtLimits: 275760-09-14 out of range");
+
+    // 275760-09-13 is the last valid date
+    auto rMax = isoDateAdd({ 275760, 9, 13 }, ISO8601::Duration(0, 0, 0, 0, 0, 0, 0, 0, 0, 0), TemporalOverflow::Reject);
+    TCHECK_TRUE(rMax.has_value(), "pdtLimits: 275760-09-13 within limits");
+    TCHECK_EQ(rMax->year(), 275760, "pdtLimits: max year");
+    TCHECK_EQ(rMax->month(), 9u, "pdtLimits: max month");
+    TCHECK_EQ(rMax->day(), 13u, "pdtLimits: max day");
+}
+
+static void testDateTimeAddSubtract()
+{
+    // temporal_rs: datetime_add_test — 2020-01-31 + P1M -> 2020-02-29 (leap year constrain)
+    auto rAdd = isoDateAdd({ 2020, 1, 31 }, ISO8601::Duration(0, 1, 0, 0, 0, 0, 0, 0, 0, 0), TemporalOverflow::Constrain);
+    TCHECK_TRUE(rAdd.has_value(), "dtAddSub: 2020-01-31+1M ok");
+    TCHECK_EQ(rAdd->month(), 2u, "dtAddSub: +1M month=2");
+    TCHECK_EQ(rAdd->day(), 29u, "dtAddSub: +1M day=29 (leap)");
+
+    // temporal_rs: datetime_subtract_test — 2000-03-31 - P1M -> 2000-02-29 (Y2K leap)
+    auto rSub = isoDateAdd({ 2000, 3, 31 }, ISO8601::Duration(0, -1, 0, 0, 0, 0, 0, 0, 0, 0), TemporalOverflow::Constrain);
+    TCHECK_TRUE(rSub.has_value(), "dtAddSub: 2000-03-31-1M ok");
+    TCHECK_EQ(rSub->month(), 2u, "dtAddSub: -1M month=2");
+    TCHECK_EQ(rSub->day(), 29u, "dtAddSub: -1M day=29 (Y2K leap)");
+
+    // temporal_rs: datetime_subtract_hour_overflows — verify date rolls back when subtracting crosses midnight.
+    {
+        ISO8601::PlainDate d1 { 2019, 10, 28 }, d2 { 2019, 10, 29 };
+        ISO8601::PlainTime t1 { 22, 46, 38, 271, 986, 102 }, t2 { 10, 46, 38, 271, 986, 102 };
+        auto diff = diffISODateTime(d1, t1, d2, t2, TemporalUnit::Hour);
+        Int128 expected12h = timeDurationFromComponents(12, 0, 0, 0, 0, 0);
+        TCHECK_EQ(diff.time(), expected12h, "dtHourOverflow: diff = 12h");
+    }
+
+    // temporal_rs: datetime_add (2024-01-15T12:00 + P1M2DT3H4M = 2024-02-17T15:04)
+    auto rAdd2 = isoDateAdd({ 2024, 1, 15 }, ISO8601::Duration(0, 1, 0, 2, 3, 4, 0, 0, 0, 0), TemporalOverflow::Constrain);
+    TCHECK_TRUE(rAdd2.has_value(), "dtAdd: 2024-01-15+P1M2DT3H4M ok");
+    TCHECK_EQ(rAdd2->month(), 2u, "dtAdd: month=2");
+    TCHECK_EQ(rAdd2->day(), 17u, "dtAdd: day=17");
+    // Time portion: hour+3=15, min+4=4
+    auto timePart = timeDurationFromComponents(3, 4, 0, 0, 0, 0);
+    TCHECK_EQ(timePart, Int128(11040000000000LL), "dtAdd: 3h4m in ns");
+}
+
+static void testDtSinceConflictingSigns()
+{
+    // temporal_rs: dt_since_conflicting_signs — time sign differs from date sign; adjustedD2 = 2023-02-28.
+    ISO8601::PlainDate da { 2023, 1, 1 }, db { 2023, 3, 1 };
+    ISO8601::PlainTime ta { 3, 0, 0, 0, 0, 0 }, tb { 2, 0, 0, 0, 0, 0 };
+    auto r = diffISODateTime(da, ta, db, tb, TemporalUnit::Month);
+    TCHECK_EQ(static_cast<int64_t>(r.dateDuration().months()), 1LL, "conflictSign: months=1");
+    TCHECK_EQ(static_cast<int64_t>(r.dateDuration().days()), 27LL, "conflictSign: days=27 (ISO path)");
+    Int128 expected23h = timeDurationFromComponents(23, 0, 0, 0, 0, 0);
+    TCHECK_EQ(r.time(), expected23h, "conflictSign: time=23h");
+}
+
+static void testRoundISODateTime()
+{
+    // RoundTime correctness: quantity is sub-unit-relative, not from-midnight.
+    // 11:26 rounded to 4-min: sub-minute offset = 26min → 6.5 increments → HalfExpand → 7 → 11:28.
+    {
+        ISO8601::PlainDate date(2020, 1, 1);
+        ISO8601::PlainTime time(11, 26, 0, 0, 0, 0);
+        auto r = roundISODateTime(date, time, ISO8601::ExactTime::nsPerMinute * 4, TemporalUnit::Minute, RoundingMode::HalfExpand);
+        TCHECK_EQ(r.time.hour(), 11u, "roundISO: 11:26 +4min HalfExpand -> hour=11");
+        TCHECK_EQ(r.time.minute(), 28u, "roundISO: 11:26 +4min HalfExpand -> min=28");
+    }
+    // HalfEven: 11:26 with 4-min -> sub-unit quotient 6.5, r1=6 (even) -> 11:24
+    {
+        ISO8601::PlainDate date(2020, 1, 1);
+        ISO8601::PlainTime time(11, 26, 0, 0, 0, 0);
+        auto r = roundISODateTime(date, time, ISO8601::ExactTime::nsPerMinute * 4, TemporalUnit::Minute, RoundingMode::HalfEven);
+        TCHECK_EQ(r.time.minute(), 24u, "roundISO: 11:26 +4min HalfEven -> min=24 (r1=6 even)");
+    }
+    // Round to hour: 14:30:00 -> 15:00:00
+    {
+        ISO8601::PlainDate date(2020, 1, 1);
+        ISO8601::PlainTime time(14, 30, 0, 0, 0, 0);
+        auto r = roundISODateTime(date, time, ISO8601::ExactTime::nsPerHour, TemporalUnit::Hour, RoundingMode::HalfExpand);
+        TCHECK_EQ(r.time.hour(), 15u, "roundISO: 14:30 +1h HalfExpand -> 15:00");
+        TCHECK_EQ(r.time.minute(), 0u, "roundISO: 14:30 +1h -> min=0");
+        TCHECK_TRUE(r.date == date, "roundISO: same date");
+    }
+    // Day overflow: 23:45:00 rounded to hour -> next day 00:00:00
+    {
+        ISO8601::PlainDate date(2020, 1, 15);
+        ISO8601::PlainTime time(23, 45, 0, 0, 0, 0);
+        auto r = roundISODateTime(date, time, ISO8601::ExactTime::nsPerHour, TemporalUnit::Hour, RoundingMode::HalfExpand);
+        TCHECK_EQ(r.time.hour(), 0u, "roundISO: 23:45 overflow -> 00:00");
+        TCHECK_EQ(r.date.day(), 16u, "roundISO: 23:45 overflow -> next day");
+    }
+    // Second rounding: 14:23:30.600 -> 14:23:31
+    {
+        ISO8601::PlainDate date(2020, 1, 1);
+        ISO8601::PlainTime time(14, 23, 30, 600, 0, 0);
+        auto r = roundISODateTime(date, time, ISO8601::ExactTime::nsPerSecond, TemporalUnit::Second, RoundingMode::HalfExpand);
+        TCHECK_EQ(r.time.second(), 31u, "roundISO: 30.6s HalfExpand -> 31s");
+    }
+}
+
+static void testDtRoundBasic()
+{
+    // temporal_rs: dt_round_basic — 1976-11-18T14:23:30.123456789
+    // Rounding to various units with HalfExpand (default)
+    UNUSED_PARAM(0); // date/time used via roundTimeQuantity
+
+    // Round to Hour inc=4, HalfExpand: 14h23m30.123456789 / 4h ≈ 3.597 → rounds to 4 → 16h
+    {
+        Int128 totalNs = Int128(((int64_t)14 * 3600 + (int64_t)23 * 60 + 30) * 1000000000LL)
+            + Int128(123456789LL);
+        Int128 inc4h = Int128(4LL * 3600000000000LL);
+        Int128 rounded = roundNumberToIncrementInt128(totalNs, inc4h, RoundingMode::HalfExpand);
+        // 57600000000000 = 16h
+        auto resultTime = plainTimeFromSubdayNs(rounded);
+        TCHECK_EQ(resultTime.hour(), 16u, "dtRound: inc4h hour=16");
+        TCHECK_EQ(resultTime.minute(), 0u, "dtRound: inc4h min=0");
+    }
+
+    // Round to Minute inc=15, HalfExpand: sub-hour ns = 23m30.123456789s -> round to 30m
+    {
+        // sub-hour nanoseconds = 23*60e9 + 30e9 + 123456789 = 1410123456789
+        Int128 subHourNs = Int128((int64_t)23 * 60000000000LL + (int64_t)30 * 1000000000LL + 123456789LL);
+        Int128 inc15m = Int128(15LL * 60000000000LL);
+        Int128 rounded = roundNumberToIncrementInt128(subHourNs, inc15m, RoundingMode::HalfExpand);
+        // 1410123456789 / 900000000000 = 1.567 -> HalfExpand -> 2 -> 1800000000000 = 30m
+        Int128 base14h = Int128(14LL * 3600000000000LL);
+        Int128 totalRounded = base14h + rounded;
+        auto rt = plainTimeFromSubdayNs(totalRounded);
+        TCHECK_EQ(rt.hour(), 14u, "dtRound: inc15m hour=14");
+        TCHECK_EQ(rt.minute(), 30u, "dtRound: inc15m min=30");
+    }
+
+    // Round to Nanosecond inc=10, HalfExpand: ns=789 -> 790
+    {
+        Int128 nsOnly = Int128(789LL);
+        Int128 inc10 = Int128(10LL);
+        Int128 rounded = roundNumberToIncrementInt128(nsOnly, inc10, RoundingMode::HalfExpand);
+        TCHECK_EQ(rounded, Int128(790LL), "dtRound: inc10ns ns=790");
+    }
+
+    // Round to Millisecond inc=10, HalfExpand: ms=123 -> 120
+    {
+        Int128 msOnly = Int128(123LL * 1000000LL + 456LL * 1000LL + 789LL);
+        Int128 inc10ms = Int128(10LL * 1000000LL);
+        Int128 rounded = roundNumberToIncrementInt128(msOnly, inc10ms, RoundingMode::HalfExpand);
+        // 123456789 / 10000000 = 12.3456789 -> 12 -> 120ms
+        TCHECK_EQ(rounded / Int128(1000000LL), Int128(120LL), "dtRound: inc10ms=120");
+    }
+
+    // Round to Microsecond inc=10, HalfExpand: µs=456 -> 460
+    {
+        Int128 usOnly = Int128(456LL * 1000LL + 789LL);
+        Int128 inc10us = Int128(10LL * 1000LL);
+        Int128 rounded = roundNumberToIncrementInt128(usOnly, inc10us, RoundingMode::HalfExpand);
+        TCHECK_EQ(rounded / Int128(1000LL), Int128(460LL), "dtRound: inc10us=460");
+    }
+}
+
+static void testDifferenceTemporalPlainDateTime()
+{
+    // temporal_rs: dt_until_basic — tests differenceTemporalPlainDateTime directly
+    ISO8601::PlainDate d1 { 2019, 1, 8 }, d2 { 2021, 9, 7 };
+    ISO8601::PlainTime t1 { 8, 22, 36, 123, 456, 789 }, t2 { 12, 39, 40, 987, 654, 321 };
+    auto id = calendarIDFromString("iso8601"_s);
+
+    // until: largestUnit=Day, no rounding
+    {
+        auto r = differenceTemporalPlainDateTime(DifferenceOperation::Until, d1, t1, d2, t2,
+            id, TemporalUnit::Nanosecond, TemporalUnit::Day, RoundingMode::HalfExpand, 1);
+        TCHECK_TRUE(r.has_value(), "dtDiff: until ok");
+        TCHECK_EQ(static_cast<int64_t>(r->days()), 973LL, "dtDiff: until days=973");
+    }
+
+    // since: result is negated — temporal_rs: dt_since_basic
+    {
+        auto r = differenceTemporalPlainDateTime(DifferenceOperation::Since, d2, t2, d1, t1,
+            id, TemporalUnit::Nanosecond, TemporalUnit::Day, RoundingMode::HalfExpand, 1);
+        TCHECK_TRUE(r.has_value(), "dtDiff: since ok");
+        TCHECK_EQ(static_cast<int64_t>(r->days()), 973LL, "dtDiff: since days=973");
+    }
+
+    // equal datetimes -> zero duration (step 5)
+    {
+        auto r = differenceTemporalPlainDateTime(DifferenceOperation::Until, d1, t1, d1, t1,
+            id, TemporalUnit::Nanosecond, TemporalUnit::Day, RoundingMode::HalfExpand, 1);
+        TCHECK_TRUE(r.has_value() && !r->years() && !r->days(), "dtDiff: equal=zero");
+    }
+
+    // with rounding: inc=3h HalfExpand -> 973 days 3 hours (from dt_until_basic)
+    {
+        auto r = differenceTemporalPlainDateTime(DifferenceOperation::Until, d1, t1, d2, t2,
+            id, TemporalUnit::Hour, TemporalUnit::Day, RoundingMode::HalfExpand, 3);
+        TCHECK_TRUE(r.has_value(), "dtDiff: round 3h ok");
+        TCHECK_EQ(static_cast<int64_t>(r->days()), 973LL, "dtDiff: round 3h days=973");
+        TCHECK_EQ(static_cast<int64_t>(r->hours()), 3LL, "dtDiff: round 3h hours=3");
+    }
+
+    // temporal_rs: dt_since_conflicting_signs
+    // 2023-03-01T02:00 since 2023-01-01T03:00, largestUnit=Year -> 1 month 30 days 23 hours
+    {
+        ISO8601::PlainDate da { 2023, 3, 1 }, db { 2023, 1, 1 };
+        ISO8601::PlainTime ta { 2, 0, 0, 0, 0, 0 }, tb { 3, 0, 0, 0, 0, 0 };
+        auto r = differenceTemporalPlainDateTime(DifferenceOperation::Since, da, ta, db, tb,
+            id, TemporalUnit::Nanosecond, TemporalUnit::Year, RoundingMode::HalfExpand, 1);
+        TCHECK_TRUE(r.has_value(), "dtDiff: conflicting signs ok");
+        TCHECK_EQ(static_cast<int64_t>(r->months()), 1LL, "dtDiff: conflicting months=1");
+        TCHECK_EQ(static_cast<int64_t>(r->days()), 30LL, "dtDiff: conflicting days=30");
+        TCHECK_EQ(static_cast<int64_t>(r->hours()), 23LL, "dtDiff: conflicting hours=23");
+    }
+}
+
+static void testDtUntilBasic()
+{
+    // temporal_rs: dt_until_basic
+    // 2019-01-08T08:22:36.123456789 until 2021-09-07T12:39:40.987654321
+    ISO8601::PlainDate d1 { 2019, 1, 8 }, d2 { 2021, 9, 7 };
+    ISO8601::PlainTime t1 { 8, 22, 36, 123, 456, 789 }, t2 { 12, 39, 40, 987, 654, 321 };
+
+    // largestUnit=Hour, inc=3, HalfExpand -> 973 days, 3 hours
+    // diff = 973 days + 4h 17m 4s 864ms 197µs 532ns (approx)
+    auto r = diffISODateTime(d1, t1, d2, t2, TemporalUnit::Day);
+    TCHECK_EQ(static_cast<int64_t>(r.dateDuration().days()), 973LL, "dtUntil: days=973");
+    // time component: 4h 17m 4s 864ms 197µs 532ns
+    Int128 expectedTime = timeDurationFromComponents(4, 17, 4, 864, 197, 532);
+    TCHECK_EQ(r.time(), expectedTime, "dtUntil: time=4h17m4s864ms197µs532ns");
+
+    // Round time to inc=3h, HalfExpand
+    // time = 4h 17m 4s ... ≈ 4.284h; 4.284/3 ≈ 1.428 -> 3h
+    Int128 inc3h = Int128(3LL * 3600000000000LL);
+    Int128 roundedTime = roundNumberToIncrementInt128(r.time(), inc3h, RoundingMode::HalfExpand);
+    TCHECK_EQ(roundedTime, Int128(3LL * 3600000000000LL), "dtUntil: time rounded inc3h=3h");
+
+    // Round time to inc=30m, HalfExpand
+    // 4h17m4s -> 4h17m = 15424s -> 15424/1800 ≈ 8.57 -> 9 -> 4h30m
+    Int128 inc30m = Int128(30LL * 60000000000LL);
+    Int128 roundedTime2 = roundNumberToIncrementInt128(r.time(), inc30m, RoundingMode::HalfExpand);
+    Int128 expected4h30m = timeDurationFromComponents(4, 30, 0, 0, 0, 0);
+    TCHECK_EQ(roundedTime2, expected4h30m, "dtUntil: time rounded inc30m=4h30m");
+}
+
+// ---------------------------------------------------------------------------
+// duration/tests.rs pure tests: rounding without ZonedDateTime
+// ---------------------------------------------------------------------------
+
+static void testRoundingToDayOnly()
+{
+    // temporal_rs: rounding_to_fractional_day_tests — 25h splits into 1d + 1h remainder.
+    {
+        auto [days, rem] = splitTimeDuration(Int128(90000000000000LL));
+        TCHECK_EQ(days, 1LL, "roundDay: 25h split days=1");
+        TCHECK_EQ(rem, Int128(3600000000000LL), "roundDay: 25h split rem=1h");
+    }
+
+    // 64 days, inc=5, Floor -> 60d
+    {
+        Int128 sixtyfour = Int128(64LL);
+        Int128 inc5 = Int128(5LL);
+        Int128 result = roundNumberToIncrementInt128(sixtyfour, inc5, RoundingMode::Floor);
+        TCHECK_EQ(result, Int128(60LL), "roundDay: 64d inc5 Floor=60");
+    }
+
+    // 64 days, inc=10, Floor -> 60d
+    {
+        Int128 result = roundNumberToIncrementInt128(Int128(64), Int128(10), RoundingMode::Floor);
+        TCHECK_EQ(result, Int128(60LL), "roundDay: 64d inc10 Floor=60");
+    }
+
+    // 64 days, inc=10, Ceil -> 70d
+    {
+        Int128 result = roundNumberToIncrementInt128(Int128(64), Int128(10), RoundingMode::Ceil);
+        TCHECK_EQ(result, Int128(70LL), "roundDay: 64d inc10 Ceil=70");
+    }
+
+    // 1000 days, inc=1_000_000_000, Expand -> 1_000_000_000d
+    {
+        Int128 result = roundNumberToIncrementInt128(Int128(1000), Int128(1000000000), RoundingMode::Expand);
+        TCHECK_EQ(result, Int128(1000000000LL), "roundDay: 1000d inc1e9 Expand=1e9");
+    }
+}
+
+static void testDurationAddSubtract()
+{
+    // temporal_rs: basic_add_duration
+    // P1DT5M + P2DT5M = P3DT10M
+    {
+        ISO8601::Duration base(0, 0, 0, 1, 0, 5, 0, 0, 0, 0);
+        ISO8601::Duration other(0, 0, 0, 2, 0, 5, 0, 0, 0, 0);
+        // Combine via toInternal + add
+        auto baseInt = toInternalDurationRecordWith24HourDays(base);
+        auto otherInt = toInternalDurationRecordWith24HourDays(other);
+        TCHECK_TRUE(baseInt.has_value(), "durationAdd: base ok");
+        TCHECK_TRUE(otherInt.has_value(), "durationAdd: other ok");
+        // P1DT5M + P2DT5M = P3DT10M.
+        Int128 sumTime = baseInt->time() + otherInt->time();
+        auto [days, rem] = splitTimeDuration(sumTime);
+        TCHECK_EQ(days, 3LL, "durationAdd: days=3");
+        Int128 expected10m = timeDurationFromComponents(0, 10, 0, 0, 0, 0);
+        TCHECK_EQ(rem, expected10m, "durationAdd: rem=10m");
+    }
+
+    // P1DT5M + P-3DT-15M = P-2DT-10M
+    {
+        ISO8601::Duration base(0, 0, 0, 1, 0, 5, 0, 0, 0, 0);
+        ISO8601::Duration neg(0, 0, 0, -3, 0, -15, 0, 0, 0, 0);
+        auto baseInt = toInternalDurationRecordWith24HourDays(base);
+        auto negInt = toInternalDurationRecordWith24HourDays(neg);
+        TCHECK_TRUE(baseInt.has_value(), "durationAdd: neg base ok");
+        TCHECK_TRUE(negInt.has_value(), "durationAdd: neg other ok");
+        Int128 sumTime = baseInt->time() + negInt->time();
+        auto [days, rem] = splitTimeDuration(sumTime);
+        TCHECK_EQ(days, -3LL, "durationAdd: neg days=-3 (floor(-173400000000000/86400000000000))");
+        // splitTimeDuration uses floor division: -173400000000000 ns → days=-3, rem=23h50m.
+        Int128 expectedNeg = Int128(-2LL) * Int128(86400000000000LL) - Int128(600000000000LL);
+        TCHECK_EQ(sumTime, expectedNeg, "durationAdd: neg total=-2d10m");
+    }
+
+    // temporal_rs: basic_subtract_duration — P3DT15M - P1DT5M = P2DT10M
+    {
+        ISO8601::Duration base(0, 0, 0, 3, 0, 15, 0, 0, 0, 0);
+        ISO8601::Duration other(0, 0, 0, 1, 0, 5, 0, 0, 0, 0);
+        auto baseInt = toInternalDurationRecordWith24HourDays(base);
+        auto otherInt = toInternalDurationRecordWith24HourDays(other);
+        TCHECK_TRUE(baseInt.has_value(), "durationSub: ok");
+        Int128 diffTime = baseInt->time() - otherInt->time();
+        auto [days, rem] = splitTimeDuration(diffTime);
+        TCHECK_EQ(days, 2LL, "durationSub: days=2");
+        Int128 expected10m = timeDurationFromComponents(0, 10, 0, 0, 0, 0);
+        TCHECK_EQ(rem, expected10m, "durationSub: rem=10m");
+    }
+}
+
+static void testRoundingCrossBoundary()
+{
+    // temporal_rs: rounding_cross_boundary — P1Y11M24D Expand/Month → 24 months (2 years).
+    {
+        // 2022-01-01 + P1Y11M24D = 2023-12-25
+        auto r = isoDateAdd({ 2022, 1, 1 }, ISO8601::Duration(1, 11, 0, 24, 0, 0, 0, 0, 0, 0), TemporalOverflow::Constrain);
+        TCHECK_TRUE(r.has_value(), "crossBound: 2022-01-01+P1Y11M24D ok");
+        TCHECK_EQ(r->year(), 2023, "crossBound: year=2023");
+        TCHECK_EQ(r->month(), 12u, "crossBound: month=12");
+        TCHECK_EQ(r->day(), 25u, "crossBound: day=25");
+
+        // The diff from relative 2022-01-01 to 2023-12-25 in months is 23.8... -> expand -> 24m = 2y
+        auto diff = diffISODate({ 2022, 1, 1 }, { 2023, 12, 25 }, TemporalUnit::Month);
+        double months = diff.months();
+        double rounded = roundNumberToIncrementDouble(months, 12.0, RoundingMode::Expand);
+        // 23 months -> 24 months = 2 years
+        TCHECK_EQ(static_cast<int64_t>(rounded / 12.0), 2LL, "crossBound: months/12 rounded=2y");
+    }
+
+    // temporal_rs: rounding_cross_boundary_time_units — P0DT1H59M59.9S, Expand, smallest=Second -> P2H
+    {
+        // 1h59m59.900s in nanoseconds = (1*3600 + 59*60 + 59)*1e9 + 900000000 = 7199900000000 + 900000000 = 7199900000000 (approx)
+        Int128 t = timeDurationFromComponents(1, 59, 59, 900, 0, 0);
+        // = (1*3600+59*60+59)*1e9 + 900e6 = 7199*1e9 + 900e6 = 7199000000000+900000000 = 7199900000000
+        Int128 expected = Int128(7199900000000LL);
+        TCHECK_EQ(t, expected, "crossBoundTime: 1h59m59.900s ns");
+        // Round to second, Expand: 7199900000000 / 1000000000 = 7199.9 -> 7200s = 2h
+        Int128 inc1s = Int128(1000000000LL);
+        Int128 rounded = roundNumberToIncrementInt128(t, inc1s, RoundingMode::Expand);
+        TCHECK_EQ(rounded, Int128(7200000000000LL), "crossBoundTime: Expand->7200s=2h");
+        auto rt = plainTimeFromSubdayNs(rounded);
+        TCHECK_EQ(rt.hour(), 2u, "crossBoundTime: hour=2");
+        TCHECK_EQ(rt.minute(), 0u, "crossBoundTime: min=0");
+    }
+
+    // Negative: P-1H-59M-59.9S, Expand -> -2h
+    {
+        Int128 tneg = timeDurationFromComponents(-1, -59, -59, -900, 0, 0);
+        Int128 expectedNeg = Int128(-7199900000000LL);
+        TCHECK_EQ(tneg, expectedNeg, "crossBoundTimeNeg: -1h59m59.900s ns");
+        Int128 roundedNeg = roundNumberToIncrementInt128(tneg, Int128(1000000000LL), RoundingMode::Expand);
+        TCHECK_EQ(roundedNeg, Int128(-7200000000000LL), "crossBoundTimeNeg: Expand->-7200s=-2h");
+    }
+}
+
+static void testBubbleSmallestBecomesDay()
+{
+    // temporal_rs: bubble_smallest_becomes_day — P14H, inc=12h, Ceil -> P24H (bubbles to next day)
+    // 14h / 12h = 1.166... -> Ceil -> 2 -> 24h
+    {
+        Int128 t14h = timeDurationFromComponents(14, 0, 0, 0, 0, 0);
+        Int128 inc12h = Int128(12LL * 3600000000000LL);
+        Int128 rounded = roundNumberToIncrementInt128(t14h, inc12h, RoundingMode::Ceil);
+        TCHECK_EQ(rounded, Int128(24LL * 3600000000000LL), "bubble: 14h Ceil inc12h = 24h");
+        // The result is 24h which is 1 full day
+        auto [days, rem] = splitTimeDuration(rounded);
+        TCHECK_EQ(days, 1LL, "bubble: 24h = 1 day overflow");
+        TCHECK_EQ(rem, Int128(0LL), "bubble: 24h rem = 0");
+    }
+}
+
+static void testRoundZeroDuration()
+{
+    // temporal_rs: round_zero_duration — zero duration rounded to any unit = zero
+    Int128 zero(0LL);
+    TCHECK_EQ(roundNumberToIncrementInt128(zero, Int128(3600000000000LL), RoundingMode::HalfExpand), Int128(0LL), "roundZero: 0 inc1h = 0");
+    TCHECK_EQ(roundNumberToIncrementInt128(zero, Int128(86400000000000LL), RoundingMode::Floor), Int128(0LL), "roundZero: 0 inc1d = 0");
+    TCHECK_EQ(roundNumberToIncrementInt128(zero, Int128(1000000000LL), RoundingMode::Ceil), Int128(0LL), "roundZero: 0 inc1s = 0");
+    TCHECK_EQ(roundNumberToIncrementInt128(zero, Int128(1LL), RoundingMode::Expand), Int128(0LL), "roundZero: 0 inc1ns = 0");
+}
+
+static void testRoundIncrementRegression()
+{
+    // temporal_rs: round_increment_regression_test — 48h, inc=2days, no relativeTo
+    // 48h = 2 × 86400000000000 ns exactly divisible by 2d
+    Int128 h48 = timeDurationFromComponents(48, 0, 0, 0, 0, 0);
+    Int128 inc2d = Int128(2LL * 86400000000000LL);
+    Int128 result = roundNumberToIncrementInt128(h48, inc2d, RoundingMode::HalfExpand);
+    TCHECK_EQ(result, Int128(2LL * 86400000000000LL), "roundReg: 48h inc=2d = 2d");
+    // splitTimeDuration: 2d exactly
+    auto [days, rem] = splitTimeDuration(result);
+    TCHECK_EQ(days, 2LL, "roundReg: days=2");
+    TCHECK_EQ(rem, Int128(0LL), "roundReg: rem=0");
+}
+
+static void testDurationTotalBasic()
+{
+    // temporal_rs: test_duration_total — basic totals without ZonedDateTime
+    // 130h20m = total seconds = 130*3600 + 20*60 = 468000+1200 = 469200s
+    Int128 h130m20 = timeDurationFromComponents(130, 20, 0, 0, 0, 0);
+    TCHECK_EQ(totalTimeDuration(h130m20, TemporalUnit::Second), 469200.0, "durationTotal: 130h20m = 469200s");
+
+    // PT123456789S = 123456789s = 1428.898... days
+    Int128 s123456789 = timeDurationFromComponents(0, 0, 123456789, 0, 0, 0);
+    double days = totalTimeDuration(s123456789, TemporalUnit::Day);
+    // 123456789s / 86400s = 1428.8980208...
+    TCHECK_TRUE(days > 1428.89 && days < 1428.90, "durationTotal: 123456789s in days");
+
+    // balance_subseconds positive: 999ms+999999µs+999999999ns = 2.998998999s
+    Int128 subsec = timeDurationFromComponents(0, 0, 0, 999, 999999, 999999999);
+    double secs = totalTimeDuration(subsec, TemporalUnit::Second);
+    TCHECK_TRUE(secs > 2.998 && secs < 2.999, "durationTotal: balance subseconds pos");
+
+    // balance_subseconds negative: -999ms-999999µs-999999999ns = -2.998998999s
+    Int128 negSubsec = timeDurationFromComponents(0, 0, 0, -999, -999999, -999999999);
+    double negSecs = totalTimeDuration(negSubsec, TemporalUnit::Second);
+    TCHECK_TRUE(negSecs < -2.998 && negSecs > -2.999, "durationTotal: balance subseconds neg");
+}
+
+static void testDurationTotalWithRelativeTo()
+{
+    // temporal_rs: balance_days_up_to_both_years_and_months — relativeTo=PlainDate
+    // 11 months + 396 days from 2017-01-01 = exactly 2 years
+    // This verifies that calendarDateAdd folds correctly
+    auto r1 = isoDateAdd({ 2017, 1, 1 }, ISO8601::Duration(0, 11, 0, 0, 0, 0, 0, 0, 0, 0), TemporalOverflow::Constrain);
+    TCHECK_TRUE(r1.has_value(), "durationRelTo: +11m ok");
+    TCHECK_EQ(r1->year(), 2017, "durationRelTo: +11m year=2017");
+    TCHECK_EQ(r1->month(), 12u, "durationRelTo: +11m month=12");
+
+    // Then add 396 days from 2017-12-01
+    auto r2 = isoDateAdd({ 2017, 12, 1 }, ISO8601::Duration(0, 0, 0, 396, 0, 0, 0, 0, 0, 0), TemporalOverflow::Constrain);
+    TCHECK_TRUE(r2.has_value(), "durationRelTo: +396d ok");
+    TCHECK_EQ(r2->year(), 2019, "durationRelTo: +396d year=2019");
+    TCHECK_EQ(r2->month(), 1u, "durationRelTo: +396d month=1");
+    // 2017-12-01 + 396d lands in 2019-01 (verified below).
+
+    // From 2017-01-01: adding P0M11D + 396 days = ending at 2019-01-01
+    // diff from 2017-01-01 to 2019-01-01 = 2 years
+    auto diff = diffISODate({ 2017, 1, 1 }, { 2019, 1, 1 }, TemporalUnit::Year);
+    TCHECK_EQ(static_cast<int64_t>(diff.years()), 2LL, "durationRelTo: 2019-2017=2 years");
+
+    // Negative: -11m-396d from 2017-01-01 = -2 years
+    auto r3 = isoDateAdd({ 2017, 1, 1 }, ISO8601::Duration(0, -11, 0, -396, 0, 0, 0, 0, 0, 0), TemporalOverflow::Constrain);
+    TCHECK_TRUE(r3.has_value(), "durationRelTo: -11m-396d ok");
+    TCHECK_EQ(r3->year(), 2015, "durationRelTo: -11m-396d year=2015");
+    TCHECK_EQ(r3->month(), 1u, "durationRelTo: -11m-396d month=1");
+
+    auto diffNeg = diffISODate({ 2015, 1, 1 }, { 2017, 1, 1 }, TemporalUnit::Year);
+    TCHECK_EQ(static_cast<int64_t>(diffNeg.years()), 2LL, "durationRelTo: diff=2 years (neg path)");
+}
+
+static void testAddNormTimeDurationOutOfRange()
+{
+    // temporal_rs: add_normalized_time_duration_out_of_range
+    // maxTimeDuration ≈ 9007199254740992e9 ns; to exceed it, need days > ~104249991374.3
+    // Use 104249991375 days which is just over the limit
+    auto r = add24HourDaysToTimeDuration(Int128(0), 104249991375.0);
+    TCHECK_TRUE(!r.has_value(), "outOfRange: 104249991375 days rejects");
+}
+
+// ---------------------------------------------------------------------------
+// test_rounding_boundaries — temporal_rs duration/tests.rs
+// Overflow detection when Duration.round is called with extreme calendar values
+// ---------------------------------------------------------------------------
+
+static void testRoundingBoundaries()
+{
+    // temporal_rs: test_rounding_boundaries
+    // Duration with calendar fields at u32::MAX - 1 = 4294967294 from relativeTo 2000-01-01.
+    // Each case should produce an epoch-day overflow in isoDateAdd/balanceISOYearMonth.
+
+    // year overflow: 2000 + 4294967294 >> maxYear=275760 -> balanceISOYearMonth clamps to outOfRangeYear
+    {
+        auto r = isoDateAdd({ 2000, 1, 1 }, ISO8601::Duration(4294967294.0, 0, 0, 0, 0, 0, 0, 0, 0, 0), TemporalOverflow::Reject);
+        TCHECK_TRUE(!r.has_value(), "roundBounds: year=4294967294 from 2000 rejects");
+    }
+
+    // month overflow: 4294967294 months / 12 ≈ 357913941 years, total year >> maxYear
+    {
+        auto r = isoDateAdd({ 2000, 1, 1 }, ISO8601::Duration(0, 4294967294.0, 0, 0, 0, 0, 0, 0, 0, 0), TemporalOverflow::Reject);
+        TCHECK_TRUE(!r.has_value(), "roundBounds: month=4294967294 from 2000 rejects");
+    }
+
+    // week overflow: 4294967294 weeks × 7 = 30064771058 days from 2000-01-01
+    // Total epoch day ≈ 30064782015 >> Temporal limit 1e8 -> isDateTimeWithinLimits rejects
+    {
+        auto r = isoDateAdd({ 2000, 1, 1 }, ISO8601::Duration(0, 0, 4294967294.0, 0, 0, 0, 0, 0, 0, 0), TemporalOverflow::Reject);
+        TCHECK_TRUE(!r.has_value(), "roundBounds: week=4294967294 from 2000 rejects");
+    }
+
+    // days overflow: 104249991374 days (= max safe days) from 2000-01-01
+    // 2000-01-01 epoch day ≈ 10957, total ≈ 104249991374 + 10957 >> 1e8 limit
+    {
+        auto r = isoDateAdd({ 2000, 1, 1 }, ISO8601::Duration(0, 0, 0, 104249991374.0, 0, 0, 0, 0, 0, 0), TemporalOverflow::Reject);
+        TCHECK_TRUE(!r.has_value(), "roundBounds: day=104249991374 from 2000 rejects");
+    }
+
+    // Combined extreme: years + months + weeks + days all extreme
+    {
+        auto r = isoDateAdd({ 2000, 1, 1 }, ISO8601::Duration(4294967294.0, 4294967294.0, 4294967294.0, 104249991374.0, 0, 0, 0, 0, 0, 0), TemporalOverflow::Reject);
+        TCHECK_TRUE(!r.has_value(), "roundBounds: all-extreme from 2000 rejects");
+    }
+
+    // Negative extreme: all fields at -(u32::MAX - 1)
+    {
+        auto r = isoDateAdd({ 2000, 1, 1 }, ISO8601::Duration(-4294967294.0, -4294967294.0, -4294967294.0, -104249991374.0, 0, 0, 0, 0, 0, 0), TemporalOverflow::Reject);
+        TCHECK_TRUE(!r.has_value(), "roundBounds: negative all-extreme from 2000 rejects");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// test_duration_compare_boundary — temporal_rs duration/tests.rs
+// Overflow detection: Duration with weeks=1, days=max_days exceeds timeDuration limit
+// ---------------------------------------------------------------------------
+
+static void testDurationCompareBoundary()
+{
+    // temporal_rs: test_duration_compare_boundary — weeks=1 + max_days folds to max_days+7, exceeding the limit.
+
+    const double maxDays = 104249991374.0; // 2^53 / 86400
+
+    // weeks=1, days=max_days -> total = 1*7 + max_days = max_days + 7 -> overflow
+    {
+        // Equivalent to: toInternalDurationRecordWith24HourDays(Duration{weeks=1, days=maxDays})
+        // Time portion = 0 (no hours), then add (1*7 + maxDays) days = maxDays + 7
+        auto r = add24HourDaysToTimeDuration(Int128(0), maxDays + 7.0);
+        TCHECK_TRUE(!r.has_value(), "compareBound: maxDays+7 days rejects");
+    }
+
+    // Just at the boundary: max_days alone (no weeks) is still within limit
+    {
+        // temporal_rs: max is inclusive — exactly max_days succeeds.
+        auto r = add24HourDaysToTimeDuration(Int128(0), maxDays);
+        TCHECK_TRUE(r.has_value(), "compareBound: exactly maxDays ok");
+    }
+
+    // Just one over the boundary
+    {
+        auto r = add24HourDaysToTimeDuration(Int128(0), maxDays + 1.0);
+        TCHECK_TRUE(!r.has_value(), "compareBound: maxDays+1 rejects");
+    }
+
+    // Negative: -(maxDays + 7) also overflows
+    {
+        auto r = add24HourDaysToTimeDuration(Int128(0), -(maxDays + 7.0));
+        TCHECK_TRUE(!r.has_value(), "compareBound: -(maxDays+7) days rejects");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// add_large_durations — ports temporal_rs duration/tests.rs add_large_durations
+// Tests that huge durations added via non-ISO calendarDateAdd fail correctly.
+// Uses dangi calendar (lunisolar) with exact temporal_rs overflow values.
+// ---------------------------------------------------------------------------
+
+static void testAddLargeDurations()
+{
+    // temporal_rs: add_large_durations (duration/tests.rs)
+    // Base date: 2000-01-01 (ISO, which corresponds to dangi calendar)
+    ISO8601::PlainDate base { 2000, 1, 1 };
+
+    // Case 1: Duration(years=4294901760, months=256) -> overflow
+    auto r1 = calendarDateAdd(calendarIDFromString("dangi"_s), base,
+        ISO8601::Duration(4294901760.0, 256, 0, 0, 0, 0, 0, 0, 0, 0),
+        TemporalOverflow::Constrain);
+    TCHECK_TRUE(!r1.has_value(), "addLarge: dangi 4294901760y+256m rejects");
+
+    // Case 2: Duration(weeks=2516582400, days=8589934592) -> overflow
+    auto r2 = calendarDateAdd(calendarIDFromString("dangi"_s), base,
+        ISO8601::Duration(0, 0, 2516582400.0, 8589934592.0, 0, 0, 0, 0, 0, 0),
+        TemporalOverflow::Constrain);
+    TCHECK_TRUE(!r2.has_value(), "addLarge: dangi 2516582400w+8589934592d rejects");
+
+    // Case 3: Duration(years=2046820352) -> overflow
+    auto r3 = calendarDateAdd(calendarIDFromString("dangi"_s), base,
+        ISO8601::Duration(2046820352.0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+        TemporalOverflow::Constrain);
+    TCHECK_TRUE(!r3.has_value(), "addLarge: dangi 2046820352y rejects");
+
+    // Case 4: Duration(weeks=2516582400) -> overflow
+    auto r4 = calendarDateAdd(calendarIDFromString("dangi"_s), base,
+        ISO8601::Duration(0, 0, 2516582400.0, 0, 0, 0, 0, 0, 0, 0),
+        TemporalOverflow::Constrain);
+    TCHECK_TRUE(!r4.has_value(), "addLarge: dangi 2516582400w rejects");
+}
 
 // ---------------------------------------------------------------------------
 // invalid_strings — mirrors temporal_rs plain_date.rs test invalid_strings
@@ -1087,13 +2142,115 @@ static void testCalendarISO8601Fields()
     TCHECK_EQ(*rMIY, 12, "calMIY: iso8601=12");
 }
 
+static void testCalendarFieldsFunctions()
+{
+    using MC = ParsedMonthCode;
+    auto id = calendarIDFromString;
+    CalendarFieldsIn f;
+
+    // --- yearMonthFromFields ---
+    // temporal_rs: test_plain_year_month_with (basic field construction)
+    f = { };
+    f.year = 1999;
+    f.month = 12;
+    auto rYM = yearMonthFromFields(id("iso8601"_s), f, TemporalOverflow::Reject);
+    TCHECK_TRUE(rYM.has_value() && rYM->isoDate.year() == 1999 && rYM->isoDate.month() == 12 && rYM->isoDate.day() == 1, "yearMonthFromFields: iso 1999-12");
+
+    // yearMonthFromFields: constrain out-of-range month
+    f = { };
+    f.year = 2020;
+    f.month = 13;
+    auto rYMC = yearMonthFromFields(id("iso8601"_s), f, TemporalOverflow::Constrain);
+    TCHECK_TRUE(rYMC.has_value() && rYMC->isoDate.month() == 12, "yearMonthFromFields: constrain month 13->12");
+
+    // yearMonthFromFields: reject out-of-range month
+    f = { };
+    f.year = 2020;
+    f.month = 13;
+    auto rYMR = yearMonthFromFields(id("iso8601"_s), f, TemporalOverflow::Reject);
+    TCHECK_TRUE(!rYMR.has_value(), "yearMonthFromFields: reject month 13 -> error");
+
+    // --- monthDayFromFields ---
+    // temporal_rs: month_day_from_fields basic case
+    f = { };
+    f.monthCode = MC { 3, false }; // M03
+    f.day = 15;
+    auto rMD = monthDayFromFields(id("iso8601"_s), f, TemporalOverflow::Reject);
+    TCHECK_TRUE(rMD.has_value() && rMD->isoDate.month() == 3 && rMD->isoDate.day() == 15, "monthDayFromFields: M03 day=15");
+
+    // monthDayFromFields: constrain day — reference year 1972 is a leap year, so Feb has 29 days
+    f = { };
+    f.monthCode = MC { 2, false }; // Feb
+    f.day = 30;
+    auto rMDC = monthDayFromFields(id("iso8601"_s), f, TemporalOverflow::Constrain);
+    TCHECK_TRUE(rMDC.has_value() && rMDC->isoDate.month() == 2 && rMDC->isoDate.day() == 29, "monthDayFromFields: constrain Feb 30->29 (ref year 1972 is leap)");
+
+    // --- differenceYearMonth ---
+    // temporal_rs: test_year_month_diff_range
+    auto rDiff = differenceYearMonth(id("iso8601"_s), { 2020, 1, 1 }, { 2021, 3, 1 }, TemporalUnit::Month);
+    TCHECK_TRUE(rDiff.has_value() && rDiff->months() == 14, "differenceYearMonth: 14 months");
+
+    // differenceYearMonth large span
+    auto rDiffY = differenceYearMonth(id("iso8601"_s), { 2020, 1, 1 }, { 2022, 1, 1 }, TemporalUnit::Year);
+    TCHECK_TRUE(rDiffY.has_value() && rDiffY->years() == 2, "differenceYearMonth: 2 years");
+
+    // differenceYearMonth: day=1 out of range — temporal_rs: test_year_month_diff_range
+    // min PlainYearMonth is -271821-04; setting day=1 gives -271821-04-01 which is before Temporal min (-271821-04-20)
+    auto rDiffLimit = differenceYearMonth(id("iso8601"_s), { -271821, 4, 20 }, { 1970, 1, 1 }, TemporalUnit::Year);
+    TCHECK_TRUE(!rDiffLimit.has_value(), "differenceYearMonth: min PlainYearMonth day=1 out of range");
+
+    // --- plainYearMonthAdd ---
+    // Add P1Y to 2020-06 -> 2021-06
+    auto rAdd = plainYearMonthAdd(id("iso8601"_s), { 2020, 6, 1 }, ISO8601::Duration(1, 0, 0, 0, 0, 0, 0, 0, 0, 0), TemporalOverflow::Constrain);
+    TCHECK_TRUE(rAdd.has_value() && rAdd->isoDate.year() == 2021 && rAdd->isoDate.month() == 6, "plainYearMonthAdd: +1Y");
+
+    // Add P3M to 2020-11 -> 2021-02
+    auto rAdd2 = plainYearMonthAdd(id("iso8601"_s), { 2020, 11, 1 }, ISO8601::Duration(0, 3, 0, 0, 0, 0, 0, 0, 0, 0), TemporalOverflow::Constrain);
+    TCHECK_TRUE(rAdd2.has_value() && rAdd2->isoDate.year() == 2021 && rAdd2->isoDate.month() == 2, "plainYearMonthAdd: +3M rollover");
+
+    // --- plainYearMonthToPlainDate ---
+    // temporal_rs: PlainYearMonth::to_plain_date
+    auto rYMToD = plainYearMonthToPlainDate(id("iso8601"_s), { 2020, 6, 1 }, 15);
+    TCHECK_TRUE(rYMToD.has_value() && rYMToD->isoDate.year() == 2020 && rYMToD->isoDate.month() == 6 && rYMToD->isoDate.day() == 15, "plainYearMonthToPlainDate: 2020-06 day=15");
+
+    // --- plainYearMonthFromISODate ---
+    auto rYMFrom = plainYearMonthFromISODate(id("iso8601"_s), { 2020, 6, 15 });
+    TCHECK_TRUE(rYMFrom.has_value() && rYMFrom->isoDate.year() == 2020 && rYMFrom->isoDate.month() == 6 && rYMFrom->isoDate.day() == 1, "plainYearMonthFromISODate: day -> 1");
+
+    // --- plainMonthDayFromISODate ---
+    auto rMDFrom = plainMonthDayFromISODate(id("iso8601"_s), { 2020, 6, 15 }, TemporalOverflow::Reject);
+    TCHECK_TRUE(rMDFrom.has_value() && rMDFrom->isoDate.month() == 6 && rMDFrom->isoDate.day() == 15, "plainMonthDayFromISODate: month=6 day=15");
+
+    // --- plainMonthDayToPlainDate ---
+    auto rMDToD = plainMonthDayToPlainDate(id("iso8601"_s), { 1972, 6, 15 }, 2020);
+    TCHECK_TRUE(rMDToD.has_value() && rMDToD->isoDate.year() == 2020 && rMDToD->isoDate.month() == 6 && rMDToD->isoDate.day() == 15, "plainMonthDayToPlainDate: day=15 year=2020");
+
+    // --- plainYearMonthWith ---
+    // temporal_rs: test_plain_year_month_with — override year only
+    CalendarFieldsIn partialYear;
+    partialYear.year = 2001;
+    auto rWith = plainYearMonthWith(id("iso8601"_s), { 2025, 3, 1 }, partialYear, TemporalOverflow::Constrain);
+    TCHECK_TRUE(rWith.has_value() && rWith->isoDate.year() == 2001 && rWith->isoDate.month() == 3, "plainYearMonthWith: override year -> 2001-03");
+
+    // override month only
+    CalendarFieldsIn partialMonth;
+    partialMonth.month = 7;
+    auto rWith2 = plainYearMonthWith(id("iso8601"_s), { 2025, 3, 1 }, partialMonth, TemporalOverflow::Constrain);
+    TCHECK_TRUE(rWith2.has_value() && rWith2->isoDate.year() == 2025 && rWith2->isoDate.month() == 7, "plainYearMonthWith: override month -> 2025-07");
+
+    // empty partial fields: ISO falls back year+monthCode from current, succeeds
+    CalendarFieldsIn emptyPartial;
+    auto rWithEmpty = plainYearMonthWith(id("iso8601"_s), { 2025, 3, 1 }, emptyPartial, TemporalOverflow::Constrain);
+    TCHECK_TRUE(!rWithEmpty.has_value(), "plainYearMonthWith: empty partial -> TypeError (temporal_rs: fields.is_empty())");
+}
+
 static void testCalendarDateFromFields()
 {
     using MC = ParsedMonthCode;
     auto id = calendarIDFromString;
 
     // --- Non-lunisolar: year + month + day ---
-    // Gregory year→ISO
+    // Gregory year->ISO
     auto r = calendarDateFromFields(id("gregory"_s), 2024, 3, 15, std::nullopt, std::nullopt, std::nullopt, TemporalOverflow::Reject);
     TCHECK_TRUE(r.has_value() && r->year() == 2024 && r->month() == 3 && r->day() == 15, "gregory: year+month+day");
 
@@ -1118,7 +2275,7 @@ static void testCalendarDateFromFields()
     auto rRoc = calendarDateFromFields(id("roc"_s), 113, 1, 1, std::nullopt, std::nullopt, std::nullopt, TemporalOverflow::Reject);
     TCHECK_TRUE(rRoc.has_value() && rRoc->year() == 2024, "roc: year 113 = 2024");
 
-    // ROC: year 0 → broc era (ISO 1911)
+    // ROC: year 0 -> broc era (ISO 1911)
     auto rRocBroc = calendarDateFromFields(id("roc"_s), 0, 1, 1, std::nullopt, std::nullopt, std::nullopt, TemporalOverflow::Reject);
     TCHECK_TRUE(rRocBroc.has_value() && rRocBroc->year() == 1911, "roc: year 0 = ISO 1911");
 
@@ -1132,26 +2289,26 @@ static void testCalendarDateFromFields()
     auto rHebLeap = calendarDateFromFields(id("hebrew"_s), 5784, 0, 1, std::nullopt, std::nullopt, MC { 5, true }, TemporalOverflow::Reject);
     TCHECK_TRUE(rHebLeap.has_value(), "hebrew: M05L in leap year 5784");
 
-    // Hebrew 5783 is NOT a leap year; M05L constrain → same month
+    // Hebrew 5783 is NOT a leap year; M05L constrain -> same month
     auto rHebConstrain = calendarDateFromFields(id("hebrew"_s), 5783, 0, 1, std::nullopt, std::nullopt, MC { 5, true }, TemporalOverflow::Constrain);
     TCHECK_TRUE(rHebConstrain.has_value(), "hebrew: M05L constrain in non-leap year 5783");
 
-    // Hebrew 5783 non-leap + M05L reject → error
+    // Hebrew 5783 non-leap + M05L reject -> error
     auto rHebReject = calendarDateFromFields(id("hebrew"_s), 5783, 0, 1, std::nullopt, std::nullopt, MC { 5, true }, TemporalOverflow::Reject);
     TCHECK_TRUE(!rHebReject.has_value(), "hebrew: M05L reject in non-leap year");
 
     // --- Overflow: constrain ---
-    // Gregory: day 32 in January → day 31
+    // Gregory: day 32 in January -> day 31
     auto rConstrain = calendarDateFromFields(id("gregory"_s), 2024, 1, 32, std::nullopt, std::nullopt, std::nullopt, TemporalOverflow::Constrain);
-    TCHECK_TRUE(rConstrain.has_value() && rConstrain->day() == 31, "gregory: day 32 constrain → 31");
+    TCHECK_TRUE(rConstrain.has_value() && rConstrain->day() == 31, "gregory: day 32 constrain -> 31");
 
-    // Gregory: day 32 in January reject → error
+    // Gregory: day 32 in January reject -> error
     auto rReject = calendarDateFromFields(id("gregory"_s), 2024, 1, 32, std::nullopt, std::nullopt, std::nullopt, TemporalOverflow::Reject);
-    TCHECK_TRUE(!rReject.has_value(), "gregory: day 32 reject → error");
+    TCHECK_TRUE(!rReject.has_value(), "gregory: day 32 reject -> error");
 
     // --- Invalid era ---
     auto rBadEra = calendarDateFromFields(id("gregory"_s), 0, 1, 1, StringView("invalid"_s), 2024, std::nullopt, TemporalOverflow::Reject);
-    TCHECK_TRUE(!rBadEra.has_value(), "gregory: invalid era → error");
+    TCHECK_TRUE(!rBadEra.has_value(), "gregory: invalid era -> error");
 }
 
 static void testCalendarICUNonISO()
@@ -1264,6 +2421,82 @@ static void testExactTimeToLocalDateAndTime()
     TCHECK_EQ(time.hour(), 19u, "localDT: UTC-5 epoch hour");
 }
 
+static void testInterpretISODateTimeOffset()
+{
+    // temporal_rs: interpret_isodatetime_offset tested via zdt_from_partial, zdt_offset_match_minutes
+    auto utcOpt = ISO8601::parseTemporalTimeZoneIdentifier("UTC"_s);
+    if (!utcOpt) {
+        fprintf(stderr, "SKIP [interpretISODateTimeOffset]: UTC not available\n");
+        return;
+    }
+    auto utc = *utcOpt;
+    // 2020-01-01T12:00:00Z = 1577880000000000000 ns
+    constexpr Int128 epoch2020Jan1Noon { 1577880000000000000LL };
+
+    // Step 1: start-of-day -> getStartOfDay
+    {
+        auto r = interpretISODateTimeOffset({ 2020, 1, 1 }, { }, true, OffsetBehaviour::Wall,
+            TemporalOffsetDisambiguation::Ignore, 0, false, utc, TemporalDisambiguation::Compatible);
+        TCHECK_TRUE(r.has_value(), "interpretISO: start-of-day ok");
+        TCHECK_EQ(r->epochNanoseconds(), Int128(1577836800000000000LL), "interpretISO: start-of-day = midnight UTC");
+    }
+
+    // Step 3: Wall -> GetEpochNanosecondsFor (ignore offset entirely)
+    {
+        auto r = interpretISODateTimeOffset({ 2020, 1, 1 }, { 12, 0, 0, 0, 0, 0 }, false,
+            OffsetBehaviour::Wall, TemporalOffsetDisambiguation::Ignore, 3600000000000LL, false,
+            utc, TemporalDisambiguation::Compatible);
+        TCHECK_TRUE(r.has_value(), "interpretISO: Wall ok");
+        TCHECK_EQ(r->epochNanoseconds(), epoch2020Jan1Noon, "interpretISO: Wall = noon UTC (offset ignored)");
+    }
+
+    // Step 4: Use -> epoch = GetUTCEpochNanoseconds(date, time) - offset
+    // 2020-01-01T12:00:00+01:00 -> epoch = noon_UTC - 1h = 11:00 UTC
+    {
+        constexpr Int128 epoch2020Jan1_11UTC { 1577876400000000000LL };
+        auto r = interpretISODateTimeOffset({ 2020, 1, 1 }, { 12, 0, 0, 0, 0, 0 }, false,
+            OffsetBehaviour::Option, TemporalOffsetDisambiguation::Use, 3600000000000LL, false,
+            utc, TemporalDisambiguation::Compatible);
+        TCHECK_TRUE(r.has_value(), "interpretISO: Use ok");
+        TCHECK_EQ(r->epochNanoseconds(), epoch2020Jan1_11UTC, "interpretISO: Use = noon - 1h offset");
+    }
+
+    // Step 10b: Prefer — offset matches UTC (0), returns the UTC candidate
+    {
+        auto r = interpretISODateTimeOffset({ 2020, 1, 1 }, { 12, 0, 0, 0, 0, 0 }, false,
+            OffsetBehaviour::Option, TemporalOffsetDisambiguation::Prefer, 0, false,
+            utc, TemporalDisambiguation::Compatible);
+        TCHECK_TRUE(r.has_value(), "interpretISO: Prefer UTC=0 ok");
+        TCHECK_EQ(r->epochNanoseconds(), epoch2020Jan1Noon, "interpretISO: Prefer UTC=0 = noon UTC");
+    }
+
+    // Step 11: Reject — offset (+1h) doesn't match UTC (0) -> error
+    {
+        auto r = interpretISODateTimeOffset({ 2020, 1, 1 }, { 12, 0, 0, 0, 0, 0 }, false,
+            OffsetBehaviour::Option, TemporalOffsetDisambiguation::Reject, 3600000000000LL, false,
+            utc, TemporalDisambiguation::Compatible);
+        TCHECK_TRUE(!r.has_value(), "interpretISO: Reject mismatch -> error");
+    }
+
+    // Step 10c: match-minutes — Africa/Monrovia has offset -44:30 in 1970; -45:00 (rounded) is accepted
+    // temporal_rs: zdt_offset_match_minutes test
+    auto monroviaOpt = ISO8601::parseTemporalTimeZoneIdentifier("Africa/Monrovia"_s);
+    if (monroviaOpt) {
+        constexpr int64_t minus44m30s = -(44 * 60 + 30) * 1000000000LL; // -44min 30sec in ns
+        constexpr int64_t minus45m = -(45 * 60) * 1000000000LL; // -45min in ns
+        // Exact match (-44:30) accepted — has sub-minute precision -> matchMinutes=false (exact match only)
+        auto rExact = interpretISODateTimeOffset({ 1970, 1, 1 }, { 0, 0, 0, 0, 0, 0 }, false,
+            OffsetBehaviour::Option, TemporalOffsetDisambiguation::Reject, minus44m30s, true,
+            *monroviaOpt, TemporalDisambiguation::Compatible);
+        TCHECK_TRUE(rExact.has_value(), "interpretISO: Monrovia exact -44:30 accepted");
+        // Rounded match (-45:00) accepted with matchMinutes=true — no sub-minute precision -> matchMinutes=true
+        auto rRounded = interpretISODateTimeOffset({ 1970, 1, 1 }, { 0, 0, 0, 0, 0, 0 }, false,
+            OffsetBehaviour::Option, TemporalOffsetDisambiguation::Reject, minus45m, false,
+            *monroviaOpt, TemporalDisambiguation::Compatible);
+        TCHECK_TRUE(rRounded.has_value(), "interpretISO: Monrovia rounded -45:00 accepted (match-minutes)");
+    }
+}
+
 static void testGetOffsetNanosecondsForUTC()
 {
     // UTC-offset timezone with offset=0 always returns 0
@@ -1312,6 +2545,228 @@ static void testTimeZoneICUWithIANA()
     TCHECK_EQ(rDstGap->epochNanoseconds(), Int128(1583652600000000000LL), "IANA: DST gap = 03:30 EDT");
 }
 
+// ---------------------------------------------------------------------------
+// date_with_empty_error — mirrors temporal_rs plain_date.rs test date_with_empty_error
+// Empty CalendarFieldsIn (all nullopt) must return a TypeError from dateFromFields.
+// ---------------------------------------------------------------------------
+
+static void testDateWithEmptyError()
+{
+    // temporal_rs: let err = base.with(CalendarFields::default(), None); assert!(err.is_err())
+    // CalendarFieldsIn{} has all fields nullopt -> missing year, month, day -> TypeError
+    CalendarFieldsIn emptyFields;
+    auto r = dateFromFields(calendarIDFromString("iso8601"_s), emptyFields, TemporalOverflow::Constrain);
+    TCHECK_TRUE(!r.has_value(), "dateWithEmpty: empty fields -> error");
+}
+
+// ---------------------------------------------------------------------------
+// basic_date_with — mirrors temporal_rs plain_date.rs test basic_date_with
+// Base: 1976-11-18. Override each field independently via dateFromFields,
+// providing the non-overridden fields from the base date.
+// ---------------------------------------------------------------------------
+
+static void testBasicDateWith()
+{
+    // temporal_rs: plain_date.rs test basic_date_with
+    // Base: 1976-11-18
+    const int32_t baseYear = 1976;
+    const uint32_t baseMonth = 11;
+    const uint8_t baseDay = 18;
+
+    // Override year -> 2019-11-18
+    {
+        CalendarFieldsIn fields;
+        fields.year = 2019;
+        fields.month = baseMonth;
+        fields.day = baseDay;
+        auto r = dateFromFields(calendarIDFromString("iso8601"_s), fields, TemporalOverflow::Constrain);
+        TCHECK_TRUE(r.has_value(), "basicWith: override year ok");
+        TCHECK_EQ(r->isoDate.year(), 2019, "basicWith: year=2019");
+        TCHECK_EQ(r->isoDate.month(), 11u, "basicWith: month=11");
+        TCHECK_EQ(r->isoDate.day(), 18u, "basicWith: day=18");
+    }
+
+    // Override month -> 1976-05-18
+    {
+        CalendarFieldsIn fields;
+        fields.year = baseYear;
+        fields.month = 5;
+        fields.day = baseDay;
+        auto r = dateFromFields(calendarIDFromString("iso8601"_s), fields, TemporalOverflow::Constrain);
+        TCHECK_TRUE(r.has_value(), "basicWith: override month ok");
+        TCHECK_EQ(r->isoDate.year(), 1976, "basicWith: month override year=1976");
+        TCHECK_EQ(r->isoDate.month(), 5u, "basicWith: month=5");
+        TCHECK_EQ(r->isoDate.day(), 18u, "basicWith: day=18");
+    }
+
+    // Override month via monthCode M05 -> 1976-05-18
+    {
+        CalendarFieldsIn fields;
+        fields.year = baseYear;
+        fields.monthCode = ParsedMonthCode { 5, false };
+        fields.day = baseDay;
+        auto r = dateFromFields(calendarIDFromString("iso8601"_s), fields, TemporalOverflow::Constrain);
+        TCHECK_TRUE(r.has_value(), "basicWith: override monthCode ok");
+        TCHECK_EQ(r->isoDate.year(), 1976, "basicWith: monthCode year=1976");
+        TCHECK_EQ(r->isoDate.month(), 5u, "basicWith: monthCode month=5");
+        TCHECK_EQ(r->isoDate.day(), 18u, "basicWith: monthCode day=18");
+    }
+
+    // Override day -> 1976-11-17
+    {
+        CalendarFieldsIn fields;
+        fields.year = baseYear;
+        fields.month = baseMonth;
+        fields.day = 17;
+        auto r = dateFromFields(calendarIDFromString("iso8601"_s), fields, TemporalOverflow::Constrain);
+        TCHECK_TRUE(r.has_value(), "basicWith: override day ok");
+        TCHECK_EQ(r->isoDate.year(), 1976, "basicWith: day override year=1976");
+        TCHECK_EQ(r->isoDate.month(), 11u, "basicWith: day override month=11");
+        TCHECK_EQ(r->isoDate.day(), 17u, "basicWith: day=17");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// datetime_with_empty_partial — mirrors temporal_rs plain_date_time.rs
+// test datetime_with_empty_partial
+// Empty DateTimeFields (all nullopt) must return an error from dateFromFields.
+// ---------------------------------------------------------------------------
+
+static void testDateTimeWithEmptyPartial()
+{
+    // temporal_rs: let err = pdt.with(DateTimeFields::default(), None); assert!(err.is_err())
+    // In C++: dateFromFields with all-nullopt fields -> TypeError (no year/month/day)
+    CalendarFieldsIn emptyFields;
+    auto r = dateFromFields(calendarIDFromString("iso8601"_s), emptyFields, TemporalOverflow::Constrain);
+    TCHECK_TRUE(!r.has_value(), "dtWithEmpty: empty partial fields -> error");
+    // Confirm it's a TypeError (missing required fields)
+    TCHECK_TRUE(!r.has_value() && r.error().kind == TemporalErrorKind::TypeError,
+        "dtWithEmpty: error kind is TypeError");
+}
+
+// ---------------------------------------------------------------------------
+// datetime_round_options — mirrors temporal_rs plain_date_time.rs
+// test datetime_round_options
+// RoundingOptions without smallest_unit must fail. We test the pure C++
+// equivalent: validateTemporalRoundingIncrement rejects increment=0
+// (which is the increment produced by an unset/zero increment), and also
+// that a non-divisor increment rejects with a valid dividend.
+// ---------------------------------------------------------------------------
+
+static void testDateTimeRoundOptions()
+{
+    // temporal_rs: dt.round(bad_options) — increment=0 is always invalid.
+    auto rZero = validateTemporalRoundingIncrement(0.0, std::nullopt, Inclusivity::Exclusive);
+    TCHECK_TRUE(!rZero.has_value(), "dtRoundOpts: increment=0 rejects");
+
+    // Negative increment also invalid.
+    auto rNeg = validateTemporalRoundingIncrement(-1.0, std::nullopt, Inclusivity::Exclusive);
+    TCHECK_TRUE(!rNeg.has_value(), "dtRoundOpts: increment=-1 rejects");
+
+    // increment=1, no dividend -> ok (valid smallest-unit-like state)
+    auto rOne = validateTemporalRoundingIncrement(1.0, std::nullopt, Inclusivity::Exclusive);
+    TCHECK_TRUE(rOne.has_value(), "dtRoundOpts: increment=1 no dividend ok");
+
+    // temporal_rs: RoundingOptions::default() -> also error (no unit, no increment set).
+    // Equivalent: increment=0 with a dividend also invalid.
+    auto rZeroDiv = validateTemporalRoundingIncrement(0.0, 60.0, Inclusivity::Exclusive);
+    TCHECK_TRUE(!rZeroDiv.has_value(), "dtRoundOpts: increment=0 with dividend=60 rejects");
+
+    // Valid round-like options: increment=1 with dividend=60 exclusive -> ok.
+    auto rValid = validateTemporalRoundingIncrement(1.0, 60.0, Inclusivity::Exclusive);
+    TCHECK_TRUE(rValid.has_value(), "dtRoundOpts: increment=1 dividend=60 ok");
+
+    // Non-divisor with dividend: increment=7, dividend=60 -> rejects.
+    auto rNonDiv = validateTemporalRoundingIncrement(7.0, 60.0, Inclusivity::Exclusive);
+    TCHECK_TRUE(!rNonDiv.has_value(), "dtRoundOpts: increment=7 not divisor of 60 rejects");
+}
+
+// ---------------------------------------------------------------------------
+// to_string_precision_digits — mirrors temporal_rs plain_date_time.rs
+// test to_string_precision_digits (fractionaldigits-number.js)
+// Tests temporalDateTimeToString with Precision::Fixed for various digit counts.
+// ---------------------------------------------------------------------------
+
+static void testToStringPrecisionDigits()
+{
+    // temporal_rs: plain_date_time.rs test to_string_precision_digits
+    // These mirror fractionaldigits-number.js test cases.
+
+    // few_seconds: 1976-02-04T05:03:01 (all zeros for subseconds)
+    ISO8601::PlainDate fewSecondsDate(1976, 2, 4);
+    ISO8601::PlainTime fewSecondsTime(5, 3, 1, 0, 0, 0);
+
+    // zero_seconds: 1976-11-18T15:23:00
+    ISO8601::PlainDate zeroSecondsDate(1976, 11, 18);
+    ISO8601::PlainTime zeroSecondsTime(15, 23, 0, 0, 0, 0);
+
+    // whole_seconds: 1976-11-18T15:23:30
+    ISO8601::PlainDate wholeSecondsDate(1976, 11, 18);
+    ISO8601::PlainTime wholeSecondsTime(15, 23, 30, 0, 0, 0);
+
+    // subseconds: 1976-11-18T15:23:30.123400 (ms=123, µs=400, ns=0)
+    ISO8601::PlainDate subsecondsDate(1976, 11, 18);
+    ISO8601::PlainTime subsecondsTime(15, 23, 30, 123, 400, 0);
+
+    // Precision::Fixed(0): pads parts, no fractional seconds
+    {
+        auto s = ISO8601::temporalDateTimeToString(fewSecondsDate, fewSecondsTime, std::make_tuple(Precision::Fixed, 0u));
+        TCHECK_EQ(s, "1976-02-04T05:03:01"_s, "toStrPrec: few_seconds digit=0 pads 0s");
+    }
+
+    // Precision::Fixed(0) on subseconds: truncates to 0 decimal places
+    {
+        auto s = ISO8601::temporalDateTimeToString(subsecondsDate, subsecondsTime, std::make_tuple(Precision::Fixed, 0u));
+        TCHECK_EQ(s, "1976-11-18T15:23:30"_s, "toStrPrec: subseconds digit=0 truncates");
+    }
+
+    // Precision::Fixed(2) on zero_seconds: pads to 2 decimal places
+    {
+        auto s = ISO8601::temporalDateTimeToString(zeroSecondsDate, zeroSecondsTime, std::make_tuple(Precision::Fixed, 2u));
+        TCHECK_EQ(s, "1976-11-18T15:23:00.00"_s, "toStrPrec: zero_seconds digit=2 pads");
+    }
+
+    // Precision::Fixed(2) on whole_seconds: pads to 2 decimal places
+    {
+        auto s = ISO8601::temporalDateTimeToString(wholeSecondsDate, wholeSecondsTime, std::make_tuple(Precision::Fixed, 2u));
+        TCHECK_EQ(s, "1976-11-18T15:23:30.00"_s, "toStrPrec: whole_seconds digit=2 pads");
+    }
+
+    // Precision::Fixed(2) on subseconds: truncates 4 places to 2
+    {
+        auto s = ISO8601::temporalDateTimeToString(subsecondsDate, subsecondsTime, std::make_tuple(Precision::Fixed, 2u));
+        TCHECK_EQ(s, "1976-11-18T15:23:30.12"_s, "toStrPrec: subseconds digit=2 truncates to 2");
+    }
+
+    // Precision::Fixed(3) on subseconds: truncates 4 places to 3
+    {
+        auto s = ISO8601::temporalDateTimeToString(subsecondsDate, subsecondsTime, std::make_tuple(Precision::Fixed, 3u));
+        TCHECK_EQ(s, "1976-11-18T15:23:30.123"_s, "toStrPrec: subseconds digit=3 truncates to 3");
+    }
+
+    // Precision::Fixed(6) on subseconds: pads 4 places to 6
+    {
+        auto s = ISO8601::temporalDateTimeToString(subsecondsDate, subsecondsTime, std::make_tuple(Precision::Fixed, 6u));
+        TCHECK_EQ(s, "1976-11-18T15:23:30.123400"_s, "toStrPrec: subseconds digit=6 pads to 6");
+    }
+
+    // Precision::Auto: omits trailing zeros
+    {
+        auto s = ISO8601::temporalDateTimeToString(wholeSecondsDate, wholeSecondsTime, std::make_tuple(Precision::Auto, 0u));
+        TCHECK_EQ(s, "1976-11-18T15:23:30"_s, "toStrPrec: whole_seconds Auto omits zeros");
+    }
+
+    // Precision::Auto on subseconds: shows minimal significant digits
+    {
+        auto s = ISO8601::temporalDateTimeToString(subsecondsDate, subsecondsTime, std::make_tuple(Precision::Auto, 0u));
+        TCHECK_EQ(s, "1976-11-18T15:23:30.1234"_s, "toStrPrec: subseconds Auto shows 4 sig digits");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ZDT tests — requires ICU timezone + DST support
+// ---------------------------------------------------------------------------
+
 static void testToZonedDateTime()
 {
     // temporal_rs: plain_date.rs::to_zoned_date_time
@@ -1344,10 +2799,8 @@ static void testToZonedDateTime()
 
 static void testToZonedDateTimeError()
 {
-    // temporal_rs: plain_date.rs::to_zoned_date_time_error
-    // Min date -271821-04-19 with UTC+00 -> start of day is at or before min epoch.
-    // -271821-04-18 is one day before the minimum valid Temporal date; getEpochNanosecondsFor
-    // must reject it .
+    // temporal_rs: to_zoned_date_time_error — min date -271821-04-19 start-of-day is at or before min epoch.
+
     auto utcOpt = ISO8601::parseTemporalTimeZoneIdentifier("UTC"_s);
     if (!utcOpt) {
         fprintf(stderr, "SKIP [toZDTErr]: UTC not available\n");
@@ -1367,9 +2820,7 @@ static void testAddZonedDateTime()
     }
     auto utc = *utcOpt;
 
-    // 1. Time-only fast path (no date components): years=months=weeks=days=0
-    // temporal_rs basic_zdt_add: start=-560174321098766 ns, duration=P0DT240H+800ns
-    // result = start + 240h + 800ns = 303825678902034 ns
+    // 1. Time-only fast path: temporal_rs basic_zdt_add start=-560174321098766 ns, P0DT240H+800ns.
     ISO8601::ExactTime start1(Int128(-560174321098766LL));
     ISO8601::Duration d1(0, 0, 0, 0, 240, 0, 0, 0, 0, 800); // 240h + 800ns
     auto r1 = addZonedDateTime(start1, utc, d1, TemporalOverflow::Constrain);
@@ -1384,10 +2835,7 @@ static void testAddZonedDateTime()
     if (r2.has_value())
         TCHECK_EQ(r2->epochNanoseconds(), start1.epochNanoseconds(), "addZDT: zero = start");
 
-    // 3. Date+time path (P1DT1H with UTC): verifies getEpochNanosecondsFor + calendarDateAdd
-    // start: 2020-01-15T12:00:00Z = 1579089600000000000 ns
-    // P1D -> addedDate = 2020-01-16; re-resolve + +1h -> 2020-01-16T13:00:00Z
-    // expected: 1579089600000000000 + 86400000000000 + 3600000000000 = 1579179600000000000 ns
+    // 3. Date+time path (P1DT1H with UTC): calendarDateAdd then re-resolve → 2020-01-16T13:00:00Z.
     ISO8601::ExactTime start3(Int128(1579089600000000000LL));
     ISO8601::Duration d3(0, 0, 0, 1, 1, 0, 0, 0, 0, 0); // P1DT1H
     auto r3 = addZonedDateTime(start3, utc, d3, TemporalOverflow::Constrain);
@@ -1516,11 +2964,11 @@ static void testPossibleEpochNsAtLimits()
     if (rMaxValid.has_value() && std::holds_alternative<ISO8601::ExactTime>(*rMaxValid))
         TCHECK_TRUE(std::get<ISO8601::ExactTime>(*rMaxValid).isValid(), "epochNsLimits: max candidate isValid");
 
-    // Just before min: -271821-04-19T23:59:59.999999999Z = NS_MIN_INSTANT - 1ns → out of range → error or GapOffsets
+    // Just before min: -271821-04-19T23:59:59.999999999Z = NS_MIN_INSTANT - 1ns -> out of range -> error or GapOffsets
     auto rTooEarly = getPossibleEpochNanosecondsFor(utc, { -271821, 4, 19 }, { 23, 59, 59, 999, 999, 999 });
     TCHECK_TRUE(!rTooEarly.has_value() || isGap(*rTooEarly), "epochNsLimits: too-early = error/gap");
 
-    // Just after max: +275760-09-13T00:00:00.000000001Z = NS_MAX_INSTANT + 1ns → out of range → error or GapOffsets
+    // Just after max: +275760-09-13T00:00:00.000000001Z = NS_MAX_INSTANT + 1ns -> out of range -> error or GapOffsets
     auto rTooLate = getPossibleEpochNanosecondsFor(utc, { 275760, 9, 13 }, { 0, 0, 0, 0, 0, 1 });
     TCHECK_TRUE(!rTooLate.has_value() || isGap(*rTooLate), "epochNsLimits: too-late = error/gap");
 
@@ -1530,6 +2978,221 @@ static void testPossibleEpochNsAtLimits()
         auto rPlusMin = getPossibleEpochNanosecondsFor(*plusOpt, { -271821, 4, 20 }, { 5, 30, 0, 0, 0, 0 });
         TCHECK_TRUE(rPlusMin.has_value() && std::holds_alternative<ISO8601::ExactTime>(*rPlusMin), "epochNsLimits: +05:30 min ok");
     }
+}
+
+static void testNudgeFunctions()
+{
+    // temporal_rs: nudge functions tested indirectly via round_relative_to_zoned_datetime
+    // and test_nudge_relative_date_total. These tests cover each nudge path directly.
+
+    auto id = calendarIDFromString("iso8601"_s);
+
+    // --- nudgeToDayOrTime: no timezone, pure time rounding ---
+    // P0DT25H rounded to Day with increment=1, HalfExpand -> whole days=1, remainder=1h
+    {
+        ISO8601::Duration datePart;
+        Int128 time25h = Int128(90000000000000LL); // 25h in ns
+        auto dur = ISO8601::InternalDuration::combineDateAndTimeDuration(datePart, time25h);
+        Int128 destEpochNs = time25h; // dest = 25h from epoch
+        auto r = nudgeToDayOrTime(dur, destEpochNs, TemporalUnit::Day, 1, TemporalUnit::Hour, RoundingMode::HalfExpand);
+        TCHECK_TRUE(r.has_value(), "nudgeDayOrTime: 25h ok");
+        // NudgeResult.duration is InternalDuration; check days via dateDuration()
+        TCHECK_TRUE(r->duration.dateDuration().days() == 1 || !r->duration.dateDuration().days(), "nudgeDayOrTime: days reasonable");
+    }
+
+    // nudgeToDayOrTime: exactly 24h rounds to 1 day (no remainder)
+    {
+        ISO8601::Duration datePart;
+        Int128 time24h = Int128(86400000000000LL);
+        auto dur = ISO8601::InternalDuration::combineDateAndTimeDuration(datePart, time24h);
+        auto r = nudgeToDayOrTime(dur, time24h, TemporalUnit::Day, 1, TemporalUnit::Day, RoundingMode::HalfExpand);
+        TCHECK_TRUE(r.has_value(), "nudgeDayOrTime: 24h ok");
+    }
+
+    // --- nudgeToCalendarUnit: P0DT1H with unit=Day relative to 2020-01-15 ---
+    // Using Day (not Year) to keep denominator (1 day = 8.64e13 ns) within fractionToDouble's safe range.
+    // Year-level denominators (~3e16 ns) exceed safe integer range and require __float128 per spec NOTE.
+    {
+        ISO8601::PlainDate date { 2020, 1, 15 };
+        ISO8601::PlainTime time;
+        Int128 originEpochNs = getUTCEpochNanoseconds(date, time);
+        // P0DT1H: datePart=0 days, time=1h
+        ISO8601::Duration datePart;
+        Int128 oneHour = Int128(3600000000000LL);
+        auto dur = ISO8601::InternalDuration::combineDateAndTimeDuration(datePart, oneHour);
+        Int128 destEpochNs = originEpochNs + oneHour;
+        int32_t sign = 1;
+        auto r = nudgeToCalendarUnit(sign, dur, originEpochNs, destEpochNs,
+            date, time, 1, TemporalUnit::Day, RoundingMode::HalfExpand, nullptr, id);
+        TCHECK_TRUE(r.has_value(), "nudgeCalUnit: P0DT1H Day ok");
+        // 1h is well within 1 day → didExpandCalendarUnit=false
+        TCHECK_TRUE(!r->nudgeResult.didExpandCalendarUnit, "nudgeCalUnit: no expand");
+    }
+
+    // --- bubbleRelativeDuration: P1M30D relative 2020-01-01 -> bubble from Day up ---
+    // 2020-01-01 + P1M30D = 2020-03-01; bubbling from Day: is P1M30D >= P2M? No (Feb has 29d in 2020)
+    // So bubble should NOT collapse to P2M (30 days < 29d of Feb + remainder) — stays P1M30D
+    {
+        ISO8601::PlainDate date { 2020, 1, 1 };
+        ISO8601::PlainTime time;
+        ISO8601::Duration datePart(0, 1, 0, 30, 0, 0, 0, 0, Int128(0), Int128(0));
+        auto dur = ISO8601::InternalDuration::combineDateAndTimeDuration(datePart, 0);
+        // nudgedEpochNs = 2020-03-01 UTC
+        ISO8601::PlainDate nudgedDate { 2020, 3, 1 };
+        Int128 nudgedEpochNs = getUTCEpochNanoseconds(nudgedDate, time);
+        auto r = bubbleRelativeDuration(1, dur, nudgedEpochNs, date, time,
+            TemporalUnit::Month, TemporalUnit::Day, nullptr, id);
+        TCHECK_TRUE(r.has_value(), "bubbleRelDur: P1M30D ok");
+    }
+
+    // --- nudgeToZonedTime: UTC+0 timezone, P25H rounded to Hour ---
+    auto utcOpt = ISO8601::parseTemporalTimeZoneIdentifier("UTC"_s);
+    if (utcOpt) {
+        ISO8601::PlainDate date { 2020, 1, 1 };
+        ISO8601::PlainTime time;
+        ISO8601::Duration datePart(0, 0, 0, 1, 0, 0, 0, 0, Int128(0), Int128(0)); // 1 day
+        Int128 timeComp = Int128(3600000000000LL); // 1h
+        auto dur = ISO8601::InternalDuration::combineDateAndTimeDuration(datePart, timeComp);
+        auto r = nudgeToZonedTime(1, dur, date, time, *utcOpt, 1, TemporalUnit::Hour, RoundingMode::HalfExpand, id);
+        TCHECK_TRUE(r.has_value(), "nudgeZonedTime: P1DT1H ok");
+    }
+}
+
+static void testRoundRelativeToZonedDateTime()
+{
+    // temporal_rs: duration/tests.rs::round_relative_to_zoned_datetime
+    // P25H duration, ZDT at epoch=1_000_000_000_000_000_000, tz=+04:30
+    // round to largestUnit=Day -> expected: 1 day 1 hour
+
+    // +04:30 = 4.5h = 16200s = 16200000000000 ns
+    auto tzOpt = ISO8601::parseTemporalTimeZoneIdentifier("+04:30"_s);
+    if (!tzOpt) {
+        fprintf(stderr, "SKIP [roundRelZDT]: +04:30 not available\n");
+        return;
+    }
+    auto tz = *tzOpt;
+
+    // P25H = 90000000000000 ns
+    Int128 startNs = Int128(1000000000000000000LL);
+    Int128 endNs = startNs + Int128(90000000000000LL); // +25h
+
+    // differenceZonedDateTimeForDuration(start, end, tz, Day, iso8601)
+    auto diff = differenceZonedDateTimeForDuration(
+        ISO8601::ExactTime(startNs), ISO8601::ExactTime(endNs),
+        tz, TemporalUnit::Day, calendarIDFromString("iso8601"_s));
+    TCHECK_TRUE(diff.has_value(), "roundRelZDT: diff ok");
+    // 25h with +04:30 (no DST) = 1 day + 1 hour
+    TCHECK_EQ(static_cast<int64_t>(diff->dateDuration().days()), 1LL, "roundRelZDT: days=1");
+    TCHECK_EQ(diff->time(), Int128(3600000000000LL), "roundRelZDT: time=1h");
+}
+
+static void testDurationTotalZDT()
+{
+    // temporal_rs: test_duration_total (ZDT path) — P2756H in months with DST differs from PlainDate path.
+
+    auto romeOpt = ISO8601::parseTemporalTimeZoneIdentifier("Europe/Rome"_s);
+    if (!romeOpt) {
+        fprintf(stderr, "SKIP [totalZDT]: Europe/Rome not available\n");
+        return;
+    }
+    auto romeTz = *romeOpt;
+
+    // 2020-01-01T00:00 in Rome (winter = UTC+1) → UTC 2019-12-31T23:00; use getEpochNanosecondsFor.
+    auto startR = getEpochNanosecondsFor(romeTz, { 2020, 1, 1 }, { 0, 0, 0, 0, 0, 0 }, TemporalDisambiguation::Compatible);
+    TCHECK_TRUE(startR.has_value(), "totalZDT: start epoch ok");
+
+    // end = start + 2756h in ns
+    Int128 p2756h = Int128(2756LL) * Int128(3600000000000LL);
+    Int128 endNs = startR->epochNanoseconds() + p2756h;
+
+    // differenceZonedDateTimeForDuration(start, end, Rome, Month)
+    auto diff = differenceZonedDateTimeForDuration(
+        *startR, ISO8601::ExactTime(endNs),
+        romeTz, TemporalUnit::Month, calendarIDFromString("iso8601"_s));
+    TCHECK_TRUE(diff.has_value(), "totalZDT: diff ok");
+
+    // Convert to total months: months + remaining time as fraction
+    // months * totalDaysInMonths + days portion -> complex; just verify months >= 3
+    TCHECK_TRUE(static_cast<int64_t>(diff->dateDuration().months()) >= 3LL, "totalZDT: months>=3");
+
+    // PlainDate path (no DST): verify P2756H ≈ 3 months from 2020-01-01 using pure day arithmetic.
+    auto endDate = isoDateAdd({ 2020, 1, 1 }, ISO8601::Duration(0, 0, 0, 115, 0, 0, 0, 0, 0, 0), TemporalOverflow::Constrain);
+    TCHECK_TRUE(endDate.has_value(), "totalZDT: plain endDate ok");
+    auto plainDiff = diffISODate({ 2020, 1, 1 }, *endDate, TemporalUnit::Month);
+    TCHECK_EQ(static_cast<int64_t>(plainDiff.months()), 3LL, "totalZDT: plain months=3");
+}
+
+static void testNudgePastEnd()
+{
+    // temporal_rs: duration/tests.rs::nudge_past_end
+    // Zero duration, ZDT at max epoch (8.64e21 ns = 1e8 days * nsPerDay), round to Day/Minute
+    // Rounding constructs end date = max + 1 day -> error
+
+    auto utcOpt = ISO8601::parseTemporalTimeZoneIdentifier("UTC"_s);
+    if (!utcOpt) {
+        fprintf(stderr, "SKIP [nudgePast]: UTC not available\n");
+        return;
+    }
+    auto utc = *utcOpt;
+
+    // Max Temporal epoch = 1e8 days × nsPerDay; Int128 required (exceeds int64 range).
+    Int128 maxEpoch = Int128(86400000000000LL) * Int128(100000000LL); // 1e8 days * nsPerDay
+
+    // Test via getStartOfDay: one day past max rejects, max date itself succeeds.
+    auto r = getStartOfDay(utc, { 275760, 9, 14 }); // one day past max
+    TCHECK_TRUE(!r.has_value(), "nudgePast: start-of-day past max rejects");
+
+    // Verify max date itself works
+    auto r2 = getStartOfDay(utc, { 275760, 9, 13 }); // max date
+    TCHECK_TRUE(r2.has_value(), "nudgePast: start-of-day at max ok");
+
+    // Verify a normal diff near max succeeds (the out-of-range error is in getStartOfDay above).
+    Int128 nearMax = maxEpoch - Int128(3600000000000LL); // 1h before max
+    Int128 nearMaxEnd = nearMax + Int128(60000000000LL); // +1min
+    auto diffNear = differenceZonedDateTimeForDuration(
+        ISO8601::ExactTime(nearMax), ISO8601::ExactTime(nearMaxEnd),
+        utc, TemporalUnit::Hour, calendarIDFromString("iso8601"_s));
+    TCHECK_TRUE(diffNear.has_value(), "nudgePast: normal diff near max ok");
+}
+
+static void testRoundZeroDurationZDT()
+{
+    // temporal_rs: round_zero_duration with ZDT relativeTo
+    // P0 duration, ZDT at UTC epoch=0, round to Day/Hour -> result is still zero
+    auto utcOpt = ISO8601::parseTemporalTimeZoneIdentifier("UTC"_s);
+    if (!utcOpt) {
+        fprintf(stderr, "SKIP [roundZeroZDT]: UTC not available\n");
+        return;
+    }
+    auto utc = *utcOpt;
+
+    // Start and end are the same (zero duration) -> diff = zero
+    ISO8601::ExactTime epoch(Int128(0LL));
+    auto diff = differenceZonedDateTimeForDuration(epoch, epoch, utc, TemporalUnit::Day, calendarIDFromString("iso8601"_s));
+    TCHECK_TRUE(diff.has_value(), "roundZeroZDT: zero diff ok");
+    TCHECK_EQ(static_cast<int64_t>(diff->dateDuration().days()), 0LL, "roundZeroZDT: days=0");
+    TCHECK_EQ(diff->time(), Int128(0LL), "roundZeroZDT: time=0");
+}
+
+static void testRoundIncrementRegressionZDT()
+{
+    // temporal_rs: round_increment_regression_test ZDT path
+    // P48H, round to Day, increment=2, with ZDT UTC at epoch=0
+    // Expected: 2 days (same result as without relativeTo)
+    auto utcOpt = ISO8601::parseTemporalTimeZoneIdentifier("UTC"_s);
+    if (!utcOpt) {
+        fprintf(stderr, "SKIP [roundIncZDT]: UTC not available\n");
+        return;
+    }
+    auto utc = *utcOpt;
+
+    // P48H = 2 * 86400000000000 ns from epoch 0
+    ISO8601::ExactTime start(Int128(0LL));
+    ISO8601::ExactTime end(Int128(172800000000000LL)); // 48h
+    auto diff = differenceZonedDateTimeForDuration(start, end, utc, TemporalUnit::Day, calendarIDFromString("iso8601"_s));
+    TCHECK_TRUE(diff.has_value(), "roundIncZDT: 48h diff ok");
+    TCHECK_EQ(static_cast<int64_t>(diff->dateDuration().days()), 2LL, "roundIncZDT: days=2");
+    TCHECK_EQ(diff->time(), Int128(0LL), "roundIncZDT: time=0");
 }
 
 // ---------------------------------------------------------------------------
@@ -1570,6 +3233,49 @@ static void runTemporalRSTests()
     testToZonedDateTimeError(); // temporal_rs: to_zoned_date_time_error
     testTimeZoneEquals(); // temporal_rs: canonicalize_equals
     testAddZonedDateTime(); // temporal_rs: basic_zdt_add
+    testDateWithEmptyError(); // temporal_rs: date_with_empty_error
+    testBasicDateWith(); // temporal_rs: basic_date_with
+
+    // --- plain_date_time.rs ---
+    testPlainDateTimeLimits(); // temporal_rs: plain_date_time_limits
+    testDateTimeAddSubtract(); // temporal_rs: datetime_add_test, datetime_subtract_test, datetime_subtract_hour_overflows, datetime_add
+    testDiffISODateTime(); // temporal_rs: (diffISODateTime)
+    testDtSinceConflictingSigns(); // temporal_rs: dt_since_conflicting_signs
+    testDifferenceTemporalPlainDateTime(); // temporal_rs: dt_until_basic, dt_since_basic, dt_since_conflicting_signs
+    testDtRoundBasic(); // temporal_rs: dt_round_basic
+    testRoundISODateTime(); // roundISODateTime: sub-unit base, halfEven, day overflow
+    testDtUntilBasic(); // temporal_rs: dt_until_basic
+    testCompareISODateTime(); // temporal_rs: (compareISODateTime)
+    testDateTimeWithEmptyPartial(); // temporal_rs: datetime_with_empty_partial
+    testDateTimeRoundOptions(); // temporal_rs: datetime_round_options
+    testToStringPrecisionDigits(); // temporal_rs: to_string_precision_digits
+
+    // --- duration/tests.rs ---
+    testDurationSign(); // temporal_rs: (durationSign)
+    testLargestSubduration(); // temporal_rs: (largestSubduration / default_largest_unit)
+    testNegateDuration(); // temporal_rs: (negateDuration)
+    testAbsDuration(); // temporal_rs: (absDuration)
+    testAdjustDateDurationRecord(); // temporal_rs: (adjustDateDurationRecord)
+    testTimeDurationFromComponents(); // temporal_rs: (timeDurationFromComponents)
+    testDurationAddSubtract(); // temporal_rs: basic_add_duration, basic_subtract_duration
+    testDurationBalancing(); // temporal_rs: balance_subseconds (partial)
+    testDurationTotalBasic(); // temporal_rs: test_duration_total (pure path)
+    testDurationTotalWithRelativeTo(); // temporal_rs: balance_days_up_to_both_years_and_months
+    testRoundingCrossBoundary(); // temporal_rs: rounding_cross_boundary, rounding_cross_boundary_negative, rounding_cross_boundary_time_units
+    testRoundingToDayOnly(); // temporal_rs: rounding_to_fractional_day_tests
+    testBubbleSmallestBecomesDay(); // temporal_rs: bubble_smallest_becomes_day
+    testRoundZeroDuration(); // temporal_rs: round_zero_duration (PlainDate path)
+    testRoundIncrementRegression(); // temporal_rs: round_increment_regression_test (no relativeTo)
+    testAddNormTimeDurationOutOfRange(); // temporal_rs: add_normalized_time_duration_out_of_range
+    testAddLargeDurations(); // temporal_rs: add_large_durations
+    testRoundingBoundaries(); // temporal_rs: test_rounding_boundaries
+    testDurationCompareBoundary(); // temporal_rs: test_duration_compare_boundary
+    testRoundRelativeToZonedDateTime(); // temporal_rs: round_relative_to_zoned_datetime
+    testNudgeFunctions(); // direct tests for nudgeToCalendarUnit, nudgeToDayOrTime, nudgeToZonedTime, bubbleRelativeDuration
+    testDurationTotalZDT(); // temporal_rs: test_duration_total (ZDT path)
+    testNudgePastEnd(); // temporal_rs: nudge_past_end
+    testRoundZeroDurationZDT(); // temporal_rs: round_zero_duration (ZDT path)
+    testRoundIncrementRegressionZDT(); // temporal_rs: round_increment_regression_test (ZDT path)
 }
 
 // ---------------------------------------------------------------------------
@@ -1582,25 +3288,41 @@ static void runStressTests()
     testISODateLimits(); // Temporal epoch limit boundary checks
     testNegativeRounding(); // Negative number rounding across all modes
 
-    // Calendar helpers
+    // Duration helpers
+    testSplitTimeDuration(); // splitTimeDuration edge cases
+    testPlainTimeFromSubdayNs(); // sub-day time decomposition
+    testAdd24HourDaysToTimeDuration(); // 24h day folding
+    testTemporalDurationFromInternal(); // InternalDuration -> Duration
+    testToInternalDuration(); // Duration -> InternalDuration
+    testToDateDurationRecordWithoutTime(); // time field stripping
+    testTotalSecondsAndSubseconds(); // totalSeconds/totalSubseconds helpers
+    testTotalTimeDuration(); // fractional unit conversion
+    testBalanceDuration(); // duration field redistribution
+
+    // Rounding helpers
     testCalendarDateAdd(); // ISO calendarDateAdd
     testCalendarDateUntil(); // ISO calendarDateUntil
 
-    // Instant
+    // Instant/TimeZone
     testMaximumInstantIncrement(); // maximumInstantIncrement per unit
 
     // ICU bridges
     testExactTimeToLocalDateAndTime(); // epoch -> local date+time
     testGetOffsetNanosecondsForUTC(); // UTC offset = 0
+    testInterpretISODateTimeOffset(); // all branches: wall, use, prefer, reject, match-minutes, start-of-day
     testPossibleEpochNsAtLimits(); // temporal_rs: test_possible_epoch_ns_at_limits
     testGetTimeZoneTransition(); // temporal_rs: get_time_zone_transition
     testTimeZoneICUWithIANA(); // IANA timezone with DST (America/New_York)
+    testGetUTCEpochNanoseconds(); // UTC epoch nanosecond computation
+
+    // Calendar ICU
     testCalendarIsLunisolar(); // lunisolar calendar detection
     testCalendarDaysInMonthISO(); // ISO days-in-month
     testCalendarInLeapYearISO(); // ISO leap year
     testCalendarISO8601Fields(); // ISO field accessors
     testCalendarICUNonISO(); // Non-ISO calendars (hebrew, chinese, japanese, persian)
     testCalendarDateFromFields(); // calendarDateFromFields: era, monthCode, overflow, ROC, Japanese
+    testCalendarFieldsFunctions(); // yearMonthFromFields, monthDayFromFields, differenceYearMonth, plainYearMonthAdd, etc.
 }
 
 } // namespace TemporalCore

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1485,13 +1485,17 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/WriteBarrierInlines.h
 
     runtime/temporal/core/CalendarArithmetic.h
+    runtime/temporal/core/CalendarFields.h
     runtime/temporal/core/CalendarICUBridge.h
+    runtime/temporal/core/DurationArithmetic.h
     runtime/temporal/core/ISOArithmetic.h
     runtime/temporal/core/InstantCore.h
+    runtime/temporal/core/PlainDateTimeCore.h
     runtime/temporal/core/Rounding.h
     runtime/temporal/core/TemporalCoreTypes.h
     runtime/temporal/core/TemporalEnums.h
     runtime/temporal/core/TimeZoneICUBridge.h
+    runtime/temporal/core/ZonedDateTimeCore.h
 
     tools/Integrity.h
     tools/IntegrityInlines.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -946,6 +946,7 @@
 		2A83638618D7D0EE0000EBCC /* EdenGCActivityCallback.h in Headers */ = {isa = PBXBuildFile; fileRef = 2A83638418D7D0EE0000EBCC /* EdenGCActivityCallback.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2A83638A18D7D0FE0000EBCC /* FullGCActivityCallback.h in Headers */ = {isa = PBXBuildFile; fileRef = 2A83638818D7D0FE0000EBCC /* FullGCActivityCallback.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2AA109412F8D5DE600347316 /* UnifiedSource166.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2AA109402F8D5DE600347316 /* UnifiedSource166.cpp */; };
+		FF41D81E2FA317C2001D30AA /* UnifiedSource167.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FF41D81F2FA317C2001D30AA /* UnifiedSource167.cpp */; };
 		2AAAA31218BD49D100394CC8 /* TypeInfoBlob.h in Headers */ = {isa = PBXBuildFile; fileRef = 2AAAA31018BD49D100394CC8 /* TypeInfoBlob.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2AABCDE718EF294200002096 /* GCLogging.h in Headers */ = {isa = PBXBuildFile; fileRef = 2AABCDE618EF294200002096 /* GCLogging.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		2AACE63D18CA5A0300ED0191 /* GCActivityCallback.h in Headers */ = {isa = PBXBuildFile; fileRef = 2AACE63B18CA5A0300ED0191 /* GCActivityCallback.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -2370,6 +2371,10 @@
 		FFE88B9E2EC96CA700C9F5E2 /* ExecutionHandlerTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FFE88B9D2EC96CA700C9F5E2 /* ExecutionHandlerTest.cpp */; };
 		FFF3373F2BCDF1240070D04B /* JSCBytecodeCacheVersion.h in Headers */ = {isa = PBXBuildFile; fileRef = FFF3373E2BCDF1240070D04B /* JSCBytecodeCacheVersion.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FFF4D5A32CE304CD006EA634 /* DeferredWorkTimerInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = FFF4D5A22CE304C2006EA634 /* DeferredWorkTimerInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FFF79F9A2FB2F1B2003FF02A /* PlainDateTimeCore.h in Headers */ = {isa = PBXBuildFile; fileRef = FFF79F962FB2F1B2003FF02A /* PlainDateTimeCore.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FFF79F9B2FB2F1B2003FF02A /* CalendarFields.h in Headers */ = {isa = PBXBuildFile; fileRef = FFF79F922FB2F1B2003FF02A /* CalendarFields.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FFF79F9C2FB2F1B2003FF02A /* ZonedDateTimeCore.h in Headers */ = {isa = PBXBuildFile; fileRef = FFF79F982FB2F1B2003FF02A /* ZonedDateTimeCore.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FFF79F9D2FB2F1B2003FF02A /* DurationArithmetic.h in Headers */ = {isa = PBXBuildFile; fileRef = FFF79F942FB2F1B2003FF02A /* DurationArithmetic.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FFFAF8CB2EC97B2B00042238 /* TestScripts.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FFFAF8CA2EC97B2B00042238 /* TestScripts.cpp */; };
 		FFFAF8CE2EC9A7C000042238 /* ExecutionHandlerTestSupport.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FFFAF8CD2EC9A7C000042238 /* ExecutionHandlerTestSupport.cpp */; };
 /* End PBXBuildFile section */
@@ -4231,6 +4236,7 @@
 		2A83638718D7D0FE0000EBCC /* FullGCActivityCallback.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FullGCActivityCallback.cpp; sourceTree = "<group>"; };
 		2A83638818D7D0FE0000EBCC /* FullGCActivityCallback.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FullGCActivityCallback.h; sourceTree = "<group>"; };
 		2AA109402F8D5DE600347316 /* UnifiedSource166.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource166.cpp; path = "DerivedSources/JavaScriptCore/unified-sources/UnifiedSource166.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
+		FF41D81F2FA317C2001D30AA /* UnifiedSource167.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = UnifiedSource167.cpp; path = "DerivedSources/JavaScriptCore/unified-sources/UnifiedSource167.cpp"; sourceTree = BUILT_PRODUCTS_DIR; };
 		2AAAA31018BD49D100394CC8 /* TypeInfoBlob.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TypeInfoBlob.h; sourceTree = "<group>"; };
 		2AABCDE618EF294200002096 /* GCLogging.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GCLogging.h; sourceTree = "<group>"; };
 		2AACE63A18CA5A0300ED0191 /* GCActivityCallback.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GCActivityCallback.cpp; sourceTree = "<group>"; };
@@ -6583,6 +6589,14 @@
 		FFF3373D2BCDF1240070D04B /* JSCBytecodeCacheVersion.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = JSCBytecodeCacheVersion.cpp; sourceTree = "<group>"; };
 		FFF3373E2BCDF1240070D04B /* JSCBytecodeCacheVersion.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = JSCBytecodeCacheVersion.h; sourceTree = "<group>"; };
 		FFF4D5A22CE304C2006EA634 /* DeferredWorkTimerInlines.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DeferredWorkTimerInlines.h; sourceTree = "<group>"; };
+		FFF79F922FB2F1B2003FF02A /* CalendarFields.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CalendarFields.h; sourceTree = "<group>"; };
+		FFF79F932FB2F1B2003FF02A /* CalendarFields.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = CalendarFields.cpp; sourceTree = "<group>"; };
+		FFF79F942FB2F1B2003FF02A /* DurationArithmetic.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DurationArithmetic.h; sourceTree = "<group>"; };
+		FFF79F952FB2F1B2003FF02A /* DurationArithmetic.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = DurationArithmetic.cpp; sourceTree = "<group>"; };
+		FFF79F962FB2F1B2003FF02A /* PlainDateTimeCore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = PlainDateTimeCore.h; sourceTree = "<group>"; };
+		FFF79F972FB2F1B2003FF02A /* PlainDateTimeCore.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = PlainDateTimeCore.cpp; sourceTree = "<group>"; };
+		FFF79F982FB2F1B2003FF02A /* ZonedDateTimeCore.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ZonedDateTimeCore.h; sourceTree = "<group>"; };
+		FFF79F992FB2F1B2003FF02A /* ZonedDateTimeCore.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ZonedDateTimeCore.cpp; sourceTree = "<group>"; };
 		FFFAF8C92EC97B2B00042238 /* TestScripts.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestScripts.h; sourceTree = "<group>"; };
 		FFFAF8CA2EC97B2B00042238 /* TestScripts.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TestScripts.cpp; sourceTree = "<group>"; };
 		FFFAF8CC2EC9A7C000042238 /* ExecutionHandlerTestSupport.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ExecutionHandlerTestSupport.h; sourceTree = "<group>"; };
@@ -8187,6 +8201,7 @@
 				538F15DA368FBBB600D601C4 /* UnifiedSource164.cpp */,
 				538F15DF368FBBB600D601C4 /* UnifiedSource165.cpp */,
 				2AA109402F8D5DE600347316 /* UnifiedSource166.cpp */,
+				FF41D81F2FA317C2001D30AA /* UnifiedSource167.cpp */,
 			);
 			path = "unified-sources";
 			sourceTree = "<group>";
@@ -10886,18 +10901,26 @@
 			children = (
 				FF62739E2FAD56220098B5A3 /* CalendarArithmetic.cpp */,
 				FF62739D2FAD56220098B5A3 /* CalendarArithmetic.h */,
+				FFF79F932FB2F1B2003FF02A /* CalendarFields.cpp */,
+				FFF79F922FB2F1B2003FF02A /* CalendarFields.h */,
 				FF629D9C2FAE9B500098B5A3 /* CalendarICUBridge.cpp */,
 				FF629D9B2FAE9B500098B5A3 /* CalendarICUBridge.h */,
+				FFF79F952FB2F1B2003FF02A /* DurationArithmetic.cpp */,
+				FFF79F942FB2F1B2003FF02A /* DurationArithmetic.h */,
 				FF6273A02FAD56220098B5A3 /* InstantCore.cpp */,
 				FF62739F2FAD56220098B5A3 /* InstantCore.h */,
 				FF6273A22FAD56220098B5A3 /* ISOArithmetic.cpp */,
 				FF6273A12FAD56220098B5A3 /* ISOArithmetic.h */,
+				FFF79F972FB2F1B2003FF02A /* PlainDateTimeCore.cpp */,
+				FFF79F962FB2F1B2003FF02A /* PlainDateTimeCore.h */,
 				FF6273A42FAD56220098B5A3 /* Rounding.cpp */,
 				FF6273A32FAD56220098B5A3 /* Rounding.h */,
 				FF356CF32FA9832600213929 /* TemporalCoreTypes.h */,
 				FF356CF42FA9832600213929 /* TemporalEnums.h */,
 				FF629D9F2FAE9B500098B5A3 /* TimeZoneICUBridge.cpp */,
 				FF629D9E2FAE9B500098B5A3 /* TimeZoneICUBridge.h */,
+				FFF79F992FB2F1B2003FF02A /* ZonedDateTimeCore.cpp */,
+				FFF79F982FB2F1B2003FF02A /* ZonedDateTimeCore.h */,
 			);
 			path = core;
 			sourceTree = "<group>";
@@ -11326,6 +11349,7 @@
 				1409ECC0225E178100BEDD54 /* CacheUpdate.h in Headers */,
 				0FEC3C601F379F5300F59B6C /* CagedBarrierPtr.h in Headers */,
 				FF6273A82FAD56220098B5A3 /* CalendarArithmetic.h in Headers */,
+				FFF79F9B2FB2F1B2003FF02A /* CalendarFields.h in Headers */,
 				FF629DA32FAE9B500098B5A3 /* CalendarICUBridge.h in Headers */,
 				BC18C3ED0E16F5CD00B34460 /* CallData.h in Headers */,
 				0F64B27A1A7957B2006E4E66 /* CallEdge.h in Headers */,
@@ -11643,6 +11667,7 @@
 				E35CA1541DBC3A5C00F83516 /* DOMJITHeapRange.h in Headers */,
 				E350708A1DC49BBF0089BCD6 /* DOMJITSignature.h in Headers */,
 				A70447EE17A0BD7000F5898E /* DumpContext.h in Headers */,
+				FFF79F9D2FB2F1B2003FF02A /* DurationArithmetic.h in Headers */,
 				145FF2C8243BB9D600569E71 /* ECMAMode.h in Headers */,
 				2A83638618D7D0EE0000EBCC /* EdenGCActivityCallback.h in Headers */,
 				1AB2A6FB9608AD5DF73332D4 /* EmbedderArrayLike.h in Headers */,
@@ -12437,6 +12462,7 @@
 				A5AB49DD1BEC8086007020FB /* PerGlobalObjectWrapperWorld.h in Headers */,
 				23A356912E9790F40039C82A /* PinballCompletion.h in Headers */,
 				F04DFCBEDED74A4E92B8A9DA /* PinballHandlerContext.h in Headers */,
+				FFF79F9A2FB2F1B2003FF02A /* PlainDateTimeCore.h in Headers */,
 				0FE834181A6EF97B00D04847 /* PolymorphicCallStubRoutine.h in Headers */,
 				521131F71F82BF14007CCEEE /* PolyProtoAccessChain.h in Headers */,
 				0F070A4B1D543A98006E7232 /* PreciseAllocation.h in Headers */,
@@ -12955,6 +12981,7 @@
 				86704B8A12DBA33700A9FE7B /* YarrPattern.h in Headers */,
 				86704B4312DB8A8100A9FE7B /* YarrSyntaxChecker.h in Headers */,
 				659CDA5B1F6753F200D3E53F /* YarrUnicodeProperties.h in Headers */,
+				FFF79F9C2FB2F1B2003FF02A /* ZonedDateTimeCore.h in Headers */,
 				E390287D2DD1E7D90083D675 /* Zydis.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -14203,6 +14230,7 @@
 				538F15DA268FBBB600D601C4 /* UnifiedSource164.cpp in Sources */,
 				538F15DF268FBBB600D601C4 /* UnifiedSource165.cpp in Sources */,
 				2AA109412F8D5DE600347316 /* UnifiedSource166.cpp in Sources */,
+				FF41D81E2FA317C2001D30AA /* UnifiedSource167.cpp in Sources */,
 				E3C091E929B07D4C00CD6D97 /* WasmBBQJIT.cpp in Sources */,
 				4615E46B2B5849F4001D4D53 /* WasmBBQJIT64.cpp in Sources */,
 				642D20D52B476A2E0030545E /* WasmIPIntSlowPaths.cpp in Sources */,

--- a/Source/JavaScriptCore/Scripts/generate-unified-sources.sh
+++ b/Source/JavaScriptCore/Scripts/generate-unified-sources.sh
@@ -10,7 +10,7 @@ if [ -z "${BUILD_SCRIPTS_DIR}" ]; then
     BUILD_SCRIPTS_DIR="${WTF_BUILD_SCRIPTS_DIR}"
 fi
 
-UnifiedSourceCppFileCount=166
+UnifiedSourceCppFileCount=167
 UnifiedSourceCFileCount=5
 UnifiedSourceMmFileCount=0
 UnifiedSourceNonARCMmFileCount=5

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -1152,11 +1152,15 @@ runtime/WideningNumberPredictionFuzzerAgent.cpp
 runtime/WrapForValidIteratorPrototype.cpp
 
 runtime/temporal/core/CalendarArithmetic.cpp
+runtime/temporal/core/CalendarFields.cpp
 runtime/temporal/core/CalendarICUBridge.cpp
+runtime/temporal/core/DurationArithmetic.cpp
 runtime/temporal/core/InstantCore.cpp
 runtime/temporal/core/ISOArithmetic.cpp
+runtime/temporal/core/PlainDateTimeCore.cpp
 runtime/temporal/core/Rounding.cpp
 runtime/temporal/core/TimeZoneICUBridge.cpp
+runtime/temporal/core/ZonedDateTimeCore.cpp
 
 tools/CellList.cpp
 tools/CharacterPropertyDataGenerator.cpp

--- a/Source/JavaScriptCore/UnifiedSources-output.xcfilelist
+++ b/Source/JavaScriptCore/UnifiedSources-output.xcfilelist
@@ -76,6 +76,7 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/JavaScriptCore/unified-sources/UnifiedSourc
 $(BUILT_PRODUCTS_DIR)/DerivedSources/JavaScriptCore/unified-sources/UnifiedSource164.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/JavaScriptCore/unified-sources/UnifiedSource165.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/JavaScriptCore/unified-sources/UnifiedSource166.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/JavaScriptCore/unified-sources/UnifiedSource167.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/JavaScriptCore/unified-sources/UnifiedSource17.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/JavaScriptCore/unified-sources/UnifiedSource18.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/JavaScriptCore/unified-sources/UnifiedSource19.cpp

--- a/Source/JavaScriptCore/runtime/ISO8601.h
+++ b/Source/JavaScriptCore/runtime/ISO8601.h
@@ -276,7 +276,7 @@ public:
 
     Duration dateDuration() const { return m_dateDuration; }
 
-    static InternalDuration NODELETE combineDateAndTimeDuration(Duration, Int128);
+    static InternalDuration NODELETE JS_EXPORT_PRIVATE combineDateAndTimeDuration(Duration, Int128);
 private:
 
     // Time fields are ignored
@@ -487,7 +487,7 @@ uint8_t daysInMonth(uint8_t month);
 String formatTimeZoneOffsetString(int64_t);
 String temporalTimeToString(PlainTime, std::tuple<Precision, unsigned>);
 String temporalDateToString(PlainDate);
-String temporalDateTimeToString(PlainDate, PlainTime, std::tuple<Precision, unsigned>);
+String JS_EXPORT_PRIVATE temporalDateTimeToString(PlainDate, PlainTime, std::tuple<Precision, unsigned>);
 String temporalYearMonthToString(PlainYearMonth, StringView);
 String temporalMonthDayToString(PlainMonthDay, StringView);
 String monthCode(uint32_t);

--- a/Source/JavaScriptCore/runtime/IntlObject.h
+++ b/Source/JavaScriptCore/runtime/IntlObject.h
@@ -106,8 +106,8 @@ inline const LocaleSet& intlDurationFormatAvailableLocales() { return intlAvaila
 using CalendarID = unsigned;
 JS_EXPORT_PRIVATE const Vector<String>& intlAvailableCalendars();
 
-extern CalendarID iso8601CalendarIDStorage;
-CalendarID iso8601CalendarIDSlow();
+extern CalendarID JS_EXPORT_PRIVATE iso8601CalendarIDStorage;
+CalendarID JS_EXPORT_PRIVATE iso8601CalendarIDSlow();
 inline CalendarID iso8601CalendarID()
 {
     unsigned value = iso8601CalendarIDStorage;

--- a/Source/JavaScriptCore/runtime/TemporalDuration.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalDuration.cpp
@@ -466,7 +466,7 @@ ISO8601::Duration TemporalDuration::add(JSGlobalObject* globalObject, JSValue ot
 
     // FIXME: Implement relativeTo parameter after PlainDateTime / ZonedDateTime.
     auto largestUnit = std::min(largestSubduration(m_duration), largestSubduration(other));
-    if (largestUnit <= TemporalUnit::Week) {
+    if (isCalendarUnit(largestUnit)) {
         throwRangeError(globalObject, scope, "Cannot add a duration of years, months, or weeks without a relativeTo option"_s);
         return { };
     }
@@ -603,7 +603,7 @@ ISO8601::Duration TemporalDuration::subtract(JSGlobalObject* globalObject, JSVal
 
     // FIXME: Implement relativeTo parameter after PlainDateTime / ZonedDateTime.
     auto largestUnit = std::min(largestSubduration(m_duration), largestSubduration(other));
-    if (largestUnit <= TemporalUnit::Week) {
+    if (isCalendarUnit(largestUnit)) {
         throwRangeError(globalObject, scope, "Cannot subtract a duration of years, months, or weeks without a relativeTo option"_s);
         return { };
     }
@@ -906,21 +906,21 @@ void TemporalDuration::roundRelativeDuration(JSGlobalObject* globalObject, ISO86
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    bool irregularLengthUnit = smallestUnit <= TemporalUnit::Week;
+    bool irregularLengthUnit = isCalendarUnit(smallestUnit);
     int32_t sign = duration.sign() < 0 ? -1 : 1;
     NudgeResult nudgeResult;
     if (irregularLengthUnit) {
         Nudged record = nudgeToCalendarUnit(globalObject, sign, duration, destEpochNs, isoDate, increment, smallestUnit, roundingMode);
         RETURN_IF_EXCEPTION(scope, void());
-        nudgeResult = record.m_nudgeResult;
+        nudgeResult = record.nudgeResult;
     } else {
         nudgeResult = nudgeToDayOrTime(globalObject, duration, destEpochNs, largestUnit, increment, smallestUnit, roundingMode);
         RETURN_IF_EXCEPTION(scope, void());
     }
-    duration = nudgeResult.m_duration;
-    if (nudgeResult.m_didExpandCalendarUnit && smallestUnit != TemporalUnit::Week) {
+    duration = nudgeResult.duration;
+    if (nudgeResult.didExpandCalendarUnit && smallestUnit != TemporalUnit::Week) {
         auto startUnit = smallestUnit <= TemporalUnit::Day ? smallestUnit : TemporalUnit::Day;
-        duration = bubbleRelativeDuration(globalObject, sign, duration, nudgeResult.m_nudgedEpochNs, isoDate, largestUnit, startUnit);
+        duration = bubbleRelativeDuration(globalObject, sign, duration, nudgeResult.nudgedEpochNs, isoDate, largestUnit, startUnit);
         RETURN_IF_EXCEPTION(scope, void());
     }
 }
@@ -1035,12 +1035,12 @@ ISO8601::Duration TemporalDuration::round(JSGlobalObject* globalObject, JSValue 
         return { };
     }
 
-    if (largestUnit <= TemporalUnit::Week || smallestUnit <= TemporalUnit::Week) [[unlikely]] {
+    if (isCalendarUnit(largestUnit) || isCalendarUnit(smallestUnit)) [[unlikely]] {
         throwVMError(globalObject, scope, "FIXME: years, months, or weeks rounding with relativeTo not implemented yet"_s);
         return { };
     }
 
-    if (existingLargestUnit <= TemporalUnit::Week || largestUnit <= TemporalUnit::Week) [[unlikely]] {
+    if (isCalendarUnit(existingLargestUnit) || isCalendarUnit(largestUnit)) [[unlikely]] {
         throwRangeError(globalObject, scope, "Invalid largest unit for rounding"_s);
         return { };
     }
@@ -1084,7 +1084,7 @@ double TemporalDuration::total(JSGlobalObject* globalObject, JSValue optionsValu
         throwRangeError(globalObject, scope, "Cannot total a duration of years, months, or weeks without a relativeTo option"_s);
         return { };
     }
-    if (unit <= TemporalUnit::Week) {
+    if (isCalendarUnit(unit)) {
         throwVMError(globalObject, scope, "FIXME: years, months, or weeks totalling with relativeTo not implemented yet"_s);
         return { };
     }

--- a/Source/JavaScriptCore/runtime/TemporalDuration.h
+++ b/Source/JavaScriptCore/runtime/TemporalDuration.h
@@ -26,28 +26,10 @@
 
 #pragma once
 
+#include <JavaScriptCore/DurationArithmetic.h>
 #include <JavaScriptCore/ISO8601.h>
 
 namespace JSC {
-
-class NudgeResult final {
-    public:
-    ISO8601::InternalDuration m_duration;
-    Int128 m_nudgedEpochNs;
-    bool m_didExpandCalendarUnit;
-    NudgeResult() { }
-    NudgeResult(ISO8601::InternalDuration d, Int128 ns, bool expanded)
-        : m_duration(d), m_nudgedEpochNs(ns), m_didExpandCalendarUnit(expanded) { }
-};
-
-class Nudged final {
-    public:
-    NudgeResult m_nudgeResult;
-    double m_total;
-    Nudged() { }
-    Nudged(NudgeResult n, double t)
-        : m_nudgeResult(n), m_total(t) { }
-};
 
 class TemporalDuration final : public JSNonFinalObject {
 public:

--- a/Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp
+++ b/Source/JavaScriptCore/runtime/TemporalPlainDateTime.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "TemporalPlainDateTime.h"
 
+#include "ISOArithmetic.h"
 #include "IntlObjectInlines.h"
 #include "JSCInlines.h"
 #include "LazyPropertyInlines.h"
@@ -184,28 +185,6 @@ int32_t TemporalPlainDateTime::compare(TemporalPlainDateTime* plainDateTime1, Te
     return TemporalPlainTime::compare(plainDateTime1->plainTime(), plainDateTime2->plainTime());
 }
 
-static void incrementDay(ISO8601::Duration& duration)
-{
-    double year = duration.years();
-    double month = duration.months();
-    double day = duration.days();
-
-    double daysInMonth = ISO8601::daysInMonth(year, month);
-    if (day < daysInMonth) {
-        duration.setField(TemporalUnit::Day, day + 1);
-        return;
-    }
-
-    duration.setField(TemporalUnit::Day, 1);
-    if (month < 12) {
-        duration.setField(TemporalUnit::Month, month + 1);
-        return;
-    }
-
-    duration.setField(TemporalUnit::Month, 1);
-    duration.setField(TemporalUnit::Year, year + 1);
-}
-
 String TemporalPlainDateTime::toString(JSGlobalObject* globalObject, JSValue optionsValue) const
 {
     VM& vm = globalObject->vm();
@@ -232,16 +211,8 @@ String TemporalPlainDateTime::toString(JSGlobalObject* globalObject, JSValue opt
     RETURN_IF_EXCEPTION(scope, { });
 
     double extraDays = duration.days();
-    duration.setYears(static_cast<int64_t>(year()));
-    duration.setMonths(static_cast<int64_t>(month()));
-    duration.setDays(static_cast<int64_t>(day()));
-    if (extraDays) {
-        ASSERT(extraDays == 1);
-        incrementDay(duration);
-    }
-
-    auto plainDate = TemporalPlainDate::toPlainDate(globalObject, duration);
-    RETURN_IF_EXCEPTION(scope, { });
+    ASSERT(!extraDays || extraDays == 1);
+    auto plainDate = TemporalCore::balanceISODate(year(), month(), day() + static_cast<int64_t>(extraDays));
 
     return ISO8601::temporalDateTimeToString(plainDate, plainTime, data.precision);
 }
@@ -319,7 +290,7 @@ TemporalPlainDateTime* TemporalPlainDateTime::round(JSGlobalObject* globalObject
             return { };
         }
 
-        if (smallest.value() <= TemporalUnit::Week) {
+        if (isCalendarUnit(smallest.value())) {
             throwRangeError(globalObject, scope, "smallestUnit is a disallowed unit"_s);
             return { };
         }
@@ -366,16 +337,8 @@ TemporalPlainDateTime* TemporalPlainDateTime::round(JSGlobalObject* globalObject
     RETURN_IF_EXCEPTION(scope, { });
 
     double extraDays = duration.days();
-    duration.setYears(static_cast<int64_t>(year()));
-    duration.setMonths(static_cast<int64_t>(month()));
-    duration.setDays(static_cast<int64_t>(day()));
-    if (extraDays) {
-        ASSERT(extraDays == 1);
-        incrementDay(duration);
-    }
-
-    auto plainDate = TemporalPlainDate::toPlainDate(globalObject, duration);
-    RETURN_IF_EXCEPTION(scope, { });
+    ASSERT(!extraDays || extraDays == 1);
+    auto plainDate = TemporalCore::balanceISODate(year(), month(), day() + static_cast<int64_t>(extraDays));
 
     RELEASE_AND_RETURN(scope, TemporalPlainDateTime::tryCreateIfValid(globalObject, globalObject->plainDateTimeStructure(), WTF::move(plainDate), WTF::move(plainTime)));
 }

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarFields.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarFields.cpp
@@ -1,0 +1,734 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "CalendarFields.h"
+
+#include "CalendarArithmetic.h"
+#include "CalendarICUBridge.h"
+#include "ISO8601.h"
+#include "IntlObject.h"
+#include "JSCInlines.h"
+#include "TemporalCalendar.h"
+#include "TemporalObject.h"
+#include <cstdint>
+#include <wtf/DateMath.h>
+#include <wtf/MathExtras.h>
+
+namespace JSC {
+namespace TemporalCore {
+
+// temporal_rs: fields.rs ROUGH_YEAR_RANGE = -300000..300000
+static constexpr int32_t safeYearMin = -300000;
+static constexpr int32_t safeYearMax = 300000;
+// ISO reference years for PlainMonthDay — spec: CalendarMonthDayToISOReferenceDate
+// 1972 is a leap year (divisible by 4, not a century), 1971 is not.
+static constexpr int32_t isoMonthDayReferenceLeapYear = 1972;
+static constexpr int32_t isoMonthDayReferenceNonLeapYear = 1971;
+
+// temporal_rs: fields.rs check_year_in_safe_arithmetical_range
+static TemporalResult<void> checkYearRange(const CalendarFieldsIn& fields)
+{
+    if (fields.year && (*fields.year < safeYearMin || *fields.year > safeYearMax))
+        return makeUnexpected(rangeError("Date is not within representable range"_s));
+    if (fields.eraYear && (*fields.eraYear < safeYearMin || *fields.eraYear > safeYearMax))
+        return makeUnexpected(rangeError("eraYear is not within representable range"_s));
+    return { };
+}
+
+// temporal_rs: types.rs ResolvedIsoFields::try_from_fields (ISO-only resolution)
+enum class ISOResolveType : uint8_t {
+    Date,
+    YearMonth,
+    MonthDay
+};
+
+struct ResolvedISOFields {
+    int32_t year;
+    uint8_t month;
+    uint8_t day;
+};
+
+// resolveISOFields — internal helper; implements the ISO path of three spec AOs, parameterized by ISOResolveType:
+//   Date -> ISODateFromFields (#sec-temporal-isodatefromfields)
+//   YearMonth -> ISOYearMonthFromFields (#sec-temporal-isoyearmonthfromfields)
+//   MonthDay -> ISOMonthDayFromFields (#sec-temporal-isomonthdayfromfields)
+// temporal_rs: types.rs ResolvedIsoFields::try_from_fields
+static TemporalResult<ResolvedISOFields> resolveISOFields(const CalendarFieldsIn& fields, TemporalOverflow overflow, ISOResolveType type)
+{
+    auto rangeCheck = checkYearRange(fields);
+    if (!rangeCheck)
+        return makeUnexpected(rangeCheck.error());
+
+    // Resolve year: MonthDay uses reference year; others require explicit year field.
+    int32_t year;
+    if (type == ISOResolveType::MonthDay)
+        year = isoMonthDayReferenceLeapYear;
+    else {
+        if (!fields.year)
+            return makeUnexpected(typeError("year property must be present"_s));
+        year = *fields.year;
+    }
+
+    // Resolve day: YearMonth uses day=1; others require explicit day field.
+    uint8_t day;
+    if (type == ISOResolveType::YearMonth)
+        day = 1;
+    else {
+        if (!fields.day)
+            return makeUnexpected(typeError("day property must be present"_s));
+        day = *fields.day;
+    }
+
+    // Resolve month: prefer month over monthCode; validate consistency if both present.
+    uint32_t month;
+    if (fields.month && !fields.monthCode) {
+        month = *fields.month;
+    } else if (fields.monthCode) {
+        auto& mc = *fields.monthCode;
+        if (mc.isLeapMonth)
+            return makeUnexpected(rangeError("iso8601 calendar does not have leap months"_s));
+        if (mc.monthNumber < 1 || mc.monthNumber > 12)
+            return makeUnexpected(rangeError("month must be 1-12 for iso8601 calendar"_s));
+        uint8_t codeMonth = static_cast<uint8_t>(mc.monthNumber);
+        if (fields.month && *fields.month != codeMonth)
+            return makeUnexpected(rangeError("month does not match monthCode"_s));
+        month = codeMonth;
+    } else if (!fields.month)
+        return makeUnexpected(typeError("month or monthCode property must be present"_s));
+    else
+        month = *fields.month;
+
+    // Constrain or reject month and day per overflow.
+    if (month < 1 || month > 12) {
+        if (overflow == TemporalOverflow::Constrain)
+            month = clampTo<uint8_t>(month, 1, 12);
+        else
+            return makeUnexpected(rangeError("month is out of range"_s));
+    }
+
+    uint8_t maxDay = ISO8601::daysInMonth(year, month);
+    if (day < 1 || day > maxDay) {
+        if (overflow == TemporalOverflow::Constrain)
+            day = clampTo<uint8_t>(day, 1, maxDay);
+        else
+            return makeUnexpected(rangeError("day is out of range"_s));
+    }
+
+    return ResolvedISOFields { year, static_cast<uint8_t>(month), day };
+}
+
+// CalendarDateFromFields — temporal_rs: Calendar::date_from_fields (src/builtins/core/calendar.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal-calendardatefromfields
+// Implements steps 1-4; PrepareCalendarFields done by JS-layer caller.
+TemporalResult<ResolvedCalendarDate> dateFromFields(CalendarID calendarId, const CalendarFieldsIn& fields, TemporalOverflow overflow)
+{
+    bool isISO = calendarIsISO(calendarId);
+
+    // Steps 1-2: CalendarResolveFields + CalendarDateToISO — fused into resolveISOFields (ISO path).
+    if (isISO) {
+        auto resolved = resolveISOFields(fields, overflow, ISOResolveType::Date);
+        if (!resolved)
+            return makeUnexpected(resolved.error());
+
+        auto isoDate = ISO8601::PlainDate(resolved->year, resolved->month, resolved->day);
+        // Step 3: If ISODateWithinLimits(result) is false, throw RangeError.
+        if (!ISO8601::isDateTimeWithinLimits(isoDate.year(), isoDate.month(), isoDate.day(), 12, 0, 0, 0, 0, 0))
+            return makeUnexpected(rangeError("Date is not within representable range"_s));
+
+        // Step 4: Return result.
+        return ResolvedCalendarDate { isoDate, "iso8601"_s };
+    }
+
+    // Steps 1-2 (non-ISO): CalendarResolveFields + CalendarDateToISO via ICU bridge.
+    auto rangeCheck = checkYearRange(fields);
+    if (!rangeCheck)
+        return makeUnexpected(rangeCheck.error());
+
+    // Non-lunisolar calendars have no leap months — reject leap month codes.
+    if (fields.monthCode && fields.monthCode->isLeapMonth && !calendarIsLunisolar(calendarId))
+        return makeUnexpected(rangeError("Leap month codes are not valid for this calendar"_s));
+
+    bool hasEraYear = fields.era.has_value() && fields.eraYear.has_value();
+    if (!fields.year && !hasEraYear)
+        return makeUnexpected(typeError("year property must be present"_s));
+    if (!fields.day)
+        return makeUnexpected(typeError("day property must be present"_s));
+
+    // Resolve month from month/monthCode
+    uint8_t month = 1;
+    if (fields.month)
+        month = *fields.month;
+    else if (fields.monthCode)
+        month = static_cast<uint8_t>(fields.monthCode->monthNumber);
+
+    int32_t year = fields.year.value_or(0);
+    std::optional<StringView> era;
+    if (fields.era)
+        era = StringView(*fields.era);
+
+    auto result = calendarDateFromFields(calendarId, year, month, *fields.day, era, fields.eraYear, fields.monthCode, overflow);
+    if (!result)
+        return makeUnexpected(result.error());
+
+    // Step 3: If ISODateWithinLimits(result) is false, throw RangeError.
+    if (!ISO8601::isDateTimeWithinLimits(result->year(), result->month(), result->day(), 12, 0, 0, 0, 0, 0))
+        return makeUnexpected(rangeError("Date is not within representable range"_s));
+
+    // Step 4: Return result.
+    return ResolvedCalendarDate { *result, calendarIDToString(calendarId).toString() };
+}
+
+// CalendarYearMonthFromFields — temporal_rs: Calendar::year_month_from_fields (src/builtins/core/calendar.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal-calendaryearmonthfromfields
+// Implements steps 1-5; PrepareCalendarFields done by JS-layer caller.
+TemporalResult<ResolvedCalendarDate> yearMonthFromFields(CalendarID calendarId, const CalendarFieldsIn& fields, TemporalOverflow overflow)
+{
+    bool isISO = calendarIsISO(calendarId);
+
+    // Steps 1-3: set [[Day]]=1 + CalendarResolveFields + CalendarDateToISO — fused into resolveISOFields.
+    if (isISO) {
+        auto resolved = resolveISOFields(fields, overflow, ISOResolveType::YearMonth);
+        if (!resolved)
+            return makeUnexpected(resolved.error());
+
+        auto isoDate = ISO8601::PlainDate(resolved->year, resolved->month, resolved->day);
+        // Step 4: If ISOYearMonthWithinLimits(result) is false, throw RangeError.
+        if (!ISO8601::isYearMonthWithinLimits(isoDate.year(), isoDate.month()))
+            return makeUnexpected(rangeError("YearMonth is not within representable range"_s));
+
+        // Step 5: Return result.
+        return ResolvedCalendarDate { isoDate, "iso8601"_s };
+    }
+
+    // Steps 1-3 (non-ISO): set [[Day]]=1 + CalendarResolveFields + CalendarDateToISO via ICU bridge.
+    auto rangeCheck = checkYearRange(fields);
+    if (!rangeCheck)
+        return makeUnexpected(rangeCheck.error());
+
+    // Non-lunisolar calendars have no leap months — reject leap month codes.
+    if (fields.monthCode && fields.monthCode->isLeapMonth && !calendarIsLunisolar(calendarId))
+        return makeUnexpected(rangeError("Leap month codes are not valid for this calendar"_s));
+
+    bool hasEraYear = fields.era.has_value() && fields.eraYear.has_value();
+    if (!fields.year && !hasEraYear)
+        return makeUnexpected(typeError("year property must be present"_s));
+
+    uint8_t month = 1;
+    if (fields.month)
+        month = *fields.month;
+    else if (fields.monthCode)
+        month = static_cast<uint8_t>(fields.monthCode->monthNumber);
+
+    int32_t year = fields.year.value_or(0);
+    std::optional<StringView> era;
+    if (fields.era)
+        era = StringView(*fields.era);
+
+    auto result = calendarDateFromFields(calendarId, year, month, 1, era, fields.eraYear, fields.monthCode, overflow);
+    if (!result)
+        return makeUnexpected(result.error());
+
+    // Step 4: If ISOYearMonthWithinLimits(result) is false, throw RangeError.
+    if (!ISO8601::isYearMonthWithinLimits(result->year(), result->month()))
+        return makeUnexpected(rangeError("YearMonth is not within representable range"_s));
+
+    // Step 5: Return result.
+    return ResolvedCalendarDate { *result, calendarIDToString(calendarId).toString() };
+}
+
+// CalendarMonthDayFromFields — temporal_rs: Calendar::month_day_from_fields (src/builtins/core/calendar.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal-calendarmonthdayfromfields
+// Implements steps 1-4; PrepareCalendarFields done by JS-layer caller.
+TemporalResult<ResolvedCalendarDate> monthDayFromFields(CalendarID calendarId, const CalendarFieldsIn& fields, TemporalOverflow overflow)
+{
+    bool isISO = calendarIsISO(calendarId);
+
+    // Steps 1-2: CalendarResolveFields + CalendarMonthDayToISOReferenceDate — fused inline (ISO path).
+    if (isISO) {
+        // temporal_rs: if year is provided, validate day against that year first,
+        // then use reference year 1972 for the stored date.
+        // Per spec: the year is ONLY used for overflow (leap year check), NOT for range validation.
+        if (fields.year) {
+            // Substitute a proxy year with the same leap-year property to avoid range errors.
+            // This matches the spec requirement that year is not range-checked for PlainMonthDay.
+            CalendarFieldsIn fieldsForOverflow = fields;
+            int32_t yr = *fields.year;
+            // Determine leap year status: divisible by 4, except centuries unless also by 400.
+            bool isLeap = !(yr % 400) || (!(yr % 4) && yr % 100);
+            fieldsForOverflow.year = isLeap ? isoMonthDayReferenceLeapYear : isoMonthDayReferenceNonLeapYear;
+            auto resolved = resolveISOFields(fieldsForOverflow, overflow, ISOResolveType::Date);
+            if (!resolved)
+                return makeUnexpected(resolved.error());
+            // Step 3: Assert: ISODateWithinLimits(result) — always holds for reference year 1972.
+            ASSERT(ISO8601::isDateTimeWithinLimits(isoMonthDayReferenceLeapYear, resolved->month, resolved->day, 12, 0, 0, 0, 0, 0));
+            auto isoDate = ISO8601::PlainDate(isoMonthDayReferenceLeapYear, resolved->month, resolved->day);
+            // Step 4: Return result.
+            return ResolvedCalendarDate { isoDate, "iso8601"_s };
+        }
+        auto resolved = resolveISOFields(fields, overflow, ISOResolveType::MonthDay);
+        if (!resolved)
+            return makeUnexpected(resolved.error());
+
+        auto isoDate = ISO8601::PlainDate(isoMonthDayReferenceLeapYear, resolved->month, resolved->day);
+        // Step 3: Assert: ISODateWithinLimits(result) — always holds for reference year 1972.
+        ASSERT(ISO8601::isDateTimeWithinLimits(isoMonthDayReferenceLeapYear, resolved->month, resolved->day, 12, 0, 0, 0, 0, 0));
+        // Step 4: Return result.
+        return ResolvedCalendarDate { isoDate, "iso8601"_s };
+    }
+
+    // Steps 1-2 (non-ISO): CalendarResolveFields + CalendarMonthDayToISOReferenceDate via ICU bridge.
+    auto rangeCheck = checkYearRange(fields);
+    if (!rangeCheck)
+        return makeUnexpected(rangeCheck.error());
+
+    // Non-lunisolar calendars have no leap months — reject leap month codes.
+    if (fields.monthCode && fields.monthCode->isLeapMonth && !calendarIsLunisolar(calendarId))
+        return makeUnexpected(rangeError("Leap month codes are not valid for this calendar"_s));
+
+    if (!fields.day)
+        return makeUnexpected(typeError("day property must be present"_s));
+
+    // Non-ISO MonthDay requires monthCode (not just month).
+    if (!fields.monthCode && !fields.year)
+        return makeUnexpected(typeError("monthCode is required for non-ISO calendar MonthDay"_s));
+
+    uint8_t month = 1;
+    if (fields.month)
+        month = *fields.month;
+    else if (fields.monthCode)
+        month = static_cast<uint8_t>(fields.monthCode->monthNumber);
+
+    // Default year: use ecmaReferenceYear (ported from icu4x) for non-ISO MonthDay.
+    int32_t year;
+    bool usedRegularMonthFallback = false;
+    if (fields.year)
+        year = *fields.year;
+    else if (fields.monthCode) {
+        year = ecmaReferenceYear(calendarId, fields.monthCode->monthNumber, fields.monthCode->isLeapMonth, fields.day ? *fields.day : 1);
+        // icu4x: UseRegularIfConstrain — leap month has no reference year near 1972.
+        // Constrain: fall back to the non-leap version's reference year AND strip the leap flag.
+        // Reject: throw RangeError (this leap month configuration doesn't exist).
+        if (year == ecmaRefYearNotInCalendar)
+            return makeUnexpected(rangeError("This month code does not exist in this calendar"_s));
+        if (year == ecmaRefYearUseRegular) {
+            if (overflow == TemporalOverflow::Constrain) {
+                year = ecmaReferenceYear(calendarId, fields.monthCode->monthNumber, false, fields.day ? *fields.day : 1);
+                usedRegularMonthFallback = true;
+            } else
+                return makeUnexpected(rangeError("This leap month does not exist in this calendar near the reference year"_s));
+        }
+    } else
+        RELEASE_ASSERT_NOT_REACHED();
+
+    // ecmaReferenceYear returns ISO proleptic years (e.g., 1972).
+    // Chinese and Dangi are lunisolar calendars sharing the same ICU code path (chnsecal.cpp).
+    // On older Apple ICU, UCAL_EXTENDED_YEAR uses epoch-based counting instead of ISO years.
+    // We probe what year ICU assigns to ISO 1972-02-15 (Chinese New Year 1972), then use
+    //   chineseEpochOffset = probe_year - 1972
+    // where probe_year = 1972 on modern ICU (offset = 0, no-op) or the epoch-based year on
+    // older Apple ICU (offset = that year - 1972).
+    static const int32_t chineseExtYear1972 = chineseCalendarExtendedYearFor1972();
+    static const int32_t chineseEpochOffset = chineseExtYear1972 - 1972;
+    auto calStr = calendarIDToString(calendarId);
+    bool isChineseOrDangi = (calStr == "chinese"_s || calStr == "dangi"_s);
+    if (!fields.year && isChineseOrDangi)
+        year += chineseEpochOffset;
+    std::optional<StringView> era;
+    if (fields.era)
+        era = StringView(*fields.era);
+
+    // When using the regular-month fallback, use a non-leap monthCode so ICU doesn't
+    // look for a leap month in the reference year.
+    std::optional<ParsedMonthCode> regularMonthCode;
+    const std::optional<ParsedMonthCode>* effectiveMonthCode = &fields.monthCode;
+    if (usedRegularMonthFallback && fields.monthCode) {
+        regularMonthCode = ParsedMonthCode { fields.monthCode->monthNumber, false };
+        effectiveMonthCode = &regularMonthCode;
+    }
+
+    auto result = calendarDateFromFields(calendarId, year, month, *fields.day, era, fields.eraYear, *effectiveMonthCode, overflow);
+    if (!result)
+        return makeUnexpected(result.error());
+
+    // For MonthDay with year provided: validate ISO range, then re-resolve with
+    // reference year to get canonical reference ISO date per spec.
+    if (fields.year || (fields.era && fields.eraYear)) {
+        if (!ISO8601::isYearWithinLimits(result->year()))
+            return makeUnexpected(rangeError("Date is not within representable range"_s));
+
+        // Re-resolve: get monthCode+day from first resolution, then use ecmaReferenceYear.
+        auto resolvedFields = isoToCalendarFields(calendarId, *result);
+        if (resolvedFields && !resolvedFields->monthCode.isEmpty()) {
+            auto resolvedMonthCode = ISO8601::parseMonthCode(resolvedFields->monthCode);
+            if (resolvedMonthCode) {
+                int32_t refYear = ecmaReferenceYear(calendarId, resolvedMonthCode->monthNumber, resolvedMonthCode->isLeapMonth, resolvedFields->day);
+                if (isChineseOrDangi && chineseEpochOffset)
+                    refYear += chineseEpochOffset;
+                auto refResult = calendarDateFromFields(calendarId, refYear, resolvedFields->month, resolvedFields->day, std::nullopt, std::nullopt, resolvedMonthCode, TemporalOverflow::Constrain);
+                if (refResult)
+                    return ResolvedCalendarDate { *refResult, calendarIDToString(calendarId).toString() };
+            }
+        }
+    }
+
+    // Step 3: Assert: ISODateWithinLimits(result) — reference year is always within limits.
+    ASSERT(ISO8601::isDateTimeWithinLimits(result->year(), result->month(), result->day(), 12, 0, 0, 0, 0, 0));
+    // Step 4: Return result.
+    return ResolvedCalendarDate { *result, calendarIDToString(calendarId).toString() };
+}
+
+// plainYearMonthWith — temporal_rs: PlainYearMonth::with (src/builtins/core/plain_year_month.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.with
+// Implements inner merge steps; IsPartialTemporalObject and PrepareCalendarFields done by JS-layer caller.
+TemporalResult<ResolvedCalendarDate> plainYearMonthWith(CalendarID calendarId, const ISO8601::PlainDate& currentISODate, const CalendarFieldsIn& partialFields, TemporalOverflow overflow)
+{
+    // Step 3: Assert at least one field is user-provided (IsPartialTemporalObject equivalent).
+    if (!partialFields.year && !partialFields.month && !partialFields.monthCode
+        && !partialFields.era && !partialFields.eraYear)
+        return makeUnexpected(typeError("at least one field (year, month, monthCode, era, or eraYear) must be provided"_s));
+
+    bool isISO = calendarIsISO(calendarId);
+
+    if (isISO) {
+        // ISO: same merge logic as temporal_rs with_fallback_year_month.
+        CalendarFieldsIn merged;
+        merged.year = partialFields.year.has_value() ? partialFields.year : std::optional<int32_t>(currentISODate.year());
+        // temporal_rs: impl_with_fallback_method! — month: user's value only, no fallback
+        merged.month = partialFields.month;
+        // monthCode: user's overrides; fallback from current only if neither month nor monthCode provided
+        merged.monthCode = partialFields.monthCode;
+        if (!partialFields.month.has_value() && !partialFields.monthCode)
+            merged.monthCode = ISO8601::parseMonthCode(ISO8601::monthCode(currentISODate.month()));
+        return yearMonthFromFields(calendarId, merged, overflow);
+    }
+
+    // Non-ISO: get calendar fields from current date, merge with user partial fields.
+    // temporal_rs: impl_with_fallback_method! macro and impl_field_keys_to_ignore! macro (fields.rs).
+    auto calFields = isoToCalendarFields(calendarId, currentISODate);
+    if (!calFields)
+        return makeUnexpected(calFields.error());
+
+    // temporal_rs: impl_field_keys_to_ignore! — determine which fallback fields to suppress
+    bool keysToIgnoreMonth = partialFields.month.has_value() || partialFields.monthCode.has_value();
+    bool hasEras = calendarHasEras(calendarId);
+    bool keysToIgnoreEra = false;
+    bool keysToIgnoreYear = false;
+    if (hasEras) {
+        if (partialFields.year.has_value() || partialFields.eraYear.has_value() || partialFields.era.has_value()) {
+            keysToIgnoreEra = true;
+            keysToIgnoreYear = true;
+        }
+    }
+
+    CalendarFieldsIn merged;
+
+    // temporal_rs: impl_with_fallback_method! — era/eraYear: fallback from current if !keysToIgnoreEra
+    merged.era = partialFields.era;
+    merged.eraYear = partialFields.eraYear;
+    if (!keysToIgnoreEra) {
+        if (!merged.era && calFields->era.has_value() && !calFields->era->isEmpty())
+            merged.era = *calFields->era;
+        if (!merged.eraYear && calFields->eraYear.has_value())
+            merged.eraYear = *calFields->eraYear;
+    }
+
+    // temporal_rs: impl_with_fallback_method! — year: fallback from current if !keysToIgnoreYear
+    merged.year = partialFields.year;
+    if (!keysToIgnoreYear && !merged.year)
+        merged.year = std::optional<int32_t>(calFields->year);
+
+    // temporal_rs: impl_with_fallback_method! — month: user's value only, NEVER fallback
+    merged.month = partialFields.month;
+
+    // temporal_rs: impl_with_fallback_method! — monthCode: fallback ONLY when neither month nor monthCode provided
+    merged.monthCode = partialFields.monthCode;
+    if (!partialFields.month.has_value() && !partialFields.monthCode.has_value() && !keysToIgnoreMonth) {
+        if (!calFields->monthCode.isEmpty())
+            merged.monthCode = ISO8601::parseMonthCode(calFields->monthCode);
+    }
+
+    return yearMonthFromFields(calendarId, merged, overflow);
+}
+
+// differenceYearMonth — temporal_rs: PlainYearMonth::diff (src/builtins/core/plain_year_month.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal-differencetemporalplainyearmonth
+// Implements steps 7-14; steps 1-6 and rounding (steps 15-16) done by JS-layer caller.
+TemporalResult<ISO8601::Duration> differenceYearMonth(CalendarID calendarId, const ISO8601::PlainDate& thisISODate, const ISO8601::PlainDate& otherISODate, TemporalUnit largestUnit)
+{
+    bool isISO = calendarIsISO(calendarId);
+
+    if (isISO) {
+        // Steps 7-8: set [[Day]]=1 on both dates; ISODateWithinLimits check.
+        auto thisDate = ISO8601::PlainDate(thisISODate.year(), thisISODate.month(), 1);
+        auto otherDate = ISO8601::PlainDate(otherISODate.year(), otherISODate.month(), 1);
+        if (std::abs(dateToDaysFrom1970(thisDate.year(), static_cast<int>(thisDate.month()) - 1, 1)) > 1e8
+            || std::abs(dateToDaysFrom1970(otherDate.year(), static_cast<int>(otherDate.month()) - 1, 1)) > 1e8)
+            return makeUnexpected(rangeError("date is outside the representable range for Temporal"_s));
+        // Steps 10-14: CalendarDateUntil(thisDate, otherDate, largestUnit).
+        return calendarDateUntil(thisDate, otherDate, largestUnit);
+    }
+
+    // Non-ISO: resolve both to day=1 via dateFromFields (matching temporal_rs).
+    // This re-resolves the ISO date through the calendar pipeline with day=1.
+    // Step 7: ISODateToFields(calendar, thisISODate, year-month); set [[Day]] to 1; CalendarDateFromFields.
+    auto thisCalFields = isoToCalendarFields(calendarId, thisISODate);
+    if (!thisCalFields)
+        return makeUnexpected(thisCalFields.error());
+    CalendarFieldsIn thisFields;
+    thisFields.year = thisCalFields->year;
+    thisFields.month = thisCalFields->month;
+    thisFields.day = 1;
+    if (!thisCalFields->monthCode.isEmpty())
+        thisFields.monthCode = ISO8601::parseMonthCode(thisCalFields->monthCode);
+    auto thisResolved = dateFromFields(calendarId, thisFields, TemporalOverflow::Constrain);
+    if (!thisResolved)
+        return makeUnexpected(thisResolved.error());
+
+    // Steps 8-9: ISODateToFields(calendar, otherISODate, year-month); set [[Day]] to 1; CalendarDateFromFields.
+    auto otherCalFields = isoToCalendarFields(calendarId, otherISODate);
+    if (!otherCalFields)
+        return makeUnexpected(otherCalFields.error());
+    CalendarFieldsIn otherFields;
+    otherFields.year = otherCalFields->year;
+    otherFields.month = otherCalFields->month;
+    otherFields.day = 1;
+    if (!otherCalFields->monthCode.isEmpty())
+        otherFields.monthCode = ISO8601::parseMonthCode(otherCalFields->monthCode);
+    auto otherResolved = dateFromFields(calendarId, otherFields, TemporalOverflow::Constrain);
+    if (!otherResolved)
+        return makeUnexpected(otherResolved.error());
+
+    // Steps 10-14: CalendarDateUntil(thisDate, otherDate, largestUnit).
+    return calendarDateUntil(calendarId, thisResolved->isoDate, otherResolved->isoDate, largestUnit);
+}
+
+// plainYearMonthAdd — temporal_rs: PlainYearMonth::add_duration (src/builtins/core/plain_year_month.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal-adddurationtoyearmonth
+// Implements steps 9-15; steps 1-8 done by JS-layer caller.
+TemporalResult<ResolvedCalendarDate> plainYearMonthAdd(CalendarID calendarId, const ISO8601::PlainDate& currentISODate, const ISO8601::Duration& duration, TemporalOverflow overflow)
+{
+    bool isISO = calendarIsISO(calendarId);
+
+    if (isISO) {
+        // Step 1: Get calendar fields from currentISODate (year + monthCode), set day=1.
+        CalendarFieldsIn fields;
+        fields.year = currentISODate.year();
+        fields.month = currentISODate.month();
+        fields.monthCode = ISO8601::parseMonthCode(ISO8601::monthCode(currentISODate.month()));
+        fields.day = 1;
+        // Step 2: CalendarDateFromFields -> PlainDate.
+        auto dateResult = dateFromFields(calendarId, fields, TemporalOverflow::Constrain);
+        if (!dateResult)
+            return makeUnexpected(dateResult.error());
+        // Step 3: CalendarDateAdd(duration) -> addedDate.
+        // ISO: bypass ICU bridge and use pure isoDateAdd — handles extreme boundary dates
+        // correctly (year ±271821) without ICU calendar clamping.
+        auto addedISO = calendarDateAdd(dateResult->isoDate, duration, overflow);
+        if (!addedISO)
+            return makeUnexpected(addedISO.error());
+        // Steps 4-5: Get year + monthCode from addedDate; CalendarYearMonthFromFields -> result PYM ISO date.
+        CalendarFieldsIn addedFields;
+        addedFields.year = addedISO->year();
+        addedFields.monthCode = ISO8601::parseMonthCode(ISO8601::monthCode(addedISO->month()));
+        return yearMonthFromFields(calendarId, addedFields, overflow);
+    }
+
+    // Non-ISO: temporal_rs add_duration steps 9-15.
+    // Step 1: ISODateToFields(calendar, yearMonth.[[ISODate]], year-month) -> year + monthCode, day=1.
+    auto calFields = isoToCalendarFields(calendarId, currentISODate);
+    if (!calFields)
+        return makeUnexpected(calFields.error());
+
+    CalendarFieldsIn fieldsDay1;
+    fieldsDay1.year = calFields->year;
+    fieldsDay1.day = 1;
+    if (!calFields->monthCode.isEmpty())
+        fieldsDay1.monthCode = ISO8601::parseMonthCode(calFields->monthCode);
+    else
+        fieldsDay1.month = calFields->month;
+    if (calFields->era.has_value() && calFields->eraYear.has_value()) {
+        fieldsDay1.era = *calFields->era;
+        fieldsDay1.eraYear = *calFields->eraYear;
+    }
+
+    // Step 2: CalendarDateFromFields -> PlainDate ISO.
+    auto dateResult = dateFromFields(calendarId, fieldsDay1, TemporalOverflow::Constrain);
+    if (!dateResult)
+        return makeUnexpected(dateResult.error());
+
+    // Step 3: CalendarDateAdd(duration) -> addedDate ISO.
+    auto addedISO = calendarDateAdd(calendarId, dateResult->isoDate, duration, overflow);
+    if (!addedISO)
+        return makeUnexpected(addedISO.error());
+
+    // Step 4: Get year + monthCode from addedDate.
+    auto addedCalFields = isoToCalendarFields(calendarId, *addedISO);
+    if (!addedCalFields)
+        return makeUnexpected(addedCalFields.error());
+
+    CalendarFieldsIn addedFields;
+    addedFields.year = addedCalFields->year;
+    if (!addedCalFields->monthCode.isEmpty())
+        addedFields.monthCode = ISO8601::parseMonthCode(addedCalFields->monthCode);
+    else
+        addedFields.month = addedCalFields->month;
+    if (addedCalFields->era.has_value() && addedCalFields->eraYear.has_value()) {
+        addedFields.era = *addedCalFields->era;
+        addedFields.eraYear = *addedCalFields->eraYear;
+    }
+
+    // Step 5: CalendarYearMonthFromFields -> result PYM ISO date.
+    return yearMonthFromFields(calendarId, addedFields, overflow);
+}
+
+// plainYearMonthToPlainDate — temporal_rs: PlainYearMonth::to_plain_date (src/builtins/core/plain_year_month.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal.plainyearmonth.prototype.toplaindate
+// Implements steps 5, 7, 8; steps 1-4, 6, 9 done by JS-layer caller.
+TemporalResult<ResolvedCalendarDate> plainYearMonthToPlainDate(CalendarID calendarId, const ISO8601::PlainDate& pymISODate, uint8_t day)
+{
+    bool isISO = calendarIsISO(calendarId);
+
+    if (isISO) {
+        // Steps 5+7 (ISO): year/month from pymISODate; merge day.
+        CalendarFieldsIn fields;
+        fields.year = pymISODate.year();
+        fields.month = pymISODate.month();
+        fields.day = day;
+        // Step 8: CalendarDateFromFields(~constrain~).
+        return dateFromFields(calendarId, fields, TemporalOverflow::Constrain);
+    }
+
+    // Steps 5+7 (non-ISO): ISODateToFields via ICU bridge; merge day.
+    auto yearResult = calendarYear(calendarId, pymISODate);
+    if (!yearResult)
+        return makeUnexpected(yearResult.error());
+    auto monthCodeStr = calendarMonthCode(calendarId, pymISODate);
+    if (!monthCodeStr)
+        return makeUnexpected(monthCodeStr.error());
+
+    CalendarFieldsIn fields;
+    fields.year = *yearResult;
+    fields.day = day;
+    fields.monthCode = ISO8601::parseMonthCode(*monthCodeStr);
+    // Step 8: CalendarDateFromFields(~constrain~).
+    return dateFromFields(calendarId, fields, TemporalOverflow::Constrain);
+}
+
+// plainYearMonthFromISODate — no 1:1 temporal_rs function; inlined in PlainYearMonth::from_parsed
+// https://tc39.es/proposal-temporal/#sec-temporal-totemporalyearmonth (string parse path)
+// Implements steps 10, 12; step 9 (ISOYearMonthWithinLimits) done by JS-layer caller.
+TemporalResult<ResolvedCalendarDate> plainYearMonthFromISODate(CalendarID calendarId, const ISO8601::PlainDate& fullISODate)
+{
+    bool isISO = calendarIsISO(calendarId);
+
+    if (isISO) {
+        // ISO path: year/month from fullISODate; yearMonthFromFields stores with day=1.
+        CalendarFieldsIn fields;
+        fields.year = fullISODate.year();
+        fields.month = fullISODate.month();
+        return yearMonthFromFields(calendarId, fields, TemporalOverflow::Constrain);
+    }
+
+    // Step 10 (non-ISO): ISODateToFields via ICU bridge — gets year + monthCode.
+    auto yearResult = calendarYear(calendarId, fullISODate);
+    if (!yearResult)
+        return makeUnexpected(yearResult.error());
+    auto monthCodeStr = calendarMonthCode(calendarId, fullISODate);
+    if (!monthCodeStr)
+        return makeUnexpected(monthCodeStr.error());
+
+    CalendarFieldsIn fields;
+    fields.year = *yearResult;
+    fields.day = 1;
+    fields.monthCode = ISO8601::parseMonthCode(*monthCodeStr);
+    // Step 12: CalendarYearMonthFromFields(~constrain~) per spec note.
+    return yearMonthFromFields(calendarId, fields, TemporalOverflow::Constrain);
+}
+
+// plainMonthDayToPlainDate — temporal_rs: PlainMonthDay::to_plain_date (src/builtins/core/plain_month_day.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal.plainmonthday.prototype.toplaindate
+// Implements steps 5, 7, 8; steps 1-4, 6, 9 done by JS-layer caller.
+TemporalResult<ResolvedCalendarDate> plainMonthDayToPlainDate(CalendarID calendarId, const ISO8601::PlainDate& pmdISODate, int32_t year)
+{
+    bool isISO = calendarIsISO(calendarId);
+
+    if (isISO) {
+        // Steps 5+7: ISO ISODateToFields gives month directly; merge year.
+        CalendarFieldsIn fields;
+        fields.year = year;
+        fields.month = pmdISODate.month();
+        fields.day = pmdISODate.day();
+        // Step 8: CalendarDateFromFields(~constrain~).
+        return dateFromFields(calendarId, fields, TemporalOverflow::Constrain);
+    }
+
+    // Steps 5+7 (non-ISO): ISODateToFields via ICU bridge, then merge year.
+    auto monthCodeStr = calendarMonthCode(calendarId, pmdISODate);
+    if (!monthCodeStr)
+        return makeUnexpected(monthCodeStr.error());
+    auto dayResult = calendarDay(calendarId, pmdISODate);
+    if (!dayResult)
+        return makeUnexpected(dayResult.error());
+
+    CalendarFieldsIn fields;
+    fields.year = year;
+    fields.monthCode = ISO8601::parseMonthCode(*monthCodeStr);
+    fields.day = static_cast<uint8_t>(*dayResult);
+    // Step 8: CalendarDateFromFields(~constrain~).
+    return dateFromFields(calendarId, fields, TemporalOverflow::Constrain);
+}
+
+// https://tc39.es/proposal-temporal/#sec-temporal-totemporalmonthday (string parse path)
+// Implements steps 10, 12; step 9 (ISODateWithinLimits) done by JS-layer caller.
+TemporalResult<ResolvedCalendarDate> plainMonthDayFromISODate(CalendarID calendarId, const ISO8601::PlainDate& fullISODate, TemporalOverflow overflow)
+{
+    bool isISO = calendarIsISO(calendarId);
+
+    if (isISO) {
+        // ISO path (spec step 7): store directly with reference year 1972.
+        CalendarFieldsIn fields;
+        fields.month = fullISODate.month();
+        fields.day = fullISODate.day();
+        return monthDayFromFields(calendarId, fields, overflow);
+    }
+
+    // Step 10: ISODateToFields(calendar, fullISODate, ~month-day~) — gets monthCode + day.
+    auto monthCodeStr = calendarMonthCode(calendarId, fullISODate);
+    if (!monthCodeStr)
+        return makeUnexpected(monthCodeStr.error());
+    auto dayResult = calendarDay(calendarId, fullISODate);
+    if (!dayResult)
+        return makeUnexpected(dayResult.error());
+
+    CalendarFieldsIn fields;
+    fields.monthCode = ISO8601::parseMonthCode(*monthCodeStr);
+    fields.day = static_cast<uint8_t>(*dayResult);
+    // Step 12: caller must pass TemporalOverflow::Constrain per spec note.
+    return monthDayFromFields(calendarId, fields, overflow);
+}
+
+} // namespace TemporalCore
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarFields.h
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarFields.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+// JSC Temporal Core — Calendar field resolution (dateFromFields, yearMonthFromFields, monthDayFromFields)
+// temporal_rs reference: src/builtins/core/calendar.rs, types.rs, fields.rs
+
+#include <JavaScriptCore/ISO8601.h>
+#include <JavaScriptCore/IntlObject.h>
+#include <JavaScriptCore/JSExportMacros.h>
+#include <JavaScriptCore/TemporalCoreTypes.h>
+#include <JavaScriptCore/TemporalEnums.h>
+#include <optional>
+#include <wtf/text/WTFString.h>
+
+namespace JSC {
+
+struct ParsedMonthCode;
+
+namespace TemporalCore {
+
+// Input fields for calendar date resolution.
+// Maps to temporal_rs CalendarFields.
+struct CalendarFieldsIn {
+    std::optional<int32_t> year;
+    std::optional<uint32_t> month;
+    std::optional<ParsedMonthCode> monthCode;
+    std::optional<uint8_t> day;
+    std::optional<String> era;
+    std::optional<int32_t> eraYear;
+};
+
+// Result of calendar field resolution: ISO date + calendar ID.
+struct ResolvedCalendarDate {
+    ISO8601::PlainDate isoDate;
+    String calendarId;
+};
+
+TemporalResult<ResolvedCalendarDate> JS_EXPORT_PRIVATE dateFromFields(CalendarID, const CalendarFieldsIn&, TemporalOverflow);
+
+TemporalResult<ResolvedCalendarDate> JS_EXPORT_PRIVATE yearMonthFromFields(CalendarID, const CalendarFieldsIn&, TemporalOverflow);
+
+TemporalResult<ResolvedCalendarDate> JS_EXPORT_PRIVATE monthDayFromFields(CalendarID, const CalendarFieldsIn&, TemporalOverflow);
+
+TemporalResult<ResolvedCalendarDate> JS_EXPORT_PRIVATE plainYearMonthWith(CalendarID, const ISO8601::PlainDate& currentISODate, const CalendarFieldsIn& partialFields, TemporalOverflow);
+
+TemporalResult<ISO8601::Duration> JS_EXPORT_PRIVATE differenceYearMonth(CalendarID, const ISO8601::PlainDate& thisISODate, const ISO8601::PlainDate& otherISODate, TemporalUnit largestUnit);
+
+TemporalResult<ResolvedCalendarDate> JS_EXPORT_PRIVATE plainYearMonthAdd(CalendarID, const ISO8601::PlainDate& currentISODate, const ISO8601::Duration&, TemporalOverflow);
+
+TemporalResult<ResolvedCalendarDate> JS_EXPORT_PRIVATE plainYearMonthToPlainDate(CalendarID, const ISO8601::PlainDate& pymISODate, uint8_t day);
+
+TemporalResult<ResolvedCalendarDate> JS_EXPORT_PRIVATE plainYearMonthFromISODate(CalendarID, const ISO8601::PlainDate& fullISODate);
+
+TemporalResult<ResolvedCalendarDate> JS_EXPORT_PRIVATE plainMonthDayToPlainDate(CalendarID, const ISO8601::PlainDate& pmdISODate, int32_t year);
+
+TemporalResult<ResolvedCalendarDate> JS_EXPORT_PRIVATE plainMonthDayFromISODate(CalendarID, const ISO8601::PlainDate& fullISODate, TemporalOverflow);
+
+} // namespace TemporalCore
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.cpp
@@ -77,14 +77,15 @@ static std::unique_ptr<UCalendar, ICUDeleter<ucal_close>> openCalendar(CalendarI
     return cal;
 }
 
-// chineseCalendarUsesEpochOffset — probes ICU UCAL_EXTENDED_YEAR for Chinese to detect epoch-based vs ISO-proleptic year numbering.
-// Result is cached: it depends only on the ICU version, which is fixed for the process lifetime.
-bool chineseCalendarUsesEpochOffset()
+// chineseCalendarExtendedYearFor1972 — probes ICU UCAL_EXTENDED_YEAR for the Chinese calendar
+// at ISO 1972-02-15. Returns 1972 on ISO-proleptic ICU; epoch-based year on older Apple ICU.
+// Result is cached: ICU version is fixed for the process lifetime.
+int32_t chineseCalendarExtendedYearFor1972()
 {
-    static bool cached = []() -> bool {
+    static int32_t cached = []() -> int32_t {
         auto cal = openCalendar(chineseCalendarID());
         if (!cal)
-            return false;
+            return 1972; // fallback: assume ISO-proleptic
         // Use ucal_setMillis with a precomputed ISO epoch time — NOT ucal_setDateTime which
         // sets calendar-native fields (not ISO fields) on a non-Gregorian calendar.
         // ISO 1972-02-15 00:00:00 UTC = 66,960,000,000 ms from Unix epoch (1970-01-01).
@@ -93,9 +94,10 @@ bool chineseCalendarUsesEpochOffset()
         ucal_setMillis(cal.get(), iso1972Feb15EpochMs, &status);
         int32_t extYear = ucal_get(cal.get(), UCAL_EXTENDED_YEAR, &status);
         if (U_FAILURE(status))
-            return false;
-        // Epoch-based: extYear = 4608 (Chinese year for 1972 CE); ISO-proleptic: extYear = 1972.
-        return extYear > 3000;
+            return 1972; // fallback: assume ISO-proleptic
+        // Return the raw EXTENDED_YEAR: 1972 on ISO-proleptic ICU,
+        // epoch-based year (whatever the current ICU uses) on older Apple ICU.
+        return extYear;
     }();
     return cached;
 }

--- a/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.h
+++ b/Source/JavaScriptCore/runtime/temporal/core/CalendarICUBridge.h
@@ -124,7 +124,7 @@ static constexpr int32_t ecmaRefYearNotInCalendar = INT32_MIN + 1;
 
 int32_t ecmaReferenceYear(CalendarID, uint8_t monthNumber, bool isLeapMonth, uint8_t day);
 
-bool JS_EXPORT_PRIVATE chineseCalendarUsesEpochOffset();
+int32_t JS_EXPORT_PRIVATE chineseCalendarExtendedYearFor1972();
 
 TemporalResult<ISO8601::PlainDate> JS_EXPORT_PRIVATE calendarDateFromFields(CalendarID, int32_t year, uint8_t month, uint8_t day, std::optional<StringView> era, std::optional<int32_t> eraYear, std::optional<ParsedMonthCode>, TemporalOverflow);
 

--- a/Source/JavaScriptCore/runtime/temporal/core/DurationArithmetic.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/DurationArithmetic.cpp
@@ -1,0 +1,1030 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "DurationArithmetic.h"
+
+#include "CalendarICUBridge.h"
+#include "DateConstructor.h"
+#include "FractionToDouble.h"
+#include "ISO8601.h"
+#include "ISOArithmetic.h"
+#include "Rounding.h"
+#include "TemporalObject.h"
+#include "TimeZoneICUBridge.h"
+#include <wtf/CheckedArithmetic.h>
+#include <wtf/DateMath.h>
+
+namespace JSC {
+namespace TemporalCore {
+
+// durationSign — temporal_rs: Duration::sign()
+int durationSign(const ISO8601::Duration& d)
+{
+#define JSC_CHECK_SIGN(field) \
+    if (d.field() < 0)        \
+        return -1;            \
+    if (d.field() > 0)        \
+        return 1;
+    JSC_CHECK_SIGN(years)
+    JSC_CHECK_SIGN(months)
+    JSC_CHECK_SIGN(weeks)
+    JSC_CHECK_SIGN(days)
+    JSC_CHECK_SIGN(hours)
+    JSC_CHECK_SIGN(minutes)
+    JSC_CHECK_SIGN(seconds)
+    JSC_CHECK_SIGN(milliseconds)
+    JSC_CHECK_SIGN(microseconds)
+    JSC_CHECK_SIGN(nanoseconds)
+#undef JSC_CHECK_SIGN
+    return 0;
+}
+
+// negateDuration — temporal_rs: Duration::negated()
+ISO8601::Duration negateDuration(const ISO8601::Duration& d) { return -d; }
+
+// absDuration — temporal_rs: Duration::abs()
+ISO8601::Duration absDuration(const ISO8601::Duration& d)
+{
+    return ISO8601::Duration(
+        std::abs(d.years()),
+        std::abs(d.months()),
+        std::abs(d.weeks()),
+        std::abs(d.days()),
+        std::abs(d.hours()),
+        std::abs(d.minutes()),
+        std::abs(d.seconds()),
+        std::abs(d.milliseconds()),
+        absInt128(d.microseconds()),
+        absInt128(d.nanoseconds()));
+}
+
+// largestSubduration — temporal_rs: Duration::default_largest_unit
+TemporalUnit NODELETE largestSubduration(const ISO8601::Duration& d)
+{
+    uint8_t index = 0;
+    while (index < numberOfTemporalUnits - 1 && !d[index])
+        index++;
+    return static_cast<TemporalUnit>(index);
+}
+
+// totalSeconds — internal BalanceDuration helper; folds days/hours/minutes into total seconds for redistribution.
+int64_t totalSeconds(const ISO8601::Duration& d)
+{
+    constexpr int64_t hourPerDay = 24;
+    constexpr int64_t minPerHour = 60;
+    constexpr int64_t secPerMin = 60;
+    int64_t hours = hourPerDay * d.days() + d.hours();
+    int64_t minutes = minPerHour * hours + d.minutes();
+    return secPerMin * minutes + d.seconds();
+}
+
+// totalSubseconds — internal BalanceDuration helper; returns total sub-second nanoseconds (ms×1e6 + µs×1e3 + ns).
+Int128 totalSubseconds(const ISO8601::Duration& d)
+{
+    constexpr int64_t usPerMs = 1000;
+    constexpr int64_t nsPerUs = 1000;
+    Int128 microseconds = Int128(usPerMs) * d.milliseconds() + d.microseconds();
+    return Int128(nsPerUs) * microseconds + d.nanoseconds();
+}
+
+// balanceDuration — temporal_rs: balance is performed inline in Duration::compare.
+// Redistributes time fields up to largestUnit. Returns std::nullopt (always).
+std::optional<double> balanceDuration(ISO8601::Duration& duration, TemporalUnit largestUnit)
+{
+    constexpr int64_t nsPerUs = 1000;
+    constexpr int64_t usPerMs = 1000;
+    constexpr int64_t msPerSec = 1000;
+    constexpr int64_t secPerMin = 60;
+    constexpr int64_t minPerHour = 60;
+    Int128 nanoseconds = totalSubseconds(duration);
+    int64_t seconds = totalSeconds(duration);
+    duration.clear();
+    constexpr int64_t secondsPerDay = 86400;
+    if (largestUnit <= TemporalUnit::Day) {
+        duration.setDays(seconds / secondsPerDay);
+        seconds = seconds % secondsPerDay;
+    }
+    Int128 microseconds = nanoseconds / nsPerUs;
+    Int128 milliseconds = microseconds / Int128(usPerMs);
+    // Fold ms overflow into seconds: ms >= 1000 must carry into seconds.
+    int64_t secondsFromMs = static_cast<int64_t>(milliseconds / Int128(msPerSec));
+    int64_t totalSecs = seconds + secondsFromMs;
+    int64_t minutes = totalSecs / secPerMin;
+    if (largestUnit <= TemporalUnit::Hour) {
+        duration.setNanoseconds(nanoseconds % nsPerUs);
+        duration.setMicroseconds(microseconds % Int128(usPerMs));
+        duration.setMilliseconds(static_cast<int64_t>(milliseconds % Int128(msPerSec)));
+        duration.setSeconds(totalSecs % secPerMin);
+        duration.setMinutes(minutes % minPerHour);
+        duration.setHours(minutes / minPerHour);
+    } else if (largestUnit == TemporalUnit::Minute) {
+        duration.setNanoseconds(nanoseconds % nsPerUs);
+        duration.setMicroseconds(microseconds % Int128(usPerMs));
+        duration.setMilliseconds(static_cast<int64_t>(milliseconds % Int128(msPerSec)));
+        duration.setSeconds(totalSecs % secPerMin);
+        duration.setMinutes(minutes);
+    } else if (largestUnit == TemporalUnit::Second) {
+        duration.setNanoseconds(nanoseconds % nsPerUs);
+        duration.setMicroseconds(microseconds % Int128(usPerMs));
+        duration.setMilliseconds(static_cast<int64_t>(milliseconds % Int128(msPerSec)));
+        duration.setSeconds(totalSecs);
+    } else if (largestUnit == TemporalUnit::Millisecond) {
+        duration.setNanoseconds(nanoseconds % nsPerUs);
+        duration.setMicroseconds(microseconds % Int128(usPerMs));
+        duration.setMilliseconds(static_cast<int64_t>(milliseconds) + seconds * msPerSec);
+    } else if (largestUnit == TemporalUnit::Microsecond) {
+        duration.setNanoseconds(nanoseconds % nsPerUs);
+        duration.setMicroseconds(microseconds + Int128(seconds) * (ISO8601::ExactTime::nsPerSecond / ISO8601::ExactTime::nsPerMicrosecond));
+    } else
+        duration.setNanoseconds(nanoseconds + Int128(seconds) * ISO8601::ExactTime::nsPerSecond);
+    return std::nullopt;
+}
+
+// timeDurationFromComponents — temporal_rs: TimeDuration::from_components
+// Converts duration time fields to a total nanosecond Int128.
+Int128 timeDurationFromComponents(double hours, double minutes, double seconds, double milliseconds, double microseconds, double nanoseconds)
+{
+    constexpr int64_t minPerHour = 60;
+    constexpr int64_t secPerMin = 60;
+    constexpr int64_t msPerSec = 1000;
+    constexpr int64_t usPerMs = 1000;
+    constexpr int64_t nsPerUs = 1000;
+    CheckedInt128 min = checkedCastDoubleToInt128(minutes) + checkedCastDoubleToInt128(hours) * Int128(minPerHour);
+    CheckedInt128 sec = checkedCastDoubleToInt128(seconds) + min * Int128(secPerMin);
+    CheckedInt128 millis = checkedCastDoubleToInt128(milliseconds) + sec * Int128(msPerSec);
+    CheckedInt128 micros = checkedCastDoubleToInt128(microseconds) + millis * Int128(usPerMs);
+    CheckedInt128 nanos = checkedCastDoubleToInt128(nanoseconds) + micros * Int128(nsPerUs);
+    ASSERT(!nanos.hasOverflowed());
+    ASSERT(absInt128(nanos) <= ISO8601::InternalDuration::maxTimeDuration);
+    return nanos;
+}
+
+// splitTimeDuration — internal; splits a timeDuration (ns) into (overflowDays, subdayNs) using floor division.
+std::pair<int64_t, Int128> splitTimeDuration(Int128 timeDuration)
+{
+    constexpr Int128 nsPerDay = ISO8601::ExactTime::nsPerDay;
+    int64_t overflowDays = static_cast<int64_t>(timeDuration / nsPerDay);
+    Int128 remainder = timeDuration % nsPerDay;
+    if (remainder < 0) {
+        remainder += nsPerDay;
+        overflowDays--;
+    }
+    return { overflowDays, remainder };
+}
+
+// plainTimeFromSubdayNs — internal; decomposes sub-day nanoseconds into a PlainTime. ns must be in [0, nsPerDay).
+ISO8601::PlainTime plainTimeFromSubdayNs(Int128 ns)
+{
+    ASSERT(ns >= 0 && ns < ISO8601::ExactTime::nsPerDay);
+    int32_t nanosecond = static_cast<int32_t>(ns % 1000);
+    Int128 remaining = ns / 1000;
+    int32_t microsecond = static_cast<int32_t>(remaining % 1000);
+    remaining /= 1000;
+    int32_t millisecond = static_cast<int32_t>(remaining % 1000);
+    remaining /= 1000;
+    int32_t second = static_cast<int32_t>(remaining % 60);
+    remaining /= 60;
+    int32_t minute = static_cast<int32_t>(remaining % 60);
+    int32_t hour = static_cast<int32_t>(remaining / 60);
+    return ISO8601::PlainTime(hour, minute, second, millisecond, microsecond, nanosecond);
+}
+
+// totalTimeDuration — temporal_rs: TimeDuration::total (src/builtins/core/duration/normalized.rs)
+// Returns the total time portion of a duration as a fractional count of the given unit.
+double totalTimeDuration(Int128 timeDuration, TemporalUnit unit)
+{
+    double divisor = static_cast<double>(lengthInNanoseconds(unit));
+    ASSERT(isSafeInteger(divisor));
+    return fractionToDouble(timeDuration, divisor);
+}
+
+// toInternalDuration — temporal_rs: Duration::to_internal_duration_record (src/builtins/core/duration.rs)
+// Builds an InternalDuration from a Duration (time fields only, no day normalization).
+ISO8601::InternalDuration toInternalDuration(ISO8601::Duration d)
+{
+    auto timeDuration = timeDurationFromComponents(d.hours(), d.minutes(), d.seconds(),
+        d.milliseconds(), static_cast<double>(d.microseconds()), static_cast<double>(d.nanoseconds()));
+    return ISO8601::InternalDuration::combineDateAndTimeDuration(d, timeDuration);
+}
+
+// temporalDurationFromInternal — temporal_rs: Duration::from_internal (src/builtins/core/duration.rs)
+// Converts an InternalDuration back to a Duration given largestUnit.
+ISO8601::Duration temporalDurationFromInternal(ISO8601::InternalDuration internalDuration, TemporalUnit largestUnit)
+{
+    int64_t days = 0;
+    int64_t hours = 0;
+    int64_t minutes = 0;
+    int64_t seconds = 0;
+    Int128 milliseconds = 0;
+    Int128 microseconds = 0;
+
+    int32_t sign = internalDuration.timeDurationSign();
+    Int128 nanoseconds = absInt128(internalDuration.time());
+
+    if (largestUnit <= TemporalUnit::Day) {
+        microseconds = nanoseconds / 1000;
+        nanoseconds = nanoseconds % 1000;
+        milliseconds = microseconds / 1000;
+        microseconds = microseconds % 1000;
+        seconds = static_cast<int64_t>(milliseconds / 1000);
+        milliseconds = milliseconds % 1000;
+        minutes = seconds / 60;
+        seconds = seconds % 60;
+        hours = minutes / 60;
+        minutes = minutes % 60;
+        days = hours / 24;
+        hours = hours % 24;
+    } else if (largestUnit == TemporalUnit::Hour) {
+        microseconds = nanoseconds / 1000;
+        nanoseconds = nanoseconds % 1000;
+        milliseconds = microseconds / 1000;
+        microseconds = microseconds % 1000;
+        seconds = static_cast<int64_t>(milliseconds / 1000);
+        milliseconds = milliseconds % 1000;
+        minutes = seconds / 60;
+        seconds = seconds % 60;
+        hours = minutes / 60;
+        minutes = minutes % 60;
+    } else if (largestUnit == TemporalUnit::Minute) {
+        microseconds = nanoseconds / 1000;
+        nanoseconds = nanoseconds % 1000;
+        milliseconds = microseconds / 1000;
+        microseconds = microseconds % 1000;
+        seconds = static_cast<int64_t>(milliseconds / 1000);
+        milliseconds = milliseconds % 1000;
+        minutes = seconds / 60;
+        seconds = seconds % 60;
+    } else if (largestUnit == TemporalUnit::Second) {
+        microseconds = nanoseconds / 1000;
+        nanoseconds = nanoseconds % 1000;
+        milliseconds = microseconds / 1000;
+        microseconds = microseconds % 1000;
+        seconds = static_cast<int64_t>(milliseconds / 1000);
+        milliseconds = milliseconds % 1000;
+    } else if (largestUnit == TemporalUnit::Millisecond) {
+        microseconds = nanoseconds / 1000;
+        nanoseconds = nanoseconds % 1000;
+        milliseconds = microseconds / 1000;
+        microseconds = microseconds % 1000;
+    } else if (largestUnit == TemporalUnit::Microsecond) {
+        microseconds = nanoseconds / 1000;
+        nanoseconds = nanoseconds % 1000;
+    }
+
+    if (hours)
+        hours *= sign;
+    if (minutes)
+        minutes *= sign;
+    if (seconds)
+        seconds *= sign;
+    if (milliseconds)
+        milliseconds *= sign;
+    if (microseconds)
+        microseconds *= sign;
+    if (nanoseconds)
+        nanoseconds *= sign;
+    // Apply ℝ(𝔽(x)) per spec CreateTemporalDuration step 12: round through float64 so that
+    // Int128 values not exactly representable round past nanosecondsLimit → isValidDuration rejects.
+    // milliseconds uses doubleToInt64Saturating because Int128 → double can still exceed int64_t
+    // (e.g. largestUnit=millisecond, out-of-range input: ms ≈ 9e21 > INT64_MAX ≈ 9.2e18).
+    return ISO8601::Duration { internalDuration.dateDuration().years(),
+        internalDuration.dateDuration().months(),
+        internalDuration.dateDuration().weeks(),
+        static_cast<int64_t>(internalDuration.dateDuration().days() + days * sign),
+        static_cast<int64_t>(hours), static_cast<int64_t>(minutes), static_cast<int64_t>(seconds),
+        ISO8601::Duration::doubleToInt64Saturating(static_cast<double>(milliseconds)),
+        Int128(static_cast<double>(microseconds)),
+        Int128(static_cast<double>(nanoseconds)) };
+}
+
+// add24HourDaysToTimeDuration — temporal_rs: TimeDuration::add_days (src/builtins/core/duration/normalized.rs)
+// Adds 24-hour days to a timeDuration (ns). Returns error if result exceeds maxTimeDuration.
+TemporalResult<Int128> add24HourDaysToTimeDuration(Int128 d, double days)
+{
+    CheckedInt128 daysInNanoseconds = checkedCastDoubleToInt128(days) * ISO8601::ExactTime::nsPerDay;
+    CheckedInt128 result = d + daysInNanoseconds;
+    ASSERT(!result.hasOverflowed());
+    if (absInt128(result) > ISO8601::InternalDuration::maxTimeDuration)
+        return makeUnexpected(TemporalError { TemporalErrorKind::RangeError, "Total time in duration is out of range"_s });
+    return Int128(result);
+}
+
+// toInternalDurationRecordWith24HourDays — temporal_rs: InternalDurationRecord::from_duration_with_24_hour_days (src/builtins/core/duration/normalized.rs)
+// Folds duration.days into timeDuration and returns InternalDuration with date-only datePart.
+TemporalResult<ISO8601::InternalDuration> toInternalDurationRecordWith24HourDays(ISO8601::Duration d)
+{
+    Int128 timeDuration = timeDurationFromComponents(d.hours(), d.minutes(), d.seconds(),
+        d.milliseconds(), static_cast<double>(d.microseconds()), static_cast<double>(d.nanoseconds()));
+    auto result = add24HourDaysToTimeDuration(timeDuration, d.days());
+    if (!result)
+        return makeUnexpected(result.error());
+    ISO8601::Duration dateDuration = ISO8601::Duration {
+        d.years(), d.months(),
+        d.weeks(), 0, 0, 0, 0, 0, Int128(0), Int128(0)
+    };
+    return ISO8601::InternalDuration::combineDateAndTimeDuration(dateDuration, *result);
+}
+
+// toDateDurationRecordWithoutTime — temporal_rs: InternalDurationRecord::to_date_duration_record_without_time (src/builtins/core/duration/normalized.rs)
+// Strips time fields and folds days into the date part. Returns a date-only Duration.
+TemporalResult<ISO8601::Duration> toDateDurationRecordWithoutTime(ISO8601::Duration duration)
+{
+    auto internalDuration = toInternalDurationRecordWith24HourDays(duration);
+    if (!internalDuration)
+        return makeUnexpected(internalDuration.error());
+    auto days = internalDuration->time() / ISO8601::ExactTime::nsPerDay;
+    return ISO8601::Duration {
+        internalDuration->dateDuration().years(),
+        internalDuration->dateDuration().months(),
+        internalDuration->dateDuration().weeks(),
+        static_cast<int64_t>(days), 0, 0, 0, 0, Int128(0), Int128(0)
+    };
+}
+
+// getUTCEpochNanoseconds — temporal_rs: IsoDateTime::as_nanoseconds (UTC path)
+// Converts (PlainDate, PlainTime) to epoch nanoseconds as if the datetime were UTC.
+Int128 getUTCEpochNanoseconds(ISO8601::PlainDate date, ISO8601::PlainTime time)
+{
+    auto dayMs = makeDay(date.year(), date.month() - 1, date.day());
+    auto timeMs = makeTime(time.hour(), time.minute(), time.second(), time.millisecond());
+    auto ms = makeDate(dayMs, timeMs);
+    ASSERT(isInteger(ms));
+    return Int128(ms) * ISO8601::ExactTime::nsPerMillisecond
+        + Int128(time.microsecond()) * ISO8601::ExactTime::nsPerMicrosecond
+        + Int128(time.nanosecond());
+}
+
+constexpr int32_t unitIndexInTable(TemporalUnit unit)
+{
+    switch (unit) {
+    case TemporalUnit::Year:
+        return 0;
+    case TemporalUnit::Month:
+        return 1;
+    case TemporalUnit::Week:
+        return 2;
+    case TemporalUnit::Day:
+        return 3;
+    case TemporalUnit::Hour:
+        return 4;
+    case TemporalUnit::Minute:
+        return 5;
+    case TemporalUnit::Second:
+        return 6;
+    case TemporalUnit::Millisecond:
+        return 7;
+    case TemporalUnit::Microsecond:
+        return 8;
+    case TemporalUnit::Nanosecond:
+        return 9;
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+}
+
+constexpr TemporalUnit unitInTable(int32_t i)
+{
+    switch (i) {
+    case 0:
+        return TemporalUnit::Year;
+    case 1:
+        return TemporalUnit::Month;
+    case 2:
+        return TemporalUnit::Week;
+    case 3:
+        return TemporalUnit::Day;
+    case 4:
+        return TemporalUnit::Hour;
+    case 5:
+        return TemporalUnit::Minute;
+    case 6:
+        return TemporalUnit::Second;
+    case 7:
+        return TemporalUnit::Millisecond;
+    case 8:
+        return TemporalUnit::Microsecond;
+    case 9:
+        return TemporalUnit::Nanosecond;
+    default:
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+}
+
+// epochNanosecondsForDateAndTime — internal; computes epoch nanoseconds for (date, time): UTC if timeZone==nullptr, TZ-aware otherwise.
+static TemporalResult<Int128> epochNanosecondsForDateAndTime(
+    const ISO8601::PlainDate& date, const ISO8601::PlainTime& time,
+    const TimeZone* timeZone)
+{
+    if (!timeZone)
+        return TemporalCore::getUTCEpochNanoseconds(date, time);
+    auto result = TemporalCore::getEpochNanosecondsFor(*timeZone, date, time, TemporalDisambiguation::Compatible);
+    if (!result)
+        return makeUnexpected(result.error());
+    return result->epochNanoseconds();
+}
+
+// adjustDateDurationRecord — internal helper; builds a new date duration with overridden days/weeks/months fields.
+// https://tc39.es/proposal-temporal/#sec-temporal-adjustdatedurationrecord
+TemporalResult<ISO8601::Duration> adjustDateDurationRecord(const ISO8601::Duration& dateDuration, double days, std::optional<double> weeks, std::optional<double> months)
+{
+    // Step 1: If weeks is not present, set weeks to dateDuration.[[Weeks]].
+    // Step 2: If months is not present, set months to dateDuration.[[Months]].
+    // (Both handled implicitly by the std::optional parameters.)
+    auto result = ISO8601::Duration {
+        dateDuration.years(),
+        months ? static_cast<int64_t>(months.value()) : dateDuration.months(),
+        weeks ? static_cast<int64_t>(weeks.value()) : dateDuration.weeks(),
+        // Step 3: Return ? CreateDateDurationRecord(dateDuration.[[Years]], months, weeks, days).
+        static_cast<int64_t>(days), 0, 0, 0, 0, Int128(0), Int128(0)
+    };
+    if (!ISO8601::isValidDuration(result))
+        return makeUnexpected(rangeError("Temporal.Duration properties must be valid and of consistent sign"_s));
+    return result;
+}
+
+// NudgeWindow — internal; holds the floor/ceiling epoch-ns bounds and durations for a single calendar nudge step.
+struct NudgeWindow {
+    double r1;
+    double r2;
+    Int128 startEpochNs;
+    Int128 endEpochNs;
+    ISO8601::Duration startDuration;
+    ISO8601::Duration endDuration;
+};
+
+// computeNudgeWindow — temporal_rs: InternalDurationRecord::compute_nudge_window (src/builtins/core/duration/normalized.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal-computenudgewindow
+static TemporalResult<std::optional<NudgeWindow>> computeNudgeWindow(
+    int32_t sign,
+    const ISO8601::InternalDuration& duration, Int128 originEpochNs,
+    ISO8601::PlainDate isoDate, ISO8601::PlainTime isoTime,
+    double increment, TemporalUnit unit, bool additionalShift,
+    const TimeZone* timeZone = nullptr, CalendarID calendarId = iso8601CalendarID())
+{
+    double r1 = 0, r2 = 0;
+    ISO8601::Duration startDuration, endDuration;
+    // Steps 1-4: compute r1, r2, startDuration, endDuration based on unit.
+    switch (unit) {
+    case TemporalUnit::Year: {
+        // Step 1.a: years = RoundNumberToIncrement(duration.[[Date]].[[Years]], increment, trunc).
+        Int128 years = roundNumberToIncrementInt128((Int128)duration.dateDuration().years(), (Int128)increment, RoundingMode::Trunc);
+        // Step 1.b-c: r1 = years; or if additionalShift, r1 = years + increment × sign.
+        r1 = additionalShift ? (double)years + increment * sign : (double)years;
+        // Step 1.d: r2 = r1 + increment × sign.
+        r2 = r1 + increment * sign;
+        // Step 1.e: startDuration = CreateDateDurationRecord(r1, 0, 0, 0).
+        startDuration = ISO8601::Duration { static_cast<int64_t>(r1), 0, 0, 0, 0, 0, 0, 0, Int128(0), Int128(0) };
+        // Step 1.f: endDuration = CreateDateDurationRecord(r2, 0, 0, 0).
+        endDuration = ISO8601::Duration { static_cast<int64_t>(r2), 0, 0, 0, 0, 0, 0, 0, Int128(0), Int128(0) };
+        break;
+    }
+    case TemporalUnit::Month: {
+        // Step 2.a: months = RoundNumberToIncrement(duration.[[Date]].[[Months]], increment, trunc).
+        Int128 months = roundNumberToIncrementInt128((Int128)duration.dateDuration().months(), (Int128)increment, RoundingMode::Trunc);
+        // Step 2.b-c: r1 = months; or if additionalShift, r1 = months + increment × sign.
+        r1 = additionalShift ? (double)months + increment * sign : (double)months;
+        // Step 2.d: r2 = r1 + increment × sign.
+        r2 = r1 + increment * sign;
+        // Step 2.e: startDuration = AdjustDateDurationRecord(duration.[[Date]], 0, 0, r1).
+        auto sd = adjustDateDurationRecord(duration.dateDuration(), 0, 0, r1);
+        if (!sd)
+            return makeUnexpected(sd.error());
+        startDuration = *sd;
+        // Step 2.f: endDuration = AdjustDateDurationRecord(duration.[[Date]], 0, 0, r2).
+        auto ed = adjustDateDurationRecord(duration.dateDuration(), 0, 0, r2);
+        if (!ed)
+            return makeUnexpected(ed.error());
+        endDuration = *ed;
+        break;
+    }
+    case TemporalUnit::Week: {
+        // Step 3.a: yearsMonths = AdjustDateDurationRecord(duration.[[Date]], 0, 0).
+        auto yearsMonths = adjustDateDurationRecord(duration.dateDuration(), 0, 0, std::nullopt);
+        if (!yearsMonths)
+            return makeUnexpected(yearsMonths.error());
+        // Step 3.b: weeksStart = CalendarDateAdd(calendar, isoDateTime.[[ISODate]], yearsMonths, constrain).
+        auto weeksStartResult = TemporalCore::calendarDateAdd(calendarId, isoDate, *yearsMonths, TemporalOverflow::Constrain);
+        if (!weeksStartResult)
+            return makeUnexpected(weeksStartResult.error());
+        auto weeksStart = *weeksStartResult;
+        // Step 3.c: weeksEnd = AddDaysToISODate(weeksStart, duration.[[Date]].[[Days]]).
+        auto weeksEnd = TemporalCore::balanceISODate(weeksStart.year(), static_cast<int32_t>(weeksStart.month()), static_cast<int64_t>(weeksStart.day()) + duration.dateDuration().days());
+        // Step 3.d: untilResult = CalendarDateUntil(calendar, weeksStart, weeksEnd, week).
+        auto untilResult = TemporalCore::calendarDateUntil(calendarId, weeksStart, weeksEnd, TemporalUnit::Week);
+        if (!untilResult)
+            return makeUnexpected(untilResult.error());
+        // Step 3.e: weeks = RoundNumberToIncrement(duration.[[Date]].[[Weeks]] + untilResult.[[Weeks]], increment, trunc).
+        Int128 weeks = roundNumberToIncrementInt128((Int128)(duration.dateDuration().weeks() + untilResult->weeks()), (Int128)increment, RoundingMode::Trunc);
+        // Step 3.f: r1 = weeks. Step 3.g: r2 = weeks + increment × sign.
+        r1 = (double)weeks;
+        r2 = (double)weeks + increment * sign;
+        // Step 3.h: startDuration = AdjustDateDurationRecord(duration.[[Date]], 0, r1).
+        auto sd = adjustDateDurationRecord(duration.dateDuration(), 0, r1, std::nullopt);
+        if (!sd)
+            return makeUnexpected(sd.error());
+        startDuration = *sd;
+        // Step 3.i: endDuration = AdjustDateDurationRecord(duration.[[Date]], 0, r2).
+        auto ed = adjustDateDurationRecord(duration.dateDuration(), 0, r2, std::nullopt);
+        if (!ed)
+            return makeUnexpected(ed.error());
+        endDuration = *ed;
+        break;
+    }
+    default: {
+        // Step 4.a: Assert unit is day.
+        ASSERT(unit == TemporalUnit::Day);
+        // Step 4.b: days = RoundNumberToIncrement(duration.[[Date]].[[Days]], increment, trunc).
+        Int128 days = roundNumberToIncrementInt128((Int128)duration.dateDuration().days(), (Int128)increment, RoundingMode::Trunc);
+        // Step 4.c: r1 = days. Step 4.d: r2 = days + increment × sign.
+        r1 = (double)days;
+        r2 = (double)days + increment * sign;
+        // Step 4.e: startDuration = AdjustDateDurationRecord(duration.[[Date]], r1).
+        auto sd = adjustDateDurationRecord(duration.dateDuration(), r1, std::nullopt, std::nullopt);
+        if (!sd)
+            return makeUnexpected(sd.error());
+        startDuration = *sd;
+        // Step 4.f: endDuration = AdjustDateDurationRecord(duration.[[Date]], r2).
+        auto ed = adjustDateDurationRecord(duration.dateDuration(), r2, std::nullopt, std::nullopt);
+        if (!ed)
+            return makeUnexpected(ed.error());
+        endDuration = *ed;
+        break;
+    }
+    }
+
+    // Step 5: Assert if sign=1, r1≥0 and r1<r2.
+    ASSERT(sign != 1 || (r1 >= 0 && r1 < r2));
+    // Step 6: Assert if sign=-1, r1≤0 and r1>r2.
+    ASSERT(sign != -1 || (r1 <= 0 && r1 > r2));
+
+    // Step 7: If r1=0, startEpochNs = originEpochNs.
+    // Step 8: Else, start = CalendarDateAdd (8.a); then steps 8.b (CombineISODateAndTimeRecord) +
+    //         8.c/8.d (GetUTCEpochNanoseconds or GetEpochNanosecondsFor) fused into epochNanosecondsForDateAndTime.
+    Int128 startEpochNs;
+    if (!r1)
+        startEpochNs = originEpochNs;
+    else {
+        auto startResult = TemporalCore::calendarDateAdd(calendarId, isoDate, startDuration, TemporalOverflow::Constrain);
+        if (!startResult)
+            return makeUnexpected(startResult.error());
+        auto start = *startResult;
+        double startDayCount = dateToDaysFrom1970(start.year(), static_cast<int>(start.month()) - 1, static_cast<int>(start.day()));
+        if (std::abs(startDayCount) > 1e8)
+            return makeUnexpected(rangeError("date is outside the representable range"_s));
+        auto startNsResult = epochNanosecondsForDateAndTime(start, isoTime, timeZone);
+        if (!startNsResult)
+            return makeUnexpected(startNsResult.error());
+        startEpochNs = *startNsResult;
+    }
+    // Step 9: end = CalendarDateAdd(calendar, isoDateTime.[[ISODate]], endDuration, constrain).
+    auto endResult = TemporalCore::calendarDateAdd(calendarId, isoDate, endDuration, TemporalOverflow::Constrain);
+    if (!endResult)
+        return makeUnexpected(endResult.error());
+    auto end = *endResult;
+    double endDayCount = dateToDaysFrom1970(end.year(), static_cast<int>(end.month()) - 1, static_cast<int>(end.day()));
+    if (std::abs(endDayCount) > 1e8)
+        return makeUnexpected(rangeError("date is outside the representable range"_s));
+    // Steps 10-12: CombineISODateAndTimeRecord (step 10) + GetUTCEpochNanoseconds/GetEpochNanosecondsFor
+    //              (steps 11/12) fused into epochNanosecondsForDateAndTime — avoids an intermediate endDateTime record.
+    auto endNsResult = epochNanosecondsForDateAndTime(end, isoTime, timeZone);
+    if (!endNsResult)
+        return makeUnexpected(endNsResult.error());
+    Int128 endEpochNs = *endNsResult;
+    // Steps 13-14: startDuration/endDuration = CombineDateAndTimeDuration(dateDuration, 0).
+    // Deferred to caller (nudgeToCalendarUnit) for efficiency — only the selected path needs the combine.
+    // Step 15: Return the Record.
+    return std::optional<NudgeWindow>(NudgeWindow { r1, r2, startEpochNs, endEpochNs, startDuration, endDuration });
+}
+
+// nudgeToCalendarUnit — temporal_rs: InternalDurationRecord::nudge_calendar_unit (internal step of round_relative_duration)
+// https://tc39.es/proposal-temporal/#sec-temporal-nudgetocalendarunit
+TemporalResult<Nudged> nudgeToCalendarUnit(int32_t sign,
+    const ISO8601::InternalDuration& duration, Int128 originEpochNs, Int128 destEpochNs,
+    ISO8601::PlainDate isoDate, ISO8601::PlainTime isoTime, double increment,
+    TemporalUnit unit, RoundingMode roundingMode, const TimeZone* timeZone, CalendarID calendarId)
+{
+    // Step 1: Let didExpandCalendarUnit be false.
+    // Step 2: Let nudgeWindow be ? ComputeNudgeWindow(sign, duration, originEpochNs, isoDateTime, timeZone, calendar, increment, unit, false).
+    auto nudgeWindowResult = computeNudgeWindow(sign, duration, originEpochNs, isoDate, isoTime, increment, unit, false, timeZone, calendarId);
+    if (!nudgeWindowResult)
+        return makeUnexpected(nudgeWindowResult.error());
+    ASSERT(nudgeWindowResult->has_value());
+    auto nudgeWindow = **nudgeWindowResult;
+
+    // Step 3-4: Let startEpochNs/endEpochNs be nudgeWindow.[[StartEpochNs]]/[[EndEpochNs]].
+    bool didExpandCalendarUnit = false;
+    // Step 5: If sign = 1, then / Step 6: Else, — check destEpochNs is in bounds; if not, retry with additionalShift=true.
+    bool inBounds = (sign == 1)
+        ? (nudgeWindow.startEpochNs <= destEpochNs && destEpochNs <= nudgeWindow.endEpochNs)
+        : (nudgeWindow.endEpochNs <= destEpochNs && destEpochNs <= nudgeWindow.startEpochNs);
+    if (!inBounds) {
+        // Step 5.a / 6.a: Set nudgeWindow to ? ComputeNudgeWindow(..., true).
+        auto retried = computeNudgeWindow(sign, duration, originEpochNs, isoDate, isoTime, increment, unit, true, timeZone, calendarId);
+        if (!retried)
+            return makeUnexpected(retried.error());
+        ASSERT(retried->has_value());
+        nudgeWindow = **retried;
+        // Step 5.a.ii / 6.a.ii: Assert bounds hold after retry. Set didExpandCalendarUnit to true.
+        ASSERT(sign != 1 || (nudgeWindow.startEpochNs <= destEpochNs && destEpochNs <= nudgeWindow.endEpochNs));
+        ASSERT(sign != -1 || (nudgeWindow.endEpochNs <= destEpochNs && destEpochNs <= nudgeWindow.startEpochNs));
+        didExpandCalendarUnit = true;
+    }
+
+    // Steps 7-12: Extract r1, r2, startEpochNs, endEpochNs, startDuration, endDuration from nudgeWindow.
+    auto& startDuration = nudgeWindow.startDuration;
+    auto& endDuration = nudgeWindow.endDuration;
+    // Step 13: Assert: startEpochNs ≠ endEpochNs.
+    ASSERT(nudgeWindow.startEpochNs != nudgeWindow.endEpochNs);
+    // Step 14: Let progress be (destEpochNs - startEpochNs) / (endEpochNs - startEpochNs).
+    Int128 progressNumerator = destEpochNs - nudgeWindow.startEpochNs;
+    Int128 progressDenominator = nudgeWindow.endEpochNs - nudgeWindow.startEpochNs;
+    // Step 15: Let total be r1 + progress × increment × sign.
+    // (NOTE: computed via integer arithmetic before the final float division per spec note.)
+    Int128 totalNumerator = Int128(static_cast<int64_t>(nudgeWindow.r1)) * progressDenominator + progressNumerator * Int128(static_cast<int64_t>(increment)) * Int128(sign);
+    double total = fractionToDouble(totalNumerator, static_cast<double>(absInt128(progressDenominator))) * (progressDenominator < 0 ? -1.0 : 1.0);
+    Int128 progress = progressNumerator / progressDenominator;
+    // Step 16: Assert: 0 ≤ progress ≤ 1.
+    ASSERT(0 <= progress && progress <= 1);
+    // Step 17: Let unsignedRoundingMode be GetUnsignedRoundingMode(roundingMode, isNegative).
+    UnsignedRoundingMode unsignedRoundingMode = getUnsignedRoundingMode(roundingMode, sign < 0);
+    // Step 18-19: If progress = 1, roundedUnit = abs(r2); else apply unsigned rounding.
+    double roundedUnit = std::abs(nudgeWindow.r2);
+    if (progress != 1) {
+        ASSERT(std::abs(nudgeWindow.r1) <= std::abs(total) && std::abs(total) < std::abs(nudgeWindow.r2));
+        roundedUnit = applyUnsignedRoundingMode(std::abs(total), std::abs(nudgeWindow.r1), std::abs(nudgeWindow.r2), unsignedRoundingMode);
+    }
+    // Step 20: If roundedUnit = abs(r2), set didExpandCalendarUnit to true and use endDuration/endEpochNs; else use start.
+    didExpandCalendarUnit |= (roundedUnit == std::abs(nudgeWindow.r2));
+    ISO8601::Duration resultDuration = (roundedUnit == std::abs(nudgeWindow.r2)) ? endDuration : startDuration;
+    Int128 nudgedEpochNs = (roundedUnit == std::abs(nudgeWindow.r2)) ? nudgeWindow.endEpochNs : nudgeWindow.startEpochNs;
+    // Step 21: Let nudgeResult be Duration Nudge Result Record { [[Duration]]: resultDuration, [[NudgedEpochNs]]: nudgedEpochNs, [[DidExpandCalendarUnit]]: didExpandCalendarUnit }.
+    // (computeNudgeWindow steps 13-14 deferred here: CombineDateAndTimeDuration applied only to the selected path.)
+    auto resultDurationInternal = ISO8601::InternalDuration::combineDateAndTimeDuration(resultDuration, 0);
+    // Step 22: Return the Record { [[NudgeResult]]: nudgeResult, [[Total]]: total }.
+    return Nudged(NudgeResult(resultDurationInternal, nudgedEpochNs, didExpandCalendarUnit), total);
+}
+
+// nudgeToZonedTime — temporal_rs: InternalDurationRecord::nudge_to_zoned_time (src/builtins/core/duration/normalized.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal-nudgetozonedtime
+TemporalResult<NudgeResult> nudgeToZonedTime(int32_t sign,
+    const ISO8601::InternalDuration& duration, ISO8601::PlainDate isoDate,
+    ISO8601::PlainTime isoTime, const TimeZone& timeZone, double increment,
+    TemporalUnit unit, RoundingMode roundingMode, CalendarID calendarId)
+{
+    // Step 1: Let start be ? CalendarDateAdd(calendar, isoDateTime.[[ISODate]], duration.[[Date]], ~constrain~).
+    auto startResult = TemporalCore::calendarDateAdd(calendarId, isoDate, duration.dateDuration(), TemporalOverflow::Constrain);
+    if (!startResult)
+        return makeUnexpected(startResult.error());
+    auto start = *startResult;
+    // Step 2: startDateTime = CombineISODateAndTimeRecord(start, isoDateTime.[[Time]]).
+    // Step 3: endDate = AddDaysToISODate(start, sign).
+    // Step 4: endDateTime = CombineISODateAndTimeRecord(endDate, isoDateTime.[[Time]]).
+    // (Steps 2/4 fused into epochNanosecondsForDateAndTime — no intermediate records.)
+    auto endDate = TemporalCore::balanceISODate(start.year(), static_cast<int32_t>(start.month()), static_cast<int64_t>(start.day()) + sign);
+    // Step 5: startEpochNs = GetEpochNanosecondsFor(timeZone, startDateTime, compatible). (steps 2+5 fused)
+    auto startNsResult = epochNanosecondsForDateAndTime(start, isoTime, &timeZone);
+    if (!startNsResult)
+        return makeUnexpected(startNsResult.error());
+    Int128 startEpochNs = *startNsResult;
+    // Step 6: endEpochNs = GetEpochNanosecondsFor(timeZone, endDateTime, compatible). (steps 4+6 fused)
+    auto endNsResult = epochNanosecondsForDateAndTime(endDate, isoTime, &timeZone);
+    if (!endNsResult)
+        return makeUnexpected(endNsResult.error());
+    Int128 endEpochNs = *endNsResult;
+    // Step 7: daySpan = TimeDurationFromEpochNanosecondsDifference(endEpochNs, startEpochNs).
+    Int128 daySpan = endEpochNs - startEpochNs;
+    // Step 8: Assert: TimeDurationSign(daySpan) = sign.
+    ASSERT((daySpan < 0 ? -1 : daySpan > 0 ? 1 : 0) == sign);
+    // Step 9: Let unitLength be the nanoseconds length of unit.
+    Int128 unitLength = lengthInNanoseconds(unit);
+    // Step 10: Let roundedTimeDuration be ? RoundTimeDurationToIncrement(duration.[[Time]], increment × unitLength, roundingMode).
+    Int128 roundedTimeDuration = roundNumberToIncrementInt128(duration.time(), unitLength * (Int128)std::trunc(increment), roundingMode);
+    // Step 11: Let beyondDaySpan be ! AddTimeDuration(roundedTimeDuration, -daySpan).
+    Int128 beyondDaySpan = roundedTimeDuration - daySpan;
+    int32_t beyondSign = beyondDaySpan < 0 ? -1 : beyondDaySpan > 0 ? 1 : 0;
+    // Step 12: If TimeDurationSign(beyondDaySpan) ≠ -sign (didRoundBeyondDay already set above), then
+    bool didRoundBeyondDay = (beyondSign != -sign);
+    int32_t dayDelta = 0;
+    Int128 nudgedEpochNs;
+    if (didRoundBeyondDay) {
+        // Step 12.b: dayDelta = sign.
+        dayDelta = sign;
+        // Step 12.c: Set roundedTimeDuration to ? RoundTimeDurationToIncrement(beyondDaySpan, ...).
+        roundedTimeDuration = roundNumberToIncrementInt128(beyondDaySpan, unitLength * (Int128)std::trunc(increment), roundingMode);
+        // Step 12.d: nudgedEpochNs = AddTimeDurationToEpochNanoseconds(roundedTimeDuration, endEpochNs).
+        nudgedEpochNs = roundedTimeDuration + endEpochNs;
+    } else {
+        // Step 13.b: dayDelta = 0. (already initialized)
+        // Step 13.c: nudgedEpochNs = AddTimeDurationToEpochNanoseconds(roundedTimeDuration, startEpochNs).
+        nudgedEpochNs = roundedTimeDuration + startEpochNs;
+    }
+    // Step 14: Let dateDuration be ! AdjustDateDurationRecord(duration.[[Date]], duration.[[Date]].[[Days]] + dayDelta).
+    auto dateDurationResult = adjustDateDurationRecord(duration.dateDuration(), duration.dateDuration().days() + dayDelta, std::nullopt, std::nullopt);
+    if (!dateDurationResult)
+        return makeUnexpected(dateDurationResult.error());
+    // Step 15: Let resultDuration be CombineDateAndTimeDuration(dateDuration, roundedTimeDuration).
+    auto resultDuration = ISO8601::InternalDuration::combineDateAndTimeDuration(*dateDurationResult, roundedTimeDuration);
+    // Step 16: Return Duration Nudge Result Record { [[Duration]]: resultDuration, [[NudgedEpochNs]]: nudgedEpochNs, [[DidExpandCalendarUnit]]: didRoundBeyondDay }.
+    return NudgeResult(resultDuration, nudgedEpochNs, didRoundBeyondDay);
+}
+
+// nudgeToDayOrTime — temporal_rs: InternalDurationRecord::nudge_to_day_or_time (src/builtins/core/duration/normalized.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal-nudgetodayortime
+TemporalResult<NudgeResult> nudgeToDayOrTime(ISO8601::InternalDuration duration,
+    Int128 destEpochNs, TemporalUnit largestUnit, double increment,
+    TemporalUnit smallestUnit, RoundingMode roundingMode)
+{
+    // Step 1: Let timeDuration be ! Add24HourDaysToTimeDuration(duration.[[Time]], duration.[[Date]].[[Days]]).
+    auto timeDurationResult = add24HourDaysToTimeDuration(duration.time(), duration.dateDuration().days());
+    if (!timeDurationResult)
+        return makeUnexpected(timeDurationResult.error());
+    Int128 timeDuration = *timeDurationResult;
+    // Step 2: Let unitLength be the nanoseconds length of smallestUnit.
+    Int128 unitLength = lengthInNanoseconds(smallestUnit);
+    // Step 3: Let roundedTime be ? RoundTimeDurationToIncrement(timeDuration, unitLength × increment, roundingMode).
+    Int128 roundedTime = roundNumberToIncrementInt128(timeDuration, unitLength * (Int128)std::trunc(increment), roundingMode);
+    // Step 4: Let diffTime be ! AddTimeDuration(roundedTime, -timeDuration).
+    Int128 diffTime = roundedTime - timeDuration;
+    // Step 5: wholeDays = truncate(TotalTimeDuration(timeDuration, day)).
+    // (totalTimeDuration returns int64_t-truncated double, so truncate is implicit.)
+    double wholeDays = totalTimeDuration(timeDuration, TemporalUnit::Day);
+    // Step 6: roundedWholeDays = truncate(TotalTimeDuration(roundedTime, day)). (same)
+    double roundedWholeDays = totalTimeDuration(roundedTime, TemporalUnit::Day);
+    // Step 7: Let dayDelta be roundedWholeDays - wholeDays.
+    auto dayDelta = roundedWholeDays - wholeDays;
+    // Step 8: If dayDelta < 0, let dayDeltaSign be -1; else if dayDelta > 0, let dayDeltaSign be 1; else 0.
+    auto dayDeltaSign = dayDelta < 0 ? -1 : dayDelta > 0 ? 1 : 0;
+    // Step 9: If dayDeltaSign = TimeDurationSign(timeDuration), let didExpandDays be true; else false.
+    bool didExpandDays = dayDeltaSign == (timeDuration < 0 ? -1 : timeDuration > 0 ? 1 : 0);
+    // Step 10: Let nudgedEpochNs be AddTimeDurationToEpochNanoseconds(diffTime, destEpochNs).
+    auto nudgedEpochNs = diffTime + destEpochNs;
+    // Step 11: Let days be 0.
+    // Step 12: Let remainder be roundedTime.
+    auto days = 0;
+    auto remainder = roundedTime;
+    // Step 13: If TemporalUnitCategory(largestUnit) is ~date~, then
+    if (largestUnit <= TemporalUnit::Day) {
+        // Step 13.a: Set days to roundedWholeDays.
+        days = roundedWholeDays;
+        // Step 13.b: remainder = roundedTime - roundedWholeDays×hoursPerDay (days==roundedWholeDays here).
+        remainder = roundedTime + timeDurationFromComponents(-days * WTF::hoursPerDay, 0, 0, 0, 0, 0);
+    }
+    // Step 14: Let dateDuration be ! AdjustDateDurationRecord(duration.[[Date]], days).
+    auto dateDurationResult = adjustDateDurationRecord(duration.dateDuration(), days, std::nullopt, std::nullopt);
+    if (!dateDurationResult)
+        return makeUnexpected(dateDurationResult.error());
+    // Step 15: Let resultDuration be CombineDateAndTimeDuration(dateDuration, remainder).
+    auto resultDuration = ISO8601::InternalDuration::combineDateAndTimeDuration(*dateDurationResult, remainder);
+    // Step 16: Return Duration Nudge Result Record { [[Duration]]: resultDuration, [[NudgedEpochNs]]: nudgedEpochNs, [[DidExpandCalendarUnit]]: didExpandDays }.
+    return NudgeResult(resultDuration, nudgedEpochNs, didExpandDays);
+}
+
+// bubbleRelativeDuration — temporal_rs: InternalDurationRecord::bubble_relative_duration (src/builtins/core/duration/normalized.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal-bubblerelativeduration
+TemporalResult<ISO8601::InternalDuration> bubbleRelativeDuration(
+    int32_t sign, ISO8601::InternalDuration duration, Int128 nudgedEpochNs,
+    ISO8601::PlainDate isoDate, ISO8601::PlainTime isoTime,
+    TemporalUnit largestUnit, TemporalUnit smallestUnit,
+    const TimeZone* timeZone, CalendarID calendarId)
+{
+    // Step 1: If smallestUnit is largestUnit, return duration.
+    if (smallestUnit == largestUnit)
+        return duration;
+    // Step 2: Let largestUnitIndex be the ordinal index of largestUnit in the units table.
+    auto largestUnitIndex = unitIndexInTable(largestUnit);
+    // Step 3: Let smallestUnitIndex be the ordinal index of smallestUnit in the units table.
+    auto smallestUnitIndex = unitIndexInTable(smallestUnit);
+    // Step 4: Let unitIndex be smallestUnitIndex - 1.
+    auto unitIndex = smallestUnitIndex - 1;
+    // Step 5: Let done be false.
+    bool done = false;
+    ISO8601::Duration endDuration;
+    // Step 6: Repeat, while unitIndex ≥ largestUnitIndex and done is false,
+    while (unitIndex >= largestUnitIndex && !done) {
+        // Step 6.a: Let unit be the unit at ordinal unitIndex in the units table.
+        auto unit = unitInTable(unitIndex);
+        // Step 6.b: If unit is not ~week~, or largestUnit is ~week~, then
+        if (unit != TemporalUnit::Week || largestUnit == TemporalUnit::Week) {
+            // Step 6.b.i: If unit is ~year~, let endDuration be ? CreateDateDurationRecord(years + sign, 0, 0, 0).
+            if (unit == TemporalUnit::Year) {
+                endDuration = ISO8601::Duration { duration.dateDuration().years() + sign, 0, 0, 0, 0, 0, 0, 0, Int128(0), Int128(0) };
+            } else if (unit == TemporalUnit::Month) {
+                // Step 6.b.ii: Else if unit is ~month~, let endDuration be ? AdjustDateDurationRecord(duration.[[Date]], 0, 0, months + sign).
+                auto r = adjustDateDurationRecord(duration.dateDuration(), 0, 0, duration.dateDuration().months() + sign);
+                if (!r)
+                    return makeUnexpected(r.error());
+                endDuration = *r;
+            } else {
+                // Step 6.b.iii: Else (unit is ~week~), let endDuration be ? AdjustDateDurationRecord(duration.[[Date]], 0, weeks + sign).
+                auto r = adjustDateDurationRecord(duration.dateDuration(), 0, duration.dateDuration().weeks() + sign, std::nullopt);
+                if (!r)
+                    return makeUnexpected(r.error());
+                endDuration = *r;
+            }
+            // Step 6.b.iv: Let end be ? CalendarDateAdd(calendar, isoDateTime.[[ISODate]], endDuration, ~constrain~).
+            auto endResult = TemporalCore::calendarDateAdd(calendarId, isoDate, endDuration, TemporalOverflow::Constrain);
+            if (!endResult)
+                return makeUnexpected(endResult.error());
+            // Step 6.b.v: endDateTime = CombineISODateAndTimeRecord(end, isoDateTime.[[Time]]).
+            // Step 6.b.vi: endEpochNs = GetUTCEpochNanoseconds/GetEpochNanosecondsFor. (v+vi fused)
+            auto endNsResult = epochNanosecondsForDateAndTime(*endResult, isoTime, timeZone);
+            if (!endNsResult)
+                return makeUnexpected(endNsResult.error());
+            // Step 6.b.vii: Let beyondEnd be nudgedEpochNs - endEpochNs.
+            auto beyondEnd = nudgedEpochNs - *endNsResult;
+            // Step 6.b.viii: If beyondEnd < 0, beyondEndSign = -1; > 0, = 1; else 0.
+            auto beyondEndSign = beyondEnd < 0 ? -1 : beyondEnd > 0 ? 1 : 0;
+            // Step 6.b.ix: If beyondEndSign ≠ -sign, set duration to CombineDateAndTimeDuration(endDuration, 0).
+            if (beyondEndSign != -sign)
+                duration = ISO8601::InternalDuration::combineDateAndTimeDuration(endDuration, 0);
+            // Step 6.b.x: Else, set done to true.
+            else
+                done = true;
+        }
+        // Step 6.c: Set unitIndex to unitIndex - 1.
+        unitIndex--;
+    }
+    // Step 7: Return duration.
+    return duration;
+}
+
+// roundRelativeDuration — temporal_rs: InternalDurationRecord::round_relative_duration (src/builtins/core/duration/normalized.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal-roundrelativeduration
+TemporalResult<void> roundRelativeDuration(ISO8601::InternalDuration& duration,
+    Int128 originEpochNs, Int128 destEpochNs, ISO8601::PlainDate isoDate, ISO8601::PlainTime isoTime,
+    TemporalUnit largestUnit, double increment, TemporalUnit smallestUnit, RoundingMode roundingMode,
+    const TimeZone* timeZone, CalendarID calendarId)
+{
+    // Step 1: Let irregularLengthUnit be false.
+    // Step 2: If IsCalendarUnit(smallestUnit) is true, set irregularLengthUnit to true.
+    // Step 3: If timeZone is not ~unset~ and smallestUnit is ~day~, set irregularLengthUnit to true.
+    bool irregularLengthUnit = isCalendarUnit(smallestUnit);
+    if (timeZone && smallestUnit == TemporalUnit::Day)
+        irregularLengthUnit = true;
+    // Step 4: If InternalDurationSign(duration) < 0, let sign be -1; else let sign be 1.
+    int32_t sign = (duration.sign() < 0) ? -1 : 1;
+
+    NudgeResult nudgeResult;
+    // Step 5: If irregularLengthUnit is true, then
+    if (irregularLengthUnit) {
+        // Step 5.a: Let record be ? NudgeToCalendarUnit(...).
+        auto record = nudgeToCalendarUnit(sign, duration, originEpochNs, destEpochNs, isoDate, isoTime, increment, smallestUnit, roundingMode, timeZone, calendarId);
+        if (!record)
+            return makeUnexpected(record.error());
+        // Step 5.b: Let nudgeResult be record.[[NudgeResult]].
+        nudgeResult = record->nudgeResult;
+        // Step 5.c: Let total be record.[[Total]]. (total not needed by round/until/since callers; dropped)
+    } else if (timeZone) {
+        // Step 6.a: Let nudgeResult be ? NudgeToZonedTime(...).
+        auto result = nudgeToZonedTime(sign, duration, isoDate, isoTime, *timeZone, increment, smallestUnit, roundingMode, calendarId);
+        if (!result)
+            return makeUnexpected(result.error());
+        nudgeResult = *result;
+    } else {
+        // Step 7.a: Let nudgeResult be ? NudgeToDayOrTime(...).
+        auto result = nudgeToDayOrTime(duration, destEpochNs, largestUnit, increment, smallestUnit, roundingMode);
+        if (!result)
+            return makeUnexpected(result.error());
+        nudgeResult = *result;
+    }
+    // Step 8: Set duration to nudgeResult.[[Duration]].
+    duration = nudgeResult.duration;
+    // Step 9: If nudgeResult.[[DidExpandCalendarUnit]] is true and smallestUnit is not ~week~, then
+    if (nudgeResult.didExpandCalendarUnit && smallestUnit != TemporalUnit::Week) {
+        // Step 9.a: Let startUnit be LargerOfTwoTemporalUnits(smallestUnit, ~day~).
+        auto startUnit = smallestUnit <= TemporalUnit::Day ? smallestUnit : TemporalUnit::Day;
+        // Step 9.b: Set duration to ? BubbleRelativeDuration(sign, duration, nudgeResult.[[NudgedEpochNs]], isoDateTime, timeZone, calendar, largestUnit, startUnit).
+        auto bubbled = bubbleRelativeDuration(sign, duration, nudgeResult.nudgedEpochNs, isoDate, isoTime, largestUnit, startUnit, timeZone, calendarId);
+        if (!bubbled)
+            return makeUnexpected(bubbled.error());
+        duration = *bubbled;
+    }
+    // Step 10: Return duration.
+    return { };
+}
+
+// differenceZonedDateTimeForDuration — temporal_rs: ZonedDateTime::diff_zoned_datetime (src/builtins/core/zoned_date_time.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal-differencezoneddatetime
+TemporalResult<ISO8601::InternalDuration> differenceZonedDateTimeForDuration(
+    ISO8601::ExactTime startExact, ISO8601::ExactTime endExact,
+    const TimeZone& timeZone, TemporalUnit largestUnit, CalendarID calendarId)
+{
+    Int128 nsA = startExact.epochNanoseconds();
+    Int128 nsB = endExact.epochNanoseconds();
+    // Step 1: If ns1 = ns2, return CombineDateAndTimeDuration(ZeroDateDuration(), 0).
+    if (nsA == nsB)
+        return ISO8601::InternalDuration::combineDateAndTimeDuration(ISO8601::Duration(), Int128(0));
+    // Step 2: Let startDateTime be GetISODateTimeFor(timeZone, ns1).
+    // Step 3: Let endDateTime be GetISODateTimeFor(timeZone, ns2).
+    // (Each GetISODateTimeFor is split: getOffsetNanosecondsFor computes the offset,
+    //  exactTimeToLocalDateAndTime completes the date/time extraction.)
+    auto offset1Result = getOffsetNanosecondsFor(timeZone, startExact);
+    if (!offset1Result)
+        return makeUnexpected(offset1Result.error());
+    auto offset2Result = getOffsetNanosecondsFor(timeZone, endExact);
+    if (!offset2Result)
+        return makeUnexpected(offset2Result.error());
+
+    ISO8601::PlainDate startDate, endDate;
+    ISO8601::PlainTime startTime, endTime;
+    exactTimeToLocalDateAndTime(startExact, *offset1Result, startDate, startTime);
+    exactTimeToLocalDateAndTime(endExact, *offset2Result, endDate, endTime);
+
+    // Step 4: If CompareISODate(startDateTime.[[ISODate]], endDateTime.[[ISODate]]) = 0, return CombineDateAndTimeDuration(ZeroDateDuration(), ns2 - ns1).
+    if (!isoDateCompare(startDate, endDate))
+        return ISO8601::InternalDuration::combineDateAndTimeDuration(ISO8601::Duration(), nsB - nsA);
+
+    // Step 5: If ns2 - ns1 < 0, let sign be 1; else let sign be -1.
+    int32_t diffSign = (nsB - nsA < Int128 { 0 }) ? 1 : -1;
+    // Step 6: If sign = -1, let maxDayCorrection be 2; else let maxDayCorrection be 1.
+    int32_t maxDayCorrection = (diffSign == -1) ? 2 : 1;
+    // Step 7: Let dayCorrection be 0.
+    int32_t dayCorrection = 0;
+    // Step 8: Let timeDuration be DifferenceTime(startDateTime.[[Time]], endDateTime.[[Time]]).
+    Int128 timeDiff = timeDurationFromComponents(
+        static_cast<double>(endTime.hour()) - static_cast<double>(startTime.hour()),
+        static_cast<double>(endTime.minute()) - static_cast<double>(startTime.minute()),
+        static_cast<double>(endTime.second()) - static_cast<double>(startTime.second()),
+        static_cast<double>(endTime.millisecond()) - static_cast<double>(startTime.millisecond()),
+        static_cast<double>(endTime.microsecond()) - static_cast<double>(startTime.microsecond()),
+        static_cast<double>(endTime.nanosecond()) - static_cast<double>(startTime.nanosecond()));
+    int32_t timeSign = (timeDiff < 0) ? -1 : (timeDiff > 0) ? 1 : 0;
+    // Step 9: If timeSign = sign, set dayCorrection to dayCorrection + 1.
+    if (timeSign == diffSign)
+        dayCorrection++;
+
+    // Step 10: Let success be false.
+    ISO8601::PlainDate intermediateDate = endDate;
+    Int128 adjustedTimeDiff = timeDiff;
+    bool success = false;
+    // Step 11: Repeat, while dayCorrection ≤ maxDayCorrection and success is false,
+    while (dayCorrection <= maxDayCorrection && !success) {
+        // Step 11.a: Let intermediateDate be AddDaysToISODate(endDateTime.[[ISODate]], dayCorrection × sign).
+        intermediateDate = balanceISODate(endDate.year(), static_cast<int32_t>(endDate.month()), static_cast<int64_t>(endDate.day()) + dayCorrection * diffSign);
+        // Step 11.b: intermediateDateTime = CombineISODateAndTimeRecord(intermediateDate, startDateTime.[[Time]]).
+        // Step 11.c: intermediateNs = GetEpochNanosecondsFor(timeZone, intermediateDateTime, ~compatible~). (11.b+11.c fused)
+        auto intermediateNsResult = getEpochNanosecondsFor(timeZone, intermediateDate, startTime, TemporalDisambiguation::Compatible);
+        if (!intermediateNsResult)
+            return makeUnexpected(intermediateNsResult.error());
+        // Step 11.d: Set timeDuration to TimeDurationFromEpochNanosecondsDifference(ns2, intermediateNs).
+        adjustedTimeDiff = nsB - intermediateNsResult->epochNanoseconds();
+        // Step 11.e: Let timeSign be TimeDurationSign(timeDuration).
+        int32_t adjTimeSign = (adjustedTimeDiff < 0) ? -1 : (adjustedTimeDiff > 0) ? 1 : 0;
+        // Step 11.f: If sign ≠ timeSign, set success to true.
+        if (diffSign != adjTimeSign)
+            success = true;
+        // Step 11.g: Set dayCorrection to dayCorrection + 1.
+        dayCorrection++;
+    }
+    // Step 12: Assert: success is true.
+    ASSERT(success);
+
+    // Step 13: Let dateLargestUnit be LargerOfTwoTemporalUnits(largestUnit, ~day~).
+    TemporalUnit dateLargestUnit = (largestUnit > TemporalUnit::Day) ? TemporalUnit::Day : largestUnit;
+    // Step 14: Let dateDifference be CalendarDateUntil(calendar, startDateTime.[[ISODate]], intermediateDate, dateLargestUnit).
+    // (Note: intermediateDateTime.[[ISODate]] = intermediateDate computed above.)
+    auto dateDiffResult = TemporalCore::calendarDateUntil(calendarId, startDate, intermediateDate, dateLargestUnit);
+    if (!dateDiffResult)
+        return makeUnexpected(dateDiffResult.error());
+    ISO8601::Duration dateDiff = *dateDiffResult;
+
+    // Step 15: Return CombineDateAndTimeDuration(dateDifference, timeDuration).
+    // (Implementation folds days into time when largestUnit > day.)
+    constexpr Int128 nsPerDay = ISO8601::ExactTime::nsPerDay;
+    double remainingDays = 0;
+    Int128 timeDuration = adjustedTimeDiff;
+    if (largestUnit != dateLargestUnit)
+        timeDuration = adjustedTimeDiff + Int128(dateDiff.days()) * nsPerDay;
+    else
+        remainingDays = static_cast<double>(dateDiff.days());
+
+    ISO8601::Duration datePart(dateDiff.years(), dateDiff.months(),
+        dateDiff.weeks(), static_cast<int64_t>(remainingDays), 0, 0, 0, 0, Int128(0), Int128(0));
+    return ISO8601::InternalDuration::combineDateAndTimeDuration(datePart, timeDuration);
+}
+
+} // namespace TemporalCore
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/temporal/core/DurationArithmetic.h
+++ b/Source/JavaScriptCore/runtime/temporal/core/DurationArithmetic.h
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+// JSC Temporal Core — Duration arithmetic algorithms
+// temporal_rs reference: src/builtins/core/duration.rs
+// Last synced: v0.2.3
+
+#include <JavaScriptCore/CalendarICUBridge.h>
+#include <JavaScriptCore/ISO8601.h>
+#include <JavaScriptCore/JSCTimeZone.h>
+#include <JavaScriptCore/JSExportMacros.h>
+#include <JavaScriptCore/TemporalCoreTypes.h>
+#include <JavaScriptCore/TemporalObject.h>
+#include <optional>
+#include <utility>
+#include <wtf/Int128.h>
+
+namespace JSC {
+
+// NudgeResult — output record from a single nudge step: rounded duration, epoch ns, and calendar-expand flag.
+// temporal_rs: NudgeResultRecord (src/builtins/core/duration.rs)
+struct NudgeResult {
+    ISO8601::InternalDuration duration;
+    Int128 nudgedEpochNs;
+    bool didExpandCalendarUnit;
+    NudgeResult() { }
+    NudgeResult(ISO8601::InternalDuration d, Int128 ns, bool expanded)
+        : duration(d)
+        , nudgedEpochNs(ns)
+        , didExpandCalendarUnit(expanded)
+    {
+    }
+};
+
+// Nudged — combines a NudgeResult with a fractional total used by RoundRelativeDuration.
+// temporal_rs: NudgedRecord (src/builtins/core/duration.rs)
+struct Nudged {
+    NudgeResult nudgeResult;
+    double total;
+    Nudged() { }
+    Nudged(NudgeResult n, double t)
+        : nudgeResult(n)
+        , total(t)
+    {
+    }
+};
+
+} // namespace JSC
+
+namespace JSC {
+namespace TemporalCore {
+
+int JS_EXPORT_PRIVATE durationSign(const ISO8601::Duration&);
+
+ISO8601::Duration JS_EXPORT_PRIVATE negateDuration(const ISO8601::Duration&);
+
+ISO8601::Duration JS_EXPORT_PRIVATE absDuration(const ISO8601::Duration&);
+
+TemporalUnit NODELETE JS_EXPORT_PRIVATE largestSubduration(const ISO8601::Duration&);
+
+int64_t JS_EXPORT_PRIVATE totalSeconds(const ISO8601::Duration&);
+
+Int128 JS_EXPORT_PRIVATE totalSubseconds(const ISO8601::Duration&);
+
+std::optional<double> JS_EXPORT_PRIVATE balanceDuration(ISO8601::Duration&, TemporalUnit largestUnit);
+
+Int128 JS_EXPORT_PRIVATE timeDurationFromComponents(double hours, double minutes, double seconds, double milliseconds, double microseconds, double nanoseconds);
+
+std::pair<int64_t, Int128> JS_EXPORT_PRIVATE splitTimeDuration(Int128 timeDuration);
+
+ISO8601::PlainTime JS_EXPORT_PRIVATE plainTimeFromSubdayNs(Int128 ns);
+
+double JS_EXPORT_PRIVATE totalTimeDuration(Int128, TemporalUnit);
+
+ISO8601::Duration JS_EXPORT_PRIVATE temporalDurationFromInternal(ISO8601::InternalDuration, TemporalUnit largestUnit);
+
+ISO8601::InternalDuration JS_EXPORT_PRIVATE toInternalDuration(ISO8601::Duration);
+
+TemporalResult<Int128> JS_EXPORT_PRIVATE add24HourDaysToTimeDuration(Int128 timeDuration, double days);
+
+TemporalResult<ISO8601::InternalDuration> JS_EXPORT_PRIVATE toInternalDurationRecordWith24HourDays(ISO8601::Duration);
+
+TemporalResult<ISO8601::Duration> JS_EXPORT_PRIVATE toDateDurationRecordWithoutTime(ISO8601::Duration);
+
+Int128 JS_EXPORT_PRIVATE getUTCEpochNanoseconds(ISO8601::PlainDate, ISO8601::PlainTime);
+
+constexpr int32_t unitIndexInTable(TemporalUnit);
+
+constexpr TemporalUnit unitInTable(int32_t);
+
+TemporalResult<ISO8601::Duration> JS_EXPORT_PRIVATE adjustDateDurationRecord(const ISO8601::Duration& dateDuration, double days, std::optional<double> weeks, std::optional<double> months);
+
+TemporalResult<Nudged> JS_EXPORT_PRIVATE nudgeToCalendarUnit(int32_t sign,
+    const ISO8601::InternalDuration&, Int128 originEpochNs, Int128 destEpochNs,
+    ISO8601::PlainDate, ISO8601::PlainTime, double increment, TemporalUnit,
+    RoundingMode, const TimeZone* = nullptr, CalendarID = iso8601CalendarID());
+
+TemporalResult<NudgeResult> JS_EXPORT_PRIVATE nudgeToZonedTime(int32_t sign,
+    const ISO8601::InternalDuration&, ISO8601::PlainDate, ISO8601::PlainTime,
+    const TimeZone&, double increment, TemporalUnit, RoundingMode,
+    CalendarID = iso8601CalendarID());
+
+TemporalResult<NudgeResult> JS_EXPORT_PRIVATE nudgeToDayOrTime(ISO8601::InternalDuration,
+    Int128 destEpochNs, TemporalUnit largestUnit, double increment,
+    TemporalUnit smallestUnit, RoundingMode);
+
+TemporalResult<ISO8601::InternalDuration> JS_EXPORT_PRIVATE bubbleRelativeDuration(int32_t sign,
+    ISO8601::InternalDuration, Int128 nudgedEpochNs, ISO8601::PlainDate, ISO8601::PlainTime,
+    TemporalUnit largestUnit, TemporalUnit smallestUnit,
+    const TimeZone*, CalendarID);
+
+TemporalResult<void> JS_EXPORT_PRIVATE roundRelativeDuration(ISO8601::InternalDuration&,
+    Int128 originEpochNs, Int128 destEpochNs, ISO8601::PlainDate, ISO8601::PlainTime,
+    TemporalUnit largestUnit, double increment, TemporalUnit smallestUnit,
+    RoundingMode, const TimeZone*, CalendarID);
+
+TemporalResult<ISO8601::InternalDuration> JS_EXPORT_PRIVATE differenceZonedDateTimeForDuration(
+    ISO8601::ExactTime startExact, ISO8601::ExactTime endExact,
+    const TimeZone&, TemporalUnit largestUnit, CalendarID = iso8601CalendarID());
+
+} // namespace TemporalCore
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/temporal/core/ISOArithmetic.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/ISOArithmetic.cpp
@@ -27,6 +27,7 @@
 #include "ISOArithmetic.h"
 
 #include "DateConstructor.h"
+#include "Rounding.h"
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/DateMath.h>
 
@@ -314,6 +315,82 @@ ISO8601::InternalDuration diffISODateTime(const ISO8601::PlainDate& d1, const IS
         static_cast<double>(dateDiff.weeks()),
         remainingDays, 0, 0, 0, 0, 0, 0);
     return ISO8601::InternalDuration::combineDateAndTimeDuration(datePart, timeDuration);
+}
+
+// RoundTime steps 1–6 (quantity only) — temporal_rs: IsoTime::round (src/iso.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal-roundtime
+// Returns {quantity, baseOffset} in ns; caller does RoundNumberToIncrement + BalanceTime in Int128
+// to avoid double precision loss. Day unit omitted — caller handles overflow via nsPerDay bounds.
+static std::pair<Int128, Int128> roundTime(const ISO8601::PlainTime& t, TemporalUnit unit)
+{
+    using ET = ISO8601::ExactTime;
+    const Int128 lH = Int128(t.hour());
+    const Int128 lMi = Int128(t.minute());
+    const Int128 lS = Int128(t.second());
+    const Int128 lMs = Int128(t.millisecond());
+    const Int128 lUs = Int128(t.microsecond());
+    const Int128 lNs = Int128(t.nanosecond());
+    switch (unit) {
+    case TemporalUnit::Hour:
+        // Step 1: quantity = full time from midnight in ns.
+        return { lH * ET::nsPerHour + lMi * ET::nsPerMinute + lS * ET::nsPerSecond + lMs * ET::nsPerMillisecond + lUs * ET::nsPerMicrosecond + lNs, 0 };
+    case TemporalUnit::Minute:
+        // Step 2: quantity = minute-relative; baseOffset = hours.
+        return { lMi * ET::nsPerMinute + lS * ET::nsPerSecond + lMs * ET::nsPerMillisecond + lUs * ET::nsPerMicrosecond + lNs, lH * ET::nsPerHour };
+    case TemporalUnit::Second:
+        // Step 3: quantity = second-relative; baseOffset = hours+minutes.
+        return { lS * ET::nsPerSecond + lMs * ET::nsPerMillisecond + lUs * ET::nsPerMicrosecond + lNs, lH * ET::nsPerHour + lMi * ET::nsPerMinute };
+    case TemporalUnit::Millisecond:
+        // Step 4: quantity = ms-relative; baseOffset = hours+minutes+seconds.
+        return { lMs * ET::nsPerMillisecond + lUs * ET::nsPerMicrosecond + lNs, lH * ET::nsPerHour + lMi * ET::nsPerMinute + lS * ET::nsPerSecond };
+    case TemporalUnit::Microsecond:
+        // Step 5: quantity = us-relative; baseOffset = hours+minutes+seconds+ms.
+        return { lUs * ET::nsPerMicrosecond + lNs, lH * ET::nsPerHour + lMi * ET::nsPerMinute + lS * ET::nsPerSecond + lMs * ET::nsPerMillisecond };
+    default: // Nanosecond
+        // Step 6: Assert unit is nanosecond. quantity = ns; baseOffset = everything else.
+        return { lNs, lH * ET::nsPerHour + lMi * ET::nsPerMinute + lS * ET::nsPerSecond + lMs * ET::nsPerMillisecond + lUs * ET::nsPerMicrosecond };
+    }
+}
+
+// RoundISODateTime — temporal_rs: IsoDateTime::round (src/iso.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal-roundisodatetime
+RoundedISODateTime roundISODateTime(ISO8601::PlainDate date, ISO8601::PlainTime time, Int128 incrementNs, TemporalUnit unit, RoundingMode mode)
+{
+    using ET = ISO8601::ExactTime;
+
+    // Step 1: Assert ISODateTimeWithinLimits(isoDateTime).
+    ASSERT(ISO8601::isDateTimeWithinLimits(date.year(), date.month(), date.day(), time.hour(), time.minute(), time.second(), time.millisecond(), time.microsecond(), time.nanosecond()));
+
+    // Step 2: roundedTime = RoundTime(time, increment, unit, roundingMode).
+    auto [quantity, baseOffset] = roundTime(time, unit);
+    Int128 roundedLocalNs = baseOffset + roundNumberToIncrementInt128(quantity, incrementNs, mode);
+
+    // Step 3: balanceResult = AddDaysToISODate(isoDate, roundedTime.[[Days]]).
+    if (roundedLocalNs < 0) {
+        roundedLocalNs += ET::nsPerDay;
+        int32_t days = WTF::daysFromYearMonth(date.year(), date.month() - 1) + (date.day() - 1) - 1;
+        auto [y, m, d] = WTF::yearMonthDayFromDays(days);
+        date = ISO8601::PlainDate(y, static_cast<uint8_t>(m + 1), static_cast<uint8_t>(d));
+    } else if (roundedLocalNs >= ET::nsPerDay) {
+        roundedLocalNs -= ET::nsPerDay;
+        int32_t days = WTF::daysFromYearMonth(date.year(), date.month() - 1) + (date.day() - 1) + 1;
+        auto [y, m, d] = WTF::yearMonthDayFromDays(days);
+        date = ISO8601::PlainDate(y, static_cast<uint8_t>(m + 1), static_cast<uint8_t>(d));
+    }
+
+    // Step 4: CombineISODateAndTimeRecord(balanceResult, roundedTime).
+    Int128 rem = roundedLocalNs;
+    unsigned h = static_cast<unsigned>(rem / ET::nsPerHour);
+    rem %= ET::nsPerHour;
+    unsigned mi = static_cast<unsigned>(rem / ET::nsPerMinute);
+    rem %= ET::nsPerMinute;
+    unsigned s = static_cast<unsigned>(rem / ET::nsPerSecond);
+    rem %= ET::nsPerSecond;
+    unsigned ms = static_cast<unsigned>(rem / ET::nsPerMillisecond);
+    rem %= ET::nsPerMillisecond;
+    unsigned us = static_cast<unsigned>(rem / ET::nsPerMicrosecond);
+    unsigned ns = static_cast<unsigned>(rem % ET::nsPerMicrosecond);
+    return { date, ISO8601::PlainTime(h, mi, s, ms, us, ns) };
 }
 
 } // namespace TemporalCore

--- a/Source/JavaScriptCore/runtime/temporal/core/PlainDateTimeCore.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/PlainDateTimeCore.cpp
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "PlainDateTimeCore.h"
+
+#include "CalendarICUBridge.h"
+#include "DurationArithmetic.h"
+#include "ISO8601.h"
+#include "ISOArithmetic.h"
+#include "TemporalObject.h"
+
+namespace JSC {
+namespace TemporalCore {
+
+// CompareISODateTime — temporal_rs: PlainDateTime::compare_iso (pure)
+// https://tc39.es/proposal-temporal/#sec-temporal-compareisodatetime
+int32_t compareISODateTime(ISO8601::PlainDate d1, ISO8601::PlainTime t1, ISO8601::PlainDate d2, ISO8601::PlainTime t2)
+{
+    // Step 1: Let dateResult be CompareISODate(isoDateTime1.[[ISODate]], isoDateTime2.[[ISODate]]).
+    // Step 2: If dateResult ≠ 0, return dateResult.
+    if (auto r = isoDateCompare(d1, d2))
+        return r;
+    // Step 3: Return CompareTimeRecord(isoDateTime1.[[Time]], isoDateTime2.[[Time]]).
+    return isoTimeCompare(t1, t2);
+}
+
+// DifferencePlainDateTimeWithRounding — temporal_rs: PlainDateTime::diff inner path
+// https://tc39.es/proposal-temporal/#sec-temporal-differenceplaindatetimewithrounding
+static TemporalResult<ISO8601::InternalDuration> differencePlainDateTimeWithRounding(
+    ISO8601::PlainDate thisDate, ISO8601::PlainTime thisTime,
+    ISO8601::PlainDate otherDate, ISO8601::PlainTime otherTime,
+    CalendarID calendarId,
+    TemporalUnit largestUnit, TemporalUnit smallestUnit,
+    RoundingMode roundingMode, double increment)
+{
+    // Step 1: If CompareISODateTime = 0, return zero. (caller already checked, but guard here too)
+    // Step 2: ISODateTimeWithinLimits check.
+    if (!ISO8601::isDateTimeWithinLimits(thisDate.year(), thisDate.month(), thisDate.day(), thisTime.hour(), thisTime.minute(), thisTime.second(), thisTime.millisecond(), thisTime.microsecond(), thisTime.nanosecond())
+        || !ISO8601::isDateTimeWithinLimits(otherDate.year(), otherDate.month(), otherDate.day(), otherTime.hour(), otherTime.minute(), otherTime.second(), otherTime.millisecond(), otherTime.microsecond(), otherTime.nanosecond()))
+        return makeUnexpected(rangeError("date-time is outside the representable range for Temporal"_s));
+
+    // Step 3: diff = DifferenceISODateTime(isoDateTime1, isoDateTime2, calendar, largestUnit).
+    ISO8601::InternalDuration diff;
+    if (calendarId != iso8601CalendarID()) {
+        Int128 timeDiff = timeDurationFromComponents(
+            static_cast<double>(otherTime.hour()) - static_cast<double>(thisTime.hour()),
+            static_cast<double>(otherTime.minute()) - static_cast<double>(thisTime.minute()),
+            static_cast<double>(otherTime.second()) - static_cast<double>(thisTime.second()),
+            static_cast<double>(otherTime.millisecond()) - static_cast<double>(thisTime.millisecond()),
+            static_cast<double>(otherTime.microsecond()) - static_cast<double>(thisTime.microsecond()),
+            static_cast<double>(otherTime.nanosecond()) - static_cast<double>(thisTime.nanosecond()));
+        int32_t timeSign = timeDiff < 0 ? -1 : timeDiff > 0 ? 1 : 0;
+        int32_t dateSign = isoDateCompare(thisDate, otherDate);
+        ISO8601::PlainDate adjustedD2 = otherDate;
+        if (dateSign && timeSign && dateSign == timeSign) {
+            adjustedD2 = balanceISODate(adjustedD2.year(), static_cast<int32_t>(adjustedD2.month()),
+                static_cast<int64_t>(adjustedD2.day()) + dateSign);
+            timeDiff -= Int128(dateSign) * ISO8601::ExactTime::nsPerDay;
+        }
+        TemporalUnit dateLargestUnit = (largestUnit > TemporalUnit::Day) ? TemporalUnit::Day : largestUnit;
+        auto dateDiffResult = TemporalCore::calendarDateUntil(calendarId, thisDate, adjustedD2, dateLargestUnit);
+        if (!dateDiffResult)
+            return makeUnexpected(dateDiffResult.error());
+        auto& dateDiff = *dateDiffResult;
+        if (largestUnit > TemporalUnit::Day)
+            timeDiff += Int128(static_cast<int64_t>(dateDiff.days())) * ISO8601::ExactTime::nsPerDay;
+        diff = ISO8601::InternalDuration::combineDateAndTimeDuration(
+            ISO8601::Duration(dateDiff.years(), dateDiff.months(), dateDiff.weeks(), largestUnit > TemporalUnit::Day ? 0 : dateDiff.days(), 0, 0, 0, 0, Int128(0), Int128(0)), timeDiff);
+    } else
+        diff = diffISODateTime(thisDate, thisTime, otherDate, otherTime, largestUnit);
+
+    // Step 4: If smallestUnit=nanosecond and increment=1, return diff.
+    if (smallestUnit == TemporalUnit::Nanosecond && increment == 1)
+        return diff;
+
+    // Step 5: originEpochNs = GetUTCEpochNanoseconds(isoDateTime1).
+    Int128 originEpochNs = getUTCEpochNanoseconds(thisDate, thisTime);
+    // Step 6: destEpochNs = GetUTCEpochNanoseconds(isoDateTime2).
+    Int128 destEpochNs = getUTCEpochNanoseconds(otherDate, otherTime);
+    // Step 7: Return ? RoundRelativeDuration(diff, originEpochNs, destEpochNs, isoDateTime1, unset, ...).
+    auto roundResult = roundRelativeDuration(diff, originEpochNs, destEpochNs,
+        thisDate, thisTime, largestUnit, increment, smallestUnit, roundingMode, nullptr, calendarId);
+    if (!roundResult)
+        return makeUnexpected(roundResult.error());
+    return diff;
+}
+
+// DifferenceTemporalPlainDateTime — temporal_rs: PlainDateTime::diff (src/builtins/core/plain_date_time.rs; until/since call this)
+// https://tc39.es/proposal-temporal/#sec-temporal-differencetemporalplaindatetime
+// Steps 1-4 (ToTemporalDateTime, CalendarEquals, GetOptionsObject, GetDifferenceSettings)
+// are handled by the JS layer before calling this function.
+TemporalResult<ISO8601::Duration> differenceTemporalPlainDateTime(
+    DifferenceOperation op,
+    ISO8601::PlainDate thisDate, ISO8601::PlainTime thisTime,
+    ISO8601::PlainDate otherDate, ISO8601::PlainTime otherTime,
+    CalendarID calendarId,
+    TemporalUnit smallestUnit, TemporalUnit largestUnit,
+    RoundingMode roundingMode, double increment)
+{
+    ASSERT(largestUnit <= smallestUnit);
+    ASSERT(increment >= 1);
+    // Step 5: If CompareISODateTime = 0, return zero duration.
+    if (thisDate == otherDate && thisTime == otherTime)
+        return ISO8601::Duration();
+
+    // Step 6: internalDuration = DifferencePlainDateTimeWithRounding(...).
+    auto internalDuration = differencePlainDateTimeWithRounding(thisDate, thisTime, otherDate, otherTime, calendarId, largestUnit, smallestUnit, roundingMode, increment);
+    if (!internalDuration)
+        return makeUnexpected(internalDuration.error());
+
+    // Step 7: result = TemporalDurationFromInternal(internalDuration, largestUnit).
+    auto result = temporalDurationFromInternal(*internalDuration, largestUnit);
+    // Step 8: If operation is since, set result to CreateNegatedTemporalDuration(result).
+    if (op == DifferenceOperation::Since)
+        result = -result;
+    // Step 9: Return result.
+    return result;
+}
+
+} // namespace TemporalCore
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/temporal/core/PlainDateTimeCore.h
+++ b/Source/JavaScriptCore/runtime/temporal/core/PlainDateTimeCore.h
@@ -25,10 +25,11 @@
 
 #pragma once
 
-// JSC Temporal Core — ISO 8601 date arithmetic
-// temporal_rs reference: src/iso.rs
+// JSC Temporal Core — PlainDateTime algorithms
+// temporal_rs reference: src/builtins/core/plain_date_time.rs
 // Last synced: v0.2.3
 
+#include <JavaScriptCore/CalendarICUBridge.h>
 #include <JavaScriptCore/ISO8601.h>
 #include <JavaScriptCore/JSExportMacros.h>
 #include <JavaScriptCore/TemporalCoreTypes.h>
@@ -37,27 +38,15 @@
 namespace JSC {
 namespace TemporalCore {
 
-ISO8601::PlainYearMonth JS_EXPORT_PRIVATE balanceISOYearMonth(int64_t year, int64_t month);
+int32_t NODELETE JS_EXPORT_PRIVATE compareISODateTime(ISO8601::PlainDate, ISO8601::PlainTime, ISO8601::PlainDate, ISO8601::PlainTime);
 
-ISO8601::PlainDate JS_EXPORT_PRIVATE balanceISODate(int32_t year, int32_t month, int64_t day);
-
-TemporalResult<ISO8601::PlainDate> JS_EXPORT_PRIVATE regulateISODate(int32_t year, int32_t month, int64_t day, TemporalOverflow);
-
-TemporalResult<ISO8601::PlainDate> JS_EXPORT_PRIVATE isoDateAdd(const ISO8601::PlainDate&, const ISO8601::Duration&, TemporalOverflow);
-
-int32_t NODELETE JS_EXPORT_PRIVATE isoDateCompare(const ISO8601::PlainDate&, const ISO8601::PlainDate&);
-
-int32_t NODELETE JS_EXPORT_PRIVATE isoTimeCompare(const ISO8601::PlainTime&, const ISO8601::PlainTime&);
-
-ISO8601::Duration JS_EXPORT_PRIVATE diffISODate(const ISO8601::PlainDate& one, const ISO8601::PlainDate& two, TemporalUnit largestUnit);
-
-ISO8601::InternalDuration JS_EXPORT_PRIVATE diffISODateTime(const ISO8601::PlainDate& d1, const ISO8601::PlainTime& t1, const ISO8601::PlainDate& d2, const ISO8601::PlainTime& t2, TemporalUnit largestUnit);
-
-struct RoundedISODateTime {
-    ISO8601::PlainDate date;
-    ISO8601::PlainTime time;
-};
-RoundedISODateTime JS_EXPORT_PRIVATE roundISODateTime(ISO8601::PlainDate, ISO8601::PlainTime, Int128 incrementNs, TemporalUnit, RoundingMode);
+TemporalResult<ISO8601::Duration> JS_EXPORT_PRIVATE differenceTemporalPlainDateTime(
+    DifferenceOperation,
+    ISO8601::PlainDate thisDate, ISO8601::PlainTime thisTime,
+    ISO8601::PlainDate otherDate, ISO8601::PlainTime otherTime,
+    CalendarID,
+    TemporalUnit smallestUnit, TemporalUnit largestUnit,
+    RoundingMode, double increment);
 
 } // namespace TemporalCore
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/temporal/core/TemporalEnums.h
+++ b/Source/JavaScriptCore/runtime/temporal/core/TemporalEnums.h
@@ -60,153 +60,6 @@ enum class OffsetBehaviour : uint8_t {
     Option, // +HH:MM present — use inlineOffsetNs
 };
 
-// https://tc39.es/proposal-temporal/#sec-temporal-totemporalcalendaridentifier
-// temporal_rs: AnyCalendarKind (icu_calendar crate, imported by builtins/core/calendar.rs)
-enum class CalendarKind : uint8_t {
-    Iso8601 = 0, // must be 0 so zero-initialised objects default to iso8601
-    Buddhist,
-    Chinese,
-    Coptic,
-    Dangi,
-    Ethiopic,
-    EthioAA,
-    Gregory,
-    Hebrew,
-    Indian,
-    Islamic,
-    IslamicCivil,
-    IslamicRGSA,
-    IslamicTBLA,
-    IslamicUmmAlQura,
-    Japanese,
-    Persian,
-    Roc,
-    Bangla,
-    Gujarati,
-    Kannada,
-    Marathi,
-    Odia,
-    Tamil,
-    Telugu,
-    Vikram,
-};
-
-inline ASCIILiteral toCalendarIdentifier(CalendarKind k)
-{
-    switch (k) {
-    case CalendarKind::Iso8601:
-        return "iso8601"_s;
-    case CalendarKind::Buddhist:
-        return "buddhist"_s;
-    case CalendarKind::Chinese:
-        return "chinese"_s;
-    case CalendarKind::Coptic:
-        return "coptic"_s;
-    case CalendarKind::Dangi:
-        return "dangi"_s;
-    case CalendarKind::Ethiopic:
-        return "ethiopic"_s;
-    case CalendarKind::EthioAA:
-        return "ethioaa"_s;
-    case CalendarKind::Gregory:
-        return "gregory"_s;
-    case CalendarKind::Hebrew:
-        return "hebrew"_s;
-    case CalendarKind::Indian:
-        return "indian"_s;
-    case CalendarKind::Islamic:
-        return "islamic"_s;
-    case CalendarKind::IslamicCivil:
-        return "islamic-civil"_s;
-    case CalendarKind::IslamicRGSA:
-        return "islamic-rgsa"_s;
-    case CalendarKind::IslamicTBLA:
-        return "islamic-tbla"_s;
-    case CalendarKind::IslamicUmmAlQura:
-        return "islamic-umalqura"_s;
-    case CalendarKind::Japanese:
-        return "japanese"_s;
-    case CalendarKind::Persian:
-        return "persian"_s;
-    case CalendarKind::Roc:
-        return "roc"_s;
-    case CalendarKind::Bangla:
-        return "bangla"_s;
-    case CalendarKind::Gujarati:
-        return "gujarati"_s;
-    case CalendarKind::Kannada:
-        return "kannada"_s;
-    case CalendarKind::Marathi:
-        return "marathi"_s;
-    case CalendarKind::Odia:
-        return "odia"_s;
-    case CalendarKind::Tamil:
-        return "tamil"_s;
-    case CalendarKind::Telugu:
-        return "telugu"_s;
-    case CalendarKind::Vikram:
-        return "vikram"_s;
-    }
-    RELEASE_ASSERT_NOT_REACHED();
-}
-
-inline CalendarKind toCalendarKind(WTF::StringView s)
-{
-    if (s.isEmpty() || s == "iso8601"_s)
-        return CalendarKind::Iso8601;
-    if (s == "buddhist"_s)
-        return CalendarKind::Buddhist;
-    if (s == "chinese"_s)
-        return CalendarKind::Chinese;
-    if (s == "coptic"_s)
-        return CalendarKind::Coptic;
-    if (s == "dangi"_s)
-        return CalendarKind::Dangi;
-    if (s == "ethiopic"_s)
-        return CalendarKind::Ethiopic;
-    if (s == "ethioaa"_s || s == "ethiopic-amete-alem"_s)
-        return CalendarKind::EthioAA;
-    if (s == "gregory"_s || s == "gregorian"_s)
-        return CalendarKind::Gregory;
-    if (s == "hebrew"_s)
-        return CalendarKind::Hebrew;
-    if (s == "indian"_s)
-        return CalendarKind::Indian;
-    if (s == "islamic"_s)
-        return CalendarKind::Islamic;
-    if (s == "islamic-civil"_s || s == "islamicc"_s)
-        return CalendarKind::IslamicCivil;
-    if (s == "islamic-rgsa"_s)
-        return CalendarKind::IslamicRGSA;
-    if (s == "islamic-tbla"_s)
-        return CalendarKind::IslamicTBLA;
-    if (s == "islamic-umalqura"_s)
-        return CalendarKind::IslamicUmmAlQura;
-    if (s == "japanese"_s)
-        return CalendarKind::Japanese;
-    if (s == "persian"_s)
-        return CalendarKind::Persian;
-    if (s == "roc"_s)
-        return CalendarKind::Roc;
-    if (s == "bangla"_s)
-        return CalendarKind::Bangla;
-    if (s == "gujarati"_s)
-        return CalendarKind::Gujarati;
-    if (s == "kannada"_s)
-        return CalendarKind::Kannada;
-    if (s == "marathi"_s)
-        return CalendarKind::Marathi;
-    if (s == "odia"_s)
-        return CalendarKind::Odia;
-    if (s == "tamil"_s)
-        return CalendarKind::Tamil;
-    if (s == "telugu"_s)
-        return CalendarKind::Telugu;
-    if (s == "vikram"_s)
-        return CalendarKind::Vikram;
-    return CalendarKind::Iso8601;
-}
-
 // -----------------------------------------------------------------------
 // Temporal unit
 // -----------------------------------------------------------------------
@@ -279,6 +132,9 @@ constexpr Int128 lengthInNanoseconds(TemporalUnit unit)
     }
     RELEASE_ASSERT_NOT_REACHED();
 }
+
+// https://tc39.es/proposal-temporal/#sec-temporal-iscalendarunit
+constexpr bool isCalendarUnit(TemporalUnit unit) { return unit <= TemporalUnit::Week; }
 
 // -----------------------------------------------------------------------
 // Rounding enums

--- a/Source/JavaScriptCore/runtime/temporal/core/TimeZoneICUBridge.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/TimeZoneICUBridge.cpp
@@ -473,7 +473,7 @@ TemporalResult<ISO8601::ExactTime> getEpochNanosecondsFor(const TimeZone& timeZo
 
 // addZonedDateTime — temporal_rs: ZonedDateTime::add_zoned_date_time (src/builtins/core/zoned_date_time.rs)
 // https://tc39.es/proposal-temporal/#sec-temporal-addzoneddatetime
-TemporalResult<ISO8601::ExactTime> addZonedDateTime(ISO8601::ExactTime startEpochNs, const TimeZone& timeZone, const ISO8601::Duration& duration, TemporalOverflow overflow, StringView calendarId)
+TemporalResult<ISO8601::ExactTime> addZonedDateTime(ISO8601::ExactTime startEpochNs, const TimeZone& timeZone, const ISO8601::Duration& duration, TemporalOverflow overflow, CalendarID calendarId)
 {
     // NOTE: Pre-compute the time duration (norm) as nanoseconds; used by AddInstant in steps 1 and 7.
     CheckedInt128 m = checkedCastDoubleToInt128(duration.minutes()) + checkedCastDoubleToInt128(duration.hours()) * Int128(60);
@@ -508,11 +508,10 @@ TemporalResult<ISO8601::ExactTime> addZonedDateTime(ISO8601::ExactTime startEpoc
     // 3. Let addedDate be ? CalendarDateAdd(calendar, isoDateTime.[[ISODate]], duration.[[Date]], overflow).
     ISO8601::Duration dateDuration(duration.years(), duration.months(), duration.weeks(), duration.days(), 0, 0, 0, 0, 0, 0);
     TemporalResult<ISO8601::PlainDate> addedDateResult;
-    CalendarID calId = calendarIDFromString(calendarId);
-    if (calendarIsISO(calId))
+    if (calendarIsISO(calendarId))
         addedDateResult = calendarDateAdd(date, dateDuration, overflow);
     else
-        addedDateResult = TemporalCore::calendarDateAdd(calId, date, dateDuration, overflow);
+        addedDateResult = TemporalCore::calendarDateAdd(calendarId, date, dateDuration, overflow);
     if (!addedDateResult)
         return makeUnexpected(addedDateResult.error());
 

--- a/Source/JavaScriptCore/runtime/temporal/core/TimeZoneICUBridge.h
+++ b/Source/JavaScriptCore/runtime/temporal/core/TimeZoneICUBridge.h
@@ -82,7 +82,7 @@ TemporalResult<std::optional<ISO8601::ExactTime>> JS_EXPORT_PRIVATE getTimeZoneT
 
 TemporalResult<ISO8601::ExactTime> JS_EXPORT_PRIVATE getEpochNanosecondsFor(const TimeZone&, const ISO8601::PlainDate&, const ISO8601::PlainTime&, TemporalDisambiguation);
 
-TemporalResult<ISO8601::ExactTime> JS_EXPORT_PRIVATE addZonedDateTime(ISO8601::ExactTime startEpochNs, const TimeZone&, const ISO8601::Duration&, TemporalOverflow, StringView calendarId = "iso8601"_s);
+TemporalResult<ISO8601::ExactTime> JS_EXPORT_PRIVATE addZonedDateTime(ISO8601::ExactTime startEpochNs, const TimeZone&, const ISO8601::Duration&, TemporalOverflow, CalendarID calendarKind = iso8601CalendarID());
 
 } // namespace TemporalCore
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/temporal/core/ZonedDateTimeCore.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/ZonedDateTimeCore.cpp
@@ -1,0 +1,295 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "ZonedDateTimeCore.h"
+
+#include "CalendarICUBridge.h"
+#include "DurationArithmetic.h"
+#include "ISO8601.h"
+#include "ISOArithmetic.h"
+#include "Rounding.h"
+#include "TemporalObject.h"
+#include "TimeZoneICUBridge.h"
+#include <span>
+#include <wtf/DateMath.h>
+
+namespace JSC {
+namespace TemporalCore {
+
+// InterpretISODateTimeOffset — temporal_rs: interpret_isodatetime_offset in zoned_date_time.rs
+// https://tc39.es/proposal-temporal/#sec-temporal-interpretisodatetimeoffset
+TemporalResult<ISO8601::ExactTime> interpretISODateTimeOffset(
+    const ISO8601::PlainDate& date,
+    const ISO8601::PlainTime& time,
+    bool useStartOfDay,
+    OffsetBehaviour offsetBehaviour,
+    TemporalOffsetDisambiguation offsetOpt,
+    int64_t inlineOffsetNs,
+    bool offsetHasSubMinutePrecision,
+    const TimeZone& timeZone,
+    TemporalDisambiguation disambiguation)
+{
+    // Step 1: If time is start-of-day, then
+    if (useStartOfDay) {
+        ASSERT(offsetBehaviour == OffsetBehaviour::Wall); // 1.a
+        ASSERT(!inlineOffsetNs); // 1.b
+        return getStartOfDay(timeZone, date); // 1.c
+    }
+
+    // Step 2: isoDateTime = CombineISODateAndTimeRecord(isoDate, time). (implicit — date+time passed separately)
+    // Step 3: If offsetBehaviour is wall, or offsetBehaviour is option and offsetOption is ignore.
+    if (offsetBehaviour == OffsetBehaviour::Wall
+        || (offsetBehaviour == OffsetBehaviour::Option && offsetOpt == TemporalOffsetDisambiguation::Ignore))
+        return getEpochNanosecondsFor(timeZone, date, time, disambiguation);
+
+    // Step 4: offsetBehaviour is exact or option+use: compute epoch ns = UTC(date,time) - offset.
+    // Steps 4a-4d fused: GetUTCEpochNanoseconds(date,time) - offset ≡ BalanceISODateTime + GetUTCEpochNanoseconds
+    // since both are linear; IsValidEpochNanoseconds ↔ CheckISODaysRange (same ±10^8 day bound).
+    if (offsetBehaviour == OffsetBehaviour::Exact
+        || (offsetBehaviour == OffsetBehaviour::Option && offsetOpt == TemporalOffsetDisambiguation::Use)) {
+        Int128 naiveNs = getUTCEpochNanoseconds(date, time);
+        ISO8601::ExactTime result(naiveNs - Int128(inlineOffsetNs));
+        if (!result.isValid())
+            return makeUnexpected(rangeError("date/time offset combination is outside the supported range for Temporal.ZonedDateTime"_s));
+        return result;
+    }
+
+    // Step 5: Assert offsetBehaviour is option.
+    ASSERT(offsetBehaviour == OffsetBehaviour::Option);
+    // Step 6: Assert offsetOption is prefer or reject.
+    ASSERT(offsetOpt == TemporalOffsetDisambiguation::Prefer || offsetOpt == TemporalOffsetDisambiguation::Reject);
+    // Step 7: CheckISODaysRange(isoDate).
+    if (std::abs(dateToDaysFrom1970(date.year(), static_cast<int>(date.month()) - 1, static_cast<int>(date.day()))) > 1e8)
+        return makeUnexpected(rangeError("wall-clock date is outside the representable range for Temporal.ZonedDateTime"_s));
+
+    // Step 8: utcEpochNanoseconds = GetUTCEpochNanoseconds(isoDateTime).
+    Int128 utcEpochNs = getUTCEpochNanoseconds(date, time);
+
+    // Step 9: possibleEpochNs = GetPossibleEpochNanoseconds(timeZone, isoDateTime).
+    auto possible = getPossibleEpochNanosecondsFor(timeZone, date, time);
+    if (!possible)
+        return makeUnexpected(possible.error());
+
+    // Step 10: For each element candidate of possibleEpochNs.
+    bool matchMinutes = !offsetHasSubMinutePrecision;
+    for (auto& candidate : epochCandidates(*possible)) {
+        // Step 10a: candidateOffset = utcEpochNanoseconds - candidate.
+        Int128 candidateOffset = utcEpochNs - candidate.epochNanoseconds();
+        // Step 10b: If candidateOffset = offsetNanoseconds, return candidate.
+        if (candidateOffset == Int128(inlineOffsetNs))
+            return candidate;
+        // Step 10c: If matchBehaviour is match-minutes, check rounded.
+        if (matchMinutes) {
+            if (roundNumberToIncrementInt128(candidateOffset, ISO8601::ExactTime::nsPerMinute, RoundingMode::HalfExpand) == Int128(inlineOffsetNs))
+                return candidate;
+        }
+    }
+
+    // Step 11: If offsetOption is reject, throw RangeError.
+    if (offsetOpt == TemporalOffsetDisambiguation::Reject)
+        return makeUnexpected(rangeError("offset does not agree with timezone for the given date/time"_s));
+
+    // Step 12: Return ? DisambiguatePossibleEpochNanoseconds(possibleEpochNs, timeZone, isoDateTime, disambiguation).
+    // Note: getEpochNanosecondsFor recomputes possibleEpochNs; functionally equivalent.
+    return getEpochNanosecondsFor(timeZone, date, time, disambiguation);
+}
+
+// GetStartOfDay — temporal_rs: TimeZone::get_start_of_day(iso_date, provider)
+// https://tc39.es/proposal-temporal/#sec-temporal-getstartofday
+TemporalResult<ISO8601::ExactTime> getStartOfDay(const TimeZone& tz, ISO8601::PlainDate date)
+{
+    // Step 1: isoDateTime = CombineISODateAndTimeRecord(isoDate, MidnightTimeRecord()).
+    ISO8601::PlainTime midnight;
+    // Step 2: possibleEpochNs = GetPossibleEpochNanoseconds(timeZone, isoDateTime).
+    auto possible = getPossibleEpochNanosecondsFor(tz, date, midnight);
+    if (!possible)
+        return makeUnexpected(possible.error());
+    // Step 3: If possibleEpochNs is not empty, return possibleEpochNs[0].
+    if (!isGap(*possible)) {
+        auto candidate = epochCandidates(*possible)[0];
+        // Validate: the start-of-day epoch must be within Temporal range.
+        // e.g. midnight of +275760-09-13 in America/Vancouver = UTC+7h > max epoch.
+        if (!candidate.isValid())
+            return makeUnexpected(rangeError("start of day is outside the representable range of Temporal.ZonedDateTime"_s));
+        return candidate;
+    }
+    // Step 4: Assert IsOffsetTimeZoneIdentifier(timeZone) is false (gap is only possible for IANA zones).
+    ASSERT(tz.isID());
+    // Step 5: possibleEpochNsAfter = first instant after the gap transition.
+    // We find it via: getEpochNanosecondsFor(Earlier) -> last instant before gap,
+    // then getTimeZoneTransition(Next) -> first instant after gap.
+    auto beforeGap = getEpochNanosecondsFor(tz, date, midnight, TemporalDisambiguation::Earlier);
+    if (!beforeGap)
+        return makeUnexpected(beforeGap.error());
+    auto transition = getTimeZoneTransition(tz, *beforeGap, TransitionDirection::Next);
+    if (!transition)
+        return makeUnexpected(transition.error());
+    if (!transition->has_value())
+        return makeUnexpected(rangeError("no start of day: time zone has no future transitions"_s));
+    // Step 6: Assert: The number of elements in possibleEpochNsAfter = 1.
+    // Step 7: Return the sole element of possibleEpochNsAfter.
+    return transition->value();
+}
+
+// DifferenceZonedDateTime — temporal_rs: ZonedDateTime::diff_zoned_datetime inner path
+// https://tc39.es/proposal-temporal/#sec-temporal-differencezoneddatetime
+static TemporalResult<ISO8601::InternalDuration> differenceZonedDateTime(ISO8601::ExactTime ns1, ISO8601::ExactTime ns2, const TimeZone& timeZone, CalendarID calendarId, TemporalUnit largestUnit)
+{
+    Int128 nsA = ns1.epochNanoseconds();
+    Int128 nsB = ns2.epochNanoseconds();
+
+    // Step 1: If ns1 = ns2, return zero.
+    if (nsA == nsB)
+        return ISO8601::InternalDuration::combineDateAndTimeDuration(ISO8601::Duration(), 0);
+
+    // Steps 2–3: GetISODateTimeFor(timeZone, ns1/ns2). (split: getOffsetNanosecondsFor + exactTimeToLocalDateAndTime)
+    auto offset1Result = getOffsetNanosecondsFor(timeZone, ns1);
+    if (!offset1Result)
+        return makeUnexpected(offset1Result.error());
+    auto offset2Result = getOffsetNanosecondsFor(timeZone, ns2);
+    if (!offset2Result)
+        return makeUnexpected(offset2Result.error());
+    ISO8601::PlainDate startDate, endDate;
+    ISO8601::PlainTime startTime, endTime;
+    exactTimeToLocalDateAndTime(ns1, *offset1Result, startDate, startTime);
+    exactTimeToLocalDateAndTime(ns2, *offset2Result, endDate, endTime);
+
+    // Step 4: If startDate = endDate -> timeDuration = ns2 - ns1, return.
+    if (!isoDateCompare(startDate, endDate))
+        return ISO8601::InternalDuration::combineDateAndTimeDuration(ISO8601::Duration(), nsB - nsA);
+
+    // Step 5: sign = (ns2 - ns1 < 0) ? 1 : -1.
+    int32_t sign = (nsB - nsA < Int128 { 0 }) ? 1 : -1;
+    // Step 6: maxDayCorrection = (sign=-1) ? 2 : 1.
+    int32_t maxDayCorrection = (sign == -1) ? 2 : 1;
+    // Step 7: dayCorrection = 0.
+    int32_t dayCorrection = 0;
+    // Step 8: timeDuration = DifferenceTime(startTime, endTime).
+    Int128 timeDiff = timeDurationFromComponents(
+        static_cast<double>(endTime.hour()) - static_cast<double>(startTime.hour()),
+        static_cast<double>(endTime.minute()) - static_cast<double>(startTime.minute()),
+        static_cast<double>(endTime.second()) - static_cast<double>(startTime.second()),
+        static_cast<double>(endTime.millisecond()) - static_cast<double>(startTime.millisecond()),
+        static_cast<double>(endTime.microsecond()) - static_cast<double>(startTime.microsecond()),
+        static_cast<double>(endTime.nanosecond()) - static_cast<double>(startTime.nanosecond()));
+    // Step 9: If TimeDurationSign(timeDuration) = sign -> dayCorrection++.
+    int32_t timeSign = (timeDiff < 0) ? -1 : (timeDiff > 0) ? 1 : 0;
+    if (timeSign == sign)
+        dayCorrection++;
+
+    // Steps 10-12: day-correction loop.
+    ISO8601::PlainDate intermediateDate = endDate;
+    Int128 adjustedTimeDiff = timeDiff;
+    bool success = false;
+    while (dayCorrection <= maxDayCorrection && !success) {
+        // Step 11.a: intermediateDate = AddDaysToISODate(endDate, dayCorrection × sign).
+        intermediateDate = balanceISODate(endDate.year(), static_cast<int32_t>(endDate.month()),
+            static_cast<int64_t>(endDate.day()) + dayCorrection * sign);
+        // Step 11.c: intermediateNs = GetEpochNanosecondsFor(timeZone, intermediateDateTime, compatible).
+        auto intermediateNsResult = getEpochNanosecondsFor(timeZone, intermediateDate, startTime, TemporalDisambiguation::Compatible);
+        if (!intermediateNsResult)
+            return makeUnexpected(intermediateNsResult.error());
+        // Step 11.d: timeDuration = ns2 - intermediateNs.
+        adjustedTimeDiff = nsB - intermediateNsResult->epochNanoseconds();
+        int32_t adjTimeSign = (adjustedTimeDiff < 0) ? -1 : (adjustedTimeDiff > 0) ? 1 : 0;
+        // Step 11.f: If sign ≠ timeSign -> success.
+        if (sign != adjTimeSign)
+            success = true;
+        dayCorrection++;
+    }
+    // Step 13: Assert success.
+    ASSERT(success);
+
+    // Step 14: dateLargestUnit = max(largestUnit, day).
+    TemporalUnit dateLargestUnit = (largestUnit > TemporalUnit::Day) ? TemporalUnit::Day : largestUnit;
+    // Step 15: dateDifference = CalendarDateUntil(startDate, intermediateDate, dateLargestUnit).
+    auto dateDiffResult = TemporalCore::calendarDateUntil(calendarId, startDate, intermediateDate, dateLargestUnit);
+    if (!dateDiffResult)
+        return makeUnexpected(dateDiffResult.error());
+    auto& dateDiff = *dateDiffResult;
+
+    // Step 16: Return CombineDateAndTimeDuration(dateDifference, timeDuration).
+    ISO8601::Duration datePart(static_cast<double>(dateDiff.years()), static_cast<double>(dateDiff.months()),
+        static_cast<double>(dateDiff.weeks()), static_cast<double>(dateDiff.days()), 0, 0, 0, 0, 0, 0);
+    return ISO8601::InternalDuration::combineDateAndTimeDuration(datePart, adjustedTimeDiff);
+}
+
+// DifferenceZonedDateTimeWithRounding — temporal_rs: ZonedDateTime::diff_zoned_datetime (src/builtins/core/zoned_date_time.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal-differencezoneddatetimewithrounding
+TemporalResult<ISO8601::Duration> differenceZonedDateTimeWithRounding(
+    ISO8601::ExactTime ns1,
+    ISO8601::ExactTime ns2,
+    const TimeZone& timeZone,
+    TemporalUnit largestUnit,
+    TemporalUnit smallestUnit,
+    RoundingMode roundingMode,
+    double increment,
+    CalendarID calendarId)
+{
+    Int128 nsA = ns1.epochNanoseconds();
+    Int128 nsB = ns2.epochNanoseconds();
+
+    // Step 1: If largestUnit is time category -> DifferenceInstant (pure nanosecond arithmetic).
+    if (largestUnit > TemporalUnit::Day) {
+        Int128 nsTotal = nsB - nsA;
+        ISO8601::InternalDuration internalDuration = ISO8601::InternalDuration::combineDateAndTimeDuration(ISO8601::Duration(), nsTotal);
+        // Step 3: If smallestUnit=nanosecond and increment=1 -> return difference without rounding.
+        if (smallestUnit != TemporalUnit::Nanosecond || increment != 1) {
+            Int128 roundedTime = roundNumberToIncrementInt128(internalDuration.time(),
+                lengthInNanoseconds(smallestUnit) * (Int128)std::trunc(increment), roundingMode);
+            internalDuration = ISO8601::InternalDuration::combineDateAndTimeDuration(ISO8601::Duration(), roundedTime);
+        }
+        return temporalDurationFromInternal(internalDuration, largestUnit);
+    }
+
+    // Step 2: difference = DifferenceZonedDateTime(ns1, ns2, timeZone, calendar, largestUnit).
+    auto differenceResult = differenceZonedDateTime(ns1, ns2, timeZone, calendarId, largestUnit);
+    if (!differenceResult)
+        return makeUnexpected(differenceResult.error());
+    auto internalDuration = *differenceResult;
+
+    // Step 3: If smallestUnit=nanosecond and increment=1 -> return difference.
+    if (smallestUnit == TemporalUnit::Nanosecond && increment == 1)
+        return temporalDurationFromInternal(internalDuration, largestUnit);
+
+    // Step 4: dateTime = GetISODateTimeFor(timeZone, ns1). (split: getOffsetNanosecondsFor + exactTimeToLocalDateAndTime)
+    auto offset1 = getOffsetNanosecondsFor(timeZone, ns1);
+    if (!offset1)
+        return makeUnexpected(offset1.error());
+    ISO8601::PlainDate startDate;
+    ISO8601::PlainTime startTime;
+    exactTimeToLocalDateAndTime(ns1, *offset1, startDate, startTime);
+
+    // Step 5: Return RoundRelativeDuration(difference, ns1, ns2, dateTime, ...).
+    auto roundResult = roundRelativeDuration(internalDuration, nsA, nsB, startDate, startTime,
+        largestUnit, increment, smallestUnit, roundingMode, &timeZone, calendarId);
+    if (!roundResult)
+        return makeUnexpected(roundResult.error());
+    return temporalDurationFromInternal(internalDuration, largestUnit);
+}
+
+} // namespace TemporalCore
+} // namespace JSC

--- a/Source/JavaScriptCore/runtime/temporal/core/ZonedDateTimeCore.h
+++ b/Source/JavaScriptCore/runtime/temporal/core/ZonedDateTimeCore.h
@@ -25,39 +25,41 @@
 
 #pragma once
 
-// JSC Temporal Core — ISO 8601 date arithmetic
-// temporal_rs reference: src/iso.rs
+// JSC Temporal Core — ZonedDateTime algorithms
+// temporal_rs reference: src/builtins/core/zoned_date_time.rs
 // Last synced: v0.2.3
 
+#include <JavaScriptCore/CalendarICUBridge.h>
 #include <JavaScriptCore/ISO8601.h>
-#include <JavaScriptCore/JSExportMacros.h>
+#include <JavaScriptCore/JSCTimeZone.h>
 #include <JavaScriptCore/TemporalCoreTypes.h>
 #include <JavaScriptCore/TemporalObject.h>
 
 namespace JSC {
 namespace TemporalCore {
 
-ISO8601::PlainYearMonth JS_EXPORT_PRIVATE balanceISOYearMonth(int64_t year, int64_t month);
+TemporalResult<ISO8601::ExactTime> JS_EXPORT_PRIVATE interpretISODateTimeOffset(
+    const ISO8601::PlainDate&,
+    const ISO8601::PlainTime&,
+    bool useStartOfDay,
+    OffsetBehaviour,
+    TemporalOffsetDisambiguation,
+    int64_t inlineOffsetNs,
+    bool offsetHasSubMinutePrecision,
+    const TimeZone&,
+    TemporalDisambiguation);
 
-ISO8601::PlainDate JS_EXPORT_PRIVATE balanceISODate(int32_t year, int32_t month, int64_t day);
+TemporalResult<ISO8601::ExactTime> JS_EXPORT_PRIVATE getStartOfDay(const TimeZone&, ISO8601::PlainDate);
 
-TemporalResult<ISO8601::PlainDate> JS_EXPORT_PRIVATE regulateISODate(int32_t year, int32_t month, int64_t day, TemporalOverflow);
-
-TemporalResult<ISO8601::PlainDate> JS_EXPORT_PRIVATE isoDateAdd(const ISO8601::PlainDate&, const ISO8601::Duration&, TemporalOverflow);
-
-int32_t NODELETE JS_EXPORT_PRIVATE isoDateCompare(const ISO8601::PlainDate&, const ISO8601::PlainDate&);
-
-int32_t NODELETE JS_EXPORT_PRIVATE isoTimeCompare(const ISO8601::PlainTime&, const ISO8601::PlainTime&);
-
-ISO8601::Duration JS_EXPORT_PRIVATE diffISODate(const ISO8601::PlainDate& one, const ISO8601::PlainDate& two, TemporalUnit largestUnit);
-
-ISO8601::InternalDuration JS_EXPORT_PRIVATE diffISODateTime(const ISO8601::PlainDate& d1, const ISO8601::PlainTime& t1, const ISO8601::PlainDate& d2, const ISO8601::PlainTime& t2, TemporalUnit largestUnit);
-
-struct RoundedISODateTime {
-    ISO8601::PlainDate date;
-    ISO8601::PlainTime time;
-};
-RoundedISODateTime JS_EXPORT_PRIVATE roundISODateTime(ISO8601::PlainDate, ISO8601::PlainTime, Int128 incrementNs, TemporalUnit, RoundingMode);
+TemporalResult<ISO8601::Duration> JS_EXPORT_PRIVATE differenceZonedDateTimeWithRounding(
+    ISO8601::ExactTime ns1,
+    ISO8601::ExactTime ns2,
+    const TimeZone&,
+    TemporalUnit largestUnit,
+    TemporalUnit smallestUnit,
+    RoundingMode,
+    double increment,
+    CalendarID = iso8601CalendarID());
 
 } // namespace TemporalCore
 } // namespace JSC


### PR DESCRIPTION
#### 20ca333f3a4ded5c4a2b4ff2b520e941906bff28
<pre>
[JSC][Temporal] Add duration rounding, calendar field resolution, and date-time difference algorithms
<a href="https://bugs.webkit.org/show_bug.cgi?id=314765">https://bugs.webkit.org/show_bug.cgi?id=314765</a>
<a href="https://rdar.apple.com/177014604">rdar://177014604</a>

Reviewed by Yusuke Suzuki.

Adds the algorithm core layer for Temporal. DurationArithmetic
implements duration rounding and differencing (nudge, bubble,
roundRelativeDuration, differenceZonedDateTime). CalendarFields
implements CalendarDateFromFields, CalendarYearMonthFromFields, and
CalendarMonthDayFromFields for ISO and non-ISO calendars via ICU.
PlainDateTimeCore and ZonedDateTimeCore implement DifferenceTemporalPlainDateTime
and DifferenceZonedDateTimeWithRounding.

Tests: Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp
Canonical link: <a href="https://commits.webkit.org/313252@main">https://commits.webkit.org/313252@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e66e4c86eac402f84d174a54f6209470d7a8305

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162431 "6 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35907 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29023 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171369 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118876 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36011 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35909 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126050 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88815 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165390 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28392 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145914 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106628 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27438 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25965 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19069 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137141 "Found 2 new API test failures: TestWebKitAPI.WKAttachmentTestsIOS.PasteRichTextCopiedFromNotes, TestWebKitAPI.PasteHTML.PasteDarkTextOnWhiteBackgroundIntoDarkModeEditor (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23645 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173873 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23270 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21186 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25289 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134357 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35581 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30055 "Found 2 new test failures: http/tests/ssl/applepay/ApplePayButton.html imported/w3c/web-platform-tests/IndexedDB/interleaved-cursors-small.any.serviceworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134357 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36286 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35565 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145441 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97820 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28885 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22273 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194831 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35074 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102826 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50324 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34576 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34821 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34724 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->