### PR TITLE
[Build perf] Add harness script for running build commands and reporting to perf dashboard

### DIFF
--- a/Tools/Scripts/measure-build-time
+++ b/Tools/Scripts/measure-build-time
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+from typing import IO
+
+log = logging.getLogger('measure-build-time')
+
+SCRIPTS = Path(__file__).parent
+
+# --- Tests and subtests ----------------------------------------------------- 
+
+class Task:
+    name: str
+    depends: frozenset[type[Task]] = frozenset()
+
+    build_command: str
+    stdout_filter: str | None
+    build_dir: Path
+    source_dir: Path
+
+    result: TestResult | None
+
+    def __init__(self, args):
+        self.build_command = args.build_command
+        self.stdout_filter = args.stdout_filter
+        self.source_dir = args.source_dir
+        self.build_dir = args.build_dir
+
+    def __enter__(self):
+        pass
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        pass
+
+    def run(self):
+        with self:
+            self.result = run_test(self.name, self.build_command, self.stdout_filter)
+        return self.result
+
+
+class CleanBuild(Task):
+    name = 'clean'
+
+    def __enter__(self):
+        if self.build_dir.exists():
+            if sys.stdin.isatty():
+                # Prompt for confirmation when being run interactively.
+                if input(f'OK to delete {self.build_dir}? [yN] ').lower() != 'y':
+                    raise SystemExit('Clean build aborted, exiting')
+            subprocess.run(('rm', '-r', self.build_dir), check=True)
+
+
+class NullBuild(Task):
+    name = 'null'
+    depends = frozenset([CleanBuild])
+
+
+AVAILABLE_TESTS = [
+    CleanBuild,
+    NullBuild
+]
+
+
+# --- Test execution and result parsing ---------------------------------------
+
+TIMING_ENTRY_RE = re.compile(
+    r'^(.+?)\s+\(\d+\s+tasks?\)\s+\|\s+([\d.]+)\s+seconds$',
+    re.MULTILINE,
+)
+
+XCODE_TIMING_SUMMARY_RE = re.compile(
+    r'^Build Timing Summary$(.+?)(?=^\*\* BUILD|\Z)',
+    re.MULTILINE | re.DOTALL,
+)
+
+TestResult = dict
+
+
+def sanitize_phase_name(task_name: str) -> str:
+    sanitized = task_name.replace('+', 'Plus')
+    return re.sub(r'[^a-zA-Z0-9]', '', sanitized)
+
+
+def parse_timing_summary(log_fd: IO[bytes]) -> dict[str, int]:
+    """Extract per-phase timing from Xcode's Build Timing Summary section."""
+
+    # The build log might be very long, but the timing summary is always at
+    # the end. Only search the final 8K of the log.
+    log_fd.seek(0, os.SEEK_END)
+    size = log_fd.tell()
+    log_fd.seek(max(0, size - 8192))
+    match = XCODE_TIMING_SUMMARY_RE.search(log_fd.read().decode('utf-8', errors='replace'))
+    if not match:
+        return {}
+    section = match.group(1)
+    timing: dict[str, int] = {}
+    for m in TIMING_ENTRY_RE.finditer(section):
+        timing[m.group(1)] = int(float(m.group(2)) * 1000)
+    return timing
+
+
+def build_type_result(wall_time_ms: int, timing_summary: dict[str, int]) -> dict:
+    result: dict = {
+        'metrics': {
+            'Time': {'current': [wall_time_ms]},
+        },
+    }
+    if timing_summary:
+        phase_tests: dict = {}
+        for task_name, task_ms in timing_summary.items():
+            phase_tests[sanitize_phase_name(task_name)] = {
+                'metrics': {'Time': {'current': [task_ms]}},
+            }
+        result['tests'] = {
+            'Phases': {
+                'metrics': {
+                    'CPUTime': {'current': [sum(timing_summary.values())]},
+                },
+                'tests': phase_tests,
+            },
+        }
+    return result
+
+
+def run_build(command: str, stdout_filter: str | None = None) -> tuple[int, int, IO[bytes]]:
+    """Run the build command, capturing output. Returns (exit_code, wall_time_ms, log_fd)."""
+    log_fd = tempfile.NamedTemporaryFile(prefix='measure-build-time-')
+    filter_cmd = stdout_filter if stdout_filter else 'cat'
+    full_command = f'set -o pipefail; ({command}) 2>&1 | tee {log_fd.name} | {filter_cmd}'
+
+    start = time.monotonic()
+    proc = subprocess.run(full_command, shell=True, executable='/bin/bash')
+    elapsed_ms = int((time.monotonic() - start) * 1000)
+
+    log_fd.seek(0)
+    return proc.returncode, elapsed_ms, log_fd
+
+
+def run_test(name: str, command: str, stdout_filter: str | None = None) -> TestResult | None:
+    log.info('Running %s build: %s', name, command)
+    rc, wall_time_ms, stdout_fd = run_build(command, stdout_filter)
+    if rc != 0:
+        log.error('%s build failed with exit code %d', name, rc)
+        return None
+    timing_summary = parse_timing_summary(stdout_fd)
+    log.info('%s build: %dms wall, %d phases parsed', name, wall_time_ms, len(timing_summary))
+    return build_type_result(wall_time_ms, timing_summary)
+
+
+# --- Test runner ------------------------------------------------------------
+
+DEFAULT_MAKE_COMMAND = ('make ARGS="' + ' '.join((
+                            '-showBuildTimingSummary',
+                            'COMPILATION_CACHE_ENABLE_CACHING=NO',
+                        )) + '"')
+
+def main() -> None:
+    logging.basicConfig(
+        level=logging.INFO,
+        format='%(asctime)s %(levelname)s %(message)s',
+    )
+
+    parser = argparse.ArgumentParser(
+        description='Measure build time and emit perf metrics JSON.',
+    )
+
+    cmd_parser = parser.add_mutually_exclusive_group(required=True)
+    cmd_parser.add_argument('--build-command',
+                            help='Shell command to run the build')
+    cmd_parser.add_argument('--make', dest='build_command', action='store_const',
+                            const=DEFAULT_MAKE_COMMAND,
+                            help='Use a default Make invocation to build WebKit. '
+                            'Does not set configuration or workspace (use set-webkit-configuration).')
+    parser.add_argument('--build-dir', type=Path,
+                        help='Path to top-level build directory (deleted by `clean` test)')
+    parser.add_argument('--source-dir', type=Path,
+                        help='Path to WebKit checkout used for incremental build testing')
+    parser.add_argument('--tests', nargs='+', default=[t.name for t in AVAILABLE_TESTS],
+                        choices=[t.name for t in AVAILABLE_TESTS],
+                        help='Which tests to run (default: all). Will skip test dependencies which are not listed.')
+    parser.add_argument('--metric-key', default='BuildTime-Unspecified',
+                        help='Top-level test key in the results. '
+                        'Can be omitted, but must be provided when emitting a real benchmark score.')
+    parser.add_argument('--stdout-filter', default=None,
+                        help='Shell command to filter build stdout through (e.g. filter-build-webkit)')
+    parser.add_argument('--output', '-o', default='build-time-results.json',
+                        help='Output JSON file path (default: build-time-results.json)')
+
+    args = parser.parse_args()
+
+    if not args.build_dir:
+        args.build_dir = Path(subprocess.check_output(
+            (SCRIPTS / 'webkit-build-directory', '--top-level'),
+            text=True
+        ).rstrip())
+    if not args.source_dir:
+        args.source_dir = SCRIPTS.parent.parent
+
+    # Read each test's `depends` lists to compute a topological order to run
+    # all the tests. Does NOT perform cycle detection.
+    plan: list[type[Task]] = []
+    roots = {T for T in AVAILABLE_TESTS if not T.depends}
+    edges = {T: set(T.depends) for T in AVAILABLE_TESTS}
+
+    while roots:
+        T = roots.pop()
+        plan.append(T)
+        for T2 in AVAILABLE_TESTS:
+            if T in edges[T2]:
+                edges[T2].remove(T)
+                if not edges[T2]:
+                    roots.add(T2)
+            
+
+    tests: dict[str, TestResult] = {}
+    for T in plan:
+        if T.name not in args.tests:
+            continue
+        if any(T2.name not in tests for T2 in T.depends if T2.name in args.tests):
+            log.info('Skipping %s build due to failed dependencies', T.name)
+            continue
+        result = T(args).run()
+        if result:
+            tests[T.name] = result
+
+    if not tests:
+        raise SystemExit('All tests failed, exiting.')
+
+    results = {
+        args.metric_key: {
+            'tests': tests,
+        },
+    }
+
+    output_json = json.dumps(results, indent=2)
+
+    with open(args.output, 'w') as f:
+        f.write(output_json)
+        f.write('\n')
+
+    print(output_json)
+
+
+if __name__ == '__main__':
+    main()

--- a/Tools/Scripts/webkitpy/scripts/measure_build_time_unittest.py
+++ b/Tools/Scripts/webkitpy/scripts/measure_build_time_unittest.py
@@ -1,0 +1,126 @@
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#     * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#     * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#     * Neither the name of Google Inc. nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+import unittest
+from pathlib import Path
+
+SCRIPT = str(Path(__file__).resolve().parents[2] / 'measure-build-time')
+
+
+class MeasureBuildTimeTest(unittest.TestCase):
+    def _run_script(self, build_command, extra_args=None):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            build_dir = os.path.join(tmpdir, 'Build')
+            os.makedirs(build_dir)
+            output_file = os.path.join(tmpdir, 'results.json')
+
+            cmd = [
+                sys.executable, SCRIPT,
+                '--build-command', build_command,
+                '--build-dir', build_dir,
+                '--source-dir', tmpdir,
+                '--output', output_file,
+            ]
+            if extra_args:
+                cmd.extend(extra_args)
+
+            proc = subprocess.run(cmd, stdin=subprocess.DEVNULL,
+                                  capture_output=True, text=True)
+            results = None
+            if os.path.exists(output_file):
+                with open(output_file) as f:
+                    results = json.load(f)
+            return proc, results
+
+    def test_clean_and_null_build(self):
+        proc, results = self._run_script('echo ok')
+
+        self.assertEqual(proc.returncode, 0)
+        self.assertIn('BuildTime-Unspecified', results)
+        tests = results['BuildTime-Unspecified']['tests']
+        self.assertIn('clean', tests)
+        self.assertIn('null', tests)
+        for name in ('clean', 'null'):
+            time_values = tests[name]['metrics']['Time']['current']
+            self.assertEqual(len(time_values), 1)
+            self.assertIsInstance(time_values[0], int)
+            self.assertGreaterEqual(time_values[0], 0)
+
+    def test_timing_summary_parsing(self):
+        timing_output = textwrap.dedent('''\
+            Build Timing Summary
+            CompileC (5 tasks) | 12.345 seconds
+            CompileC++ (3 tasks) | 4.567 seconds
+            Ld (1 task) | 2.100 seconds
+            ** BUILD SUCCEEDED **
+        ''')
+        build_command = "cat <<'ENDOFBUILD'\n" + timing_output + "ENDOFBUILD\n"
+        proc, results = self._run_script(build_command, ['--tests', 'clean'])
+
+        self.assertEqual(proc.returncode, 0)
+        clean = results['BuildTime-Unspecified']['tests']['clean']
+        phases = clean['tests']['Phases']
+
+        self.assertIn('CPUTime', phases['metrics'])
+        cpu_time = phases['metrics']['CPUTime']['current'][0]
+        self.assertEqual(cpu_time, 12345 + 4567 + 2100)
+
+        phase_tests = phases['tests']
+        self.assertIn('CompileC', phase_tests)
+        self.assertIn('CompileCPlusPlus', phase_tests)
+        self.assertIn('Ld', phase_tests)
+        self.assertEqual(phase_tests['CompileC']['metrics']['Time']['current'], [12345])
+        self.assertEqual(phase_tests['CompileCPlusPlus']['metrics']['Time']['current'], [4567])
+        self.assertEqual(phase_tests['Ld']['metrics']['Time']['current'], [2100])
+
+    def test_build_failure(self):
+        proc, results = self._run_script('exit 1')
+
+        self.assertNotEqual(proc.returncode, 0)
+        self.assertIsNone(results)
+
+    def test_single_test_selection(self):
+        proc, results = self._run_script('echo ok', ['--tests', 'null'])
+
+        self.assertEqual(proc.returncode, 0)
+        tests = results['BuildTime-Unspecified']['tests']
+        self.assertIn('null', tests)
+        self.assertNotIn('clean', tests)
+
+    def test_custom_metric_key(self):
+        proc, results = self._run_script('echo ok', ['--tests', 'null', '--metric-key', 'BuildTime-Release'])
+
+        self.assertEqual(proc.returncode, 0)
+        self.assertIn('BuildTime-Release', results)
+        self.assertNotIn('BuildTime-Unspecified', results)


### PR DESCRIPTION
#### f9a50d37cc182e86a0814fc51163cbeed9c54eaa
<pre>
[Build perf] Add harness script for running build commands and reporting to perf dashboard
<a href="https://bugs.webkit.org/show_bug.cgi?id=314769">https://bugs.webkit.org/show_bug.cgi?id=314769</a>
<a href="https://rdar.apple.com/177021487">rdar://177021487</a>

Reviewed by Ryan Haddad.

`measure-build-time` takes a build command and runs it through various
build tests.

As base cases, `clean` and `null` are supported, with the infrastructure
in place to add more. `clean` deletes the build directory before
building, and `null` does nothing.

CI will invoke this script like:

    python3 Tools/Scripts/measure-build-time \
        --make \
        --metric-key BuildTime-Debug \
        --output build-time-results.json

and emit the results to the perf dashboard.

Add an end-to-end test in webkitpy that exercises the script.

* Tools/Scripts/measure-build-time: Added.
(Task):
(Task.__init__):
(Task.__enter__):
(Task.__exit__):
(Task.run):
(CleanBuild):
(CleanBuild.__enter__):
(NullBuild):
(sanitize_phase_name):
(parse_timing_summary):
(build_type_result):
(run_build):
(run_test):
(main):
* Tools/Scripts/webkitpy/scripts/__init__.py: Added.
* Tools/Scripts/webkitpy/scripts/measure_build_time_unittest.py: Added.
(MeasureBuildTimeTest):
(MeasureBuildTimeTest._run_script):
(MeasureBuildTimeTest.test_clean_and_null_build):
(MeasureBuildTimeTest.test_timing_summary_parsing):

Canonical link: <a href="https://commits.webkit.org/313340@main">https://commits.webkit.org/313340@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bfd22cc174abb1616972e2b54b333f9795222bad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162811 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36288 "Hash bfd22cc1 for PR 64885 does not build (failure)") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/29492 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171749 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119257 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e8d593ab-1027-4a0b-a4e0-e4c1446a89e1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164680 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36392 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36291 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126379 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/89006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d63ed85a-865c-4076-a3d4-7ee1a256472d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165770 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28724 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/146333 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106956 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/217e0f48-90bb-4aed-838f-ea72115185e6) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/162131 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27770 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26305 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19449 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137478 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/24062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174253 "Built successfully") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/25707 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134686 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35961 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30408 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134681 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35946 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/145858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98360 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24756 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/29219 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/22694 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35455 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34956 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35201 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35104 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->