### PR TITLE
Fixed a stray -Wunsafe-buffer-usage pragma that accidentally disabled the check

### DIFF
--- a/Source/JavaScriptCore/llint/LLIntData.h
+++ b/Source/JavaScriptCore/llint/LLIntData.h
@@ -77,8 +77,6 @@ extern "C" uint8_t os_script_config_storage_stub[] __asm__("_os_script_config_st
 extern "C" uint8_t os_script_config_storage[];
 #endif
 
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-
 inline OpcodeConfig* addressOfOpcodeConfig() { return std::bit_cast<OpcodeConfig*>(&os_script_config_storage); }
 
 #define g_opcodeConfig (*JSC::LLInt::addressOfOpcodeConfig())

--- a/Source/JavaScriptCore/runtime/JSLock.cpp
+++ b/Source/JavaScriptCore/runtime/JSLock.cpp
@@ -163,6 +163,7 @@ void JSLock::unlock()
 }
 
 #if PLATFORM(COCOA) && CPU(ADDRESS64) && CPU(ARM64)
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 // FIXME: rdar://168614004
 NO_RETURN_DUE_TO_CRASH NEVER_INLINE void JSLock::dumpInfoAndCrashForLockNotOwned() // __attribute__((optnone))
 {
@@ -266,6 +267,7 @@ NO_RETURN_DUE_TO_CRASH NEVER_INLINE void JSLock::dumpInfoAndCrashForLockNotOwned
 
 #undef updateDumpState
 }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 #endif
 
 // Use WTF_IGNORES_THREAD_SAFETY_ANALYSIS because this function conditionally unlocks m_lock, which

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -424,17 +424,17 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
         std::call_once(registerFlag, [this]() {
             int pid = getpid();
             const char* key = "com.apple.WebKit.bytecode.profiler";
-            dataLogF("<BYTECODE.STAT><%d> Registering callback for dumping profiles, dumping to %s.\n", pid, pathOutString->data());
-            dataLogF("<BYTECODE.STAT><%d> Use `notifyutil -v -p %s` to dump statistics.\n", pid, key);
+            dataLogLn("<BYTECODE.STAT><", pid, "> Registering callback for dumping profiles, dumping to ", pathOutString.get(), ".");
+            dataLogLn("<BYTECODE.STAT><", pid, "> Use `notifyutil -v -p ", key, "` to dump statistics.");
 
             int token;
             notify_register_dispatch(key, &token, mainDispatchQueueSingleton(), ^(int) {
-                dataLogF("<BYTECODE.STAT><%d> Dumping\n", pid);
+                dataLogLn("<BYTECODE.STAT><", pid, "> Dumping");
                 if (!m_perBytecodeProfiler->save(pathOutString->data()))
-                    dataLogF("<BYTECODE.STAT><%d> Failed to dump to %s. Do you need to add a sandbox extension? ((allow file-write* (subpath \"/private/tmp/\")) in WebProcess.sb.in\n", pid, pathOutString->data());
+                    dataLogLn("<BYTECODE.STAT><", pid, "> Failed to dump to ", pathOutString.get(), ". Do you need to add a sandbox extension? ((allow file-write* (subpath \"/private/tmp/\")) in WebProcess.sb.in");
                 else
-                    dataLogF("<BYTECODE.STAT><%d> Dumped to %s\n", pid, pathOutString->data());
-                dataLogF("<BYTECODE.STAT><%d> Dumping finished\n", pid);
+                    dataLogLn("<BYTECODE.STAT><", pid, "> Dumped to ", pathOutString.get());
+                dataLogLn("<BYTECODE.STAT><", pid, "> Dumping finished");
             });
         });
 #endif

--- a/Source/JavaScriptCore/tools/CharacterPropertyDataGenerator.cpp
+++ b/Source/JavaScriptCore/tools/CharacterPropertyDataGenerator.cpp
@@ -185,10 +185,10 @@ private:
         for (unsigned y = 0; y < numChars; ++y) {
             const char16_t ch = y + minChar;
             dataLogF("/* %02X %c */ {B(", ch, ch < 0x7F ? ch : ' ');
-            const char* prefix = "";
+            ASCIILiteral prefix = ""_s;
             for (unsigned x = 0; x < numCharsRoundUp8; ++x) {
-                dataLogF("%s%u", prefix, static_cast<unsigned>(m_pair[y].get(x)));
-                prefix = (x % 8 == 7) ? "),B(" : ",";
+                dataLog(prefix, static_cast<unsigned>(m_pair[y].get(x)));
+                prefix = (x % 8 == 7) ? "),B("_s : ","_s;
             }
             dataLogLn(")},");
         }

--- a/Source/JavaScriptCore/tools/FunctionOverrides.cpp
+++ b/Source/JavaScriptCore/tools/FunctionOverrides.cpp
@@ -291,7 +291,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     
     int result = fclose(file);
     if (result)
-        dataLogF("Failed to close file %s: %s\n", fileName, safeStrerror(errno).data());
+        dataLogLn("Failed to close file ", fileName, ": ", safeStrerror(errno).data());
 }
     
 } // namespace JSC

--- a/Source/JavaScriptCore/wasm/js/WebAssemblySuspending.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblySuspending.cpp
@@ -111,7 +111,7 @@ void* runWebAssemblySuspendingFunction(JSGlobalObject* globalObject, CallFrame* 
     }
 
     CPURegister* vmEntryFrameCalleeSaves = vmEntryRecord(vm.topEntryFrame)->calleeSaveRegistersBuffer;
-    memcpySpan(std::span<CPURegister>(vmEntryFrameCalleeSaves, NUMBER_OF_CALLEE_SAVES_REGISTERS), std::span(originalCalleeSaves, NUMBER_OF_CALLEE_SAVES_REGISTERS));
+    memcpySpan(unsafeMakeSpan(vmEntryFrameCalleeSaves, NUMBER_OF_CALLEE_SAVES_REGISTERS), unsafeMakeSpan(originalCalleeSaves, NUMBER_OF_CALLEE_SAVES_REGISTERS));
 
     JSObject* callee = callFrame->jsCallee();
     JSFunctionWithFields* self = uncheckedDowncast<JSFunctionWithFields>(callee);


### PR DESCRIPTION
#### 85015722cb650d16b85f0010b9e8ccb910c02cd4
<pre>
Fixed a stray -Wunsafe-buffer-usage pragma that accidentally disabled the check
<a href="https://bugs.webkit.org/show_bug.cgi?id=314771">https://bugs.webkit.org/show_bug.cgi?id=314771</a>
<a href="https://rdar.apple.com/177022310">rdar://177022310</a>

Reviewed by Chris Dumez.

* Source/JavaScriptCore/llint/LLIntData.h: Don&apos;t WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
because we&apos;re already in a WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN, and since they&apos;re a
stack, being unbalanced will skip all warnings in the code that follows.

* Source/JavaScriptCore/runtime/JSLock.cpp: Skip enforcement for now because this
code never conformed before.

* Source/JavaScriptCore/runtime/VM.cpp: Adopt dataLogLn to avoid
-Wunsafe-buffer-usage-in-format-attr-call now that the warning fires here.

* Source/JavaScriptCore/wasm/js/WebAssemblySuspending.cpp:
(JSC::runWebAssemblySuspendingFunction): Adopt unsafeMakeSpan because
NUMBER_OF_CALLEE_SAVES_REGISTERS matches the spirit of a &quot;safe&quot; unsafe construction.

Canonical link: <a href="https://commits.webkit.org/313247@main">https://commits.webkit.org/313247@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f693cd3fb26edfcd1b3ba68e76cee7920f7c25fb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162472 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35948 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29064 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171410 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/118917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c7ff08fd-f4ad-48d6-bf7e-3588675d2de0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164341 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36052 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35952 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126084 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/118917 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165431 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28434 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145955 "Found 1 new API test failure: TestWebKitAPI.UnifiedPDF.SelectAllTextInObjectHostedPDF (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106662 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27480 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26005 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19110 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137184 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23685 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173914 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23311 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21227 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25329 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134394 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35622 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30096 "Found 1 new test failure: imported/w3c/web-platform-tests/IndexedDB/interleaved-cursors-small.any.serviceworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134393 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35606 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145481 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97865 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24695 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28927 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22314 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194872 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35115 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102867 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50358 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34617 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34862 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34765 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->