### PR TITLE
Web process sometimes crashes with excessive stack depth in TextExtraction::extractRecursive

### DIFF
--- a/LayoutTests/fast/text-extraction/max-recursion-depth-cap-expected.html
+++ b/LayoutTests/fast/text-extraction/max-recursion-depth-cap-expected.html
@@ -1,0 +1,28 @@
+<!-- webkit-test-runner [ textExtractionEnabled=true ] -->
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<style>
+body { white-space: pre; font: 12px monospace; margin: 0; }
+</style>
+<script src="../../resources/ui-helper.js"></script>
+</head>
+<body>
+<div id="nest"></div>
+<script>
+addEventListener("load", async () => {
+    let parent = document.getElementById("nest");
+    for (let i = 0; i < 300; i++) {
+        const child = document.createElement("div");
+        parent.appendChild(child);
+        parent = child;
+    }
+    parent.textContent = "leaf";
+
+    const result = await UIHelper.requestTextExtraction({ });
+    document.body.textContent = result;
+    document.documentElement.classList.remove("reftest-wait");
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/text-extraction/max-recursion-depth-cap.html
+++ b/LayoutTests/fast/text-extraction/max-recursion-depth-cap.html
@@ -1,0 +1,28 @@
+<!-- webkit-test-runner [ textExtractionEnabled=true ] -->
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<style>
+body { white-space: pre; font: 12px monospace; margin: 0; }
+</style>
+<script src="../../resources/ui-helper.js"></script>
+</head>
+<body>
+<div id="nest"></div>
+<script>
+addEventListener("load", async () => {
+    let parent = document.getElementById("nest");
+    for (let i = 0; i < 350; i++) {
+        const child = document.createElement("div");
+        parent.appendChild(child);
+        parent = child;
+    }
+    parent.textContent = "leaf";
+
+    const result = await UIHelper.requestTextExtraction({ });
+    document.body.textContent = result;
+    document.documentElement.classList.remove("reftest-wait");
+});
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -270,6 +270,8 @@ static void addBoxShadowIfNeeded(Node& node, const String& colorAsString)
 
 using ClientNodeAttributesMap = WeakHashMap<Node, HashMap<String, String>, WeakPtrImplWithEventTargetData>;
 
+static constexpr unsigned maxExtractionRecursionDepth = 255;
+
 struct TraversalContext {
     const Request originalRequest;
     const ClientNodeAttributesMap clientNodeAttributes;
@@ -280,7 +282,9 @@ struct TraversalContext {
     Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>> enclosingBlocks;
     WeakHashMap<Node, unsigned, WeakPtrImplWithEventTargetData> enclosingBlockNumberMap;
     WeakHashSet<Node, WeakPtrImplWithEventTargetData> additionalContainersToCollect;
+    WeakHashSet<Node, WeakPtrImplWithEventTargetData> visitedContainers;
     unsigned inAdditionalContainerToCollectCount { 0 };
+    unsigned depth { 0 };
     Vector<bool, 1> hasOverflowItemsStack;
     Vector<unsigned, 2> visualBlockContainerStack { 0 };
     unsigned nextVisualBlockContainerNumber { 1 };
@@ -859,8 +863,21 @@ static bool isVisuallyDistinctContainer(const RenderStyle& style, const FloatRec
 
 static inline void extractRecursive(Node& node, Item& parentItem, TraversalContext& context)
 {
+    if (context.depth >= maxExtractionRecursionDepth)
+        return;
+
     if (context.nodesToSkip.contains(node))
         return;
+
+    if (RefPtr container = dynamicDowncast<ContainerNode>(node)) {
+        if (!context.visitedContainers.add(*container).isNewEntry)
+            return;
+    }
+
+    ++context.depth;
+    auto depthScope = makeScopeExit([&] {
+        --context.depth;
+    });
 
     bool isBlock = WebCore::isBlock(node);
     if (isBlock)
@@ -1382,7 +1399,9 @@ Result extractItem(Request&& request, LocalFrame& frame)
             .enclosingBlocks = { },
             .enclosingBlockNumberMap = { },
             .additionalContainersToCollect = WTF::move(additionalContainersToCollect),
+            .visitedContainers = { },
             .inAdditionalContainerToCollectCount = 0,
+            .depth = 0,
             .hasOverflowItemsStack = { false },
             .onlyCollectTextAndLinksCount = 0,
             .mergeParagraphs = request.mergeParagraphs,


### PR DESCRIPTION
#### 26970a5ac7ec026b06e9da87ff75bc72ce997fcd
<pre>
Web process sometimes crashes with excessive stack depth in TextExtraction::extractRecursive
<a href="https://bugs.webkit.org/show_bug.cgi?id=314772">https://bugs.webkit.org/show_bug.cgi?id=314772</a>
<a href="https://rdar.apple.com/177009329">rdar://177009329</a>

Reviewed by Abrar Rahman Protyasha.

Add a couple of mitigations to prevent crashes due to excessive stack depth:

-   Avoid ever re-traversing the same element (which is theoretically possible if layout is
    triggered in the middle of recursive extraction).

-   Enforce a maximum traversal depth and bail early if the stack grows too deep.

Test: fast/text-extraction/max-recursion-depth-cap.html

* LayoutTests/fast/text-extraction/max-recursion-depth-cap-expected.html: Added.
* LayoutTests/fast/text-extraction/max-recursion-depth-cap.html: Added.
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::extractRecursive):

Canonical link: <a href="https://commits.webkit.org/313243@main">https://commits.webkit.org/313243@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b078d4a52bd8366d1d6d18b84390a9ae4467d984

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162455 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35931 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29047 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171393 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/118900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164324 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36035 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35935 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126071 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/118900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/39bbc2f8-036f-4b4c-9038-db1fff3437db) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165414 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28416 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145936 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106649 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27462 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25988 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19093 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137165 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23667 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173897 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21210 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25311 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134385 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35605 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30079 "Found 1 new test failure: imported/w3c/web-platform-tests/IndexedDB/interleaved-cursors-small.any.serviceworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134378 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36278 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35589 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145463 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97844 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28910 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22295 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35098 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102850 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34600 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34845 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34748 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->