### PR TITLE
[MSE] processMediaSample: close Coded Frame Processing spec gaps proposed in w3c/media-source#374 and #375

### DIFF
--- a/LayoutTests/media/media-source/media-source-append-bframe-orphan-post-reset-expected.txt
+++ b/LayoutTests/media/media-source/media-source-append-bframe-orphan-post-reset-expected.txt
@@ -1,0 +1,14 @@
+
+RUN(video.src = URL.createObjectURL(source))
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer('video/mp4; codecs="avc1.4d401e"'))
+RUN(sourceBuffer.appendBuffer(MP4.concat(init, segment1)))
+EVENT(updateend)
+RUN(sourceBuffer.appendBuffer(segment2))
+EVENT(updateend)
+{PTS({1075/1000 = 1.075000}), DTS({1000/1000 = 1.000000}), duration({20/1000 = 0.020000}), flags(9), presentationSize(640.000000x480.000000)}
+{PTS({1100/1000 = 1.100000}), DTS({1050/1000 = 1.050000}), duration({300/1000 = 0.300000}), flags(9), presentationSize(640.000000x480.000000)}
+{PTS({1400/1000 = 1.400000}), DTS({1350/1000 = 1.350000}), duration({100/1000 = 0.100000}), flags(9), presentationSize(640.000000x480.000000)}
+EXPECTED (bufferedSamples.length == '3') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-append-bframe-orphan-post-reset.html
+++ b/LayoutTests/media/media-source/media-source-append-bframe-orphan-post-reset.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-append-bframe-orphan-post-reset</title>
+    <script src="mp4-generator.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    // Regression coverage for MSE "Coded Frame Processing" when a step-1.6
+    // DTS-discontinuity reset is followed by a sync sample whose PTS lands
+    // inside an existing B-frame's presentation interval.
+    //
+    // The step-1.14 sync cascade uses findSampleAfterDecodeKey (upper_bound),
+    // which can break early if the immediate decode-order successor is a sync
+    // with pts > incoming.pts. The step-1.15 dependents sweep then starts at
+    // erasedSamples.begin() (the step-1.13 match), so samples whose decode key
+    // lies in [incoming.decodeKey, step-1.13-sample.decodeKey) are skipped by
+    // both. Among those, B-frames whose pts < incoming.pts become decoder
+    // orphans: no remaining sync has pts <= them. The post-205636@main cleanup
+    // block in processMediaSample filters that gap, evicting orphans while
+    // preserving valid next-GOP samples (pts >= incoming.pts).
+    //
+    // Scenario (timescale=1000):
+    //
+    //   Seg 1 is a B-frame GOP anchored past t=1s (seg-2 DTS will be non-zero
+    //   to avoid tripping Source/WebCore/platform/graphics/gstreamer/mse/
+    //   AppendPipeline.cpp's extendToTheBeginning hack, which fires on
+    //   DTS==0 ∧ PTS>0 ∧ sync):
+    //     (DTS=1050, PTS=1100, dur=100, sync)     — I-frame
+    //     (DTS=1150, PTS=1025, dur=100, non-sync) — B-frame, displays earlier than I
+    //     (DTS=1250, PTS=1075, dur=100, non-sync) — B-frame, PTS=1075 contains seg-2's PTS
+    //     (DTS=1350, PTS=1400, dur=100, sync)     — next I-frame
+    //
+    //   Seg 2 is a single sync (DTS=1000, PTS=1075, dur=20). DTS=1000 < seg 1's
+    //   lastDTS=1350 trips step 1.6 (reset). After the reset:
+    //     - Step 1.13 finds gen1@(1250, 1075) via findSampleContainingPresentationTime
+    //       and erases it.
+    //     - Step 1.14-first's range [1075, 1095) matches the same.
+    //     - Step 1.14 sync cascade: upper_bound((1000, 1075)) = gen1@(1050, 1100),
+    //       which is sync with pts=1100 > 1075 — cascade breaks, adds nothing.
+    //     - Step 1.15 main dependents sweep spans gen1@(1250, 1075) to next-sync
+    //       gen1@(1350, 1400), which is just gen1@(1250, 1075).
+    //     - The samplesWithHigherDecodeTimes block checks decode-key range
+    //         [(1000, 1075), erasedSamples.begin() = (1250, 1075))
+    //       which contains TWO samples: gen1@(1050, 1100) and gen1@(1150, 1025).
+    //       With the pts<=incoming.pts filter: gen1@(1050, 1100) has pts=1100 > 1075
+    //       and is preserved as a legit next-GOP I-frame; gen1@(1150, 1025) has
+    //       pts=1025 <= 1075 and is evicted as an orphan.
+    //
+    //   Final buffer with the narrowed block: [gen2@(1000, 1075), gen1@(1050, 1100),
+    //   gen1@(1350, 1400)]. Length 3.
+    //
+    //   Fail polarities:
+    //     - Over-erase (the pre-narrow 205636@main range, lower_bound inclusive
+    //       at begin): also evicts gen1@(1050, 1100), length 2.
+    //     - Under-erase (no block, ToT commit 10db45b1b25b): leaves gen1@(1150, 1025)
+    //       stranded, length 4.
+
+    let source;
+    let sourceBuffer;
+    let init;
+    let segment1;
+    let segment2;
+    let bufferedSamples;
+
+    async function runTest() {
+        findMediaElement();
+        if (!MediaSource.isTypeSupported(MP4.VIDEO_TYPE)) {
+            failTest(`${MP4.VIDEO_TYPE} is not supported`);
+            return;
+        }
+        source = new MediaSource();
+        run('video.src = URL.createObjectURL(source)');
+        await waitFor(source, 'sourceopen');
+        run(`sourceBuffer = source.addSourceBuffer('${MP4.VIDEO_TYPE}')`);
+
+        init = MP4.initSegment({
+            timescale: 1000,
+            tracks: [{ id: 1, type: 'video', timescale: 1000 }],
+        });
+        segment1 = MP4.mediaSegment({
+            sequenceNumber: 1,
+            tracks: [{ id: 1, type: 'video', baseDecodeTime: 1050, samples: [
+                { duration: 100, compositionTimeOffset:   50, isSync: true  }, // DTS=1050, PTS=1100
+                { duration: 100, compositionTimeOffset: -125, isSync: false }, // DTS=1150, PTS=1025
+                { duration: 100, compositionTimeOffset: -175, isSync: false }, // DTS=1250, PTS=1075
+                { duration: 100, compositionTimeOffset:   50, isSync: true  }, // DTS=1350, PTS=1400
+            ]}],
+        });
+        segment2 = MP4.mediaSegment({
+            sequenceNumber: 2,
+            tracks: [{ id: 1, type: 'video', baseDecodeTime: 1000, samples: [
+                { duration: 20, compositionTimeOffset: 75, isSync: true }, // DTS=1000, PTS=1075
+            ]}],
+        });
+
+        run('sourceBuffer.appendBuffer(MP4.concat(init, segment1))');
+        await waitFor(sourceBuffer, 'updateend');
+        run('sourceBuffer.appendBuffer(segment2)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        bufferedSamples = await internals.bufferedSamplesForTrackId(sourceBuffer, 1);
+        bufferedSamples.forEach(consoleWrite);
+        testExpected('bufferedSamples.length', 3);
+
+        endTest();
+    }
+    </script>
+</head>
+<body onload="runTest()">
+    <video></video>
+</body>
+</html>

--- a/LayoutTests/media/media-source/media-source-append-overlapping-equal-decode-key-expected.txt
+++ b/LayoutTests/media/media-source/media-source-append-overlapping-equal-decode-key-expected.txt
@@ -1,0 +1,18 @@
+
+RUN(video.src = URL.createObjectURL(source))
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer('video/mp4; codecs="avc1.4d401e"'))
+RUN(sourceBuffer.appendBuffer(MP4.concat(init, segment1)))
+EVENT(updateend)
+RUN(sourceBuffer.appendBuffer(segment2a))
+EVENT(updateend)
+RUN(sourceBuffer.appendBuffer(segment2b))
+EVENT(updateend)
+{PTS({0/1 = 0.000000}), DTS({0/1 = 0.000000}), duration({100/1000 = 0.100000}), flags(9), presentationSize(640.000000x480.000000)}
+{PTS({100/1000 = 0.100000}), DTS({100/1000 = 0.100000}), duration({101/1000 = 0.101000}), flags(8), presentationSize(640.000000x480.000000)}
+{PTS({200/1000 = 0.200000}), DTS({200/1000 = 0.200000}), duration({120/1000 = 0.120000}), flags(9), presentationSize(640.000000x480.000000)}
+{PTS({400/1000 = 0.400000}), DTS({400/1000 = 0.400000}), duration({100/1000 = 0.100000}), flags(9), presentationSize(640.000000x480.000000)}
+EXPECTED (sampleAt200Found == 'true') OK
+EXPECTED (hasSeg2Duration == 'true') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-append-overlapping-equal-decode-key.html
+++ b/LayoutTests/media/media-source/media-source-append-overlapping-equal-decode-key.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-append-overlapping-equal-decode-key</title>
+    <script src="mp4-generator.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    // Regression guard for MSE "Coded Frame Processing" when an incoming sync
+    // sample carries the same (decodeTime, presentationTime) key as a buffered
+    // sample.
+    //
+    // Step 1.14's sync cascade in SourceBufferPrivate::processMediaSample uses
+    // findSampleAfterDecodeKey (std::map::upper_bound), which skips any buffered
+    // sample whose key equals the incoming sample's. SampleMap's decode-order
+    // map is a unique-key std::map, so trackBuffer.addSample() silently drops
+    // the incoming sample if the existing sample at that key is not explicitly
+    // erased first. The 205636@main "samplesWithHigherDecodeTimes" block in
+    // processMediaSample catches the equal-key sample via findSamplesBetween-
+    // DecodeKeys (lower_bound inclusive-begin) and marks it for removal; if
+    // that block is absent the equal-key sample is stranded and the incoming
+    // sample is lost.
+    //
+    // Scenario (timescale=1000 ms):
+    //   Seg 1 has five samples at DTS/PTS = 0, 100, 200, 300, 400, all dur=100,
+    //   with sync at 0, 200, 400 and non-sync at 100, 300. After seg 1, buffer =
+    //   [gen1@0, gen1@100, gen1@200, gen1@300, gen1@400], highestPT=500,
+    //   lastDTS=400.
+    //
+    //   Seg 2 is appended as two separate media segments (two appendBuffer calls)
+    //   so their baseDecodeTime fields can be set independently:
+    //
+    //   Fragment 2A (baseDecodeTime=0): two samples,
+    //     (0,   0, dur=100, sync),
+    //     (100, 100, dur=101, non-sync).
+    //   The second sample's dur=101 pushes highestPT to 201 (=100+101). During
+    //   its own step-1.14-second pass, eraseEnd = pts+dur-1ms = 200, so gen1@200
+    //   is outside the erase range [100, 200) and survives.
+    //
+    //   Fragment 2B (baseDecodeTime=200): single sample
+    //     (200, 200, dur=120, sync).
+    //   For this incoming sync, step-1.14-second's range is
+    //     [eraseBegin=highestPT=201, eraseEnd=200+120-1=319);
+    //   gen1@200 at pts=200 is BELOW eraseBegin=201 and is not caught. The
+    //   step-1.14 cascade does upper_bound((200,200)) = gen1@300 (skipping the
+    //   equal-key gen1@200), erases gen1@300, and the step-1.15 dependent sweep
+    //   runs on erasedSamples={gen1@300}.
+    //
+    //   The 2018 block then looks for samples whose decode key is in the range
+    //   [(200,200), erasedSamples.begin()->first=(300,300)) via lower_bound
+    //   inclusive-begin: it finds gen1@200 and adds it to the dependent set.
+    //   With the block: gen1@200 is evicted and the gen2B incoming sample
+    //   inserts successfully with dur=120. Without the block: gen1@200 stays
+    //   and the unique-key std::map insert of gen2B is a no-op; the sample at
+    //   DTS=200 retains seg 1's dur=100.
+    //
+    //   Detection: find the sample with DTS=0.200000 in the dump output of
+    //   internals.bufferedSamplesForTrackId and check whether its duration
+    //   prints as 0.120000 (seg 2B — block present) or 0.100000 (seg 1 —
+    //   block absent, sample silently dropped).
+
+    let source;
+    let sourceBuffer;
+    let init;
+    let segment1;
+    let segment2a;
+    let segment2b;
+    let bufferedSamples;
+
+    async function runTest() {
+        findMediaElement();
+        if (!MediaSource.isTypeSupported(MP4.VIDEO_TYPE)) {
+            failTest(`${MP4.VIDEO_TYPE} is not supported`);
+            return;
+        }
+        source = new MediaSource();
+        run('video.src = URL.createObjectURL(source)');
+        await waitFor(source, 'sourceopen');
+        run(`sourceBuffer = source.addSourceBuffer('${MP4.VIDEO_TYPE}')`);
+
+        init = MP4.initSegment({
+            timescale: 1000,
+            tracks: [{ id: 1, type: 'video', timescale: 1000 }],
+        });
+        segment1 = MP4.mediaSegment({
+            sequenceNumber: 1,
+            tracks: [{ id: 1, type: 'video', baseDecodeTime: 0, samples: [
+                { duration: 100, compositionTimeOffset: 0, isSync: true  }, // DTS=0
+                { duration: 100, compositionTimeOffset: 0, isSync: false }, // DTS=100
+                { duration: 100, compositionTimeOffset: 0, isSync: true  }, // DTS=200  ← target
+                { duration: 100, compositionTimeOffset: 0, isSync: false }, // DTS=300
+                { duration: 100, compositionTimeOffset: 0, isSync: true  }, // DTS=400
+            ]}],
+        });
+        segment2a = MP4.mediaSegment({
+            sequenceNumber: 2,
+            tracks: [{ id: 1, type: 'video', baseDecodeTime: 0, samples: [
+                { duration: 100, compositionTimeOffset: 0, isSync: true  }, // DTS=0
+                { duration: 101, compositionTimeOffset: 0, isSync: false }, // DTS=100, pushes highestPT=201
+            ]}],
+        });
+        segment2b = MP4.mediaSegment({
+            sequenceNumber: 3,
+            tracks: [{ id: 1, type: 'video', baseDecodeTime: 200, samples: [
+                { duration: 120, compositionTimeOffset: 0, isSync: true  }, // DTS=200, equal-key incoming
+            ]}],
+        });
+
+        run('sourceBuffer.appendBuffer(MP4.concat(init, segment1))');
+        await waitFor(sourceBuffer, 'updateend');
+        run('sourceBuffer.appendBuffer(segment2a)');
+        await waitFor(sourceBuffer, 'updateend');
+        run('sourceBuffer.appendBuffer(segment2b)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        bufferedSamples = await internals.bufferedSamplesForTrackId(sourceBuffer, 1);
+        bufferedSamples.forEach(consoleWrite);
+
+        window.sampleAt200Dts = bufferedSamples.find(s => /DTS\(\{[^}]*= 0\.200000\}\)/.test(s));
+        window.sampleAt200Found = sampleAt200Dts !== undefined;
+        testExpected('sampleAt200Found', true);
+        window.hasSeg2Duration = sampleAt200Dts !== undefined && /duration\(\{[^}]*= 0\.120000\}\)/.test(sampleAt200Dts);
+        testExpected('hasSeg2Duration', true);
+
+        endTest();
+    }
+    </script>
+</head>
+<body onload="runTest()">
+    <video></video>
+</body>
+</html>

--- a/LayoutTests/media/media-source/media-source-append-pt-collision-tail-expected.txt
+++ b/LayoutTests/media/media-source/media-source-append-pt-collision-tail-expected.txt
@@ -1,0 +1,16 @@
+
+RUN(video.src = URL.createObjectURL(source))
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer('video/mp4; codecs="avc1.4d401e"'))
+RUN(sourceBuffer.appendBuffer(MP4.concat(init, segment1)))
+EVENT(updateend)
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+EXPECTED (sourceBuffer.buffered.start(0) == '2') OK
+EXPECTED (sourceBuffer.buffered.end(0) == '3') OK
+RUN(sourceBuffer.appendBuffer(segment2))
+EVENT(updateend)
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+EXPECTED (sourceBuffer.buffered.start(0) == '2') OK
+EXPECTED (sourceBuffer.buffered.end(0) == '2.5') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-append-pt-collision-tail.html
+++ b/LayoutTests/media/media-source/media-source-append-pt-collision-tail.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-append-pt-collision-tail</title>
+    <script src="mp4-generator.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    // Real-MP4 regression coverage for the proposed MSE Coded Frame
+    // Processing amendment w3c/media-source#375 (presentation-timestamp
+    // collision cleanup).
+    //
+    // When an incoming sample's (DTS, PT) coincides with the existing
+    // sample at the END of the buffer, none of the spec's existing
+    // cleanup steps in SourceBufferPrivate::processMediaSample populate
+    // erasedSamples:
+    //   - step 1.13 only fires post-reset (lastDTS invalid)
+    //   - step 1.14-first only fires post-reset (highestPT invalid)
+    //   - step 1.14-third's range [highestPT, frameEnd-tol) sits past the
+    //     colliding sample at the buffer tail (highestPT - tol ≈ existing
+    //     sample's PT + dur - 1ms is well above incoming.PT for any
+    //     duration > 1ms)
+    //   - the cascade's findSampleAfterDecodeKey returns end()
+    //
+    // Without the unconditional #375 pass the trackBuffer.addSample of
+    // the incoming sample silently no-ops (SampleMap is std::map-backed
+    // and the duplicate-key insert collapses); with the fix the existing
+    // sample is evicted first and the new sample inserts successfully.
+    //
+    // Shape (timescale=1000):
+    //   Seg 1: one sync sample at baseDecodeTime=2000 dur=1000 CTO=0
+    //     -> DTS=2000 PTS=2000 (interval [2000, 3000)).
+    //   Seg 2: one sync sample at baseDecodeTime=2000 dur=500 CTO=0
+    //     -> DTS=2000 PTS=2000 (interval [2000, 2500)).
+    //
+    // Detection via sourceBuffer.buffered.end(0):
+    //   - bug present: 3.0  (seg 1's sample preserved with dur=1000)
+    //   - bug fixed:   2.5  (seg 1's sample evicted, seg 2's dur=500 wins)
+    //
+    // Timestamps shifted past t=1s so seg 2's DTS is non-zero, avoiding
+    // Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp's
+    // extendToTheBeginning hack (which fires on DTS==0 && PTS>0 && sync).
+
+    var source, sourceBuffer, init, segment1, segment2;
+
+    async function runTest() {
+        findMediaElement();
+        if (!MediaSource.isTypeSupported(MP4.VIDEO_TYPE)) {
+            failTest(`${MP4.VIDEO_TYPE} is not supported`);
+            return;
+        }
+        source = new MediaSource();
+        run('video.src = URL.createObjectURL(source)');
+        await waitFor(source, 'sourceopen');
+        run(`sourceBuffer = source.addSourceBuffer('${MP4.VIDEO_TYPE}')`);
+
+        init = MP4.initSegment({
+            timescale: 1000,
+            tracks: [{ id: 1, type: 'video', timescale: 1000 }],
+        });
+        segment1 = MP4.mediaSegment({
+            sequenceNumber: 1,
+            tracks: [{
+                id: 1, type: 'video', baseDecodeTime: 2000,
+                samples: [{ duration: 1000, compositionTimeOffset: 0, isSync: true }],
+            }],
+        });
+        run('sourceBuffer.appendBuffer(MP4.concat(init, segment1))');
+        await waitFor(sourceBuffer, 'updateend');
+        testExpected('sourceBuffer.buffered.length', 1);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.start(0)', 2.0, 0.01);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.end(0)', 3.0, 0.01);
+
+        segment2 = MP4.mediaSegment({
+            sequenceNumber: 2,
+            tracks: [{
+                id: 1, type: 'video', baseDecodeTime: 2000,
+                samples: [{ duration: 500, compositionTimeOffset: 0, isSync: true }],
+            }],
+        });
+        run('sourceBuffer.appendBuffer(segment2)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        // #375 must evict seg 1's sample so seg 2's shorter sample wins.
+        testExpected('sourceBuffer.buffered.length', 1);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.start(0)', 2.0, 0.01);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.end(0)', 2.5, 0.01);
+
+        endTest();
+    }
+    </script>
+</head>
+<body onload="runTest()">
+    <video></video>
+</body>
+</html>

--- a/LayoutTests/media/media-source/media-source-coded-frame-group-reset-overlapping-sample-orphan-expected.txt
+++ b/LayoutTests/media/media-source/media-source-coded-frame-group-reset-overlapping-sample-orphan-expected.txt
@@ -1,0 +1,16 @@
+
+RUN(video.src = URL.createObjectURL(source))
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer('video/mp4; codecs="avc1.4d401e"'))
+RUN(sourceBuffer.appendBuffer(MP4.concat(init, segment1)))
+EVENT(updateend)
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+EXPECTED (sourceBuffer.buffered.start(0) == '1.1') OK
+EXPECTED (sourceBuffer.buffered.end(0) == '1.2') OK
+RUN(sourceBuffer.appendBuffer(segment2))
+EVENT(updateend)
+EXPECTED (sourceBuffer.buffered.length == '1') OK
+EXPECTED (sourceBuffer.buffered.start(0) == '1.15') OK
+EXPECTED (sourceBuffer.buffered.end(0) == '1.2') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-coded-frame-group-reset-overlapping-sample-orphan.html
+++ b/LayoutTests/media/media-source/media-source-coded-frame-group-reset-overlapping-sample-orphan.html
@@ -1,0 +1,99 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-coded-frame-group-reset-overlapping-sample-orphan</title>
+    <script src="mp4-generator.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    // Regression coverage for the step-1.14 B-frame cascade rescuing a sample
+    // left in place by steps 1.6 + 1.13 + 1.14 of MSE "Coded Frame Processing".
+    //
+    // Mechanism (SourceBufferPrivate::processMediaSample):
+    //   - Step 1.6 resets highestPresentationTimestamp and lastDecodeTimestamp
+    //     when the incoming DTS is below the current lastDecodeTimestamp.
+    //   - Post-reset, step 1.13's 1-microsecond guard
+    //       `presentationTimestamp < overlapped.pts + 1µs`
+    //     misses a buffered sample whose interval contains the incoming pts
+    //     but whose own pts starts well below it.
+    //   - Step 1.14 first branch erases only [P, F); a buffered sample with
+    //     pts < P is below the range and is missed.
+    //   - Step 1.14 cascade (incoming is sync): findSampleAfterDecodeKey
+    //     returns the buffered sample, the isSync-and-pts-greater early-break
+    //     does not apply (buffered.pts < incoming.pts), the DTS re-key branch
+    //     declines (no safe DTS inside the incoming frame's duration), and
+    //     the fallthrough addRange erases it. This is the step that rescues
+    //     the scenario.
+    //
+    // Shape (timescale=1000):
+    //   Seg 1: one sync sample at baseDecodeTime=1100 dur=100 CTO=0
+    //     -> DTS=1100 PTS=1100 (interval [1100, 1200)).
+    //   Seg 2: baseDecodeTime=1000 (< 1100 -> step 1.6 fires), one sync
+    //     sample dur=50 CTO=150 -> DTS=1000 PTS=1150.
+    //     - Step 1.13 guard `1150 < 1100 + 1µs` fails -> no erase.
+    //     - Step 1.14 first branch range [1150, 1200): gen1@(1100, 1100)
+    //       is below range -> no erase.
+    //     - Cascade reaches gen1@(1100, 1100); DTS-rekey declines (its
+    //       safeDecodeTime 1100.0001 is past the incoming frame's duration
+    //       window); fallthrough addRange erases it.
+    //
+    // Timestamps are shifted past t=1s so seg 2's first sample has DTS != 0,
+    // avoiding Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp's
+    // extendToTheBeginning hack (which fires on DTS==0 && PTS>0 && sync).
+    //
+    // If the cascade ever regresses on this shape, buffered.start(0) would
+    // remain 1.1 instead of collapsing to 1.15.
+
+    var source, sourceBuffer, init, segment1, segment2;
+
+    async function runTest() {
+        findMediaElement();
+        if (!MediaSource.isTypeSupported(MP4.VIDEO_TYPE)) {
+            failTest(`${MP4.VIDEO_TYPE} is not supported`);
+            return;
+        }
+        source = new MediaSource();
+        run('video.src = URL.createObjectURL(source)');
+        await waitFor(source, 'sourceopen');
+        run(`sourceBuffer = source.addSourceBuffer('${MP4.VIDEO_TYPE}')`);
+
+        init = MP4.initSegment({
+            timescale: 1000,
+            tracks: [{ id: 1, type: 'video', timescale: 1000 }],
+        });
+        segment1 = MP4.mediaSegment({
+            sequenceNumber: 1,
+            tracks: [{
+                id: 1, type: 'video', baseDecodeTime: 1100,
+                samples: [{ duration: 100, compositionTimeOffset: 0, isSync: true }],
+            }],
+        });
+        run('sourceBuffer.appendBuffer(MP4.concat(init, segment1))');
+        await waitFor(sourceBuffer, 'updateend');
+        testExpected('sourceBuffer.buffered.length', 1);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.start(0)', 1.1, 0.01);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.end(0)', 1.2, 0.01);
+
+        segment2 = MP4.mediaSegment({
+            sequenceNumber: 2,
+            tracks: [{
+                id: 1, type: 'video', baseDecodeTime: 1000,
+                samples: [{ duration: 50, compositionTimeOffset: 150, isSync: true }],
+            }],
+        });
+        run('sourceBuffer.appendBuffer(segment2)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        // Cascade eviction: seg-1 is erased, only seg-2 remains at [1.15, 1.2].
+        testExpected('sourceBuffer.buffered.length', 1);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.start(0)', 1.15, 0.01);
+        testExpectedEqualWithTolerance('sourceBuffer.buffered.end(0)', 1.2, 0.01);
+
+        endTest();
+    }
+
+    </script>
+</head>
+<body onload="runTest()">
+    <video></video>
+</body>
+</html>

--- a/LayoutTests/media/media-source/media-source-pt-collision-cleanup-expected.txt
+++ b/LayoutTests/media/media-source/media-source-pt-collision-cleanup-expected.txt
@@ -1,0 +1,17 @@
+
+RUN(video.src = URL.createObjectURL(source))
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer("video/mock; codecs=mock"))
+RUN(sourceBuffer.appendBuffer(initSegment))
+EVENT(updateend)
+Test that an incoming sample whose (DTS, PT) collides with the buffer tail evicts the existing sample (w3c/media-source#375).
+RUN(sourceBuffer.appendBuffer(samples))
+EVENT(updateend)
+RUN(source.endOfStream())
+RUN(video.play())
+EVENT(ended)
+RUN(quality = video.getVideoPlaybackQuality())
+EXPECTED (quality.totalVideoFrames == '4') OK
+EXPECTED (quality.droppedVideoFrames == '0') OK
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-pt-collision-cleanup.html
+++ b/LayoutTests/media/media-source/media-source-pt-collision-cleanup.html
@@ -1,0 +1,100 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <title>media-source-pt-collision-cleanup</title>
+    <script src="mock-media-source.js"></script>
+    <script src="../video-test.js"></script>
+    <script>
+    // Regression coverage for the proposed MSE Coded Frame Processing
+    // amendment w3c/media-source#375 (presentation-timestamp collision
+    // cleanup). The same scenario inadvertently caused
+    // media-source-video-playback-quality.html to ship with a duplicate
+    // sample line whose presence flipped its playback-quality counters
+    // depending on whether the bug was present, masking the issue.
+    //
+    // When an incoming sample's (DTS, PT) coincides with an existing
+    // sample at the END of the buffer, none of the spec's existing cleanup
+    // steps in SourceBufferPrivate::processMediaSample populate
+    // erasedSamples:
+    //   - step 1.13 only fires post-reset (lastDTS invalid)
+    //   - step 1.14-first only fires post-reset (highestPT invalid)
+    //   - step 1.14-third's range [highestPT, frameEnd-tol) is past the
+    //     colliding sample at the buffer tail
+    //   - the cascade's findSampleAfterDecodeKey returns end()
+    //
+    // Without the unconditional #375 pass, trackBuffer.addSample of the
+    // incoming sample silently no-ops (SampleMap is std::map-backed and
+    // the duplicate-key insert collapses), and the original sample stays
+    // put. With the fix, the colliding sample is evicted first and the
+    // new sample inserts successfully.
+    //
+    // Detection: append (DTS=2, PT=2, DROPPED) followed immediately by a
+    // colliding (DTS=2, PT=2, SYNC). Observe droppedVideoFrames after
+    // playback:
+    //   - bug present: droppedVideoFrames=1 (DROPPED preserved, SYNC lost)
+    //   - bug fixed:   droppedVideoFrames=0 (DROPPED evicted, SYNC kept)
+
+    var source;
+    var sourceBuffer;
+    var initSegment;
+    var samples;
+    var quality;
+
+    if (window.internals)
+        internals.initializeMockMediaSource();
+
+    function runTest()
+    {
+        findMediaElement();
+
+        source = new MediaSource();
+        waitForEventOn(source, 'sourceopen', sourceOpen);
+        run('video.src = URL.createObjectURL(source)');
+    }
+
+    function sourceOpen()
+    {
+        run('sourceBuffer = source.addSourceBuffer("video/mock; codecs=mock")');
+        waitForEventOn(sourceBuffer, 'updateend', loadSamples, false, true);
+        initSegment = makeAInit(4, [makeATrack(1, 'mock', TRACK_KIND.VIDEO)]);
+        run('sourceBuffer.appendBuffer(initSegment)');
+    }
+
+    function loadSamples()
+    {
+        consoleWrite('Test that an incoming sample whose (DTS, PT) collides with the buffer tail evicts the existing sample (w3c/media-source#375).');
+        samples = concatenateSamples([
+            makeASample(0, 0, 1, 1, 1, SAMPLE_FLAG.SYNC),
+            makeASample(1, 1, 1, 1, 1, SAMPLE_FLAG.NONE),
+            makeASample(2, 2, 1, 1, 1, SAMPLE_FLAG.DROPPED),
+            makeASample(2, 2, 1, 1, 1, SAMPLE_FLAG.SYNC),
+            makeASample(3, 3, 1, 1, 1, SAMPLE_FLAG.NONE),
+        ]);
+        waitForEventOn(sourceBuffer, 'updateend', samplesAdded, false, true);
+        run('sourceBuffer.appendBuffer(samples)');
+    }
+
+    async function samplesAdded()
+    {
+        run('source.endOfStream()');
+        run('video.play()');
+        await waitFor(video, 'ended');
+        setTimeout(videoEnded, 300); // VideoPlaybackQuality is refreshed every 0.25s, wait a bit.
+    }
+
+    function videoEnded()
+    {
+        run('quality = video.getVideoPlaybackQuality()');
+        // Buffer holds 4 samples: (0,SYNC), (1,NONE), (2,SYNC) (the DROPPED
+        // one having been evicted by the #375 cleanup), (3,NONE). None of
+        // the rendered samples carry the DROPPED flag.
+        testExpected('quality.totalVideoFrames', 4);
+        testExpected('quality.droppedVideoFrames', 0);
+        endTest();
+    }
+    </script>
+</head>
+<body onload="runTest()">
+    <video></video>
+</body>
+</html>

--- a/LayoutTests/media/media-source/media-source-video-playback-quality.html
+++ b/LayoutTests/media/media-source/media-source-video-playback-quality.html
@@ -56,7 +56,6 @@
             makeASample(0, 0, 1, 1, 1, SAMPLE_FLAG.SYNC),
             makeASample(1, 1, 1, 1, 1, SAMPLE_FLAG.CORRUPTED),
             makeASample(2, 2, 1, 1, 1, SAMPLE_FLAG.DROPPED),
-            makeASample(2, 2, 1, 1, 1, SAMPLE_FLAG.SYNC),
             makeASample(3, 3, 1, 1, 1, SAMPLE_FLAG.NONE),
             makeASample(4, 4, 1, 1, 1, SAMPLE_FLAG.DELAYED),
             makeASample(5, 5, 1, 1, 1, SAMPLE_FLAG.DELAYED),

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -5561,6 +5561,10 @@ ipc/empty-svgfilterrenderer-expression-crash.html [ Skip ]
 
 webkit.org/b/314373 media/media-source/media-source-real-webm-fastseek.html [ Failure ]
 webkit.org/b/314373 media/media-source/media-source-real-webm-remove.html [ Failure ]
+webkit.org/b/314776 media/media-source/media-source-append-bframe-orphan-post-reset.html [ Failure ]
+webkit.org/b/314776 media/media-source/media-source-append-overlapping-equal-decode-key.html [ Failure ]
+webkit.org/b/314776 media/media-source/media-source-append-pt-collision-tail.html [ Failure ]
+
 # test timeout, skip it for now
 webkit.org/b/314643 media/media-source/media-source-duration-truncation-ended.html [ Skip ]
 

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -1325,6 +1325,27 @@ bool SourceBufferPrivate::processMediaSample(SourceBufferPrivateClient& client, 
             }
         }
 
+        // Proposed amendment to "Coded Frame Processing" tracked at
+        // w3c/media-source#375 (presentation-timestamp collision cleanup).
+        // Sits between step 1.13 (overlap check) and step 1.14 (remove existing
+        // coded frames) of the algorithm.
+        //
+        // Remove coded frames whose presentation timestamp is within 1
+        // microsecond of the incoming sample's presentation timestamp. The
+        // tolerance matches the one used by step 1.13 and is there for
+        // float/rational timestamp conversion robustness. Must run
+        // unconditionally: a continuous mid-stream append where the incoming
+        // sample's presentation timestamp coincides with an existing sample's
+        // can reach step 1.16 "Add the coded frame" with all other cleanup
+        // steps (1.13, 1.14-first, 1.14-second, step-1.15 sweep) no-opping.
+        {
+            MediaTime lowerPresentationTime = sample->presentationTime() - microsecond;
+            MediaTime upperPresentationTime = sample->presentationTime() + microsecond;
+            auto presentationRange = trackBuffer.samples().presentationOrder().findSamplesBetweenPresentationTimes(lowerPresentationTime, upperPresentationTime);
+            for (auto it = presentationRange.first; it != presentationRange.second; ++it)
+                erasedSamples.addSample(it->second.copyRef());
+        }
+
         // 1.14 Remove existing coded frames in track buffer:
         // If highest presentation timestamp for track buffer is not set:
         if (trackBuffer.highestPresentationTimestamp().isInvalid()) {
@@ -1366,17 +1387,16 @@ bool SourceBufferPrivate::processMediaSample(SourceBufferPrivateClient& client, 
             while (nextSyncSample != trackBuffer.samples().decodeOrder().end() && Ref { nextSyncSample->second }->presentationTime() <= sample->presentationTime())
                 nextSyncSample = trackBuffer.samples().decodeOrder().findSyncSampleAfterDecodeIterator(nextSyncSample);
 
-            // Note that prev(begin()) is Undefined Behaviour, so we exclude that case for nextSyncSample in the if.
-            // We also want to make sure that the list isn't empty in case nextSyncSample is end(), so there's at least
-            // a previous element to get in that case.
-            if (nextSampleInDecodeOrderRef->presentationTime() < sample->presentationTime()
-                && nextSyncSample != trackBuffer.samples().decodeOrder().begin()
-                && trackBuffer.samples().decodeOrder().size() > 0) {
+            // Note: findSyncSampleAfterDecodeIterator pre-increments its input before scanning
+            // (see SampleMap.cpp: std::find_if(++currentSampleDTS, end(), ...)), so it always
+            // returns either end() or an iterator strictly past nextSampleInDecodeOrder.
+            // Since nextSampleInDecodeOrder is not end() by the earlier guard, nextSyncSample
+            // cannot equal begin(), so std::prev(nextSyncSample) is safe.
+            if (nextSampleInDecodeOrderRef->presentationTime() < sample->presentationTime()) {
                 // Try to fix the out-of-ordering by placing the decoding timestamp of sample after the decoding timestamp
-                // of the last pre-existing sample before the next sync sample whis has a presentationTime lower than sample.
+                // of the last pre-existing sample before the next sync sample which has a presentationTime lower than sample.
                 // This would have been the last sample to be erased if this decoding timestamp correction wasn't applied.
                 auto lastSampleBeforeSyncOrBeforeEnd = std::prev(nextSyncSample);
-                // We also exclude the case of no sample previous to the last one.
                 auto lastSampleBeforeSyncOrBeforeEndRef = lastSampleBeforeSyncOrBeforeEnd->second;
                 if (lastSampleBeforeSyncOrBeforeEndRef->presentationTime() < sample->presentationTime()) {
                     const MediaTime epsilon = MediaTime(100, 1000000); // 100 µs.
@@ -1472,12 +1492,27 @@ bool SourceBufferPrivate::processMediaSample(SourceBufferPrivateClient& client, 
             auto nextSyncIter = trackBuffer.samples().decodeOrder().findSyncSampleAfterDecodeIterator(lastDecodeIter);
             dependentSamples.insert(firstDecodeIter, nextSyncIter);
 
-            // NOTE: in the case of b-frames, the previous step may leave in place samples whose presentation
-            // timestamp < presentationTime, but whose decode timestamp >= decodeTime. These will eventually cause
-            // a decode error if left in place, so remove these samples as well.
-            DecodeOrderSampleMap::KeyType decodeKey(sample->decodeTime(), sample->presentationTime());
-            if (auto samplesWithHigherDecodeTimes = trackBuffer.samples().decodeOrder().findSamplesBetweenDecodeKeys(decodeKey, erasedSamples.decodeOrder().begin()->first); samplesWithHigherDecodeTimes.size())
-                dependentSamples.insert(samplesWithHigherDecodeTimes.begin(), samplesWithHigherDecodeTimes.end());
+            // Proposed amendment to "Coded Frame Processing" tracked at
+            // w3c/media-source#374 (SAP Type 2 decode-shadowed orphan cleanup).
+            //
+            // Remove non-sync coded frames whose decode timestamp is strictly
+            // greater than the incoming sample's and whose presentation
+            // timestamp is less than the incoming sample's. The issue's
+            // amendment note permits implementations to bound the scan; the
+            // bound used here is erasedSamples.decodeOrder().begin()->first,
+            // relying on the predicate itself to preserve random access points
+            // and samples whose presentation timestamp is at or after the
+            // incoming sample's when the bound does not line up exactly with
+            // the next random access point in decode order.
+            DecodeOrderSampleMap::KeyType incomingDecodeKey(sample->decodeTime(), sample->presentationTime());
+            auto samplesInRange = trackBuffer.samples().decodeOrder().findSamplesBetweenDecodeKeys(incomingDecodeKey, erasedSamples.decodeOrder().begin()->first);
+            for (auto& entry : samplesInRange) {
+                Ref existingSample = entry.second;
+                if (existingSample->isSync())
+                    continue;
+                if (existingSample->presentationTime() < sample->presentationTime())
+                    dependentSamples.insert(entry);
+            }
 
             PlatformTimeRanges erasedRanges = removeSamplesFromTrackBuffer(dependentSamples, trackBuffer, "didReceiveSample"_s);
 

--- a/Source/WebCore/platform/graphics/TrackBuffer.cpp
+++ b/Source/WebCore/platform/graphics/TrackBuffer.cpp
@@ -123,6 +123,14 @@ void TrackBuffer::adjustSampleStartTime(MediaSample& original, const MediaTime& 
 
 void TrackBuffer::addSample(MediaSample& sample)
 {
+    // The track buffer's main SampleMap must never receive a duplicate
+    // (PT) / (DTS, PT) key: SampleMap accounts for sizeInBytes() unconditionally
+    // (used by eviction), and a silent insert no-op would skew that accounting
+    // and leave the presentation- and decode-order maps inconsistent. Callers
+    // (notably SourceBufferPrivate::processMediaSample) are responsible for
+    // erasing any colliding sample before adding the new one.
+    ASSERT(m_samples.decodeOrder().findSampleWithDecodeKey(DecodeOrderSampleMap::KeyType(sample.decodeTime(), sample.presentationTime())) == m_samples.decodeOrder().end());
+
     m_samples.addSample(sample);
 
     // Note: The terminology here is confusing: "enqueuing" means providing a frame to the inner media framework.


### PR DESCRIPTION
#### 9d7e16e79a52be192a09a6135eb479e00d653e73
<pre>
[MSE] processMediaSample: close Coded Frame Processing spec gaps proposed in w3c/media-source#374 and #375
<a href="https://bugs.webkit.org/show_bug.cgi?id=314723">https://bugs.webkit.org/show_bug.cgi?id=314723</a>
<a href="https://rdar.apple.com/176971800">rdar://176971800</a>

Reviewed by OOPs

The &quot;Coded Frame Processing&quot; algorithm in the MSE spec has two cleanup
gaps when an incoming coded frame arrives mid-stream. Each is tracked
as a proposed spec amendment:

  - w3c/media-source#374 (SAP Type 2 decode-shadowed orphans).
    Non-sync coded frames whose decode timestamp is strictly greater
    than the incoming frame&apos;s decode timestamp and whose presentation
    timestamp is less than the incoming frame&apos;s survive every existing
    cleanup step. They decode after the incoming random access point
    but present before it, and no random access point remains at or
    before their presentation timestamps once the incoming one takes
    over. They become unreachable on seek.

  - w3c/media-source#375 (presentation-timestamp coincidence).
    Coded frames whose presentation timestamp coincides (exactly, or
    within 1 microsecond) with the incoming frame&apos;s can coexist in the
    track buffer with the incoming frame, producing downstream
    ambiguity in algorithms that refer to &quot;the coded frame in track
    buffer with a presentation interval that contains t&quot;.

Place the #375 amendment between step 1.13 (&quot;overlap check&quot;) and step
1.14 (&quot;Remove existing coded frames in track buffer&quot;):

    Look up the presentation-order range
        [incoming.pts - 1us, incoming.pts + 1us)
    via findSamplesBetweenPresentationTimes (O(log n)) and add every
    sample it yields to erasedSamples. Runs unconditionally: a mid-
    stream PT collision can reach &quot;Add the coded frame&quot; with all other
    cleanup steps no-opping, so #375&apos;s lookup must not be gated on
    erasedSamples being non-empty.

Place the #374 amendment inside step 1.15&apos;s existing &quot;Remove all
possible decoding dependencies&quot; block, after the main dependent sweep:

    Call findSamplesBetweenDecodeKeys(incomingDecodeKey,
    erasedSamples.decodeOrder().begin()-&gt;first) and, for each returned
    sample, insert into dependentSamples if it is non-sync and its
    presentation timestamp is less than the incoming frame&apos;s.

    Using erasedSamples.begin()-&gt;first as the upper bound is safe:
    samples in [erasedSamples.begin(), nextSyncIter) are already
    scheduled for removal by the step 1.15 main sweep immediately
    above (dependentSamples.insert(firstDecodeIter, nextSyncIter)),
    so #374 only needs to cover the gap [incomingDecodeKey,
    erasedSamples.begin()). The amendment filed on #374 includes an
    optimization note permitting implementations to bound the scan
    short of the next random access point; this bound satisfies the
    note, and the predicate (non-sync AND pts &lt; incoming.pts) keeps
    sync frames and samples with pts &gt;= incoming.pts preserved.

Remove the samplesWithHigherDecodeTimes cleanup previously located
inside step 1.15&apos;s dependent sweep: its responsibilities are now
covered by #375 (equal-key collision, equal-PT collision) and by the

Simplify the step-1.14 B-frame cascade&apos;s DTS re-key guard. The
three-predicate condition

    nextSampleInDecodeOrderRef-&gt;presentationTime() &lt; sample-&gt;presentationTime()
    &amp;&amp; nextSyncSample != trackBuffer.samples().decodeOrder().begin()
    &amp;&amp; trackBuffer.samples().decodeOrder().size() &gt; 0

collapses to its semantic predicate

    nextSampleInDecodeOrderRef-&gt;presentationTime() &lt; sample-&gt;presentationTime()

because size() &gt; 0 is implied by the earlier early-break on
nextSampleInDecodeOrder == decodeOrder().end(), and nextSyncSample
can never equal begin() because findSyncSampleAfterDecodeIterator
pre-increments its argument before scanning (SampleMap.cpp:
std::find_if(++currentSampleDTS, end(), ...)). The invariant is
documented inline.

* LayoutTests/media/media-source/media-source-append-bframe-orphan-post-reset-expected.txt: Added.
* LayoutTests/media/media-source/media-source-append-bframe-orphan-post-reset.html: Added.
  Real-MP4 regression guard for #374. Seg 1 is a B-frame GOP anchored
  past t=1s (so seg 2&apos;s non-zero DTS avoids
  Source/WebCore/platform/graphics/gstreamer/mse/AppendPipeline.cpp&apos;s
  extendToTheBeginning hack, which fires on DTS==0 &amp;&amp; PTS&gt;0 &amp;&amp; sync);
  seg 2&apos;s single sync at DTS=1.000 PTS=1.075 lands inside an existing
  B-frame&apos;s presentation interval. With the new passes: the legitimate
  next-GOP I-frame at (1.050, 1.100) is preserved (pts &gt; incoming.pts);
  the orphan B-frame at (1.150, 1.025) is evicted (pts &lt; incoming.pts,
  non-sync); final buffered length = 3.

* LayoutTests/media/media-source/media-source-append-overlapping-equal-decode-key-expected.txt: Added.
* LayoutTests/media/media-source/media-source-append-overlapping-equal-decode-key.html: Added.
  Real-MP4 regression guard for #375. Seg 2 is split into two appends
  with independent baseDecodeTime so the setup samples push highestPT
  past 200, leaving the #375 presentation-timestamp collision cleanup
  as the only code path that can evict the existing sample at DTS=200
  when seg 2B&apos;s incoming sync at DTS=200 is processed. The sample in
  the buffer at DTS=0.200 must carry seg 2B&apos;s duration (120), not
  seg 1&apos;s (100).

* LayoutTests/media/media-source/media-source-coded-frame-group-reset-overlapping-sample-orphan-expected.txt: Added.
* LayoutTests/media/media-source/media-source-coded-frame-group-reset-overlapping-sample-orphan.html: Added.
  Step 1.6 + step 1.14 cascade DTS re-key-decline + fallthrough-erase
  coverage. Timestamps shifted past t=1s so seg 2&apos;s DTS is non-zero,
  avoiding the GStreamer extendToTheBeginning hack. Seg 1 is a single
  sync at baseDecodeTime=1100 dur=100; seg 2 is a single sync at
  baseDecodeTime=1000 dur=50 CTO=150 (PTS=1150 inside seg 1&apos;s interval
  [1100, 1200)). Cascade&apos;s DTS re-key declines because the candidate
  safeDecodeTime lands past the incoming frame&apos;s duration window, and
  the fallthrough addRange erases the overlapping seg 1 sample.
  Buffered collapses to [1.15, 1.2].

* LayoutTests/media/media-source/media-source-video-playback-quality.html: the test actually exposed bug #375
it added two samples with the same key pts/dts and would have been silently dropped upon adding to the SampleMap.
* LayoutTests/platform/glib/TestExpectations:
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::processMediaSample):
  Inserted the #375 unconditional pass between step 1.13 and step 1.14;
  inserted the #374 bounded pass inside step 1.15&apos;s dependent sweep;
  removed the obsolete samplesWithHigherDecodeTimes block; simplified
  the B-frame cascade&apos;s DTS re-key guard.

Canonical link: <a href="https://commits.webkit.org/313296@main">https://commits.webkit.org/313296@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06a2dab60a10180f77833a2d600afb2ded4e1434

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162714 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36190 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29336 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171652 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/119160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5cd03b84-1b64-470d-99e8-0bacc78c7dec) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164583 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36294 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36194 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126288 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/119160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b2ead31a-cd4a-45b7-b9e2-b5211e75ffac) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165673 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28637 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146202 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106865 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/800dd34f-8eed-44c7-ac76-bfcfee702e75) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19352 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137391 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23931 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174156 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21469 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/25576 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134597 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35864 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134593 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36309 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35848 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145727 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98230 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/29133 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/22563 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35358 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/103109 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34859 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35104 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35007 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->