### PR TITLE
swift.org shows a black region on its right when the Safari sidebar is open on the left

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -406,6 +406,10 @@ fast/events/do-not-drag-and-drop-data-detectors-link.html [ Skip ]
 # Testing against scroller style changes only makes sense on Mac
 scrollbars/custom-scrollbar-scroller-style-change.html [ Skip ]
 
+# Only useful on macOS
+compositing/geometry/frame-clipping-layer-with-bottom-right-inset.html [ Skip ]
+compositing/geometry/frame-clipping-layer-with-top-left-inset.html [ Skip ]
+
 # A rounding error may cause 90deg 3d-rotated elements to count as painted
 imported/w3c/web-platform-tests/paint-timing/fcp-only/fcp-invisible-3d-rotate-descendant.html
 

--- a/LayoutTests/compositing/geometry/frame-clipping-layer-with-bottom-right-inset-expected.txt
+++ b/LayoutTests/compositing/geometry/frame-clipping-layer-with-bottom-right-inset-expected.txt
@@ -1,0 +1,43 @@
+(GraphicsLayer
+  (children 3
+    (GraphicsLayer
+      (anchor 0.00 0.00)
+      (bounds 800.00 600.00)
+      (backgroundColor #FFFFFF)
+    )
+    (GraphicsLayer
+      (anchor 0.00 0.00)
+      (bounds 735.00 550.00)
+      (clips 1)
+      (children 1
+        (GraphicsLayer
+          (anchor 0.00 0.00)
+          (children 1
+            (GraphicsLayer
+              (anchor 0.00 0.00)
+              (bounds 735.00 2000.00)
+              (children 1
+                (GraphicsLayer
+                  (bounds 735.00 2000.00)
+                  (contentsOpaque 1)
+                  (children 1
+                    (GraphicsLayer
+                      (bounds 100.00 100.00)
+                      (contentsOpaque 1)
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+    (GraphicsLayer
+      (position 735.00 0.00)
+      (bounds 15.00 550.00)
+      (drawsContent 1)
+    )
+  )
+)
+

--- a/LayoutTests/compositing/geometry/frame-clipping-layer-with-bottom-right-inset.html
+++ b/LayoutTests/compositing/geometry/frame-clipping-layer-with-bottom-right-inset.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    body {
+        height: 2000px;
+        margin: 0;
+    }
+
+    .composited {
+        width: 100px;
+        height: 100px;
+        background-color: green;
+        will-change: transform;
+    }
+</style>
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+
+    async function doTest()
+    {
+        await testRunner.setObscuredContentInsets(0, 50, 50, 0);
+        await testRunner.updatePresentation();
+
+        document.getElementById("layerTree").innerText = window.internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_ROOT_LAYERS | internals.LAYER_TREE_INCLUDES_CLIPPING);
+        testRunner.notifyDone();
+    }
+
+    window.addEventListener("load", doTest);
+</script>
+</head>
+<body>
+<div class="composited"></div>
+<pre id="layerTree"></pre>
+</body>
+</html>

--- a/LayoutTests/compositing/geometry/frame-clipping-layer-with-top-left-inset-expected.txt
+++ b/LayoutTests/compositing/geometry/frame-clipping-layer-with-top-left-inset-expected.txt
@@ -1,0 +1,45 @@
+(GraphicsLayer
+  (children 3
+    (GraphicsLayer
+      (position 50.00 50.00)
+      (anchor 0.00 0.00)
+      (bounds 750.00 550.00)
+      (backgroundColor #FFFFFF)
+    )
+    (GraphicsLayer
+      (position 50.00 50.00)
+      (anchor 0.00 0.00)
+      (bounds 735.00 550.00)
+      (clips 1)
+      (children 1
+        (GraphicsLayer
+          (anchor 0.00 0.00)
+          (children 1
+            (GraphicsLayer
+              (anchor 0.00 0.00)
+              (bounds 735.00 2000.00)
+              (children 1
+                (GraphicsLayer
+                  (bounds 735.00 2000.00)
+                  (contentsOpaque 1)
+                  (children 1
+                    (GraphicsLayer
+                      (bounds 100.00 100.00)
+                      (contentsOpaque 1)
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+    (GraphicsLayer
+      (position 785.00 50.00)
+      (bounds 15.00 550.00)
+      (drawsContent 1)
+    )
+  )
+)
+

--- a/LayoutTests/compositing/geometry/frame-clipping-layer-with-top-left-inset.html
+++ b/LayoutTests/compositing/geometry/frame-clipping-layer-with-top-left-inset.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    body {
+        height: 2000px;
+        margin: 0;
+    }
+
+    .composited {
+        width: 100px;
+        height: 100px;
+        background-color: green;
+        will-change: transform;
+    }
+</style>
+<script>
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+
+    async function doTest()
+    {
+        await testRunner.setObscuredContentInsets(50, 0, 0, 50);
+        await testRunner.updatePresentation();
+
+        document.getElementById("layerTree").innerText = window.internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_ROOT_LAYERS | internals.LAYER_TREE_INCLUDES_CLIPPING);
+        testRunner.notifyDone();
+    }
+
+    window.addEventListener("load", doTest);
+</script>
+</head>
+<body>
+<div class="composited"></div>
+<pre id="layerTree"></pre>
+</body>
+</html>

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -82,6 +82,9 @@ media/mediacapabilities/mediacapabilities-decodingInfo-spatialRendering.html [ F
 # Individually failing tests should be marked in separate expectations.
 [ Sonoma+ ] imported/w3c/web-platform-tests/css/css-text/word-break/auto-phrase [ Pass ]
 
+compositing/geometry/frame-clipping-layer-with-bottom-right-inset.html [ Pass ]
+compositing/geometry/frame-clipping-layer-with-top-left-inset.html [ Pass ]
+
 #//////////////////////////////////////////////////////////////////////////////////////////
 # End platform-specific directories.
 #//////////////////////////////////////////////////////////////////////////////////////////

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -2669,7 +2669,16 @@ FloatRect LocalFrameView::insetClipLayerRect(const FloatPoint& scrollPosition, c
 
     auto adjustedSize = sizeForVisibleContent;
     if (obscuredContentInset.top())
-        adjustedSize.setHeight(std::max(0.f, sizeForVisibleContent.height() - position.y()));
+        adjustedSize.setHeight(std::max(0.f, adjustedSize.height() - position.y()));
+
+    if (obscuredContentInset.bottom())
+        adjustedSize.setHeight(std::max(0.f, adjustedSize.height() - obscuredContentInset.bottom()));
+
+    if (obscuredContentInset.left())
+        adjustedSize.setWidth(std::max(0.f, adjustedSize.width() - position.x()));
+
+    if (obscuredContentInset.right())
+        adjustedSize.setWidth(std::max(0.f, adjustedSize.width() - obscuredContentInset.right()));
 
     return { position, adjustedSize };
 }

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -4994,6 +4994,7 @@ void RenderLayerCompositor::updateSizeAndPositionForOverhangAreaLayer()
     Ref frameView = m_renderView.frameView();
     auto obscuredContentInsets = frameView->obscuredContentInsets();
     IntSize overhangAreaSize = frameView->frameRect().size();
+    // FIXME: Handle bottom and right insets too.
     overhangAreaSize.contract(obscuredContentInsets.left(), obscuredContentInsets.top());
     overhangAreaSize.clampNegativeToZero();
     layer->setSize(overhangAreaSize);

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -3560,6 +3560,8 @@ static OptionSet<LayerTreeAsTextOptions> NODELETE toLayerTreeAsTextOptions(unsig
         layerTreeFlags.add(LayerTreeAsTextOptions::IncludeExtendedColor);
     if (flags & Internals::LAYER_TREE_INCLUDES_DEVICE_SCALE)
         layerTreeFlags.add(LayerTreeAsTextOptions::IncludeDeviceScale);
+    if (flags & Internals::LAYER_TREE_INCLUDES_ROOT_LAYERS)
+        layerTreeFlags.add(LayerTreeAsTextOptions::IncludeRootLayers);
 
     return layerTreeFlags;
 }

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -563,6 +563,7 @@ public:
         LAYER_TREE_INCLUDES_EVENT_REGION = 512,
         LAYER_TREE_INCLUDES_EXTENDED_COLOR = 1024,
         LAYER_TREE_INCLUDES_DEVICE_SCALE = 2048,
+        LAYER_TREE_INCLUDES_ROOT_LAYERS = 4096,
     };
     ExceptionOr<String> layerTreeAsText(Document&, unsigned short flags) const;
     ExceptionOr<uint64_t> layerIDForElement(Element&);

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -808,6 +808,7 @@ enum ContentsFormat {
     const unsigned short LAYER_TREE_INCLUDES_EVENT_REGION = 512;
     const unsigned short LAYER_TREE_INCLUDES_EXTENDED_COLOR = 1024;
     const unsigned short LAYER_TREE_INCLUDES_DEVICE_SCALE = 2048;
+    const unsigned short LAYER_TREE_INCLUDES_ROOT_LAYERS = 4096;
     DOMString layerTreeAsText(Document document, optional unsigned short flags = 0);
 
     unsigned long long layerIDForElement(Element element);


### PR DESCRIPTION
#### 99ef9027da45f74d670cb12b9af8f4fa801e25dd
<pre>
swift.org shows a black region on its right when the Safari sidebar is open on the left
<a href="https://bugs.webkit.org/show_bug.cgi?id=314770">https://bugs.webkit.org/show_bug.cgi?id=314770</a>
<a href="https://rdar.apple.com/173191807">rdar://173191807</a>

Reviewed by Tim Horton.

When Safari&apos;s sidebar is open on the left, `LocalFrameView::insetClipLayerRect()` is called
with a non-zero left inset. We failed to take this into account when sizing the `frame clipping`
layer, which gets its size from this function. Thus, the page tiles projected unclipped
under the scrollbar, and the dark scrollbar over black tile areas made it invisible.

Fix by accounting for insets on all sides here; when the system language is RTL, the Safari
sidebar is on the right, and accounting for the right inset also makes the rendering
correct.

The tests only make sense on macOS where the layer tree dump starts at the root layer,
when the optional flag is passed (which requires a little plumbing here).

Tests: compositing/geometry/frame-clipping-layer-with-bottom-right-inset.html
       compositing/geometry/frame-clipping-layer-with-top-left-inset.html

* LayoutTests/TestExpectations:
* LayoutTests/compositing/geometry/frame-clipping-layer-with-bottom-right-inset-expected.txt: Added.
* LayoutTests/compositing/geometry/frame-clipping-layer-with-bottom-right-inset.html: Added.
* LayoutTests/compositing/geometry/frame-clipping-layer-with-top-left-inset-expected.txt: Added.
* LayoutTests/compositing/geometry/frame-clipping-layer-with-top-left-inset.html: Added.
* LayoutTests/platform/mac/TestExpectations:
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::insetClipLayerRect):
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::updateSizeAndPositionForOverhangAreaLayer):
* Source/WebCore/testing/Internals.cpp:
(WebCore::toLayerTreeAsTextOptions):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:

Canonical link: <a href="https://commits.webkit.org/313513@main">https://commits.webkit.org/313513@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21fe404a585a9bf2c13c597aa87c31c63af1674a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162780 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36256 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29411 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171718 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119226 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/091f5be7-5a13-4477-a411-0bfd38f33a77) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164649 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36360 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36260 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126349 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88987 "1 flakes 17 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/955514f6-cc3b-4e5f-91f3-88a0900e80c9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165739 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28697 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146265 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106926 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/961a9573-01a3-4d6a-bd77-32637106e25e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27743 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26274 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19418 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137451 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23994 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174222 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21714 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25639 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134659 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35930 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30377 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134654 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36421 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35914 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145790 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98329 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/29195 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22626 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35424 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/103401 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34925 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/649 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35170 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35073 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->