### PR TITLE
AX: nodeChangeForObject overwrites childrenIDs in the nodeMap, sometimes causing content to be missing in the isolated tree

### DIFF
--- a/LayoutTests/accessibility/dynamic-subtree-replacement-with-stale-parent-children-expected.txt
+++ b/LayoutTests/accessibility/dynamic-subtree-replacement-with-stale-parent-children-expected.txt
@@ -1,0 +1,13 @@
+Tests that all newly-added children of a container are reachable in the AX tree after the contents are dynamically replaced.
+
+Initial state:
+PASS: container.childrenCount === 2
+
+After swap:
+PASS: container.childrenCount === 13
+PASS: reachableButtons === buttonCount
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Q1Q2Q3Q4Q5Q6Q7Q8Q9Q10Q11Q12Next

--- a/LayoutTests/accessibility/dynamic-subtree-replacement-with-stale-parent-children.html
+++ b/LayoutTests/accessibility/dynamic-subtree-replacement-with-stale-parent-children.html
@@ -1,0 +1,66 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<div id="container" role="region" aria-label="Survey">
+    <button id="initial-button">Initial</button>
+    <button id="nav-button">Next</button>
+</div>
+
+<script>
+var output = "Tests that all newly-added children of a container are reachable in the AX tree after the contents are dynamically replaced.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var container = accessibilityController.accessibleElementById("container");
+    output += "Initial state:\n";
+    output += expect("container.childrenCount", "2");
+
+    var buttonCount = 12;
+    var reachableButtons;
+    setTimeout(async function() {
+        var notificationCounter = 0;
+        var makePageDirty = setInterval(function() {
+            // Continuously dirty layout to defer AXObjectCache::performDeferredCacheUpdate,
+            // necessary to trigger the bug.
+            document.body.style.paddingTop = (Math.floor(Math.random() * 4)) + "px";
+            // Continuously queue an AX notification on the container so that
+            // notificationPostTimer fires repeatedly with a queued nodeUpdate for
+            // the container.
+            document.getElementById("container").setAttribute("aria-atomic", String(notificationCounter++));
+        }, 1);
+
+        // Update the role, triggering a full node update.
+        document.getElementById("container").setAttribute("role", "group");
+        var newContents = "";
+        for (var i = 1; i <= buttonCount; i++)
+            newContents += `<button id="q${i}-button">Q${i}</button>`;
+        newContents += `<button id="nav-button">Next</button>`;
+        document.getElementById("container").innerHTML = newContents;
+
+        container = accessibilityController.accessibleElementById("container");
+        output += "\nAfter swap:\n";
+        output += await expectAsync("container.childrenCount", "13");
+
+        reachableButtons = 0;
+        for (var i = 1; i <= buttonCount; i++) {
+            let button = await waitForElementById(`q${i}-button`);
+            if (button)
+                reachableButtons++;
+        }
+        output += expect("reachableButtons", "buttonCount");
+
+        clearInterval(makePageDirty);
+
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
+++ b/Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp
@@ -343,7 +343,16 @@ std::optional<AXIsolatedTree::NodeChange> AXIsolatedTree::nodeChangeForObject(Re
     AX_ASSERT(axObject->wrapper());
     auto data = createIsolatedObjectData(axObject, *this);
     Markable parentID = data.parentID;
-    m_nodeMap.set(axObject->objectID(), ParentChildrenIDs { parentID, data.childrenIDs });
+    auto iterator = m_nodeMap.find(axObject->objectID());
+    if (iterator == m_nodeMap.end())
+        m_nodeMap.set(axObject->objectID(), ParentChildrenIDs { parentID, data.childrenIDs });
+    else {
+        // We don't want to update the childrenIDs for an existing object, as |updateChildren| relies on
+        // knowing what children have changed (which are new, which are old) to decide what objects to create
+        // and destroy. If we were to update childrenIDs here, |updateChildren| would either fail to create
+        // objects for new children, and / or leak old ones. |collectNodeChangesForSubtree| has the same behavior.
+        iterator->value.parentID = parentID;
+    }
     NodeChange nodeChange { WTF::move(data), axObject->wrapper() };
 
     if (axObject->isRoot())


### PR DESCRIPTION
#### e30fb3e304f3ec7eefa43a791d52f3ee2bc91676
<pre>
AX: nodeChangeForObject overwrites childrenIDs in the nodeMap, sometimes causing content to be missing in the isolated tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=314773">https://bugs.webkit.org/show_bug.cgi?id=314773</a>
<a href="https://rdar.apple.com/176891627">rdar://176891627</a>

Reviewed by Dominic Mazzoni.

With this sequence, content can become missing from the isolated tree:

  1. An attribute change (e.g. role) on parent X is posted as a notification
     into AXObjectCache&apos;s m_notificationsToPost, which schedules
     notificationPostTimer.

  2. X&apos;s children are dynamically replaced (innerHTML, etc.), so live
     children differ from what&apos;s stored in m_nodeMap[X].childrenIDs. The
     children-changed events sit in AXObjectCache&apos;s m_deferredChildrenChangedList
     waiting for performDeferredCacheUpdate to drain them into
     AXIsolatedTree&apos;s m_needsUpdateChildren.

  3. performCacheUpdate fires before notificationPostTimer, but bails
     because layout is dirty. m_deferredChildrenChangedList stays untouched,
     so AXIsolatedTree&apos;s m_needsUpdateChildren stays empty for X.

  4. notificationPostTimer fires. It (a) queues a full node update for X
     into m_needsUpdateNode via updateIsolatedTree, and (b) calls
     processQueuedIsolatedNodeUpdates synchronously inside
     postPlatformNotification (so the AT sees an up-to-date tree when
     it responds to the notification).

  5. processQueuedNodeUpdates runs with m_needsUpdateNode={X} and
     m_needsUpdateChildren={} (still empty from step 3). It calls
     resolveAppends -&gt; nodeChangeForObject(X), which sees live children
     = NEW and stored children = OLD, and overwrites m_nodeMap[X].childrenIDs
     with the NEW IDs without registering any of them in m_nodeMap.

  6. Later, performCacheUpdate runs successfully and queues
     updateChildren(X) into m_needsUpdateChildren. The snapshot timer
     fires processQueuedNodeUpdates, which calls updateChildren(X).
     It reads oldChildrenIDs from the polluted m_nodeMap (= NEW IDs)
     and compares against newChildrenIDs from live (= the same NEW IDs).
     old == new, so it never calls collectNodeChangesForSubtree on the
     new children, and thus they never get isolated objects created for them.

  7. AXIsolatedObject::children resolves the stored childrenIDs against
     tree().objectForID(...). The unregistered NEW IDs return null and
     get silently dropped via WTF::compactMap, leaving them invisible
     to AT clients.

Fix this in the same way we fixed a similar problem for collectNodeChangesForSubtree
in <a href="https://commits.webkit.org/285352@main.">https://commits.webkit.org/285352@main.</a> If the object is already in the nodemap,
we leave the existing childrenIDs alone. Arguably we should do this even if the
object isn&apos;t in the nodemap, but rethinking this is saved for a later commit since
this change alone fixes the bug on the webpage.

* LayoutTests/accessibility/dynamic-subtree-replacement-with-stale-parent-children-expected.txt: Added.
* LayoutTests/accessibility/dynamic-subtree-replacement-with-stale-parent-children.html: Added.
* Source/WebCore/accessibility/isolatedtree/AXIsolatedTree.cpp:
(WebCore::AXIsolatedTree::nodeChangeForObject):

Canonical link: <a href="https://commits.webkit.org/313241@main">https://commits.webkit.org/313241@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a18367156142d01ee5e37ab520502ffde464d1df

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162466 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35942 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29058 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171404 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/118911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164335 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36046 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35946 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126080 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/118911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165425 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28426 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145946 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106658 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f8080b0a-7005-4a6b-b120-d19855665c5d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27472 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25998 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19104 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137175 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23676 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173908 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21221 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25320 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134389 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35616 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30089 "Found 1 new test failure: imported/w3c/web-platform-tests/IndexedDB/interleaved-cursors-small.any.serviceworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134388 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36276 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35600 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145472 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97859 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28922 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22305 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35109 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102861 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34611 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34856 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34759 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->