### PR TITLE
[Build Speed] Reduce mpark::variant template instantiation overhead

### DIFF
--- a/Source/WebCore/css/calc/CSSCalcTree.cpp
+++ b/Source/WebCore/css/calc/CSSCalcTree.cpp
@@ -68,6 +68,112 @@ WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(Sqrt);
 WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(Sum);
 WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(Tan);
 
+// MARK: - Child
+
+Child::Child(Child&&) = default;
+Child& Child::operator=(Child&&) = default;
+Child::~Child() = default;
+bool Child::operator==(const Child&) const = default;
+
+static_assert(sizeof(Child) <= 24, "Child should stay small");
+
+// MARK: - ChildOrNone
+
+ChildOrNone::ChildOrNone(Child&& child)
+    : value(WTF::move(child))
+{
+}
+
+ChildOrNone::ChildOrNone(CSS::Keyword::None none)
+    : value(none)
+{
+}
+
+// MARK: - Children
+
+Children::Children(Vector<Child>&& other)
+    : value(WTF::move(other))
+{
+}
+
+Children& Children::operator=(Vector<Child>&& other)
+{
+    value = WTF::move(other);
+    return *this;
+}
+
+Children::iterator Children::begin()
+{
+    return value.begin();
+}
+
+Children::iterator Children::end()
+{
+    return value.end();
+}
+
+Children::reverse_iterator Children::rbegin()
+{
+    return value.rbegin();
+}
+
+Children::reverse_iterator Children::rend()
+{
+    return value.rend();
+}
+
+Children::const_iterator Children::begin() const
+{
+    return value.begin();
+}
+
+Children::const_iterator Children::end() const
+{
+    return value.end();
+}
+
+Children::const_reverse_iterator Children::rbegin() const
+{
+    return value.rbegin();
+}
+
+Children::const_reverse_iterator Children::rend() const
+{
+    return value.rend();
+}
+
+bool Children::isEmpty() const
+{
+    return value.isEmpty();
+}
+
+size_t Children::size() const
+{
+    return value.size();
+}
+
+Child& Children::operator[](size_t i)
+{
+    return value[i];
+}
+
+const Child& Children::operator[](size_t i) const
+{
+    return value[i];
+}
+
+// MARK: - AnchorSide
+
+AnchorSide::AnchorSide(CSSValueID valueID)
+    : value(valueID)
+{
+}
+
+AnchorSide::AnchorSide(Child&& child)
+    : value(WTF::move(child))
+{
+}
+
 bool isNumeric(const Child& root)
 {
     return WTF::switchOn(root,

--- a/Source/WebCore/css/calc/CSSCalcTree.h
+++ b/Source/WebCore/css/calc/CSSCalcTree.h
@@ -240,9 +240,13 @@ struct Child {
         requires std::constructible_from<Node, T>
     Child(T&&);
 
+    Child(Child&&);
+    Child& operator=(Child&&);
+    ~Child();
+
     FORWARD_VARIANT_FUNCTIONS(Child, value)
 
-    bool operator==(const Child&) const = default;
+    bool operator==(const Child&) const;
 };
 
 struct ChildOrNone {
@@ -1203,107 +1207,6 @@ Child::Child(T&& value)
     : value(std::forward<T>(value))
 {
 }
-
-// MARK: ChildOrNone Definition
-
-inline ChildOrNone::ChildOrNone(Child&& child)
-    : value(WTF::move(child))
-{
-}
-
-inline ChildOrNone::ChildOrNone(CSS::Keyword::None none)
-    : value(none)
-{
-}
-
-// MARK: Children Definition
-
-inline Children::Children(Vector<Child>&& other)
-    : value(WTF::move(other))
-{
-}
-
-inline Children& Children::operator=(Vector<Child>&& other)
-{
-    value = WTF::move(other);
-    return *this;
-}
-
-inline Children::iterator Children::begin() LIFETIME_BOUND
-{
-    return value.begin();
-}
-
-inline Children::iterator Children::end() LIFETIME_BOUND
-{
-    return value.end();
-}
-
-inline Children::reverse_iterator Children::rbegin() LIFETIME_BOUND
-{
-    return value.rbegin();
-}
-
-inline Children::reverse_iterator Children::rend() LIFETIME_BOUND
-{
-    return value.rend();
-}
-
-inline Children::const_iterator Children::begin() const LIFETIME_BOUND
-{
-    return value.begin();
-}
-
-inline Children::const_iterator Children::end() const LIFETIME_BOUND
-{
-    return value.end();
-}
-
-inline Children::const_reverse_iterator Children::rbegin() const LIFETIME_BOUND
-{
-    return value.rbegin();
-}
-
-inline Children::const_reverse_iterator Children::rend() const LIFETIME_BOUND
-{
-    return value.rend();
-}
-
-inline bool Children::isEmpty() const
-{
-    return value.isEmpty();
-}
-
-inline size_t Children::size() const
-{
-    return value.size();
-}
-
-inline Child& Children::operator[](size_t i) LIFETIME_BOUND
-{
-    return value[i];
-}
-
-inline const Child& Children::operator[](size_t i) const LIFETIME_BOUND
-{
-    return value[i];
-}
-
-// AnchorSize
-
-inline AnchorSide::AnchorSide(CSSValueID valueID)
-    : value(valueID)
-{
-}
-
-inline AnchorSide::AnchorSide(Child&& child)
-    : value(WTF::move(child))
-{
-}
-
-// MARK: Size assertions
-
-static_assert(sizeof(Child) <= 24, "Child should stay small");
 
 } // namespace CSSCalc
 } // namespace WebCore

--- a/Source/WebCore/rendering/PathOperation.cpp
+++ b/Source/WebCore/rendering/PathOperation.cpp
@@ -76,6 +76,14 @@ ReferencePathOperation::ReferencePathOperation(std::optional<Path>&& path)
 
 // MARK: - ShapePathOperation
 
+ShapePathOperation::ShapePathOperation(Style::BasicShape shape, CSSBoxType referenceBox)
+    : PathOperation(Type::Shape, referenceBox)
+    , m_shape(WTF::move(shape))
+{
+}
+
+ShapePathOperation::~ShapePathOperation() = default;
+
 Ref<ShapePathOperation> ShapePathOperation::create(Style::BasicShape shape, CSSBoxType referenceBox)
 {
     return adoptRef(*new ShapePathOperation(WTF::move(shape), referenceBox));

--- a/Source/WebCore/rendering/PathOperation.h
+++ b/Source/WebCore/rendering/PathOperation.h
@@ -140,11 +140,8 @@ public:
 private:
     bool operator==(const PathOperation&) const override;
 
-    ShapePathOperation(Style::BasicShape shape, CSSBoxType referenceBox)
-        : PathOperation(Type::Shape, referenceBox)
-        , m_shape(WTF::move(shape))
-    {
-    }
+    ShapePathOperation(Style::BasicShape, CSSBoxType);
+    ~ShapePathOperation();
 
     Style::BasicShape m_shape;
 };

--- a/Source/WebCore/style/calc/StyleCalculationTree.cpp
+++ b/Source/WebCore/style/calc/StyleCalculationTree.cpp
@@ -65,6 +65,104 @@ WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(Sqrt);
 WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(Sum);
 WTF_MAKE_STRUCT_TZONE_ALLOCATED_IMPL(Tan);
 
+// MARK: - Child
+
+Child::Child(Child&&) = default;
+Child& Child::operator=(Child&&) = default;
+Child::~Child() = default;
+bool Child::operator==(const Child&) const = default;
+
+static_assert(sizeof(Child) <= 16, "Child should stay small");
+
+// MARK: - ChildOrNone
+
+ChildOrNone::ChildOrNone(Child&& child)
+    : value(WTF::move(child))
+{
+}
+
+ChildOrNone::ChildOrNone(CSS::Keyword::None none)
+    : value(none)
+{
+}
+
+// MARK: - Children
+
+Children::Children(Children&&) = default;
+Children& Children::operator=(Children&&) = default;
+Children::~Children() = default;
+
+Children::Children(Vector<Child>&& other)
+    : value(WTF::move(other))
+{
+}
+
+Children& Children::operator=(Vector<Child>&& other)
+{
+    value = WTF::move(other);
+    return *this;
+}
+
+Children::iterator Children::begin()
+{
+    return value.begin();
+}
+
+Children::iterator Children::end()
+{
+    return value.end();
+}
+
+Children::reverse_iterator Children::rbegin()
+{
+    return value.rbegin();
+}
+
+Children::reverse_iterator Children::rend()
+{
+    return value.rend();
+}
+
+Children::const_iterator Children::begin() const
+{
+    return value.begin();
+}
+
+Children::const_iterator Children::end() const
+{
+    return value.end();
+}
+
+Children::const_reverse_iterator Children::rbegin() const
+{
+    return value.rbegin();
+}
+
+Children::const_reverse_iterator Children::rend() const
+{
+    return value.rend();
+}
+
+bool Children::isEmpty() const
+{
+    return value.isEmpty();
+}
+
+size_t Children::size() const
+{
+    return value.size();
+}
+
+Child& Children::operator[](size_t i)
+{
+    return value[i];
+}
+
+const Child& Children::operator[](size_t i) const
+{
+    return value[i];
+}
+
 Child number(double value)
 {
     return makeChild(Number { .value = value });

--- a/Source/WebCore/style/calc/StyleCalculationTree.h
+++ b/Source/WebCore/style/calc/StyleCalculationTree.h
@@ -172,9 +172,13 @@ struct Child {
         requires std::constructible_from<Node, T>
     Child(T&&);
 
+    Child(Child&&);
+    Child& operator=(Child&&);
+    ~Child();
+
     FORWARD_VARIANT_FUNCTIONS(Child, value)
 
-    bool operator==(const Child&) const = default;
+    bool operator==(const Child&) const;
 };
 
 struct ChildOrNone {
@@ -197,10 +201,11 @@ struct Children {
 
     Vector<Child> value;
 
-    Children(Children&&) = default;
+    Children(Children&&);
     Children(Vector<Child>&&);
-    Children& operator=(Children&&) = default;
+    Children& operator=(Children&&);
     Children& operator=(Vector<Child>&&);
+    ~Children();
 
     iterator begin() LIFETIME_BOUND;
     iterator end() LIFETIME_BOUND;
@@ -535,8 +540,6 @@ struct Blend {
     bool operator==(const Blend&) const = default;
 };
 
-static_assert(sizeof(Child) <= 16, "Child should stay small");
-
 // MARK: Construction
 
 // Default implementation of ChildConstruction used for all indirect nodes.
@@ -544,19 +547,9 @@ template<typename Op> struct ChildConstruction {
     static Child make(Op&& op) { return Child { IndirectNode<Op> { makeUniqueRef<Op>(WTF::move(op)) } }; }
 };
 
-// Specialized implementation of ChildConstruction for Number, needed to avoid `makeUniqueRef`.
-template<> struct ChildConstruction<Number> {
-    static Child make(Number&& op) { return Child { WTF::move(op) }; }
-};
-
-// Specialized implementation of ChildConstruction for Percentage, needed to avoid `makeUniqueRef`.
-template<> struct ChildConstruction<Percentage> {
-    static Child make(Percentage&& op) { return Child { WTF::move(op) }; }
-};
-
-// Specialized implementation of ChildConstruction for Dimension, needed to avoid `makeUniqueRef`.
-template<> struct ChildConstruction<Dimension> {
-    static Child make(Dimension&& op) { return Child { WTF::move(op) }; }
+// Specialized implementation of ChildConstruction for leaf nodes, needed to avoid `makeUniqueRef`.
+template<Leaf T> struct ChildConstruction<T> {
+    static Child make(T&& op) { return Child { WTF::move(op) }; }
 };
 
 template<typename Op> Child makeChild(Op&& op)
@@ -805,91 +798,6 @@ template<typename T>
 Child::Child(T&& value)
     : value(std::forward<T>(value))
 {
-}
-
-// MARK: ChildOrNone Definition
-
-inline ChildOrNone::ChildOrNone(Child&& child)
-    : value(WTF::move(child))
-{
-}
-
-inline ChildOrNone::ChildOrNone(CSS::Keyword::None none)
-    : value(none)
-{
-}
-
-// MARK: Children Definition
-
-inline Children::Children(Vector<Child>&& other)
-    : value(WTF::move(other))
-{
-}
-
-inline Children& Children::operator=(Vector<Child>&& other)
-{
-    value = WTF::move(other);
-    return *this;
-}
-
-inline Children::iterator Children::begin() LIFETIME_BOUND
-{
-    return value.begin();
-}
-
-inline Children::iterator Children::end() LIFETIME_BOUND
-{
-    return value.end();
-}
-
-inline Children::reverse_iterator Children::rbegin() LIFETIME_BOUND
-{
-    return value.rbegin();
-}
-
-inline Children::reverse_iterator Children::rend() LIFETIME_BOUND
-{
-    return value.rend();
-}
-
-inline Children::const_iterator Children::begin() const LIFETIME_BOUND
-{
-    return value.begin();
-}
-
-inline Children::const_iterator Children::end() const LIFETIME_BOUND
-{
-    return value.end();
-}
-
-inline Children::const_reverse_iterator Children::rbegin() const LIFETIME_BOUND
-{
-    return value.rbegin();
-}
-
-inline Children::const_reverse_iterator Children::rend() const LIFETIME_BOUND
-{
-    return value.rend();
-}
-
-inline bool Children::isEmpty() const
-{
-    return value.isEmpty();
-}
-
-inline size_t Children::size() const
-{
-    return value.size();
-}
-
-inline Child& Children::operator[](size_t i) LIFETIME_BOUND
-{
-    return value[i];
-}
-
-inline const Child& Children::operator[](size_t i) const LIFETIME_BOUND
-{
-    return value[i];
 }
 
 } // namespace Calculation

--- a/Source/WebCore/style/values/shapes/StyleShapeFunction.cpp
+++ b/Source/WebCore/style/values/shapes/StyleShapeFunction.cpp
@@ -43,6 +43,22 @@
 namespace WebCore {
 namespace Style {
 
+// MARK: - Shape
+
+Shape::Shape(std::optional<FillRule> fillRule, Position&& startingPoint, Commands&& commands)
+    : fillRule(fillRule)
+    , startingPoint(WTF::move(startingPoint))
+    , commands(WTF::move(commands))
+{
+}
+
+Shape::Shape(Shape&&) = default;
+Shape::Shape(const Shape&) = default;
+Shape& Shape::operator=(Shape&&) = default;
+Shape& Shape::operator=(const Shape&) = default;
+Shape::~Shape() = default;
+bool Shape::operator==(const Shape&) const = default;
+
 // MARK: - Control Point Evaluation
 
 template<typename ControlPoint> static ControlPointAnchor NODELETE evaluateControlPointAnchoring(const ControlPoint& value, ControlPointAnchor defaultValue)
@@ -629,10 +645,10 @@ auto Blending<Shape>::canBlend(const Shape& a, const Shape& b) -> bool
 
 auto Blending<Shape>::blend(const Shape& a, const Shape& b, const BlendingContext& context) -> Shape
 {
-    return {
-        .fillRule = a.fillRule,
-        .startingPoint = WebCore::Style::blend(a.startingPoint, b.startingPoint, context),
-        .commands = WebCore::Style::blend(a.commands, b.commands, context)
+    return Shape {
+        std::optional<FillRule> { a.fillRule },
+        WebCore::Style::blend(a.startingPoint, b.startingPoint, context),
+        WebCore::Style::blend(a.commands, b.commands, context)
     };
 }
 
@@ -667,9 +683,9 @@ std::optional<Shape> makeShapeFromPath(const Path& path)
         return { };
 
     return Shape {
-        .fillRule = path.fillRule,
-        .startingPoint = converter.initialMove().value_or(Position { 0_css_px, 0_css_px }),
-        .commands = { WTF::move(shapeCommands) }
+        path.fillRule,
+        converter.initialMove().value_or(Position { 0_css_px, 0_css_px }),
+        Shape::Commands { WTF::move(shapeCommands) }
     };
 }
 

--- a/Source/WebCore/style/values/shapes/StyleShapeFunction.h
+++ b/Source/WebCore/style/values/shapes/StyleShapeFunction.h
@@ -389,7 +389,14 @@ struct Shape {
     Position startingPoint;
     Commands commands;
 
-    bool operator==(const Shape&) const = default;
+    Shape(std::optional<FillRule>, Position&&, Commands&&);
+    Shape(Shape&&);
+    Shape(const Shape&);
+    Shape& operator=(Shape&&);
+    Shape& operator=(const Shape&);
+    ~Shape();
+
+    bool operator==(const Shape&) const;
 };
 using ShapeFunction = FunctionNotation<CSSValueShape, Shape>;
 

--- a/Source/WebCore/style/values/shapes/StyleShapeOutside.cpp
+++ b/Source/WebCore/style/values/shapes/StyleShapeOutside.cpp
@@ -37,6 +37,62 @@
 namespace WebCore {
 namespace Style {
 
+// MARK: - ShapeOutside
+
+ShapeOutside::ShapeOutside(Shape&& value)
+    : m_value { Value::create(WTF::move(value)) }
+{
+}
+
+ShapeOutside::ShapeOutside(ShapeBox&& value)
+    : m_value { Value::create(WTF::move(value)) }
+{
+}
+
+ShapeOutside::ShapeOutside(ShapeAndShapeBox&& value)
+    : m_value { Value::create(WTF::move(value)) }
+{
+}
+
+ShapeOutside::ShapeOutside(Image&& value)
+    : m_value { Value::create(WTF::move(value)) }
+{
+}
+
+// MARK: - ShapeOutside::Value
+
+Ref<ShapeOutside::Value> ShapeOutside::Value::create(Kind&& value)
+{
+    return adoptRef(*new Value(WTF::move(value)));
+}
+
+ShapeOutside::Value::Value(Kind&& value)
+    : value { WTF::move(value) }
+{
+}
+
+ShapeOutside::Value::~Value() = default;
+
+bool ShapeOutside::Value::operator==(const Value& other) const
+{
+    return value == other.value;
+}
+
+// MARK: - ShapeOutside::ShapeAndShapeBox
+
+ShapeOutside::ShapeAndShapeBox::ShapeAndShapeBox(Shape&& shape, ShapeBox box)
+    : shape(WTF::move(shape))
+    , box(box)
+{
+}
+
+ShapeOutside::ShapeAndShapeBox::ShapeAndShapeBox(ShapeAndShapeBox&&) = default;
+ShapeOutside::ShapeAndShapeBox::ShapeAndShapeBox(const ShapeAndShapeBox&) = default;
+ShapeOutside::ShapeAndShapeBox& ShapeOutside::ShapeAndShapeBox::operator=(ShapeAndShapeBox&&) = default;
+ShapeOutside::ShapeAndShapeBox& ShapeOutside::ShapeAndShapeBox::operator=(const ShapeAndShapeBox&) = default;
+ShapeOutside::ShapeAndShapeBox::~ShapeAndShapeBox() = default;
+bool ShapeOutside::ShapeAndShapeBox::operator==(const ShapeAndShapeBox&) const = default;
+
 bool ShapeOutside::Image::isValid() const
 {
     Ref styleImage = image.value;
@@ -88,7 +144,7 @@ auto CSSValueConversion<ShapeOutside>::operator()(BuilderState& state, const CSS
         }
 
         if (referenceBox != CSSBoxType::BoxMissing)
-            return ShapeOutside::ShapeAndShapeBox { .shape = WTF::move(*shape), .box = referenceBox };
+            return ShapeOutside::ShapeAndShapeBox { WTF::move(*shape), referenceBox };
         return ShapeOutside::Shape { WTF::move(*shape) };
     }
 
@@ -137,8 +193,8 @@ auto Blending<ShapeOutside>::blend(const ShapeOutside& a, const ShapeOutside& b,
     return WTF::visit(WTF::makeVisitor(
         [&](const ShapeOutside::ShapeAndShapeBox& a, const ShapeOutside::ShapeAndShapeBox& b) -> ShapeOutside {
             return ShapeOutside::ShapeAndShapeBox {
-                .shape = Style::blend(a.shape, b.shape, context),
-                .box = a.box
+                Style::blend(a.shape, b.shape, context),
+                a.box
             };
         },
         [&](const ShapeOutside::Shape& a, const ShapeOutside::Shape& b) -> ShapeOutside {

--- a/Source/WebCore/style/values/shapes/StyleShapeOutside.h
+++ b/Source/WebCore/style/values/shapes/StyleShapeOutside.h
@@ -43,7 +43,14 @@ struct ShapeOutside {
         Shape shape;
         ShapeBox box;
 
-        bool operator==(const ShapeAndShapeBox&) const = default;
+        ShapeAndShapeBox(Shape&&, ShapeBox);
+        ShapeAndShapeBox(ShapeAndShapeBox&&);
+        ShapeAndShapeBox(const ShapeAndShapeBox&);
+        ShapeAndShapeBox& operator=(ShapeAndShapeBox&&);
+        ShapeAndShapeBox& operator=(const ShapeAndShapeBox&);
+        ~ShapeAndShapeBox();
+
+        bool operator==(const ShapeAndShapeBox&) const;
     };
     struct Image {
         ImageWrapper image;
@@ -54,10 +61,10 @@ struct ShapeOutside {
     };
 
     ShapeOutside(CSS::Keyword::None) { }
-    ShapeOutside(Shape&& value) : m_value { Value::create(WTF::move(value)) } { }
-    ShapeOutside(ShapeBox&& value) : m_value { Value::create(WTF::move(value)) } { }
-    ShapeOutside(ShapeAndShapeBox&& value) : m_value { Value::create(WTF::move(value)) } { }
-    ShapeOutside(Image&& value) : m_value { Value::create(WTF::move(value)) } { }
+    ShapeOutside(Shape&&);
+    ShapeOutside(ShapeBox&&);
+    ShapeOutside(ShapeAndShapeBox&&);
+    ShapeOutside(Image&&);
 
     bool isNone() const { return !m_value; }
 
@@ -100,26 +107,19 @@ private:
     public:
         using Kind = Variant<Shape, ShapeBox, ShapeAndShapeBox, Image>;
 
-        static Ref<Value> create(Kind&& value)
-        {
-            return adoptRef(*new Value(WTF::move(value)));
-        }
-
-        explicit Value(Kind&& value)
-            : value { WTF::move(value) }
-        {
-        }
+        static Ref<Value> create(Kind&&);
+        ~Value();
 
         inline const BasicShape* shape() const;
         inline CSSBoxType effectiveCSSBox() const;
         inline RefPtr<Style::Image> image() const;
 
-        bool operator==(const Value& other) const
-        {
-            return value == other.value;
-        }
+        bool operator==(const Value&) const;
 
         Kind value;
+
+    private:
+        explicit Value(Kind&&);
     };
 
     RefPtr<Value> m_value { };


### PR DESCRIPTION
#### 898a587c355e381bb60f8dcf8fab59921aba1ec1
<pre>
[Build Speed] Reduce mpark::variant template instantiation overhead
<a href="https://bugs.webkit.org/show_bug.cgi?id=314777">https://bugs.webkit.org/show_bug.cgi?id=314777</a>
<a href="https://rdar.apple.com/177027730">rdar://177027730</a>

Reviewed by Sam Weinig.

Saves ~12 wall seconds (168 CPU seconds) in a clean build.

mpark::variant template instantiation is O(N^2) with regard to number
of variant types, plus other fixed costs.

This patch takes our most profilgate types and out-of-lines their template
instantiations.

* Source/WebCore/css/calc/CSSCalcTree.cpp:
(WebCore::CSSCalc::ChildOrNone::ChildOrNone):
(WebCore::CSSCalc::Children::Children):
(WebCore::CSSCalc::Children::operator=):
(WebCore::CSSCalc::Children::begin):
(WebCore::CSSCalc::Children::end):
(WebCore::CSSCalc::Children::rbegin):
(WebCore::CSSCalc::Children::rend):
(WebCore::CSSCalc::Children::begin const):
(WebCore::CSSCalc::Children::end const):
(WebCore::CSSCalc::Children::rbegin const):
(WebCore::CSSCalc::Children::rend const):
(WebCore::CSSCalc::Children::isEmpty const):
(WebCore::CSSCalc::Children::size const):
(WebCore::CSSCalc::Children::operator[]):
(WebCore::CSSCalc::Children::operator[] const):
(WebCore::CSSCalc::AnchorSide::AnchorSide):
* Source/WebCore/css/calc/CSSCalcTree.h:
(WebCore::CSSCalc::ChildOrNone::ChildOrNone): Deleted.
(WebCore::CSSCalc::Children::Children): Deleted.
(WebCore::CSSCalc::Children::operator=): Deleted.
(WebCore::CSSCalc::Children::isEmpty const): Deleted.
(WebCore::CSSCalc::Children::size const): Deleted.
(WebCore::CSSCalc::AnchorSide::AnchorSide): Deleted.
* Source/WebCore/rendering/PathOperation.cpp:
(WebCore::ShapePathOperation::ShapePathOperation):
* Source/WebCore/rendering/PathOperation.h:
* Source/WebCore/style/calc/StyleCalculationTree.cpp:
(WebCore::Style::Calculation::ChildOrNone::ChildOrNone):
(WebCore::Style::Calculation::Children::Children):
(WebCore::Style::Calculation::Children::operator=):
(WebCore::Style::Calculation::Children::begin):
(WebCore::Style::Calculation::Children::end):
(WebCore::Style::Calculation::Children::rbegin):
(WebCore::Style::Calculation::Children::rend):
(WebCore::Style::Calculation::Children::begin const):
(WebCore::Style::Calculation::Children::end const):
(WebCore::Style::Calculation::Children::rbegin const):
(WebCore::Style::Calculation::Children::rend const):
(WebCore::Style::Calculation::Children::isEmpty const):
(WebCore::Style::Calculation::Children::size const):
(WebCore::Style::Calculation::Children::operator[]):
(WebCore::Style::Calculation::Children::operator[] const):
* Source/WebCore/style/calc/StyleCalculationTree.h:
(WebCore::Style::Calculation::ChildConstruction&lt;T&gt;::make):
(WebCore::Style::Calculation::ChildConstruction&lt;Number&gt;::make): Deleted.
(WebCore::Style::Calculation::ChildConstruction&lt;Percentage&gt;::make): Deleted.
(WebCore::Style::Calculation::ChildConstruction&lt;Dimension&gt;::make): Deleted.
(WebCore::Style::Calculation::ChildOrNone::ChildOrNone): Deleted.
(WebCore::Style::Calculation::Children::Children): Deleted.
(WebCore::Style::Calculation::Children::operator=): Deleted.
(): Deleted.
(WebCore::Style::Calculation::Children::isEmpty const): Deleted.
(WebCore::Style::Calculation::Children::size const): Deleted.
* Source/WebCore/style/values/shapes/StyleShapeFunction.cpp:
(WebCore::Style::Shape::Shape):
(WebCore::Style::Blending&lt;Shape&gt;::blend):
(WebCore::Style::makeShapeFromPath):
* Source/WebCore/style/values/shapes/StyleShapeFunction.h:
* Source/WebCore/style/values/shapes/StyleShapeOutside.cpp:
(WebCore::Style::ShapeOutside::ShapeOutside):
(WebCore::Style::ShapeOutside::Value::create):
(WebCore::Style::ShapeOutside::Value::Value):
(WebCore::Style::ShapeOutside::Value::operator== const):
(WebCore::Style::ShapeOutside::ShapeAndShapeBox::ShapeAndShapeBox):
(WebCore::Style::CSSValueConversion&lt;ShapeOutside&gt;::operator):
(WebCore::Style::Blending&lt;ShapeOutside&gt;::blend):
* Source/WebCore/style/values/shapes/StyleShapeOutside.h:
(WebCore::Style::ShapeOutside::Value::create): Deleted.
(WebCore::Style::ShapeOutside::Value::Value): Deleted.
(WebCore::Style::ShapeOutside::Value::operator== const): Deleted.

Canonical link: <a href="https://commits.webkit.org/313214@main">https://commits.webkit.org/313214@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/27a207b9aa2ed674d51b54690f8f5f628d3c6050

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162450 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35926 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29042 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171388 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/118895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164319 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36030 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35930 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126068 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/118895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165409 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28413 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/145933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106646 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27459 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/25985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19088 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23664 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173892 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21205 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25308 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134373 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35600 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134373 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35584 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145460 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97839 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24675 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28905 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/22292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35093 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102845 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34595 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34840 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34743 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->