### PR TITLE
[Site Isolation] [intersection-observer] Make converting from main frame local to absolute coordinate SI-safe

### DIFF
--- a/LayoutTests/http/tests/intersection-observer/resources/root-margin-with-zoom-subframe.html
+++ b/LayoutTests/http/tests/intersection-observer/resources/root-margin-with-zoom-subframe.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+
+<style>
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  #target {
+    position: absolute;
+    height: 40px;
+    width: 40px;
+    background-color: green;
+  }
+</style>
+
+<div id="target"></div>
+
+<script>
+  let options = {
+    rootMargin: '40px 0px 0px 0px',
+    threshold: [1]
+  }
+
+  let observer = new IntersectionObserver((observations) => {
+    const lastObservation = observations[observations.length - 1];
+    window.top.postMessage({
+      isIntersecting: lastObservation.isIntersecting
+    }, "*");
+  }, options);
+
+  observer.observe(document.getElementById("target"));
+</script>

--- a/LayoutTests/http/tests/intersection-observer/resources/zoomed-page-subframe.html
+++ b/LayoutTests/http/tests/intersection-observer/resources/zoomed-page-subframe.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+
+<style>
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  #target {
+    width: 100px;
+    height: 100px;
+    background: green;
+  }
+</style>
+
+<div id="target"></div>
+
+<script>
+  let options = {
+    threshold: [1]
+  };
+
+  let observer = new IntersectionObserver((observations) => {
+    const lastObservation = observations[observations.length - 1];
+    window.top.postMessage({
+      intersectionRect: {
+        x: lastObservation.intersectionRect.x,
+        y: lastObservation.intersectionRect.y,
+        width: lastObservation.intersectionRect.width,
+        height: lastObservation.intersectionRect.height
+      },
+      isIntersecting: lastObservation.isIntersecting
+    }, "*");
+  }, options);
+
+  observer.observe(target);
+</script>

--- a/LayoutTests/http/tests/intersection-observer/root-margin-with-zoom-iframe-same-origin-expected.txt
+++ b/LayoutTests/http/tests/intersection-observer/root-margin-with-zoom-iframe-same-origin-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Intersection Observer: root margin is applied when observer is in a same-origin iframe, and page is zoomed
+

--- a/LayoutTests/http/tests/intersection-observer/root-margin-with-zoom-iframe-same-origin.html
+++ b/LayoutTests/http/tests/intersection-observer/root-margin-with-zoom-iframe-same-origin.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+
+<title>Intersection Observer: root margin is applied when observer is in a same-origin iframe, and page is zoomed</title>
+
+<script src="/js-test-resources/ui-helper.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  #iframe {
+    width: 40px;
+    height: 40px;
+    display: block;
+    position: fixed;
+    left: 0;
+    top: -40px;
+    border: 0;
+  }
+</style>
+
+<iframe id="iframe"></iframe>
+
+<script>
+  isIntersecting = null;
+  window.addEventListener("message", event => {
+    isIntersecting = event.data.isIntersecting;
+  });
+
+  function loadFrame() {
+    return new Promise(resolve => {
+      iframe.addEventListener("load", resolve, { once: true });
+      iframe.src = "resources/root-margin-with-zoom-subframe.html";
+    });
+  }
+
+  promise_test(async (t) => {
+    window.internals.setPageZoomFactor(2);
+
+    await loadFrame();
+
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+
+    assert_true(isIntersecting);
+  });
+</script>

--- a/LayoutTests/http/tests/intersection-observer/zoomed-page-iframe-cross-origin-expected.txt
+++ b/LayoutTests/http/tests/intersection-observer/zoomed-page-iframe-cross-origin-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Intersection Observer in a cross-origin iframe works when the page is zoomed
+

--- a/LayoutTests/http/tests/intersection-observer/zoomed-page-iframe-cross-origin.html
+++ b/LayoutTests/http/tests/intersection-observer/zoomed-page-iframe-cross-origin.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+
+<title>Tests that intersection observer works in a cross-origin iframe when the page is zoomed</title>
+
+<style>
+  #subframe {
+    width: 300px;
+    height: 300px;
+  }
+
+  #spacer {
+    height: 2000px;
+  }
+</style>
+
+<script src="/js-test-resources/ui-helper.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<iframe id="subframe"></iframe>
+<div id="spacer"></div>
+
+<script>
+  lastObservation = null;
+  window.addEventListener("message", event => {
+    lastObservation = event.data;
+  });
+
+  function assertRect(actual, expectedX, expectedY, expectedWidth, expectedHeight) {
+    assert_equals(actual.x, expectedX);
+    assert_equals(actual.y, expectedY);
+    assert_equals(actual.width, expectedWidth);
+    assert_equals(actual.height, expectedHeight);
+  }
+
+  function loadFrame() {
+    return new Promise(resolve => {
+      subframe.addEventListener("load", resolve, { once: true });
+      subframe.src = "http://localhost:8000/intersection-observer/resources/zoomed-page-subframe.html";
+    });
+  }
+
+  promise_test(async (t) => {
+    await loadFrame();
+
+    await UIHelper.zoomToScale(2);
+
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+    assert_true(lastObservation.isIntersecting, "Target is initially visible");
+    assertRect(lastObservation.intersectionRect, 0, 0, 100, 100);
+
+    window.scroll(0, 2000);
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+    assert_false(lastObservation.isIntersecting, "Scrolled past target, target is no longer visible");
+    assertRect(lastObservation.intersectionRect, 0, 0, 0, 0);
+
+    window.scroll(0, 0);
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+    assert_true(lastObservation.isIntersecting, "Scrolled to top of page, target is visible again");
+    assertRect(lastObservation.intersectionRect, 0, 0, 100, 100);
+  }, "Intersection Observer in a cross-origin iframe works when the page is zoomed");
+</script>

--- a/LayoutTests/http/tests/intersection-observer/zoomed-page-iframe-same-origin-expected.txt
+++ b/LayoutTests/http/tests/intersection-observer/zoomed-page-iframe-same-origin-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Intersection Observer in a same-origin iframe works when the page is zoomed
+

--- a/LayoutTests/http/tests/intersection-observer/zoomed-page-iframe-same-origin.html
+++ b/LayoutTests/http/tests/intersection-observer/zoomed-page-iframe-same-origin.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+
+<title>Tests that intersection observer works in a same-origin iframe when the page is zoomed</title>
+
+<style>
+  #subframe {
+    width: 300px;
+    height: 300px;
+  }
+
+  #spacer {
+    height: 2000px;
+  }
+</style>
+
+<script src="/js-test-resources/ui-helper.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<iframe id="subframe"></iframe>
+<div id="spacer"></div>
+
+<script>
+  lastObservation = null;
+  window.addEventListener("message", event => {
+    lastObservation = event.data;
+  });
+
+  function assertRect(actual, expectedX, expectedY, expectedWidth, expectedHeight) {
+    assert_equals(actual.x, expectedX);
+    assert_equals(actual.y, expectedY);
+    assert_equals(actual.width, expectedWidth);
+    assert_equals(actual.height, expectedHeight);
+  }
+
+  function loadFrame() {
+    return new Promise(resolve => {
+      subframe.addEventListener("load", resolve, { once: true });
+      subframe.src = "resources/zoomed-page-subframe.html";
+    });
+  }
+
+  promise_test(async (t) => {
+    await loadFrame();
+
+    await UIHelper.zoomToScale(2);
+
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+    assert_true(lastObservation.isIntersecting, "Target is initially visible");
+    assertRect(lastObservation.intersectionRect, 0, 0, 100, 100);
+
+    window.scroll(0, 2000);
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+    assert_false(lastObservation.isIntersecting, "Scrolled past target, target is no longer visible");
+    assertRect(lastObservation.intersectionRect, 0, 0, 0, 0);
+
+    window.scroll(0, 0);
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+    assert_true(lastObservation.isIntersecting, "Scrolled to top of page, target is visible again");
+    assertRect(lastObservation.intersectionRect, 0, 0, 100, 100);
+  }, "Intersection Observer in a same-origin iframe works when the page is zoomed");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/resources/root-margin-in-same-origin-iframe-subframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/resources/root-margin-in-same-origin-iframe-subframe.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+
+<style>
+  body {
+    margin: 0;
+    padding: 0;
+  }
+
+  #target {
+    position: absolute;
+    height: 40px;
+    width: 40px;
+    background-color: green;
+  }
+</style>
+
+<div id="target"></div>
+
+<script>
+  let options = {
+    rootMargin: '40px 0px 0px 0px',
+    threshold: [1]
+  }
+
+  let observer = new IntersectionObserver((observations) => {
+    const lastObservation = observations[observations.length - 1];
+    window.top.postMessage({
+      isIntersecting: lastObservation.isIntersecting
+    }, "*");
+  }, options);
+
+  observer.observe(document.getElementById("target"));
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/root-margin-in-same-origin-iframe-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/root-margin-in-same-origin-iframe-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS Intersection Observer: root margin is applied when observer is in a same-origin iframe
+

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/root-margin-in-same-origin-iframe.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/root-margin-in-same-origin-iframe.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+
+<title>Intersection Observer: root margin is applied when observer is in a same-origin iframe</title>
+<link rel="author" title="Kiet Ho" href="mailto:kiet.ho@apple.com">
+
+<script src="/common/rendering-utils.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  #iframe {
+    width: 40px;
+    height: 40px;
+    display: block;
+    position: fixed;
+    left: 0;
+    top: -40px;
+    border: 0;
+  }
+</style>
+
+<iframe id="iframe"></iframe>
+
+<script>
+  isIntersecting = null;
+  window.addEventListener("message", event => {
+    isIntersecting = event.data.isIntersecting;
+  });
+
+  function loadFrame() {
+    return new Promise(resolve => {
+      iframe.addEventListener("load", resolve, { once: true });
+      iframe.src = "resources/root-margin-in-same-origin-iframe-subframe.html";
+    });
+  }
+
+  promise_test(async (t) => {
+    await loadFrame();
+
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+    await waitForAtLeastOneFrame();
+
+    assert_true(isIntersecting);
+  });
+</script>

--- a/LayoutTests/intersection-observer/zoomed-visual-viewport.html
+++ b/LayoutTests/intersection-observer/zoomed-visual-viewport.html
@@ -54,7 +54,7 @@
         promise_test(async t => {
             await UIHelper.renderingUpdate();
             await UIHelper.renderingUpdate();
-            assert_false(lastObservation.isIntersecting, "Target is initially visible");
+            assert_false(lastObservation.isIntersecting, "Target is initially not visible");
             assertRootBounds(lastObservation.rootBounds, 0, 0, document.documentElement.clientWidth, document.documentElement.clientHeight);
 
             await UIHelper.zoomToScale(2);
@@ -63,13 +63,13 @@
             container.scrollTop = 1000;
             await UIHelper.renderingUpdate();
             await UIHelper.renderingUpdate();
-            assert_true(lastObservation.isIntersecting, "Scrolled past target, target is no longer visible");
+            assert_true(lastObservation.isIntersecting, "Scrolled into target, target is now visible");
             assertRootBounds(lastObservation.rootBounds, 0, 0, document.documentElement.clientWidth, document.documentElement.clientHeight);
 
             container.scrollTop = 0;
             await UIHelper.renderingUpdate();
             await UIHelper.renderingUpdate();
-            assert_false(lastObservation.isIntersecting, "Scrolled to top of container, target is visible again");
+            assert_false(lastObservation.isIntersecting, "Scrolled to top of container, target is no longer visible again");
             assertRootBounds(lastObservation.rootBounds, 0, 0, document.documentElement.clientWidth, document.documentElement.clientHeight);
         });
     </script>

--- a/LayoutTests/platform/ios-site-isolation/TestExpectations
+++ b/LayoutTests/platform/ios-site-isolation/TestExpectations
@@ -374,3 +374,6 @@ http/tests/security/block-top-level-navigations-by-sandboxed-iframe-with-propaga
 http/tests/security/block-top-level-navigations-by-third-party-iframes.html [ Failure ]
 http/tests/security/block-top-level-navigations-by-third-party-sandboxed-iframe.html [ Failure ]
 http/tests/security/frameNavigation/not-opener.html [ Failure ]
+
+# Intersection Observer x Site Isolation is not fully implemented.
+http/tests/intersection-observer/zoomed-page-iframe-cross-origin.html [ Failure ]

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -449,6 +449,9 @@ http/tests/security/frameNavigation/not-opener.html [ Failure ]
 # stored and run separately at http/tests/site-isolation/inspector/unit-tests/target-manager.html.
 inspector/unit-tests/target-manager.html [ Skip ]
 
+# Intersection Observer x Site Isolation is not fully implemented.
+http/tests/intersection-observer/zoomed-page-iframe-cross-origin.html [ Failure ]
+
 # Inspector protocol commands (e.g. CSS.getMatchedStylesForNode) return
 # "Not yet implemented for frame targets" under site isolation.
 inspector/css/getMatchedStylesForNodeAdoptedStyleSheet.html [ Skip ]

--- a/Source/WebCore/page/IntersectionObserver.cpp
+++ b/Source/WebCore/page/IntersectionObserver.cpp
@@ -472,7 +472,6 @@ auto IntersectionObserver::computeIntersectionState(const IntersectionObserverRe
     bool isFirstObservation = !registration.previousThresholdIndex;
 
     // This is only set for explicit roots.
-    // FIXME: remove one remaining place that needs this to work with implicit root.
     CheckedPtr<RenderBlock> rootRenderer;
 
     CheckedPtr<RenderElement> targetRenderer;
@@ -514,13 +513,6 @@ auto IntersectionObserver::computeIntersectionState(const IntersectionObserverRe
             return;
         }
 
-        // This is needed to get the root's renderer to compute the root bounds.
-        // FIXME: remove this when computing root bounds no longer requires rootRenderer.
-        RefPtr hostLocalFrameView = dynamicDowncast<LocalFrameView>(hostFrameView);
-        if (!hostLocalFrameView)
-            return;
-        rootRenderer = hostLocalFrameView->renderView();
-
         intersectionState.canComputeIntersection = true;
         intersectionState.rootBounds = layoutViewportRectForIntersection();
     };
@@ -535,6 +527,8 @@ auto IntersectionObserver::computeIntersectionState(const IntersectionObserverRe
         auto rootUsedZoom = [&] () -> float {
             if (rootRenderer)
                 return rootRenderer->style().usedZoom();
+
+            ASSERT(!root());
 
             // If applyRootMargin is Yes, the root and target frames are same-origin.
             // Therefore the root frame should be in the same process as the target frame
@@ -612,8 +606,29 @@ auto IntersectionObserver::computeIntersectionState(const IntersectionObserverRe
     if (isFirstObservation || intersectionState.isIntersecting)
         intersectionState.absoluteTargetRect = targetRenderer->localToAbsoluteQuad(FloatRect(localTargetBounds)).boundingBox();
 
+    auto rootLocalToAbsoluteRect = [&] (FloatRect rect) {
+        if (rootRenderer)
+            return rootRenderer->localToAbsoluteQuad(rect).boundingBox();
+
+        // The below codepath is specific to implicit root, where the root is the main frame.
+        ASSERT(!root());
+
+        // When page scale is > 1 (e.g by pinch-to-zoom), a scale transform is applied on the
+        // main frame's RenderView in Style::resolveForDocument(). Therefore we have to apply
+        // this transform to the local coordinate to turn it into absolute.
+        // This is identical to calling localToAbsoluteQuad() on the main frame's RenderView,
+        // as it'll apply the same transform.
+        // This is not applicable on iOS, as it applies the page scale differently.
+#if !PLATFORM(IOS)
+        if (RefPtr hostPage = hostFrameView.frame().page())
+            rect.scale(hostPage->pageScaleFactor());
+#endif
+
+        return rect;
+    };
+
     if (intersectionState.isIntersecting) {
-        auto rootAbsoluteIntersectionRect = rootRenderer->localToAbsoluteQuad(rootLocalIntersectionRect).boundingBox();
+        auto rootAbsoluteIntersectionRect = rootLocalToAbsoluteRect(rootLocalIntersectionRect);
 
         if (root() && &targetRenderer->frame() == &rootRenderer->frame())
             intersectionState.absoluteIntersectionRect = rootAbsoluteIntersectionRect;
@@ -644,7 +659,7 @@ auto IntersectionObserver::computeIntersectionState(const IntersectionObserverRe
 
     intersectionState.observationChanged = isFirstObservation || intersectionState.thresholdIndex != registration.previousThresholdIndex;
     if (intersectionState.observationChanged) {
-        intersectionState.absoluteRootBounds = rootRenderer->localToAbsoluteQuad(intersectionState.rootBounds).boundingBox();
+        intersectionState.absoluteRootBounds = rootLocalToAbsoluteRect(intersectionState.rootBounds);
 
         if (!intersectionState.absoluteTargetRect)
             intersectionState.absoluteTargetRect = targetRenderer->localToAbsoluteQuad(FloatRect(localTargetBounds)).boundingBox();


### PR DESCRIPTION
#### 8eb66859e569c49f0dd54d7cf7eedd9c9f760ab9
<pre>
[Site Isolation] [intersection-observer] Make converting from main frame local to absolute coordinate SI-safe
<a href="https://rdar.apple.com/177029615">rdar://177029615</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=314778">https://bugs.webkit.org/show_bug.cgi?id=314778</a>

Reviewed by Simon Fraser.

In some places, IntersectionObserver::computeIntersectionState calls
localToAbsoluteQuad() on the root renderer. In Site Isolation mode, if the root is
implicit (meaning the root is the main frame) and the intersection observer is in
a cross-site frame, then the observer lives in a different process than the main
frame and won&apos;t have access to the root renderer (the main frame&apos;s RenderView).
Hence we need a way to make it work.

Normally the RenderView local coordinates is already absolute, but pinch-to-zoom
puts a page scale transform on the RenderView, which makes the local and absolute
coordinate different (see the attempt at 303055@main that got reverted at
306392@main). This patch applies the page scale to the local coordinate to convert
it to absolute. The page scale is fetched from the Page object and is synchronized
between processes.

Tests: http/tests/intersection-observer/root-margin-with-zoom-iframe-same-origin.html
       http/tests/intersection-observer/zoomed-page-iframe-cross-origin.html
       http/tests/intersection-observer/zoomed-page-iframe-same-origin.html
       imported/w3c/web-platform-tests/intersection-observer/root-margin-in-same-origin-iframe.html

* LayoutTests/http/tests/intersection-observer/resources/root-margin-with-zoom-subframe.html: Added.
* LayoutTests/http/tests/intersection-observer/resources/zoomed-page-subframe.html: Added.
* LayoutTests/http/tests/intersection-observer/root-margin-with-zoom-iframe-same-origin-expected.txt: Added.
* LayoutTests/http/tests/intersection-observer/root-margin-with-zoom-iframe-same-origin.html: Added.
    - Add a test that checks that root margin is applied when the intersection observer
      is in a same-origin iframe, and the whole page is zoomed.

* LayoutTests/http/tests/intersection-observer/zoomed-page-iframe-cross-origin-expected.txt: Added.
* LayoutTests/http/tests/intersection-observer/zoomed-page-iframe-cross-origin.html: Added.
    - Add a test that checks that intersection observer works when the observer
      is in a cross-origin iframe, and the whole page is zoomed.

* LayoutTests/http/tests/intersection-observer/zoomed-page-iframe-same-origin-expected.txt: Added.
* LayoutTests/http/tests/intersection-observer/zoomed-page-iframe-same-origin.html: Added.
    - Add a test that checks that intersection observer works when the observer
      is in a same-origin iframe, and the whole page is zoomed.

* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/resources/root-margin-in-same-origin-iframe-subframe.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/root-margin-in-same-origin-iframe-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/root-margin-in-same-origin-iframe.html: Added.
    - Add a test that checks that root margin is applied when the intersection observer
      is in a same-origin iframe.

* LayoutTests/intersection-observer/zoomed-visual-viewport.html:
    - Fix assert messages - some asserts expect true but the message says it should be false,
      and vice versa.

* LayoutTests/platform/ios-site-isolation/TestExpectations:
* LayoutTests/platform/mac-site-isolation/TestExpectations:
    - Mark LayoutTests/http/tests/intersection-observer/zoomed-page-iframe-cross-origin.html
      as failed - Intersection Observer x Site Isolation currently doesn&apos;t work as there&apos;re
      some more work to do.

* Source/WebCore/page/IntersectionObserver.cpp:
(WebCore::IntersectionObserver::computeIntersectionState const):

Canonical link: <a href="https://commits.webkit.org/313774@main">https://commits.webkit.org/313774@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23cb90a636a959a0f464ceaa42756f09c70e3e48

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164071 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37555 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30774 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173100 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a265e45a-3c5f-4b97-9477-461f6bb52254) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165940 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37888 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37555 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127462 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9fb2afc8-c7f9-4688-b22e-98cd2c48be0e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167030 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29748 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147494 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108010 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28794 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27420 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20864 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138695 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25211 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175626 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28447 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26879 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135774 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37225 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31534 "Found 1 new test failure: http/tests/subresource-integrity/sri-enabled-with-setting.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135744 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36583 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38010 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147006 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100207 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31046 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23862 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36820 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109866 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36218 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1912 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36468 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36365 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->