### PR TITLE
[JSC] Add missing RISCV64 offlineasm register mappings

### DIFF
--- a/Source/JavaScriptCore/offlineasm/riscv64.rb
+++ b/Source/JavaScriptCore/offlineasm/riscv64.rb
@@ -34,9 +34,9 @@
 # x2  => sp (through alias sp) (RISC-V stack pointer register)
 # x3  => not used (RISC-V global pointer register)
 # x4  => not used (RISC-V thread pointer register)
-# x5  => not used
-# x6  => ws0
-# x7  => ws1
+# x5  => t8
+# x6  => t9, ws0
+# x7  => t10, ws1
 # x8  => cfr (through alias fp) (RISC-V frame pointer register)
 # x9  => csr0
 # x10 => t0, a0, wa0, r0
@@ -57,8 +57,8 @@
 # x25 => csr8 (numberTag)
 # x26 => csr9 (notCellMask)
 # x27 => csr10
-# x28 => scratch register
-# x29 => scratch register
+# x28 => t11, ws2, scratch register
+# x29 => t12, ws3, scratch register
 # x30 => scratch register
 # x31 => scratch register
 #
@@ -70,8 +70,8 @@
 # f3  => ft3
 # f4  => ft4
 # f5  => ft5
-# f6  => not used
-# f7  => not used
+# f6  => ft6
+# f7  => ft7
 # f8  => csfr0
 # f9  => csfr1
 # f10 => fa0, wfa0
@@ -170,10 +170,16 @@ class RegisterID
             'x16'
         when 't7', 'a7', 'wa7'
             'x17'
-        when 'ws0'
+        when 't8'
+            'x5'
+        when 't9', 'ws0'
             'x6'
-        when 'ws1'
+        when 't10', 'ws1'
             'x7'
+        when 't11', 'ws2'
+            'x28'
+        when 't12', 'ws3'
+            'x29'
         when 'csr0'
             'x9'
         when 'csr1'
@@ -223,6 +229,10 @@ class FPRegisterID
             'f4'
         when 'ft5'
             'f5'
+        when 'ft6'
+            'f6'
+        when 'ft7'
+            'f7'
         when 'csfr0'
             'f8'
         when 'csfr1'
@@ -273,6 +283,81 @@ class SpecialRegister
     def riscv64Operand
         @name
     end
+end
+
+# x28/x29 have fixed offlineasm names and are also scratch registers, so
+# temporaries must not be allocated to them across a fixed use of the same GPR.
+def riscv64FixedScratchGPRMentions(list, registers)
+    scratchGPRs = registers.map {
+        | register |
+        register.riscv64Operand
+    }
+
+    mentions = Hash.new {
+        | hash, register |
+        hash[register] = []
+    }
+    list.each_with_index {
+        | node, index |
+        (node.filter(RegisterID) + node.filter(SpecialRegister)).uniq.each {
+            | register |
+            name = register.riscv64Operand
+            mentions[name] << index if scratchGPRs.include? name
+        }
+    }
+    mentions
+end
+
+def riscv64RegisterMentionedInRange(mentions, firstMention, lastMention)
+    mentions.any? {
+        | mention |
+        mention >= firstMention && mention <= lastMention
+    }
+end
+
+def riscv64AssignRegistersToTemporaries(list, kind, registers)
+    return assignRegistersToTemporaries(list, kind, registers) unless kind == :gpr
+
+    list.each_with_index {
+        | node, index |
+        node.filter(Tmp).uniq.each {
+            | tmp |
+            tmp.mention! index if tmp.kind == kind
+        }
+    }
+
+    fixedScratchGPRMentions = riscv64FixedScratchGPRMentions(list, registers)
+    freeRegisters = registers.dup
+    list.each_with_index {
+        | node, index |
+        tmpList = node.filter(Tmp).uniq
+        tmpList.each {
+            | tmp |
+            if tmp.kind == kind and tmp.firstMention == index
+                candidates = freeRegisters.reject {
+                    | register |
+                    mentions = fixedScratchGPRMentions[register.riscv64Operand]
+                    riscv64RegisterMentionedInRange(mentions, tmp.firstMention, tmp.lastMention)
+                }
+                raise "Could not allocate register to temporary at #{node.codeOriginString}" if candidates.empty?
+                tmp.register = candidates.last
+                freeRegisters.delete(tmp.register)
+            end
+        }
+        tmpList.each {
+            | tmp |
+            if tmp.kind == kind and tmp.lastMention == index
+                freeRegisters.push tmp.register
+                raise "Register allocation inconsistency at #{node.codeOriginString}" if freeRegisters.size > registers.size
+            end
+        }
+        freeRegisters.sort_by! { |register| registers.find_index(register) }
+    }
+
+    list.map {
+        | node |
+        node.replaceTemporariesWithRegisters(kind)
+    }
 end
 
 class Immediate
@@ -1568,7 +1653,7 @@ class Sequence
 
         result = riscv64GenerateWASMPlaceholders(result)
 
-        result = assignRegistersToTemporaries(result, :gpr, RISCV64_EXTRA_GPRS)
+        result = riscv64AssignRegistersToTemporaries(result, :gpr, RISCV64_EXTRA_GPRS)
         result = assignRegistersToTemporaries(result, :fpr, RISCV64_EXTRA_FPRS)
         return result
     end


### PR DESCRIPTION
#### 0ce4cd64ef3d60453cce7e4de046d88e091578a5
<pre>
[JSC] Add missing RISCV64 offlineasm register mappings
<a href="https://bugs.webkit.org/show_bug.cgi?id=314730">https://bugs.webkit.org/show_bug.cgi?id=314730</a>

Reviewed by NOBODY (OOPS!).

Map the generic offlineasm GPR names t8 through t12 and FPR names ft6 and ft7 to RISCV64 registers so the backend can lower operands emitted by shared LLInt/offlineasm code.

The mappings for t11 and t12 use x28 and x29, which are also available to the RISCV64 scratch register pool. Teach the RISCV64 temporary allocator to keep a scratch temporary away from a physical GPR that is used as a fixed operand during the temporary's live range. This avoids aliasing fixed registers while preserving the full scratch pool for ranges where those registers are not fixed.

No new tests. Verified with a RISCV64 JSCOnly build that generated JavaScriptCore/DerivedSources/LLIntAssembly.h.

* Source/JavaScriptCore/offlineasm/riscv64.rb:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f81cd6f97a92ba74349f8208c8f071040c35f65c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162462 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35938 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29054 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171400 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118907 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36042 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35942 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126078 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88828 "17 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165421 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28422 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145945 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106656 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27468 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25995 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19100 "Built successfully") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137171 "Found 1 new API test failure: TestWebKitAPI.WKAttachmentTestsIOS.PasteRichTextCopiedFromNotes (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23675 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173904 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23301 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21217 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25319 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134384 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35612 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30086 "Found 1 new test failure: imported/w3c/web-platform-tests/IndexedDB/interleaved-cursors-small.any.serviceworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134384 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35596 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145471 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/97851 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28917 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22304 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194862 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35105 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102857 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50353 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34607 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34852 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34755 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->