### PR TITLE
Use protect() instead of Ref { } in style code

### DIFF
--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -156,7 +156,7 @@ void Scope::createOrFindSharedShadowTreeResolver()
         m_resolver->ruleSets().setUsesSharedUserStyle(!isForUserAgentShadowTree());
         m_resolver->appendAuthorStyleSheets(m_activeStyleSheets);
 
-        return Ref { *m_resolver };
+        return protect(*m_resolver);
     });
 
     if (!result.isNewEntry) {

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -1304,7 +1304,7 @@ void TreeResolver::resolveComposedTree()
             continue;
         }
 
-        Ref element = Ref { downcast<Element>(node.get()) };
+        Ref element { downcast<Element>(node.get()) };
 
         // At the maximum render tree depth, only the first child per parent gets a renderer.
         // The HTML parser caps DOM depth by attaching overflow elements as siblings at this

--- a/Source/WebCore/style/Styleable.cpp
+++ b/Source/WebCore/style/Styleable.cpp
@@ -609,7 +609,7 @@ static void updateCSSTransitionsForStyleableAndProperty(const Styleable& styleab
             if (auto* keyframeEffectStack = styleable.keyframeEffectStack()) {
                 for (const auto& effect : keyframeEffectStack->sortedEffects()) {
                     if (effect->animatesProperty(property))
-                        Ref { *effect }->apply(style, { nullptr });
+                        protect(*effect)->apply(style, { nullptr });
                 }
             }
             return style;
@@ -697,7 +697,7 @@ static void updateCSSTransitionsForStyleableAndProperty(const Styleable& styleab
             if (auto* lastStyleChangeEventStyle = styleable.lastStyleChangeEventStyle()) {
                 auto style = RenderStyle::clone(*lastStyleChangeEventStyle);
                 ASSERT(previouslyRunningTransition->keyframeEffect());
-                Ref { *previouslyRunningTransition->keyframeEffect() }->apply(style, { nullptr });
+                protect(*previouslyRunningTransition->keyframeEffect())->apply(style, { nullptr });
                 return style;
             }
             return RenderStyle::clone(currentStyle);

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
@@ -34,7 +34,7 @@
 #define SET_NESTED(group, parent, variable, value) SET_STYLE_PROPERTY(group->parent->variable, group.access().parent.access().variable, value)
 #define SET_DOUBLY_NESTED(group, grandparent, parent, variable, value) SET_STYLE_PROPERTY(group->grandparent->parent->variable, group.access().grandparent.access().parent.access().variable, value)
 #define SET_NESTED_STRUCT(group, parent, variable, value) SET_STYLE_PROPERTY(group->parent.variable, group.access().parent.variable, value)
-#define SET_STYLE_PROPERTY_PAIR(read, write, variable1, value1, variable2, value2) do { Ref readable = Ref { *read }; if (!compareEqual(readable->variable1, value1) || !compareEqual(readable->variable2, value2)) { auto& writable = write; writable.variable1 = value1; writable.variable2 = value2; } } while (0)
+#define SET_STYLE_PROPERTY_PAIR(read, write, variable1, value1, variable2, value2) do { Ref readable { *read }; if (!compareEqual(readable->variable1, value1) || !compareEqual(readable->variable2, value2)) { auto& writable = write; writable.variable1 = value1; writable.variable2 = value2; } } while (0)
 #define SET_PAIR(group, variable1, value1, variable2, value2) SET_STYLE_PROPERTY_PAIR(group, group.access(), variable1, value1, variable2, value2)
 #define SET_NESTED_PAIR(group, parent, variable1, value1, variable2, value2) SET_STYLE_PROPERTY_PAIR(group->parent, group.access().parent.access(), variable1, value1, variable2, value2)
 #define SET_DOUBLY_NESTED_PAIR(group, grandparent, parent, variable1, value1, variable2, value2) SET_STYLE_PROPERTY_PAIR(group->grandparent->parent, group.access().grandparent.access().parent.access(), variable1, value1, variable2, value2)

--- a/Source/WebCore/style/computed/StyleComputedStyleProperties+SettersCustomInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleProperties+SettersCustomInlines.h
@@ -32,7 +32,7 @@
 #define SET_NESTED(group, parent, variable, value) SET_STYLE_PROPERTY(group->parent->variable, group.access().parent.access().variable, value)
 #define SET_DOUBLY_NESTED(group, grandparent, parent, variable, value) SET_STYLE_PROPERTY(group->grandparent->parent->variable, group.access().grandparent.access().parent.access().variable, value)
 #define SET_NESTED_STRUCT(group, parent, variable, value) SET_STYLE_PROPERTY(group->parent.variable, group.access().parent.variable, value)
-#define SET_STYLE_PROPERTY_PAIR(read, write, variable1, value1, variable2, value2) do { Ref readable = Ref { *read }; if (!compareEqual(readable->variable1, value1) || !compareEqual(readable->variable2, value2)) { auto& writable = write; writable.variable1 = value1; writable.variable2 = value2; } } while (0)
+#define SET_STYLE_PROPERTY_PAIR(read, write, variable1, value1, variable2, value2) do { Ref readable { *read }; if (!compareEqual(readable->variable1, value1) || !compareEqual(readable->variable2, value2)) { auto& writable = write; writable.variable1 = value1; writable.variable2 = value2; } } while (0)
 #define SET_PAIR(group, variable1, value1, variable2, value2) SET_STYLE_PROPERTY_PAIR(group, group.access(), variable1, value1, variable2, value2)
 #define SET_NESTED_PAIR(group, parent, variable1, value1, variable2, value2) SET_STYLE_PROPERTY_PAIR(group->parent, group.access().parent.access(), variable1, value1, variable2, value2)
 #define SET_DOUBLY_NESTED_PAIR(group, grandparent, parent, variable1, value1, variable2, value2) SET_STYLE_PROPERTY_PAIR(group->grandparent->parent, group.access().grandparent.access().parent.access(), variable1, value1, variable2, value2)

--- a/Source/WebCore/style/computed/data/StyleCustomPropertyData.cpp
+++ b/Source/WebCore/style/computed/data/StyleCustomPropertyData.cpp
@@ -54,10 +54,10 @@ CustomPropertyData::CustomPropertyData(const CustomPropertyData& other)
 
     // If there are mutations on multiple levels this constructs a linked list of property data objects.
     if (shouldReferenceAsParentValues)
-        lazyInitialize(m_parentValues, Ref { other });
+        lazyInitialize(m_parentValues, protect(other));
     else {
         if (other.m_parentValues)
-            lazyInitialize(m_parentValues, Ref { *other.m_parentValues });
+            lazyInitialize(m_parentValues, protect(*other.m_parentValues));
         m_ownValues = other.m_ownValues;
     }
 

--- a/Source/WebCore/style/values/anchor-position/StylePositionTryFallback.cpp
+++ b/Source/WebCore/style/values/anchor-position/StylePositionTryFallback.cpp
@@ -143,7 +143,7 @@ auto CSSValueConversion<PositionTryFallback>::operator()(BuilderState& state, co
     }
 
     // Turn the inlined position-area fallback into properties object that can be applied similarly to @position-try declarations.
-    auto property = CSSProperty { CSSPropertyPositionArea, Ref { const_cast<CSSValue&>(value) } };
+    auto property = CSSProperty { CSSPropertyPositionArea, protect(const_cast<CSSValue&>(value)) };
     return {
         .positionArea = { ImmutableStyleProperties::createDeduplicating(std::span { &property, 1 }, HTMLStandardMode) }
     };

--- a/Source/WebCore/style/values/images/kinds/StyleFilterImage.cpp
+++ b/Source/WebCore/style/values/images/kinds/StyleFilterImage.cpp
@@ -140,7 +140,7 @@ RefPtr<WebCore::Image> FilterImage::image(const RenderElement* renderElement, co
     auto preferredFilterRenderingModes = protect(renderer->page())->preferredFilterRenderingModes(destinationContext);
     auto sourceImageRect = FloatRect { { }, size };
 
-    auto renderingOptions(Ref { renderer->settings() }->showDebugBorders() ? std::make_optional(FilterRenderingOption::ShowDebugOverlay) : std::nullopt);
+    auto renderingOptions(protect(renderer->settings())->showDebugBorders() ? std::make_optional(FilterRenderingOption::ShowDebugOverlay) : std::nullopt);
     auto cssFilter = CSSFilterRenderer::create(const_cast<RenderElement&>(*renderer), m_filter, {
             .referenceBox = sourceImageRect,
             .filterRegion = sourceImageRect,


### PR DESCRIPTION
#### 772188b773db8a6bd494b7c5f8ad9eb73e1ed5a5
<pre>
Use protect() instead of Ref { } in style code
<a href="https://bugs.webkit.org/show_bug.cgi?id=314781">https://bugs.webkit.org/show_bug.cgi?id=314781</a>
<a href="https://rdar.apple.com/177033111">rdar://177033111</a>

Reviewed by Anne van Kesteren.

Mechanical migration from brace-initialized Ref temporaries to the protect()
free function in Source/WebCore/style, aligning with the codebase-wide
transition.

Three of the ten sites are local-variable initializations where the style
checker (safercpp/protected_getter_for_init) forbids protect(); those are
converted to direct brace-init form (Ref x { y };) instead.

No new tests needed (no behavioral change, style-only refactor).

* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::createOrFindSharedShadowTreeResolver):
* Source/WebCore/style/StyleTreeResolver.cpp:
(WebCore::Style::TreeResolver::resolveComposedTree):
* Source/WebCore/style/Styleable.cpp:
(WebCore::updateCSSTransitionsForStyleableAndProperty):
* Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h:
* Source/WebCore/style/computed/StyleComputedStyleProperties+SettersCustomInlines.h:
* Source/WebCore/style/computed/data/StyleCustomPropertyData.cpp:
(WebCore::Style::CustomPropertyData::CustomPropertyData):
* Source/WebCore/style/values/anchor-position/StylePositionTryFallback.cpp:
(WebCore::Style::CSSValueConversion&lt;PositionTryFallback&gt;::operator()):
* Source/WebCore/style/values/images/kinds/StyleFilterImage.cpp:
(WebCore::Style::FilterImage::image):

Canonical link: <a href="https://commits.webkit.org/313298@main">https://commits.webkit.org/313298@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b21069838cfe8747356429a46dde55c6ab3a93b9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162461 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35937 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29107 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171399 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118906 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164330 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36041 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35941 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126077 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88825 "18 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c8dc3629-1c1e-481d-a293-1eb159741d8d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165420 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28423 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145997 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106655 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27469 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/25994 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19099 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137172 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23727 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173903 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21216 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25371 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134386 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35611 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30215 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134385 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36312 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35595 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145523 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97850 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28915 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22356 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35104 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102856 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34606 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34851 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34754 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->