### PR TITLE
[AppKit Gestures] Occasional debug assert when scrolling (ASSERT(m_layerHitTestMutex.isLocked()))

### DIFF
--- a/Source/WebCore/page/scrolling/ScrollingTree.cpp
+++ b/Source/WebCore/page/scrolling/ScrollingTree.cpp
@@ -782,10 +782,13 @@ WebCore::RectEdges<bool> ScrollingTree::pinnedStateIncludingAncestorsAtPoint(Flo
     if (!rootNode)
         return false;
 
-    Locker locker { m_treeStateLock };
-
     FloatPoint position = viewPoint;
-    position.move(rootNode->viewToContentsOffset(m_treeState.mainFrameScrollPosition));
+    {
+        Locker locker { m_treeStateLock };
+        position.move(rootNode->viewToContentsOffset(m_treeState.mainFrameScrollPosition));
+    }
+
+    HitTestLocker hitTestLocker { *this };
 
     WebCore::RectEdges<bool> pinnedState = { true, true, true, true };
 

--- a/Source/WebCore/page/scrolling/ScrollingTree.h
+++ b/Source/WebCore/page/scrolling/ScrollingTree.h
@@ -234,6 +234,21 @@ public:
     virtual void lockLayersForHitTesting() { }
     virtual void unlockLayersForHitTesting() { }
 
+    class HitTestLocker {
+    public:
+        HitTestLocker(ScrollingTree& tree)
+            : m_tree(tree)
+        {
+            m_tree->lockLayersForHitTesting();
+        }
+        ~HitTestLocker()
+        {
+            m_tree->unlockLayersForHitTesting();
+        }
+    private:
+        const Ref<ScrollingTree> m_tree;
+    };
+
     virtual bool isScrollingSynchronizedWithMainThread() WTF_REQUIRES_LOCK(m_treeLock) { return true; }
 
     Lock& treeLock() LIFETIME_BOUND WTF_RETURNS_LOCK(m_treeLock) { return m_treeLock; }

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h
@@ -143,23 +143,6 @@ private:
 #endif
 };
 
-class RemoteLayerTreeHitTestLocker {
-public:
-    RemoteLayerTreeHitTestLocker(RemoteScrollingTree& scrollingTree)
-        : m_scrollingTree(scrollingTree)
-    {
-        m_scrollingTree->lockLayersForHitTesting();
-    }
-    
-    ~RemoteLayerTreeHitTestLocker()
-    {
-        m_scrollingTree->unlockLayersForHitTesting();
-    }
-
-private:
-    const Ref<RemoteScrollingTree> m_scrollingTree;
-};
-
 } // namespace WebKit
 
 SPECIALIZE_TYPE_TRAITS_SCROLLING_TREE(WebKit::RemoteScrollingTree, isRemoteScrollingTree());

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm
@@ -237,7 +237,7 @@ void RemoteLayerTreeEventDispatcher::scrollingThreadHandleWheelEvent(const WebWh
     if (!scrollingTree)
         return;
 
-    auto locker = RemoteLayerTreeHitTestLocker { *scrollingTree };
+    ScrollingTree::HitTestLocker locker { *scrollingTree };
 
     auto platformWheelEvent = platform(webWheelEvent);
     auto processingSteps = determineWheelEventProcessing(platformWheelEvent, rubberBandableEdges);
@@ -468,7 +468,7 @@ void RemoteLayerTreeEventDispatcher::didRefreshDisplay(PlatformDisplayID display
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER)
     {
         // Make sure the lock is held for the handleSyntheticWheelEvent callback.
-        auto locker = RemoteLayerTreeHitTestLocker { *scrollingTree };
+        ScrollingTree::HitTestLocker locker { *scrollingTree };
         m_momentumEventDispatcher->displayDidRefresh(displayID);
     }
 #endif


### PR DESCRIPTION
#### 7b509571d1cc10b9862b052d3222f2f68f7791ec
<pre>
[AppKit Gestures] Occasional debug assert when scrolling (ASSERT(m_layerHitTestMutex.isLocked()))
<a href="https://bugs.webkit.org/show_bug.cgi?id=314782">https://bugs.webkit.org/show_bug.cgi?id=314782</a>
<a href="https://rdar.apple.com/177023194">rdar://177023194</a>

Reviewed by Richard Robinson.

ScrollingTree::pinnedStateIncludingAncestorsAtPoint() walks the
scrolling tree via scrollingNodeForPoint(), but only acquires the tree
state lock and not the mutex for layer hit-tests. This is problematic
for the UI process scrolling path, since scrollingNodeForPoint() assumes
that as a caller responsibility.

In this patch, we acquire said mutex for the ancestor walk scope. We
also move our state tree lock scope to only cover our read of the main
frame scroll position, so that the lock ordering is preserved.

In writing this patch, I noticed that we have multiple RAII utilities
for this same pattern. We consolidate to ScrollingTree::HitTestLocker
in WebCore as the canonical helper and migrate the other lockers away
from their respective helpers.

* Source/WebCore/page/scrolling/ScrollingTree.cpp:
(WebCore::ScrollingTree::pinnedStateIncludingAncestorsAtPoint):
* Source/WebCore/page/scrolling/ScrollingTree.h:
(WebCore::ScrollingTree::HitTestLocker::HitTestLocker):
(WebCore::ScrollingTree::HitTestLocker::~HitTestLocker):
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteScrollingTree.h:
(WebKit::RemoteLayerTreeHitTestLocker::RemoteLayerTreeHitTestLocker): Deleted.
(WebKit::RemoteLayerTreeHitTestLocker::~RemoteLayerTreeHitTestLocker): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm:
(WebKit::RemoteLayerTreeEventDispatcher::scrollingThreadHandleWheelEvent):
(WebKit::RemoteLayerTreeEventDispatcher::didRefreshDisplay):

Canonical link: <a href="https://commits.webkit.org/313258@main">https://commits.webkit.org/313258@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1710f3ca4df5d396810845d53653c139844175d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162468 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35944 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29060 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171406 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118913 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164337 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36048 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35948 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126083 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165427 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28428 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145947 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106661 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27474 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26001 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19106 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137177 "Found 1 new API test failure: TestWebKitAPI.WKAttachmentTestsIOS.PasteRichTextCopiedFromNotes (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23677 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173910 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21223 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25321 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134391 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35618 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30092 "Found 2 new test failures: http/tests/ssl/applepay/ApplePayButton.html imported/w3c/web-platform-tests/IndexedDB/interleaved-cursors-small.any.serviceworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134390 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35602 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145473 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97861 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24698 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28923 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22306 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35111 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102863 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34613 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34858 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34761 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->