### PR TITLE
Update CoreIPCNSURLRequest serialization members

### DIFF
--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.h
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.h
@@ -97,6 +97,12 @@ enum class NSURLRequestFlags : int16_t {
     ShouldStartSynchronously = (1 << 12)
 };
 
+enum class APProxyRequestType : uint8_t {
+    Undefined,
+    WebView,
+    Video
+};
+
 struct ProtocolProperties {
     std::optional<bool> isTopLevelNavigation;
     std::optional<bool> allowAllPOSTCaching;
@@ -106,6 +112,10 @@ struct ProtocolProperties {
     std::optional<CoreIPCNumber> fileProtocolExpectedDevice;
     std::optional<bool> shouldSniff;
     std::optional<bool> contentDecoderSkipURLCheck;
+    std::optional<CoreIPCString> adIdentifier;
+    std::optional<CoreIPCNumber> maximumRequestCount;
+    std::optional<bool> apProxyIsRecursive;
+    std::optional<APProxyRequestType> requestType;
 };
 
 struct CoreIPCNSURLRequestData {

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm
@@ -99,6 +99,13 @@ CoreIPCNSURLRequest::CoreIPCNSURLRequest(NSURLRequest *request)
         SET_PROTOCOL_PROPERTY(protocolPropertiesDict, @"NSURLRequestFileProtocolExpectedDevice", NSNumber, CoreIPCNumber, props.fileProtocolExpectedDevice);
         SET_PROTOCOL_PROPERTY_BOOL(protocolPropertiesDict, @"_kCFURLConnectionPropertyShouldSniff", props.shouldSniff);
         SET_PROTOCOL_PROPERTY_BOOL(protocolPropertiesDict, @"kCFURLRequestContentDecoderSkipURLCheck", props.contentDecoderSkipURLCheck);
+        SET_PROTOCOL_PROPERTY(protocolPropertiesDict, @"adIdentifier", NSString, CoreIPCString, props.adIdentifier);
+        SET_PROTOCOL_PROPERTY(protocolPropertiesDict, @"maximumRequestCount", NSNumber, CoreIPCNumber, props.maximumRequestCount);
+        SET_PROTOCOL_PROPERTY_BOOL(protocolPropertiesDict, @"com.apple.ap.pc.proxy-is-recursive", props.apProxyIsRecursive);
+        if (RetainPtr value = dynamic_objc_cast<NSNumber>([protocolPropertiesDict objectForKey:@"requestType"])) {
+            if (auto integerValue = [value integerValue]; isValidEnum<APProxyRequestType>(integerValue))
+                props.requestType = static_cast<APProxyRequestType>(integerValue);
+        }
 
         m_data.protocolProperties = WTF::move(props);
     }
@@ -255,7 +262,7 @@ RetainPtr<id> CoreIPCNSURLRequest::toID() const
     RetainPtr dict = adoptNS([[NSMutableDictionary alloc] initWithCapacity:CoreIPCNSURLRequestData::numberOfFields]);
 
     if (m_data.protocolProperties) {
-        RetainPtr protocolPropertiesDict = adoptNS([[NSMutableDictionary alloc] initWithCapacity:8]);
+        RetainPtr protocolPropertiesDict = adoptNS([[NSMutableDictionary alloc] initWithCapacity:12]);
         SET_PROTOCOL_DICT_BOOL(protocolPropertiesDict, @"_kCFHTTPCookiePolicyPropertyIsTopLevelNavigation", m_data.protocolProperties->isTopLevelNavigation);
         SET_PROTOCOL_DICT_BOOL(protocolPropertiesDict, @"kCFURLRequestAllowAllPOSTCaching", m_data.protocolProperties->allowAllPOSTCaching);
         SET_PROTOCOL_DICT_MEMBER(protocolPropertiesDict, @"_kCFHTTPCookiePolicyPropertySiteForCookies", m_data.protocolProperties->siteForCookies);
@@ -264,6 +271,11 @@ RetainPtr<id> CoreIPCNSURLRequest::toID() const
         SET_PROTOCOL_DICT_MEMBER(protocolPropertiesDict, @"NSURLRequestFileProtocolExpectedDevice", m_data.protocolProperties->fileProtocolExpectedDevice);
         SET_PROTOCOL_DICT_BOOL(protocolPropertiesDict, @"_kCFURLConnectionPropertyShouldSniff", m_data.protocolProperties->shouldSniff);
         SET_PROTOCOL_DICT_BOOL(protocolPropertiesDict, @"kCFURLRequestContentDecoderSkipURLCheck", m_data.protocolProperties->contentDecoderSkipURLCheck);
+        SET_PROTOCOL_DICT_MEMBER(protocolPropertiesDict, @"adIdentifier", m_data.protocolProperties->adIdentifier);
+        SET_PROTOCOL_DICT_MEMBER(protocolPropertiesDict, @"maximumRequestCount", m_data.protocolProperties->maximumRequestCount);
+        SET_PROTOCOL_DICT_BOOL(protocolPropertiesDict, @"com.apple.ap.pc.proxy-is-recursive", m_data.protocolProperties->apProxyIsRecursive);
+        if (m_data.protocolProperties->requestType)
+            [protocolPropertiesDict setObject:[NSNumber numberWithInteger:static_cast<NSInteger>(*m_data.protocolProperties->requestType)] forKey:@"requestType"];
 
         [dict setObject:protocolPropertiesDict.get() forKey:@"protocolProperties"];
     }

--- a/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.serialization.in
@@ -96,6 +96,13 @@ header: "CoreIPCNSURLRequest.h"
 using WebKit::CoreIPCNSURLRequestData::BodyParts = Variant<WebKit::CoreIPCString, WebKit::CoreIPCData>;
 using WebKit::CoreIPCNSURLRequestData::HeaderField = std::pair<String, Variant<String, Vector<String>>>;
 
+header: "CoreIPCNSURLRequest.h"
+[CustomHeader, WebKitPlatform] enum class WebKit::APProxyRequestType : uint8_t {
+    Undefined,
+    WebView,
+    Video
+}
+
 [CustomHeader, WebKitPlatform] struct WebKit::ProtocolProperties {
     std::optional<bool> isTopLevelNavigation;
     std::optional<bool> allowAllPOSTCaching;
@@ -105,6 +112,10 @@ using WebKit::CoreIPCNSURLRequestData::HeaderField = std::pair<String, Variant<S
     std::optional<WebKit::CoreIPCNumber> fileProtocolExpectedDevice;
     std::optional<bool> shouldSniff;
     std::optional<bool> contentDecoderSkipURLCheck;
+    std::optional<WebKit::CoreIPCString> adIdentifier;
+    std::optional<WebKit::CoreIPCNumber> maximumRequestCount;
+    std::optional<bool> apProxyIsRecursive;
+    std::optional<WebKit::APProxyRequestType> requestType;
 }
 
 header: "CoreIPCNSURLRequest.h"

--- a/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
+++ b/Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm
@@ -1745,6 +1745,10 @@ TEST(IPCSerialization, NSURLRequestProtocolProperties)
     props.fileProtocolExpectedDevice = WebKit::CoreIPCNumber(@123);
     props.shouldSniff = false;
     props.contentDecoderSkipURLCheck = true;
+    props.adIdentifier = WebKit::CoreIPCString(@"test-ad-id");
+    props.maximumRequestCount = WebKit::CoreIPCNumber(@5);
+    props.apProxyIsRecursive = true;
+    props.requestType = WebKit::APProxyRequestType::WebView;
     requestData.protocolProperties = WTF::move(props);
 
     WebKit::CoreIPCNSURLRequest wrapper(WTF::move(requestData));
@@ -1756,7 +1760,7 @@ TEST(IPCSerialization, NSURLRequestProtocolProperties)
     RetainPtr plistData = [reconstructedRequest _webKitPropertyListData];
     RetainPtr protocolProperties = [plistData.get() objectForKey:@"protocolProperties"];
     EXPECT_TRUE(protocolProperties != nil);
-    EXPECT_EQ([protocolProperties count], 8U);
+    EXPECT_EQ([protocolProperties count], 12U);
 
     EXPECT_TRUE([[protocolProperties objectForKey:@"_kCFHTTPCookiePolicyPropertyIsTopLevelNavigation"] boolValue]);
     EXPECT_FALSE([[protocolProperties objectForKey:@"kCFURLRequestAllowAllPOSTCaching"] boolValue]);
@@ -1766,6 +1770,10 @@ TEST(IPCSerialization, NSURLRequestProtocolProperties)
     EXPECT_EQ([[protocolProperties objectForKey:@"NSURLRequestFileProtocolExpectedDevice"] intValue], 123);
     EXPECT_FALSE([[protocolProperties objectForKey:@"_kCFURLConnectionPropertyShouldSniff"] boolValue]);
     EXPECT_TRUE([[protocolProperties objectForKey:@"kCFURLRequestContentDecoderSkipURLCheck"] boolValue]);
+    EXPECT_TRUE([[protocolProperties objectForKey:@"adIdentifier"] isEqualToString:@"test-ad-id"]);
+    EXPECT_EQ([[protocolProperties objectForKey:@"maximumRequestCount"] intValue], 5);
+    EXPECT_TRUE([[protocolProperties objectForKey:@"com.apple.ap.pc.proxy-is-recursive"] boolValue]);
+    EXPECT_EQ([[protocolProperties objectForKey:@"requestType"] intValue], 1);
 
     // Test full round-trip serialization
     runTestNS({ reconstructedRequest });
@@ -1819,6 +1827,26 @@ TEST(IPCSerialization, NSURLRequestProtocolProperties)
     EXPECT_EQ([[protocolProperties3 objectForKey:@"NSURLRequestFileProtocolExpectedDevice"] intValue], 0);
 
     runTestNS({ reconstructedRequest3 });
+}
+
+TEST(IPCSerialization, NSURLRequestNSURLProtocolProperties)
+{
+    RetainPtr request = adoptNS([[NSMutableURLRequest alloc] initWithURL:[NSURL URLWithString:@"https://webkit.org/"]]);
+    [NSURLProtocol setProperty:@"ad-123" forKey:@"adIdentifier" inRequest:request.get()];
+    [NSURLProtocol setProperty:@3 forKey:@"maximumRequestCount" inRequest:request.get()];
+    [NSURLProtocol setProperty:@YES forKey:@"com.apple.ap.pc.proxy-is-recursive" inRequest:request.get()];
+    [NSURLProtocol setProperty:@2 forKey:@"requestType" inRequest:request.get()];
+
+    WebKit::CoreIPCNSURLRequest wrapper(request.get());
+    RetainPtr reconstructed = dynamic_objc_cast<NSURLRequest>(wrapper.toID().get());
+    EXPECT_TRUE(reconstructed);
+
+    EXPECT_TRUE([[NSURLProtocol propertyForKey:@"adIdentifier" inRequest:reconstructed.get()] isEqualToString:@"ad-123"]);
+    EXPECT_EQ([[NSURLProtocol propertyForKey:@"maximumRequestCount" inRequest:reconstructed.get()] intValue], 3);
+    EXPECT_TRUE([[NSURLProtocol propertyForKey:@"com.apple.ap.pc.proxy-is-recursive" inRequest:reconstructed.get()] boolValue]);
+    EXPECT_EQ([[NSURLProtocol propertyForKey:@"requestType" inRequest:reconstructed.get()] integerValue], 2);
+
+    runTestNS({ request.get() });
 }
 
 #endif // PLATFORM(COCOA) && HAVE(WK_SECURE_CODING_NSURLREQUEST)


### PR DESCRIPTION
#### 4af385bb802bdaed9ed1c5a9c8bb417fa2601fa5
<pre>
Update CoreIPCNSURLRequest serialization members
<a href="https://bugs.webkit.org/show_bug.cgi?id=314784">https://bugs.webkit.org/show_bug.cgi?id=314784</a>
<a href="https://rdar.apple.com/176487693">rdar://176487693</a>

Reviewed by Abrar Rahman Protyasha.

A previous hardening change (307823@main) caused members to be omitted.
This change adds them back in explicitly.

Test: Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm

* Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.h:
* Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.mm:
(WebKit::CoreIPCNSURLRequest::CoreIPCNSURLRequest):
(WebKit::CoreIPCNSURLRequest::toID const):
* Source/WebKit/Shared/Cocoa/CoreIPCNSURLRequest.serialization.in:
* Tools/TestWebKitAPI/Tests/IPC/IPCSerialization.mm:
(TEST(IPCSerialization, NSURLRequestProtocolProperties)):
(TEST(IPCSerialization, NSURLRequestNSURLProtocolProperties)):

Canonical link: <a href="https://commits.webkit.org/313255@main">https://commits.webkit.org/313255@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3bc6f01e49a3e48243041529f58b614d846a334

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162488 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35964 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29081 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171426 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/118933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164357 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36068 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35968 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126101 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/118933 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165447 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28446 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145970 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106679 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27492 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26018 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19126 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137196 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23700 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173930 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21243 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25344 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134410 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35638 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134408 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35622 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145496 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97893 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24697 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28943 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22329 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35131 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102883 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34633 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34878 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34781 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->