### PR TITLE
[model] Adopt public RealityCoreRenderer and ShaderGraph APIs

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift
@@ -24,9 +24,9 @@
 import Metal
 import WebKit
 
-#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreTextureProcessing, _version: 24) && canImport(_USDKit_RealityKit, _version: 42) && arch(arm64)
+#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreTextureProcessing, _version: 24) && canImport(_USDKit_RealityKit, _version: 42) && canImport(RealityCoreRenderer, _version: 22) && canImport(ShaderGraph, _version: 156) && arch(arm64)
 @_spi(UsdLoaderAPI) import _USDKit_RealityKit
-@_spi(RealityCoreRendererAPI) import RealityKit
+import RealityKit
 import USDKit
 @_spi(SwiftAPI) import DirectResource
 import ShaderGraph
@@ -300,7 +300,7 @@ extension WKBridgeUpdateMesh {
     }
 }
 
-#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreTextureProcessing, _version: 24) && canImport(_USDKit_RealityKit, _version: 42) && arch(arm64)
+#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreTextureProcessing, _version: 24) && canImport(_USDKit_RealityKit, _version: 42) && canImport(RealityCoreRenderer, _version: 22) && canImport(ShaderGraph, _version: 156) && arch(arm64)
 func decodeValues<T>(from data: Data) -> [T] where T: BitwiseCopyable {
     let stride = MemoryLayout<T>.stride
     guard !data.isEmpty, data.count % stride == 0 else { return [] }
@@ -618,7 +618,7 @@ extension WKBridgeMaterialGraph {
     }
 }
 
-#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreTextureProcessing, _version: 24) && canImport(_USDKit_RealityKit, _version: 42) && arch(arm64)
+#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreTextureProcessing, _version: 24) && canImport(_USDKit_RealityKit, _version: 42) && canImport(RealityCoreRenderer, _version: 22) && canImport(ShaderGraph, _version: 156) && arch(arm64)
 
 func toData<T>(_ input: [T]) -> Data {
     // rdar://164559261 - this is needed because there is no way to represnt an NSArray of

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelIBLTextures.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelIBLTextures.swift
@@ -21,7 +21,7 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreTextureProcessing, _version: 24) && canImport(_USDKit_RealityKit, _version: 42) && arch(arm64)
+#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreTextureProcessing, _version: 24) && canImport(_USDKit_RealityKit, _version: 42) && canImport(RealityCoreRenderer, _version: 22) && canImport(ShaderGraph, _version: 156) && arch(arm64)
 
 import Metal
 import USDKit
@@ -30,12 +30,12 @@ import USDKit
 
 class IBLTextures {
     static func loadIBLTextures(
-        renderContext: any _Proto_LowLevelRenderContext_v1,
+        renderContext: any LowLevelRenderContext,
         diffuseTextureOriginal: any MTLTexture,
         specularTextureOriginal: any MTLTexture
     ) throws -> (
-        diffuse: _Proto_LowLevelTextureResource_v1,
-        specular: _Proto_LowLevelTextureResource_v1
+        diffuse: LowLevelTextureResource,
+        specular: LowLevelTextureResource
     ) {
         guard let commandQueue = renderContext.device.makeCommandQueue() else {
             fatalError("Failed to create command queue")
@@ -81,8 +81,8 @@ class IBLTextures {
             )
         )
 
-        let diffuseTexture = diffuseTextureResource.replace(using: commandBuffer)
-        let specularTexture = specularTextureResource.replace(using: commandBuffer)
+        let diffuseTexture = diffuseTextureResource.replace(commandBuffer: commandBuffer)
+        let specularTexture = specularTextureResource.replace(commandBuffer: commandBuffer)
 
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelParameters.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelParameters.swift
@@ -21,18 +21,18 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreTextureProcessing, _version: 24) && canImport(_USDKit_RealityKit, _version: 42) && arch(arm64)
+#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreTextureProcessing, _version: 24) && canImport(_USDKit_RealityKit, _version: 42) && canImport(RealityCoreRenderer, _version: 22) && canImport(ShaderGraph, _version: 156) && arch(arm64)
 
 import USDKit
 @_spi(UsdLoaderAPI) import _USDKit_RealityKit
-@_spi(RealityCoreRendererAPI) import RealityKit
+import RealityKit
 
 func makeParameters(
-    for function: any _Proto_LowLevelMaterialResource_v1.Function,
-    renderContext: any _Proto_LowLevelRenderContext_v1,
-    buffers: [_Proto_LowLevelBufferSpan_v1] = [],
-    textures: [_Proto_LowLevelTextureResource_v1] = []
-) throws -> _Proto_LowLevelArgumentTable_v1? {
+    for function: any LowLevelMaterialResource.Function,
+    renderContext: any LowLevelRenderContext,
+    buffers: [LowLevelBufferSlice] = [],
+    textures: [LowLevelTextureResource] = []
+) throws -> LowLevelArgumentTable? {
     guard let argumentTableDescriptor = function.argumentTableDescriptor else {
         return nil
     }
@@ -44,19 +44,19 @@ func makeParameters(
 }
 
 func makeParameters(
-    for material: _Proto_LowLevelMaterialResource_v1,
-    renderContext: any _Proto_LowLevelRenderContext_v1,
-    geometryBuffers: [_Proto_LowLevelBufferSpan_v1] = [],
-    geometryTextures: [_Proto_LowLevelTextureResource_v1] = [],
-    surfaceBuffers: [_Proto_LowLevelBufferSpan_v1] = [],
-    surfaceTextures: [_Proto_LowLevelTextureResource_v1] = [],
-    lightingBuffers: [_Proto_LowLevelBufferSpan_v1] = [],
-    lightingTextures: [_Proto_LowLevelTextureResource_v1] = []
+    for material: LowLevelMaterialResource,
+    renderContext: any LowLevelRenderContext,
+    geometryBuffers: [LowLevelBufferSlice] = [],
+    geometryTextures: [LowLevelTextureResource] = [],
+    surfaceBuffers: [LowLevelBufferSlice] = [],
+    surfaceTextures: [LowLevelTextureResource] = [],
+    lightingBuffers: [LowLevelBufferSlice] = [],
+    lightingTextures: [LowLevelTextureResource] = []
 ) throws
     -> (
-        geometryArguments: _Proto_LowLevelArgumentTable_v1?,
-        surfaceArguments: _Proto_LowLevelArgumentTable_v1?,
-        lightingArguments: _Proto_LowLevelArgumentTable_v1?
+        geometryArguments: LowLevelArgumentTable?,
+        surfaceArguments: LowLevelArgumentTable?,
+        lightingArguments: LowLevelArgumentTable?
     )
 {
     let geometryArguments = try makeParameters(

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift
@@ -21,26 +21,27 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreTextureProcessing, _version: 24) && canImport(_USDKit_RealityKit, _version: 42) && arch(arm64)
+#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreTextureProcessing, _version: 24) && canImport(_USDKit_RealityKit, _version: 42) && canImport(RealityCoreRenderer, _version: 22) && canImport(ShaderGraph, _version: 156) && arch(arm64)
 
 import QuartzCore
 import USDKit
 @_spi(UsdLoaderAPI) import _USDKit_RealityKit
-@_spi(RealityCoreRendererAPI) @_spi(Private) import RealityKit
+@_spi(Private) import RealityKit
 import simd
 
 class Renderer {
     let device: any MTLDevice
     let commandQueue: any MTLCommandQueue
-    var renderContext: (any _Proto_LowLevelRenderContext_v1)?
-    var renderer: _Proto_LowLevelRenderer_v1?
-    var renderTargetDescriptor: _Proto_LowLevelRenderTarget_v1.Descriptor {
+    var renderContext: (any LowLevelRenderContext)?
+    var renderer: LowLevelRenderer?
+    var renderTargetDescriptor: LowLevelRenderTarget.Descriptor {
         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
         // swift-format-ignore: NeverForceUnwrap
         renderer!.renderTargetDescriptor
     }
 
-    var pose: _Proto_Pose_v1
+    var cameraPosition: SIMD3<Float>
+    var cameraRotation: simd_quatf
     static let cameraDistance: Float = 0.5
     var effectiveCameraDistance: Float = Renderer.cameraDistance
     var fovY: Float = 60 * .pi / 180
@@ -55,29 +56,28 @@ class Renderer {
 
         self.device = device
         self.commandQueue = commandQueue
-        self.pose = .init(
-            translation: [0, 0, Renderer.cameraDistance],
-            rotation: .init(ix: 0, iy: 0, iz: 0, r: 1)
-        )
+        self.cameraPosition = [0, 0, Renderer.cameraDistance]
+        self.cameraRotation = .init(ix: 0, iy: 0, iz: 0, r: 1)
         self.memoryOwner = memoryOwner
     }
 
     func createMaterialCompiler(colorPixelFormat: MTLPixelFormat, rasterSampleCount: Int, colorSpace: CGColorSpace? = nil) async throws {
-        var configuration = _Proto_LowLevelRenderContextStandaloneConfiguration_v1(device: device)
+        var configuration = LowLevelRenderContextStandalone.Configuration(device: device)
         configuration.memoryOwner = self.memoryOwner
-        configuration.residencySetBehavior = _Proto_LowLevelRenderContextStandaloneConfiguration_v1.ResidencySetBehavior.disable
-        let renderContext = try await _Proto_makeLowLevelRenderContextStandalone_v1(configuration: configuration)
+        configuration.residencySetBehavior = LowLevelRenderContextStandalone.Configuration.ResidencySetBehavior.disable
+        let renderContext = try await LowLevelRenderContextStandalone(configuration: configuration)
 
-        let renderer = try await _Proto_LowLevelRenderer_v1(
+        let renderer = try await LowLevelRenderer(
             configuration: .init(
                 output: .init(colorPixelFormat: colorPixelFormat),
                 rasterSampleCount: rasterSampleCount,
                 enableTonemap: true,
                 enableColorMatch: colorSpace != nil,
-                hasTransparentContent: false
+                alphaPremultiply: false
             ),
             renderContext: renderContext
         )
+        renderer.meshInstancesArrayCount = 1
         self.renderContext = renderContext
         self.renderer = renderer
     }
@@ -91,7 +91,7 @@ class Renderer {
     }
 
     func render(
-        meshInstances: _Proto_LowLevelMeshInstanceArray_v1,
+        meshInstances: LowLevelMeshInstanceArray,
         texture: any MTLTexture,
         commandBuffer: any MTLCommandBuffer
     ) throws {
@@ -104,7 +104,7 @@ class Renderer {
 
         let aspect = Float(texture.width) / Float(texture.height)
         let d = effectiveCameraDistance
-        let projection = _Proto_LowLevelRenderer_v1.Camera.Projection.perspective(
+        let projection = LowLevelRenderer.Camera.Projection.perspective(
             fovYRadians: fovY,
             aspectRatio: aspect,
             nearZ: d * 0.01,
@@ -112,14 +112,31 @@ class Renderer {
             reverseZ: true
         )
 
-        renderer.cameras[0].pose = pose
+        renderer.cameras[0].position = cameraPosition
+        renderer.cameras[0].rotation = cameraRotation
         renderer.cameras[0].projection = projection
         renderer.output.clearColor = clearColor
         renderer.output.color = .init(texture: texture)
-        renderer.meshInstances = meshInstances
+        try renderer.setMeshInstances(meshInstances, at: 0)
 
         commandBuffer.label = "Render Camera"
-        try renderer.render(for: commandBuffer)
+        var indices = Array(meshInstances.indices)
+        indices = LowLevelRenderer.cullMeshInstances(
+            meshInstances,
+            indices: indices.span,
+            configuration: .init(frustum: .init(from: renderer.cameras[0]))
+        )
+        var span = indices.mutableSpan
+        LowLevelRenderer.sortMeshInstances(
+            meshInstances,
+            indices: &span,
+            configuration: .init(cameraPosition: renderer.cameras[0].position)
+        )
+        renderer.render(using: commandBuffer) { state in
+            for index in indices {
+                state.render(meshInstancesArrayIndex: 0, meshInstanceIndex: index)
+            }
+        }
         commandBuffer.commit()
     }
 
@@ -144,12 +161,13 @@ class Renderer {
         let col2 = simd_float3(cameraMatrix.columns.2.x, cameraMatrix.columns.2.y, cameraMatrix.columns.2.z)
         let scale = simd_float3(simd_length(col0), simd_length(col1), simd_length(col2))
         let rotation = simd_quatf(simd_float3x3(col0 / scale.x, col1 / scale.y, col2 / scale.z))
-        let translation = simd_float3(cameraMatrix.columns.3.x, cameraMatrix.columns.3.y, cameraMatrix.columns.3.z)
-        pose = .init(translation: translation, rotation: rotation)
+        let position = simd_float3(cameraMatrix.columns.3.x, cameraMatrix.columns.3.y, cameraMatrix.columns.3.z)
+        cameraPosition = position
+        cameraRotation = rotation
         // Derive the near/far distance from the camera's world-space position.
         // The model lives at its USD-space coordinates, so the camera can be far from
         // origin for large or offset models; simd_length gives the actual view distance.
-        effectiveCameraDistance = max(simd_length(translation), Self.cameraDistance)
+        effectiveCameraDistance = max(simd_length(position), Self.cameraDistance)
     }
 }
 

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelUtils.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelUtils.swift
@@ -21,33 +21,33 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreTextureProcessing, _version: 24) && canImport(_USDKit_RealityKit, _version: 42) && arch(arm64)
+#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreTextureProcessing, _version: 24) && canImport(_USDKit_RealityKit, _version: 42) && canImport(RealityCoreRenderer, _version: 22) && canImport(ShaderGraph, _version: 156) && arch(arm64)
 
 import DirectResource
 import Metal
 import USDKit
 @_spi(UsdLoaderAPI) import _USDKit_RealityKit
-@_spi(RealityCoreRendererAPI) import RealityKit
+import RealityKit
 
 final class MeshInstancePool {
-    private(set) var meshInstances: _Proto_LowLevelMeshInstanceArray_v1
-    private let renderContext: any _Proto_LowLevelRenderContext_v1
+    private(set) var meshInstances: LowLevelMeshInstanceArray
+    private let renderContext: any LowLevelRenderContext
 
     init(
-        renderContext: any _Proto_LowLevelRenderContext_v1,
-        renderTargets: [_Proto_LowLevelRenderTarget_v1.Descriptor],
+        renderContext: any LowLevelRenderContext,
+        renderTargets: [LowLevelRenderTarget.Descriptor],
         initialCapacity: Int
     ) throws {
         self.renderContext = renderContext
-        self.meshInstances = try renderContext.makeMeshInstanceArray(renderTargets: renderTargets, count: initialCapacity)
+        self.meshInstances = try renderContext.makeMeshInstanceArray(renderTargets: .init(renderTargets), count: initialCapacity)
     }
 
-    init(renderContext: any _Proto_LowLevelRenderContext_v1, meshInstances: _Proto_LowLevelMeshInstanceArray_v1) {
+    init(renderContext: any LowLevelRenderContext, meshInstances: LowLevelMeshInstanceArray) {
         self.renderContext = renderContext
         self.meshInstances = meshInstances
     }
 
-    func add(_ instance: _Proto_LowLevelMeshInstance_v1) throws {
+    func add(_ instance: LowLevelMeshInstance) throws {
         if let emptyIndex = meshInstances.firstIndex(where: { $0 == nil }) {
             try meshInstances.setMeshInstance(instance, index: emptyIndex)
         } else {
@@ -61,7 +61,7 @@ final class MeshInstancePool {
         }
     }
 
-    func remove(_ instance: _Proto_LowLevelMeshInstance_v1) throws {
+    func remove(_ instance: LowLevelMeshInstance) throws {
         guard let index = meshInstances.firstIndex(where: { $0 === instance }) else {
             fatalError("Mesh instance not found in MeshInstancePool")
         }
@@ -85,7 +85,7 @@ extension simd_float4x4 {
     }
 }
 
-extension _Proto_LowLevelMeshResource_v1.Descriptor {
+extension LowLevelMeshResource.Descriptor {
     static func fromLlmDescriptor(_ llmDescriptor: LowLevelMesh.Descriptor) -> Self {
         var descriptor = Self.init()
         descriptor.vertexCapacity = llmDescriptor.vertexCapacity
@@ -118,7 +118,7 @@ private func copyDataIntoBuffer(_ buffer: inout MutableRawSpan, from data: Data)
     unsafe buffer.withUnsafeMutableBytes { unsafe $0.copyBytes(from: data) }
 }
 
-extension _Proto_LowLevelMeshResource_v1 {
+extension LowLevelMeshResource {
     func replaceVertexData(_ vertexData: [Data]) {
         for (vertexBufferIndex, vertexData) in vertexData.enumerated() {
             self.replaceVertices(at: vertexBufferIndex) { copyDataIntoBuffer(&$0, from: vertexData) }
@@ -140,9 +140,9 @@ extension _Proto_LowLevelMeshResource_v1 {
     }
 }
 
-extension _Proto_LowLevelTextureResource_v1.Descriptor {
-    static func from(_ textureDescriptor: MTLTextureDescriptor) -> _Proto_LowLevelTextureResource_v1.Descriptor {
-        var descriptor = _Proto_LowLevelTextureResource_v1.Descriptor()
+extension LowLevelTextureResource.Descriptor {
+    static func from(_ textureDescriptor: MTLTextureDescriptor) -> LowLevelTextureResource.Descriptor {
+        var descriptor = LowLevelTextureResource.Descriptor()
         descriptor.width = textureDescriptor.width
         descriptor.height = textureDescriptor.height
         descriptor.depth = textureDescriptor.depth
@@ -156,8 +156,8 @@ extension _Proto_LowLevelTextureResource_v1.Descriptor {
         return descriptor
     }
 
-    static func from(_ texture: any MTLTexture, swizzle: MTLTextureSwizzleChannels) -> _Proto_LowLevelTextureResource_v1.Descriptor {
-        var descriptor = _Proto_LowLevelTextureResource_v1.Descriptor()
+    static func from(_ texture: any MTLTexture, swizzle: MTLTextureSwizzleChannels) -> LowLevelTextureResource.Descriptor {
+        var descriptor = LowLevelTextureResource.Descriptor()
         descriptor.width = texture.width
         descriptor.height = texture.height
         descriptor.depth = texture.depth
@@ -186,7 +186,7 @@ extension _Proto_LowLevelTextureResource_v1.Descriptor {
     }
 }
 
-private func mapSemantic(_ semantic: LowLevelMesh.VertexSemantic) -> _Proto_LowLevelMeshResource_v1.VertexSemantic {
+private func mapSemantic(_ semantic: LowLevelMesh.VertexSemantic) -> LowLevelMeshResource.VertexSemantic {
     switch semantic {
     case .position: .position
     case .color: .color
@@ -206,7 +206,7 @@ private func mapSemantic(_ semantic: LowLevelMesh.VertexSemantic) -> _Proto_LowL
     }
 }
 
-private func mapSemantic(_ semantic: WKBridgeVertexSemantic) -> _Proto_LowLevelMeshResource_v1.VertexSemantic {
+private func mapSemantic(_ semantic: WKBridgeVertexSemantic) -> LowLevelMeshResource.VertexSemantic {
     switch semantic {
     case .position: .position
     case .color: .color
@@ -226,7 +226,7 @@ private func mapSemantic(_ semantic: WKBridgeVertexSemantic) -> _Proto_LowLevelM
     }
 }
 
-extension _Proto_LowLevelMeshResource_v1.Descriptor {
+extension LowLevelMeshResource.Descriptor {
     static func fromLlmDescriptor(_ llmDescriptor: WKBridgeMeshDescriptor) -> Self {
         var descriptor = Self.init()
         descriptor.vertexCapacity = Int(llmDescriptor.vertexCapacity)

--- a/Source/WebKit/GPUProcess/graphics/Model/USDModel+Deformation.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/USDModel+Deformation.swift
@@ -26,9 +26,8 @@ import OSLog
 import WebKit
 import simd
 
-#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreTextureProcessing, _version: 24) && canImport(_USDKit_RealityKit, _version: 42) && arch(arm64)
+#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreTextureProcessing, _version: 24) && canImport(_USDKit_RealityKit, _version: 42) && canImport(RealityCoreRenderer, _version: 22) && canImport(ShaderGraph, _version: 156) && arch(arm64)
 @_spi(UsdLoaderAPI) import _USDKit_RealityKit
-@_spi(RealityCoreRendererAPI) import RealityKit
 @_spi(RealityCoreTextureProcessingAPI) import RealityCoreTextureProcessing
 import USDKit
 @_spi(SwiftAPI) import DirectResource
@@ -358,7 +357,7 @@ func configureDeformation(
     deformationData: WKBridgeDeformationData,
     commandBuffer: any MTLCommandBuffer,
     device: any MTLDevice,
-    meshResource: _Proto_LowLevelMeshResource_v1,
+    meshResource: LowLevelMeshResource,
     meshResourceToDeformationContext: inout [WKBridgeTypedResourceId: DeformationContext],
     deformationSystem: _Proto_LowLevelDeformationSystem_v1,
     memoryOwner: task_id_token_t
@@ -404,7 +403,7 @@ func updateDeformationContextInPlace(deformationData: WKBridgeDeformationData, c
 }
 
 func buildDeformationContext(
-    meshResource: _Proto_LowLevelMeshResource_v1,
+    meshResource: LowLevelMeshResource,
     deformationData: WKBridgeDeformationData,
     commandBuffer: any MTLCommandBuffer,
     device: any MTLDevice,
@@ -496,7 +495,7 @@ struct DeformationMeshDescriptionData {
 }
 
 func makeMeshDescriptionForDeformation(
-    meshResource: _Proto_LowLevelMeshResource_v1,
+    meshResource: LowLevelMeshResource,
     deformationData: WKBridgeDeformationData,
     commandBuffer: any MTLCommandBuffer,
     isInput: Bool,
@@ -513,7 +512,7 @@ func makeMeshDescriptionForDeformation(
     // Similar usage as the buffer index table. See comment above
     var meshResourceLayoutIndexToDeformationLayoutIndex: [Int: Int] = [:]
 
-    var inputAttributeSemantics: [_Proto_LowLevelMeshResource_v1.VertexSemantic] = [.position]
+    var inputAttributeSemantics: [LowLevelMeshResource.VertexSemantic] = [.position]
     if deformationData.renormalizationData != nil {
         inputAttributeSemantics.append(contentsOf: [.normal, .tangent, .bitangent])
     }
@@ -533,7 +532,7 @@ func makeMeshDescriptionForDeformation(
         } else {
             meshResourceBufferIndexToDeformationBufferIndex[bufferIndex] = deformationBufferIndex
 
-            let vertexBuffer = meshResource.readVertices_v2(at: bufferIndex, using: commandBuffer)
+            let vertexBuffer = meshResource.readVertices(at: bufferIndex, commandBuffer: commandBuffer)
             if isInput {
                 // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
                 // swift-format-ignore: NeverForceUnwrap
@@ -572,7 +571,7 @@ func makeMeshDescriptionForDeformation(
 }
 
 func makeInputMeshDescriptionForDeformation(
-    meshResource: _Proto_LowLevelMeshResource_v1,
+    meshResource: LowLevelMeshResource,
     deformationData: WKBridgeDeformationData,
     commandBuffer: any MTLCommandBuffer,
     device: any MTLDevice,
@@ -624,7 +623,7 @@ func makeInputMeshDescriptionForDeformation(
 }
 
 func makeOutputMeshDescriptionForDeformation(
-    meshResource: _Proto_LowLevelMeshResource_v1,
+    meshResource: LowLevelMeshResource,
     deformationData: WKBridgeDeformationData,
     commandBuffer: any MTLCommandBuffer,
     device: any MTLDevice,
@@ -655,7 +654,7 @@ func makeOutputMeshDescriptionForDeformation(
     }
 }
 
-extension _Proto_LowLevelMeshResource_v1.VertexSemantic {
+extension LowLevelMeshResource.VertexSemantic {
     func toDeformationVertexSemantic() -> _Proto_LowLevelDeformationDescription_v1.MeshSemantic? {
         switch self {
         case .position:

--- a/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
@@ -26,7 +26,7 @@ import OSLog
 import WebKit
 import simd
 
-#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreTextureProcessing, _version: 24) && canImport(_USDKit_RealityKit, _version: 42) && arch(arm64)
+#if ENABLE_GPU_PROCESS_MODEL && canImport(RealityCoreTextureProcessing, _version: 24) && canImport(_USDKit_RealityKit, _version: 42) && canImport(RealityCoreRenderer, _version: 22) && canImport(ShaderGraph, _version: 156) && arch(arm64)
 @_spi(UsdLoaderAPI) import _USDKit_RealityKit
 @_spi(RealityCoreRendererAPI) import RealityKit
 import USDKit
@@ -212,14 +212,14 @@ private func makeMTLTextureFromImageAsset(
 private func makeTextureFromImageAsset(
     _ imageAsset: WKBridgeImageAsset,
     device: any MTLDevice,
-    renderContext: any _Proto_LowLevelRenderContext_v1,
+    renderContext: any LowLevelRenderContext,
     commandQueue: any MTLCommandQueue,
     generateMips: Bool,
     memoryOwner: task_id_token_t,
     swizzle: MTLTextureSwizzleChannels,
-    existingTexture: _Proto_LowLevelTextureResource_v1?,
+    existingTexture: LowLevelTextureResource?,
     layout: [WKBridgeTextureLevelInfo]
-) -> _Proto_LowLevelTextureResource_v1? {
+) -> LowLevelTextureResource? {
     guard
         let (mtlTexture, mipLevelsInData) = makeMTLTextureFromImageAsset(
             imageAsset,
@@ -233,7 +233,7 @@ private func makeTextureFromImageAsset(
         return nil
     }
 
-    let descriptor = _Proto_LowLevelTextureResource_v1.Descriptor.from(mtlTexture, swizzle: swizzle)
+    let descriptor = LowLevelTextureResource.Descriptor.from(mtlTexture, swizzle: swizzle)
     if let textureResource = existingTexture ?? (try? renderContext.makeTextureResource(descriptor: descriptor)) {
         guard let commandBuffer = commandQueue.makeCommandBuffer() else {
             fatalError("Could not create command buffer")
@@ -245,7 +245,7 @@ private func makeTextureFromImageAsset(
             blitEncoder.generateMipmaps(for: mtlTexture)
         }
 
-        let outTexture = textureResource.replace(using: commandBuffer)
+        let outTexture = textureResource.replace(commandBuffer: commandBuffer)
         blitEncoder.copy(from: mtlTexture, to: outTexture)
 
         blitEncoder.endEncoding()
@@ -260,12 +260,12 @@ private func makeTextureFromImageAsset(
 private func makeTextureFromImageAsset(
     _ imageAsset: WKBridgeImageAsset,
     device: any MTLDevice,
-    renderContext: any _Proto_LowLevelRenderContext_v1,
+    renderContext: any LowLevelRenderContext,
     commandQueue: any MTLCommandQueue,
     generateMips: Bool,
     memoryOwner: task_id_token_t,
     swizzle: MTLTextureSwizzleChannels = .init(red: .red, green: .green, blue: .blue, alpha: .alpha)
-) -> _Proto_LowLevelTextureResource_v1? {
+) -> LowLevelTextureResource? {
     makeTextureFromImageAsset(
         imageAsset,
         device: device,
@@ -282,13 +282,13 @@ private func makeTextureFromImageAsset(
 private func makeTextureFromImageAsset(
     _ imageAsset: WKBridgeImageAsset,
     device: any MTLDevice,
-    renderContext: any _Proto_LowLevelRenderContext_v1,
+    renderContext: any LowLevelRenderContext,
     commandQueue: any MTLCommandQueue,
     generateMips: Bool,
     memoryOwner: task_id_token_t,
-    existingTexture: _Proto_LowLevelTextureResource_v1?,
+    existingTexture: LowLevelTextureResource?,
     layout: [WKBridgeTextureLevelInfo]
-) -> _Proto_LowLevelTextureResource_v1? {
+) -> LowLevelTextureResource? {
     makeTextureFromImageAsset(
         imageAsset,
         device: device,
@@ -303,16 +303,16 @@ private func makeTextureFromImageAsset(
 }
 
 private func makeParameters(
-    for function: (any _Proto_LowLevelMaterialResource_v1.Function)?,
-    renderContext: any _Proto_LowLevelRenderContext_v1,
-    textureHashesAndResources: [WKBridgeTypedResourceId: (String, _Proto_LowLevelTextureResource_v1)],
-    fallbackTexture: _Proto_LowLevelTextureResource_v1
-) throws -> _Proto_LowLevelArgumentTable_v1? {
+    for function: (any LowLevelMaterialResource.Function)?,
+    renderContext: any LowLevelRenderContext,
+    textureHashesAndResources: [WKBridgeTypedResourceId: (String, LowLevelTextureResource)],
+    fallbackTexture: LowLevelTextureResource
+) throws -> LowLevelArgumentTable? {
     guard let function else { return nil }
     guard let argumentTableDescriptor = function.argumentTableDescriptor else { return nil }
     let parameterMapping = function.parameterMapping
 
-    var optTextures: [_Proto_LowLevelTextureResource_v1?] = argumentTableDescriptor.textures.map({ _ in nil })
+    var optTextures: [LowLevelTextureResource?] = argumentTableDescriptor.textures.map({ _ in nil })
     for parameter in parameterMapping?.textures ?? [] {
         if let textureHashAndResource = textureHashesAndResources.values.first(where: { $0.0 == parameter.name }) {
             optTextures[parameter.textureIndex] = textureHashAndResource.1
@@ -324,7 +324,7 @@ private func makeParameters(
     }
     let textures = optTextures.map({ $0! })
 
-    let buffers: [_Proto_LowLevelBufferSpan_v1] = try argumentTableDescriptor.buffers.map { bufferRequirements in
+    let buffers: [LowLevelBufferSlice] = try argumentTableDescriptor.buffers.map { bufferRequirements in
         let capacity = (bufferRequirements.size + 16 - 1) / 16 * 16
         let buffer = try renderContext.makeBufferResource(descriptor: .init(capacity: capacity))
         buffer.replace { span in
@@ -332,7 +332,7 @@ private func makeParameters(
                 span.storeBytes(of: 0, toByteOffset: byteOffset, as: UInt8.self)
             }
         }
-        return try _Proto_LowLevelBufferSpan_v1(buffer: buffer, offset: 0, size: bufferRequirements.size)
+        return try LowLevelBufferSlice(buffer: buffer, offset: 0, size: bufferRequirements.size)
     }
 
     return try renderContext.makeArgumentTable(
@@ -366,7 +366,7 @@ extension WKBridgeUSDConfiguration {
         get { appRenderer.commandQueue }
     }
     @nonobjc
-    fileprivate final var renderer: _Proto_LowLevelRenderer_v1 {
+    fileprivate final var renderer: LowLevelRenderer {
         get {
             // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
             // swift-format-ignore: NeverForceUnwrap
@@ -374,7 +374,7 @@ extension WKBridgeUSDConfiguration {
         }
     }
     @nonobjc
-    fileprivate final var renderContext: any _Proto_LowLevelRenderContext_v1 {
+    fileprivate final var renderContext: any LowLevelRenderContext {
         get {
             // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
             // swift-format-ignore: NeverForceUnwrap
@@ -383,7 +383,7 @@ extension WKBridgeUSDConfiguration {
     }
 
     @nonobjc
-    fileprivate final var renderTarget: _Proto_LowLevelRenderTarget_v1.Descriptor {
+    fileprivate final var renderTarget: LowLevelRenderTarget.Descriptor {
         get { appRenderer.renderTargetDescriptor }
     }
 
@@ -419,31 +419,31 @@ extension WKBridgeReceiver {
     fileprivate let commandQueue: any MTLCommandQueue
 
     @nonobjc
-    fileprivate let renderContext: any _Proto_LowLevelRenderContext_v1
+    fileprivate let renderContext: any LowLevelRenderContext
     @nonobjc
-    fileprivate let renderer: _Proto_LowLevelRenderer_v1
+    fileprivate let renderer: LowLevelRenderer
     @nonobjc
     fileprivate let appRenderer: Renderer
     @nonobjc
-    fileprivate let lightingFunction: _Proto_LowLevelMaterialResource_v1.LightingFunction
+    fileprivate let lightingFunction: LowLevelMaterialResource.LightingFunction
     @nonobjc
-    fileprivate let lightingArguments: _Proto_LowLevelArgumentTable_v1
+    fileprivate let lightingArguments: LowLevelArgumentTable
     @nonobjc
-    fileprivate var lightingArgumentBuffer: _Proto_LowLevelArgumentTable_v1?
+    fileprivate var lightingArgumentBuffer: LowLevelArgumentTable?
 
     @nonobjc
-    fileprivate final var renderTarget: _Proto_LowLevelRenderTarget_v1.Descriptor {
+    fileprivate final var renderTarget: LowLevelRenderTarget.Descriptor {
         get { appRenderer.renderTargetDescriptor }
     }
     @nonobjc
     fileprivate var meshInstancePool: MeshInstancePool
 
     @nonobjc
-    fileprivate var meshResources: [WKBridgeTypedResourceId: _Proto_LowLevelMeshResource_v1] = [:]
+    fileprivate var meshResources: [WKBridgeTypedResourceId: LowLevelMeshResource] = [:]
     @nonobjc
     fileprivate var meshResourceToMaterials: [WKBridgeTypedResourceId: [WKBridgeTypedResourceId]] = [:]
     @nonobjc
-    fileprivate var meshToMeshInstances: [WKBridgeTypedResourceId: [_Proto_LowLevelMeshInstance_v1]] = [:]
+    fileprivate var meshToMeshInstances: [WKBridgeTypedResourceId: [LowLevelMeshInstance]] = [:]
     @nonobjc
     fileprivate var rotationAngle: Float = 0
 
@@ -454,16 +454,16 @@ extension WKBridgeReceiver {
     fileprivate var meshResourceToDeformationContext: [WKBridgeTypedResourceId: DeformationContext] = [:]
 
     struct Material {
-        let resource: _Proto_LowLevelMaterialResource_v1
-        let geometryArguments: _Proto_LowLevelArgumentTable_v1?
-        let surfaceArguments: _Proto_LowLevelArgumentTable_v1?
-        let blending: _Proto_LowLevelMaterialResource_v1.ShaderGraphOutput.Blending
+        let resource: LowLevelMaterialResource
+        let geometryArguments: LowLevelArgumentTable?
+        let surfaceArguments: LowLevelArgumentTable?
+        let blending: LowLevelMaterialResource.ShaderGraphOutput.Blending
     }
     @nonobjc
     fileprivate var materialsAndParams: [WKBridgeTypedResourceId: Material] = [:]
 
     @nonobjc
-    fileprivate var textureHashesAndResources: [WKBridgeTypedResourceId: (String, _Proto_LowLevelTextureResource_v1)] = [:]
+    fileprivate var textureHashesAndResources: [WKBridgeTypedResourceId: (String, LowLevelTextureResource)] = [:]
 
     @nonobjc
     fileprivate var dontCaptureAgain: Bool = false
@@ -474,7 +474,7 @@ extension WKBridgeReceiver {
     }
 
     @nonobjc
-    fileprivate let fallbackTexture: _Proto_LowLevelTextureResource_v1
+    fileprivate let fallbackTexture: LowLevelTextureResource
 
     struct DeferredMeshUpdate {
         enum UpdateType {
@@ -486,9 +486,9 @@ extension WKBridgeReceiver {
 
         let identifier: WKBridgeTypedResourceId
         let type: UpdateType
-        var updatedInstances: [_Proto_LowLevelMeshInstance_v1]
+        var updatedInstances: [LowLevelMeshInstance]
 
-        init(identifier: WKBridgeTypedResourceId, type: UpdateType, updatedInstances: [_Proto_LowLevelMeshInstance_v1]) {
+        init(identifier: WKBridgeTypedResourceId, type: UpdateType, updatedInstances: [LowLevelMeshInstance]) {
             self.identifier = identifier
             self.type = type
             self.updatedInstances = updatedInstances
@@ -514,7 +514,7 @@ extension WKBridgeReceiver {
         self.deformationSystem = try _Proto_LowLevelDeformationSystem_v1.make(configuration.device, configuration.commandQueue).get()
         let meshInstances = try configuration.renderContext.makeMeshInstanceArray(renderTargets: [configuration.renderTarget], count: 16)
         self.meshInstancePool = MeshInstancePool(renderContext: configuration.renderContext, meshInstances: meshInstances)
-        let lightingFunction = configuration.renderContext.makePhysicallyBasedLightingFunction()
+        let lightingFunction = configuration.renderContext.lighting.makeImageBasedLightingFunction()
         guard
             let diffuseTexture = makeTextureFromImageAsset(
                 diffuseAsset,
@@ -622,7 +622,7 @@ extension WKBridgeReceiver {
             let existingTexture = textureHashesAndResources[textureData.identifier]?.1
             let needsNewTexture: Bool
             if let existingTexture {
-                needsNewTexture = existingTexture.descriptor != _Proto_LowLevelTextureResource_v1.Descriptor(from: asset)
+                needsNewTexture = existingTexture.descriptor != LowLevelTextureResource.Descriptor(from: asset)
             } else {
                 needsNewTexture = true
             }
@@ -652,11 +652,14 @@ extension WKBridgeReceiver {
                 let identifier = data.identifier
                 logInfo("updateMaterial \(identifier)")
 
-                guard let shaderGraph = _Proto_ShaderNodeGraph.fromWKDescriptor(data.materialGraph) else {
+                guard let shaderGraph = ShaderGraph.fromWKDescriptor(data.materialGraph) else {
                     fatalError("No materialGraph data provided for material \(identifier)")
                 }
 
-                let shaderGraphOutput = try await renderContext.makeShaderGraphFunctions(shaderGraph: shaderGraph)
+                let shaderGraphOutput = try await renderContext.shaderGraph.makeShaderGraphFunctions(
+                    shaderGraph: shaderGraph,
+                    constantValues: .init()
+                )
 
                 let geometryArguments = try makeParameters(
                     for: shaderGraphOutput.geometryModifier,
@@ -736,12 +739,12 @@ extension WKBridgeReceiver {
             for meshData in updates {
                 let identifier = meshData.identifier
 
-                let meshResource: _Proto_LowLevelMeshResource_v1
+                let meshResource: LowLevelMeshResource
                 if meshData.updateType == .initial || meshData.descriptor != nil {
                     // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
                     // swift-format-ignore: NeverForceUnwrap
                     let meshDescriptor = meshData.descriptor!
-                    let descriptor = _Proto_LowLevelMeshResource_v1.Descriptor.fromLlmDescriptor(meshDescriptor)
+                    let descriptor = LowLevelMeshResource.Descriptor.fromLlmDescriptor(meshDescriptor)
                     if let cachedMeshResource = meshResources[identifier] {
                         meshResource = cachedMeshResource
                     } else {
@@ -814,20 +817,21 @@ extension WKBridgeReceiver {
                                 indexCount: meshData.parts[partIndex].indexCount,
                                 primitive: meshData.parts[partIndex].topology,
                                 windingOrder: .counterClockwise,
-                                boundsMin: meshData.parts[partIndex].boundsMin,
-                                boundsMax: meshData.parts[partIndex].boundsMax
+                                bounds: .init(
+                                    boxMin: meshData.parts[partIndex].boundsMin,
+                                    boxMax: meshData.parts[partIndex].boundsMax
+                                )
                             )
 
                             for instanceTransform in meshData.instanceTransforms {
-                                let position = instanceTransform.transformPosition(.zero)
                                 let meshInstance = try renderContext.makeMeshInstance(
                                     meshPart: meshPart,
                                     pipeline: pipeline,
                                     geometryArguments: material.geometryArguments,
                                     surfaceArguments: material.surfaceArguments,
                                     lightingArguments: lightingArguments,
-                                    transform: .single(instanceTransform),
-                                    sortCategory: material.blending == .transparent ? .transparent(sortPosition: position) : .opaque
+                                    transform: instanceTransform,
+                                    sortCategory: material.blending == .transparent ? .transparent : .opaque
                                 )
 
                                 // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
@@ -843,7 +847,7 @@ extension WKBridgeReceiver {
                         // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
                         // swift-format-ignore: NeverForceUnwrap
                         var newTransforms: [simd_float4x4] = []
-                        var updatedInstances: [_Proto_LowLevelMeshInstance_v1] = []
+                        var updatedInstances: [LowLevelMeshInstance] = []
 
                         let partCount = meshToMeshInstances[identifier]!.count / meshData.instanceTransforms.count
                         for (instanceIndex, instanceTransform) in meshData.instanceTransforms.enumerated() {
@@ -879,7 +883,7 @@ extension WKBridgeReceiver {
                     }
                 case .transformUpdate(let newTransforms):
                     for (instanceIndex, meshInstance) in deferredUpdate.updatedInstances.enumerated() {
-                        meshInstance.setTransform(.single(newTransforms[instanceIndex]))
+                        meshInstance.transform = newTransforms[instanceIndex]
                     }
                 }
             }
@@ -930,13 +934,13 @@ extension WKBridgeReceiver {
             let diffuseMTLTextureDescriptor = try self.imageBasedLightTextureGenerator.makeDiffuseDescriptor(
                 fromCube: cubeMTLTexture
             )
-            let diffuseTextureDescriptor = _Proto_LowLevelTextureResource_v1.Descriptor.from(diffuseMTLTextureDescriptor)
+            let diffuseTextureDescriptor = LowLevelTextureResource.Descriptor.from(diffuseMTLTextureDescriptor)
             let diffuseTexture = try self.renderContext.makeTextureResource(descriptor: diffuseTextureDescriptor)
 
             let specularMTLTextureDescriptor = try self.imageBasedLightTextureGenerator.makeSpecularDescriptor(
                 fromCube: cubeMTLTexture
             )
-            let specularTextureDescriptor = _Proto_LowLevelTextureResource_v1.Descriptor.from(specularMTLTextureDescriptor)
+            let specularTextureDescriptor = LowLevelTextureResource.Descriptor.from(specularMTLTextureDescriptor)
             let specularTexture = try self.renderContext.makeTextureResource(descriptor: specularTextureDescriptor)
 
             // FIXME: https://bugs.webkit.org/show_bug.cgi?id=305857
@@ -949,8 +953,8 @@ extension WKBridgeReceiver {
                 into: cubeMTLTexture
             )
 
-            let diffuseMTLTexture = diffuseTexture.replace(using: commandBuffer)
-            let specularMTLTexture = specularTexture.replace(using: commandBuffer)
+            let diffuseMTLTexture = diffuseTexture.replace(commandBuffer: commandBuffer)
+            let specularMTLTexture = specularTexture.replace(commandBuffer: commandBuffer)
 
             try self.imageBasedLightTextureGenerator.generateDiffuse(
                 using: commandBuffer,
@@ -963,8 +967,8 @@ extension WKBridgeReceiver {
                 into: specularMTLTexture
             )
 
-            try self.lightingArguments.setTexture(at: 0, diffuseTexture)
-            try self.lightingArguments.setTexture(at: 1, specularTexture)
+            try self.lightingArguments.setTexture(diffuseTexture, at: 0)
+            try self.lightingArguments.setTexture(specularTexture, at: 1)
 
             commandBuffer.commit()
         } catch {
@@ -1349,7 +1353,7 @@ private func texcoordName(for coord: _Proto_TextureCoordinate) -> String {
     }
 }
 
-private func textureCoordinate(from name: String) -> _Proto_TextureCoordinate? {
+private func textureCoordinate(from name: String) -> ShaderGraph.TextureCoordinate? {
     switch name {
     case "UV0": .uv0
     case "UV1": .uv1
@@ -1435,23 +1439,23 @@ func webUpdateMaterialRequestFromUpdateMaterialRequest(
     )
 }
 
-extension _Proto_ShaderNodeGraph {
-    // Reconstructs the graph from the IPC bridge representation using the _Proto_ShaderNodeGraph API.
-    static func fromWKDescriptor(_ descriptor: WKBridgeMaterialGraph?) -> _Proto_ShaderNodeGraph? {
+extension ShaderGraph {
+    // Reconstructs the graph from the IPC bridge representation using the ShaderGraph API.
+    static func fromWKDescriptor(_ descriptor: WKBridgeMaterialGraph?) -> ShaderGraph? {
         guard let descriptor else { return nil }
 
         do {
-            let graph = try _Proto_ShaderNodeGraph(
+            let graph = try ShaderGraph(
                 named: descriptor.graphName.isEmpty ? "MaterialGraph" : descriptor.graphName,
                 inputs: descriptor.inputs.map {
-                    _Proto_ShaderGraphNodeDefinition.Input(
+                    ShaderGraph.NodeDefinition.Input(
                         name: $0.name,
                         type: fromWKBridgeDataType($0.type),
                         semanticType: $0.semanticTypeName.map { .init(name: $0) }
                     )
                 },
                 outputs: descriptor.outputs.map {
-                    _Proto_ShaderGraphNodeDefinition.Output(
+                    ShaderGraph.NodeDefinition.Output(
                         name: $0.name,
                         type: fromWKBridgeDataType($0.type),
                         semanticType: $0.semanticTypeName.map { .init(name: $0) }
@@ -1459,19 +1463,19 @@ extension _Proto_ShaderNodeGraph {
                 }
             )
 
-            let library = _Proto_ShaderNodeGraphLibrary.shared
+            let library = ShaderGraph.NodeLibrary(version: .materialX138)
 
             for bridgeNode in descriptor.nodes {
                 switch bridgeNode.bridgeNodeType {
                 case .constant:
                     if let constant = bridgeNode.constant {
-                        try graph.add(constant: fromWKBridgeConstant(constant), named: constant.name)
+                        try graph.addConstant(fromWKBridgeConstant(constant), named: constant.name)
                     }
                 case .builtin:
                     if let builtin = bridgeNode.builtin, !builtin.definition.isEmpty,
                         let definition = library.definition(named: builtin.definition)
                     {
-                        try graph.add(node: .init(name: builtin.name, data: .definition(definition)))
+                        try graph.addNode(.init(name: builtin.name, data: .definition(definition)))
                     }
                 case .arguments, .results:
                     break
@@ -1485,9 +1489,9 @@ extension _Proto_ShaderNodeGraph {
                 do {
                     try graph.connect(
                         bridgeEdge.outputNode,
-                        bridgeEdge.outputPort,
+                        outputPort: bridgeEdge.outputPort,
                         to: bridgeEdge.inputNode,
-                        bridgeEdge.inputPort
+                        inputPort: bridgeEdge.inputPort
                     )
                 } catch {
                     logError(
@@ -1516,7 +1520,7 @@ extension _Proto_ShaderNodeGraph {
     }
 }
 
-private func fromWKBridgeDataType(_ dataType: WKBridgeDataType) -> _Proto_ShaderDataType {
+private func fromWKBridgeDataType(_ dataType: WKBridgeDataType) -> ShaderGraph.DataType {
     switch dataType {
     case .bool: .bool
     case .uchar: .uchar
@@ -1528,6 +1532,8 @@ private func fromWKBridgeDataType(_ dataType: WKBridgeDataType) -> _Proto_Shader
     case .float: .float
     case .cgColor3: .cgColor3
     case .cgColor4: .cgColor4
+    case .color3h: .cgColor3
+    case .color4h: .cgColor4
     case .float2: .float2
     case .float3: .float3
     case .float4: .float4
@@ -1541,18 +1547,17 @@ private func fromWKBridgeDataType(_ dataType: WKBridgeDataType) -> _Proto_Shader
     case .matrix2h: .half2x2
     case .matrix3h: .half3x3
     case .matrix4h: .half4x4
-    case .quat: .quaternion
     case .surfaceShader: .surfaceShader
     case .geometryModifier: .geometryModifier
     case .postLightingShader: .postLightingShader
     case .string: .string
-    case .token: .string // Map token to string
-    case .asset: .filename // Map asset to filename
-    @unknown default: .invalid
+    case .asset: .texture
+    case .token, .quat: .string
+    @unknown default: fatalError("fromWKBridgeDataType: unknown WKBridgeDataType")
     }
 }
 
-private func fromWKBridgeConstant(_ constant: WKBridgeConstantContainer) -> _Proto_ShaderGraphValue {
+private func fromWKBridgeConstant(_ constant: WKBridgeConstantContainer) -> ShaderGraph.Value {
     let values = constant.constantValues
 
     switch constant.constant {
@@ -1570,7 +1575,7 @@ private func fromWKBridgeConstant(_ constant: WKBridgeConstantContainer) -> _Pro
         return .uint(UInt32(v.number.uintValue))
     case .half:
         guard let v = values.first else { fatalError("fromWKBridgeConstant: missing value for half constant '\(constant.name)'") }
-        return .half(v.number.uint16Value)
+        return .half(.init(bitPattern: v.number.uint16Value))
     case .float:
         guard let v = values.first else { fatalError("fromWKBridgeConstant: missing value for float constant '\(constant.name)'") }
         return .float(v.number.floatValue)
@@ -1620,9 +1625,9 @@ private func fromWKBridgeConstant(_ constant: WKBridgeConstantContainer) -> _Pro
             fatalError("fromWKBridgeConstant: expected 2 values for half2 constant '\(constant.name)', got \(values.count)")
         }
         return .half2(
-            SIMD2<UInt16>(
-                values[0].number.uint16Value,
-                values[1].number.uint16Value
+            SIMD2<Float16>(
+                .init(bitPattern: values[0].number.uint16Value),
+                .init(bitPattern: values[1].number.uint16Value)
             )
         )
     case .vector3h, .half3, .point3h, .normal3h, .texCoord3h:
@@ -1631,10 +1636,10 @@ private func fromWKBridgeConstant(_ constant: WKBridgeConstantContainer) -> _Pro
             fatalError("fromWKBridgeConstant: expected 3 values for half3 constant '\(constant.name)', got \(values.count)")
         }
         return .half3(
-            SIMD3<UInt16>(
-                values[0].number.uint16Value,
-                values[1].number.uint16Value,
-                values[2].number.uint16Value
+            SIMD3<Float16>(
+                .init(bitPattern: values[0].number.uint16Value),
+                .init(bitPattern: values[1].number.uint16Value),
+                .init(bitPattern: values[2].number.uint16Value)
             )
         )
     case .half4:
@@ -1642,11 +1647,11 @@ private func fromWKBridgeConstant(_ constant: WKBridgeConstantContainer) -> _Pro
             fatalError("fromWKBridgeConstant: expected 4 values for half4 constant '\(constant.name)', got \(values.count)")
         }
         return .half4(
-            SIMD4<UInt16>(
-                values[0].number.uint16Value,
-                values[1].number.uint16Value,
-                values[2].number.uint16Value,
-                values[3].number.uint16Value
+            SIMD4<Float16>(
+                .init(bitPattern: values[0].number.uint16Value),
+                .init(bitPattern: values[1].number.uint16Value),
+                .init(bitPattern: values[2].number.uint16Value),
+                .init(bitPattern: values[3].number.uint16Value)
             )
         )
     case .int2:
@@ -1688,9 +1693,11 @@ private func fromWKBridgeConstant(_ constant: WKBridgeConstantContainer) -> _Pro
             fatalError("fromWKBridgeConstant: expected 9 values for matrix3f constant '\(constant.name)', got \(values.count)")
         }
         return .float3x3(
-            SIMD3<Float>(values[0].number.floatValue, values[1].number.floatValue, values[2].number.floatValue),
-            SIMD3<Float>(values[3].number.floatValue, values[4].number.floatValue, values[5].number.floatValue),
-            SIMD3<Float>(values[6].number.floatValue, values[7].number.floatValue, values[8].number.floatValue)
+            .init(
+                SIMD3<Float>(values[0].number.floatValue, values[1].number.floatValue, values[2].number.floatValue),
+                SIMD3<Float>(values[3].number.floatValue, values[4].number.floatValue, values[5].number.floatValue),
+                SIMD3<Float>(values[6].number.floatValue, values[7].number.floatValue, values[8].number.floatValue)
+            )
         )
     case .matrix4f:
         // matrix4f maps to float4x4 - needs 16 values (4 columns of 4 rows each)
@@ -1698,29 +1705,31 @@ private func fromWKBridgeConstant(_ constant: WKBridgeConstantContainer) -> _Pro
             fatalError("fromWKBridgeConstant: expected 16 values for matrix4f constant '\(constant.name)', got \(values.count)")
         }
         return .float4x4(
-            SIMD4<Float>(
-                values[0].number.floatValue,
-                values[1].number.floatValue,
-                values[2].number.floatValue,
-                values[3].number.floatValue
-            ),
-            SIMD4<Float>(
-                values[4].number.floatValue,
-                values[5].number.floatValue,
-                values[6].number.floatValue,
-                values[7].number.floatValue
-            ),
-            SIMD4<Float>(
-                values[8].number.floatValue,
-                values[9].number.floatValue,
-                values[10].number.floatValue,
-                values[11].number.floatValue
-            ),
-            SIMD4<Float>(
-                values[12].number.floatValue,
-                values[13].number.floatValue,
-                values[14].number.floatValue,
-                values[15].number.floatValue
+            .init(
+                SIMD4<Float>(
+                    values[0].number.floatValue,
+                    values[1].number.floatValue,
+                    values[2].number.floatValue,
+                    values[3].number.floatValue
+                ),
+                SIMD4<Float>(
+                    values[4].number.floatValue,
+                    values[5].number.floatValue,
+                    values[6].number.floatValue,
+                    values[7].number.floatValue
+                ),
+                SIMD4<Float>(
+                    values[8].number.floatValue,
+                    values[9].number.floatValue,
+                    values[10].number.floatValue,
+                    values[11].number.floatValue
+                ),
+                SIMD4<Float>(
+                    values[12].number.floatValue,
+                    values[13].number.floatValue,
+                    values[14].number.floatValue,
+                    values[15].number.floatValue
+                )
             )
         )
     case .quatf, .quath:
@@ -1788,7 +1797,7 @@ private func fromWKBridgeConstant(_ constant: WKBridgeConstantContainer) -> _Pro
         ]
         return .cgColor3(CGColor(red: components3f[0], green: components3f[1], blue: components3f[2], alpha: 1.0))
     case .color3h:
-        // USD/MaterialX color3h — half-precision; represented as cgColor3 in _Proto_ShaderGraphValue.
+        // USD/MaterialX color3h — half-precision; represented as cgColor3 in ShaderGraph.Value.
         guard values.count >= 3 else {
             fatalError("fromWKBridgeConstant: expected 3 values for color3h constant '\(constant.name)', got \(values.count)")
         }
@@ -1801,7 +1810,7 @@ private func fromWKBridgeConstant(_ constant: WKBridgeConstantContainer) -> _Pro
             )
         )
     case .color4h:
-        // USD/MaterialX color4h — half-precision; represented as cgColor4 in _Proto_ShaderGraphValue.
+        // USD/MaterialX color4h — half-precision; represented as cgColor4 in ShaderGraph.Value.
         guard values.count >= 4 else {
             fatalError("fromWKBridgeConstant: expected 4 values for color4h constant '\(constant.name)', got \(values.count)")
         }
@@ -2109,13 +2118,13 @@ extension WKBridgeModelLoader {
 }
 
 private func makeFallBackTextureResource(
-    _ renderContext: any _Proto_LowLevelRenderContext_v1,
+    _ renderContext: any LowLevelRenderContext,
     commandQueue: any MTLCommandQueue,
     device: any MTLDevice,
     memoryOwner: task_id_token_t
-) -> _Proto_LowLevelTextureResource_v1 {
+) -> LowLevelTextureResource {
     // Create 1x1 white fallback texture
-    let fallbackDescriptor = _Proto_LowLevelTextureResource_v1.Descriptor(
+    let fallbackDescriptor = LowLevelTextureResource.Descriptor(
         textureType: .type2D,
         pixelFormat: .rgba8Unorm,
         width: 1,
@@ -2134,7 +2143,7 @@ private func makeFallBackTextureResource(
     // Create command buffer to upload white pixel data
     // swift-format-ignore: NeverForceUnwrap
     let fallbackCommandBuffer = commandQueue.makeCommandBuffer()!
-    let fallbackMTLTexture = fallbackTexture.replace(using: fallbackCommandBuffer)
+    let fallbackMTLTexture = fallbackTexture.replace(commandBuffer: fallbackCommandBuffer)
 
     // Use blit encoder to copy from buffer to texture
     // swift-format-ignore: NeverForceUnwrap


### PR DESCRIPTION
#### 4adff5893b791c7b0fc251f8a0761670a9f02cf6
<pre>
[model] Adopt public RealityCoreRenderer and ShaderGraph APIs
<a href="https://bugs.webkit.org/show_bug.cgi?id=314780">https://bugs.webkit.org/show_bug.cgi?id=314780</a>
<a href="https://rdar.apple.com/175205378">rdar://175205378</a>

Reviewed by Mike Wyrzykowski.

RealityCoreRenderer-21 promoted its SPI types from the _Proto_*_v1 naming
convention to public API names. ShaderGraph-156 similarly promoted
_Proto_ShaderNodeGraph and its nested types to a new public ShaderGraph class.
Adopt these public names in the GPUProcess model code.

Also adopts the RCR-22 LowLevelRenderContextShaderGraph protocol for
makeShaderGraphFunctions.

Bumps the #if canImport guards to require RealityCoreRenderer 22 and
ShaderGraph 156 across all seven model files.

Leaves _Proto_* references in place for RealityCoreDeformation,
_USDKit_RealityKit, and RealityCoreTextureProcessing - those frameworks have
not yet promoted their SPIs to public API. Also leaves serialize-side
ShaderGraph helpers on _Proto_ShaderNodeGraph since USDKit&apos;s
_Proto_MaterialDataUpdate_v1.shaderGraph still returns the old type.
Follow-up work will migrate each family as those frameworks complete their
API promotions.

* Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift:
* Source/WebKit/GPUProcess/graphics/Model/ModelIBLTextures.swift:
* Source/WebKit/GPUProcess/graphics/Model/ModelParameters.swift:
* Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift:
* Source/WebKit/GPUProcess/graphics/Model/ModelUtils.swift:
* Source/WebKit/GPUProcess/graphics/Model/USDModel+Deformation.swift:
* Source/WebKit/GPUProcess/graphics/Model/USDModel.swift:
(textureCoordinate(from:)):
(ShaderGraph.fromWKDescriptor(_:)):
(fromWKBridgeDataType(_:)):
(fromWKBridgeConstant(_:)):

Canonical link: <a href="https://commits.webkit.org/313327@main">https://commits.webkit.org/313327@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bffdcd27de901e3e888708cff934538e1eedda9e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162795 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36272 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29427 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171733 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/119241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dfc59b8f-11f6-49cb-b1a6-e381e7260c15) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36375 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36275 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126363 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/119241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cc3d6e7f-3573-46bf-befc-d1103d7644dc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165754 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28709 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146271 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106940 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/40c1418c-4da3-46b2-8492-09f1c2b7e413) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19433 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137463 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174237 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21729 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25645 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134671 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35945 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30393 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134666 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36328 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35930 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145796 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98344 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/29200 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22632 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35439 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/103452 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34940 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35185 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35088 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->