### PR TITLE
REGRESSION (303819@main): Child with filter:blur() ignores border radius overflow clipping

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/blur-clip-border-radius-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/blur-clip-border-radius-expected.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<style>
+  .clip {
+    position: absolute;
+    width: 300px;
+    height: 300px;
+    overflow: clip;
+    border-radius: 50%;
+    border: 1px solid black;
+    box-sizing: border-box;
+  }
+
+  .outer {
+    top: 20px;
+    left: 20px;
+  }
+
+  .mask {
+    position: absolute;
+    top: 170px;
+    left: 170px;
+    width: 150px;
+    height: 150px;
+    border-top-left-radius: 150px;
+    border-bottom-right-radius: 150px;
+    background-color: gray;
+    border: 1px solid gray;
+  }
+
+  p {
+    margin-top: 350px;
+  }
+</style>
+<p>You should see no red above</p>
+<div class="outer clip"></div>
+<div class="mask"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/blur-clip-border-radius-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/blur-clip-border-radius-ref.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<style>
+  .clip {
+    position: absolute;
+    width: 300px;
+    height: 300px;
+    overflow: clip;
+    border-radius: 50%;
+    border: 1px solid black;
+    box-sizing: border-box;
+  }
+
+  .outer {
+    top: 20px;
+    left: 20px;
+  }
+
+  .mask {
+    position: absolute;
+    top: 170px;
+    left: 170px;
+    width: 150px;
+    height: 150px;
+    border-top-left-radius: 150px;
+    border-bottom-right-radius: 150px;
+    background-color: gray;
+    border: 1px solid gray;
+  }
+
+  p {
+    margin-top: 350px;
+  }
+</style>
+<p>You should see no red above</p>
+<div class="outer clip"></div>
+<div class="mask"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/blur-clip-border-radius.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/blur-clip-border-radius.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<title>CSS Test: Ancestors with rounded clips should correctly clip a filtered element</title>
+<link rel="help" href="https://drafts.fxtf.org/filter-effects/#funcdef-filter-blur">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-clip">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=312584">
+<link rel="match" href="blur-clip-border-radius-ref.html">
+<meta name="fuzzy" content="maxDifference=0-4; totalPixels=0-30">
+<style>
+  .clip {
+    position: absolute;
+    width: 300px;
+    height: 300px;
+    overflow: clip;
+    border-radius: 50%;
+    border: 1px solid black;
+    box-sizing: border-box;
+  }
+
+  .outer {
+    top: 20px;
+    left: 20px;
+  }
+
+  .inner {
+    top: 150px;
+    left: 150px;
+  }
+
+  .filtered {
+    width: 100%;
+    height: 100%;
+    background-color: red;
+    filter: blur(10px);
+  }
+
+  .mask {
+    position: absolute;
+    top: 170px;
+    left: 170px;
+    width: 150px;
+    height: 150px;
+    border-top-left-radius: 150px;
+    border-bottom-right-radius: 150px;
+    background-color: gray;
+    border: 1px solid gray;
+  }
+
+  p {
+    margin-top: 350px;
+  }
+</style>
+<p>You should see no red above</p>
+<div class="outer clip">
+    <div class="inner clip">
+        <div class="filtered"></div>
+    </div>
+</div>
+<div class="mask"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/grayscale-clip-border-radius-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/grayscale-clip-border-radius-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<style>
+  .filtered {
+    width: 200px;
+    height: 200px;
+    border-radius: 20px;
+    background-color: limegreen;
+    filter: grayscale(50%);
+  }
+</style>
+<p>You should see a muted green rounded rectangle.</p>
+<div class="filtered"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/grayscale-clip-border-radius-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/grayscale-clip-border-radius-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<style>
+  .filtered {
+    width: 200px;
+    height: 200px;
+    border-radius: 20px;
+    background-color: limegreen;
+    filter: grayscale(50%);
+  }
+</style>
+<p>You should see a muted green rounded rectangle.</p>
+<div class="filtered"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/grayscale-clip-border-radius.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/grayscale-clip-border-radius.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<title>CSS Test: Filtered descendant of an element with border-radius and overflow:hidden should render correctly</title>
+<link rel="help" href="https://drafts.fxtf.org/filter-effects/#funcdef-filter-grayscale">
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-3/#border-radius">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=312584">
+<link rel="match" href="grayscale-clip-border-radius-ref.html">
+<meta name="fuzzy" content="maxDifference=0-40; totalPixels=0-160">
+<style>
+  .container {
+    width: 200px;
+    height: 200px;
+    overflow: hidden;
+    border-radius: 20px;
+  }
+  .filtered {
+    width: 100%;
+    height: 100%;
+    background-color: limegreen;
+    filter: grayscale(50%);
+  }
+</style>
+<p>You should see a muted green rounded rectangle.</p>
+<div class="container">
+    <div class="filtered"></div>
+</div>

--- a/Source/WebCore/platform/graphics/GraphicsContextSwitcher.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextSwitcher.h
@@ -27,6 +27,7 @@
 
 #include "DestinationColorSpace.h"
 #include "FloatRect.h"
+#include <wtf/Function.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
@@ -46,7 +47,7 @@ public:
 
     virtual bool hasSourceImage() const { return false; }
 
-    virtual void beginClipAndDrawSourceImage(GraphicsContext& destinationContext, const FloatRect& repaintRect, const FloatRect& clipRect) = 0;
+    virtual void beginClipAndDrawSourceImage(GraphicsContext& destinationContext, const FloatRect& repaintRect, const FloatRect& clipRect, NOESCAPE const Function<void(GraphicsContext&)>& applyAdditionalDestinationClip = { }) = 0;
     virtual void endClipAndDrawSourceImage(GraphicsContext& destinationContext, const DestinationColorSpace&) = 0;
 
     virtual void beginDrawSourceImage(GraphicsContext& destinationContext, float opacity = 1.f) = 0;

--- a/Source/WebCore/platform/graphics/ImageBufferContextSwitcher.cpp
+++ b/Source/WebCore/platform/graphics/ImageBufferContextSwitcher.cpp
@@ -63,7 +63,7 @@ GraphicsContext* ImageBufferContextSwitcher::drawingContext(GraphicsContext& con
     return m_sourceImage ? &m_sourceImage->context() : &context;
 }
 
-void ImageBufferContextSwitcher::beginClipAndDrawSourceImage(GraphicsContext& destinationContext, const FloatRect& repaintRect, const FloatRect&)
+void ImageBufferContextSwitcher::beginClipAndDrawSourceImage(GraphicsContext& destinationContext, const FloatRect& repaintRect, const FloatRect&, NOESCAPE const Function<void(GraphicsContext&)>&)
 {
     if (auto* context = drawingContext(destinationContext)) {
         context->save();

--- a/Source/WebCore/platform/graphics/ImageBufferContextSwitcher.h
+++ b/Source/WebCore/platform/graphics/ImageBufferContextSwitcher.h
@@ -43,7 +43,7 @@ private:
 
     bool hasSourceImage() const override { return m_sourceImage; }
 
-    void beginClipAndDrawSourceImage(GraphicsContext& destinationContext, const FloatRect& repaintRect, const FloatRect& clipRect) override;
+    void beginClipAndDrawSourceImage(GraphicsContext& destinationContext, const FloatRect& repaintRect, const FloatRect& clipRect, NOESCAPE const Function<void(GraphicsContext&)>& applyAdditionalDestinationClip) override;
     void endClipAndDrawSourceImage(GraphicsContext& destinationContext, const DestinationColorSpace&) override;
 
     void beginDrawSourceImage(GraphicsContext&, float = 1.f) override { }

--- a/Source/WebCore/platform/graphics/TransparencyLayerContextSwitcher.cpp
+++ b/Source/WebCore/platform/graphics/TransparencyLayerContextSwitcher.cpp
@@ -42,8 +42,17 @@ TransparencyLayerContextSwitcher::TransparencyLayerContextSwitcher(GraphicsConte
         m_filterStyles = m_filter->createFilterStyles(destinationContext, sourceImageRect);
 }
 
-void TransparencyLayerContextSwitcher::beginClipAndDrawSourceImage(GraphicsContext& destinationContext, const FloatRect&, const FloatRect& clipRect)
+void TransparencyLayerContextSwitcher::beginClipAndDrawSourceImage(GraphicsContext& destinationContext, const FloatRect&, const FloatRect& clipRect, NOESCAPE const Function<void(GraphicsContext&)>& applyAdditionalDestinationClip)
 {
+    // Workaround for a CG accelerated-drawing bug rdar://177036180: CGStyle filters fail if there's a
+    // non-rectangular clip, so apply the rounded clip in its own wrapping transparency layer.
+    if (applyAdditionalDestinationClip) {
+        destinationContext.save();
+        applyAdditionalDestinationClip(destinationContext);
+        destinationContext.beginTransparencyLayer(1);
+        m_beganOuterClipLayer = true;
+    }
+
     for (auto& filterStyle : m_filterStyles) {
         destinationContext.save();
         destinationContext.clip(intersection(filterStyle.imageRect, clipRect));
@@ -72,6 +81,12 @@ void TransparencyLayerContextSwitcher::endDrawSourceImage(GraphicsContext& desti
     for ([[maybe_unused]] auto& filterStyle : m_filterStyles) {
         destinationContext.endTransparencyLayer();
         destinationContext.restore();
+    }
+
+    if (m_beganOuterClipLayer) {
+        destinationContext.endTransparencyLayer();
+        destinationContext.restore();
+        m_beganOuterClipLayer = false;
     }
 
     if (m_beganOpacityLayer) {

--- a/Source/WebCore/platform/graphics/TransparencyLayerContextSwitcher.h
+++ b/Source/WebCore/platform/graphics/TransparencyLayerContextSwitcher.h
@@ -37,7 +37,7 @@ public:
     TransparencyLayerContextSwitcher(GraphicsContext& destinationContext, const FloatRect& sourceImageRect, RefPtr<Filter>&&);
 
 private:
-    void beginClipAndDrawSourceImage(GraphicsContext& destinationContext, const FloatRect& repaintRect, const FloatRect& clipRect) override;
+    void beginClipAndDrawSourceImage(GraphicsContext& destinationContext, const FloatRect& repaintRect, const FloatRect& clipRect, NOESCAPE const Function<void(GraphicsContext&)>& applyAdditionalDestinationClip) override;
     void endClipAndDrawSourceImage(GraphicsContext& destinationContext, const DestinationColorSpace& colorSpace) override { endDrawSourceImage(destinationContext, colorSpace); }
 
     void beginDrawSourceImage(GraphicsContext& destinationContext, float opacity = 1.f) override;
@@ -45,6 +45,7 @@ private:
 
     FilterStyleVector m_filterStyles;
     bool m_beganOpacityLayer { false };
+    bool m_beganOuterClipLayer { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -3234,7 +3234,6 @@ void RenderLayer::paint(GraphicsContext& context, const LayoutRect& damageRect, 
 
 void RenderLayer::clipToRect(GraphicsContext& context, GraphicsContextStateSaver& stateSaver, RegionContextStateSaver& regionContextStateSaver, const LayerPaintingInfo& paintingInfo, OptionSet<PaintBehavior> paintBehavior, const ClipRect& clipRect, BorderRadiusClippingRule rule)
 {
-    float deviceScaleFactor = renderer().document().deviceScaleFactor();
     bool needsClipping = !clipRect.isInfinite() && clipRect.rect() != paintingInfo.paintDirtyRect;
     if (needsClipping || clipRect.affectedByRadius())
         stateSaver.save();
@@ -3247,27 +3246,33 @@ void RenderLayer::clipToRect(GraphicsContext& context, GraphicsContextStateSaver
         regionContextStateSaver.pushClip(enclosingIntRect(snappedClipRect));
     }
 
-    if (clipRect.affectedByRadius()) {
-        // If the clip rect has been tainted by a border radius, then we have to walk up our layer chain applying the clips from
-        // any layers with overflow. The condition for being able to apply these clips is that the overflow object be in our
-        // containing block chain so we check that also.
-        for (RenderLayer* layer = rule == IncludeSelfForBorderRadius ? this : parent(); layer; layer = layer->parent()) {
-            if (paintBehavior.contains(PaintBehavior::CompositedOverflowScrollContent) && layer->usesCompositedScrolling())
-                break;
-        
-            if (layer->renderer().hasNonVisibleOverflow() && layer->renderer().style().border().hasBorderRadius() && ancestorLayerIsInContainingBlockChain(*layer)) {
-                auto adjustedClipRect = LayoutRect { LayoutPoint { layer->offsetFromAncestor(paintingInfo.rootLayer, AdjustForColumns) }, layer->rendererBorderBoxRect().size() };
-                adjustedClipRect.move(paintingInfo.subpixelOffset);
-                auto borderShape = BorderShape::shapeForBorderRect(layer->renderer().style(), adjustedClipRect);
-                if (borderShape.innerShapeContains(paintingInfo.paintDirtyRect))
-                    context.clip(snapRectToDevicePixels(intersection(paintingInfo.paintDirtyRect, adjustedClipRect), deviceScaleFactor));
-                else
-                    borderShape.clipToInnerShape(context, deviceScaleFactor);
-            }
-            
-            if (layer == paintingInfo.rootLayer)
-                break;
+    if (clipRect.affectedByRadius())
+        applyAncestorClippingForBorderRadius(context, paintingInfo, paintBehavior, rule);
+}
+
+void RenderLayer::applyAncestorClippingForBorderRadius(GraphicsContext& context, const LayerPaintingInfo& paintingInfo, OptionSet<PaintBehavior> paintBehavior, BorderRadiusClippingRule rule)
+{
+    float deviceScaleFactor = renderer().document().deviceScaleFactor();
+
+    // If the clip rect has been tainted by a border radius, then we have to walk up our layer chain applying the clips from
+    // any layers with overflow. The condition for being able to apply these clips is that the overflow object be in our
+    // containing block chain so we check that also.
+    for (RenderLayer* layer = rule == IncludeSelfForBorderRadius ? this : parent(); layer; layer = layer->parent()) {
+        if (paintBehavior.contains(PaintBehavior::CompositedOverflowScrollContent) && layer->usesCompositedScrolling())
+            break;
+
+        if (layer->renderer().hasNonVisibleOverflow() && layer->renderer().style().border().hasBorderRadius() && ancestorLayerIsInContainingBlockChain(*layer)) {
+            auto adjustedClipRect = LayoutRect { LayoutPoint { layer->offsetFromAncestor(paintingInfo.rootLayer, AdjustForColumns) }, layer->rendererBorderBoxRect().size() };
+            adjustedClipRect.move(paintingInfo.subpixelOffset);
+            auto borderShape = BorderShape::shapeForBorderRect(layer->renderer().style(), adjustedClipRect);
+            if (borderShape.innerShapeContains(paintingInfo.paintDirtyRect))
+                context.clip(snapRectToDevicePixels(intersection(paintingInfo.paintDirtyRect, adjustedClipRect), deviceScaleFactor));
+            else
+                borderShape.clipToInnerShape(context, deviceScaleFactor);
         }
+
+        if (layer == paintingInfo.rootLayer)
+            break;
     }
 }
 
@@ -3624,7 +3629,18 @@ GraphicsContext* RenderLayer::setupFilters(GraphicsContext& destinationContext, 
 
     auto rootRelativeBounds = calculateLayerBounds(paintingInfo.rootLayer, offsetFromRoot, { RenderLayer::PreserveAncestorFlags });
 
-    GraphicsContext* filterContext = paintingFilters->beginFilterEffect(renderer(), destinationContext, enclosingIntRect(rootRelativeBounds), enclosingIntRect(paintingInfo.paintDirtyRect), enclosingIntRect(filterRepaintRect), backgroundRect.rect());
+    // When the filter is applied via a transparency layer directly on the destination context (e.g. CG drop-shadow),
+    // the switcher doesn't consult applyFilters's clipToRect path, so the ancestor border-radius clip would be lost.
+    // Provide a callback that applies that rounded clip on the destination before the transparency layer begins.
+    Function<void(GraphicsContext&)> applyAdditionalDestinationClip;
+    if (backgroundRect.affectedByRadius()) {
+        applyAdditionalDestinationClip = [checkedThis = CheckedPtr { this }, &paintingInfo](GraphicsContext& context) {
+            checkedThis->applyAncestorClippingForBorderRadius(context, paintingInfo, paintingInfo.paintBehavior);
+        };
+    }
+
+    GraphicsContext* filterContext = paintingFilters->beginFilterEffect(renderer(), destinationContext, enclosingIntRect(rootRelativeBounds), enclosingIntRect(paintingInfo.paintDirtyRect), enclosingIntRect(filterRepaintRect),
+        backgroundRect.rect(), applyAdditionalDestinationClip);
     if (!filterContext)
         return nullptr;
 

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -1117,6 +1117,7 @@ private:
     LayoutRect clipRectRelativeToAncestor(const RenderLayer* ancestor, LayoutSize offsetFromAncestor, const LayoutRect& constrainingRect, bool temporaryClipRects = false) const;
 
     void clipToRect(GraphicsContext&, GraphicsContextStateSaver&, RegionContextStateSaver&, const LayerPaintingInfo&, OptionSet<PaintBehavior>, const ClipRect&, BorderRadiusClippingRule = IncludeSelfForBorderRadius);
+    void applyAncestorClippingForBorderRadius(GraphicsContext&, const LayerPaintingInfo&, OptionSet<PaintBehavior>, BorderRadiusClippingRule = IncludeSelfForBorderRadius);
 
     bool shouldRepaintAfterLayout() const;
 

--- a/Source/WebCore/rendering/RenderLayerFilters.cpp
+++ b/Source/WebCore/rendering/RenderLayerFilters.cpp
@@ -156,7 +156,7 @@ IntOutsets RenderLayerFilters::calculateOutsets(RenderElement& renderer, const F
     return CSSFilterRenderer::calculateOutsets(renderer, filter, targetBoundingBox);
 }
 
-GraphicsContext* RenderLayerFilters::beginFilterEffect(RenderElement& renderer, GraphicsContext& context, const LayoutRect& filterBoxRect, const LayoutRect& dirtyRect, const LayoutRect& layerRepaintRect, const LayoutRect& clipRect)
+GraphicsContext* RenderLayerFilters::beginFilterEffect(RenderElement& renderer, GraphicsContext& context, const LayoutRect& filterBoxRect, const LayoutRect& dirtyRect, const LayoutRect& layerRepaintRect, const LayoutRect& clipRect, NOESCAPE const Function<void(GraphicsContext&)>& applyAdditionalDestinationClip)
 {
     auto preferredFilterRenderingModes = renderer.page().preferredFilterRenderingModes(context);
     auto outsets = calculateOutsets(renderer, filterBoxRect);
@@ -236,7 +236,7 @@ GraphicsContext* RenderLayerFilters::beginFilterEffect(RenderElement& renderer, 
     if (!m_targetSwitcher)
         return nullptr;
 
-    m_targetSwitcher->beginClipAndDrawSourceImage(context, m_repaintRect, clipRect);
+    m_targetSwitcher->beginClipAndDrawSourceImage(context, m_repaintRect, clipRect, applyAdditionalDestinationClip);
 
     return m_targetSwitcher->drawingContext(context);
 }

--- a/Source/WebCore/rendering/RenderLayerFilters.h
+++ b/Source/WebCore/rendering/RenderLayerFilters.h
@@ -76,7 +76,7 @@ public:
     // Per render
     LayoutRect repaintRect() const { return m_repaintRect; }
 
-    GraphicsContext* beginFilterEffect(RenderElement&, GraphicsContext&, const LayoutRect& filterBoxRect, const LayoutRect& dirtyRect, const LayoutRect& layerRepaintRect, const LayoutRect& clipRect);
+    GraphicsContext* beginFilterEffect(RenderElement&, GraphicsContext&, const LayoutRect& filterBoxRect, const LayoutRect& dirtyRect, const LayoutRect& layerRepaintRect, const LayoutRect& clipRect, NOESCAPE const Function<void(GraphicsContext&)>& applyAdditionalDestinationClip = { });
     void applyFilterEffect(GraphicsContext& destinationContext);
 
 private:


### PR DESCRIPTION
#### b8414eccb3b1ca2bd5d48b490e51e0dbcd41bc01
<pre>
REGRESSION (303819@main): Child with filter:blur() ignores border radius overflow clipping
<a href="https://bugs.webkit.org/show_bug.cgi?id=312584">https://bugs.webkit.org/show_bug.cgi?id=312584</a>
<a href="https://rdar.apple.com/175519148">rdar://175519148</a>

Reviewed by Said Abou-Hallawa.

When using the TransparencyLayerContextSwitcher path for filters, we need to be able
to supply a complex clip for items clipped by border-radius on ancestors; this
requires running the code in `applyAncestorClippingForBorderRadius()` after
saving the graphics state, before starting the transparency layer, so factor
the code to allow this by passing a function to GraphicsContextSwitcher.

The previous attempt to fix this (312531@main) was reverted for causing rendering
regressions of youtube buttons and on wayfair.com; this turned out to be a Core Graphics
accelerated rendering bug (<a href="https://rdar.apple.com/177036180">rdar://177036180</a>) which we work around by applying the
rounded clip in an outer transparency layer. `grayscale-clip-border-radius.html` tests
this workaround.

Tests: imported/w3c/web-platform-tests/css/filter-effects/blur-clip-border-radius-ref.html
       imported/w3c/web-platform-tests/css/filter-effects/blur-clip-border-radius.html
       imported/w3c/web-platform-tests/css/filter-effects/grayscale-clip-border-radius-ref.html
       imported/w3c/web-platform-tests/css/filter-effects/grayscale-clip-border-radius.html

* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/blur-clip-border-radius-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/blur-clip-border-radius-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/blur-clip-border-radius.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/grayscale-clip-border-radius-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/grayscale-clip-border-radius-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/grayscale-clip-border-radius.html: Added.
* Source/WebCore/platform/graphics/GraphicsContextSwitcher.h:
(WebCore::GraphicsContextSwitcher::beginClipAndDrawSourceImage):
* Source/WebCore/platform/graphics/ImageBufferContextSwitcher.cpp:
(WebCore::ImageBufferContextSwitcher::beginClipAndDrawSourceImage):
* Source/WebCore/platform/graphics/ImageBufferContextSwitcher.h:
* Source/WebCore/platform/graphics/TransparencyLayerContextSwitcher.cpp:
(WebCore::TransparencyLayerContextSwitcher::beginClipAndDrawSourceImage):
(WebCore::TransparencyLayerContextSwitcher::endDrawSourceImage):
* Source/WebCore/platform/graphics/TransparencyLayerContextSwitcher.h:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::clipToRect):
(WebCore::RenderLayer::applyAncestorClippingForBorderRadius):
(WebCore::RenderLayer::setupFilters):
* Source/WebCore/rendering/RenderLayer.h:
* Source/WebCore/rendering/RenderLayerFilters.cpp:
(WebCore::RenderLayerFilters::beginFilterEffect):
* Source/WebCore/rendering/RenderLayerFilters.h:

Canonical link: <a href="https://commits.webkit.org/313267@main">https://commits.webkit.org/313267@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b0b0160e8366b90b1500545fc73d30108ed5a7b7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162479 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35955 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29072 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171417 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118924 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0080856b-c763-477e-8524-8bd12ac3790c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164348 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36059 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35959 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126094 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/859ae31e-1af1-46c4-98bb-3fe60274687a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165438 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28439 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145960 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106672 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/89b8b0eb-393b-4d55-bcda-31003eafa499) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27485 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26011 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19117 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137189 "Found 2 new API test failures: TestWebKitAPI.WKAttachmentTestsIOS.InsertPastedContactAsAttachment, TestWebKitAPI.WKAttachmentTestsIOS.PasteRichTextCopiedFromNotes (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23690 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173921 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21234 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25334 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134402 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35629 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30102 "Found 1 new test failure: imported/w3c/web-platform-tests/IndexedDB/interleaved-cursors-small.any.serviceworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134401 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36290 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35613 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145486 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97876 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28934 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22319 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35122 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102874 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34624 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34869 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34772 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->