### PR TITLE
[model] Remove dead imports in GPUProcess model source

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift
@@ -29,7 +29,6 @@ import WebKit
 @_spi(RealityCoreRendererAPI) import RealityKit
 import USDKit
 @_spi(SwiftAPI) import DirectResource
-import _USDKit_RealityKit
 import ShaderGraph
 #endif
 

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelIBLTextures.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelIBLTextures.swift
@@ -27,7 +27,6 @@ import Metal
 import USDKit
 @_spi(UsdLoaderAPI) import _USDKit_RealityKit
 @_spi(RealityCoreRendererAPI) import RealityKit
-@_spi(RealityCoreTextureProcessingAPI) import RealityKit
 
 class IBLTextures {
     static func loadIBLTextures(


### PR DESCRIPTION
#### 2abe3122be3f832e283c6418f996af3b263c7a5e
<pre>
[model] Remove dead imports in GPUProcess model source
<a href="https://bugs.webkit.org/show_bug.cgi?id=314786">https://bugs.webkit.org/show_bug.cgi?id=314786</a>
<a href="https://rdar.apple.com/177039712">rdar://177039712</a>

Reviewed by Mike Wyrzykowski.

Remove two dead imports:

- ModelBridge.swift: plain `import _USDKit_RealityKit` duplicates the
  `@_spi(UsdLoaderAPI)` import above it (SPI import is a superset).

- ModelIBLTextures.swift: `@_spi(RealityCoreTextureProcessingAPI) import
  RealityKit` has been dead since the file&apos;s first commit - the file body
  references zero RealityCoreTextureProcessing types.

* Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift:
* Source/WebKit/GPUProcess/graphics/Model/ModelIBLTextures.swift:

Canonical link: <a href="https://commits.webkit.org/313299@main">https://commits.webkit.org/313299@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0511deb2f3ce5e569fa74a3f4a250ffe22afc5a2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162480 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35956 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29073 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171418 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118925 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36060 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35960 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126095 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88836 "1 flakes 18 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165439 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28441 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145961 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106673 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27487 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26012 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19118 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137191 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173922 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21235 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25335 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134403 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35630 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30217 "Found 2 new test failures: http/tests/ssl/applepay/ApplePayButton.html imported/w3c/web-platform-tests/IndexedDB/interleaved-cursors-small.any.serviceworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134402 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36310 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35614 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145487 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97880 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28935 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22320 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35123 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102875 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34625 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34870 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34773 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->