### PR TITLE
[css-grid] Nested CSS Subgrid with overflow:hidden clips content on subsequent items

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/sibling-nested-subgrids-overflow-hidden-contribution-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/sibling-nested-subgrids-overflow-hidden-contribution-expected.txt
@@ -1,0 +1,12 @@
+Top
+
+Long text long enough to wrap onto multiple lines so that overflow:hidden can clip the overflowing portion
+Top
+
+Long text long enough to wrap onto multiple lines so that overflow:hidden can clip the overflowing portion
+Top
+
+Long text long enough to wrap onto multiple lines so that overflow:hidden can clip the overflowing portion
+
+PASS Sibling nested subgrids with overflow:hidden leaves must size their rows identically
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/sibling-nested-subgrids-overflow-hidden-contribution.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/sibling-nested-subgrids-overflow-hidden-contribution.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<title>CSS Grid Test: Sibling nested subgrids with overflow:hidden leaf contribute equally to their tracks</title>
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#subgrid-item-contribution">
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#subgrids">
+<meta name="assert" content="Test passes if the row heights of nested-subgrid leaves with overflow:hidden are identical across sibling subgrids, regardless of each sibling's position in the outer grid. This test only checks row sizing; column sizing is not exercised.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+.grid {
+    display: grid;
+    gap: 16px;
+    width: 400px;
+}
+.card {
+    border: 1px solid black;
+    display: grid;
+    grid-template-rows: subgrid;
+    grid-row: span 3;
+    row-gap: 0;
+}
+.content {
+    display: grid;
+    grid-template-rows: subgrid;
+    grid-row: span 2;
+    padding: 16px;
+}
+.footer {
+    overflow: hidden;
+}
+</style>
+</head>
+<body>
+<div class="grid">
+    <div class="card">
+        <h2>Top</h2>
+        <div class="content">
+            <div class="footer" id="f1">
+                Long text long enough to wrap onto multiple lines so that overflow:hidden can clip the overflowing portion
+            </div>
+        </div>
+    </div>
+    <div class="card">
+        <h2>Top</h2>
+        <div class="content">
+            <div class="footer" id="f2">
+                Long text long enough to wrap onto multiple lines so that overflow:hidden can clip the overflowing portion
+            </div>
+        </div>
+    </div>
+    <div class="card">
+        <h2>Top</h2>
+        <div class="content">
+            <div class="footer" id="f3">
+                Long text long enough to wrap onto multiple lines so that overflow:hidden can clip the overflowing portion
+            </div>
+        </div>
+    </div>
+</div>
+<script>
+test(() => {
+    const h1 = document.getElementById("f1").getBoundingClientRect().height;
+    const h2 = document.getElementById("f2").getBoundingClientRect().height;
+    const h3 = document.getElementById("f3").getBoundingClientRect().height;
+    assert_equals(h2, h1, "Second card's .footer height matches the first's");
+    assert_equals(h3, h1, "Third card's .footer height matches the first's");
+}, "Sibling nested subgrids with overflow:hidden leaves must size their rows identically");
+</script>
+</body>
+</html>

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -1669,7 +1669,7 @@ static std::optional<LayoutUnit> extraMarginFromSubgridAncestorGutters(const Ren
 
         if (gridItemSpanInAncestor.startLine())
             gutterTotal += (currentAncestorSubgrid.gridGap(direction) - currentAncestorSubgridParent->gridGap(direction)) / 2;
-        if (itemSpan.endLine() != numTracksForCurrentAncestor)
+        if (gridItemSpanInAncestor.endLine() != numTracksForCurrentAncestor)
             gutterTotal += (currentAncestorSubgrid.gridGap(direction) - currentAncestorSubgridParent->gridGap(direction)) / 2;
         direction = GridLayoutFunctions::flowAwareDirectionForParent(currentAncestorSubgrid, *currentAncestorSubgridParent, direction);
     }


### PR DESCRIPTION
#### fa6448eb65a4ff24ace8e7b4f7b896127ffd929c
<pre>
[css-grid] Nested CSS Subgrid with overflow:hidden clips content on subsequent items
<a href="https://bugs.webkit.org/show_bug.cgi?id=313648">https://bugs.webkit.org/show_bug.cgi?id=313648</a>
<a href="https://rdar.apple.com/175877530">rdar://175877530</a>

Reviewed by Elika Etemad.

extraMarginFromSubgridAncestorGutters() walks an item&apos;s ancestor subgrid
chain and, at each ancestor&apos;s internal boundaries, adds half the
gutter-size difference between that ancestor and its parent to the
track.

The start-line check correctly used gridItemSpanInAncestor (ancestor-
local coords), but the end-line check compared itemSpan.endLine()
(outermost-grid coords) against the ancestor&apos;s local track count. For
any sibling subgrid after the first — whose outer-grid start line is
non-zero — the two sides live in different coordinate spaces and the
check fires spuriously, shifting the row&apos;s margin + border + padding
(MBP) floor by (subgridGap − parentGap) / 2.

Content contributions normally outrun this floor and hide the defect.
When a leaf uses overflow:hidden its automatic minimum resolves to
zero, the MBP floor becomes dominant, and the shift surfaces as
vertical clipping in every card after the first.

This patch fixes by evaluating the end-line check in ancestor-local
coords via gridItemSpanInAncestor.endLine(), matching the start-line
branch and GridLayoutFunctions::extraMarginForSubgrid.

Test: imported/w3c/web-platform-tests/css/css-grid/subgrid/sibling-nested-subgrids-overflow-hidden-contribution.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/sibling-nested-subgrids-overflow-hidden-contribution-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/sibling-nested-subgrids-overflow-hidden-contribution.html: Added.
* Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp:
(WebCore::extraMarginFromSubgridAncestorGutters):

Canonical link: <a href="https://commits.webkit.org/313503@main">https://commits.webkit.org/313503@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f5782de74d9c9e6a3adfbf1f68eb507e2975a8f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162893 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36371 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29537 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171831 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119339 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4ce562bc-3f26-48ec-b6a7-b6082a973064) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164762 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36833 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36373 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126446 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89135 "3 flakes 18 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/54c41596-5b23-43f8-b673-96e8833cb7aa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165852 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28889 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146378 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107023 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c6f0108a-80b2-40d6-902c-b85803808c0f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27935 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26374 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19531 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137826 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24107 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174335 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/22066 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25753 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134756 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36043 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30477 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134751 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36416 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37022 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145903 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98460 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30216 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22740 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35537 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/103804 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35038 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/762 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35283 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35186 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->