### PR TITLE
[JSC] Support Inlined InternalMicrotask reaction with Promise

### DIFF
--- a/JSTests/stress/dynamic-import-inline-microtask-result-promise.js
+++ b/JSTests/stress/dynamic-import-inline-microtask-result-promise.js
@@ -1,0 +1,92 @@
+// Regression test for performPromiseThenWithInternalMicrotask taking the
+// inline-reaction fast path when a result JSPromise* is supplied. The result
+// promise is stashed in JSPromise's payloadCell and must be recovered in
+// settleInlineInternalMicrotask (and spillInlineReaction) so the result
+// promise observed by JS resolves/rejects with the right value.
+//
+// The user-visible path is JSModuleLoader::loadModule wiring up
+// ModuleLoadLinkEvaluateSettled — i.e. every dynamic import() call.
+
+var abort = $vm.abort;
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("expected " + String(expected) + ", got " + String(actual));
+}
+
+(async function () {
+    {
+        const m = await import('./import-tests/cocoa.js');
+        shouldBe(m.hello(), 42);
+        shouldBe(typeof m.Cocoa, 'function');
+    }
+
+    // Re-import: a fresh resultPromise is allocated and routed through the
+    // inline path on every call, even when the underlying module is cached.
+    {
+        const a = await import('./import-tests/cocoa.js');
+        const b = await import('./import-tests/cocoa.js');
+        const c = await import('./import-tests/cocoa.js');
+        shouldBe(a, b);
+        shouldBe(b, c);
+    }
+
+    // Many concurrent imports of the same module: each gets its own pending
+    // intermediate promise + inline reaction. If the inline payloadCell were
+    // aliased or overwritten across imports, some awaits would see undefined
+    // or the wrong namespace.
+    {
+        const promises = [];
+        for (let i = 0; i < 64; ++i)
+            promises.push(import('./import-tests/cocoa.js'));
+        const results = await Promise.all(promises);
+        for (const r of results)
+            shouldBe(r.hello(), 42);
+    }
+
+    // Concurrent imports of distinct modules — the per-import resultPromise
+    // stashed in payloadCell must not leak across imports.
+    {
+        const [cocoa, should] = await Promise.all([
+            import('./import-tests/cocoa.js'),
+            import('./import-tests/should.js'),
+        ]);
+        shouldBe(cocoa.hello(), 42);
+        shouldBe(typeof should.shouldBe, 'function');
+    }
+
+    // Nested dynamic import (import() invoked from inside an imported module)
+    // — exercises the inline path on a different referrer.
+    {
+        const multiple = await import('./import-tests/multiple.js');
+        const inner = await multiple.result();
+        shouldBe(typeof inner, 'object');
+    }
+
+    // Failure path: the resultPromise must reject with the load error rather
+    // than resolve with undefined.
+    {
+        let err = null;
+        try {
+            await import('./this-module-does-not-exist.js');
+        } catch (e) {
+            err = e;
+        }
+        if (err === null)
+            throw new Error('missing module did not reject');
+    }
+
+    // Interleave: kick off a failing import and a successful import together;
+    // both resultPromises sit in their own payloadCell slot and must settle
+    // independently with the right outcome.
+    {
+        const ok = import('./import-tests/cocoa.js');
+        const bad = import('./this-module-does-not-exist.js').then(
+            () => { throw new Error('bad import resolved'); },
+            e => 'rejected'
+        );
+        const [okValue, badValue] = await Promise.all([ok, bad]);
+        shouldBe(okValue.hello(), 42);
+        shouldBe(badValue, 'rejected');
+    }
+}()).then(() => {}, abort);

--- a/Source/JavaScriptCore/runtime/CyclicModuleRecord.cpp
+++ b/Source/JavaScriptCore/runtime/CyclicModuleRecord.cpp
@@ -490,7 +490,7 @@ void CyclicModuleRecord::executeAsync(JSGlobalObject* globalObject)
     // 7. Let onRejected be CreateBuiltinFunction(rejectedClosure, 0, "", « »).
     // Also handled in JSMicrotask.cpp.
     // 8. Perform PerformPromiseThen(capability.[[Promise]], onFulfilled, onRejected).
-    promise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::AsyncModuleExecutionDone, jsUndefined(), this);
+    promise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::AsyncModuleExecutionDone, nullptr, this);
     // 9. Perform ! module.ExecuteModule(capability).
     execute(globalObject, promise);
     RETURN_IF_EXCEPTION(scope, void());

--- a/Source/JavaScriptCore/runtime/JSMicrotask.cpp
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.cpp
@@ -1441,7 +1441,7 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
         if (!promiseSpeciesWatchpointIsValid(vm, promise)) [[unlikely]]
             RELEASE_AND_RETURN(scope, promiseResolveThenableJobWithInternalMicrotaskFastSlow(globalObject, promise, task, context));
 
-        promise->performPromiseThenWithInternalMicrotask(vm, globalObject, task, jsUndefined(), context);
+        promise->performPromiseThenWithInternalMicrotask(vm, globalObject, task, nullptr, context);
         return;
     }
 

--- a/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
+++ b/Source/JavaScriptCore/runtime/JSModuleLoader.cpp
@@ -720,7 +720,7 @@ JSPromise* JSModuleLoader::loadModule(JSGlobalObject* globalObject, const Module
     resultPromise->markAsHandled();
 
     promise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::ModuleLoadLinkEvaluateSettled, resultPromise, context);
-    resultPromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::ModuleLoadStoreError, jsUndefined(), context);
+    resultPromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::ModuleLoadStoreError, nullptr, context);
 
     return resultPromise;
 }
@@ -778,7 +778,7 @@ void JSModuleLoader::innerModuleLoading(JSGlobalObject* globalObject, ModuleGrap
                 ASSERT(module->loadedModules().size() <= loadedModulesCountBefore + 1);
                 ASSERT(needsErrorReaction != module->loadedModules().contains(ModuleMapKey { request.m_specifier.impl(), request.type() }));
                 if (needsErrorReaction)
-                    promise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::ModuleGraphLoadingError, jsUndefined(), state);
+                    promise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::ModuleGraphLoadingError, nullptr, state);
             }
             // 2.d.iv. If state.[[IsLoading]] is false, return UNUSED.
             if (!state->isLoading())

--- a/Source/JavaScriptCore/runtime/JSPromise.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromise.cpp
@@ -237,7 +237,7 @@ JSPromise* JSPromise::rejectWithCaughtException(JSGlobalObject* globalObject, Th
     return this;
 }
 
-void JSPromise::setInlineMicrotaskReaction(VM& vm, InternalMicrotask task, JSValue context)
+void JSPromise::setInlineMicrotaskReaction(VM& vm, InternalMicrotask task, JSPromise* promise, JSValue context)
 {
     ASSERT(status() == Status::Pending);
     ASSERT(inlineReactionKind() == InlineReactionKind::None);
@@ -249,7 +249,7 @@ void JSPromise::setInlineMicrotaskReaction(VM& vm, InternalMicrotask task, JSVal
         | (static_cast<uint16_t>(InlineReactionKind::InternalMicrotask) << inlineReactionKindShift)
         | (static_cast<uint16_t>(task) << inlineReactionMicrotaskShift);
     setSlot(vm, context);
-    setFlags(newFlags);
+    setPackedCell(vm, newFlags, promise);
 }
 
 void JSPromise::setInlineHandlerReaction(VM& vm, InlineReactionKind kind, JSPromise* resultPromise, JSValue handler)
@@ -275,7 +275,8 @@ JSPromiseReaction* JSPromise::spillInlineReaction(VM& vm)
     case InlineReactionKind::InternalMicrotask: {
         InternalMicrotask task = inlineReactionMicrotask();
         JSValue context = m_slot.get();
-        reaction = JSSlimPromiseReaction::create(vm, jsUndefined(), task, context, nullptr);
+        auto* promise = uncheckedDowncast<JSPromise>(payloadCell());
+        reaction = JSSlimPromiseReaction::create(vm, promise ? JSValue(promise) : jsUndefined(), task, context, nullptr);
         break;
     }
     case InlineReactionKind::FulfillHandler:
@@ -373,16 +374,17 @@ void JSPromise::performPromiseThen(VM& vm, JSGlobalObject* globalObject, JSValue
     }
 }
 
-void JSPromise::performPromiseThenWithInternalMicrotask(VM& vm, JSGlobalObject* globalObject, InternalMicrotask task, JSValue promise, JSValue context)
+void JSPromise::performPromiseThenWithInternalMicrotask(VM& vm, JSGlobalObject* globalObject, InternalMicrotask task, JSPromise* promise, JSValue context)
 {
+    JSValue promiseValue = promise ? JSValue(promise) : jsUndefined();
     switch (status()) {
     case JSPromise::Status::Pending: {
-        if (promise.isUndefined() && inlineReactionKind() == InlineReactionKind::None && !payloadCell()) [[likely]] {
-            setInlineMicrotaskReaction(vm, task, context);
+        if (inlineReactionKind() == InlineReactionKind::None && !payloadCell()) [[likely]] {
+            setInlineMicrotaskReaction(vm, task, promise, context);
             break;
         }
         JSPromiseReaction* existing = reactionHead(vm);
-        auto* reaction = JSSlimPromiseReaction::create(vm, promise, task, context, existing);
+        auto* reaction = JSSlimPromiseReaction::create(vm, promiseValue, task, context, existing);
         setPackedCell(vm, flags() | isHandledFlag, reaction);
         break;
     }
@@ -390,13 +392,13 @@ void JSPromise::performPromiseThenWithInternalMicrotask(VM& vm, JSGlobalObject* 
         JSValue settled = settlementValue();
         if (!isHandled())
             globalObject->globalObjectMethodTable()->promiseRejectionTracker(globalObject, this, JSPromiseRejectionOperation::Handle);
-        globalObject->queueMicrotask(vm, task, static_cast<uint8_t>(Status::Rejected), promise, settled, context);
+        globalObject->queueMicrotask(vm, task, static_cast<uint8_t>(Status::Rejected), promiseValue, settled, context);
         markAsHandled();
         break;
     }
     case JSPromise::Status::Fulfilled: {
         JSValue settled = settlementValue();
-        globalObject->queueMicrotask(vm, task, static_cast<uint8_t>(Status::Fulfilled), promise, settled, context);
+        globalObject->queueMicrotask(vm, task, static_cast<uint8_t>(Status::Fulfilled), promiseValue, settled, context);
         break;
     }
     }
@@ -431,10 +433,12 @@ ALWAYS_INLINE void JSPromise::settleInlineInternalMicrotask(VM& vm, JSGlobalObje
     ASSERT(flagsSnapshot & isHandledFlag);
     InternalMicrotask task = static_cast<InternalMicrotask>((flagsSnapshot & inlineReactionMicrotaskMask) >> inlineReactionMicrotaskShift);
     JSValue context = m_slot.get();
+    auto* promise = uncheckedDowncast<JSPromise>(payloadCell());
+    JSValue promiseValue = promise ? JSValue(promise) : jsUndefined();
     uint16_t settledFlags = (flagsSnapshot & ~(inlineReactionKindMask | inlineReactionMicrotaskMask)) | static_cast<uint16_t>(newStatus);
     setSlot(vm, argument);
     setPackedCell(vm, settledFlags, nullptr);
-    globalObject->queueMicrotask(vm, task, static_cast<uint8_t>(newStatus), jsUndefined(), argument, context);
+    globalObject->queueMicrotask(vm, task, static_cast<uint8_t>(newStatus), promiseValue, argument, context);
 }
 
 ALWAYS_INLINE void JSPromise::settleInlineHandler(VM& vm, JSGlobalObject* globalObject, Status newStatus, JSValue argument, uint16_t flagsSnapshot)
@@ -783,7 +787,7 @@ void JSPromise::resolveWithInternalMicrotaskForAsyncAwait(JSGlobalObject* global
     if (resolution.inherits<JSPromise>()) {
         auto* promise = uncheckedDowncast<JSPromise>(resolution);
         if (promiseSpeciesWatchpointIsValid(vm, promise)) [[likely]]
-            return promise->performPromiseThenWithInternalMicrotask(vm, globalObject, task, jsUndefined(), context);
+            return promise->performPromiseThenWithInternalMicrotask(vm, globalObject, task, nullptr, context);
 
         JSValue constructor;
         JSValue error;
@@ -807,7 +811,7 @@ void JSPromise::resolveWithInternalMicrotaskForAsyncAwait(JSGlobalObject* global
         }
 
         if (constructor == globalObject->promiseConstructor())
-            return promise->performPromiseThenWithInternalMicrotask(vm, globalObject, task, jsUndefined(), context);
+            return promise->performPromiseThenWithInternalMicrotask(vm, globalObject, task, nullptr, context);
     }
 
     resolveWithInternalMicrotask(globalObject, vm, resolution, task, context);

--- a/Source/JavaScriptCore/runtime/JSPromise.h
+++ b/Source/JavaScriptCore/runtime/JSPromise.h
@@ -155,7 +155,7 @@ public:
     static void rejectWithInternalMicrotask(VM&, JSGlobalObject*, JSValue argument, InternalMicrotask, JSValue context);
     static void fulfillWithInternalMicrotask(VM&, JSGlobalObject*, JSValue argument, InternalMicrotask, JSValue context);
 
-    void performPromiseThenWithInternalMicrotask(VM&, JSGlobalObject*, InternalMicrotask, JSValue promise, JSValue context);
+    void performPromiseThenWithInternalMicrotask(VM&, JSGlobalObject*, InternalMicrotask, JSPromise*, JSValue context);
 
     bool isThenFastAndNonObservable();
 
@@ -216,8 +216,8 @@ private:
     void setSlot(VM& vm, JSValue value) { m_slot.set(vm, this, value); }
     void clearSlot() { m_slot.clear(); }
 
-    void setInlineMicrotaskReaction(VM&, InternalMicrotask, JSValue context);
-    void setInlineHandlerReaction(VM&, InlineReactionKind, JSPromise* resultPromise, JSValue handler);
+    void setInlineMicrotaskReaction(VM&, InternalMicrotask, JSPromise*, JSValue context);
+    void setInlineHandlerReaction(VM&, InlineReactionKind, JSPromise*, JSValue handler);
     JSPromiseReaction* spillInlineReaction(VM&);
     JSPromiseReaction* reactionHead(VM&);
     void settleInlineInternalMicrotask(VM&, JSGlobalObject*, Status, JSValue argument, uint16_t flags);

--- a/Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp
@@ -453,7 +453,7 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyCompileStreamingFunc, (JSGlobalObject* globa
     JSPromise* sourcePromise = JSPromise::resolvedPromise(globalObject, callFrame->argument(0));
     RETURN_IF_EXCEPTION(scope, JSValue::encode(promise->rejectWithCaughtException(globalObject, scope)));
 
-    sourcePromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::WebAssemblyCompileStreaming, jsUndefined(), context);
+    sourcePromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::WebAssemblyCompileStreaming, nullptr, context);
     return JSValue::encode(promise);
 }
 
@@ -497,7 +497,7 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyInstantiateStreamingFunc, (JSGlobalObject* g
     JSPromise* sourcePromise = JSPromise::resolvedPromise(globalObject, callFrame->argument(0));
     RETURN_IF_EXCEPTION(scope, JSValue::encode(promise->rejectWithCaughtException(globalObject, scope)));
 
-    sourcePromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::WebAssemblyInstantiateStreaming, jsUndefined(), context);
+    sourcePromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::WebAssemblyInstantiateStreaming, nullptr, context);
     return JSValue::encode(promise);
 }
 


### PR DESCRIPTION
#### 8f742098b444303d409e7b87ea10cf42cafaa5a7
<pre>
[JSC] Support Inlined InternalMicrotask reaction with Promise
<a href="https://bugs.webkit.org/show_bug.cgi?id=314788">https://bugs.webkit.org/show_bug.cgi?id=314788</a>
<a href="https://rdar.apple.com/177040942">rdar://177040942</a>

Reviewed by Sosuke Suzuki.

313220@main now offers yet another JSCell* space in JSPromise, thus we
can just store JSPromise* as well when adding inline InternalMicrotask
reaction. This patch supports it and now all InternalMicrotask reaction
can be inlined when it is only one reaction in the promise.

Test: JSTests/stress/dynamic-import-inline-microtask-result-promise.js

* JSTests/stress/dynamic-import-inline-microtask-result-promise.js: Added.
(shouldBe):
(async const):
(catch):
(err.null.throw.new.Error):
(then):
* Source/JavaScriptCore/runtime/CyclicModuleRecord.cpp:
(JSC::CyclicModuleRecord::executeAsync):
* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::runInternalMicrotask):
* Source/JavaScriptCore/runtime/JSModuleLoader.cpp:
(JSC::JSModuleLoader::loadModule):
(JSC::JSModuleLoader::innerModuleLoading):
* Source/JavaScriptCore/runtime/JSPromise.cpp:
(JSC::JSPromise::setInlineMicrotaskReaction):
(JSC::JSPromise::spillInlineReaction):
(JSC::JSPromise::performPromiseThenWithInternalMicrotask):
(JSC::JSPromise::settleInlineInternalMicrotask):
(JSC::JSPromise::resolveWithInternalMicrotaskForAsyncAwait):
* Source/JavaScriptCore/runtime/JSPromise.h:
* Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/313230@main">https://commits.webkit.org/313230@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da1ea4d5cd9c902a199024b4f15c175d182ec0ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162491 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35967 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29085 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171429 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/118936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36071 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35971 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126104 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/118936 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165450 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28449 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145969 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106682 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5c7569f0-406e-4803-9ae1-be38f7f7aaf0) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27495 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26021 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19129 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137199 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23699 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173933 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23330 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21246 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25343 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134412 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35641 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30112 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134410 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35625 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145495 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97896 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24685 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28944 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/22328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194891 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35134 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102886 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/50370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34636 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34881 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34784 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->