### PR TITLE
WKBackForwardList.BackForwardNavigationSkipsItemsWithoutUserGesture* API tests are flaky

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKBackForwardListTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKBackForwardListTests.mm
@@ -32,6 +32,7 @@
 #import "Helpers/cocoa/TestNavigationDelegate.h"
 #import "Helpers/cocoa/TestUIDelegate.h"
 #import "Helpers/cocoa/TestWKWebView.h"
+#import "TestURLSchemeHandler.h"
 #import <WebKit/WKBackForwardListItemPrivate.h>
 #import <WebKit/WKBackForwardListPrivate.h>
 #import <WebKit/WKNavigationDelegatePrivate.h>
@@ -43,6 +44,7 @@
 #import <WebKit/_WKProcessPoolConfiguration.h>
 #import <WebKit/_WKSessionState.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/cocoa/SpanCocoa.h>
 #import <wtf/darwin/DispatchExtras.h>
 #import <wtf/text/MakeString.h>
 #import <wtf/text/WTFString.h>
@@ -392,7 +394,6 @@ TEST(WKBackForwardList, InteractionStateRestorationMultipleItems)
 
 @interface WKBackForwardNavigationDelegate : NSObject <WKNavigationDelegatePrivate>
 - (void)waitForDidFinishNavigationOrDidSameDocumentNavigation;
-- (BOOL)waitForDidFinishNavigationOrDidSameDocumentNavigationWithTimeout:(NSTimeInterval)seconds;
 @end
 
 static RetainPtr<WKNavigation> lastNavigation;
@@ -433,12 +434,6 @@ static RetainPtr<WKNavigation> lastNavigation;
 {
     _navigated = false;
     TestWebKitAPI::Util::run(&_navigated);
-}
-
-- (BOOL)waitForDidFinishNavigationOrDidSameDocumentNavigationWithTimeout:(NSTimeInterval)seconds
-{
-    _navigated = false;
-    return TestWebKitAPI::Util::runFor(&_navigated, Seconds { seconds });
 }
 
 - (void)waitForDidFinishNavigation
@@ -529,170 +524,235 @@ TEST(WKBackForwardList, BackSwipeNavigationDoesNotSkipItemsWithUserGesture)
     EXPECT_EQ([webView backForwardList].forwardList.count, 1U);
 }
 
-static void runBackForwardNavigationSkipsItemsWithoutUserGestureTest(Function<void(WKWebView *, ASCIILiteral destination)>&& navigate)
-{
-    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
+struct SkipItemsBackForwardListFixture {
+    RetainPtr<WKWebView> webView;
+    RetainPtr<WKBackForwardNavigationDelegate> navigationDelegate;
+    RetainPtr<NSURL> url1;
+    RetainPtr<NSURL> url2;
+    RetainPtr<NSURL> url3;
+};
 
+// Builds the back/forward list:
+// url1 -> url2 -> url2#a (no user gesture) -> url2#b (no user gesture) -> url2#c (no user gesture) -> url3 **
+static SkipItemsBackForwardListFixture setupBackForwardListWithItemsWithoutUserGesture(NOESCAPE Function<void(WKWebView *, ASCIILiteral destination)>&& navigate)
+{
+    static RetainPtr url1 = adoptNS([[NSURL alloc] initWithString:@"test://example/simple.html"]);
+    static RetainPtr url2 = adoptNS([[NSURL alloc] initWithString:@"test://example/simple2.html"]);
+    static RetainPtr url3 = adoptNS([[NSURL alloc] initWithString:@"test://example/simple3.html"]);
+
+    // Build a single shared WKWebViewConfiguration once: the URL scheme handler (with
+    // pre-built per-URL responses), a shared WKProcessPool so WebProcesses get cached
+    // across fixtures and --gtest_repeat iterations, and a shared ephemeral
+    // WKWebsiteDataStore so cookies/cache stay in memory (avoiding disk I/O entirely).
+    static RetainPtr configuration = ([] {
+        static constexpr auto htmlBytes = "<html><body>simple</body></html>"_s;
+        RetainPtr data = toNSDataNoCopy(htmlBytes.span8(), FreeWhenDone::No);
+        auto makeResponse = [&data](NSURL *url) {
+            return adoptNS([[NSURLResponse alloc] initWithURL:url MIMEType:@"text/html" expectedContentLength:[data length] textEncodingName:nil]);
+        };
+        RetainPtr<NSDictionary> responseByURL = adoptNS([[NSDictionary alloc] initWithObjectsAndKeys:
+            makeResponse(url1.get()).get(), url1.get(),
+            makeResponse(url2.get()).get(), url2.get(),
+            makeResponse(url3.get()).get(), url3.get(),
+            nil]);
+
+        RetainPtr schemeHandler = adoptNS([[TestURLSchemeHandler alloc] init]);
+        [schemeHandler setStartURLSchemeTaskHandler:^(WKWebView *, id<WKURLSchemeTask> task) {
+            [task didReceiveResponse:[responseByURL objectForKey:[[task request] URL]]];
+            [task didReceiveData:data.get()];
+            [task didFinish];
+        }];
+
+        RetainPtr config = adoptNS([[WKWebViewConfiguration alloc] init]);
+        [config setURLSchemeHandler:schemeHandler.get() forURLScheme:@"test"];
+        [config setProcessPool:adoptNS([WKProcessPool new]).get()];
+        [config setWebsiteDataStore:[WKWebsiteDataStore nonPersistentDataStore]];
+        return config;
+    }());
+
+    RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+    [webView _launchInitialProcessIfNecessary];
     RetainPtr navigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
     webView.get().navigationDelegate = navigationDelegate.get();
 
-    RetainPtr url1 = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
-    RetainPtr url2 = [NSBundle.test_resourcesBundle URLForResource:@"simple2" withExtension:@"html"];
-    RetainPtr url3 = [NSBundle.test_resourcesBundle URLForResource:@"simple3" withExtension:@"html"];
-
-    // Waits for the navigation delegate to see didFinishNavigation or didSameDocumentNavigation,
-    // with a finite timeout so that a rare hang (webkit.org/b/313844) surfaces as a fast EXPECT
-    // failure with the context we were waiting for rather than a silent test-framework timeout.
-    // Returns false on timeout so callers can bail out before the next wait also times out,
-    // keeping total runtime bounded.
-    auto waitForNavigation = [&](const char* context) -> bool {
-        if ([navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigationWithTimeout:10])
-            return true;
-        NSLog(@"WKBackForwardNavigationDelegate wait timed out (%s); webView.URL = %@", context, [webView URL]);
-        EXPECT_TRUE(false);
-        return false;
-    };
-
     [webView loadRequest:[NSURLRequest requestWithURL:url1.get()]];
-    if (!waitForNavigation("loadRequest url1"))
-        return;
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
 
     [webView loadRequest:[NSURLRequest requestWithURL:url2.get()]];
-    if (!waitForNavigation("loadRequest url2"))
-        return;
-
-    // Test case:
-    // url1 -> url2 -> url2#a (no user gesture) -> url2#b (no user gesture) -> url2#c (no user gesture) -> url3.
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
 
     // Add back/forward list items without user gestures.
     navigate(webView.get(), "location.pathname + '#a'"_s);
-    if (!waitForNavigation("navigate to url2#a"))
-        return;
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
     EXPECT_FALSE([lastNavigation _isUserInitiated]);
     EXPECT_TRUE(webView.get().backForwardList.currentItem._wasCreatedByJSWithoutUserInteraction);
     RetainPtr expectedURLString = makeString(String([url2 absoluteString]), "#a"_s).createNSString();
     EXPECT_WK_STREQ([lastNavigation _request].URL.absoluteString.UTF8String, expectedURLString.get().UTF8String);
 
     navigate(webView.get(), "location.pathname + '#b'"_s);
-    if (!waitForNavigation("navigate to url2#b"))
-        return;
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
     EXPECT_FALSE([lastNavigation _isUserInitiated]);
     EXPECT_TRUE(webView.get().backForwardList.currentItem._wasCreatedByJSWithoutUserInteraction);
     expectedURLString = makeString(String([url2 absoluteString]), "#b"_s).createNSString();
     EXPECT_WK_STREQ([lastNavigation _request].URL.absoluteString.UTF8String, expectedURLString.get().UTF8String);
 
     navigate(webView.get(), "location.pathname + '#c'"_s);
-    if (!waitForNavigation("navigate to url2#c"))
-        return;
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
     EXPECT_FALSE([lastNavigation _isUserInitiated]);
     EXPECT_TRUE(webView.get().backForwardList.currentItem._wasCreatedByJSWithoutUserInteraction);
     expectedURLString = makeString(String([url2 absoluteString]), "#c"_s).createNSString();
     EXPECT_WK_STREQ([lastNavigation _request].URL.absoluteString.UTF8String, expectedURLString.get().UTF8String);
 
     [webView loadRequest:[NSURLRequest requestWithURL:url3.get()]];
-    if (!waitForNavigation("loadRequest url3"))
-        return;
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
     EXPECT_FALSE([webView backForwardList].currentItem._wasCreatedByJSWithoutUserInteraction);
 
-    // url1 -> url2 -> url2#a (no user gesture) -> url2#b (no user gesture) -> url2#c (no user gesture) -> url3 **
     EXPECT_EQ([webView backForwardList].backList.count, 2U);
     EXPECT_EQ([webView backForwardList].forwardList.count, 0U);
 
+    SkipItemsBackForwardListFixture fixture;
+    fixture.webView = WTF::move(webView);
+    fixture.navigationDelegate = WTF::move(navigationDelegate);
+    fixture.url1 = url1;
+    fixture.url2 = url2;
+    fixture.url3 = url3;
+    return fixture;
+}
+
+// Phase 1 check: idempotent — leaves state unchanged (back to url3, backList=2, forwardList=0).
+static void runBackForwardNavigationSkipsItemsWithoutUserGestureCheck(const SkipItemsBackForwardListFixture& fixture)
+{
     // We are now on url3. Let's go back.
-    [webView goBack];
-    if (!waitForNavigation("goBack from url3"))
-        return;
+    [fixture.webView goBack];
+    [fixture.navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
 
     // url1 -> url2 -> url2#a (no user gesture) -> url2#b (no user gesture) -> url2#c (no user gesture) ** -> url3
-    expectedURLString = makeString(String([url2 absoluteString]), "#c"_s).createNSString();
-    EXPECT_STREQ([webView URL].absoluteString.UTF8String, expectedURLString.get().UTF8String);
-    EXPECT_EQ([webView backForwardList].backList.count, 1U);
-    EXPECT_EQ([webView backForwardList].forwardList.count, 1U);
+    RetainPtr expectedURLString = makeString(String([fixture.url2 absoluteString]), "#c"_s).createNSString();
+    EXPECT_STREQ([fixture.webView URL].absoluteString.UTF8String, expectedURLString.get().UTF8String);
+    EXPECT_EQ([fixture.webView backForwardList].backList.count, 1U);
+    EXPECT_EQ([fixture.webView backForwardList].forwardList.count, 1U);
 
     // Let's go back again.
-    [webView goBack];
-    if (!waitForNavigation("goBack from url2#c (skipping)"))
-        return;
+    [fixture.webView goBack];
+    [fixture.navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
 
     // We should have skipped over url2#b, url2#a and url2, to end up on url1.
     // url1 ** -> url2 -> url2#a (no user gesture) -> url2#b (no user gesture) -> url2#c (no user gesture) -> url3
-    EXPECT_STREQ([webView URL].absoluteString.UTF8String, [url1 absoluteString].UTF8String);
-    EXPECT_EQ([webView backForwardList].backList.count, 0U);
-    EXPECT_EQ([webView backForwardList].forwardList.count, 2U);
+    EXPECT_STREQ([fixture.webView URL].absoluteString.UTF8String, [fixture.url1 absoluteString].UTF8String);
+    EXPECT_EQ([fixture.webView backForwardList].backList.count, 0U);
+    EXPECT_EQ([fixture.webView backForwardList].forwardList.count, 2U);
 
     // Now let's go forward.
-    [webView goForward];
-    if (!waitForNavigation("goForward from url1"))
-        return;
+    [fixture.webView goForward];
+    [fixture.navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
 
     // We should get to the latest url2 URL, that is url2#c.
     // url1 -> url2 -> url2#a (no user gesture) -> url2#b (no user gesture) -> url2#c (no user gesture) ** -> url3
-    expectedURLString = makeString(String([url2 absoluteString]), "#c"_s).createNSString();
-    EXPECT_STREQ([webView URL].absoluteString.UTF8String, expectedURLString.get().UTF8String);
-    EXPECT_EQ([webView backForwardList].backList.count, 1U);
-    EXPECT_EQ([webView backForwardList].forwardList.count, 1U);
+    expectedURLString = makeString(String([fixture.url2 absoluteString]), "#c"_s).createNSString();
+    EXPECT_STREQ([fixture.webView URL].absoluteString.UTF8String, expectedURLString.get().UTF8String);
+    EXPECT_EQ([fixture.webView backForwardList].backList.count, 1U);
+    EXPECT_EQ([fixture.webView backForwardList].forwardList.count, 1U);
 
     // Let's go forward again.
-    [webView goForward];
-    if (!waitForNavigation("goForward from url2#c"))
-        return;
+    [fixture.webView goForward];
+    [fixture.navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
 
     // We should now be on url3.
-    EXPECT_STREQ([webView URL].absoluteString.UTF8String, [url3 absoluteString].UTF8String);
+    EXPECT_STREQ([fixture.webView URL].absoluteString.UTF8String, [fixture.url3 absoluteString].UTF8String);
 
-    EXPECT_EQ([webView backForwardList].backList.count, 2U);
-    EXPECT_EQ([webView backForwardList].forwardList.count, 0U);
+    EXPECT_EQ([fixture.webView backForwardList].backList.count, 2U);
+    EXPECT_EQ([fixture.webView backForwardList].forwardList.count, 0U);
+}
 
+// Phase 2 check: mutating — leaves state on url2#b. Must run after the Phase 1 check.
+static void runJSHistoryBackDoesNotSkipItemsWithoutUserGestureCheck(const SkipItemsBackForwardListFixture& fixture)
+{
     // Navigating via the JS API shouldn't skip those back/forward list items.
-    [webView _evaluateJavaScriptWithoutUserGesture:@"history.back();" completionHandler:^(id, NSError *) { }];
-    if (!waitForNavigation("history.back() from url3"))
-        return;
+    [fixture.webView _evaluateJavaScriptWithoutUserGesture:@"history.back();" completionHandler:^(id, NSError *) { }];
+    [fixture.navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
 
-    expectedURLString = makeString(String([url2 absoluteString]), "#c"_s).createNSString();
-    EXPECT_STREQ([webView URL].absoluteString.UTF8String, expectedURLString.get().UTF8String);
-    EXPECT_EQ([webView backForwardList].backList.count, 1U);
-    EXPECT_EQ([webView backForwardList].forwardList.count, 1U);
+    RetainPtr expectedURLString = makeString(String([fixture.url2 absoluteString]), "#c"_s).createNSString();
+    EXPECT_STREQ([fixture.webView URL].absoluteString.UTF8String, expectedURLString.get().UTF8String);
+    EXPECT_EQ([fixture.webView backForwardList].backList.count, 1U);
+    EXPECT_EQ([fixture.webView backForwardList].forwardList.count, 1U);
 
-    [webView _evaluateJavaScriptWithoutUserGesture:@"history.back();" completionHandler:^(id, NSError *) { }];
-    if (!waitForNavigation("history.back() from url2#c (same-document)"))
-        return;
-    expectedURLString = makeString(String([url2 absoluteString]), "#b"_s).createNSString();
-    EXPECT_STREQ([webView URL].absoluteString.UTF8String, expectedURLString.get().UTF8String);
-    EXPECT_EQ([webView backForwardList].backList.count, 1U);
-    EXPECT_EQ([webView backForwardList].forwardList.count, 1U);
+    [fixture.webView _evaluateJavaScriptWithoutUserGesture:@"history.back();" completionHandler:^(id, NSError *) { }];
+    [fixture.navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+    expectedURLString = makeString(String([fixture.url2 absoluteString]), "#b"_s).createNSString();
+    EXPECT_STREQ([fixture.webView URL].absoluteString.UTF8String, expectedURLString.get().UTF8String);
+    EXPECT_EQ([fixture.webView backForwardList].backList.count, 1U);
+    EXPECT_EQ([fixture.webView backForwardList].forwardList.count, 1U);
 }
 
-TEST(WKBackForwardList, BackForwardNavigationSkipsItemsWithoutUserGesturePushState)
+// Test fixtures: the back/forward list setup is built once per fixture (via SetUpTestSuite)
+// and reused across both Phase 1 (skip checks) and Phase 2 (JS history.back checks). Phase 1
+// is idempotent, so it must come first; Phase 2 mutates and runs last. Tests within a fixture
+// are run in source order.
+
+static void pushStateNavigate(WKWebView *webView, ASCIILiteral destination)
 {
-    runBackForwardNavigationSkipsItemsWithoutUserGestureTest([](WKWebView* webView, ASCIILiteral destination) {
-        [webView _evaluateJavaScriptWithoutUserGesture:makeString("history.pushState(null, document.title, "_s, destination, ");"_s).createNSString().get() completionHandler:nil];
-    });
+    [webView _evaluateJavaScriptWithoutUserGesture:makeString("history.pushState(null, document.title, "_s, destination, ");"_s).createNSString().get() completionHandler:nil];
 }
 
-// FIXME when webkit.org/b/313844 is resolved.
-#if PLATFORM(MAC)
-TEST(WKBackForwardList, DISABLED_BackForwardNavigationSkipsItemsWithoutUserGestureFragment)
-#else
-TEST(WKBackForwardList, BackForwardNavigationSkipsItemsWithoutUserGestureFragment)
-#endif
+static void fragmentNavigate(WKWebView *webView, ASCIILiteral destination)
 {
-    runBackForwardNavigationSkipsItemsWithoutUserGestureTest([](WKWebView* webView, ASCIILiteral destination) {
-        [webView _evaluateJavaScriptWithoutUserGesture:makeString("location.href = "_s, destination, ";"_s).createNSString().get() completionHandler:nil];
-    });
+    [webView _evaluateJavaScriptWithoutUserGesture:makeString("location.href = "_s, destination, ";"_s).createNSString().get() completionHandler:nil];
 }
 
-TEST(WKBackForwardList, BackForwardNavigationSkipsItemsWithoutUserGesturePushStateAfterEvaluateJS)
+static void pushStateAfterEvaluateJSNavigate(WKWebView *webView, ASCIILiteral destination)
 {
-    runBackForwardNavigationSkipsItemsWithoutUserGestureTest([](WKWebView* webView, ASCIILiteral destination) {
-        // Do a call to evaluateJavaScript (with user gesture) *BEFORE* the pushState and make sure it doesn't count
-        // as a user gesture for the pushState().
-        __block bool didRunScript = false;
-        [webView evaluateJavaScript:@"window.foo = 1;" completionHandler:^(id, NSError *) {
-            didRunScript = true;
-        }];
-        TestWebKitAPI::Util::run(&didRunScript);
-        [webView _evaluateJavaScriptWithoutUserGesture:makeString("history.pushState(null, document.title, "_s, destination, ");"_s).createNSString().get() completionHandler:nil];
-    });
+    // Do a call to evaluateJavaScript (with user gesture) *BEFORE* the pushState and make sure it doesn't count
+    // as a user gesture for the pushState().
+    __block bool didRunScript = false;
+    [webView evaluateJavaScript:@"window.foo = 1;" completionHandler:^(id, NSError *) {
+        didRunScript = true;
+    }];
+    TestWebKitAPI::Util::run(&didRunScript);
+    pushStateNavigate(webView, destination);
+}
+
+template<auto navigate>
+class WKBackForwardListSkipItemsTestBase : public testing::Test {
+public:
+    static void SetUpTestSuite() { s_fixture = setupBackForwardListWithItemsWithoutUserGesture(navigate); }
+    static void TearDownTestSuite() { s_fixture.reset(); }
+    static std::optional<SkipItemsBackForwardListFixture> s_fixture;
+};
+template<auto navigate>
+std::optional<SkipItemsBackForwardListFixture> WKBackForwardListSkipItemsTestBase<navigate>::s_fixture;
+
+class WKBackForwardListSkipItemsPushStateTest : public WKBackForwardListSkipItemsTestBase<pushStateNavigate> { };
+class WKBackForwardListSkipItemsFragmentTest : public WKBackForwardListSkipItemsTestBase<fragmentNavigate> { };
+class WKBackForwardListSkipItemsPushStateAfterEvaluateJSTest : public WKBackForwardListSkipItemsTestBase<pushStateAfterEvaluateJSNavigate> { };
+
+TEST_F(WKBackForwardListSkipItemsPushStateTest, BackForwardNavigationSkipsItemsWithoutUserGesture)
+{
+    runBackForwardNavigationSkipsItemsWithoutUserGestureCheck(*s_fixture);
+}
+
+TEST_F(WKBackForwardListSkipItemsPushStateTest, JSHistoryBackDoesNotSkipItemsWithoutUserGesture)
+{
+    runJSHistoryBackDoesNotSkipItemsWithoutUserGestureCheck(*s_fixture);
+}
+
+TEST_F(WKBackForwardListSkipItemsFragmentTest, BackForwardNavigationSkipsItemsWithoutUserGesture)
+{
+    runBackForwardNavigationSkipsItemsWithoutUserGestureCheck(*s_fixture);
+}
+
+TEST_F(WKBackForwardListSkipItemsFragmentTest, JSHistoryBackDoesNotSkipItemsWithoutUserGesture)
+{
+    runJSHistoryBackDoesNotSkipItemsWithoutUserGestureCheck(*s_fixture);
+}
+
+TEST_F(WKBackForwardListSkipItemsPushStateAfterEvaluateJSTest, BackForwardNavigationSkipsItemsWithoutUserGesture)
+{
+    runBackForwardNavigationSkipsItemsWithoutUserGestureCheck(*s_fixture);
+}
+
+TEST_F(WKBackForwardListSkipItemsPushStateAfterEvaluateJSTest, JSHistoryBackDoesNotSkipItemsWithoutUserGesture)
+{
+    runJSHistoryBackDoesNotSkipItemsWithoutUserGestureCheck(*s_fixture);
 }
 
 TEST(WKBackForwardList, BackForwardNavigationSkipsItemsWithoutUserGestureSubframe)


### PR DESCRIPTION
#### a735fd3063f79481584a963d7de114ea0dd2f089
<pre>
WKBackForwardList.BackForwardNavigationSkipsItemsWithoutUserGesture* API tests are flaky
<a href="https://bugs.webkit.org/show_bug.cgi?id=314785">https://bugs.webkit.org/show_bug.cgi?id=314785</a>
<a href="https://rdar.apple.com/176046782">rdar://176046782</a>

Reviewed by Brady Eidson.

The shared helper runBackForwardNavigationSkipsItemsWithoutUserGestureTest
runs ~12 sequential navigations in a single TEST(), and is shared across
three variants (PushState, Fragment, PushStateAfterEvaluateJS). On loaded
bots this exceeds the per-test timeout, producing flaky failures across all
three variants — including failures at the very first loadRequest on a fresh
WKWebView.

A previous attempt (313126@main) added a 10-second inner timeout to each
wait. That made things worse: 10 seconds is too tight for slow bots that
previously recovered within the per-test framework timeout, so the inner
timeout converted slow steps into hard fails rather than catching genuine
hangs.

Reduce per-test work by splitting the helper into a setup function and two
phase checks:
  - Phase 1: the goBack/goForward navigations that verify items without
    user gesture are skipped (idempotent — leaves state unchanged).
  - Phase 2: the JS history.back() navigations that verify the JS API does
    not skip those items (mutating — must run after Phase 1).

Use a templated testing::Test base WKBackForwardListSkipItemsTestBase&lt;navigate&gt;
parameterized by a per-variant navigate function, so the back/forward list
setup is built once via SetUpTestSuite and shared across both phase checks
within the suite. Each variant becomes a one-line subclass with two TEST_F
entries (six tests in total). Gtest registration (source) order ensures
Phase 1 runs before Phase 2 within each suite.

Make the setup more resilient to slow / I/O-saturated bots:
  - Switch from file:// URLs to a custom URL scheme handler serving in-memory
    HTML for a &quot;test://&quot; scheme. Avoids the file scheme handler path in
    NetworkProcess, which can be slow under disk pressure.
  - Share a single WKProcessPool across all fixtures (and across
    --gtest_repeat iterations) so WebProcesses get cached and reused
    instead of cold-launched per WebView.
  - Share a single ephemeral WKWebsiteDataStore so cookies/cache stay in
    memory and we avoid disk I/O entirely.
  - Call _launchInitialProcessIfNecessary right after WKWebView creation
    so the WebProcess launch overlaps with the rest of test setup rather
    than blocking the first loadRequest.

Also restore the unbounded waitForDidFinishNavigationOrDidSameDocumentNavigation,
matching what the other tests in this file use, and re-enable
BackForwardNavigationSkipsItemsWithoutUserGestureFragment on macOS.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKBackForwardListTests.mm:
(-[WKBackForwardNavigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigationWithTimeout:]): Deleted.
(setupBackForwardListWithItemsWithoutUserGesture):
(runBackForwardNavigationSkipsItemsWithoutUserGestureCheck):
(runJSHistoryBackDoesNotSkipItemsWithoutUserGestureCheck):
(pushStateNavigate):
(fragmentNavigate):
(pushStateAfterEvaluateJSNavigate):
(WKBackForwardListSkipItemsTestBase::SetUpTestSuite):
(WKBackForwardListSkipItemsTestBase::TearDownTestSuite):
(TEST_F(WKBackForwardListSkipItemsPushStateTest, BackForwardNavigationSkipsItemsWithoutUserGesture)):
(TEST_F(WKBackForwardListSkipItemsPushStateTest, JSHistoryBackDoesNotSkipItemsWithoutUserGesture)):
(TEST_F(WKBackForwardListSkipItemsFragmentTest, BackForwardNavigationSkipsItemsWithoutUserGesture)):
(TEST_F(WKBackForwardListSkipItemsFragmentTest, JSHistoryBackDoesNotSkipItemsWithoutUserGesture)):
(TEST_F(WKBackForwardListSkipItemsPushStateAfterEvaluateJSTest, BackForwardNavigationSkipsItemsWithoutUserGesture)):
(TEST_F(WKBackForwardListSkipItemsPushStateAfterEvaluateJSTest, JSHistoryBackDoesNotSkipItemsWithoutUserGesture)):

Canonical link: <a href="https://commits.webkit.org/313274@main">https://commits.webkit.org/313274@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/19894af7e99091de83628fd73c08b27f2923f299

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162497 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35973 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29091 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171435 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118942 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164366 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36077 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35977 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126106 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165456 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28452 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145978 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106684 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27498 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26026 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19135 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137202 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23708 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173939 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25352 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134418 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35647 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30117 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134416 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36297 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35631 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145504 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97903 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28949 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22337 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35140 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34642 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34887 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34790 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->