### PR TITLE
[Media] timeupdate event can dispatch ahead of 'seeking' under stress

### DIFF
--- a/LayoutTests/media/media-fullscreen-loop-inline.html
+++ b/LayoutTests/media/media-fullscreen-loop-inline.html
@@ -5,6 +5,7 @@
     <script src="video-test.js"></script>
     <script src="media-file.js"></script>
     <script>
+    var lastTime = 0;
     function go()
     {
         if (!window.internals) {
@@ -56,7 +57,9 @@
 
     function timeupdate()
     {
-        if (video.currentTime == 0) {
+        // Detect the loop via the backward time jump: finishSeek's post-loop
+        // timeupdate fires after clearSeeking(), so currentTime may not be 0 yet.
+        if (video.currentTime < lastTime) {
             consoleWrite("Looped");
             run('video.ontimeupdate = null');
             testExpected('video.playsInline', false);
@@ -65,6 +68,7 @@
                endTest();
             }, 0);
         }
+        lastTime = video.currentTime;
     }
     </script>
 </head>

--- a/LayoutTests/media/video-timeupdate-before-seeking-expected.txt
+++ b/LayoutTests/media/video-timeupdate-before-seeking-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS timeupdate queued before an explicit seek must not dispatch ahead of 'seeking'
+

--- a/LayoutTests/media/video-timeupdate-before-seeking.html
+++ b/LayoutTests/media/video-timeupdate-before-seeking.html
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html>
+<title>A timeupdate event queued before an explicit seek must not dispatch ahead of 'seeking'</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+<script src="media-file.js"></script>
+<body>
+<video></video>
+<script>
+// Per HTML spec time-marches-on step 6
+// (https://html.spec.whatwg.org/multipage/media.html#time-marches-on):
+//   "(In the other cases, such as explicit seeks, relevant events get fired
+//   as part of the overall process of changing the current playback position.)"
+// — any timeupdate queued before a JS-driven explicit seek must give way to
+// the seek's own events. This test reproduces the race using pause() to
+// queue a non-periodic timeupdate immediately followed by a currentTime
+// assignment to trigger the seek.
+
+async_test(function(t) {
+    var video = document.querySelector('video');
+    video.src = findMediaFile('video', 'content/test-25fps');
+
+    var events = [];
+    var record = t.step_func(function(e) { events.push(e.type); });
+    ['timeupdate', 'seeking', 'seeked', 'pause'].forEach(function(type) {
+        video.addEventListener(type, record);
+    });
+
+    video.addEventListener('error', t.unreached_func('error'));
+
+    video.addEventListener('playing', t.step_func(function() {
+        // Let playback advance long enough that currentTime differs from
+        // m_lastTimeUpdateEventMovieTime — otherwise pause() won't queue a
+        // timeupdate (the scheduleTimeupdateEvent deduplication check would
+        // filter it out).
+        t.step_timeout(function() {
+            // Clear any events accumulated before this point (canplay-time
+            // timeupdates, the 'playing' itself). From here on, we assert
+            // the ordering of the new events we trigger.
+            events.length = 0;
+
+            // pause() synchronously calls pauseInternal(), which queues a
+            // non-periodic timeupdate followed by a 'pause' event on the
+            // media-element task queue.
+            video.pause();
+
+            // Setting currentTime triggers HTMLMediaElement::seek(), which
+            // must cancel any still-pending timeupdate before queueing
+            // 'seeking'.
+            video.currentTime = video.duration / 2;
+        }, 300);
+    }));
+
+    video.addEventListener('seeked', t.step_func_done(function() {
+        // Events observed after the pause()+seek pair.
+        //
+        // With the cancellation in place: ['pause', 'seeking', 'timeupdate', 'seeked']
+        //   ('timeupdate' here is the post-seek one queued by finishSeek.)
+        // Without the cancellation (the race): ['timeupdate', 'pause', 'seeking', ...]
+        //   or similar — a pre-seek 'timeupdate' appears before 'seeking'.
+
+        var seekingIdx = events.indexOf('seeking');
+        assert_not_equals(seekingIdx, -1, "'seeking' event fired");
+
+        var preSeekingEvents = events.slice(0, seekingIdx);
+        assert_equals(preSeekingEvents.indexOf('timeupdate'), -1,
+            "no 'timeupdate' event dispatched before 'seeking'. Saw: " + JSON.stringify(events));
+    }));
+
+    video.addEventListener('canplay', t.step_func(function() {
+        video.play().catch(t.unreached_func('play() rejected'));
+    }), { once: true });
+}, "timeupdate queued before an explicit seek must not dispatch ahead of 'seeking'");
+</script>
+</body>
+</html>

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -3936,6 +3936,19 @@ void HTMLMediaElement::seekWithTolerance(const SeekTarget& target, bool fromDOM)
     // 4 - Set the seeking IDL attribute to true.
     // The flag will be cleared when the engine tells us the time has actually changed.
     setSeeking(true);
+
+    // Drop any queued timeupdate task before the seekTask (or any other task)
+    // has a chance to dispatch, per the HTML spec time-marches-on algorithm
+    // (https://html.spec.whatwg.org/multipage/media.html#time-marches-on, step 6):
+    //   "(In the other cases, such as explicit seeks, relevant events get fired
+    //   as part of the overall process of changing the current playback
+    //   position.)"
+    // This must happen synchronously from the DOM-side entry point: the seek
+    // path below enqueues seekTask onto the same task queue where a pending
+    // timeupdate may already be waiting, and the event loop would otherwise
+    // dispatch the timeupdate first.
+    m_timeupdateCancellationGroup.cancel();
+
     if (m_playing) {
         if (m_lastSeekTime < now)
             addPlayedRange(m_lastSeekTime, now);
@@ -4026,7 +4039,8 @@ void HTMLMediaElement::seekTask()
         ALWAYS_LOG(LOGIDENTIFIER, "ignored seek to ", time);
         if (time == now) {
             scheduleEvent(eventNames().seekingEvent);
-            scheduleTimeupdateEvent(false);
+            // Emit directly: scheduleTimeupdateEvent's m_seeking guard would drop it.
+            scheduleEvent(eventNames().timeupdateEvent);
             scheduleEvent(eventNames().seekedEvent);
 
             if (protect(document())->quirks().needsCanPlayAfterSeekedQuirk() && m_readyState > HAVE_CURRENT_DATA)
@@ -4041,13 +4055,6 @@ void HTMLMediaElement::seekTask()
     m_lastSeekTime = time;
     m_pendingSeekType = thisSeekType;
     setSeeking(true);
-
-    // Before scheduling the 'seeking' event, drop any queued periodic timeupdate
-    // task. Without this, a periodic timeupdate queued by playbackProgressTimerFired
-    // just before setCurrentTime could dispatch ahead of 'seeking', producing the
-    // spec-incorrect event ordering observed in mediasource-duration.html. The
-    // seek-completion timeupdate is queued separately by finishSeek and survives.
-    m_periodicTimeupdateCancellationGroup.cancel();
 
     // 10 - Queue a task to fire a simple event named seeking at the element.
     scheduleEvent(eventNames().seekingEvent);
@@ -5066,9 +5073,9 @@ void HTMLMediaElement::scheduleTimeupdateEvent(bool periodicEvent)
     // Per HTML spec, the periodic timeupdate is only for "the time reached through the
     // usual monotonic increase of the current playback position during normal playback".
     // During an active seek, the seek algorithm's own events (seeking -> timeupdate ->
-    // seeked via finishSeek) are responsible for notifying the page. Suppress periodic
-    // timeupdates while seeking so they don't interleave with the seek-driven ordering.
-    if (periodicEvent && m_seeking)
+    // seeked via finishSeek) are responsible for notifying the page. Suppress timeupdates
+    // while seeking so they don't interleave with the seek-driven ordering.
+    if (m_seeking)
         return;
 
     MonotonicTime now = MonotonicTime::now();
@@ -5085,14 +5092,14 @@ void HTMLMediaElement::scheduleTimeupdateEvent(bool periodicEvent)
     // event at a given time so filter here
     MediaTime movieTime = currentMediaTime();
     if (movieTime != m_lastTimeUpdateEventMovieTime) {
-        if (periodicEvent) {
-            // Periodic timeupdates are cancellable by the seek path — if a seek starts
-            // before this task dispatches, the pending timeupdate would race ahead of
-            // the 'seeking' event, producing spec-incorrect event ordering that fails
-            // mediasource-duration.html.
-            queueCancellableTaskToDispatchEvent(*this, TaskSource::MediaElement, m_periodicTimeupdateCancellationGroup, Event::create(eventNames().timeupdateEvent, Event::CanBubble::No, Event::IsCancelable::Yes));
-        } else
-            scheduleEvent(eventNames().timeupdateEvent);
+        // Route through the cancellation group so seek() can drop the pending
+        // timeupdate before queueing 'seeking', per the HTML spec
+        // time-marches-on algorithm
+        // (https://html.spec.whatwg.org/multipage/media.html#time-marches-on, step 6):
+        //   "(In the other cases, such as explicit seeks, relevant events get
+        //   fired as part of the overall process of changing the current
+        //   playback position.)"
+        queueCancellableTaskToDispatchEvent(*this, TaskSource::MediaElement, m_timeupdateCancellationGroup, Event::create(eventNames().timeupdateEvent, Event::CanBubble::No, Event::IsCancelable::Yes));
         m_clockTimeAtLastUpdateEvent = now;
         m_lastTimeUpdateEventMovieTime = movieTime;
     }

--- a/Source/WebCore/html/HTMLMediaElement.h
+++ b/Source/WebCore/html/HTMLMediaElement.h
@@ -1215,7 +1215,7 @@ private:
     TaskCancellationGroup m_updateShouldAutoplayTaskCancellationGroup;
     RefPtr<TimeRanges> m_playedTimeRanges;
     TaskCancellationGroup m_asyncEventsCancellationGroup;
-    TaskCancellationGroup m_periodicTimeupdateCancellationGroup;
+    TaskCancellationGroup m_timeupdateCancellationGroup;
     TaskCancellationGroup m_volumeRevertTaskCancellationGroup;
 
     PlayPromiseVector m_pendingPlayPromises;


### PR DESCRIPTION
#### 118bdae825bb28da9cd77930f931928325c11042
<pre>
[Media] timeupdate event can dispatch ahead of &apos;seeking&apos; under stress
<a href="https://bugs.webkit.org/show_bug.cgi?id=314792">https://bugs.webkit.org/show_bug.cgi?id=314792</a>
<a href="https://rdar.apple.com/problem/177044662">rdar://problem/177044662</a>

Reviewed by Jer Noble.

Commit 612b528 (&quot;[MSE] timeupdate event can fire during seek operation,
before the seek completes.&quot;) routed periodic timeupdates through
m_periodicTimeupdateCancellationGroup so HTMLMediaElement::seek() could
drop them before queueing &apos;seeking&apos;, preserving the spec-required
seeking -&gt; timeupdate -&gt; seeked ordering. It deliberately left
non-periodic timeupdates outside the group:

  Non-periodic timeupdate calls (finishSeek, updateReadyState,
  mediaPlayerTimeChanged&apos;s discontinuity path) continue to use the
  general async-events group and are not cancelled.

Under stress, mediasource-duration.html test 2 (&quot;Test appendBuffer
completes previous seek to truncated duration&quot;) still races. A
non-periodic timeupdate scheduled by HTMLMediaElement::pauseInternal,
by HTMLMediaElement::setReadyState&apos;s else branch (when
MediaSource::monitorSourceBuffers drops readyState below
HAVE_FUTURE_DATA after sourceBuffer.remove()), or by
mediaPlayerTimeChanged from the AVFObjC MSE boundary-observer callback,
dispatches ahead of the JS-driven setDuration -&gt; seek&apos;s &apos;seeking&apos;
event.

Per HTML spec time-marches-on step 6
(<a href="https://html.spec.whatwg.org/multipage/media.html#time-marches-on)">https://html.spec.whatwg.org/multipage/media.html#time-marches-on)</a>:

  &quot;(In the other cases, such as explicit seeks, relevant events get
  fired as part of the overall process of changing the current
  playback position.)&quot;

— a timeupdate queued before an explicit seek must give way to the
seek&apos;s own events. Generalise 612b528&apos;s approach to cover all
timeupdates: route every scheduleTimeupdateEvent call through the
cancellation group, and have the seek path cancel the group before
any subsequent task can dispatch a queued timeupdate. The
seek-completion timeupdate is queued by finishSeek after the cancel
runs and is unaffected.

The cancel must run synchronously from the DOM-side entry point. The
original 612b528 placed it in seekTask, which runs asynchronously from
setCurrentTime; any timeupdate queued on the same MediaElement task
queue by an earlier synchronous call (e.g. pause()) is dispatched by
the event loop before seekTask runs, so its cancel() is too late to
drop it. Move the cancel into seekInternal, right after setSeeking(true)
and before seekTask is queued, so the cancellation happens in the same
synchronous chain as setCurrentTime.

Rename m_periodicTimeupdateCancellationGroup -&gt;
m_timeupdateCancellationGroup to reflect the broadened scope. Also add
an explanatory comment in the AVFObjC boundary-observer callback noting
that timeChanged()&apos;s timeupdate side effect is now cancellable by a
follow-up seek.

The synchronous cancel() closes the backward window (timeupdates queued
before the seek) but not the forward one: AVFoundation&apos;s periodic time
observer posts work via callOnMainThread/ensureOnMainThread, which can
run on the main runloop after the cancel() but before the event-loop
drain. Inside that callback, mediaPlayerTimeChanged&apos;s else branch calls
scheduleTimeupdateEvent(false) and queues a fresh cancellable task that
the earlier cancel() cannot retroactively catch; it then dispatches
before seekTask schedules &apos;seeking&apos;. Close the forward window by
generalising the existing m_seeking guard in scheduleTimeupdateEvent
from periodic-only to unconditional: once setSeeking(true) has run, any
new timeupdate call is by definition a racer that belongs to the seek&apos;s
own event sequence. seekTask&apos;s noSeekRequired-and-time==now fast path
reaches scheduleTimeupdateEvent with m_seeking still true, so emit that
middle timeupdate directly via scheduleEvent as finishSeek does for its
step 16 timeupdate.

LayoutTests/media/media-fullscreen-loop-inline.html: the handler
required video.currentTime == 0 exactly after the loop-back seek. That
was never spec-guaranteed — HTML §4.8.10.9 clears &apos;seeking&apos; at step 14
before queueing the post-seek &apos;timeupdate&apos; at step 16, so at dispatch
time currentMediaTime() reads from the player and can have advanced
past 0 on fast hardware. The test only passed historically because the
non-cancellable pre-loop &apos;timeupdate&apos; scheduled from
mediaPlayerTimeChanged&apos;s else branch dispatched while m_seeking was
still true, causing currentMediaTime() to fall back to m_lastSeekTime
(0) via the early-return at HTMLMediaElement::currentMediaTime(). With
that call now routed through the cancellation group, seekInternal(0)
drops it and only finishSeek&apos;s post-clear &apos;timeupdate&apos; remains — flaky
on slower systems. Detect the backward time jump instead, which matches
the test&apos;s stated intent.

Test: media/video-timeupdate-before-seeking.html. Reproduces the race

* LayoutTests/media/media-fullscreen-loop-inline.html: Detect loop via
  backward time jump instead of strict currentTime == 0.
* LayoutTests/media/video-timeupdate-before-seeking-expected.txt: Added.
* LayoutTests/media/video-timeupdate-before-seeking.html: Added.
* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::seekWithTolerance):
(WebCore::HTMLMediaElement::seekTask):
(WebCore::HTMLMediaElement::scheduleTimeupdateEvent):
* Source/WebCore/html/HTMLMediaElement.h:

Canonical link: <a href="https://commits.webkit.org/313283@main">https://commits.webkit.org/313283@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2340bdb1ede4b72ab362c281570b99692185e21d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162570 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36046 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/29287 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171508 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119015 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164439 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36150 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36050 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126163 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88869 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165529 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28518 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/146158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106741 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0fa54f74-1674-4666-b5ca-9b9d5e9b07f7) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27564 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26093 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19208 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137268 "Found 2 new API test failures: TestWebKitAPI.WKAttachmentTestsIOS.PasteRichTextCopiedFromNotes, TestWebKitAPI.WKWebsiteDataStore.RemoveAndFetchData (failure)") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/23887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174012 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21325 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/25532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134472 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35720 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30186 "Found 1 new test failure: imported/w3c/web-platform-tests/IndexedDB/interleaved-cursors-small.any.serviceworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134470 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36301 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35704 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/145683 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98034 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/29015 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/22517 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35214 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102965 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34715 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34960 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34863 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->