### PR TITLE
AudioVideoRenderer TimeProgressEstimator incorrectly set m_effectiveRate

### DIFF
--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
@@ -67,6 +67,15 @@ using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteAudioVideoRendererProxyManager);
 
+static WebCore::MediaTimeUpdateData timeUpdateDataFor(WebCore::AudioVideoRenderer& renderer)
+{
+    return {
+        .currentTime = renderer.currentTime(),
+        .effectiveRate = renderer.timeIsProgressing() ? renderer.effectiveRate() : 0.0,
+        .wallTime = MonotonicTime::now(),
+    };
+}
+
 RefPtr<AudioVideoRenderer> RemoteAudioVideoRendererProxyManager::createRenderer()
 {
 #if USE(AVFOUNDATION)
@@ -351,28 +360,34 @@ void RemoteAudioVideoRendererProxyManager::notifyWhenErrorOccurs(RemoteAudioVide
 }
 
 // SynchronizerInterface
-void RemoteAudioVideoRendererProxyManager::play(RemoteAudioVideoRendererIdentifier identifier, std::optional<MonotonicTime> hostTime)
+void RemoteAudioVideoRendererProxyManager::play(RemoteAudioVideoRendererIdentifier identifier, std::optional<MonotonicTime> hostTime, CompletionHandler<void(WebCore::MediaTimeUpdateData&&)>&& completionHandler)
 {
     if (RefPtr renderer = rendererFor(identifier)) {
         renderer->play(hostTime);
-        m_gpuConnectionToWebProcess.get()->connection().send(Messages::AudioVideoRendererRemoteMessageReceiver::StateUpdate(stateFor(identifier)), identifier);
+        completionHandler(timeUpdateDataFor(*renderer));
+        return;
     }
+    completionHandler({ });
 }
 
-void RemoteAudioVideoRendererProxyManager::pause(RemoteAudioVideoRendererIdentifier identifier, std::optional<MonotonicTime> hostTime)
+void RemoteAudioVideoRendererProxyManager::pause(RemoteAudioVideoRendererIdentifier identifier, std::optional<MonotonicTime> hostTime, CompletionHandler<void(WebCore::MediaTimeUpdateData&&)>&& completionHandler)
 {
     if (RefPtr renderer = rendererFor(identifier)) {
         renderer->pause(hostTime);
-        m_gpuConnectionToWebProcess.get()->connection().send(Messages::AudioVideoRendererRemoteMessageReceiver::StateUpdate(stateFor(identifier)), identifier);
+        completionHandler(timeUpdateDataFor(*renderer));
+        return;
     }
+    completionHandler({ });
 }
 
-void RemoteAudioVideoRendererProxyManager::setRate(RemoteAudioVideoRendererIdentifier identifier, double rate)
+void RemoteAudioVideoRendererProxyManager::setRate(RemoteAudioVideoRendererIdentifier identifier, double rate, CompletionHandler<void(WebCore::MediaTimeUpdateData&&)>&& completionHandler)
 {
     if (RefPtr renderer = rendererFor(identifier)) {
         renderer->setRate(rate);
-        m_gpuConnectionToWebProcess.get()->connection().send(Messages::AudioVideoRendererRemoteMessageReceiver::StateUpdate(stateFor(identifier)), identifier);
+        completionHandler(timeUpdateDataFor(*renderer));
+        return;
     }
+    completionHandler({ });
 }
 
 void RemoteAudioVideoRendererProxyManager::stall(RemoteAudioVideoRendererIdentifier identifier)
@@ -579,11 +594,7 @@ RemoteAudioVideoRendererState RemoteAudioVideoRendererProxyManager::stateFor(Rem
     if (!renderer)
         return { };
     return {
-        .timeUpdateData = {
-            .currentTime = renderer->currentTime(),
-            .effectiveRate = renderer->timeIsProgressing() ? renderer->effectiveRate() : 0.0,
-            .wallTime = MonotonicTime::now(),
-        },
+        .timeUpdateData = timeUpdateDataFor(*renderer),
         .paused = renderer->paused(),
         .videoPlaybackQualityMetrics = renderer->videoPlaybackQualityMetrics()
     };

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
@@ -113,9 +113,9 @@ private:
     void notifyWhenErrorOccurs(RemoteAudioVideoRendererIdentifier, CompletionHandler<void(WebCore::PlatformMediaError)>&&);
 
     // SynchronizerInterface
-    void play(RemoteAudioVideoRendererIdentifier, std::optional<MonotonicTime>);
-    void pause(RemoteAudioVideoRendererIdentifier, std::optional<MonotonicTime>);
-    void setRate(RemoteAudioVideoRendererIdentifier, double);
+    void play(RemoteAudioVideoRendererIdentifier, std::optional<MonotonicTime>, CompletionHandler<void(WebCore::MediaTimeUpdateData&&)>&&);
+    void pause(RemoteAudioVideoRendererIdentifier, std::optional<MonotonicTime>, CompletionHandler<void(WebCore::MediaTimeUpdateData&&)>&&);
+    void setRate(RemoteAudioVideoRendererIdentifier, double, CompletionHandler<void(WebCore::MediaTimeUpdateData&&)>&&);
     void stall(RemoteAudioVideoRendererIdentifier);
     void prepareToSeek(RemoteAudioVideoRendererIdentifier, const MediaTime&, CompletionHandler<void(WebCore::MediaTimePromise::Result&&)>&&);
     void finishSeek(RemoteAudioVideoRendererIdentifier, const MediaTime&, CompletionHandler<void(GenericPromise::Result&&)>&&);

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in
@@ -54,9 +54,9 @@ messages -> RemoteAudioVideoRendererProxyManager {
     ApplicationWillResignActive(WebKit::RemoteAudioVideoRendererIdentifier identifier)
     SetSpatialTrackingInfo(WebKit::RemoteAudioVideoRendererIdentifier identifier, bool prefersSpatialAudioExperience, enum:uint8_t WebCore::MediaPlayerSoundStageSize soundStageSize, String sceneIdentifier, String defaultLabel, String label)
 
-    Play(WebKit::RemoteAudioVideoRendererIdentifier identifier, std::optional<MonotonicTime> hostTime)
-    Pause(WebKit::RemoteAudioVideoRendererIdentifier identifier, std::optional<MonotonicTime> hostTime)
-    SetRate(WebKit::RemoteAudioVideoRendererIdentifier identifier, double rate)
+    Play(WebKit::RemoteAudioVideoRendererIdentifier identifier, std::optional<MonotonicTime> hostTime) -> (struct WebCore::MediaTimeUpdateData timeUpdateData)
+    Pause(WebKit::RemoteAudioVideoRendererIdentifier identifier, std::optional<MonotonicTime> hostTime) -> (struct WebCore::MediaTimeUpdateData timeUpdateData)
+    SetRate(WebKit::RemoteAudioVideoRendererIdentifier identifier, double rate) -> (struct WebCore::MediaTimeUpdateData timeUpdateData)
     Stall(WebKit::RemoteAudioVideoRendererIdentifier identifier)
     PrepareToSeek(WebKit::RemoteAudioVideoRendererIdentifier identifier, MediaTime seekTime) -> (Expected<MediaTime, WebCore::PlatformMediaError> result)
     FinishSeek(WebKit::RemoteAudioVideoRendererIdentifier identifier, MediaTime seekTime) -> (GenericPromise::Result result)

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
@@ -124,12 +124,10 @@ void AudioVideoRendererRemote::TimeProgressEstimator::setRate(double rate)
         auto elapsed = std::min(now - m_wallTime, kUpdateInterval);
         m_cachedTime += MediaTime::createWithDouble(currentRate * elapsed.seconds());
         m_wallTime = now;
-        m_effectiveRate = rate;
     }
-    if (!rate) {
-        m_effectiveRate = 0;
+    m_effectiveRate = rate;
+    if (!rate)
         m_lastReturnedTime.reset();
-    }
     m_forceUseCachedTime = true;
 }
 
@@ -476,9 +474,12 @@ void AudioVideoRendererRemote::play(std::optional<MonotonicTime> hostTime)
         Locker locker { m_lock };
         m_cachedState.paused = false;
     }
-    // The GPU will reply with a StateUpdate carrying the new effective rate so the estimator can resume extrapolation without waiting for the 250ms periodic tick.
+    // The GPU will reply with the current MediaTimeUpdateData so the estimator can resume extrapolation without waiting for the 250ms periodic tick.
     ensureOnDispatcherWithConnection([hostTime](auto& renderer, auto& connection) {
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::Play(renderer.m_identifier, hostTime), 0);
+        connection.sendWithAsyncReplyOnDispatcher(Messages::RemoteAudioVideoRendererProxyManager::Play(renderer.m_identifier, hostTime), queueSingleton(), [weakThis = ThreadSafeWeakPtr { renderer }](WebCore::MediaTimeUpdateData&& timeUpdateData) {
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->m_timeEstimator.setTime(timeUpdateData);
+        });
     });
 }
 
@@ -489,9 +490,12 @@ void AudioVideoRendererRemote::pause(std::optional<MonotonicTime> hostTime)
         m_cachedState.paused = true;
     }
     m_timeEstimator.pause();
-    // The GPU will reply with a StateUpdate so cached fields (videoPlaybackQualityMetrics, etc.) match its view immediately.
+    // The GPU will reply with the current MediaTimeUpdateData so the estimator re-anchors against the GPU's view.
     ensureOnDispatcherWithConnection([hostTime](auto& renderer, auto& connection) {
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::Pause(renderer.m_identifier, hostTime), 0);
+        connection.sendWithAsyncReplyOnDispatcher(Messages::RemoteAudioVideoRendererProxyManager::Pause(renderer.m_identifier, hostTime), queueSingleton(), [weakThis = ThreadSafeWeakPtr { renderer }](WebCore::MediaTimeUpdateData&& timeUpdateData) {
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->m_timeEstimator.setTime(timeUpdateData);
+        });
     });
 }
 
@@ -504,9 +508,12 @@ bool AudioVideoRendererRemote::paused() const
 void AudioVideoRendererRemote::setRate(double rate)
 {
     m_timeEstimator.setRate(rate);
-    // The GPU will reply with a StateUpdate that unfreezes the estimator (setTime clears m_forceUseCachedTime) with the real effective rate.
+    // The GPU will reply with the current MediaTimeUpdateData that unfreezes the estimator (setTime clears m_forceUseCachedTime) with the real effective rate.
     ensureOnDispatcherWithConnection([rate](auto& renderer, auto& connection) {
-        connection.send(Messages::RemoteAudioVideoRendererProxyManager::SetRate(renderer.m_identifier, rate), 0);
+        connection.sendWithAsyncReplyOnDispatcher(Messages::RemoteAudioVideoRendererProxyManager::SetRate(renderer.m_identifier, rate), queueSingleton(), [weakThis = ThreadSafeWeakPtr { renderer }](WebCore::MediaTimeUpdateData&& timeUpdateData) {
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->m_timeEstimator.setTime(timeUpdateData);
+        });
     });
 }
 


### PR DESCRIPTION
#### 5a1e30384382df1fbfedb3c0429b94d6c9cbf456
<pre>
AudioVideoRenderer TimeProgressEstimator incorrectly set m_effectiveRate
<a href="https://bugs.webkit.org/show_bug.cgi?id=314795">https://bugs.webkit.org/show_bug.cgi?id=314795</a>
<a href="https://rdar.apple.com/177046564">rdar://177046564</a>

Reviewed by Jer Noble and Eric Carlson.

311867@main (&quot;Use a TimeProgressEstimator to interpolate
AudioVideoRendererRemote::currentTime() between GPU updates&quot;) introduced
two issues.

1. Every Play / Pause / SetRate IPC from WebContent caused the GPU-side
RemoteAudioVideoRendererProxyManager handler to synchronously build a
RemoteAudioVideoRendererState via stateFor() and push a StateUpdate IPC
back to the WebContent. stateFor() reads videoPlaybackQualityMetrics,
which on the protected-content AVSampleBufferDisplayLayer path (for
example Netflix) fans into four separate [renderer videoPerformanceMetrics]
synchronous XPCs into mediaserverd. The only consumer of that reply in the
WebContent is the client-side TimeProgressEstimator, which only needs the
MediaTimeUpdateData fields (currentTime, effectiveRate, wallTime) to
unfreeze and re-anchor after the local setRate / pause already froze it.
The full state payload and its metrics fetch were wasted work on every
transition.

2. AudioVideoRendererRemote::TimeProgressEstimator::setRate() gated the
assignment m_effectiveRate = rate on the same &quot;if (currentRate)&quot; guard
that controls the rebase of m_cachedTime. The guard is only meaningful
for the rebase (nothing to fold in when the old rate was already zero);
the new-rate assignment shouldn&apos;t ride on it. As a result, when setRate()
was called on an estimator whose current rate was 0 (for example
immediately after a stall()), m_effectiveRate stayed at 0 locally until
the next setTime() arrived. timeIsProgressing() and effectiveRate() would
keep reporting 0 in that round-trip window.

Fix 1: change Play / Pause / SetRate to asynchronous replies carrying only
WebCore::MediaTimeUpdateData. The GPU handlers now call renderer-&gt;play /
pause / setRate and invoke the completion with a fresh MediaTimeUpdateData
built by a new static helper timeUpdateDataFor(renderer). stateFor() is
refactored to reuse the same helper for the fields it shares. The new
payload contains no videoPlaybackQualityMetrics, so these transitions no
longer touch mediaserverd. The WebContent callers use
sendWithAsyncReplyOnDispatcher on queueSingleton(); the reply handler
applies m_timeEstimator.setTime(timeUpdateData) which is exactly the
unfreeze that the old StateUpdate reply performed via updateCacheState.

Fix 2: hoist m_effectiveRate = rate out of the rebase guard in
TimeProgressEstimator::setRate, and drop the now-redundant
m_effectiveRate = 0 inside the if (!rate) branch. All four (currentRate,
rate) cases now leave m_effectiveRate == rate on exit.

In a follow-up change we will extract the AudioVideoRendererRemote&apos;s TimeProgressEstimator
to its own class and combine with the one used in MediaPlayerPrivateRemote
this will allow for API tests and simplify the change. It will also allows
for using a SharedMemory timeBase removing the need for sending IPC messages.

* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in:
Declare MediaTimeUpdateData async replies on Play, Pause, SetRate.

* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h:
(WebKit::RemoteAudioVideoRendererProxyManager::play):
(WebKit::RemoteAudioVideoRendererProxyManager::pause):
(WebKit::RemoteAudioVideoRendererProxyManager::setRate): Take a
CompletionHandler&lt;void(WebCore::MediaTimeUpdateData&amp;&amp;)&gt;&amp;&amp;.

* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp:
(WebKit::timeUpdateDataFor): New file-local helper that returns a
MediaTimeUpdateData without fetching videoPlaybackQualityMetrics. Stamps
effectiveRate = timeIsProgressing() ? effectiveRate() : 0 and
wallTime = MonotonicTime::now(), matching what stateFor() used to do
inline.
(WebKit::RemoteAudioVideoRendererProxyManager::play):
(WebKit::RemoteAudioVideoRendererProxyManager::pause):
(WebKit::RemoteAudioVideoRendererProxyManager::setRate): Invoke the
completion with timeUpdateDataFor(*renderer) instead of sending a
StateUpdate(stateFor(...)). Null-renderer path still invokes the
completion with a default MediaTimeUpdateData so the IPC reply never
hangs.
(WebKit::RemoteAudioVideoRendererProxyManager::stateFor): Reuse
timeUpdateDataFor for the timeUpdateData sub-struct.

* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp:
(WebKit::AudioVideoRendererRemote::TimeProgressEstimator::setRate):
Always apply m_effectiveRate = rate; only the m_cachedTime / m_wallTime
rebase remains conditional on the prior rate being non-zero. Drop the
redundant m_effectiveRate = 0 inside the if (!rate) branch.
(WebKit::AudioVideoRendererRemote::play):
(WebKit::AudioVideoRendererRemote::pause):
(WebKit::AudioVideoRendererRemote::setRate): Use
sendWithAsyncReplyOnDispatcher on queueSingleton(); the reply handler
calls m_timeEstimator.setTime(timeUpdateData) so the estimator still gets
the same anchor it used to receive from the full StateUpdate reply.

Canonical link: <a href="https://commits.webkit.org/313249@main">https://commits.webkit.org/313249@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9ad1aa9e1129dd7c57686ee39f95e6d38c2df90

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162505 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35981 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29101 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171443 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/118950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36085 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35985 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126116 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/118950 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165464 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28459 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145984 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106694 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27505 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26032 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19143 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137209 "Found 1 new API test failure: TestWebKitAPI.WKAttachmentTestsIOS.PasteRichTextCopiedFromNotes (failure)") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173947 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21260 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25358 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134424 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35655 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30123 "Found 1 new test failure: imported/w3c/web-platform-tests/IndexedDB/interleaved-cursors-small.any.serviceworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134422 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36282 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35639 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145510 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97913 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28953 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22343 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35148 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102900 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34650 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34895 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34798 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->