### PR TITLE
[JSC] Optimize initial `then` call

### DIFF
--- a/JSTests/stress/perform-promise-then-one-handler.js
+++ b/JSTests/stress/perform-promise-then-one-handler.js
@@ -1,0 +1,167 @@
+// Exercises both the converted (PerformPromiseThenOneHandler) and non-converted
+// (PerformPromiseThen) paths produced by DFGConstantFoldingPhase. Each test
+// function is noInline'd and run in a hot loop so DFG/FTL tier-up is forced.
+//
+// Conversion happens in DFGConstantFoldingPhase only when the abstract interpreter
+// has *proven* that one handler is SpecFunction and the other is SpecOther
+// (undefined or null). Otherwise we keep the generic 4-child PerformPromiseThen
+// node, whose runtime semantics this test also verifies.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' vs ' + expected);
+}
+
+async function shouldReject(p, expected) {
+    try {
+        await p;
+    } catch (e) {
+        shouldBe(e, expected);
+        return;
+    }
+    throw new Error('expected rejection with ' + expected);
+}
+
+// --- Converted FulfillHandler kind: .then(fn) — onRejected is implicit undefined ---
+function fulfillOnly(p) {
+    return p.then(v => v + 1);
+}
+noInline(fulfillOnly);
+
+// --- Converted RejectHandler kind: .then(undefined, fn) ---
+function rejectOnlyUndefined(p) {
+    return p.then(undefined, e => 'caught:' + e);
+}
+noInline(rejectOnlyUndefined);
+
+// --- Converted RejectHandler kind: .then(null, fn) — null is also SpecOther ---
+function rejectOnlyNull(p) {
+    return p.then(null, e => 'null-caught:' + e);
+}
+noInline(rejectOnlyNull);
+
+// --- Non-converted: two callable handlers — neither side is SpecOther ---
+function bothHandlers(p) {
+    return p.then(v => 'ok:' + v, e => 'err:' + e);
+}
+noInline(bothHandlers);
+
+// --- Non-converted: a non-callable, non-Other literal as fulfill handler ---
+// AI proves SpecInt32, which is neither SpecFunction nor SpecOther → keep PerformPromiseThen.
+// Runtime treats non-callable as no-handler → fulfill value passes through; the
+// rejection handler runs on rejection.
+function intHandlerWithReject(p) {
+    return p.then(1, e => 'int-rej:' + e);
+}
+noInline(intHandlerWithReject);
+
+async function main() {
+    for (let i = 0; i < testLoopCount; ++i) {
+        // 1. Converted fulfill, pending → fast inline write.
+        {
+            let resolve, p = new Promise(r => { resolve = r; });
+            let q = fulfillOnly(p);
+            resolve(i);
+            shouldBe(await q, i + 1);
+        }
+
+        // 2. Converted fulfill, already-fulfilled → JIT precondition fails on status,
+        // takes inline slow branch (calls operationPerformPromiseThenOneHandler).
+        shouldBe(await fulfillOnly(Promise.resolve(i)), i + 1);
+
+        // 3. Converted fulfill, rejection passes through (no onRejected → propagation).
+        await shouldReject(fulfillOnly(Promise.reject('boom-' + i)), 'boom-' + i);
+
+        // 4. Converted reject (undefined fulfill), pending → fast inline write.
+        {
+            let reject, p = new Promise((_, rj) => { reject = rj; });
+            let q = rejectOnlyUndefined(p);
+            reject('e-' + i);
+            shouldBe(await q, 'caught:e-' + i);
+        }
+
+        // 5. Converted reject (undefined fulfill), already-rejected → slow branch.
+        shouldBe(await rejectOnlyUndefined(Promise.reject('rej-' + i)), 'caught:rej-' + i);
+
+        // 6. Converted reject, fulfillment passes through.
+        shouldBe(await rejectOnlyUndefined(Promise.resolve('keep-' + i)), 'keep-' + i);
+
+        // 7. Converted reject (null fulfill), pending.
+        {
+            let reject, p = new Promise((_, rj) => { reject = rj; });
+            let q = rejectOnlyNull(p);
+            reject('n-' + i);
+            shouldBe(await q, 'null-caught:n-' + i);
+        }
+
+        // 8. Non-converted (two handlers), fulfilled side.
+        shouldBe(await bothHandlers(Promise.resolve(i)), 'ok:' + i);
+
+        // 9. Non-converted (two handlers), rejected side.
+        shouldBe(await bothHandlers(Promise.reject('x-' + i)), 'err:x-' + i);
+
+        // 10. Non-converted (two handlers), pending → fulfilled.
+        {
+            let resolve, p = new Promise(r => { resolve = r; });
+            let q = bothHandlers(p);
+            resolve(i);
+            shouldBe(await q, 'ok:' + i);
+        }
+
+        // 11. Non-converted (two handlers), pending → rejected.
+        {
+            let reject, p = new Promise((_, rj) => { reject = rj; });
+            let q = bothHandlers(p);
+            reject('p-' + i);
+            shouldBe(await q, 'err:p-' + i);
+        }
+
+        // 12. Non-converted (int handler), fulfillment passes through.
+        shouldBe(await intHandlerWithReject(Promise.resolve('pass-' + i)), 'pass-' + i);
+
+        // 13. Non-converted (int handler), rejection runs user handler.
+        shouldBe(await intHandlerWithReject(Promise.reject('bang-' + i)), 'int-rej:bang-' + i);
+
+        // 14. Multi-await on the same pending promise: first .then takes the
+        // inline-fast path; the second/third force a spill into a real
+        // JSSlimPromiseReaction chain.
+        {
+            let resolve, p = new Promise(r => { resolve = r; });
+            let a = fulfillOnly(p);
+            let b = fulfillOnly(p);
+            let c = fulfillOnly(p);
+            resolve(i);
+            shouldBe(await a, i + 1);
+            shouldBe(await b, i + 1);
+            shouldBe(await c, i + 1);
+        }
+
+        // 15. isHandledFlag pre-set on a pending promise, with no reaction yet
+        // (state=Pending, kind=None, payload=null). The JIT fast-path precondition
+        // mask intentionally ignores isHandledFlag, so the fast path must still
+        // proceed correctly: the OR of isHandledFlag into m_packed is a no-op and
+        // the reaction is installed as normal. This state is unreachable from
+        // pure JS, so we use $vm.markPromiseAsHandled to construct it.
+        {
+            let resolve, p = new Promise(r => { resolve = r; });
+            $vm.markPromiseAsHandled(p);
+            let q = fulfillOnly(p);
+            resolve(i);
+            shouldBe(await q, i + 1);
+        }
+
+        // 16. Same as above for the RejectHandler kind.
+        {
+            let reject, p = new Promise((_, rj) => { reject = rj; });
+            $vm.markPromiseAsHandled(p);
+            let q = rejectOnlyUndefined(p);
+            reject('h-' + i);
+            shouldBe(await q, 'caught:h-' + i);
+        }
+    }
+}
+
+main().then(
+    () => {},
+    e => { print('FAIL: ' + (e && e.stack || e)); $vm.abort(); }
+);

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -5992,6 +5992,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
     }
 
     case PerformPromiseThen:
+    case PerformPromiseThenOneHandler:
         clobberWorld();
         break;
 

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -2625,6 +2625,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
     case PromiseReject:
     case PromiseThen:
     case PerformPromiseThen:
+    case PerformPromiseThenOneHandler:
         clobberTop();
         return;
 

--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -65,6 +65,17 @@ static bool isNegativeBigInt(JSValue& value)
     return value.asHeapBigInt()->sign();
 }
 
+static std::optional<JSPromise::InlineReactionKind> classifyPerformPromiseThen(const AbstractValue& fulfilledValue, const AbstractValue& rejectedValue)
+{
+    if (fulfilledValue.m_type == SpecNone || rejectedValue.m_type == SpecNone)
+        return std::nullopt;
+    if (fulfilledValue.isType(SpecFunction) && rejectedValue.isType(SpecOther))
+        return JSPromise::InlineReactionKind::FulfillHandler;
+    if (rejectedValue.isType(SpecFunction) && fulfilledValue.isType(SpecOther))
+        return JSPromise::InlineReactionKind::RejectHandler;
+    return std::nullopt;
+}
+
 class ConstantFoldingPhase : public Phase {
 public:
     ConstantFoldingPhase(Graph& graph)
@@ -2052,12 +2063,24 @@ private:
                                     auto* resultPromise = m_insertionSet.insertNode(indexInBlock, SpecPromiseObject, NewPromise, node->origin, OpInfo(m_graph.registerStructure(globalObject->promiseStructure())));
                                     m_insertionSet.insertNode(indexInBlock, SpecNone, ExitOK, node->origin);
 
-                                    unsigned firstChild = m_graph.m_varArgChildren.size();
-                                    m_graph.m_varArgChildren.append(Edge(node->child1().node(), KnownCellUse));
-                                    m_graph.m_varArgChildren.append(node->child2());
-                                    m_graph.m_varArgChildren.append(node->child3());
-                                    m_graph.m_varArgChildren.append(Edge(resultPromise, KnownCellUse));
-                                    m_insertionSet.insertNode(indexInBlock, SpecNone, PerformPromiseThen, node->origin, AdjacencyList(AdjacencyList::Variable, firstChild, 4));
+                                    Edge onFulfilled = node->child2();
+                                    Edge onRejected = node->child3();
+                                    if (auto kindOpt = classifyPerformPromiseThen(m_state.forNode(onFulfilled), m_state.forNode(onRejected))) {
+                                        Edge handlerEdge = (*kindOpt == JSPromise::InlineReactionKind::FulfillHandler) ? onFulfilled : onRejected;
+
+                                        m_insertionSet.insertNode(indexInBlock, SpecNone, PerformPromiseThenOneHandler, node->origin,
+                                            OpInfo(static_cast<uint32_t>(*kindOpt)),
+                                            Edge(node->child1().node(), KnownCellUse),
+                                            Edge(handlerEdge.node(), KnownCellUse),
+                                            Edge(resultPromise, KnownCellUse));
+                                    } else {
+                                        unsigned firstChild = m_graph.m_varArgChildren.size();
+                                        m_graph.m_varArgChildren.append(Edge(node->child1().node(), KnownCellUse));
+                                        m_graph.m_varArgChildren.append(onFulfilled);
+                                        m_graph.m_varArgChildren.append(onRejected);
+                                        m_graph.m_varArgChildren.append(Edge(resultPromise, KnownCellUse));
+                                        m_insertionSet.insertNode(indexInBlock, SpecNone, PerformPromiseThen, node->origin, AdjacencyList(AdjacencyList::Variable, firstChild, 4));
+                                    }
                                     m_insertionSet.insertNode(indexInBlock, SpecNone, ExitOK, node->origin);
 
                                     node->convertToIdentityOn(resultPromise);
@@ -2067,6 +2090,28 @@ private:
                             }
                         }
                     }
+                }
+                break;
+            }
+
+            case PerformPromiseThen: {
+                Edge onFulfilled = m_graph.varArgChild(node, 1);
+                Edge onRejected = m_graph.varArgChild(node, 2);
+                if (auto kindOpt = classifyPerformPromiseThen(m_state.forNode(onFulfilled), m_state.forNode(onRejected))) {
+                    m_interpreter.execute(indexInBlock);
+                    alreadyHandled = true;
+
+                    Edge inputPromise = m_graph.varArgChild(node, 0);
+                    Edge resultPromise = m_graph.varArgChild(node, 3);
+                    Edge handlerEdge = (*kindOpt == JSPromise::InlineReactionKind::FulfillHandler) ? onFulfilled : onRejected;
+
+                    m_insertionSet.insertNode(indexInBlock, SpecNone, PerformPromiseThenOneHandler, node->origin,
+                        OpInfo(static_cast<uint32_t>(*kindOpt)),
+                        Edge(inputPromise.node(), KnownCellUse),
+                        Edge(handlerEdge.node(), KnownCellUse),
+                        Edge(resultPromise.node(), KnownCellUse));
+                    node->remove(m_graph);
+                    changed = true;
                 }
                 break;
             }

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -505,6 +505,7 @@ bool doesGC(Graph& graph, Node* node)
     case PromiseReject:
     case PromiseThen:
     case PerformPromiseThen:
+    case PerformPromiseThenOneHandler:
     case ArrayIsArray:
 #else // not ASSERT_ENABLED
     // See comment at the top for why the default for all nodes should be to

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -3691,6 +3691,7 @@ private:
         case PromiseReject:
         case PromiseThen:
         case PerformPromiseThen:
+        case PerformPromiseThenOneHandler:
             break;
 #else // not ASSERT_ENABLED
         default:

--- a/Source/JavaScriptCore/dfg/DFGMayExit.cpp
+++ b/Source/JavaScriptCore/dfg/DFGMayExit.cpp
@@ -131,6 +131,7 @@ ExitMode mayExitImpl(Graph& graph, Node* node, StateType& state)
     case LogShadowChickenPrologue:
     case LogShadowChickenTail:
     case PerformPromiseThen:
+    case PerformPromiseThenOneHandler:
         break;
 
     case Switch: {

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -53,6 +53,7 @@
 #include "GetByVariant.h"
 #include "InlineCacheCompiler.h"
 #include "JSCJSValue.h"
+#include "JSPromise.h"
 #include "JSPropertyNameEnumerator.h"
 #include "Operands.h"
 #include "PrivateFieldPutKind.h"
@@ -1612,6 +1613,12 @@ public:
     {
         ASSERT(hasInternalFieldIndex());
         return m_opInfo.as<uint32_t>();
+    }
+
+    JSPromise::InlineReactionKind performPromiseThenInlineReactionKind()
+    {
+        ASSERT(op() == PerformPromiseThenOneHandler);
+        return static_cast<JSPromise::InlineReactionKind>(m_opInfo.as<uint32_t>());
     }
     
     bool hasDirectArgumentsOffset()

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -663,6 +663,7 @@ namespace JSC { namespace DFG {
     macro(PromiseReject, NodeMustGenerate | NodeResultJS) \
     macro(PromiseThen, NodeMustGenerate | NodeResultJS) \
     macro(PerformPromiseThen, NodeMustGenerate | NodeHasVarArgs) \
+    macro(PerformPromiseThenOneHandler, NodeMustGenerate) \
 
 
 // This enum generates a monotonically increasing id for all Node types,

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -1730,6 +1730,18 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationPerformPromiseThen, void, (JSGlobalOb
     inputPromise->performPromiseThen(vm, globalObject, JSValue::decode(onFulfilled), JSValue::decode(onRejected), resultPromise);
 }
 
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationPerformPromiseThenOneHandler, void, (JSGlobalObject* globalObject, JSPromise* inputPromise, JSObject* handler, JSPromise* resultPromise, int32_t kindAsInt))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto kind = static_cast<JSPromise::InlineReactionKind>(kindAsInt);
+    JSValue handlerValue(handler);
+    JSValue onFulfilled = (kind == JSPromise::InlineReactionKind::FulfillHandler) ? handlerValue : jsUndefined();
+    JSValue onRejected = (kind == JSPromise::InlineReactionKind::RejectHandler) ? handlerValue : jsUndefined();
+    inputPromise->performPromiseThen(vm, globalObject, onFulfilled, onRejected, resultPromise);
+}
+
 JSC_DEFINE_JIT_OPERATION(operationRegExpTestString, size_t, (JSGlobalObject* globalObject, RegExpObject* regExpObject, JSString* input))
 {
     SuperSamplerScope superSamplerScope(false);

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -369,6 +369,7 @@ JSC_DECLARE_JIT_OPERATION(operationPromiseResolve, JSObject*, (JSGlobalObject*, 
 JSC_DECLARE_JIT_OPERATION(operationPromiseReject, JSObject*, (JSGlobalObject*, JSObject*, EncodedJSValue));
 JSC_DECLARE_JIT_OPERATION(operationPromiseThen, JSObject*, (JSGlobalObject*, JSPromise*, EncodedJSValue, EncodedJSValue));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationPerformPromiseThen, void, (JSGlobalObject*, JSPromise*, EncodedJSValue, EncodedJSValue, JSPromise*));
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationPerformPromiseThenOneHandler, void, (JSGlobalObject*, JSPromise*, JSObject*, JSPromise*, int32_t));
 
 JSC_DECLARE_JIT_OPERATION(operationNewSymbol, Symbol*, (VM*));
 JSC_DECLARE_JIT_OPERATION(operationNewSymbolWithStringDescription, Symbol*, (JSGlobalObject*, JSString*));

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1812,6 +1812,7 @@ private:
         case PromiseReject:
         case PromiseThen:
         case PerformPromiseThen:
+        case PerformPromiseThenOneHandler:
             break;
             
         // This gets ignored because it only pretends to produce a value.

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -804,6 +804,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case PromiseReject:
     case PromiseThen:
     case PerformPromiseThen:
+    case PerformPromiseThenOneHandler:
     case SetAdd:
     case MapSet:
     case MapOrSetDelete:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -18400,6 +18400,45 @@ void SpeculativeJIT::compilePerformPromiseThen(Node* node)
     noResult(node);
 }
 
+void SpeculativeJIT::compilePerformPromiseThenOneHandler(Node* node)
+{
+    auto kind = node->performPromiseThenInlineReactionKind();
+
+    SpeculateCellOperand inputPromise(this, node->child1());
+    SpeculateCellOperand handler(this, node->child2());
+    SpeculateCellOperand resultPromise(this, node->child3());
+
+    GPRReg inputPromiseGPR = inputPromise.gpr();
+    GPRReg handlerGPR = handler.gpr();
+    GPRReg resultPromiseGPR = resultPromise.gpr();
+
+#if USE(JSVALUE64)
+    GPRTemporary packed(this);
+    GPRReg packedGPR = packed.gpr();
+
+    constexpr unsigned pointerBits = CompactPointerTuple<JSCell*, uint16_t>::maxNumberOfBitsInPointer;
+    constexpr uint64_t pointerMask = (1ULL << pointerBits) - 1;
+    constexpr uint64_t flagMask = static_cast<uint64_t>(JSPromise::stateMask | JSPromise::inlineReactionKindMask) << pointerBits;
+    constexpr uint64_t mask = pointerMask | flagMask;
+
+    load64(Address(inputPromiseGPR, JSPromise::offsetOfPacked()), packedGPR);
+    Jump slowPath = branchTest64(NonZero, packedGPR, TrustedImm64(mask));
+
+    uint64_t orBits = static_cast<uint64_t>(JSPromise::isHandledFlag | (static_cast<uint16_t>(kind) << JSPromise::inlineReactionKindShift)) << pointerBits;
+    or64(TrustedImm64(orBits), packedGPR);
+    or64(resultPromiseGPR, packedGPR);
+
+    store64(handlerGPR, Address(inputPromiseGPR, JSPromise::offsetOfSlot()));
+    store64(packedGPR, Address(inputPromiseGPR, JSPromise::offsetOfPacked()));
+
+    addSlowPathGenerator(slowPathCall(slowPath, this, operationPerformPromiseThenOneHandler, NeedToSpill, ExceptionCheckRequirement::CheckNotNeeded, NoResult, LinkableConstant::globalObject(*this, node), inputPromiseGPR, handlerGPR, resultPromiseGPR, TrustedImm32(static_cast<int32_t>(kind))));
+#else
+    flushRegisters();
+    callOperationWithoutExceptionCheck(operationPerformPromiseThenOneHandler, LinkableConstant::globalObject(*this, node), inputPromiseGPR, handlerGPR, resultPromiseGPR, TrustedImm32(static_cast<int32_t>(kind)));
+#endif
+    noResult(node);
+}
+
 unsigned SpeculativeJIT::appendExceptionHandlingOSRExit(ExitKind kind, unsigned eventStreamIndex, CodeOrigin opCatchOrigin, HandlerInfo* exceptionHandler, CallSiteIndex callSite, MacroAssembler::JumpList jumpsToFail)
 {
     if (Options::validateDFGMayExit()) [[unlikely]] {

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1821,6 +1821,7 @@ public:
     void compilePromiseReject(Node*);
     void compilePromiseThen(Node*);
     void compilePerformPromiseThen(Node*);
+    void compilePerformPromiseThenOneHandler(Node*);
 
     template<typename JSClass, typename Operation>
     void compileCreateInternalFieldObject(Node*, Operation);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -4429,6 +4429,10 @@ void SpeculativeJIT::compile(Node* node)
         compilePerformPromiseThen(node);
         break;
 
+    case PerformPromiseThenOneHandler:
+        compilePerformPromiseThenOneHandler(node);
+        break;
+
     case Unreachable:
         unreachable(node);
         break;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -6588,6 +6588,10 @@ void SpeculativeJIT::compile(Node* node)
         compilePerformPromiseThen(node);
         break;
 
+    case PerformPromiseThenOneHandler:
+        compilePerformPromiseThenOneHandler(node);
+        break;
+
 #if ENABLE(FTL_JIT)        
     case CheckTierUpInLoop: {
         Jump callTierUp = branchAdd32(PositiveOrZero, TrustedImm32(Options::ftlTierUpCounterIncrementForLoop()), Address(GPRInfo::jitDataRegister, JITData::offsetOfTierUpCounter()));

--- a/Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp
@@ -349,6 +349,12 @@ private:
                 break;
             }
 
+            case PerformPromiseThenOneHandler: {
+                considerBarrier(m_node->child1(), m_node->child2());
+                considerBarrier(m_node->child1(), m_node->child3());
+                break;
+            }
+
             case PutCellButterflySlot: {
                 considerBarrier(m_node->child1(), m_node->child3());
                 break;
@@ -527,6 +533,10 @@ private:
                         break;
                     case NukeStructureAndSetButterfly:
                         escape(m_node->child2().node());
+                        break;
+                    case PerformPromiseThenOneHandler:
+                        escape(m_node->child2().node());
+                        escape(m_node->child3().node());
                         break;
                     case SetLocal:
                     case PutStack:

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -518,6 +518,7 @@ inline CapabilityLevel canCompile(Node* node)
     case PromiseReject:
     case PromiseThen:
     case PerformPromiseThen:
+    case PerformPromiseThenOneHandler:
         // These are OK.
         break;
 

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -1978,6 +1978,9 @@ private:
         case PerformPromiseThen:
             compilePerformPromiseThen();
             break;
+        case PerformPromiseThenOneHandler:
+            compilePerformPromiseThenOneHandler();
+            break;
 
         case LoopHint: {
             compileLoopHint();
@@ -21111,6 +21114,41 @@ IGNORE_CLANG_WARNINGS_END
         LValue onRejected = lowJSValue(m_graph.varArgChild(m_node, 2));
         LValue resultPromise = lowCell(m_graph.varArgChild(m_node, 3));
         vmCall(Void, operationPerformPromiseThen, weakPointer(globalObject), inputPromise, onFulfilled, onRejected, resultPromise);
+    }
+
+    void compilePerformPromiseThenOneHandler()
+    {
+        auto* globalObject = m_graph.globalObjectFor(m_origin.semantic);
+        auto kind = m_node->performPromiseThenInlineReactionKind();
+
+        LValue inputPromise = lowCell(m_node->child1());
+        LValue handler = lowCell(m_node->child2());
+        LValue resultPromise = lowCell(m_node->child3());
+
+        constexpr unsigned pointerBits = CompactPointerTuple<JSCell*, uint16_t>::maxNumberOfBitsInPointer;
+        constexpr uint64_t pointerMask = (1ULL << pointerBits) - 1;
+        constexpr uint64_t flagMask = static_cast<uint64_t>(JSPromise::stateMask | JSPromise::inlineReactionKindMask) << pointerBits;
+        constexpr uint64_t mask = pointerMask | flagMask;
+        uint64_t orBits = static_cast<uint64_t>(JSPromise::isHandledFlag | (static_cast<uint16_t>(kind) << JSPromise::inlineReactionKindShift)) << pointerBits;
+
+        LBasicBlock fastPath = m_out.newBlock();
+        LBasicBlock slowPath = m_out.newBlock();
+        LBasicBlock continuation = m_out.newBlock();
+
+        LValue packed = m_out.load64(inputPromise, m_heaps.JSPromise_packed);
+        m_out.branch(m_out.notZero64(m_out.bitAnd(packed, m_out.constInt64(mask))), rarely(slowPath), usually(fastPath));
+
+        LBasicBlock lastNext = m_out.appendTo(fastPath, slowPath);
+        LValue newPacked = m_out.bitOr(m_out.bitOr(packed, m_out.constInt64(orBits)), resultPromise);
+        m_out.store64(handler, inputPromise, m_heaps.JSPromise_slot);
+        m_out.store64(newPacked, inputPromise, m_heaps.JSPromise_packed);
+        m_out.jump(continuation);
+
+        m_out.appendTo(slowPath, continuation);
+        vmCall(Void, operationPerformPromiseThenOneHandler, weakPointer(globalObject), inputPromise, handler, resultPromise, m_out.constInt32(static_cast<int32_t>(kind)));
+        m_out.jump(continuation);
+
+        m_out.appendTo(continuation, lastNext);
     }
 
     void compileLoopHint()

--- a/Source/JavaScriptCore/tools/JSDollarVM.cpp
+++ b/Source/JavaScriptCore/tools/JSDollarVM.cpp
@@ -2216,6 +2216,7 @@ static JSC_DECLARE_HOST_FUNCTION(functionGetStructureTransitionList);;
 static JSC_DECLARE_HOST_FUNCTION(functionGetConcurrently);
 static JSC_DECLARE_HOST_FUNCTION(functionHasOwnLengthProperty);
 static JSC_DECLARE_HOST_FUNCTION(functionRejectPromiseAsHandled);
+static JSC_DECLARE_HOST_FUNCTION(functionMarkPromiseAsHandled);
 static JSC_DECLARE_HOST_FUNCTION(functionSetUserPreferredLanguages);
 static JSC_DECLARE_HOST_FUNCTION(functionICUVersion);
 static JSC_DECLARE_HOST_FUNCTION(functionICUMinorVersion);
@@ -3990,6 +3991,14 @@ JSC_DEFINE_HOST_FUNCTION(functionRejectPromiseAsHandled, (JSGlobalObject* global
     return JSValue::encode(jsUndefined());
 }
 
+JSC_DEFINE_HOST_FUNCTION(functionMarkPromiseAsHandled, (JSGlobalObject*, CallFrame* callFrame))
+{
+    DollarVMAssertScope assertScope;
+    JSPromise* promise = uncheckedDowncast<JSPromise>(callFrame->uncheckedArgument(0));
+    promise->markAsHandled();
+    return JSValue::encode(jsUndefined());
+}
+
 JSC_DEFINE_HOST_FUNCTION(functionSetUserPreferredLanguages, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     DollarVMAssertScope assertScope;
@@ -4549,6 +4558,7 @@ void JSDollarVM::finishCreation(VM& vm)
 
     addFunction(vm, allowIfNotFuzz, "hasOwnLengthProperty"_s, functionHasOwnLengthProperty, 1);
     addFunction(vm, allowIfNotFuzz, "rejectPromiseAsHandled"_s, functionRejectPromiseAsHandled, 1);
+    addFunction(vm, allowIfNotFuzz, "markPromiseAsHandled"_s, functionMarkPromiseAsHandled, 1);
 
     addFunction(vm, allowIfNotFuzz, "setUserPreferredLanguages"_s, functionSetUserPreferredLanguages, 1);
     addFunction(vm, allowIfNotFuzz, "icuVersion"_s, functionICUVersion, 0);


### PR DESCRIPTION
#### c3276f48dfd6994459ac58011af18625925f9fba
<pre>
[JSC] Optimize initial `then` call
<a href="https://bugs.webkit.org/show_bug.cgi?id=314798">https://bugs.webkit.org/show_bug.cgi?id=314798</a>
<a href="https://rdar.apple.com/177048510">rdar://177048510</a>

Reviewed by Yijia Huang.

313220@main avoids reaction cell creation for initial `then` call.
This makes `then` function itself super simple, and we can make this
fast path fully inlined easily. This patch adds PerformPromiseThenOneHandler
DFG node which inlines the fast path. We directly update flags and store values.

Test: JSTests/stress/perform-promise-then-one-handler.js

* JSTests/stress/perform-promise-then-one-handler.js: Added.
(shouldBe):
(async shouldReject):
(fulfillOnly):
(rejectOnlyUndefined):
(rejectOnlyNull):
(bothHandlers):
(intHandlerWithReject):
(async main):
(main.then):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp:
(JSC::DFG::classifyPerformPromiseThen):
(JSC::DFG::ConstantFoldingPhase::foldConstants):
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGMayExit.cpp:
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::performPromiseThenInlineReactionKind):
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGStoreBarrierInsertionPhase.cpp:
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/tools/JSDollarVM.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
(JSC::JSDollarVM::finishCreation):

Canonical link: <a href="https://commits.webkit.org/313277@main">https://commits.webkit.org/313277@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f96f8a3979d22fba45422d28400a7010645fd702

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162635 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36111 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29251 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171573 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/119081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e163698e-32ce-4d2e-a887-4f79612ce83e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164504 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36215 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36115 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126221 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/119081 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/16dd8453-3891-4853-9f6b-0dcd303d2d1b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165594 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28572 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146117 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106799 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27618 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19273 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137324 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23847 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174077 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23474 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21390 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25492 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134531 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35785 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134527 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35769 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145643 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98121 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24721 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/29067 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/22477 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195036 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35279 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/103030 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/50434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34780 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35025 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34928 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->