### PR TITLE
[GTK][WPE] Always warn on wkdev-sdk container version mismatch, regardless of auto-enter

### DIFF
--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -2564,12 +2564,15 @@ sub maybeEnterWebKitContainerSDK()
     # Mirror the cheap opt-out checks from maybe_enter_webkit_container_sdk so
     # that the overwhelmingly common no-op case avoids forking a Python
     # interpreter on every wrapper invocation. Keep in sync with that function.
-    return if ($ENV{'WEBKIT_CONTAINER_SDK_ENABLE_AUTOENTER'} // '') ne '1';
-    return if ($ENV{'WEBKIT_CONTAINER_SDK'} // '') eq '1';
     return if ($ENV{'WEBKIT_FLATPAK'} // '') eq '1';
     return if ($ENV{'WEBKIT_JHBUILD'} // '') eq '1';
     return if ($ENV{'WEBKIT_CONTAINER_SDK_INSIDE_MOUNT_NAMESPACE'} // '') eq '1';
     return unless -f File::Spec->catfile(sourceDir(), ".wkdev-sdk-version");
+
+    # Auto-enter is opt-in on the host. Inside the container we always invoke
+    # the helper so the version-mismatch warning fires regardless of opt-in.
+    return if (($ENV{'WEBKIT_CONTAINER_SDK'} // '') ne '1'
+               and ($ENV{'WEBKIT_CONTAINER_SDK_ENABLE_AUTOENTER'} // '') ne '1');
 
     # Delegate to the Python helper. It either replaces this process with
     # `podman exec ...` (never returning), or exits with

--- a/Tools/Scripts/webkitpy/port/linux_container_sdk_utils.py
+++ b/Tools/Scripts/webkitpy/port/linux_container_sdk_utils.py
@@ -390,7 +390,10 @@ def maybe_enter_webkit_container_sdk(argv=None):
     on first use using the version pinned in .wkdev-sdk-version.
 
     When already running inside a wkdev-sdk container, verify the running SDK
-    version matches the pinned one and warn loudly if not, but continue.
+    version matches the pinned one and warn loudly if not, but continue. The
+    in-container version check fires regardless of
+    WEBKIT_CONTAINER_SDK_ENABLE_AUTOENTER so users always learn when the
+    running container is out of sync with .wkdev-sdk-version.
 
     `argv` defaults to `sys.argv` when omitted; pass it explicitly when the
     caller is a wrapper (e.g. container-sdk-autoenter) whose own argv differs
@@ -410,21 +413,15 @@ def maybe_enter_webkit_container_sdk(argv=None):
     if any(os.environ.get(e) == '1' for e in ('WEBKIT_FLATPAK', 'WEBKIT_JHBUILD', 'WEBKIT_CONTAINER_SDK_INSIDE_MOUNT_NAMESPACE')):
         return
 
-    # Auto-enter is opt-in: bots and users flip it on via the environment.
-    if os.environ.get('WEBKIT_CONTAINER_SDK_ENABLE_AUTOENTER') != '1':
-        return
-
-    # Cross-target builds use their own toolchain wrapper (see webkitdirs.pm's
-    # runInCrossTargetEnvironment); don't double-wrap them in the SDK container.
-    if os.environ.get('WEBKIT_CROSS_TARGET'):
-        return
-
     source_dir = _source_dir()
     pinned_version = _read_pinned_sdk_version(source_dir)
     if not pinned_version:
         return
 
-    # Inside container: version-match check (warn, continue).
+    # Inside container: version-match check (warn, continue). Performed
+    # unconditionally -- the auto-enter opt-in below only gates host-side
+    # behavior, since by the time we are inside the container the user has
+    # already chosen the SDK they want to use.
     if os.environ.get('WEBKIT_CONTAINER_SDK') == '1':
         running_version = _read_running_sdk_version()
         if running_version and running_version != pinned_version:
@@ -436,6 +433,15 @@ def maybe_enter_webkit_container_sdk(argv=None):
                 '         from the host to recreate the container at the pinned version.',
                 '         Continuing with the current container.',
             ])
+        return
+
+    # Auto-enter is opt-in: bots and users flip it on via the environment.
+    if os.environ.get('WEBKIT_CONTAINER_SDK_ENABLE_AUTOENTER') != '1':
+        return
+
+    # Cross-target builds use their own toolchain wrapper (see webkitdirs.pm's
+    # runInCrossTargetEnvironment); don't double-wrap them in the SDK container.
+    if os.environ.get('WEBKIT_CROSS_TARGET'):
         return
 
     # Host side: podman is the only prerequisite.


### PR DESCRIPTION
#### 6bebe6dfcd60d2cc90898ef049e4e9ba8fcc8916
<pre>
[GTK][WPE] Always warn on wkdev-sdk container version mismatch, regardless of auto-enter
<a href="https://bugs.webkit.org/show_bug.cgi?id=314800">https://bugs.webkit.org/show_bug.cgi?id=314800</a>

Reviewed by Claudio Saavedra.

The version-mismatch warning in maybe_enter_webkit_container_sdk() previously
fired only when WEBKIT_CONTAINER_SDK_ENABLE_AUTOENTER=1, and never at all from
Perl wrappers (build-webkit, run-javascriptcore-tests, ...) because their fast-
path mirror in webkitdirs.pm short-circuited when WEBKIT_CONTAINER_SDK==1. As
a result, a developer running an outdated wkdev-sdk container without auto-enter
got no signal that their container had drifted from .wkdev-sdk-version.

Reorder the Python helper so the in-container version-mismatch check runs
before the auto-enter opt-in gate (only host-side auto-enter remains gated on
WEBKIT_CONTAINER_SDK_ENABLE_AUTOENTER and WEBKIT_CROSS_TARGET). Update the Perl
mirror so it invokes the helper when inside the container regardless of opt-in,
keeping the host-side opt-out as the only fast-path skip.

Canonical link: <a href="https://commits.webkit.org/313228@main">https://commits.webkit.org/313228@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/62c258925034afb15d6764634f25bfa10297cd61

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162510 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35986 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/29106 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171448 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/118955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164379 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36090 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35990 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/126119 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/118955 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165469 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/28461 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/145996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106697 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/161830 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27507 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26037 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/19148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/23726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173952 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23349 "Built successfully and passed tests") | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/25370 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/134429 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35660 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134427 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35644 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/145522 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97918 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24684 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28956 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/22355 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194910 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35154 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/50376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34655 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34900 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34803 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->