### PR TITLE
Implement case sensitive modifier (s) in attribute selector

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/attribute-selectors/attribute-case/cssom-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/attribute-selectors/attribute-case/cssom-expected.txt
@@ -39,36 +39,36 @@ PASS [*|foo="bar" i] insertRule in @media
 PASS [*|foo="bar" i] getting CSSRule#cssText in @media
 PASS [*|foo="bar" i] getting CSSStyleRule#selectorText in @media
 PASS [*|foo="bar" i] setting CSSStyleRule#selectorText in @media
-FAIL [foo="bar" s] insertRule The string did not match the expected pattern.
-FAIL [foo="bar" s] getting CSSRule#cssText The string did not match the expected pattern.
-FAIL [foo="bar" s] getting CSSStyleRule#selectorText The string did not match the expected pattern.
-FAIL [foo="bar" s] setting CSSStyleRule#selectorText assert_equals: expected "[foo=\"bar\" s]" but got "foobar"
-FAIL [foo="bar" s] insertRule in @media The string did not match the expected pattern.
-FAIL [foo="bar" s] getting CSSRule#cssText in @media The string did not match the expected pattern.
-FAIL [foo="bar" s] getting CSSStyleRule#selectorText in @media The string did not match the expected pattern.
-FAIL [foo="bar" s] setting CSSStyleRule#selectorText in @media assert_equals: expected "[foo=\"bar\" s]" but got "foobar"
-FAIL [foo="bar" /**/ s] insertRule The string did not match the expected pattern.
-FAIL [foo="bar" /**/ s] getting CSSRule#cssText The string did not match the expected pattern.
-FAIL [foo="bar" /**/ s] getting CSSStyleRule#selectorText The string did not match the expected pattern.
-FAIL [foo="bar" /**/ s] setting CSSStyleRule#selectorText assert_equals: expected "[foo=\"bar\" s]" but got "foobar"
-FAIL [foo="bar" /**/ s] insertRule in @media The string did not match the expected pattern.
-FAIL [foo="bar" /**/ s] getting CSSRule#cssText in @media The string did not match the expected pattern.
-FAIL [foo="bar" /**/ s] getting CSSStyleRule#selectorText in @media The string did not match the expected pattern.
-FAIL [foo="bar" /**/ s] setting CSSStyleRule#selectorText in @media assert_equals: expected "[foo=\"bar\" s]" but got "foobar"
-FAIL [foo="bar"/**/s] insertRule The string did not match the expected pattern.
-FAIL [foo="bar"/**/s] getting CSSRule#cssText The string did not match the expected pattern.
-FAIL [foo="bar"/**/s] getting CSSStyleRule#selectorText The string did not match the expected pattern.
-FAIL [foo="bar"/**/s] setting CSSStyleRule#selectorText assert_equals: expected "[foo=\"bar\" s]" but got "foobar"
-FAIL [foo="bar"/**/s] insertRule in @media The string did not match the expected pattern.
-FAIL [foo="bar"/**/s] getting CSSRule#cssText in @media The string did not match the expected pattern.
-FAIL [foo="bar"/**/s] getting CSSStyleRule#selectorText in @media The string did not match the expected pattern.
-FAIL [foo="bar"/**/s] setting CSSStyleRule#selectorText in @media assert_equals: expected "[foo=\"bar\" s]" but got "foobar"
-FAIL [*|foo="bar" s] insertRule The string did not match the expected pattern.
-FAIL [*|foo="bar" s] getting CSSRule#cssText The string did not match the expected pattern.
-FAIL [*|foo="bar" s] getting CSSStyleRule#selectorText The string did not match the expected pattern.
-FAIL [*|foo="bar" s] setting CSSStyleRule#selectorText assert_equals: expected "[*|foo=\"bar\" s]" but got "foobar"
-FAIL [*|foo="bar" s] insertRule in @media The string did not match the expected pattern.
-FAIL [*|foo="bar" s] getting CSSRule#cssText in @media The string did not match the expected pattern.
-FAIL [*|foo="bar" s] getting CSSStyleRule#selectorText in @media The string did not match the expected pattern.
-FAIL [*|foo="bar" s] setting CSSStyleRule#selectorText in @media assert_equals: expected "[*|foo=\"bar\" s]" but got "foobar"
+PASS [foo="bar" s] insertRule
+PASS [foo="bar" s] getting CSSRule#cssText
+PASS [foo="bar" s] getting CSSStyleRule#selectorText
+PASS [foo="bar" s] setting CSSStyleRule#selectorText
+PASS [foo="bar" s] insertRule in @media
+PASS [foo="bar" s] getting CSSRule#cssText in @media
+PASS [foo="bar" s] getting CSSStyleRule#selectorText in @media
+PASS [foo="bar" s] setting CSSStyleRule#selectorText in @media
+PASS [foo="bar" /**/ s] insertRule
+PASS [foo="bar" /**/ s] getting CSSRule#cssText
+PASS [foo="bar" /**/ s] getting CSSStyleRule#selectorText
+PASS [foo="bar" /**/ s] setting CSSStyleRule#selectorText
+PASS [foo="bar" /**/ s] insertRule in @media
+PASS [foo="bar" /**/ s] getting CSSRule#cssText in @media
+PASS [foo="bar" /**/ s] getting CSSStyleRule#selectorText in @media
+PASS [foo="bar" /**/ s] setting CSSStyleRule#selectorText in @media
+PASS [foo="bar"/**/s] insertRule
+PASS [foo="bar"/**/s] getting CSSRule#cssText
+PASS [foo="bar"/**/s] getting CSSStyleRule#selectorText
+PASS [foo="bar"/**/s] setting CSSStyleRule#selectorText
+PASS [foo="bar"/**/s] insertRule in @media
+PASS [foo="bar"/**/s] getting CSSRule#cssText in @media
+PASS [foo="bar"/**/s] getting CSSStyleRule#selectorText in @media
+PASS [foo="bar"/**/s] setting CSSStyleRule#selectorText in @media
+PASS [*|foo="bar" s] insertRule
+PASS [*|foo="bar" s] getting CSSRule#cssText
+PASS [*|foo="bar" s] getting CSSStyleRule#selectorText
+PASS [*|foo="bar" s] setting CSSStyleRule#selectorText
+PASS [*|foo="bar" s] insertRule in @media
+PASS [*|foo="bar" s] getting CSSRule#cssText in @media
+PASS [*|foo="bar" s] getting CSSStyleRule#selectorText in @media
+PASS [*|foo="bar" s] setting CSSStyleRule#selectorText in @media
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/attribute-selectors/attribute-case/semantics-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/attribute-selectors/attribute-case/semantics-expected.txt
@@ -57,39 +57,39 @@ PASS [foo='BAR'][foo='bar' i] <div foo="BAR"> in standards mode
 PASS [foo='BAR'][foo='bar' i] <div foo="BAR"> with querySelector in standards mode
 PASS [foo='bar' i][foo='BAR'] <div foo="BAR"> in standards mode
 PASS [foo='bar' i][foo='BAR'] <div foo="BAR"> with querySelector in standards mode
-FAIL [foo='bar' s] <div foo="bar"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div foo="bar"> with querySelector in standards mode '[foo='bar' s]' is not a valid selector.
-FAIL [foo='' s] <div foo=""> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='' s] <div foo=""> with querySelector in standards mode '[foo='' s]' is not a valid selector.
-FAIL [foo='ä' s] /* COMBINING in both */ <div foo="ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in both */ <div foo="ä"> with querySelector in standards mode '[foo='ä' s] /* COMBINING in both */' is not a valid selector.
-FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="bar" {c}foo="x"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="bar" {c}foo="x"> with querySelector in standards mode '[*|foo='bar' s]' is not a valid selector.
-FAIL [*|foo='bar' s] <div foo="bar" {a}foo="x" {b}foo="x" {c}foo="x"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|foo='bar' s] <div foo="bar" {a}foo="x" {b}foo="x" {c}foo="x"> with querySelector in standards mode '[*|foo='bar' s]' is not a valid selector.
-FAIL [align='left' s] <div align="left"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [align='left' s] <div align="left"> with querySelector in standards mode '[align='left' s]' is not a valid selector.
-FAIL [align='LEFT' s] <div align="LEFT"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [align='LEFT' s] <div align="LEFT"> with querySelector in standards mode '[align='LEFT' s]' is not a valid selector.
-FAIL [class~='a' s] <div class="x a b"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [class~='a' s] <div class="x a b"> with querySelector in standards mode '[class~='a' s]' is not a valid selector.
-FAIL [class~='A' s] <div class="X A B"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [class~='A' s] <div class="X A B"> with querySelector in standards mode '[class~='A' s]' is not a valid selector.
-FAIL [id^='a' s] <div id="ab"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [id^='a' s] <div id="ab"> with querySelector in standards mode '[id^='a' s]' is not a valid selector.
-FAIL [id$='A' s] <div id="XA"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [id$='A' s] <div id="XA"> with querySelector in standards mode '[id$='A' s]' is not a valid selector.
-FAIL [lang|='a' s] <div lang="a-b"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [lang|='a' s] <div lang="a-b"> with querySelector in standards mode '[lang|='a' s]' is not a valid selector.
-FAIL [lang*='A' s] <div lang="XAB"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [lang*='A' s] <div lang="XAB"> with querySelector in standards mode '[lang*='A' s]' is not a valid selector.
-FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> with querySelector in standards mode '[*|lang='a' s]' is not a valid selector.
-FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> with querySelector in standards mode '[*|lang='A' s]' is not a valid selector.
-FAIL @namespace x 'http://www.w3.org/XML/1998/namespace'; [x|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in standards mode assert_equals: rule didn't parse into CSSOM expected 2 but got 1
-FAIL [foo='BAR' s][foo='BAR' s] <div foo="BAR"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='BAR' s][foo='BAR' s] <div foo="BAR"> with querySelector in standards mode '[foo='BAR' s][foo='BAR' s]' is not a valid selector.
+PASS [foo='bar' s] <div foo="bar"> in standards mode
+PASS [foo='bar' s] <div foo="bar"> with querySelector in standards mode
+PASS [foo='' s] <div foo=""> in standards mode
+PASS [foo='' s] <div foo=""> with querySelector in standards mode
+PASS [foo='ä' s] /* COMBINING in both */ <div foo="ä"> in standards mode
+PASS [foo='ä' s] /* COMBINING in both */ <div foo="ä"> with querySelector in standards mode
+PASS [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="bar" {c}foo="x"> in standards mode
+PASS [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="bar" {c}foo="x"> with querySelector in standards mode
+PASS [*|foo='bar' s] <div foo="bar" {a}foo="x" {b}foo="x" {c}foo="x"> in standards mode
+PASS [*|foo='bar' s] <div foo="bar" {a}foo="x" {b}foo="x" {c}foo="x"> with querySelector in standards mode
+PASS [align='left' s] <div align="left"> in standards mode
+PASS [align='left' s] <div align="left"> with querySelector in standards mode
+PASS [align='LEFT' s] <div align="LEFT"> in standards mode
+PASS [align='LEFT' s] <div align="LEFT"> with querySelector in standards mode
+PASS [class~='a' s] <div class="x a b"> in standards mode
+PASS [class~='a' s] <div class="x a b"> with querySelector in standards mode
+PASS [class~='A' s] <div class="X A B"> in standards mode
+PASS [class~='A' s] <div class="X A B"> with querySelector in standards mode
+PASS [id^='a' s] <div id="ab"> in standards mode
+PASS [id^='a' s] <div id="ab"> with querySelector in standards mode
+PASS [id$='A' s] <div id="XA"> in standards mode
+PASS [id$='A' s] <div id="XA"> with querySelector in standards mode
+PASS [lang|='a' s] <div lang="a-b"> in standards mode
+PASS [lang|='a' s] <div lang="a-b"> with querySelector in standards mode
+PASS [lang*='A' s] <div lang="XAB"> in standards mode
+PASS [lang*='A' s] <div lang="XAB"> with querySelector in standards mode
+PASS [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in standards mode
+PASS [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> with querySelector in standards mode
+PASS [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in standards mode
+PASS [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> with querySelector in standards mode
+PASS @namespace x 'http://www.w3.org/XML/1998/namespace'; [x|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in standards mode
+PASS [foo='BAR' s][foo='BAR' s] <div foo="BAR"> in standards mode
+PASS [foo='BAR' s][foo='BAR' s] <div foo="BAR"> with querySelector in standards mode
 PASS [align='left'] /* sanity check (match HTML) */ <div align="LEFT"> in standards mode
 PASS [align='left'] /* sanity check (match HTML) */ <div align="LEFT"> with querySelector in standards mode
 PASS [align='LEFT'] /* sanity check (match HTML) */ <div align="left"> in standards mode
@@ -205,121 +205,121 @@ PASS [foo*='É' i] <div foo="é"> in standards mode
 PASS [foo*='É' i] <div foo="é"> with querySelector in standards mode
 PASS [foo|='É' i] <div foo="é"> in standards mode
 PASS [foo|='É' i] <div foo="é"> with querySelector in standards mode
-FAIL [foo='' s] <div foo="BAR"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='' s] <div foo="BAR"> with querySelector in standards mode '[foo='' s]' is not a valid selector.
-FAIL [foo='\0' s] /* \0 in selector */ <div foo=""> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='\0' s] /* \0 in selector */ <div foo=""> with querySelector in standards mode '[foo='\0' s] /* \0 in selector */' is not a valid selector.
-FAIL [foo='' s] /* \0 in attribute */ <div foo="\0"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='' s] /* \0 in attribute */ <div foo="\0"> with querySelector in standards mode '[foo='' s] /* \0 in attribute */' is not a valid selector.
-FAIL [foo='ä' s] <div foo="Ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] <div foo="Ä"> with querySelector in standards mode '[foo='ä' s]' is not a valid selector.
-FAIL [foo='Ä' s] <div foo="ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] <div foo="ä"> with querySelector in standards mode '[foo='Ä' s]' is not a valid selector.
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="Ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="Ä"> with querySelector in standards mode '[foo='ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo~='ä' s] /* COMBINING in selector */ <div foo="ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo~='ä' s] /* COMBINING in selector */ <div foo="ä"> with querySelector in standards mode '[foo~='ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo^='Ä' s] /* COMBINING in selector */ <div foo="Ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo^='Ä' s] /* COMBINING in selector */ <div foo="Ä"> with querySelector in standards mode '[foo^='Ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo$='Ä' s] /* COMBINING in selector */ <div foo="ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo$='Ä' s] /* COMBINING in selector */ <div foo="ä"> with querySelector in standards mode '[foo$='Ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo*='ä' s] /* COMBINING in attribute */ <div foo="ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo*='ä' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in standards mode '[foo*='ä' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo|='ä' s] /* COMBINING in attribute */ <div foo="Ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo|='ä' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in standards mode '[foo|='ä' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in standards mode '[foo='Ä' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="Ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in standards mode '[foo='Ä' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="a"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="a"> with querySelector in standards mode '[foo='ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="A"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="A"> with querySelector in standards mode '[foo='ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="a"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="a"> with querySelector in standards mode '[foo='Ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="A"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="A"> with querySelector in standards mode '[foo='Ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in standards mode '[foo='a' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in standards mode '[foo='A' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="Ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in standards mode '[foo='a' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="Ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in standards mode '[foo='A' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='i' s] <div foo="İ"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='i' s] <div foo="İ"> with querySelector in standards mode '[foo='i' s]' is not a valid selector.
-FAIL [foo='i' s] <div foo="ı"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='i' s] <div foo="ı"> with querySelector in standards mode '[foo='i' s]' is not a valid selector.
-FAIL [foo='I' s] <div foo="İ"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='I' s] <div foo="İ"> with querySelector in standards mode '[foo='I' s]' is not a valid selector.
-FAIL [foo='I' s] <div foo="ı"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='I' s] <div foo="ı"> with querySelector in standards mode '[foo='I' s]' is not a valid selector.
-FAIL [foo='İ' s] <div foo="i"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='İ' s] <div foo="i"> with querySelector in standards mode '[foo='İ' s]' is not a valid selector.
-FAIL [foo='ı' s] <div foo="i"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ı' s] <div foo="i"> with querySelector in standards mode '[foo='ı' s]' is not a valid selector.
-FAIL [foo='İ' s] <div foo="I"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='İ' s] <div foo="I"> with querySelector in standards mode '[foo='İ' s]' is not a valid selector.
-FAIL [foo='ı' s] <div foo="I"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ı' s] <div foo="I"> with querySelector in standards mode '[foo='ı' s]' is not a valid selector.
-FAIL [foo='bar' s] <div foo="x" {a}foo="BAR"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div foo="x" {a}foo="BAR"> with querySelector in standards mode '[foo='bar' s]' is not a valid selector.
-FAIL [|foo='bar' s] <div foo="x" {a}foo="BAR"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [|foo='bar' s] <div foo="x" {a}foo="BAR"> with querySelector in standards mode '[|foo='bar' s]' is not a valid selector.
-FAIL [foo='bar' s] <div FOO="bar"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div FOO="bar"> with querySelector in standards mode '[foo='bar' s]' is not a valid selector.
-FAIL [foo='	' s] /* tab in selector */ <div foo=" "> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='	' s] /* tab in selector */ <div foo=" "> with querySelector in standards mode '[foo='	' s] /* tab in selector */' is not a valid selector.
-FAIL [foo=' ' s] /* tab in attribute */ <div foo="	"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo=' ' s] /* tab in attribute */ <div foo="	"> with querySelector in standards mode '[foo=' ' s] /* tab in attribute */' is not a valid selector.
-FAIL @namespace x 'a'; [x|foo='' s] <div {A}foo=""> in standards mode assert_equals: rule didn't parse into CSSOM expected 2 but got 1
-FAIL @namespace x 'A'; [x|foo='' s] <div {a}foo=""> in standards mode assert_equals: rule didn't parse into CSSOM expected 2 but got 1
-FAIL [foo='bar' s][foo='bar'] <div foo="BAR"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s][foo='bar'] <div foo="BAR"> with querySelector in standards mode '[foo='bar' s][foo='bar']' is not a valid selector.
-FAIL [foo='bar' s] <div baz="BAR"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div baz="BAR"> with querySelector in standards mode '[foo='bar' s]' is not a valid selector.
-FAIL [foo='bar' s] <div foo="BAR"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div foo="BAR"> with querySelector in standards mode '[foo='bar' s]' is not a valid selector.
-FAIL [foo='ä' s] /* COMBINING in both */ <div foo="Ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in both */ <div foo="Ä"> with querySelector in standards mode '[foo='ä' s] /* COMBINING in both */' is not a valid selector.
-FAIL [foo='Ä' s] /* COMBINING in both */ <div foo="ä"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in both */ <div foo="ä"> with querySelector in standards mode '[foo='Ä' s] /* COMBINING in both */' is not a valid selector.
-FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="BAR" {c}foo="x"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="BAR" {c}foo="x"> with querySelector in standards mode '[*|foo='bar' s]' is not a valid selector.
-FAIL [*|foo='bar' s] <div foo="BAR" {a}foo="x" {b}foo="x" {c}foo="x"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|foo='bar' s] <div foo="BAR" {a}foo="x" {b}foo="x" {c}foo="x"> with querySelector in standards mode '[*|foo='bar' s]' is not a valid selector.
-FAIL [align='left' s] <div align="LEFT"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [align='left' s] <div align="LEFT"> with querySelector in standards mode '[align='left' s]' is not a valid selector.
-FAIL [align='LEFT' s] <div align="left"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [align='LEFT' s] <div align="left"> with querySelector in standards mode '[align='LEFT' s]' is not a valid selector.
-FAIL [class~='a' s] <div class="X A B"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [class~='a' s] <div class="X A B"> with querySelector in standards mode '[class~='a' s]' is not a valid selector.
-FAIL [class~='A' s] <div class="x a b"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [class~='A' s] <div class="x a b"> with querySelector in standards mode '[class~='A' s]' is not a valid selector.
-FAIL [id^='a' s] <div id="AB"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [id^='a' s] <div id="AB"> with querySelector in standards mode '[id^='a' s]' is not a valid selector.
-FAIL [id$='A' s] <div id="xa"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [id$='A' s] <div id="xa"> with querySelector in standards mode '[id$='A' s]' is not a valid selector.
-FAIL [lang|='a' s] <div lang="A-B"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [lang|='a' s] <div lang="A-B"> with querySelector in standards mode '[lang|='a' s]' is not a valid selector.
-FAIL [lang*='A' s] <div lang="xab"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [lang*='A' s] <div lang="xab"> with querySelector in standards mode '[lang*='A' s]' is not a valid selector.
-FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> with querySelector in standards mode '[*|lang='a' s]' is not a valid selector.
-FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> with querySelector in standards mode '[*|lang='A' s]' is not a valid selector.
-FAIL @namespace x 'http://www.w3.org/XML/1998/namespace'; [x|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in standards mode assert_equals: rule didn't parse into CSSOM expected 2 but got 1
-FAIL [foo='bar' s][foo='bar' s] <div foo="BAR"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s][foo='bar' s] <div foo="BAR"> with querySelector in standards mode '[foo='bar' s][foo='bar' s]' is not a valid selector.
-FAIL [foo='BAR' s][foo='bar'] <div foo="BAR"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='BAR' s][foo='bar'] <div foo="BAR"> with querySelector in standards mode '[foo='BAR' s][foo='bar']' is not a valid selector.
-FAIL [foo='bar'][foo='BAR' s] <div foo="BAR"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar'][foo='BAR' s] <div foo="BAR"> with querySelector in standards mode '[foo='bar'][foo='BAR' s]' is not a valid selector.
-FAIL [foo='BAR'][foo='bar' s] <div foo="BAR"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='BAR'][foo='bar' s] <div foo="BAR"> with querySelector in standards mode '[foo='BAR'][foo='bar' s]' is not a valid selector.
-FAIL [foo='bar' s][foo='BAR'] <div foo="bar"> in standards mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s][foo='BAR'] <div foo="bar"> with querySelector in standards mode '[foo='bar' s][foo='BAR']' is not a valid selector.
+PASS [foo='' s] <div foo="BAR"> in standards mode
+PASS [foo='' s] <div foo="BAR"> with querySelector in standards mode
+PASS [foo='\0' s] /* \0 in selector */ <div foo=""> in standards mode
+PASS [foo='\0' s] /* \0 in selector */ <div foo=""> with querySelector in standards mode
+PASS [foo='' s] /* \0 in attribute */ <div foo="\0"> in standards mode
+PASS [foo='' s] /* \0 in attribute */ <div foo="\0"> with querySelector in standards mode
+PASS [foo='ä' s] <div foo="Ä"> in standards mode
+PASS [foo='ä' s] <div foo="Ä"> with querySelector in standards mode
+PASS [foo='Ä' s] <div foo="ä"> in standards mode
+PASS [foo='Ä' s] <div foo="ä"> with querySelector in standards mode
+PASS [foo='ä' s] /* COMBINING in selector */ <div foo="Ä"> in standards mode
+PASS [foo='ä' s] /* COMBINING in selector */ <div foo="Ä"> with querySelector in standards mode
+PASS [foo~='ä' s] /* COMBINING in selector */ <div foo="ä"> in standards mode
+PASS [foo~='ä' s] /* COMBINING in selector */ <div foo="ä"> with querySelector in standards mode
+PASS [foo^='Ä' s] /* COMBINING in selector */ <div foo="Ä"> in standards mode
+PASS [foo^='Ä' s] /* COMBINING in selector */ <div foo="Ä"> with querySelector in standards mode
+PASS [foo$='Ä' s] /* COMBINING in selector */ <div foo="ä"> in standards mode
+PASS [foo$='Ä' s] /* COMBINING in selector */ <div foo="ä"> with querySelector in standards mode
+PASS [foo*='ä' s] /* COMBINING in attribute */ <div foo="ä"> in standards mode
+PASS [foo*='ä' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in standards mode
+PASS [foo|='ä' s] /* COMBINING in attribute */ <div foo="Ä"> in standards mode
+PASS [foo|='ä' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in standards mode
+PASS [foo='Ä' s] /* COMBINING in attribute */ <div foo="ä"> in standards mode
+PASS [foo='Ä' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in standards mode
+PASS [foo='Ä' s] /* COMBINING in attribute */ <div foo="Ä"> in standards mode
+PASS [foo='Ä' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in standards mode
+PASS [foo='ä' s] /* COMBINING in selector */ <div foo="a"> in standards mode
+PASS [foo='ä' s] /* COMBINING in selector */ <div foo="a"> with querySelector in standards mode
+PASS [foo='ä' s] /* COMBINING in selector */ <div foo="A"> in standards mode
+PASS [foo='ä' s] /* COMBINING in selector */ <div foo="A"> with querySelector in standards mode
+PASS [foo='Ä' s] /* COMBINING in selector */ <div foo="a"> in standards mode
+PASS [foo='Ä' s] /* COMBINING in selector */ <div foo="a"> with querySelector in standards mode
+PASS [foo='Ä' s] /* COMBINING in selector */ <div foo="A"> in standards mode
+PASS [foo='Ä' s] /* COMBINING in selector */ <div foo="A"> with querySelector in standards mode
+PASS [foo='a' s] /* COMBINING in attribute */ <div foo="ä"> in standards mode
+PASS [foo='a' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in standards mode
+PASS [foo='A' s] /* COMBINING in attribute */ <div foo="ä"> in standards mode
+PASS [foo='A' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in standards mode
+PASS [foo='a' s] /* COMBINING in attribute */ <div foo="Ä"> in standards mode
+PASS [foo='a' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in standards mode
+PASS [foo='A' s] /* COMBINING in attribute */ <div foo="Ä"> in standards mode
+PASS [foo='A' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in standards mode
+PASS [foo='i' s] <div foo="İ"> in standards mode
+PASS [foo='i' s] <div foo="İ"> with querySelector in standards mode
+PASS [foo='i' s] <div foo="ı"> in standards mode
+PASS [foo='i' s] <div foo="ı"> with querySelector in standards mode
+PASS [foo='I' s] <div foo="İ"> in standards mode
+PASS [foo='I' s] <div foo="İ"> with querySelector in standards mode
+PASS [foo='I' s] <div foo="ı"> in standards mode
+PASS [foo='I' s] <div foo="ı"> with querySelector in standards mode
+PASS [foo='İ' s] <div foo="i"> in standards mode
+PASS [foo='İ' s] <div foo="i"> with querySelector in standards mode
+PASS [foo='ı' s] <div foo="i"> in standards mode
+PASS [foo='ı' s] <div foo="i"> with querySelector in standards mode
+PASS [foo='İ' s] <div foo="I"> in standards mode
+PASS [foo='İ' s] <div foo="I"> with querySelector in standards mode
+PASS [foo='ı' s] <div foo="I"> in standards mode
+PASS [foo='ı' s] <div foo="I"> with querySelector in standards mode
+PASS [foo='bar' s] <div foo="x" {a}foo="BAR"> in standards mode
+PASS [foo='bar' s] <div foo="x" {a}foo="BAR"> with querySelector in standards mode
+PASS [|foo='bar' s] <div foo="x" {a}foo="BAR"> in standards mode
+PASS [|foo='bar' s] <div foo="x" {a}foo="BAR"> with querySelector in standards mode
+PASS [foo='bar' s] <div FOO="bar"> in standards mode
+PASS [foo='bar' s] <div FOO="bar"> with querySelector in standards mode
+PASS [foo='	' s] /* tab in selector */ <div foo=" "> in standards mode
+PASS [foo='	' s] /* tab in selector */ <div foo=" "> with querySelector in standards mode
+PASS [foo=' ' s] /* tab in attribute */ <div foo="	"> in standards mode
+PASS [foo=' ' s] /* tab in attribute */ <div foo="	"> with querySelector in standards mode
+PASS @namespace x 'a'; [x|foo='' s] <div {A}foo=""> in standards mode
+PASS @namespace x 'A'; [x|foo='' s] <div {a}foo=""> in standards mode
+PASS [foo='bar' s][foo='bar'] <div foo="BAR"> in standards mode
+PASS [foo='bar' s][foo='bar'] <div foo="BAR"> with querySelector in standards mode
+PASS [foo='bar' s] <div baz="BAR"> in standards mode
+PASS [foo='bar' s] <div baz="BAR"> with querySelector in standards mode
+PASS [foo='bar' s] <div foo="BAR"> in standards mode
+PASS [foo='bar' s] <div foo="BAR"> with querySelector in standards mode
+PASS [foo='ä' s] /* COMBINING in both */ <div foo="Ä"> in standards mode
+PASS [foo='ä' s] /* COMBINING in both */ <div foo="Ä"> with querySelector in standards mode
+PASS [foo='Ä' s] /* COMBINING in both */ <div foo="ä"> in standards mode
+PASS [foo='Ä' s] /* COMBINING in both */ <div foo="ä"> with querySelector in standards mode
+PASS [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="BAR" {c}foo="x"> in standards mode
+PASS [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="BAR" {c}foo="x"> with querySelector in standards mode
+PASS [*|foo='bar' s] <div foo="BAR" {a}foo="x" {b}foo="x" {c}foo="x"> in standards mode
+PASS [*|foo='bar' s] <div foo="BAR" {a}foo="x" {b}foo="x" {c}foo="x"> with querySelector in standards mode
+PASS [align='left' s] <div align="LEFT"> in standards mode
+PASS [align='left' s] <div align="LEFT"> with querySelector in standards mode
+PASS [align='LEFT' s] <div align="left"> in standards mode
+PASS [align='LEFT' s] <div align="left"> with querySelector in standards mode
+PASS [class~='a' s] <div class="X A B"> in standards mode
+PASS [class~='a' s] <div class="X A B"> with querySelector in standards mode
+PASS [class~='A' s] <div class="x a b"> in standards mode
+PASS [class~='A' s] <div class="x a b"> with querySelector in standards mode
+PASS [id^='a' s] <div id="AB"> in standards mode
+PASS [id^='a' s] <div id="AB"> with querySelector in standards mode
+PASS [id$='A' s] <div id="xa"> in standards mode
+PASS [id$='A' s] <div id="xa"> with querySelector in standards mode
+PASS [lang|='a' s] <div lang="A-B"> in standards mode
+PASS [lang|='a' s] <div lang="A-B"> with querySelector in standards mode
+PASS [lang*='A' s] <div lang="xab"> in standards mode
+PASS [lang*='A' s] <div lang="xab"> with querySelector in standards mode
+PASS [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in standards mode
+PASS [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> with querySelector in standards mode
+PASS [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in standards mode
+PASS [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> with querySelector in standards mode
+PASS @namespace x 'http://www.w3.org/XML/1998/namespace'; [x|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in standards mode
+PASS [foo='bar' s][foo='bar' s] <div foo="BAR"> in standards mode
+PASS [foo='bar' s][foo='bar' s] <div foo="BAR"> with querySelector in standards mode
+PASS [foo='BAR' s][foo='bar'] <div foo="BAR"> in standards mode
+PASS [foo='BAR' s][foo='bar'] <div foo="BAR"> with querySelector in standards mode
+PASS [foo='bar'][foo='BAR' s] <div foo="BAR"> in standards mode
+PASS [foo='bar'][foo='BAR' s] <div foo="BAR"> with querySelector in standards mode
+PASS [foo='BAR'][foo='bar' s] <div foo="BAR"> in standards mode
+PASS [foo='BAR'][foo='bar' s] <div foo="BAR"> with querySelector in standards mode
+PASS [foo='bar' s][foo='BAR'] <div foo="bar"> in standards mode
+PASS [foo='bar' s][foo='BAR'] <div foo="bar"> with querySelector in standards mode
 PASS [foo='BAR'] /* sanity check (match) */ <div foo="BAR"> in quirks mode
 PASS [foo='BAR'] /* sanity check (match) */ <div foo="BAR"> with querySelector in quirks mode
 PASS [foo='bar'] /* sanity check (match) */ <div foo="bar"> in quirks mode
@@ -378,39 +378,39 @@ PASS [foo='BAR'][foo='bar' i] <div foo="BAR"> in quirks mode
 PASS [foo='BAR'][foo='bar' i] <div foo="BAR"> with querySelector in quirks mode
 PASS [foo='bar' i][foo='BAR'] <div foo="BAR"> in quirks mode
 PASS [foo='bar' i][foo='BAR'] <div foo="BAR"> with querySelector in quirks mode
-FAIL [foo='bar' s] <div foo="bar"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div foo="bar"> with querySelector in quirks mode '[foo='bar' s]' is not a valid selector.
-FAIL [foo='' s] <div foo=""> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='' s] <div foo=""> with querySelector in quirks mode '[foo='' s]' is not a valid selector.
-FAIL [foo='ä' s] /* COMBINING in both */ <div foo="ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in both */ <div foo="ä"> with querySelector in quirks mode '[foo='ä' s] /* COMBINING in both */' is not a valid selector.
-FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="bar" {c}foo="x"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="bar" {c}foo="x"> with querySelector in quirks mode '[*|foo='bar' s]' is not a valid selector.
-FAIL [*|foo='bar' s] <div foo="bar" {a}foo="x" {b}foo="x" {c}foo="x"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|foo='bar' s] <div foo="bar" {a}foo="x" {b}foo="x" {c}foo="x"> with querySelector in quirks mode '[*|foo='bar' s]' is not a valid selector.
-FAIL [align='left' s] <div align="left"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [align='left' s] <div align="left"> with querySelector in quirks mode '[align='left' s]' is not a valid selector.
-FAIL [align='LEFT' s] <div align="LEFT"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [align='LEFT' s] <div align="LEFT"> with querySelector in quirks mode '[align='LEFT' s]' is not a valid selector.
-FAIL [class~='a' s] <div class="x a b"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [class~='a' s] <div class="x a b"> with querySelector in quirks mode '[class~='a' s]' is not a valid selector.
-FAIL [class~='A' s] <div class="X A B"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [class~='A' s] <div class="X A B"> with querySelector in quirks mode '[class~='A' s]' is not a valid selector.
-FAIL [id^='a' s] <div id="ab"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [id^='a' s] <div id="ab"> with querySelector in quirks mode '[id^='a' s]' is not a valid selector.
-FAIL [id$='A' s] <div id="XA"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [id$='A' s] <div id="XA"> with querySelector in quirks mode '[id$='A' s]' is not a valid selector.
-FAIL [lang|='a' s] <div lang="a-b"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [lang|='a' s] <div lang="a-b"> with querySelector in quirks mode '[lang|='a' s]' is not a valid selector.
-FAIL [lang*='A' s] <div lang="XAB"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [lang*='A' s] <div lang="XAB"> with querySelector in quirks mode '[lang*='A' s]' is not a valid selector.
-FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> with querySelector in quirks mode '[*|lang='a' s]' is not a valid selector.
-FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> with querySelector in quirks mode '[*|lang='A' s]' is not a valid selector.
-FAIL @namespace x 'http://www.w3.org/XML/1998/namespace'; [x|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 2 but got 1
-FAIL [foo='BAR' s][foo='BAR' s] <div foo="BAR"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='BAR' s][foo='BAR' s] <div foo="BAR"> with querySelector in quirks mode '[foo='BAR' s][foo='BAR' s]' is not a valid selector.
+PASS [foo='bar' s] <div foo="bar"> in quirks mode
+PASS [foo='bar' s] <div foo="bar"> with querySelector in quirks mode
+PASS [foo='' s] <div foo=""> in quirks mode
+PASS [foo='' s] <div foo=""> with querySelector in quirks mode
+PASS [foo='ä' s] /* COMBINING in both */ <div foo="ä"> in quirks mode
+PASS [foo='ä' s] /* COMBINING in both */ <div foo="ä"> with querySelector in quirks mode
+PASS [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="bar" {c}foo="x"> in quirks mode
+PASS [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="bar" {c}foo="x"> with querySelector in quirks mode
+PASS [*|foo='bar' s] <div foo="bar" {a}foo="x" {b}foo="x" {c}foo="x"> in quirks mode
+PASS [*|foo='bar' s] <div foo="bar" {a}foo="x" {b}foo="x" {c}foo="x"> with querySelector in quirks mode
+PASS [align='left' s] <div align="left"> in quirks mode
+PASS [align='left' s] <div align="left"> with querySelector in quirks mode
+PASS [align='LEFT' s] <div align="LEFT"> in quirks mode
+PASS [align='LEFT' s] <div align="LEFT"> with querySelector in quirks mode
+PASS [class~='a' s] <div class="x a b"> in quirks mode
+PASS [class~='a' s] <div class="x a b"> with querySelector in quirks mode
+PASS [class~='A' s] <div class="X A B"> in quirks mode
+PASS [class~='A' s] <div class="X A B"> with querySelector in quirks mode
+PASS [id^='a' s] <div id="ab"> in quirks mode
+PASS [id^='a' s] <div id="ab"> with querySelector in quirks mode
+PASS [id$='A' s] <div id="XA"> in quirks mode
+PASS [id$='A' s] <div id="XA"> with querySelector in quirks mode
+PASS [lang|='a' s] <div lang="a-b"> in quirks mode
+PASS [lang|='a' s] <div lang="a-b"> with querySelector in quirks mode
+PASS [lang*='A' s] <div lang="XAB"> in quirks mode
+PASS [lang*='A' s] <div lang="XAB"> with querySelector in quirks mode
+PASS [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in quirks mode
+PASS [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> with querySelector in quirks mode
+PASS [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in quirks mode
+PASS [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> with querySelector in quirks mode
+PASS @namespace x 'http://www.w3.org/XML/1998/namespace'; [x|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in quirks mode
+PASS [foo='BAR' s][foo='BAR' s] <div foo="BAR"> in quirks mode
+PASS [foo='BAR' s][foo='BAR' s] <div foo="BAR"> with querySelector in quirks mode
 PASS [align='left'] /* sanity check (match HTML) */ <div align="LEFT"> in quirks mode
 PASS [align='left'] /* sanity check (match HTML) */ <div align="LEFT"> with querySelector in quirks mode
 PASS [align='LEFT'] /* sanity check (match HTML) */ <div align="left"> in quirks mode
@@ -526,121 +526,121 @@ PASS [foo*='É' i] <div foo="é"> in quirks mode
 PASS [foo*='É' i] <div foo="é"> with querySelector in quirks mode
 PASS [foo|='É' i] <div foo="é"> in quirks mode
 PASS [foo|='É' i] <div foo="é"> with querySelector in quirks mode
-FAIL [foo='' s] <div foo="BAR"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='' s] <div foo="BAR"> with querySelector in quirks mode '[foo='' s]' is not a valid selector.
-FAIL [foo='\0' s] /* \0 in selector */ <div foo=""> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='\0' s] /* \0 in selector */ <div foo=""> with querySelector in quirks mode '[foo='\0' s] /* \0 in selector */' is not a valid selector.
-FAIL [foo='' s] /* \0 in attribute */ <div foo="\0"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='' s] /* \0 in attribute */ <div foo="\0"> with querySelector in quirks mode '[foo='' s] /* \0 in attribute */' is not a valid selector.
-FAIL [foo='ä' s] <div foo="Ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] <div foo="Ä"> with querySelector in quirks mode '[foo='ä' s]' is not a valid selector.
-FAIL [foo='Ä' s] <div foo="ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] <div foo="ä"> with querySelector in quirks mode '[foo='Ä' s]' is not a valid selector.
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="Ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="Ä"> with querySelector in quirks mode '[foo='ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo~='ä' s] /* COMBINING in selector */ <div foo="ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo~='ä' s] /* COMBINING in selector */ <div foo="ä"> with querySelector in quirks mode '[foo~='ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo^='Ä' s] /* COMBINING in selector */ <div foo="Ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo^='Ä' s] /* COMBINING in selector */ <div foo="Ä"> with querySelector in quirks mode '[foo^='Ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo$='Ä' s] /* COMBINING in selector */ <div foo="ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo$='Ä' s] /* COMBINING in selector */ <div foo="ä"> with querySelector in quirks mode '[foo$='Ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo*='ä' s] /* COMBINING in attribute */ <div foo="ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo*='ä' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in quirks mode '[foo*='ä' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo|='ä' s] /* COMBINING in attribute */ <div foo="Ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo|='ä' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in quirks mode '[foo|='ä' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in quirks mode '[foo='Ä' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="Ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in quirks mode '[foo='Ä' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="a"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="a"> with querySelector in quirks mode '[foo='ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="A"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="A"> with querySelector in quirks mode '[foo='ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="a"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="a"> with querySelector in quirks mode '[foo='Ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="A"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="A"> with querySelector in quirks mode '[foo='Ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in quirks mode '[foo='a' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in quirks mode '[foo='A' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="Ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in quirks mode '[foo='a' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="Ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in quirks mode '[foo='A' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='i' s] <div foo="İ"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='i' s] <div foo="İ"> with querySelector in quirks mode '[foo='i' s]' is not a valid selector.
-FAIL [foo='i' s] <div foo="ı"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='i' s] <div foo="ı"> with querySelector in quirks mode '[foo='i' s]' is not a valid selector.
-FAIL [foo='I' s] <div foo="İ"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='I' s] <div foo="İ"> with querySelector in quirks mode '[foo='I' s]' is not a valid selector.
-FAIL [foo='I' s] <div foo="ı"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='I' s] <div foo="ı"> with querySelector in quirks mode '[foo='I' s]' is not a valid selector.
-FAIL [foo='İ' s] <div foo="i"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='İ' s] <div foo="i"> with querySelector in quirks mode '[foo='İ' s]' is not a valid selector.
-FAIL [foo='ı' s] <div foo="i"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ı' s] <div foo="i"> with querySelector in quirks mode '[foo='ı' s]' is not a valid selector.
-FAIL [foo='İ' s] <div foo="I"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='İ' s] <div foo="I"> with querySelector in quirks mode '[foo='İ' s]' is not a valid selector.
-FAIL [foo='ı' s] <div foo="I"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ı' s] <div foo="I"> with querySelector in quirks mode '[foo='ı' s]' is not a valid selector.
-FAIL [foo='bar' s] <div foo="x" {a}foo="BAR"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div foo="x" {a}foo="BAR"> with querySelector in quirks mode '[foo='bar' s]' is not a valid selector.
-FAIL [|foo='bar' s] <div foo="x" {a}foo="BAR"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [|foo='bar' s] <div foo="x" {a}foo="BAR"> with querySelector in quirks mode '[|foo='bar' s]' is not a valid selector.
-FAIL [foo='bar' s] <div FOO="bar"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div FOO="bar"> with querySelector in quirks mode '[foo='bar' s]' is not a valid selector.
-FAIL [foo='	' s] /* tab in selector */ <div foo=" "> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='	' s] /* tab in selector */ <div foo=" "> with querySelector in quirks mode '[foo='	' s] /* tab in selector */' is not a valid selector.
-FAIL [foo=' ' s] /* tab in attribute */ <div foo="	"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo=' ' s] /* tab in attribute */ <div foo="	"> with querySelector in quirks mode '[foo=' ' s] /* tab in attribute */' is not a valid selector.
-FAIL @namespace x 'a'; [x|foo='' s] <div {A}foo=""> in quirks mode assert_equals: rule didn't parse into CSSOM expected 2 but got 1
-FAIL @namespace x 'A'; [x|foo='' s] <div {a}foo=""> in quirks mode assert_equals: rule didn't parse into CSSOM expected 2 but got 1
-FAIL [foo='bar' s][foo='bar'] <div foo="BAR"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s][foo='bar'] <div foo="BAR"> with querySelector in quirks mode '[foo='bar' s][foo='bar']' is not a valid selector.
-FAIL [foo='bar' s] <div baz="BAR"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div baz="BAR"> with querySelector in quirks mode '[foo='bar' s]' is not a valid selector.
-FAIL [foo='bar' s] <div foo="BAR"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div foo="BAR"> with querySelector in quirks mode '[foo='bar' s]' is not a valid selector.
-FAIL [foo='ä' s] /* COMBINING in both */ <div foo="Ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in both */ <div foo="Ä"> with querySelector in quirks mode '[foo='ä' s] /* COMBINING in both */' is not a valid selector.
-FAIL [foo='Ä' s] /* COMBINING in both */ <div foo="ä"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in both */ <div foo="ä"> with querySelector in quirks mode '[foo='Ä' s] /* COMBINING in both */' is not a valid selector.
-FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="BAR" {c}foo="x"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="BAR" {c}foo="x"> with querySelector in quirks mode '[*|foo='bar' s]' is not a valid selector.
-FAIL [*|foo='bar' s] <div foo="BAR" {a}foo="x" {b}foo="x" {c}foo="x"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|foo='bar' s] <div foo="BAR" {a}foo="x" {b}foo="x" {c}foo="x"> with querySelector in quirks mode '[*|foo='bar' s]' is not a valid selector.
-FAIL [align='left' s] <div align="LEFT"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [align='left' s] <div align="LEFT"> with querySelector in quirks mode '[align='left' s]' is not a valid selector.
-FAIL [align='LEFT' s] <div align="left"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [align='LEFT' s] <div align="left"> with querySelector in quirks mode '[align='LEFT' s]' is not a valid selector.
-FAIL [class~='a' s] <div class="X A B"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [class~='a' s] <div class="X A B"> with querySelector in quirks mode '[class~='a' s]' is not a valid selector.
-FAIL [class~='A' s] <div class="x a b"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [class~='A' s] <div class="x a b"> with querySelector in quirks mode '[class~='A' s]' is not a valid selector.
-FAIL [id^='a' s] <div id="AB"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [id^='a' s] <div id="AB"> with querySelector in quirks mode '[id^='a' s]' is not a valid selector.
-FAIL [id$='A' s] <div id="xa"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [id$='A' s] <div id="xa"> with querySelector in quirks mode '[id$='A' s]' is not a valid selector.
-FAIL [lang|='a' s] <div lang="A-B"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [lang|='a' s] <div lang="A-B"> with querySelector in quirks mode '[lang|='a' s]' is not a valid selector.
-FAIL [lang*='A' s] <div lang="xab"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [lang*='A' s] <div lang="xab"> with querySelector in quirks mode '[lang*='A' s]' is not a valid selector.
-FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> with querySelector in quirks mode '[*|lang='a' s]' is not a valid selector.
-FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> with querySelector in quirks mode '[*|lang='A' s]' is not a valid selector.
-FAIL @namespace x 'http://www.w3.org/XML/1998/namespace'; [x|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 2 but got 1
-FAIL [foo='bar' s][foo='bar' s] <div foo="BAR"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s][foo='bar' s] <div foo="BAR"> with querySelector in quirks mode '[foo='bar' s][foo='bar' s]' is not a valid selector.
-FAIL [foo='BAR' s][foo='bar'] <div foo="BAR"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='BAR' s][foo='bar'] <div foo="BAR"> with querySelector in quirks mode '[foo='BAR' s][foo='bar']' is not a valid selector.
-FAIL [foo='bar'][foo='BAR' s] <div foo="BAR"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar'][foo='BAR' s] <div foo="BAR"> with querySelector in quirks mode '[foo='bar'][foo='BAR' s]' is not a valid selector.
-FAIL [foo='BAR'][foo='bar' s] <div foo="BAR"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='BAR'][foo='bar' s] <div foo="BAR"> with querySelector in quirks mode '[foo='BAR'][foo='bar' s]' is not a valid selector.
-FAIL [foo='bar' s][foo='BAR'] <div foo="bar"> in quirks mode assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s][foo='BAR'] <div foo="bar"> with querySelector in quirks mode '[foo='bar' s][foo='BAR']' is not a valid selector.
+PASS [foo='' s] <div foo="BAR"> in quirks mode
+PASS [foo='' s] <div foo="BAR"> with querySelector in quirks mode
+PASS [foo='\0' s] /* \0 in selector */ <div foo=""> in quirks mode
+PASS [foo='\0' s] /* \0 in selector */ <div foo=""> with querySelector in quirks mode
+PASS [foo='' s] /* \0 in attribute */ <div foo="\0"> in quirks mode
+PASS [foo='' s] /* \0 in attribute */ <div foo="\0"> with querySelector in quirks mode
+PASS [foo='ä' s] <div foo="Ä"> in quirks mode
+PASS [foo='ä' s] <div foo="Ä"> with querySelector in quirks mode
+PASS [foo='Ä' s] <div foo="ä"> in quirks mode
+PASS [foo='Ä' s] <div foo="ä"> with querySelector in quirks mode
+PASS [foo='ä' s] /* COMBINING in selector */ <div foo="Ä"> in quirks mode
+PASS [foo='ä' s] /* COMBINING in selector */ <div foo="Ä"> with querySelector in quirks mode
+PASS [foo~='ä' s] /* COMBINING in selector */ <div foo="ä"> in quirks mode
+PASS [foo~='ä' s] /* COMBINING in selector */ <div foo="ä"> with querySelector in quirks mode
+PASS [foo^='Ä' s] /* COMBINING in selector */ <div foo="Ä"> in quirks mode
+PASS [foo^='Ä' s] /* COMBINING in selector */ <div foo="Ä"> with querySelector in quirks mode
+PASS [foo$='Ä' s] /* COMBINING in selector */ <div foo="ä"> in quirks mode
+PASS [foo$='Ä' s] /* COMBINING in selector */ <div foo="ä"> with querySelector in quirks mode
+PASS [foo*='ä' s] /* COMBINING in attribute */ <div foo="ä"> in quirks mode
+PASS [foo*='ä' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in quirks mode
+PASS [foo|='ä' s] /* COMBINING in attribute */ <div foo="Ä"> in quirks mode
+PASS [foo|='ä' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in quirks mode
+PASS [foo='Ä' s] /* COMBINING in attribute */ <div foo="ä"> in quirks mode
+PASS [foo='Ä' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in quirks mode
+PASS [foo='Ä' s] /* COMBINING in attribute */ <div foo="Ä"> in quirks mode
+PASS [foo='Ä' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in quirks mode
+PASS [foo='ä' s] /* COMBINING in selector */ <div foo="a"> in quirks mode
+PASS [foo='ä' s] /* COMBINING in selector */ <div foo="a"> with querySelector in quirks mode
+PASS [foo='ä' s] /* COMBINING in selector */ <div foo="A"> in quirks mode
+PASS [foo='ä' s] /* COMBINING in selector */ <div foo="A"> with querySelector in quirks mode
+PASS [foo='Ä' s] /* COMBINING in selector */ <div foo="a"> in quirks mode
+PASS [foo='Ä' s] /* COMBINING in selector */ <div foo="a"> with querySelector in quirks mode
+PASS [foo='Ä' s] /* COMBINING in selector */ <div foo="A"> in quirks mode
+PASS [foo='Ä' s] /* COMBINING in selector */ <div foo="A"> with querySelector in quirks mode
+PASS [foo='a' s] /* COMBINING in attribute */ <div foo="ä"> in quirks mode
+PASS [foo='a' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in quirks mode
+PASS [foo='A' s] /* COMBINING in attribute */ <div foo="ä"> in quirks mode
+PASS [foo='A' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in quirks mode
+PASS [foo='a' s] /* COMBINING in attribute */ <div foo="Ä"> in quirks mode
+PASS [foo='a' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in quirks mode
+PASS [foo='A' s] /* COMBINING in attribute */ <div foo="Ä"> in quirks mode
+PASS [foo='A' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in quirks mode
+PASS [foo='i' s] <div foo="İ"> in quirks mode
+PASS [foo='i' s] <div foo="İ"> with querySelector in quirks mode
+PASS [foo='i' s] <div foo="ı"> in quirks mode
+PASS [foo='i' s] <div foo="ı"> with querySelector in quirks mode
+PASS [foo='I' s] <div foo="İ"> in quirks mode
+PASS [foo='I' s] <div foo="İ"> with querySelector in quirks mode
+PASS [foo='I' s] <div foo="ı"> in quirks mode
+PASS [foo='I' s] <div foo="ı"> with querySelector in quirks mode
+PASS [foo='İ' s] <div foo="i"> in quirks mode
+PASS [foo='İ' s] <div foo="i"> with querySelector in quirks mode
+PASS [foo='ı' s] <div foo="i"> in quirks mode
+PASS [foo='ı' s] <div foo="i"> with querySelector in quirks mode
+PASS [foo='İ' s] <div foo="I"> in quirks mode
+PASS [foo='İ' s] <div foo="I"> with querySelector in quirks mode
+PASS [foo='ı' s] <div foo="I"> in quirks mode
+PASS [foo='ı' s] <div foo="I"> with querySelector in quirks mode
+PASS [foo='bar' s] <div foo="x" {a}foo="BAR"> in quirks mode
+PASS [foo='bar' s] <div foo="x" {a}foo="BAR"> with querySelector in quirks mode
+PASS [|foo='bar' s] <div foo="x" {a}foo="BAR"> in quirks mode
+PASS [|foo='bar' s] <div foo="x" {a}foo="BAR"> with querySelector in quirks mode
+PASS [foo='bar' s] <div FOO="bar"> in quirks mode
+PASS [foo='bar' s] <div FOO="bar"> with querySelector in quirks mode
+PASS [foo='	' s] /* tab in selector */ <div foo=" "> in quirks mode
+PASS [foo='	' s] /* tab in selector */ <div foo=" "> with querySelector in quirks mode
+PASS [foo=' ' s] /* tab in attribute */ <div foo="	"> in quirks mode
+PASS [foo=' ' s] /* tab in attribute */ <div foo="	"> with querySelector in quirks mode
+PASS @namespace x 'a'; [x|foo='' s] <div {A}foo=""> in quirks mode
+PASS @namespace x 'A'; [x|foo='' s] <div {a}foo=""> in quirks mode
+PASS [foo='bar' s][foo='bar'] <div foo="BAR"> in quirks mode
+PASS [foo='bar' s][foo='bar'] <div foo="BAR"> with querySelector in quirks mode
+PASS [foo='bar' s] <div baz="BAR"> in quirks mode
+PASS [foo='bar' s] <div baz="BAR"> with querySelector in quirks mode
+PASS [foo='bar' s] <div foo="BAR"> in quirks mode
+PASS [foo='bar' s] <div foo="BAR"> with querySelector in quirks mode
+PASS [foo='ä' s] /* COMBINING in both */ <div foo="Ä"> in quirks mode
+PASS [foo='ä' s] /* COMBINING in both */ <div foo="Ä"> with querySelector in quirks mode
+PASS [foo='Ä' s] /* COMBINING in both */ <div foo="ä"> in quirks mode
+PASS [foo='Ä' s] /* COMBINING in both */ <div foo="ä"> with querySelector in quirks mode
+PASS [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="BAR" {c}foo="x"> in quirks mode
+PASS [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="BAR" {c}foo="x"> with querySelector in quirks mode
+PASS [*|foo='bar' s] <div foo="BAR" {a}foo="x" {b}foo="x" {c}foo="x"> in quirks mode
+PASS [*|foo='bar' s] <div foo="BAR" {a}foo="x" {b}foo="x" {c}foo="x"> with querySelector in quirks mode
+PASS [align='left' s] <div align="LEFT"> in quirks mode
+PASS [align='left' s] <div align="LEFT"> with querySelector in quirks mode
+PASS [align='LEFT' s] <div align="left"> in quirks mode
+PASS [align='LEFT' s] <div align="left"> with querySelector in quirks mode
+PASS [class~='a' s] <div class="X A B"> in quirks mode
+PASS [class~='a' s] <div class="X A B"> with querySelector in quirks mode
+PASS [class~='A' s] <div class="x a b"> in quirks mode
+PASS [class~='A' s] <div class="x a b"> with querySelector in quirks mode
+PASS [id^='a' s] <div id="AB"> in quirks mode
+PASS [id^='a' s] <div id="AB"> with querySelector in quirks mode
+PASS [id$='A' s] <div id="xa"> in quirks mode
+PASS [id$='A' s] <div id="xa"> with querySelector in quirks mode
+PASS [lang|='a' s] <div lang="A-B"> in quirks mode
+PASS [lang|='a' s] <div lang="A-B"> with querySelector in quirks mode
+PASS [lang*='A' s] <div lang="xab"> in quirks mode
+PASS [lang*='A' s] <div lang="xab"> with querySelector in quirks mode
+PASS [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in quirks mode
+PASS [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> with querySelector in quirks mode
+PASS [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in quirks mode
+PASS [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> with querySelector in quirks mode
+PASS @namespace x 'http://www.w3.org/XML/1998/namespace'; [x|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in quirks mode
+PASS [foo='bar' s][foo='bar' s] <div foo="BAR"> in quirks mode
+PASS [foo='bar' s][foo='bar' s] <div foo="BAR"> with querySelector in quirks mode
+PASS [foo='BAR' s][foo='bar'] <div foo="BAR"> in quirks mode
+PASS [foo='BAR' s][foo='bar'] <div foo="BAR"> with querySelector in quirks mode
+PASS [foo='bar'][foo='BAR' s] <div foo="BAR"> in quirks mode
+PASS [foo='bar'][foo='BAR' s] <div foo="BAR"> with querySelector in quirks mode
+PASS [foo='BAR'][foo='bar' s] <div foo="BAR"> in quirks mode
+PASS [foo='BAR'][foo='bar' s] <div foo="BAR"> with querySelector in quirks mode
+PASS [foo='bar' s][foo='BAR'] <div foo="bar"> in quirks mode
+PASS [foo='bar' s][foo='BAR'] <div foo="bar"> with querySelector in quirks mode
 PASS [foo='BAR'] /* sanity check (match) */ <div foo="BAR"> in XML
 PASS [foo='BAR'] /* sanity check (match) */ <div foo="BAR"> with querySelector in XML
 PASS [foo='bar'] /* sanity check (match) */ <div foo="bar"> in XML
@@ -699,39 +699,39 @@ PASS [foo='BAR'][foo='bar' i] <div foo="BAR"> in XML
 PASS [foo='BAR'][foo='bar' i] <div foo="BAR"> with querySelector in XML
 PASS [foo='bar' i][foo='BAR'] <div foo="BAR"> in XML
 PASS [foo='bar' i][foo='BAR'] <div foo="BAR"> with querySelector in XML
-FAIL [foo='bar' s] <div foo="bar"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div foo="bar"> with querySelector in XML '[foo='bar' s]' is not a valid selector.
-FAIL [foo='' s] <div foo=""> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='' s] <div foo=""> with querySelector in XML '[foo='' s]' is not a valid selector.
-FAIL [foo='ä' s] /* COMBINING in both */ <div foo="ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in both */ <div foo="ä"> with querySelector in XML '[foo='ä' s] /* COMBINING in both */' is not a valid selector.
-FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="bar" {c}foo="x"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="bar" {c}foo="x"> with querySelector in XML '[*|foo='bar' s]' is not a valid selector.
-FAIL [*|foo='bar' s] <div foo="bar" {a}foo="x" {b}foo="x" {c}foo="x"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|foo='bar' s] <div foo="bar" {a}foo="x" {b}foo="x" {c}foo="x"> with querySelector in XML '[*|foo='bar' s]' is not a valid selector.
-FAIL [align='left' s] <div align="left"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [align='left' s] <div align="left"> with querySelector in XML '[align='left' s]' is not a valid selector.
-FAIL [align='LEFT' s] <div align="LEFT"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [align='LEFT' s] <div align="LEFT"> with querySelector in XML '[align='LEFT' s]' is not a valid selector.
-FAIL [class~='a' s] <div class="x a b"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [class~='a' s] <div class="x a b"> with querySelector in XML '[class~='a' s]' is not a valid selector.
-FAIL [class~='A' s] <div class="X A B"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [class~='A' s] <div class="X A B"> with querySelector in XML '[class~='A' s]' is not a valid selector.
-FAIL [id^='a' s] <div id="ab"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [id^='a' s] <div id="ab"> with querySelector in XML '[id^='a' s]' is not a valid selector.
-FAIL [id$='A' s] <div id="XA"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [id$='A' s] <div id="XA"> with querySelector in XML '[id$='A' s]' is not a valid selector.
-FAIL [lang|='a' s] <div lang="a-b"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [lang|='a' s] <div lang="a-b"> with querySelector in XML '[lang|='a' s]' is not a valid selector.
-FAIL [lang*='A' s] <div lang="XAB"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [lang*='A' s] <div lang="XAB"> with querySelector in XML '[lang*='A' s]' is not a valid selector.
-FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> with querySelector in XML '[*|lang='a' s]' is not a valid selector.
-FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> with querySelector in XML '[*|lang='A' s]' is not a valid selector.
-FAIL @namespace x 'http://www.w3.org/XML/1998/namespace'; [x|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in XML assert_equals: rule didn't parse into CSSOM expected 2 but got 1
-FAIL [foo='BAR' s][foo='BAR' s] <div foo="BAR"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='BAR' s][foo='BAR' s] <div foo="BAR"> with querySelector in XML '[foo='BAR' s][foo='BAR' s]' is not a valid selector.
+PASS [foo='bar' s] <div foo="bar"> in XML
+PASS [foo='bar' s] <div foo="bar"> with querySelector in XML
+PASS [foo='' s] <div foo=""> in XML
+PASS [foo='' s] <div foo=""> with querySelector in XML
+PASS [foo='ä' s] /* COMBINING in both */ <div foo="ä"> in XML
+PASS [foo='ä' s] /* COMBINING in both */ <div foo="ä"> with querySelector in XML
+PASS [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="bar" {c}foo="x"> in XML
+PASS [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="bar" {c}foo="x"> with querySelector in XML
+PASS [*|foo='bar' s] <div foo="bar" {a}foo="x" {b}foo="x" {c}foo="x"> in XML
+PASS [*|foo='bar' s] <div foo="bar" {a}foo="x" {b}foo="x" {c}foo="x"> with querySelector in XML
+PASS [align='left' s] <div align="left"> in XML
+PASS [align='left' s] <div align="left"> with querySelector in XML
+PASS [align='LEFT' s] <div align="LEFT"> in XML
+PASS [align='LEFT' s] <div align="LEFT"> with querySelector in XML
+PASS [class~='a' s] <div class="x a b"> in XML
+PASS [class~='a' s] <div class="x a b"> with querySelector in XML
+PASS [class~='A' s] <div class="X A B"> in XML
+PASS [class~='A' s] <div class="X A B"> with querySelector in XML
+PASS [id^='a' s] <div id="ab"> in XML
+PASS [id^='a' s] <div id="ab"> with querySelector in XML
+PASS [id$='A' s] <div id="XA"> in XML
+PASS [id$='A' s] <div id="XA"> with querySelector in XML
+PASS [lang|='a' s] <div lang="a-b"> in XML
+PASS [lang|='a' s] <div lang="a-b"> with querySelector in XML
+PASS [lang*='A' s] <div lang="XAB"> in XML
+PASS [lang*='A' s] <div lang="XAB"> with querySelector in XML
+PASS [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in XML
+PASS [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> with querySelector in XML
+PASS [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in XML
+PASS [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> with querySelector in XML
+PASS @namespace x 'http://www.w3.org/XML/1998/namespace'; [x|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in XML
+PASS [foo='BAR' s][foo='BAR' s] <div foo="BAR"> in XML
+PASS [foo='BAR' s][foo='BAR' s] <div foo="BAR"> with querySelector in XML
 PASS [missingattr] /* sanity check (no match) */ <div foo="BAR"> in XML
 PASS [missingattr] /* sanity check (no match) */ <div foo="BAR"> with querySelector in XML
 PASS [foo='bar'] /* sanity check (no match) */ <div foo="BAR"> in XML
@@ -839,120 +839,120 @@ PASS [foo*='É' i] <div foo="é"> in XML
 PASS [foo*='É' i] <div foo="é"> with querySelector in XML
 PASS [foo|='É' i] <div foo="é"> in XML
 PASS [foo|='É' i] <div foo="é"> with querySelector in XML
-FAIL [foo='' s] <div foo="BAR"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='' s] <div foo="BAR"> with querySelector in XML '[foo='' s]' is not a valid selector.
-FAIL [foo='\0' s] /* \0 in selector */ <div foo=""> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='\0' s] /* \0 in selector */ <div foo=""> with querySelector in XML '[foo='\0' s] /* \0 in selector */' is not a valid selector.
-FAIL [foo='' s] /* \0 in attribute */ <div foo="\0"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='' s] /* \0 in attribute */ <div foo="\0"> with querySelector in XML '[foo='' s] /* \0 in attribute */' is not a valid selector.
-FAIL [foo='ä' s] <div foo="Ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] <div foo="Ä"> with querySelector in XML '[foo='ä' s]' is not a valid selector.
-FAIL [foo='Ä' s] <div foo="ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] <div foo="ä"> with querySelector in XML '[foo='Ä' s]' is not a valid selector.
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="Ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="Ä"> with querySelector in XML '[foo='ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo~='ä' s] /* COMBINING in selector */ <div foo="ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo~='ä' s] /* COMBINING in selector */ <div foo="ä"> with querySelector in XML '[foo~='ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo^='Ä' s] /* COMBINING in selector */ <div foo="Ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo^='Ä' s] /* COMBINING in selector */ <div foo="Ä"> with querySelector in XML '[foo^='Ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo$='Ä' s] /* COMBINING in selector */ <div foo="ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo$='Ä' s] /* COMBINING in selector */ <div foo="ä"> with querySelector in XML '[foo$='Ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo*='ä' s] /* COMBINING in attribute */ <div foo="ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo*='ä' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in XML '[foo*='ä' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo|='ä' s] /* COMBINING in attribute */ <div foo="Ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo|='ä' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in XML '[foo|='ä' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in XML '[foo='Ä' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="Ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in XML '[foo='Ä' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="a"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="a"> with querySelector in XML '[foo='ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="A"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in selector */ <div foo="A"> with querySelector in XML '[foo='ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="a"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="a"> with querySelector in XML '[foo='Ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="A"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in selector */ <div foo="A"> with querySelector in XML '[foo='Ä' s] /* COMBINING in selector */' is not a valid selector.
-FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in XML '[foo='a' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in XML '[foo='A' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="Ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='a' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in XML '[foo='a' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="Ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='A' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in XML '[foo='A' s] /* COMBINING in attribute */' is not a valid selector.
-FAIL [foo='i' s] <div foo="İ"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='i' s] <div foo="İ"> with querySelector in XML '[foo='i' s]' is not a valid selector.
-FAIL [foo='i' s] <div foo="ı"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='i' s] <div foo="ı"> with querySelector in XML '[foo='i' s]' is not a valid selector.
-FAIL [foo='I' s] <div foo="İ"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='I' s] <div foo="İ"> with querySelector in XML '[foo='I' s]' is not a valid selector.
-FAIL [foo='I' s] <div foo="ı"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='I' s] <div foo="ı"> with querySelector in XML '[foo='I' s]' is not a valid selector.
-FAIL [foo='İ' s] <div foo="i"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='İ' s] <div foo="i"> with querySelector in XML '[foo='İ' s]' is not a valid selector.
-FAIL [foo='ı' s] <div foo="i"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ı' s] <div foo="i"> with querySelector in XML '[foo='ı' s]' is not a valid selector.
-FAIL [foo='İ' s] <div foo="I"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='İ' s] <div foo="I"> with querySelector in XML '[foo='İ' s]' is not a valid selector.
-FAIL [foo='ı' s] <div foo="I"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ı' s] <div foo="I"> with querySelector in XML '[foo='ı' s]' is not a valid selector.
-FAIL [foo='bar' s] <div foo="x" {a}foo="BAR"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div foo="x" {a}foo="BAR"> with querySelector in XML '[foo='bar' s]' is not a valid selector.
-FAIL [|foo='bar' s] <div foo="x" {a}foo="BAR"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [|foo='bar' s] <div foo="x" {a}foo="BAR"> with querySelector in XML '[|foo='bar' s]' is not a valid selector.
-FAIL [foo='bar' s] <div FOO="bar"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div FOO="bar"> with querySelector in XML '[foo='bar' s]' is not a valid selector.
-FAIL [foo='	' s] /* tab in selector */ <div foo=" "> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='	' s] /* tab in selector */ <div foo=" "> with querySelector in XML '[foo='	' s] /* tab in selector */' is not a valid selector.
-FAIL [foo=' ' s] /* tab in attribute */ <div foo="	"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo=' ' s] /* tab in attribute */ <div foo="	"> with querySelector in XML '[foo=' ' s] /* tab in attribute */' is not a valid selector.
-FAIL @namespace x 'a'; [x|foo='' s] <div {A}foo=""> in XML assert_equals: rule didn't parse into CSSOM expected 2 but got 1
-FAIL @namespace x 'A'; [x|foo='' s] <div {a}foo=""> in XML assert_equals: rule didn't parse into CSSOM expected 2 but got 1
-FAIL [foo='bar' s][foo='bar'] <div foo="BAR"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s][foo='bar'] <div foo="BAR"> with querySelector in XML '[foo='bar' s][foo='bar']' is not a valid selector.
-FAIL [foo='bar' s] <div baz="BAR"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div baz="BAR"> with querySelector in XML '[foo='bar' s]' is not a valid selector.
-FAIL [foo='bar' s] <div foo="BAR"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s] <div foo="BAR"> with querySelector in XML '[foo='bar' s]' is not a valid selector.
-FAIL [foo='ä' s] /* COMBINING in both */ <div foo="Ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='ä' s] /* COMBINING in both */ <div foo="Ä"> with querySelector in XML '[foo='ä' s] /* COMBINING in both */' is not a valid selector.
-FAIL [foo='Ä' s] /* COMBINING in both */ <div foo="ä"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='Ä' s] /* COMBINING in both */ <div foo="ä"> with querySelector in XML '[foo='Ä' s] /* COMBINING in both */' is not a valid selector.
-FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="BAR" {c}foo="x"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="BAR" {c}foo="x"> with querySelector in XML '[*|foo='bar' s]' is not a valid selector.
-FAIL [*|foo='bar' s] <div foo="BAR" {a}foo="x" {b}foo="x" {c}foo="x"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|foo='bar' s] <div foo="BAR" {a}foo="x" {b}foo="x" {c}foo="x"> with querySelector in XML '[*|foo='bar' s]' is not a valid selector.
-FAIL [align='left' s] <div align="LEFT"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [align='left' s] <div align="LEFT"> with querySelector in XML '[align='left' s]' is not a valid selector.
-FAIL [align='LEFT' s] <div align="left"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [align='LEFT' s] <div align="left"> with querySelector in XML '[align='LEFT' s]' is not a valid selector.
-FAIL [class~='a' s] <div class="X A B"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [class~='a' s] <div class="X A B"> with querySelector in XML '[class~='a' s]' is not a valid selector.
-FAIL [class~='A' s] <div class="x a b"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [class~='A' s] <div class="x a b"> with querySelector in XML '[class~='A' s]' is not a valid selector.
-FAIL [id^='a' s] <div id="AB"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [id^='a' s] <div id="AB"> with querySelector in XML '[id^='a' s]' is not a valid selector.
-FAIL [id$='A' s] <div id="xa"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [id$='A' s] <div id="xa"> with querySelector in XML '[id$='A' s]' is not a valid selector.
-FAIL [lang|='a' s] <div lang="A-B"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [lang|='a' s] <div lang="A-B"> with querySelector in XML '[lang|='a' s]' is not a valid selector.
-FAIL [lang*='A' s] <div lang="xab"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [lang*='A' s] <div lang="xab"> with querySelector in XML '[lang*='A' s]' is not a valid selector.
-FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> with querySelector in XML '[*|lang='a' s]' is not a valid selector.
-FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> with querySelector in XML '[*|lang='A' s]' is not a valid selector.
-FAIL @namespace x 'http://www.w3.org/XML/1998/namespace'; [x|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in XML assert_equals: rule didn't parse into CSSOM expected 2 but got 1
-FAIL [foo='bar' s][foo='bar' s] <div foo="BAR"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s][foo='bar' s] <div foo="BAR"> with querySelector in XML '[foo='bar' s][foo='bar' s]' is not a valid selector.
-FAIL [foo='BAR' s][foo='bar'] <div foo="BAR"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='BAR' s][foo='bar'] <div foo="BAR"> with querySelector in XML '[foo='BAR' s][foo='bar']' is not a valid selector.
-FAIL [foo='bar'][foo='BAR' s] <div foo="BAR"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar'][foo='BAR' s] <div foo="BAR"> with querySelector in XML '[foo='bar'][foo='BAR' s]' is not a valid selector.
-FAIL [foo='BAR'][foo='bar' s] <div foo="BAR"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='BAR'][foo='bar' s] <div foo="BAR"> with querySelector in XML '[foo='BAR'][foo='bar' s]' is not a valid selector.
-FAIL [foo='bar' s][foo='BAR'] <div foo="bar"> in XML assert_equals: rule didn't parse into CSSOM expected 1 but got 0
-FAIL [foo='bar' s][foo='BAR'] <div foo="bar"> with querySelector in XML '[foo='bar' s][foo='BAR']' is not a valid selector.
+PASS [foo='' s] <div foo="BAR"> in XML
+PASS [foo='' s] <div foo="BAR"> with querySelector in XML
+PASS [foo='\0' s] /* \0 in selector */ <div foo=""> in XML
+PASS [foo='\0' s] /* \0 in selector */ <div foo=""> with querySelector in XML
+PASS [foo='' s] /* \0 in attribute */ <div foo="\0"> in XML
+PASS [foo='' s] /* \0 in attribute */ <div foo="\0"> with querySelector in XML
+PASS [foo='ä' s] <div foo="Ä"> in XML
+PASS [foo='ä' s] <div foo="Ä"> with querySelector in XML
+PASS [foo='Ä' s] <div foo="ä"> in XML
+PASS [foo='Ä' s] <div foo="ä"> with querySelector in XML
+PASS [foo='ä' s] /* COMBINING in selector */ <div foo="Ä"> in XML
+PASS [foo='ä' s] /* COMBINING in selector */ <div foo="Ä"> with querySelector in XML
+PASS [foo~='ä' s] /* COMBINING in selector */ <div foo="ä"> in XML
+PASS [foo~='ä' s] /* COMBINING in selector */ <div foo="ä"> with querySelector in XML
+PASS [foo^='Ä' s] /* COMBINING in selector */ <div foo="Ä"> in XML
+PASS [foo^='Ä' s] /* COMBINING in selector */ <div foo="Ä"> with querySelector in XML
+PASS [foo$='Ä' s] /* COMBINING in selector */ <div foo="ä"> in XML
+PASS [foo$='Ä' s] /* COMBINING in selector */ <div foo="ä"> with querySelector in XML
+PASS [foo*='ä' s] /* COMBINING in attribute */ <div foo="ä"> in XML
+PASS [foo*='ä' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in XML
+PASS [foo|='ä' s] /* COMBINING in attribute */ <div foo="Ä"> in XML
+PASS [foo|='ä' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in XML
+PASS [foo='Ä' s] /* COMBINING in attribute */ <div foo="ä"> in XML
+PASS [foo='Ä' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in XML
+PASS [foo='Ä' s] /* COMBINING in attribute */ <div foo="Ä"> in XML
+PASS [foo='Ä' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in XML
+PASS [foo='ä' s] /* COMBINING in selector */ <div foo="a"> in XML
+PASS [foo='ä' s] /* COMBINING in selector */ <div foo="a"> with querySelector in XML
+PASS [foo='ä' s] /* COMBINING in selector */ <div foo="A"> in XML
+PASS [foo='ä' s] /* COMBINING in selector */ <div foo="A"> with querySelector in XML
+PASS [foo='Ä' s] /* COMBINING in selector */ <div foo="a"> in XML
+PASS [foo='Ä' s] /* COMBINING in selector */ <div foo="a"> with querySelector in XML
+PASS [foo='Ä' s] /* COMBINING in selector */ <div foo="A"> in XML
+PASS [foo='Ä' s] /* COMBINING in selector */ <div foo="A"> with querySelector in XML
+PASS [foo='a' s] /* COMBINING in attribute */ <div foo="ä"> in XML
+PASS [foo='a' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in XML
+PASS [foo='A' s] /* COMBINING in attribute */ <div foo="ä"> in XML
+PASS [foo='A' s] /* COMBINING in attribute */ <div foo="ä"> with querySelector in XML
+PASS [foo='a' s] /* COMBINING in attribute */ <div foo="Ä"> in XML
+PASS [foo='a' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in XML
+PASS [foo='A' s] /* COMBINING in attribute */ <div foo="Ä"> in XML
+PASS [foo='A' s] /* COMBINING in attribute */ <div foo="Ä"> with querySelector in XML
+PASS [foo='i' s] <div foo="İ"> in XML
+PASS [foo='i' s] <div foo="İ"> with querySelector in XML
+PASS [foo='i' s] <div foo="ı"> in XML
+PASS [foo='i' s] <div foo="ı"> with querySelector in XML
+PASS [foo='I' s] <div foo="İ"> in XML
+PASS [foo='I' s] <div foo="İ"> with querySelector in XML
+PASS [foo='I' s] <div foo="ı"> in XML
+PASS [foo='I' s] <div foo="ı"> with querySelector in XML
+PASS [foo='İ' s] <div foo="i"> in XML
+PASS [foo='İ' s] <div foo="i"> with querySelector in XML
+PASS [foo='ı' s] <div foo="i"> in XML
+PASS [foo='ı' s] <div foo="i"> with querySelector in XML
+PASS [foo='İ' s] <div foo="I"> in XML
+PASS [foo='İ' s] <div foo="I"> with querySelector in XML
+PASS [foo='ı' s] <div foo="I"> in XML
+PASS [foo='ı' s] <div foo="I"> with querySelector in XML
+PASS [foo='bar' s] <div foo="x" {a}foo="BAR"> in XML
+PASS [foo='bar' s] <div foo="x" {a}foo="BAR"> with querySelector in XML
+PASS [|foo='bar' s] <div foo="x" {a}foo="BAR"> in XML
+PASS [|foo='bar' s] <div foo="x" {a}foo="BAR"> with querySelector in XML
+PASS [foo='bar' s] <div FOO="bar"> in XML
+PASS [foo='bar' s] <div FOO="bar"> with querySelector in XML
+PASS [foo='	' s] /* tab in selector */ <div foo=" "> in XML
+PASS [foo='	' s] /* tab in selector */ <div foo=" "> with querySelector in XML
+PASS [foo=' ' s] /* tab in attribute */ <div foo="	"> in XML
+PASS [foo=' ' s] /* tab in attribute */ <div foo="	"> with querySelector in XML
+PASS @namespace x 'a'; [x|foo='' s] <div {A}foo=""> in XML
+PASS @namespace x 'A'; [x|foo='' s] <div {a}foo=""> in XML
+PASS [foo='bar' s][foo='bar'] <div foo="BAR"> in XML
+PASS [foo='bar' s][foo='bar'] <div foo="BAR"> with querySelector in XML
+PASS [foo='bar' s] <div baz="BAR"> in XML
+PASS [foo='bar' s] <div baz="BAR"> with querySelector in XML
+PASS [foo='bar' s] <div foo="BAR"> in XML
+PASS [foo='bar' s] <div foo="BAR"> with querySelector in XML
+PASS [foo='ä' s] /* COMBINING in both */ <div foo="Ä"> in XML
+PASS [foo='ä' s] /* COMBINING in both */ <div foo="Ä"> with querySelector in XML
+PASS [foo='Ä' s] /* COMBINING in both */ <div foo="ä"> in XML
+PASS [foo='Ä' s] /* COMBINING in both */ <div foo="ä"> with querySelector in XML
+PASS [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="BAR" {c}foo="x"> in XML
+PASS [*|foo='bar' s] <div foo="x" {a}foo="x" {b}foo="BAR" {c}foo="x"> with querySelector in XML
+PASS [*|foo='bar' s] <div foo="BAR" {a}foo="x" {b}foo="x" {c}foo="x"> in XML
+PASS [*|foo='bar' s] <div foo="BAR" {a}foo="x" {b}foo="x" {c}foo="x"> with querySelector in XML
+PASS [align='left' s] <div align="LEFT"> in XML
+PASS [align='left' s] <div align="LEFT"> with querySelector in XML
+PASS [align='LEFT' s] <div align="left"> in XML
+PASS [align='LEFT' s] <div align="left"> with querySelector in XML
+PASS [class~='a' s] <div class="X A B"> in XML
+PASS [class~='a' s] <div class="X A B"> with querySelector in XML
+PASS [class~='A' s] <div class="x a b"> in XML
+PASS [class~='A' s] <div class="x a b"> with querySelector in XML
+PASS [id^='a' s] <div id="AB"> in XML
+PASS [id^='a' s] <div id="AB"> with querySelector in XML
+PASS [id$='A' s] <div id="xa"> in XML
+PASS [id$='A' s] <div id="xa"> with querySelector in XML
+PASS [lang|='a' s] <div lang="A-B"> in XML
+PASS [lang|='a' s] <div lang="A-B"> with querySelector in XML
+PASS [lang*='A' s] <div lang="xab"> in XML
+PASS [lang*='A' s] <div lang="xab"> with querySelector in XML
+PASS [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> in XML
+PASS [*|lang='a' s] <div {http://www.w3.org/XML/1998/namespace}lang="A"> with querySelector in XML
+PASS [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in XML
+PASS [*|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> with querySelector in XML
+PASS @namespace x 'http://www.w3.org/XML/1998/namespace'; [x|lang='A' s] <div {http://www.w3.org/XML/1998/namespace}lang="a"> in XML
+PASS [foo='bar' s][foo='bar' s] <div foo="BAR"> in XML
+PASS [foo='bar' s][foo='bar' s] <div foo="BAR"> with querySelector in XML
+PASS [foo='BAR' s][foo='bar'] <div foo="BAR"> in XML
+PASS [foo='BAR' s][foo='bar'] <div foo="BAR"> with querySelector in XML
+PASS [foo='bar'][foo='BAR' s] <div foo="BAR"> in XML
+PASS [foo='bar'][foo='BAR' s] <div foo="BAR"> with querySelector in XML
+PASS [foo='BAR'][foo='bar' s] <div foo="BAR"> in XML
+PASS [foo='BAR'][foo='bar' s] <div foo="BAR"> with querySelector in XML
+PASS [foo='bar' s][foo='BAR'] <div foo="bar"> in XML
+PASS [foo='bar' s][foo='BAR'] <div foo="bar"> with querySelector in XML
 
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/attribute-selectors/attribute-case/syntax-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/attribute-selectors/attribute-case/syntax-expected.txt
@@ -55,60 +55,58 @@ PASS [|foo='bar' i] in standards mode
 PASS [|foo='bar' i] with querySelector in standards mode
 PASS [*|foo='bar' i] in standards mode
 PASS [*|foo='bar' i] with querySelector in standards mode
-FAIL [baz='quux' s] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' s] with querySelector in standards mode '[baz='quux' s]' is not a valid selector.
-FAIL [baz='quux' S] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' S] with querySelector in standards mode '[baz='quux' S]' is not a valid selector.
-FAIL [baz=quux s] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz=quux s] with querySelector in standards mode '[baz=quux s]' is not a valid selector.
-FAIL [baz="quux" s] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz="quux" s] with querySelector in standards mode '[baz="quux" s]' is not a valid selector.
-FAIL [baz='quux's] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux's] with querySelector in standards mode '[baz='quux's]' is not a valid selector.
-FAIL [baz='quux's ] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux's ] with querySelector in standards mode '[baz='quux's ]' is not a valid selector.
-FAIL [baz='quux' s ] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' s ] with querySelector in standards mode '[baz='quux' s ]' is not a valid selector.
-FAIL [baz='quux' /**/ s] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' /**/ s] with querySelector in standards mode '[baz='quux' /**/ s]' is not a valid selector.
-FAIL [baz='quux' s /**/ ] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' s /**/ ] with querySelector in standards mode '[baz='quux' s /**/ ]' is not a valid selector.
-FAIL [baz='quux'/**/s/**/] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux'/**/s/**/] with querySelector in standards mode '[baz='quux'/**/s/**/]' is not a valid selector.
-FAIL [baz=quux/**/s] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz=quux/**/s] with querySelector in standards mode '[baz=quux/**/s]' is not a valid selector.
-FAIL [baz='quux'	s	] /* \t */ in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux'	s	] /* \t */ with querySelector in standards mode '[baz='quux'	s	] /* \t */' is not a valid selector.
-FAIL [baz='quux'
+PASS [baz='quux' s] in standards mode
+PASS [baz='quux' s] with querySelector in standards mode
+PASS [baz='quux' S] in standards mode
+PASS [baz='quux' S] with querySelector in standards mode
+PASS [baz=quux s] in standards mode
+PASS [baz=quux s] with querySelector in standards mode
+PASS [baz="quux" s] in standards mode
+PASS [baz="quux" s] with querySelector in standards mode
+PASS [baz='quux's] in standards mode
+PASS [baz='quux's] with querySelector in standards mode
+PASS [baz='quux's ] in standards mode
+PASS [baz='quux's ] with querySelector in standards mode
+PASS [baz='quux' s ] in standards mode
+PASS [baz='quux' s ] with querySelector in standards mode
+PASS [baz='quux' /**/ s] in standards mode
+PASS [baz='quux' /**/ s] with querySelector in standards mode
+PASS [baz='quux' s /**/ ] in standards mode
+PASS [baz='quux' s /**/ ] with querySelector in standards mode
+PASS [baz='quux'/**/s/**/] in standards mode
+PASS [baz='quux'/**/s/**/] with querySelector in standards mode
+PASS [baz=quux/**/s] in standards mode
+PASS [baz=quux/**/s] with querySelector in standards mode
+PASS [baz='quux'	s	] /* \t */ in standards mode
+PASS [baz='quux'	s	] /* \t */ with querySelector in standards mode
+PASS [baz='quux'
 s
-] /* \n */ in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux'
+] /* \n */ in standards mode
+PASS [baz='quux'
 s
-] /* \n */ with querySelector in standards mode '[baz='quux'
-s
-] /* \n */' is not a valid selector.
-FAIL [baz='quux'\rs\r] /* \r */ in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux'\rs\r] /* \r */ with querySelector in standards mode '[baz='quux'\rs\r] /* \r */' is not a valid selector.
-FAIL [baz='quux' \s] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' \s] with querySelector in standards mode '[baz='quux' \s]' is not a valid selector.
-FAIL [baz='quux' \73] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' \73] with querySelector in standards mode '[baz='quux' \73]' is not a valid selector.
-FAIL [baz='quux' \53] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' \53] with querySelector in standards mode '[baz='quux' \53]' is not a valid selector.
-FAIL [baz~='quux' s] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz~='quux' s] with querySelector in standards mode '[baz~='quux' s]' is not a valid selector.
-FAIL [baz^='quux' s] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz^='quux' s] with querySelector in standards mode '[baz^='quux' s]' is not a valid selector.
-FAIL [baz$='quux' s] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz$='quux' s] with querySelector in standards mode '[baz$='quux' s]' is not a valid selector.
-FAIL [baz*='quux' s] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz*='quux' s] with querySelector in standards mode '[baz*='quux' s]' is not a valid selector.
-FAIL [baz|='quux' s] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz|='quux' s] with querySelector in standards mode '[baz|='quux' s]' is not a valid selector.
-FAIL [|baz='quux' s] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [|baz='quux' s] with querySelector in standards mode '[|baz='quux' s]' is not a valid selector.
-FAIL [*|baz='quux' s] in standards mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|baz='quux' s] with querySelector in standards mode '[*|baz='quux' s]' is not a valid selector.
+] /* \n */ with querySelector in standards mode
+PASS [baz='quux'\rs\r] /* \r */ in standards mode
+PASS [baz='quux'\rs\r] /* \r */ with querySelector in standards mode
+PASS [baz='quux' \s] in standards mode
+PASS [baz='quux' \s] with querySelector in standards mode
+PASS [baz='quux' \73] in standards mode
+PASS [baz='quux' \73] with querySelector in standards mode
+PASS [baz='quux' \53] in standards mode
+PASS [baz='quux' \53] with querySelector in standards mode
+PASS [baz~='quux' s] in standards mode
+PASS [baz~='quux' s] with querySelector in standards mode
+PASS [baz^='quux' s] in standards mode
+PASS [baz^='quux' s] with querySelector in standards mode
+PASS [baz$='quux' s] in standards mode
+PASS [baz$='quux' s] with querySelector in standards mode
+PASS [baz*='quux' s] in standards mode
+PASS [baz*='quux' s] with querySelector in standards mode
+PASS [baz|='quux' s] in standards mode
+PASS [baz|='quux' s] with querySelector in standards mode
+PASS [|baz='quux' s] in standards mode
+PASS [|baz='quux' s] with querySelector in standards mode
+PASS [*|baz='quux' s] in standards mode
+PASS [*|baz='quux' s] with querySelector in standards mode
 PASS [foo[ /* sanity check (invalid) */ in standards mode
 PASS [foo[ /* sanity check (invalid) */ with querySelector in standards mode
 PASS [foo='bar' i i] in standards mode
@@ -241,60 +239,58 @@ PASS [|foo='bar' i] in quirks mode
 PASS [|foo='bar' i] with querySelector in quirks mode
 PASS [*|foo='bar' i] in quirks mode
 PASS [*|foo='bar' i] with querySelector in quirks mode
-FAIL [baz='quux' s] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' s] with querySelector in quirks mode '[baz='quux' s]' is not a valid selector.
-FAIL [baz='quux' S] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' S] with querySelector in quirks mode '[baz='quux' S]' is not a valid selector.
-FAIL [baz=quux s] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz=quux s] with querySelector in quirks mode '[baz=quux s]' is not a valid selector.
-FAIL [baz="quux" s] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz="quux" s] with querySelector in quirks mode '[baz="quux" s]' is not a valid selector.
-FAIL [baz='quux's] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux's] with querySelector in quirks mode '[baz='quux's]' is not a valid selector.
-FAIL [baz='quux's ] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux's ] with querySelector in quirks mode '[baz='quux's ]' is not a valid selector.
-FAIL [baz='quux' s ] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' s ] with querySelector in quirks mode '[baz='quux' s ]' is not a valid selector.
-FAIL [baz='quux' /**/ s] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' /**/ s] with querySelector in quirks mode '[baz='quux' /**/ s]' is not a valid selector.
-FAIL [baz='quux' s /**/ ] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' s /**/ ] with querySelector in quirks mode '[baz='quux' s /**/ ]' is not a valid selector.
-FAIL [baz='quux'/**/s/**/] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux'/**/s/**/] with querySelector in quirks mode '[baz='quux'/**/s/**/]' is not a valid selector.
-FAIL [baz=quux/**/s] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz=quux/**/s] with querySelector in quirks mode '[baz=quux/**/s]' is not a valid selector.
-FAIL [baz='quux'	s	] /* \t */ in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux'	s	] /* \t */ with querySelector in quirks mode '[baz='quux'	s	] /* \t */' is not a valid selector.
-FAIL [baz='quux'
+PASS [baz='quux' s] in quirks mode
+PASS [baz='quux' s] with querySelector in quirks mode
+PASS [baz='quux' S] in quirks mode
+PASS [baz='quux' S] with querySelector in quirks mode
+PASS [baz=quux s] in quirks mode
+PASS [baz=quux s] with querySelector in quirks mode
+PASS [baz="quux" s] in quirks mode
+PASS [baz="quux" s] with querySelector in quirks mode
+PASS [baz='quux's] in quirks mode
+PASS [baz='quux's] with querySelector in quirks mode
+PASS [baz='quux's ] in quirks mode
+PASS [baz='quux's ] with querySelector in quirks mode
+PASS [baz='quux' s ] in quirks mode
+PASS [baz='quux' s ] with querySelector in quirks mode
+PASS [baz='quux' /**/ s] in quirks mode
+PASS [baz='quux' /**/ s] with querySelector in quirks mode
+PASS [baz='quux' s /**/ ] in quirks mode
+PASS [baz='quux' s /**/ ] with querySelector in quirks mode
+PASS [baz='quux'/**/s/**/] in quirks mode
+PASS [baz='quux'/**/s/**/] with querySelector in quirks mode
+PASS [baz=quux/**/s] in quirks mode
+PASS [baz=quux/**/s] with querySelector in quirks mode
+PASS [baz='quux'	s	] /* \t */ in quirks mode
+PASS [baz='quux'	s	] /* \t */ with querySelector in quirks mode
+PASS [baz='quux'
 s
-] /* \n */ in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux'
+] /* \n */ in quirks mode
+PASS [baz='quux'
 s
-] /* \n */ with querySelector in quirks mode '[baz='quux'
-s
-] /* \n */' is not a valid selector.
-FAIL [baz='quux'\rs\r] /* \r */ in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux'\rs\r] /* \r */ with querySelector in quirks mode '[baz='quux'\rs\r] /* \r */' is not a valid selector.
-FAIL [baz='quux' \s] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' \s] with querySelector in quirks mode '[baz='quux' \s]' is not a valid selector.
-FAIL [baz='quux' \73] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' \73] with querySelector in quirks mode '[baz='quux' \73]' is not a valid selector.
-FAIL [baz='quux' \53] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' \53] with querySelector in quirks mode '[baz='quux' \53]' is not a valid selector.
-FAIL [baz~='quux' s] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz~='quux' s] with querySelector in quirks mode '[baz~='quux' s]' is not a valid selector.
-FAIL [baz^='quux' s] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz^='quux' s] with querySelector in quirks mode '[baz^='quux' s]' is not a valid selector.
-FAIL [baz$='quux' s] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz$='quux' s] with querySelector in quirks mode '[baz$='quux' s]' is not a valid selector.
-FAIL [baz*='quux' s] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz*='quux' s] with querySelector in quirks mode '[baz*='quux' s]' is not a valid selector.
-FAIL [baz|='quux' s] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz|='quux' s] with querySelector in quirks mode '[baz|='quux' s]' is not a valid selector.
-FAIL [|baz='quux' s] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [|baz='quux' s] with querySelector in quirks mode '[|baz='quux' s]' is not a valid selector.
-FAIL [*|baz='quux' s] in quirks mode assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|baz='quux' s] with querySelector in quirks mode '[*|baz='quux' s]' is not a valid selector.
+] /* \n */ with querySelector in quirks mode
+PASS [baz='quux'\rs\r] /* \r */ in quirks mode
+PASS [baz='quux'\rs\r] /* \r */ with querySelector in quirks mode
+PASS [baz='quux' \s] in quirks mode
+PASS [baz='quux' \s] with querySelector in quirks mode
+PASS [baz='quux' \73] in quirks mode
+PASS [baz='quux' \73] with querySelector in quirks mode
+PASS [baz='quux' \53] in quirks mode
+PASS [baz='quux' \53] with querySelector in quirks mode
+PASS [baz~='quux' s] in quirks mode
+PASS [baz~='quux' s] with querySelector in quirks mode
+PASS [baz^='quux' s] in quirks mode
+PASS [baz^='quux' s] with querySelector in quirks mode
+PASS [baz$='quux' s] in quirks mode
+PASS [baz$='quux' s] with querySelector in quirks mode
+PASS [baz*='quux' s] in quirks mode
+PASS [baz*='quux' s] with querySelector in quirks mode
+PASS [baz|='quux' s] in quirks mode
+PASS [baz|='quux' s] with querySelector in quirks mode
+PASS [|baz='quux' s] in quirks mode
+PASS [|baz='quux' s] with querySelector in quirks mode
+PASS [*|baz='quux' s] in quirks mode
+PASS [*|baz='quux' s] with querySelector in quirks mode
 PASS [foo[ /* sanity check (invalid) */ in quirks mode
 PASS [foo[ /* sanity check (invalid) */ with querySelector in quirks mode
 PASS [foo='bar' i i] in quirks mode
@@ -427,60 +423,58 @@ PASS [|foo='bar' i] in XML
 PASS [|foo='bar' i] with querySelector in XML
 PASS [*|foo='bar' i] in XML
 PASS [*|foo='bar' i] with querySelector in XML
-FAIL [baz='quux' s] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' s] with querySelector in XML '[baz='quux' s]' is not a valid selector.
-FAIL [baz='quux' S] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' S] with querySelector in XML '[baz='quux' S]' is not a valid selector.
-FAIL [baz=quux s] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz=quux s] with querySelector in XML '[baz=quux s]' is not a valid selector.
-FAIL [baz="quux" s] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz="quux" s] with querySelector in XML '[baz="quux" s]' is not a valid selector.
-FAIL [baz='quux's] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux's] with querySelector in XML '[baz='quux's]' is not a valid selector.
-FAIL [baz='quux's ] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux's ] with querySelector in XML '[baz='quux's ]' is not a valid selector.
-FAIL [baz='quux' s ] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' s ] with querySelector in XML '[baz='quux' s ]' is not a valid selector.
-FAIL [baz='quux' /**/ s] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' /**/ s] with querySelector in XML '[baz='quux' /**/ s]' is not a valid selector.
-FAIL [baz='quux' s /**/ ] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' s /**/ ] with querySelector in XML '[baz='quux' s /**/ ]' is not a valid selector.
-FAIL [baz='quux'/**/s/**/] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux'/**/s/**/] with querySelector in XML '[baz='quux'/**/s/**/]' is not a valid selector.
-FAIL [baz=quux/**/s] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz=quux/**/s] with querySelector in XML '[baz=quux/**/s]' is not a valid selector.
-FAIL [baz='quux'	s	] /* \t */ in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux'	s	] /* \t */ with querySelector in XML '[baz='quux'	s	] /* \t */' is not a valid selector.
-FAIL [baz='quux'
+PASS [baz='quux' s] in XML
+PASS [baz='quux' s] with querySelector in XML
+PASS [baz='quux' S] in XML
+PASS [baz='quux' S] with querySelector in XML
+PASS [baz=quux s] in XML
+PASS [baz=quux s] with querySelector in XML
+PASS [baz="quux" s] in XML
+PASS [baz="quux" s] with querySelector in XML
+PASS [baz='quux's] in XML
+PASS [baz='quux's] with querySelector in XML
+PASS [baz='quux's ] in XML
+PASS [baz='quux's ] with querySelector in XML
+PASS [baz='quux' s ] in XML
+PASS [baz='quux' s ] with querySelector in XML
+PASS [baz='quux' /**/ s] in XML
+PASS [baz='quux' /**/ s] with querySelector in XML
+PASS [baz='quux' s /**/ ] in XML
+PASS [baz='quux' s /**/ ] with querySelector in XML
+PASS [baz='quux'/**/s/**/] in XML
+PASS [baz='quux'/**/s/**/] with querySelector in XML
+PASS [baz=quux/**/s] in XML
+PASS [baz=quux/**/s] with querySelector in XML
+PASS [baz='quux'	s	] /* \t */ in XML
+PASS [baz='quux'	s	] /* \t */ with querySelector in XML
+PASS [baz='quux'
 s
-] /* \n */ in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux'
+] /* \n */ in XML
+PASS [baz='quux'
 s
-] /* \n */ with querySelector in XML '[baz='quux'
-s
-] /* \n */' is not a valid selector.
-FAIL [baz='quux'\rs\r] /* \r */ in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux'\rs\r] /* \r */ with querySelector in XML '[baz='quux'\rs\r] /* \r */' is not a valid selector.
-FAIL [baz='quux' \s] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' \s] with querySelector in XML '[baz='quux' \s]' is not a valid selector.
-FAIL [baz='quux' \73] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' \73] with querySelector in XML '[baz='quux' \73]' is not a valid selector.
-FAIL [baz='quux' \53] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz='quux' \53] with querySelector in XML '[baz='quux' \53]' is not a valid selector.
-FAIL [baz~='quux' s] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz~='quux' s] with querySelector in XML '[baz~='quux' s]' is not a valid selector.
-FAIL [baz^='quux' s] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz^='quux' s] with querySelector in XML '[baz^='quux' s]' is not a valid selector.
-FAIL [baz$='quux' s] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz$='quux' s] with querySelector in XML '[baz$='quux' s]' is not a valid selector.
-FAIL [baz*='quux' s] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz*='quux' s] with querySelector in XML '[baz*='quux' s]' is not a valid selector.
-FAIL [baz|='quux' s] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [baz|='quux' s] with querySelector in XML '[baz|='quux' s]' is not a valid selector.
-FAIL [|baz='quux' s] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [|baz='quux' s] with querySelector in XML '[|baz='quux' s]' is not a valid selector.
-FAIL [*|baz='quux' s] in XML assert_equals: valid rule didn't parse into CSSOM expected 1 but got 0
-FAIL [*|baz='quux' s] with querySelector in XML '[*|baz='quux' s]' is not a valid selector.
+] /* \n */ with querySelector in XML
+PASS [baz='quux'\rs\r] /* \r */ in XML
+PASS [baz='quux'\rs\r] /* \r */ with querySelector in XML
+PASS [baz='quux' \s] in XML
+PASS [baz='quux' \s] with querySelector in XML
+PASS [baz='quux' \73] in XML
+PASS [baz='quux' \73] with querySelector in XML
+PASS [baz='quux' \53] in XML
+PASS [baz='quux' \53] with querySelector in XML
+PASS [baz~='quux' s] in XML
+PASS [baz~='quux' s] with querySelector in XML
+PASS [baz^='quux' s] in XML
+PASS [baz^='quux' s] with querySelector in XML
+PASS [baz$='quux' s] in XML
+PASS [baz$='quux' s] with querySelector in XML
+PASS [baz*='quux' s] in XML
+PASS [baz*='quux' s] with querySelector in XML
+PASS [baz|='quux' s] in XML
+PASS [baz|='quux' s] with querySelector in XML
+PASS [|baz='quux' s] in XML
+PASS [|baz='quux' s] with querySelector in XML
+PASS [*|baz='quux' s] in XML
+PASS [*|baz='quux' s] with querySelector in XML
 PASS [foo[ /* sanity check (invalid) */ in XML
 PASS [foo[ /* sanity check (invalid) */ with querySelector in XML
 PASS [foo='bar' i i] in XML

--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -667,10 +667,17 @@ String CSSSelector::selectorText(StringView separator, StringView rightSide) con
             }
             if (selector->match() != Match::Set) {
                 serializeString(builder, selector->serializingValue());
-                if (selector->attributeValueMatchingIsCaseInsensitive())
-                    builder.append(" i]"_s);
-                else
+                switch (selector->attributeMatchType()) {
+                case AttributeMatchType::Default:
                     builder.append(']');
+                    break;
+                case AttributeMatchType::CaseInsensitive:
+                    builder.append(" i]"_s);
+                    break;
+                case AttributeMatchType::CaseSensitive:
+                    builder.append(" s]"_s);
+                    break;
+                }
             }
         } else if (selector->match() == Match::PagePseudoClass) {
             switch (selector->pagePseudoClass()) {
@@ -742,7 +749,7 @@ void CSSSelector::setAttribute(const QualifiedName& value, AttributeMatchType ma
 {
     createRareData();
     m_data.rareData->attribute = value;
-    m_caseInsensitiveAttributeValueMatching = matchType == CaseInsensitive;
+    m_attributeMatchType = std::to_underlying(matchType);
 }
 
 void CSSSelector::setArgument(const AtomString& value)
@@ -865,7 +872,7 @@ CSSSelector::CSSSelector(const CSSSelector& other)
     , m_hasRareData(other.m_hasRareData)
     , m_isForPage(other.m_isForPage)
     , m_tagIsForNamespaceRule(other.m_tagIsForNamespaceRule)
-    , m_caseInsensitiveAttributeValueMatching(other.m_caseInsensitiveAttributeValueMatching)
+    , m_attributeMatchType(other.m_attributeMatchType)
     , m_isImplicit(other.m_isImplicit)
 {
     // Manually ref count the m_data union because they are stored as raw ptr, not as Ref.
@@ -1018,7 +1025,7 @@ bool CSSSelector::simpleSelectorEqual(const CSSSelector& other) const
         && m_pseudoType == other.m_pseudoType
         && m_hasRareData == other.m_hasRareData
         && m_tagIsForNamespaceRule == other.m_tagIsForNamespaceRule
-        && m_caseInsensitiveAttributeValueMatching == other.m_caseInsensitiveAttributeValueMatching
+        && m_attributeMatchType == other.m_attributeMatchType
         && m_isImplicit == other.m_isImplicit
         && valuesEqual();
 }

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -122,7 +122,7 @@ public:
         Right,
     };
 
-    enum AttributeMatchType { CaseSensitive, CaseInsensitive };
+    enum class AttributeMatchType : uint8_t { Default, CaseInsensitive, CaseSensitive };
 
     // Maps from the selector pseudo-element type to the style type. Only pseudo-elements that are not element-backed have a type in style.
     static std::optional<PseudoElementType> NODELETE stylePseudoElementTypeFor(PseudoElement);
@@ -154,7 +154,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     const AtomString& serializingValue() const LIFETIME_BOUND;
     const QualifiedName& attribute() const LIFETIME_BOUND;
     const AtomString& argument() const LIFETIME_BOUND { return m_hasRareData ? m_data.rareData->argument : nullAtom(); }
-    bool attributeValueMatchingIsCaseInsensitive() const;
+    AttributeMatchType attributeMatchType() const;
     const FixedVector<int>* integerList() const LIFETIME_BOUND { return m_hasRareData ? std::get_if<FixedVector<int>>(&m_data.rareData->argumentList) : nullptr; }
     const FixedVector<AtomString>* stringList() const LIFETIME_BOUND { return m_hasRareData ? std::get_if<FixedVector<AtomString>>(&m_data.rareData->argumentList) : nullptr; }
     const FixedVector<PossiblyQuotedIdentifier>* langList() const LIFETIME_BOUND { return m_hasRareData ? std::get_if<FixedVector<PossiblyQuotedIdentifier>>(&m_data.rareData->argumentList) : nullptr; }
@@ -231,9 +231,9 @@ private:
     unsigned m_hasRareData : 1 { false };
     unsigned m_isForPage : 1 { false };
     unsigned m_tagIsForNamespaceRule : 1 { false };
-    unsigned m_caseInsensitiveAttributeValueMatching : 1 { false };
+    unsigned m_attributeMatchType : 2 { std::to_underlying(AttributeMatchType::Default) };
     unsigned m_isImplicit : 1 { false };
-    // 25 bits
+    // 26 bits
 #if !ASSERT_WITH_SECURITY_IMPLICATION_DISABLED
     unsigned m_destructorHasBeenCalled : 1 { false };
 #endif
@@ -383,7 +383,7 @@ inline CSSSelector::CSSSelector(CSSSelector&& other)
     , m_hasRareData(other.m_hasRareData)
     , m_isForPage(other.m_isForPage)
     , m_tagIsForNamespaceRule(other.m_tagIsForNamespaceRule)
-    , m_caseInsensitiveAttributeValueMatching(other.m_caseInsensitiveAttributeValueMatching)
+    , m_attributeMatchType(other.m_attributeMatchType)
     , m_isImplicit(other.m_isImplicit)
     , m_data(WTF::move(other.m_data))
 {
@@ -445,9 +445,9 @@ inline const AtomString& CSSSelector::serializingValue() const
     return *reinterpret_cast<const AtomString*>(&m_data.value);
 }
 
-inline bool CSSSelector::attributeValueMatchingIsCaseInsensitive() const
+inline auto CSSSelector::attributeMatchType() const -> AttributeMatchType
 {
-    return m_caseInsensitiveAttributeValueMatching;
+    return static_cast<AttributeMatchType>(m_attributeMatchType);
 }
 
 inline auto CSSSelector::pseudoClass() const -> PseudoClass

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -695,11 +695,18 @@ bool SelectorChecker::attributeSelectorMatches(const Element& element, const Qua
     auto& selectorName = isHTML ? selectorAttribute.localNameLowercase() : selectorAttribute.localName();
     if (!Attribute::nameMatchesFilter(attributeName, selectorAttribute.prefix(), selectorName, selectorAttribute.namespaceURI()))
         return false;
-    bool caseSensitive = true;
-    if (selector.attributeValueMatchingIsCaseInsensitive())
-        caseSensitive = false;
-    else if (element.document().isHTMLDocument() && element.isHTMLElement() && !HTMLDocument::isCaseSensitiveAttribute(selector.attribute()))
-        caseSensitive = false;
+    bool caseSensitive = [&] {
+        switch (selector.attributeMatchType()) {
+        case CSSSelector::AttributeMatchType::CaseInsensitive:
+            return false;
+        case CSSSelector::AttributeMatchType::CaseSensitive:
+            return true;
+        case CSSSelector::AttributeMatchType::Default:
+            return !(element.document().isHTMLDocument() && element.isHTMLElement() && !HTMLDocument::isCaseSensitiveAttribute(selector.attribute()));
+        }
+        ASSERT_NOT_REACHED();
+        return true;
+    }();
     return attributeValueMatches(Attribute(attributeName, attributeValue), selector.match(), selector.value(), caseSensitive);
 }
 
@@ -810,11 +817,18 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, LocalContext& c
             return false;
 
         const QualifiedName& attr = selector.attribute();
-        bool caseSensitive = true;
-        if (selector.attributeValueMatchingIsCaseInsensitive())
-            caseSensitive = false;
-        else if (m_documentIsHTML && element->isHTMLElement() && !HTMLDocument::isCaseSensitiveAttribute(attr))
-            caseSensitive = false;
+        bool caseSensitive = [&] {
+            switch (selector.attributeMatchType()) {
+            case CSSSelector::AttributeMatchType::CaseInsensitive:
+                return false;
+            case CSSSelector::AttributeMatchType::CaseSensitive:
+                return true;
+            case CSSSelector::AttributeMatchType::Default:
+                return !(m_documentIsHTML && element->isHTMLElement() && !HTMLDocument::isCaseSensitiveAttribute(attr));
+            }
+            ASSERT_NOT_REACHED();
+            return true;
+        }();
 
         return anyAttributeMatches(element, selector, attr, caseSensitive);
     }

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -790,7 +790,7 @@ std::unique_ptr<MutableCSSSelector> CSSSelectorParser::consumeAttribute(CSSParse
     auto selector = makeUnique<MutableCSSSelector>();
 
     if (block.atEnd()) {
-        selector->setAttribute(qualifiedName, CSSSelector::CaseSensitive);
+        selector->setAttribute(qualifiedName, CSSSelector::AttributeMatchType::Default);
         selector->setMatch(CSSSelector::Match::Set);
         return selector;
     }
@@ -1140,12 +1140,14 @@ CSSSelector::Match CSSSelectorParser::consumeAttributeMatch(CSSParserTokenRange&
 CSSSelector::AttributeMatchType CSSSelectorParser::consumeAttributeFlags(CSSParserTokenRange& range)
 {
     if (range.peek().type() != IdentToken)
-        return CSSSelector::CaseSensitive;
+        return CSSSelector::AttributeMatchType::Default;
     const CSSParserToken& flag = range.consumeIncludingWhitespace();
     if (equalLettersIgnoringASCIICase(flag.value(), "i"_s))
-        return CSSSelector::CaseInsensitive;
+        return CSSSelector::AttributeMatchType::CaseInsensitive;
+    if (equalLettersIgnoringASCIICase(flag.value(), "s"_s))
+        return CSSSelector::AttributeMatchType::CaseSensitive;
     m_failedParsing = true;
-    return CSSSelector::CaseSensitive;
+    return CSSSelector::AttributeMatchType::Default;
 }
 
 // <an+b> token sequences have special serialization rules: https://www.w3.org/TR/css-syntax-3/#serializing-anb

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -387,8 +387,14 @@ static AttributeCaseSensitivity attributeSelectorCaseSensitivity(const CSSSelect
     if (selector.match() == CSSSelector::Match::Set)
         return AttributeCaseSensitivity::CaseSensitive;
 
-    if (selector.attributeValueMatchingIsCaseInsensitive())
+    switch (selector.attributeMatchType()) {
+    case CSSSelector::AttributeMatchType::CaseInsensitive:
         return AttributeCaseSensitivity::CaseInsensitive;
+    case CSSSelector::AttributeMatchType::CaseSensitive:
+        return AttributeCaseSensitivity::CaseSensitive;
+    case CSSSelector::AttributeMatchType::Default:
+        break;
+    }
     if (HTMLDocument::isCaseSensitiveAttribute(selector.attribute()))
         return AttributeCaseSensitivity::CaseSensitive;
     return AttributeCaseSensitivity::HTMLLegacyCaseInsensitive;
@@ -400,7 +406,7 @@ public:
         : m_selector(&selector)
         , m_attributeCaseSensitivity(attributeSelectorCaseSensitivity(selector))
     {
-        ASSERT(!(m_attributeCaseSensitivity == AttributeCaseSensitivity::CaseInsensitive && !selector.attributeValueMatchingIsCaseInsensitive()));
+        ASSERT(!(m_attributeCaseSensitivity == AttributeCaseSensitivity::CaseInsensitive && selector.attributeMatchType() != CSSSelector::AttributeMatchType::CaseInsensitive));
         ASSERT(!(selector.match() == CSSSelector::Match::Set && m_attributeCaseSensitivity != AttributeCaseSensitivity::CaseSensitive));
     }
 

--- a/Source/WebCore/dom/SelectorQuery.cpp
+++ b/Source/WebCore/dom/SelectorQuery.cpp
@@ -84,7 +84,7 @@ template<typename Output> static ALWAYS_INLINE void appendOutputForElement(Outpu
 static bool NODELETE canBeUsedForIdFastPath(const CSSSelector& selector)
 {
     return selector.match() == CSSSelector::Match::Id
-        || (selector.match() == CSSSelector::Match::Exact && selector.attribute() == HTMLNames::idAttr && !selector.attributeValueMatchingIsCaseInsensitive());
+        || (selector.match() == CSSSelector::Match::Exact && selector.attribute() == HTMLNames::idAttr && selector.attributeMatchType() != CSSSelector::AttributeMatchType::CaseInsensitive);
 }
 
 static IdMatchingType NODELETE findIdMatchingType(const CSSSelector& firstSelector)
@@ -105,7 +105,7 @@ static IdMatchingType NODELETE findIdMatchingType(const CSSSelector& firstSelect
 static bool canOptimizeSingleAttributeExactMatch(const CSSSelector& selector)
 {
     // Bailout if attribute name needs to be definitely case-insensitive.
-    if (selector.attributeValueMatchingIsCaseInsensitive())
+    if (selector.attributeMatchType() == CSSSelector::AttributeMatchType::CaseInsensitive)
         return false;
 
     const auto& attribute = selector.attribute();


### PR DESCRIPTION
#### ff2f768ad68a9b40d3497b3c17ee29d6ecce4560
<pre>
Implement case sensitive modifier (s) in attribute selector
<a href="https://bugs.webkit.org/show_bug.cgi?id=272573">https://bugs.webkit.org/show_bug.cgi?id=272573</a>
<a href="https://rdar.apple.com/126331481">rdar://126331481</a>

Reviewed by Anne van Kesteren.

<a href="https://drafts.csswg.org/selectors/#attribute-case">https://drafts.csswg.org/selectors/#attribute-case</a>

An explicit &apos;s&apos; modifier forces case-sensitive matching regardless of
HTML&apos;s legacy case-insensitive attribute list, complementing the
existing &apos;i&apos; modifier.

Extend CSSSelector::AttributeMatchType from two values to three:
Default (no flag, honors HTML quirk), CaseInsensitive (i), and
CaseSensitive (s). The value is stored in a single 2-bit field exposed
via a new attributeMatchType() accessor, replacing the earlier boolean
predicate pair. Matching call sites switch on the enum; explicit &apos;s&apos;
short-circuits the HTML legacy list.

* LayoutTests/imported/w3c/web-platform-tests/css/selectors/attribute-selectors/attribute-case/cssom-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/attribute-selectors/attribute-case/semantics-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/attribute-selectors/attribute-case/syntax-expected.txt:

Rebaseline: 620 previously-failing &apos;s&apos; flag subtests now pass.

* Source/WebCore/css/CSSSelector.h:
(WebCore::CSSSelector::CSSSelector):
(WebCore::CSSSelector::attributeMatchType const):
(WebCore::CSSSelector::attributeValueMatchingIsCaseInsensitive const): Deleted.

Replace the two bit fields with one 2-bit m_attributeMatchType and
extend AttributeMatchType with Default / CaseSensitive.

* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::selectorText const):

Emit &apos; s]&apos; for explicit case-sensitive so round-tripping preserves the flag.

(WebCore::CSSSelector::setAttribute):
(WebCore::CSSSelector::CSSSelector):
(WebCore::CSSSelector::simpleSelectorEqual const):

* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::consumeAttribute):
(WebCore::CSSSelectorParser::consumeAttributeFlags):

Accept &apos;s&apos; and return CaseSensitive; use Default for the no-flag case.

* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::attributeSelectorMatches):
(WebCore::SelectorChecker::checkOne const):

Switch on attributeMatchType(); Default falls through to the existing
HTML legacy case-insensitive check.

* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::attributeSelectorCaseSensitivity):

Return CaseSensitive for explicit &apos;s&apos; before consulting the HTML legacy list.

(WebCore::SelectorCompiler::AttributeMatchingInfo::AttributeMatchingInfo):

* Source/WebCore/dom/SelectorQuery.cpp:
(WebCore::canBeUsedForIdFastPath):
(WebCore::canOptimizeSingleAttributeExactMatch):

Compare against CSSSelector::CaseInsensitive directly; explicit &apos;s&apos; and
Default continue to take the existing fast paths.

Canonical link: <a href="https://commits.webkit.org/313234@main">https://commits.webkit.org/313234@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ed52e575136eafbfb6a77410e4a8adab3c85801

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162525 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36001 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29125 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171463 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/118970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164394 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36105 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36005 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/126131 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/118970 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165484 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28479 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/146008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106709 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5e2fb92b-505f-4aa0-8e13-f0b3b89d4d33) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27525 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19163 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137229 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23738 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173967 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21280 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25383 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/134441 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35675 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30141 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134439 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36273 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35659 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145534 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97953 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28972 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/22367 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35169 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102920 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34670 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34915 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34818 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->