### PR TITLE
Re-import close watcher WPTs

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5981,6 +5981,9 @@ webkit.org/b/263305 imported/w3c/web-platform-tests/close-watcher/user-activatio
 webkit.org/b/263305 imported/w3c/web-platform-tests/close-watcher/user-activation/yyy-CloseWatcher-dialog-popover.html [ Skip ]
 webkit.org/b/263305 imported/w3c/web-platform-tests/close-watcher/user-activation/yyy-popovers.html [ Skip ]
 webkit.org/b/263305 imported/w3c/web-platform-tests/close-watcher/user-activation/yyy.html?dialog [ Skip ]
+webkit.org/b/263305 imported/w3c/web-platform-tests/close-watcher/iframes/dialog-same-origin-nn.html [ Skip ]
+webkit.org/b/263305 imported/w3c/web-platform-tests/close-watcher/iframes/dialog-same-origin-ynn.html [ Skip ]
+webkit.org/b/263305 imported/w3c/web-platform-tests/close-watcher/iframes/dialog-same-origin-ynyn.html [ Skip ]
 
 # Needs moveBefore support
 webkit.org/b/281223 imported/w3c/web-platform-tests/dom/nodes/moveBefore/focus-preserve-render.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/META.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/META.yml
@@ -1,4 +1,3 @@
-spec: https://wicg.github.io/close-watcher/
+spec: https://html.spec.whatwg.org/multipage/#close-requests-and-close-watchers
 suggested_reviewers:
-  - domenic
   - natechapin

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-same-origin-nn.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-same-origin-nn.html
@@ -1,0 +1,48 @@
+<!doctype html>
+<meta name="timeout" content="long">
+<link rel="author" href="mailto:wpt@keithcirkel.co.uk" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<body>
+  <iframe id="iframe1" src="resources/dialog-prevents-close.html"></iframe>
+  <iframe id="iframe2" src="resources/dialog-prevents-close.html"></iframe>
+
+  <script>
+    function awaitEvent(el, type, signal) {
+      return new Promise((resolve) =>
+        el.addEventListener(type, resolve, { once: true, signal }),
+      );
+    }
+
+    async function iframeDialogIsOpen(iframe, signal) {
+      const reply = awaitEvent(window, "message", signal);
+      iframe.contentWindow.postMessage("dialog_open", "*");
+      const {data} = (await reply);
+      if (data.error) throw new Error(data.error);
+      return data.open;
+    }
+
+    promise_test(async (t) => {
+      await awaitEvent(iframe1, "load", t.get_signal());
+      await awaitEvent(iframe2, "load", t.get_signal());
+
+      assert_true(await iframeDialogIsOpen(iframe1, t.get_signal()), "Dialog 1 is open");
+      assert_true(await iframeDialogIsOpen(iframe2, t.get_signal()), "Dialog 2 is open");
+
+      await test_driver.send_keys(iframe1, "\uE00C");
+
+      assert_false(await iframeDialogIsOpen(iframe1, t.get_signal()), "Dialog 1 is now closed");
+      assert_true(await iframeDialogIsOpen(iframe2, t.get_signal()), "Dialog 2 is still open");
+
+      await test_driver.send_keys(iframe2, "\uE00C");
+
+      assert_false(await iframeDialogIsOpen(iframe1, t.get_signal()), "Dialog 1 is still closed");
+      assert_false(await iframeDialogIsOpen(iframe2, t.get_signal()), "Dialog 2 is now closed");
+    });
+  </script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-same-origin-ynn.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-same-origin-ynn.html
@@ -1,0 +1,55 @@
+<!doctype html>
+<meta name="timeout" content="long">
+<link rel="author" href="mailto:wpt@keithcirkel.co.uk" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<body>
+  <iframe id="iframe1" src="resources/dialog-prevents-close.html"></iframe>
+  <iframe id="iframe2" src="resources/dialog-prevents-close.html"></iframe>
+
+  <script>
+    function awaitEvent(el, type, signal) {
+      return new Promise((resolve) =>
+        el.addEventListener(type, resolve, { once: true, signal }),
+      );
+    }
+
+    async function iframeDialogIsOpen(iframe, signal) {
+      const reply = awaitEvent(window, "message", signal);
+      iframe.contentWindow.postMessage("dialog_open", "*");
+      const {data} = (await reply);
+      if (data.error) throw new Error(data.error);
+      return data.open;
+    }
+
+    promise_test(async (t) => {
+      await awaitEvent(iframe1, "load", t.get_signal());
+      await awaitEvent(iframe2, "load", t.get_signal());
+
+      test_driver.bless();
+
+      assert_true(await iframeDialogIsOpen(iframe1, t.get_signal()), "Dialog 1 is open");
+      assert_true(await iframeDialogIsOpen(iframe2, t.get_signal()), "Dialog 2 is open");
+
+      await test_driver.send_keys(iframe1, "\uE00C");
+
+      assert_true(await iframeDialogIsOpen(iframe1, t.get_signal()), "Dialog 1 is still open");
+      assert_true(await iframeDialogIsOpen(iframe2, t.get_signal()), "Dialog 2 is still open");
+
+      await test_driver.send_keys(iframe1, "\uE00C");
+
+      assert_false(await iframeDialogIsOpen(iframe1, t.get_signal()), "Dialog 1 is now closed");
+      assert_true(await iframeDialogIsOpen(iframe2, t.get_signal()), "Dialog 2 is still open");
+
+      await test_driver.send_keys(iframe2, "\uE00C");
+
+      assert_false(await iframeDialogIsOpen(iframe1, t.get_signal()), "Dialog 1 is still closed");
+      assert_false(await iframeDialogIsOpen(iframe2, t.get_signal()), "Dialog 2 is now closed");
+    });
+  </script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-same-origin-ynyn.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-same-origin-ynyn.html
@@ -1,0 +1,62 @@
+<!doctype html>
+<meta name="timeout" content="long">
+<link rel="author" href="mailto:wpt@keithcirkel.co.uk" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="../resources/helpers.js"></script>
+
+<body>
+  <iframe id="iframe1" src="resources/dialog-prevents-close.html"></iframe>
+  <iframe id="iframe2" src="resources/dialog-prevents-close.html"></iframe>
+
+  <script>
+    function awaitEvent(el, type, signal) {
+      return new Promise((resolve) =>
+        el.addEventListener(type, resolve, { once: true, signal }),
+      );
+    }
+
+    async function iframeDialogIsOpen(iframe, signal) {
+      const reply = awaitEvent(window, "message", signal);
+      iframe.contentWindow.postMessage("dialog_open", "*");
+      const {data} = (await reply);
+      if (data.error) throw new Error(data.error);
+      return data.open;
+    }
+
+    promise_test(async (t) => {
+      await awaitEvent(iframe1, "load", t.get_signal());
+      await awaitEvent(iframe2, "load", t.get_signal());
+
+      test_driver.bless();
+
+      assert_true(await iframeDialogIsOpen(iframe1, t.get_signal()), "Dialog 1 is open");
+      assert_true(await iframeDialogIsOpen(iframe2, t.get_signal()), "Dialog 2 is open");
+
+      await test_driver.send_keys(iframe1, "\uE00C");
+
+      assert_true(await iframeDialogIsOpen(iframe1, t.get_signal()), "Dialog 1 is still open");
+      assert_true(await iframeDialogIsOpen(iframe2, t.get_signal()), "Dialog 2 is still open");
+
+      await test_driver.send_keys(iframe1, "\uE00C");
+
+      assert_false(await iframeDialogIsOpen(iframe1, t.get_signal()), "Dialog 1 is now closed");
+      assert_true(await iframeDialogIsOpen(iframe2, t.get_signal()), "Dialog 2 is still open");
+
+      test_driver.bless();
+
+      await test_driver.send_keys(iframe2, "\uE00C");
+
+      assert_false(await iframeDialogIsOpen(iframe1, t.get_signal()), "Dialog 1 is now closed");
+      assert_true(await iframeDialogIsOpen(iframe2, t.get_signal()), "Dialog 2 is still open");
+
+      await test_driver.send_keys(iframe2, "\uE00C");
+
+      assert_false(await iframeDialogIsOpen(iframe1, t.get_signal()), "Dialog 1 is still closed");
+      assert_false(await iframeDialogIsOpen(iframe2, t.get_signal()), "Dialog 2 is now closed");
+    });
+  </script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/resources/dialog-prevents-close.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/resources/dialog-prevents-close.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<link rel="author" href="mailto:wpt@keithcirkel.co.uk" />
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<body>
+  <dialog id="d"></dialog>
+  <script>
+    d.showModal();
+    d.addEventListener("cancel", (e) => e.preventDefault());
+    window.addEventListener("message", async (e) => {
+      if (event.data == "dialog_open") {
+        window.parent.postMessage({ open: d.open }, "*");
+      } else {
+        window.parent.postMessage({ error: `invalid command: ${e.data}` }, "*");
+      }
+    });
+  </script>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/resources/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/resources/w3c-import.log
@@ -1,0 +1,17 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/resources/dialog-prevents-close.html

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/w3c-import.log
@@ -1,0 +1,19 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-same-origin-nn.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-same-origin-ynn.html
+/LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-same-origin-ynyn.html

--- a/LayoutTests/tests-options.json
+++ b/LayoutTests/tests-options.json
@@ -845,6 +845,15 @@
     "imported/w3c/web-platform-tests/clipboard-apis/async-idlharness.https.html": [
         "slow"
     ],
+    "imported/w3c/web-platform-tests/close-watcher/iframes/dialog-same-origin-nn.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/close-watcher/iframes/dialog-same-origin-ynn.html": [
+        "slow"
+    ],
+    "imported/w3c/web-platform-tests/close-watcher/iframes/dialog-same-origin-ynyn.html": [
+        "slow"
+    ],
     "imported/w3c/web-platform-tests/content-security-policy/embedded-enforcement/required_csp-header-crlf.html": [
         "slow"
     ],


### PR DESCRIPTION
#### ccc4b106b593192c92c3432bb1acdfae7cd3a7b2
<pre>
Re-import close watcher WPTs
<a href="https://bugs.webkit.org/show_bug.cgi?id=314735">https://bugs.webkit.org/show_bug.cgi?id=314735</a>

Reviewed by Anne van Kesteren.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/ddfb74862dc00e3211cb90efd34819349153694b">https://github.com/web-platform-tests/wpt/commit/ddfb74862dc00e3211cb90efd34819349153694b</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/META.yml:
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-same-origin-nn.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-same-origin-ynn.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-same-origin-ynyn.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/resources/dialog-prevents-close.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/resources/w3c-import.log: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/w3c-import.log: Added.
* LayoutTests/tests-options.json:

Canonical link: <a href="https://commits.webkit.org/313244@main">https://commits.webkit.org/313244@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a16de339940b38717ad8aa23df8741da54b5372e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162515 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35991 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29112 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171453 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/118960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36095 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/35995 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126124 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/118960 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165474 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28469 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/145993 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106702 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27515 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19153 "Built successfully") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137219 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23723 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173957 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25367 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134434 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35665 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30133 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134432 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36279 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35649 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145519 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97926 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28964 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22352 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35159 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34660 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34905 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34808 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->