### PR TITLE
[AppKit Gestures] Triple click does not generate a line selection on a PDF file

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -4740,6 +4740,7 @@ PDFSelection *UnifiedPDFPlugin::selectionAtPoint(FloatPoint pointInPage, PDFPage
         case TextGranularity::WordGranularity:
             return PDFSelectionGranularityWord;
         case TextGranularity::LineGranularity:
+        case TextGranularity::ParagraphGranularity:
             return PDFSelectionGranularityLine;
         default:
             ASSERT_NOT_REACHED();

--- a/Tools/TestWebKitAPI/Helpers/cocoa/WebPage+Extras.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/WebPage+Extras.swift
@@ -164,6 +164,14 @@ extension WebPage {
         }
     }
 
+    /// Copies the current selection to the system pasteboard and returns its string representation.
+    public func copySelection() async -> String? {
+        NSPasteboard.general.clearContents()
+        NSApp.sendAction(#selector(NSText.copy(_:)), to: backingWebView, from: nil)
+        await waitForNextPresentationUpdate()
+        return NSPasteboard.general.string(forType: .string)
+    }
+
     private func mouseEvent(
         _ type: NSEvent.EventType,
         at location: NSPoint,

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm
@@ -865,6 +865,27 @@ UNIFIED_PDF_TEST(SelectAllTextInObjectHostedPDF)
     });
 }
 
+UNIFIED_PDF_TEST(TripleClickSelectsLineInPDF)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 600, 600) configuration:configurationForWebViewTestingUnifiedPDF().get()]);
+    [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"pdf"]]];
+    [webView waitForNextPresentationUpdate];
+
+    [[webView window] makeFirstResponder:webView.get()];
+    [[webView window] makeKeyAndOrderFront:nil];
+    [[webView window] orderFrontRegardless];
+
+    [[NSPasteboard generalPasteboard] clearContents];
+
+    [webView sendClicksAtPoint:NSMakePoint(100, 500) numberOfClicks:3];
+    [webView waitForPendingMouseEvents];
+    [webView waitForNextPresentationUpdate];
+    [webView copy:nil];
+    [webView waitForNextPresentationUpdate];
+
+    EXPECT_WK_STREQ("Test PDF Content", [[NSPasteboard generalPasteboard] stringForType:NSPasteboardTypeString]);
+}
+
 #endif // PLATFORM(MAC)
 
 #if PLATFORM(IOS_FAMILY)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift
@@ -199,6 +199,48 @@ struct AppKitGesturesTests {
         #expect(newSelection == crazySelection)
     }
 
+    @Test(
+        .bug("https://webkit.org/b/314804", "Triple click does not generate a line selection on PDF")
+    )
+    func tripleClickingInPDFSelectsLine() async throws {
+        let pdfURL = try #require(Bundle.testResources.url(forResource: "test", withExtension: "pdf"))
+        try await page.load(URLRequest(url: pdfURL)).wait()
+        await page.waitForNextPresentationUpdate()
+
+        // Recap requires this test to be ran within an app host.
+        guard NSApp.isActive else {
+            return
+        }
+
+        let pointInDOMCoords = try #require(
+            DOMRect(decodedRepresentation: [
+                "x": 100.0,
+                "y": 100.0,
+                "width": 0.0,
+                "height": 0.0,
+            ])
+        )
+        let clickPoint = convertToCoreGraphicsScreenCoordinates(
+            rectInViewportCoordinates: pointInDOMCoords,
+            window: window
+        )
+        .origin
+
+        await recap.play { composer in
+            composer._wk_click(at: clickPoint, for: .seconds(0.1))
+            composer.advanceTime(0.1)
+            composer._wk_click(at: clickPoint, for: .seconds(0.1))
+            composer.advanceTime(0.1)
+            composer._wk_click(at: clickPoint, for: .seconds(0.1))
+        }
+
+        await page.waitForPendingMouseEvents()
+        await page.waitForNextPresentationUpdate()
+
+        let selectedText = await page.copySelection()
+        #expect(selectedText == "Test PDF Content")
+    }
+
     @Test(arguments: [0.1, 0.5, 0.9])
     func clickingInWordChangesSelection(fractionOfWordToClick: Double) async throws {
         try await loadHTML(contentEditable: true)


### PR DESCRIPTION
#### d59fcec2dc3b52bc4ee17efb43945f604e9cbcd0
<pre>
[AppKit Gestures] Triple click does not generate a line selection on a PDF file
<a href="https://bugs.webkit.org/show_bug.cgi?id=314804">https://bugs.webkit.org/show_bug.cgi?id=314804</a>
<a href="https://rdar.apple.com/177052413">rdar://177052413</a>

Reviewed by Aditya Keerthi and Richard Robinson.

Right now, a triple click action leads to a .ParagraphGranularity
selection request from WebCore, but we fail to respect that and fallback
to a character granularity selection. Triple clicks, however, are used to
produce line selections for PDF content elsewhere in the system, namely
in Preview.app.

Since PDFKit performs this same decomposition from
NSTextSelectionGranularityParagraph to PDFSelectionGranularityLine for
this purpose, we just follow suit in this patch.

Test: AppKitGestureTests.tripleClickingInPDFSelectsLine
      UnifiedPDF.TripleClickSelectsLineInPDF

* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::documentEditingContext const):
* Tools/TestWebKitAPI/Helpers/cocoa/WebPage+Extras.swift:
(copySelection):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm:
(TestWebKitAPI::UNIFIED_PDF_TEST):
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift:
(AppKitGesturesTests.tripleClickingInPDFSelectsLine):

Canonical link: <a href="https://commits.webkit.org/313288@main">https://commits.webkit.org/313288@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1e72fe96ba604f3470ec692b8bdfb328518466d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162664 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36140 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29281 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171602 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/119110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/85b99ed0-3307-47ef-a615-f648a633c1dd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164533 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36244 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36144 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126249 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/119110 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/edf90c86-ebe3-4727-8a44-a1d67491db35) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165623 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28603 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146150 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106826 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d511810b-4a4c-42dc-b02f-c9db2e2ce55c) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27649 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26175 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19302 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137356 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23879 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174106 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21419 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25524 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134558 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35814 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134554 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35798 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145675 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98150 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24728 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/29095 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22509 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35308 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/103059 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34809 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35054 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34957 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->