### PR TITLE
[GTK][WPE] Drop --pid host from wkdev-build container creation

### DIFF
--- a/Tools/Scripts/webkitpy/port/linux_container_sdk_utils.py
+++ b/Tools/Scripts/webkitpy/port/linux_container_sdk_utils.py
@@ -204,7 +204,11 @@ def _build_podman_create_args(pinned_version):
         '--ulimit', 'host',
         '--pids-limit', '-1',
         '--tmpfs', '/tmp',
-        '--pid', 'host',
+        # No --pid host: crun rejects sharing the host PID namespace when the
+        # container is not creating its own cgroup ("containers not creating
+        # Cgroups must create a private PID namespace"). The build container
+        # runs `sleep infinity` as its own PID 1 with no systemd inside, so a
+        # private PID namespace is fine.
         '--ipc', 'host',
         '--network', 'host',
         '--pull=newer',


### PR DESCRIPTION
#### e67bead77ea13a5d79908a5cc086a98ab1cef94a
<pre>
[GTK][WPE] Drop --pid host from wkdev-build container creation
<a href="https://bugs.webkit.org/show_bug.cgi?id=314805">https://bugs.webkit.org/show_bug.cgi?id=314805</a>

Unreviewed build fix

The auto-enter helper was passing `--pid host` to `podman create`, which
crun rejects on some host configurations with:

    Error: containers not creating Cgroups must create a private PID namespace: invalid argument
    ERROR: Failed to create WebKit Container SDK container named &apos;wkdev-build&apos;.

Remove --pid host, we don&apos;t need it for the wkdev-build container
(unlike the full SDK container, for convenience).

* Tools/Scripts/webkitpy/port/linux_container_sdk_utils.py:
(_build_podman_create_args):

Canonical link: <a href="https://commits.webkit.org/313232@main">https://commits.webkit.org/313232@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1049a49916e500f5b0300ef559b8f8e6f2310004

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162520 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/35996 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/29118 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171458 "Failed to checkout and rebase branch from PR 64920") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/118965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164389 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36100 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36000 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/171458 "Failed to checkout and rebase branch from PR 64920") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/118965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [  ~~🧪 webkitperl~~](https://ews-build.webkit.org/#/builders/11/builds/165479 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/28472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/146000 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/171458 "Failed to checkout and rebase branch from PR 64920") | 
| [  ~~🧪 webkitpy~~](https://ews-build.webkit.org/#/builders/6/builds/161840 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27518 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19158 "Failed to checkout and rebase branch from PR 64920") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137222 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/23730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173962 "Failed to checkout and rebase branch from PR 64920") | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/25374 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/173962 "Failed to checkout and rebase branch from PR 64920") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35670 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30136 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/173962 "Failed to checkout and rebase branch from PR 64920") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35654 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/145526 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97938 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24687 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/28967 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/22359 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35164 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34665 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34910 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34813 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->