### PR TITLE
[GTK][WPE] Cap wkdev-build container hostname to HOST_NAME_MAX

### DIFF
--- a/Tools/Scripts/webkitpy/port/linux_container_sdk_utils.py
+++ b/Tools/Scripts/webkitpy/port/linux_container_sdk_utils.py
@@ -179,6 +179,17 @@ def _bind_mount(src, dst, options='rslave'):
     return ['--mount', 'type=bind,source={},destination={},{}'.format(src, dst, options)]
 
 
+def _container_hostname():
+    # Linux caps hostnames at HOST_NAME_MAX (64) bytes; sethostname(2) returns
+    # EINVAL above that, which surfaces from crun as "sethostname: Invalid
+    # argument" and aborts container startup. In a Kubernetes pod the host
+    # hostname is already up to 63 chars, so blindly appending it overflows.
+    hostname = '{}.{}'.format(WKDEV_CONTAINER_NAME, socket.gethostname())
+    if len(hostname) > 63:
+        hostname = hostname[:63]
+    return hostname
+
+
 def _build_podman_create_args(pinned_version):
     image_ref = '{}:{}'.format(WKDEV_SDK_IMAGE_REPOSITORY, pinned_version)
     container_home = _container_home_path()
@@ -188,7 +199,7 @@ def _build_podman_create_args(pinned_version):
 
     args = [
         '--name', WKDEV_CONTAINER_NAME,
-        '--hostname', '{}.{}'.format(WKDEV_CONTAINER_NAME, socket.gethostname()),
+        '--hostname', _container_hostname(),
         '--workdir', '/home/{}'.format(user),
         '--userns', 'keep-id',
         '--user', 'root:root',


### PR DESCRIPTION
#### 3ece54788730b769f69815d72ecc42f0b8688223
<pre>
[GTK][WPE] Cap wkdev-build container hostname to HOST_NAME_MAX
<a href="https://bugs.webkit.org/show_bug.cgi?id=314810">https://bugs.webkit.org/show_bug.cgi?id=314810</a>

Unreviewed build fix.

In a Kubernetes pod the host hostname is the pod name (up to 63 chars),
so blindly appending it to the container name overflows the 64-byte
HOST_NAME_MAX. crun then fails to start the container with:

    Error: OCI runtime error: ... crun: sethostname: Invalid argument
    ERROR: Failed to start container &apos;wkdev-build&apos;.

Route the hostname through a small helper that truncates to 63 chars.

* Tools/Scripts/webkitpy/port/linux_container_sdk_utils.py:
(_container_hostname):
(_build_podman_create_args):

Canonical link: <a href="https://commits.webkit.org/313235@main">https://commits.webkit.org/313235@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/096924895697563b6387e60a251fbd757f91aebe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162530 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36006 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/29131 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171468 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/118975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164399 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36110 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36010 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/126135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/118975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165489 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/28482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/146013 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/106713 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/161850 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27528 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19168 "Built successfully") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137232 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/23743 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/173972 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/25388 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/173972 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35680 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/173972 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35664 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/145539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/97963 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24689 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/28977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/22372 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35174 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34675 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34920 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34823 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->