### PR TITLE
[JSC] Cache `isDefinitelyNonThenable` result on Structure

### DIFF
--- a/JSTests/microbenchmarks/await-object-literal.js
+++ b/JSTests/microbenchmarks/await-object-literal.js
@@ -1,0 +1,14 @@
+// Stresses isDefinitelyNonThenable() through `await object`, the dominant pattern
+// in async functions returning plain objects.
+
+async function run() {
+    let acc = 0;
+    for (let i = 0; i < 1e6; i++) {
+        const o = await { a: i, b: i + 1, c: i + 2 };
+        acc += o.a;
+    }
+    return acc;
+}
+
+run();
+drainMicrotasks();

--- a/JSTests/microbenchmarks/promise-resolve-object-literal.js
+++ b/JSTests/microbenchmarks/promise-resolve-object-literal.js
@@ -1,0 +1,6 @@
+// Stresses isDefinitelyNonThenable() through Promise.resolve(object). Resolving a
+// plain object literal must check whether it is a thenable, which walks the
+// prototype chain unless cached on the Structure.
+
+for (var i = 0; i < 1e6; ++i)
+    Promise.resolve({ a: i, b: i + 1, c: i + 2 });

--- a/JSTests/microbenchmarks/promise-then-chain-object-literal.js
+++ b/JSTests/microbenchmarks/promise-then-chain-object-literal.js
@@ -1,0 +1,8 @@
+// Stresses isDefinitelyNonThenable() through a `.then()` handler chain that returns
+// plain object literals — every link must check whether the returned object is a
+// thenable.
+
+let p = Promise.resolve({ a: 1, b: 2, c: 3 });
+for (let i = 0; i < 1e6; i++)
+    p = p.then((x) => ({ a: x.a + 1, b: x.b + 1, c: x.c + 1 }));
+drainMicrotasks();

--- a/JSTests/stress/promise-resolve-non-thenable-structure-cache-cross-realm.js
+++ b/JSTests/stress/promise-resolve-non-thenable-structure-cache-cross-realm.js
@@ -1,0 +1,75 @@
+// The isDefinitelyNonThenable Structure cache compares structure->realm() against
+// the calling JSGlobalObject before trusting a cached `true`. This test exercises
+// cross-realm Promise resolution to ensure a cache populated by one realm's
+// watchpoint set is never trusted by another realm.
+
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error(`bad value (${msg ?? ""}): got ${String(actual)}, expected ${String(expected)}`);
+}
+
+function asyncTest(fn) {
+    let done = false;
+    let error;
+    fn().then(() => { done = true; }, (e) => { error = e; done = true; });
+    drainMicrotasks();
+    if (!done)
+        throw new Error("async test did not settle: " + fn.name);
+    if (error)
+        throw error;
+}
+
+const other = createGlobalObject();
+const otherObject = other.Function("return { a: 1, b: 2, c: 3 };")();
+const otherProto = other.Object.prototype;
+
+// --- 1. Resolve a foreign object literal in this realm. ---
+asyncTest(async function resolveForeignObject() {
+    for (let i = 0; i < testLoopCount; i++) {
+        const o = await Promise.resolve(otherObject);
+        shouldBe(o.a, 1);
+        shouldBe(o.b, 2);
+        shouldBe(o.c, 3);
+    }
+});
+
+// --- 2. The other realm warms its own cache, then this realm resolves the
+//        same Structure. Each realm's watchpoint set must guard independently. ---
+asyncTest(async function bothRealmsWarm() {
+    // Warm the other realm.
+    other.Function("p", `
+        for (let i = 0; i < 100; i++)
+            p.resolve({ a: i });
+    `)(other.Promise);
+    other.drainMicrotasks();
+
+    // Now resolve foreign objects from this realm.
+    const factory = other.Function("i", "return { a: i, b: i * 2 };");
+    for (let i = 0; i < 100; i++) {
+        const o = await Promise.resolve(factory(i));
+        shouldBe(o.a, i, "bothRealmsWarm.a");
+        shouldBe(o.b, i * 2, "bothRealmsWarm.b");
+    }
+});
+
+// --- 3. Poison the OTHER realm's Object.prototype.then. The structure of
+//        otherObject lives in the other realm; resolving it from THIS realm
+//        must observe the foreign `then`. ---
+asyncTest(async function poisonOtherRealmObjectProto() {
+    // Warm-up resolves from this realm.
+    const factory = other.Function("i", "return { p: i };");
+    for (let i = 0; i < 100; i++) {
+        const o = await Promise.resolve(factory(i));
+        shouldBe(o.p, i, "poisonOtherRealm.warm");
+    }
+    // Poison the foreign Object.prototype.
+    other.Function(`
+        Object.prototype.then = function(resolve) { resolve("foreign-poisoned"); };
+    `)();
+    try {
+        const v = await Promise.resolve(factory(42));
+        shouldBe(v, "foreign-poisoned", "poisonOtherRealm.afterPoison");
+    } finally {
+        other.Function("delete Object.prototype.then;")();
+    }
+});

--- a/JSTests/stress/promise-resolve-non-thenable-structure-cache-dictionary.js
+++ b/JSTests/stress/promise-resolve-non-thenable-structure-cache-dictionary.js
@@ -1,0 +1,88 @@
+//@ requireOptions("--useDollarVM=1")
+// Dictionary structures are mutated in place when properties are added, so the
+// Structure-level isDefinitelyNonThenable cache must not store NonThenable for
+// them: a later in-place addition of `then` would not invalidate the cache and
+// the promise would resolve with the object instead of calling its `then`.
+//
+// These tests warm the cache on a dictionary structure, then add `then` in
+// place and check that promise resolution observes it.
+
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error(`bad value (${msg ?? ""}): got ${String(actual)}, expected ${String(expected)}`);
+}
+
+function asyncTest(fn) {
+    let done = false;
+    let error;
+    fn().then(() => { done = true; }, (e) => { error = e; done = true; });
+    drainMicrotasks();
+    if (!done)
+        throw new Error("async test did not settle: " + fn.name);
+    if (error)
+        throw error;
+}
+
+// --- 1. CacheableDictionary: add `then` in place after warm-up ---
+asyncTest(async function cacheableDictionaryGainsThen() {
+    const o = { a: 1, b: 2, c: 3 };
+    $vm.toCacheableDictionary(o);
+
+    // Warm: would tempt the cache to record NonThenable on the dictionary structure.
+    for (let i = 0; i < testLoopCount; i++)
+        shouldBe((await o).a, 1, "cacheableDict.warm");
+
+    // In-place mutation: same Structure object, now thenable.
+    o.then = function (resolve) { resolve("dict-then"); };
+    for (let i = 0; i < 100; i++)
+        shouldBe(await o, "dict-then", "cacheableDict.poisoned");
+
+    // In-place removal: must also be observed (only loses the optimization if cached as MaybeThenable).
+    delete o.then;
+    for (let i = 0; i < 100; i++)
+        shouldBe((await o).a, 1, "cacheableDict.afterDelete");
+});
+
+// --- 2. UncacheableDictionary: same, after delete forces UncacheableDictionary ---
+asyncTest(async function uncacheableDictionaryGainsThen() {
+    const o = { a: 1, b: 2, c: 3 };
+    $vm.toUncacheableDictionary(o);
+
+    for (let i = 0; i < testLoopCount; i++)
+        shouldBe((await o).a, 1, "uncacheableDict.warm");
+
+    o.then = function (resolve) { resolve("uncacheable-dict-then"); };
+    for (let i = 0; i < 100; i++)
+        shouldBe(await o, "uncacheable-dict-then", "uncacheableDict.poisoned");
+
+    delete o.then;
+    for (let i = 0; i < 100; i++)
+        shouldBe((await o).a, 1, "uncacheableDict.afterDelete");
+});
+
+// --- 3. CacheableDictionary via Promise.resolve ---
+asyncTest(async function cacheableDictionaryPromiseResolve() {
+    const o = { x: 42 };
+    $vm.toCacheableDictionary(o);
+
+    for (let i = 0; i < testLoopCount; i++)
+        shouldBe((await Promise.resolve(o)).x, 42, "cacheableDict.resolve.warm");
+
+    o.then = function (resolve) { resolve("resolved-then"); };
+    for (let i = 0; i < 100; i++)
+        shouldBe(await Promise.resolve(o), "resolved-then", "cacheableDict.resolve.poisoned");
+});
+
+// --- 4. Dictionary with null prototype: shortest cacheable chain shape ---
+asyncTest(async function dictionaryNullProtoGainsThen() {
+    const o = Object.create(null);
+    o.a = 1;
+    $vm.toCacheableDictionary(o);
+
+    for (let i = 0; i < testLoopCount; i++)
+        shouldBe((await o).a, 1, "nullProtoDict.warm");
+
+    o.then = function (resolve) { resolve("null-proto-then"); };
+    for (let i = 0; i < 100; i++)
+        shouldBe(await o, "null-proto-then", "nullProtoDict.poisoned");
+});

--- a/JSTests/stress/promise-resolve-non-thenable-structure-cache.js
+++ b/JSTests/stress/promise-resolve-non-thenable-structure-cache.js
@@ -1,0 +1,323 @@
+// Stress test for the Structure-level isDefinitelyNonThenable cache.
+//
+// The cache stores "this Structure's prototype chain definitely cannot resolve a
+// thenable" in a 2-bit field on Structure. A `true` cache is sound only while the
+// realm's promiseThenWatchpointSet (which also watches `then` absence on
+// Object.prototype) is intact. Each test below stresses a path where the cache
+// might miscompile if the watchpoint or fallback walk were wrong.
+
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error(`bad value (${msg ?? ""}): got ${String(actual)}, expected ${String(expected)}`);
+}
+
+function asyncTest(fn) {
+    let done = false;
+    let error;
+    fn().then(() => { done = true; }, (e) => { error = e; done = true; });
+    drainMicrotasks();
+    if (!done)
+        throw new Error("async test did not settle: " + fn.name);
+    if (error)
+        throw error;
+}
+
+// --- 1. Plain object literal: cache hit fast path ---
+asyncTest(async function plainObjectLiteral() {
+    for (let i = 0; i < testLoopCount; i++) {
+        const o = await { a: i, b: i + 1, c: i + 2 };
+        shouldBe(o.a, i);
+        shouldBe(o.b, i + 1);
+        shouldBe(o.c, i + 2);
+    }
+});
+
+// --- 2. Promise.resolve with object literal ---
+asyncTest(async function promiseResolveObjectLiteral() {
+    for (let i = 0; i < testLoopCount; i++) {
+        const o = await Promise.resolve({ x: i, y: i * 2 });
+        shouldBe(o.x, i);
+        shouldBe(o.y, i * 2);
+    }
+});
+
+// --- 3. Object with own `then` property (data property) ---
+asyncTest(async function ownThenDataProperty() {
+    for (let i = 0; i < 100; i++) {
+        const v = await { then(resolve) { resolve(i); } };
+        shouldBe(v, i, "ownThenDataProperty");
+    }
+});
+
+// --- 4. Object with own `then` getter ---
+asyncTest(async function ownThenGetter() {
+    for (let i = 0; i < 100; i++) {
+        const v = await { get then() { return (resolve) => resolve(i * 3); } };
+        shouldBe(v, i * 3, "ownThenGetter");
+    }
+});
+
+// --- 5. Null prototype object ---
+asyncTest(async function nullProto() {
+    for (let i = 0; i < 100; i++) {
+        const o = Object.create(null);
+        o.a = i;
+        const v = await o;
+        shouldBe(v.a, i, "nullProto");
+    }
+});
+
+// --- 6. Frozen / sealed objects ---
+asyncTest(async function frozenSealed() {
+    const f = Object.freeze({ a: 1 });
+    shouldBe((await f).a, 1, "frozen");
+    const s = Object.seal({ b: 2 });
+    shouldBe((await s).b, 2, "sealed");
+    const p = Object.preventExtensions({ c: 3 });
+    shouldBe((await p).c, 3, "preventExtensions");
+});
+
+// --- 7. Class instance: deep prototype chain (Uncacheable state) ---
+asyncTest(async function classInstanceDeepChain() {
+    class A { constructor() { this.a = 1; } }
+    class B extends A { constructor() { super(); this.b = 2; } }
+    class C extends B { constructor() { super(); this.c = 3; } }
+    for (let i = 0; i < testLoopCount; i++) {
+        const o = await new C();
+        shouldBe(o.a, 1);
+        shouldBe(o.b, 2);
+        shouldBe(o.c, 3);
+    }
+});
+
+// --- 8. Class proto gains `then` after cache warm-up ---
+asyncTest(async function classProtoGainsThen() {
+    class Foo { constructor() { this.x = 1; } }
+    // Warm.
+    for (let i = 0; i < 100; i++) {
+        const o = await new Foo();
+        shouldBe(o.x, 1);
+    }
+    // Poison the proto. The Structure for Foo instances is Uncacheable
+    // (chain depth >= 2), so this MUST be picked up immediately by the walk.
+    Foo.prototype.then = function(resolve) { resolve("foo-thenable"); };
+    const v = await new Foo();
+    shouldBe(v, "foo-thenable", "classProtoGainsThen");
+    delete Foo.prototype.then;
+    // After delete, behavior should revert.
+    const o2 = await new Foo();
+    shouldBe(o2.x, 1, "classProtoThenDeleted");
+});
+
+// --- 9. Many distinct shapes: Structure-level cache must not bleed across shapes ---
+asyncTest(async function megamorphicShapes() {
+    function makeShape(i) {
+        const o = {};
+        for (let j = 0; j <= i % 8; j++)
+            o["p" + j] = j;
+        return o;
+    }
+    for (let i = 0; i < 200; i++) {
+        const o = await makeShape(i);
+        shouldBe(o.p0, 0);
+    }
+});
+
+// --- 10. Property addition transitions to a fresh Structure with NotComputed state ---
+asyncTest(async function structureTransition() {
+    for (let i = 0; i < 100; i++) {
+        const o = { a: 1 };
+        shouldBe((await o).a, 1);
+        o.b = 2; // transition to a new Structure
+        shouldBe((await o).b, 2);
+        o.then = function(resolve) { resolve("tail-then"); }; // another transition; now thenable
+        const v = await o;
+        shouldBe(v, "tail-then", "structureTransition.then");
+    }
+});
+
+// --- 11. for-await-of (iterator result objects {value, done}) ---
+asyncTest(async function forAwaitOf() {
+    async function* gen() {
+        yield { v: 1 };
+        yield { v: 2 };
+        yield { v: 3 };
+    }
+    let sum = 0;
+    for (let i = 0; i < 100; i++) {
+        for await (const x of gen())
+            sum += x.v;
+    }
+    shouldBe(sum, 600, "forAwaitOf");
+});
+
+// --- 12. async generator returning object literals ---
+asyncTest(async function asyncGenObjectLiterals() {
+    async function* g() {
+        for (let i = 0; i < 50; i++)
+            yield { i };
+    }
+    let acc = 0;
+    for await (const o of g())
+        acc += o.i;
+    shouldBe(acc, 1225, "asyncGenObjectLiterals");
+});
+
+// --- 13. Promise.all with mixed thenables and non-thenables ---
+asyncTest(async function promiseAllMixed() {
+    const results = await Promise.all([
+        { a: 1 },
+        Promise.resolve({ a: 2 }),
+        { then(resolve) { resolve({ a: 3 }); } },
+        Object.create(null, { a: { value: 4 } }),
+    ]);
+    shouldBe(results[0].a, 1);
+    shouldBe(results[1].a, 2);
+    shouldBe(results[2].a, 3);
+    shouldBe(results[3].a, 4);
+});
+
+// --- 14. Same Structure shared across many objects ---
+asyncTest(async function sharedStructure() {
+    function make(i) { return { x: i, y: i, z: i }; }
+    for (let i = 0; i < testLoopCount; i++) {
+        const o = await make(i);
+        shouldBe(o.x, i);
+    }
+});
+
+// --- 15. Symbol-keyed properties don't poison the cache ---
+asyncTest(async function symbolKeysHarmless() {
+    const sym = Symbol("k");
+    for (let i = 0; i < 100; i++) {
+        const o = { a: i, [sym]: i * 10 };
+        const v = await o;
+        shouldBe(v.a, i);
+        shouldBe(v[sym], i * 10);
+    }
+});
+
+// --- 16. then defined as accessor on the object's prototype ---
+asyncTest(async function thenAccessorOnProto() {
+    function Wrapper(v) { this.v = v; }
+    Object.defineProperty(Wrapper.prototype, "then", {
+        get() { const v = this.v; return (resolve) => resolve("w" + v); },
+        configurable: true,
+    });
+    const r = await new Wrapper(7);
+    shouldBe(r, "w7", "thenAccessorOnProto");
+});
+
+// --- 17. `then` added in the middle of a deep prototype chain ---
+asyncTest(async function thenMidChain() {
+    class A { constructor() { this.a = 1; } }
+    class B extends A { constructor() { super(); this.b = 2; } }
+    class C extends B { constructor() { super(); this.c = 3; } }
+    // Warm.
+    for (let i = 0; i < 100; i++)
+        shouldBe((await new C()).c, 3);
+    // Add `then` to A.prototype: two hops away from a C instance, but still on the chain.
+    A.prototype.then = function(resolve) { resolve("mid-chain"); };
+    try {
+        const v = await new C();
+        shouldBe(v, "mid-chain", "thenMidChain");
+    } finally {
+        delete A.prototype.then;
+    }
+    shouldBe((await new C()).c, 3, "thenMidChain.afterDelete");
+});
+
+// --- 18. Object.setPrototypeOf changes the chain after warm-up ---
+asyncTest(async function setPrototypeOf() {
+    function MakeProto() {}
+    const obj = { v: 1 };
+    Object.setPrototypeOf(obj, MakeProto.prototype); // transition to a new Structure
+    for (let i = 0; i < 100; i++)
+        shouldBe((await obj).v, 1);
+    // Replace the proto with a thenable. This causes another transition.
+    Object.setPrototypeOf(obj, { then(resolve) { resolve("sp-thenable"); } });
+    const v = await obj;
+    shouldBe(v, "sp-thenable", "setPrototypeOf");
+});
+
+// --- 19. Reflect.construct with custom newTarget (poly-proto-ish path) ---
+asyncTest(async function reflectConstruct() {
+    function Base() { this.b = 1; }
+    function Derived() { this.d = 2; }
+    Derived.prototype = Object.create(Base.prototype);
+    for (let i = 0; i < 100; i++) {
+        const o = Reflect.construct(Base, [], Derived);
+        const v = await o;
+        shouldBe(v.b, 1, "reflectConstruct");
+    }
+});
+
+// --- 20. Array and TypedArray (built-in prototype chains) ---
+asyncTest(async function builtins() {
+    const arr = await [1, 2, 3];
+    shouldBe(arr.length, 3, "array");
+    const ta = await new Uint8Array([4, 5, 6]);
+    shouldBe(ta[0], 4, "typedArray");
+    const map = await new Map([[1, "a"]]);
+    shouldBe(map.get(1), "a", "map");
+});
+
+// --- 21. Proxy: getOwnPropertyDescriptor trap must always be consulted ---
+asyncTest(async function proxyAlwaysSlow() {
+    let trapCalled = false;
+    const target = { a: 1 };
+    const handler = {
+        get(t, k) {
+            if (k === "then")
+                trapCalled = true;
+            return Reflect.get(t, k);
+        },
+    };
+    const v = await new Proxy(target, handler);
+    shouldBe(v.a, 1, "proxy.value");
+    shouldBe(trapCalled, true, "proxy.trapCalled");
+});
+
+// --- 22. Object.prototype gains a NON-`then` property after warm-up.
+//          The adaptive watchpoint must re-arm on the new Structure (not fire),
+//          so the cache stays usable AND the result stays correct. ---
+asyncTest(async function objectProtoNonThenAdditionHarmless() {
+    // Warm.
+    for (let i = 0; i < testLoopCount; i++)
+        shouldBe((await { a: i, b: i }).a, i);
+    Object.prototype.someUnrelatedProperty = 42;
+    try {
+        for (let i = 0; i < 100; i++) {
+            const o = await { a: i, b: i };
+            shouldBe(o.a, i, "nonThenAddition.a");
+            shouldBe(o.someUnrelatedProperty, 42, "nonThenAddition.proto");
+        }
+    } finally {
+        delete Object.prototype.someUnrelatedProperty;
+    }
+});
+
+// --- 23. Object.prototype.then poison MUST come last:
+//          it permanently fires the watchpoint set for this realm. ---
+asyncTest(async function objectProtoThenPoisonLast() {
+    // Warm the cache for several Structures.
+    for (let i = 0; i < testLoopCount; i++)
+        await { a: i, b: i, c: i };
+
+    Object.prototype.then = function(resolve) { resolve("op-poisoned"); };
+    try {
+        const v1 = await { a: 1, b: 2, c: 3 };
+        shouldBe(v1, "op-poisoned", "objectProtoThenPoison.literal");
+        const v2 = await { p0: 0 }; // a different shape, also covered
+        shouldBe(v2, "op-poisoned", "objectProtoThenPoison.otherShape");
+        class Z { constructor() { this.z = 1; } }
+        const v3 = await new Z(); // class instance: walk reaches Object.prototype
+        shouldBe(v3, "op-poisoned", "objectProtoThenPoison.classInstance");
+    } finally {
+        delete Object.prototype.then;
+    }
+    // After delete, watchpoint stays fired -> always slow path, but result is correct.
+    const v4 = await { a: 1, b: 2, c: 3 };
+    shouldBe(v4.a, 1, "afterDelete.a");
+    shouldBe(v4.b, 2, "afterDelete.b");
+});

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -2285,6 +2285,7 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     installObjectPropertyChangeAdaptiveWatchpoint(setupAdaptiveWatchpoint(this, jsSetPrototype(), vm.propertyNames->keys), m_setPrimordialPropertiesWatchpointSet);
 
     installObjectPropertyChangeAdaptiveWatchpoint(setupAdaptiveWatchpoint(this, promisePrototype(), vm.propertyNames->then), m_promiseThenWatchpointSet);
+    installObjectAdaptiveStructureWatchpoint(setupAbsenceAdaptiveWatchpoint(this, m_objectPrototype.get(), vm.propertyNames->then, nullptr), m_promiseThenWatchpointSet);
     installObjectPropertyChangeAdaptiveWatchpoint(setupAdaptiveWatchpoint(this, m_promiseConstructor.get(), vm.propertyNames->resolve), m_promiseResolveWatchpointSet);
 
     // Detect property absence.

--- a/Source/JavaScriptCore/runtime/JSPromise.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromise.cpp
@@ -410,21 +410,47 @@ bool isDefinitelyNonThenable(JSObject* object, JSGlobalObject* globalObject)
         return false;
 
     auto* structure = object->structure();
-    if (globalObject->iteratorResultObjectStructure() == structure)
+    auto state = structure->definitelyNonThenableState();
+    if (state == Structure::DefinitelyNonThenableState::NonThenable && structure->realm() == globalObject)
         return true;
+    if (state == Structure::DefinitelyNonThenableState::MaybeThenable)
+        return false;
 
-    while (structure) {
-        if (structure->hasSpecialProperties())
-            return false;
-        if (structure->typeInfo().getOwnPropertySlotIsImpureForPropertyAbsence())
-            return false;
-        if (structure->typeInfo().overridesGetPrototype())
-            return false;
-        if (!structure->hasMonoProto())
-            return false;
-        structure = structure->storedPrototypeStructure();
+    bool result = true;
+    auto* current = structure;
+    while (current) {
+        if (current->hasSpecialProperties()
+            || current->typeInfo().getOwnPropertySlotIsImpureForPropertyAbsence()
+            || current->typeInfo().overridesGetPrototype()
+            || !current->hasMonoProto()) {
+            result = false;
+            break;
+        }
+        current = current->storedPrototypeStructure();
     }
-    return true;
+
+    // Dictionary structures are mutated in place when properties are added or removed,
+    // so the cached state could become stale (e.g. caching NonThenable, then adding `then`).
+    // Give up caching entirely for them; the per-call walk above remains correct because
+    // `hasSpecialProperties` is updated in place even for dictionaries.
+    if (state == Structure::DefinitelyNonThenableState::NotComputed && !structure->isDictionary()) [[unlikely]] {
+        if (!result) {
+            // Always safe: a stale `false` only loses the optimization, never miscompiles.
+            structure->setDefinitelyNonThenableState(Structure::DefinitelyNonThenableState::MaybeThenable);
+        } else {
+            // A `true` result is cacheable only when the entire prototype chain stays
+            // under the protection of promiseThenWatchpointSet, which watches `then`
+            // absence on Object.prototype. That limits the cacheable chain to [self]
+            // (null proto) or [self, Object.prototype]. Mark anything else Uncacheable
+            // so subsequent calls skip this check and go straight to the walk.
+            JSValue proto = structure->storedPrototype();
+            if (!proto.isObject() || asObject(proto) == globalObject->objectPrototype())
+                structure->setDefinitelyNonThenableState(Structure::DefinitelyNonThenableState::NonThenable);
+            else
+                structure->setDefinitelyNonThenableState(Structure::DefinitelyNonThenableState::Uncacheable);
+        }
+    }
+    return result;
 }
 
 ALWAYS_INLINE void JSPromise::settleInlineInternalMicrotask(VM& vm, JSGlobalObject* globalObject, Status newStatus, JSValue argument, uint16_t flagsSnapshot)

--- a/Source/JavaScriptCore/runtime/Structure.h
+++ b/Source/JavaScriptCore/runtime/Structure.h
@@ -848,13 +848,20 @@ public:
 private:
     JS_EXPORT_PRIVATE void didReplacePropertySlow(PropertyOffset);
 
-    typedef enum { 
+    typedef enum {
         NoneDictionaryKind = 0,
         CachedDictionaryKind = 1,
         UncachedDictionaryKind = 2
     } DictionaryKind;
 
 public:
+    enum class DefinitelyNonThenableState : uint8_t {
+        NotComputed = 0,
+        NonThenable = 1, // Cached `true`. Sound only while the realm's promiseThenWatchpointSet is intact.
+        MaybeThenable = 2, // Cached `false`. Always safe (a stale `false` only loses the optimization).
+        Uncacheable = 3, // Prototype chain isn't covered by the watchpoint; always recompute.
+    };
+
 #define DEFINE_BITFIELD(type, lowerName, upperName, width, offset) \
     static constexpr uint32_t s_##lowerName##Shift = offset;\
     static constexpr uint32_t s_##lowerName##Mask = ((1 << (width - 1)) | ((1 << (width - 1)) - 1));\
@@ -874,6 +881,7 @@ public:
     DEFINE_BITFIELD(bool, isQuickPropertyAccessAllowedForEnumeration, IsQuickPropertyAccessAllowedForEnumeration, 1, 5);
     DEFINE_BITFIELD(bool, hasNonEnumerableProperties, HasNonEnumerableProperties, 1, 6);
     DEFINE_BITFIELD(bool, hasSpecialProperties, HasSpecialProperties, 1, 7);
+    DEFINE_BITFIELD(DefinitelyNonThenableState, definitelyNonThenableState, DefinitelyNonThenableState, 2, 8); // This flag can be flipped on the main thread at any timing.
     DEFINE_BITFIELD(TransitionKind, transitionKind, TransitionKind, 5, 13);
     DEFINE_BITFIELD(bool, isWatchingReplacement, IsWatchingReplacement, 1, 18); // This flag can be fliped on the main thread at any timing.
     DEFINE_BITFIELD(bool, mayBePrototype, MayBePrototype, 1, 19);


### PR DESCRIPTION
#### cdf77b6570ffbe789a2dab116ee1097319ff3145
<pre>
[JSC] Cache `isDefinitelyNonThenable` result on Structure
<a href="https://bugs.webkit.org/show_bug.cgi?id=314815">https://bugs.webkit.org/show_bug.cgi?id=314815</a>

Reviewed by Yusuke Suzuki.

isDefinitelyNonThenable() walks the resolution object&apos;s prototype chain on every
promise resolution -- once per `await`, once per `.then()` handler return -- to
prove the object cannot have a `then` property. For the dominant pattern of
resolving plain object literals (`{ a, b, c }`), the chain is just
[self, Object.prototype], yet we still pay 4 bit checks plus a load per
prototype hop on every call. V8 reaches the same conclusion in O(1) by carrying
a &quot;may have interesting properties&quot; bit on each Map.

This patch caches the result on the Structure in a 2-bit lazily-computed state.
A `true` cache (NonThenable) is sound only while the realm&apos;s
promiseThenWatchpointSet is intact, so we extend that watchpoint set to also
watch `then` absence on Object.prototype: any addition of `then` to
Object.prototype fires it before a stale `true` could be read. Caching `true`
is therefore restricted to chains the watchpoint fully covers -- exactly
[self, Object.prototype] or [self] (null proto). Deeper chains
([self, Foo.prototype, ...]) cannot be guarded against a later
`Foo.prototype.then = ...`, so they are marked Uncacheable: subsequent calls
go straight to the walk and skip the cache-establishment check, leaving the
existing fast path unchanged. A `false` cache (MaybeThenable) is always safe
because going stale only forgoes the optimization, never miscompiles.

Dictionary structures are mutated in place when properties are added or removed,
so any cached state could become stale (caching NonThenable, then adding `then`
later does not produce a new Structure). We give up caching entirely for them;
the per-call walk remains correct because `hasSpecialProperties` is updated in
place even for dictionaries.

                                            Baseline                  Patched

promise-resolve-object-literal           9.9748+-0.1166     ^      9.2475+-0.2010        ^ definitely 1.0787x faster
promise-then-chain-object-literal       20.6694+-0.1839     ^     20.0792+-0.1701        ^ definitely 1.0294x faster
await-object-literal                    17.3544+-0.1630     ^     16.3586+-0.0531        ^ definitely 1.0609x faster

Tests: JSTests/microbenchmarks/await-object-literal.js
       JSTests/microbenchmarks/promise-resolve-object-literal.js
       JSTests/microbenchmarks/promise-then-chain-object-literal.js
       JSTests/stress/promise-resolve-non-thenable-structure-cache-cross-realm.js
       JSTests/stress/promise-resolve-non-thenable-structure-cache-dictionary.js
       JSTests/stress/promise-resolve-non-thenable-structure-cache.js

* JSTests/microbenchmarks/await-object-literal.js: Added.
(async run):
* JSTests/microbenchmarks/promise-resolve-object-literal.js: Added.
* JSTests/microbenchmarks/promise-then-chain-object-literal.js: Added.
(i.p.p.then.x):
* JSTests/stress/promise-resolve-non-thenable-structure-cache-cross-realm.js: Added.
(shouldBe):
(asyncTest.async resolveForeignObject):
(asyncTest.async bothRealmsWarm):
(asyncTest.async poisonOtherRealmObjectProto.other.Function):
(asyncTest.async poisonOtherRealmObjectProto):
* JSTests/stress/promise-resolve-non-thenable-structure-cache-dictionary.js: Added.
(shouldBe):
(asyncTest):
(asyncTest.async cacheableDictionaryGainsThen):
(asyncTest.async uncacheableDictionaryGainsThen):
(asyncTest.async cacheableDictionaryPromiseResolve):
(asyncTest.async dictionaryNullProtoGainsThen):
* JSTests/stress/promise-resolve-non-thenable-structure-cache.js: Added.
(shouldBe):
(asyncTest.async plainObjectLiteral):
(asyncTest.async promiseResolveObjectLiteral):
(asyncTest.async ownThenDataProperty):
(asyncTest.async ownThenGetter.const.v.await.get then):
(asyncTest.async ownThenGetter):
(asyncTest.async nullProto):
(asyncTest.async frozenSealed):
(asyncTest.async classInstanceDeepChain.A):
(asyncTest.async classInstanceDeepChain.B):
(asyncTest.async classInstanceDeepChain.C):
(asyncTest.async classInstanceDeepChain):
(asyncTest.async classProtoGainsThen.Foo):
(asyncTest.async classProtoGainsThen.Foo.prototype.then):
(asyncTest.async classProtoGainsThen):
(asyncTest.async megamorphicShapes.makeShape):
(asyncTest.async megamorphicShapes):
(asyncTest.async structureTransition.o.then):
(asyncTest.async structureTransition):
(asyncTest.async forAwaitOf.async gen):
(asyncTest.async forAwaitOf):
(asyncTest.async asyncGenObjectLiterals.async g):
(asyncTest.async asyncGenObjectLiterals):
(asyncTest.async promiseAllMixed):
(asyncTest.async sharedStructure.make):
(asyncTest.async sharedStructure):
(asyncTest.async symbolKeysHarmless):
(asyncTest.async thenAccessorOnProto.Wrapper):
(asyncTest.async thenMidChain.A):
(asyncTest.async thenMidChain.B):
(asyncTest.async thenMidChain.C):
(asyncTest.async thenMidChain.A.prototype.then):
(asyncTest.async thenMidChain):
(asyncTest.async setPrototypeOf.MakeProto):
(asyncTest.async setPrototypeOf):
(asyncTest.async reflectConstruct.Base):
(asyncTest.async reflectConstruct.Derived):
(asyncTest.async reflectConstruct):
(asyncTest.async builtins):
(asyncTest.async objectProtoNonThenAdditionHarmless):
(asyncTest.async objectProtoThenPoisonLast.Object.prototype.then):
(asyncTest.async objectProtoThenPoisonLast.try.Z):
(asyncTest.async objectProtoThenPoisonLast):
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
* Source/JavaScriptCore/runtime/JSPromise.cpp:
(JSC::isDefinitelyNonThenable):
* Source/JavaScriptCore/runtime/Structure.h:

Canonical link: <a href="https://commits.webkit.org/313294@main">https://commits.webkit.org/313294@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0daa353a4cf494ed02a128c227402c793eac1189

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162682 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36158 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29301 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171620 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/119128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36262 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36162 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126265 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/119128 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165641 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28617 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/146172 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106842 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27663 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26193 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19320 "Built successfully") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137371 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23901 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174124 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23521 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21437 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25546 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134575 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35832 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30290 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134571 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36305 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35816 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145697 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98176 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/29112 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22531 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195083 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35326 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/103077 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/50475 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34827 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35072 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34975 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->