### PR TITLE
[MSE] SourceBuffer.remove() removes one extra sample, and buffered trims coverage still backed by retained samples

### DIFF
--- a/LayoutTests/media/media-source/media-source-remove-decodeorder-crash-expected.txt
+++ b/LayoutTests/media/media-source/media-source-remove-decodeorder-crash-expected.txt
@@ -7,7 +7,7 @@ RUN(sourceBuffer.appendBuffer(initSegment))
 EVENT(updateend)
 RUN(sourceBuffer.appendBuffer(samples))
 EVENT(updateend)
-RUN(sourceBuffer.remove(1.9, 2))
+RUN(sourceBuffer.remove(1, 2))
 EVENT(updateend)
 EXPECTED (sourceBuffer.buffered.length == '2') OK
 EXPECTED (sourceBuffer.buffered.start(0) == '0') OK

--- a/LayoutTests/media/media-source/media-source-remove-decodeorder-crash.html
+++ b/LayoutTests/media/media-source/media-source-remove-decodeorder-crash.html
@@ -39,7 +39,7 @@
 
     function remove() {
         waitForEventOn(sourceBuffer, 'updateend', checkRemoved, false, true);
-        run('sourceBuffer.remove(1.9, 2)');
+        run('sourceBuffer.remove(1, 2)');
     }
 
     function checkRemoved() {

--- a/Source/WebCore/platform/graphics/TrackBuffer.cpp
+++ b/Source/WebCore/platform/graphics/TrackBuffer.cpp
@@ -362,20 +362,34 @@ PlatformTimeRanges TrackBuffer::removeSamples(const DecodeOrderSampleMap::MapTyp
     bytesRemoved += startBufferSize - m_samples.sizeInBytes();
 #endif
 
-    // Because we may have added artificial padding in the buffered ranges when adding samples, we may
-    // need to remove that padding when removing those same samples. Walk over the erased ranges looking
-    // for unbuffered areas and expand erasedRanges to encompass those areas.
+    // Walk each disjoint erased range and consult its retained neighbour on
+    // each side. The neighbour can be in one of four states, handled
+    // symmetrically at both boundaries:
+    //   - no neighbour: extend erasedRanges out to 0 or +inf so the
+    //     surrounding unbuffered area is erased too.
+    //   - gap (neighbour doesn't reach the erased range): pad the gap so
+    //     artificial padding added during append() is removed here as well.
+    //   - contiguous: nothing to do.
+    //   - overlap (neighbour's range reaches inside the erased range):
+    //     clip the erased range so m_buffered isn't stripped of coverage
+    //     that a retained sample still holds (e.g. WebM sub-ms overlaps
+    //     allowed by contiguousFrameTolerance).
+    PlatformTimeRanges clippedErasedRanges;
     PlatformTimeRanges additionalErasedRanges;
     for (unsigned i = 0; i < erasedRanges.length(); ++i) {
         auto erasedStart = erasedRanges.start(i);
         auto erasedEnd = erasedRanges.end(i);
+
         auto startIterator = m_samples.presentationOrder().reverseFindSampleBeforePresentationTime(erasedStart);
         if (startIterator == m_samples.presentationOrder().rend())
             additionalErasedRanges.add(MediaTime::zeroTime(), erasedStart);
         else {
             Ref previousSample = startIterator->second.get();
-            if (previousSample->presentationTime() + previousSample->duration() < erasedStart)
-                additionalErasedRanges.add(previousSample->presentationTime() + previousSample->duration(), erasedStart);
+            auto previousEnd = previousSample->presentationTime() + previousSample->duration();
+            if (previousEnd < erasedStart)
+                additionalErasedRanges.add(previousEnd, erasedStart);
+            else if (previousEnd > erasedStart)
+                erasedStart = std::min(previousEnd, erasedEnd);
         }
 
         auto endIterator = m_samples.presentationOrder().findSampleStartingAfterPresentationTime(erasedStart);
@@ -383,10 +397,17 @@ PlatformTimeRanges TrackBuffer::removeSamples(const DecodeOrderSampleMap::MapTyp
             additionalErasedRanges.add(erasedEnd, MediaTime::positiveInfiniteTime());
         else {
             Ref nextSample = endIterator->second.get();
-            if (nextSample->presentationTime() > erasedEnd)
-                additionalErasedRanges.add(erasedEnd, nextSample->presentationTime());
+            auto nextStart = nextSample->presentationTime();
+            if (nextStart > erasedEnd)
+                additionalErasedRanges.add(erasedEnd, nextStart);
+            else if (nextStart < erasedEnd)
+                erasedEnd = std::max(nextStart, erasedStart);
         }
+
+        if (erasedStart < erasedEnd)
+            clippedErasedRanges.add(erasedStart, erasedEnd, AddTimeRangeOption::EliminateSmallGaps);
     }
+    erasedRanges = WTF::move(clippedErasedRanges);
     if (additionalErasedRanges.length())
         erasedRanges.unionWith(additionalErasedRanges);
 
@@ -422,27 +443,17 @@ int64_t TrackBuffer::removeCodedFrames(const MediaTime& start, const MediaTime& 
 
     // NOTE: To handle MediaSamples which may be an amalgamation of multiple shorter samples, find samples whose presentation
     // interval straddles the start and end times, and divide them if possible:
-    auto divideSampleIfPossibleAtPresentationTime = [&] (const MediaTime& time) {
-        auto sampleIterator = m_samples.presentationOrder().findSampleContainingPresentationTime(time);
-        if (sampleIterator == m_samples.presentationOrder().end())
-            return;
-        Ref sample = sampleIterator->second;
-        if (!sample->isDivisable())
-            return;
-        MediaTime microsecond(1, 1000000);
-        MediaTime roundedTime = roundTowardsTimeScaleWithRoundingMargin(time, sample->presentationTime().timeScale(), microsecond);
-        std::pair<RefPtr<MediaSample>, RefPtr<MediaSample>> replacementSamples = sample->divide(roundedTime);
-        if (!replacementSamples.first || !replacementSamples.second)
-            return;
-        DEBUG_LOG_IF(m_logger, LOGIDENTIFIER, "splitting sample ", sample.get(), " into ", Ref { *replacementSamples.first }.get(), " and ", Ref { *replacementSamples.second }.get());
-        m_samples.removeSample(sample);
-        m_samples.addSample(replacementSamples.first.releaseNonNull());
-        m_samples.addSample(replacementSamples.second.releaseNonNull());
-    };
-    divideSampleIfPossibleAtPresentationTime(start);
-    divideSampleIfPossibleAtPresentationTime(end);
+    // Per spec 3.5.9 step 3.3, only samples with starting PTS >= start should be removed.
+    // If the sample whose range contains `start` was successfully split, the "after" piece is the
+    // first sample to erase — find it by its actual PTS (which may differ slightly from `start`
+    // due to timescale rounding, in either direction). Otherwise the original sample (with PTS <
+    // start) must be retained per spec; use findSampleStartingOnOrAfter to skip it.
+    auto splitAtStart = tryDivideSampleAtTime(start, ApplyDivide::Yes);
+    tryDivideSampleAtTime(end, ApplyDivide::Yes);
 
-    auto removePresentationStart = m_samples.presentationOrder().findSampleContainingOrAfterPresentationTime(start);
+    auto removePresentationStart = splitAtStart.afterSplitPresentationTime.isValid()
+        ? m_samples.presentationOrder().findSampleStartingOnOrAfterPresentationTime(splitAtStart.afterSplitPresentationTime)
+        : m_samples.presentationOrder().findSampleStartingOnOrAfterPresentationTime(start);
     auto removePresentationEnd = m_samples.presentationOrder().findSampleStartingOnOrAfterPresentationTime(end);
     if (removePresentationStart == m_samples.presentationOrder().end() || removePresentationStart == removePresentationEnd)
         return framesSizeBefore - samples().sizeInBytes(); // This could be negative if new frames were created above.
@@ -484,29 +495,24 @@ int64_t TrackBuffer::codedFramesIntervalSize(const MediaTime& start, const Media
 {
     ASSERT(start.isValid());
     ASSERT(end.isValid());
-    auto removePresentationStart = m_samples.presentationOrder().findSampleContainingOrAfterPresentationTime(start);
+
+    // Mirror removeCodedFrames' iterator selection. Compute split sizes without mutating the
+    // sample map (ApplyDivide::No).
+    auto splitAtStart = tryDivideSampleAtTime(start, ApplyDivide::No);
+    auto splitAtEnd = tryDivideSampleAtTime(end, ApplyDivide::No);
+
+    auto removePresentationStart = splitAtStart.afterSplitPresentationTime.isValid()
+        ? m_samples.presentationOrder().findSampleStartingOnOrAfterPresentationTime(splitAtStart.afterSplitPresentationTime)
+        : m_samples.presentationOrder().findSampleStartingOnOrAfterPresentationTime(start);
     auto removePresentationEnd = m_samples.presentationOrder().findSampleStartingOnOrAfterPresentationTime(end);
     if (removePresentationStart == m_samples.presentationOrder().end() || removePresentationStart == removePresentationEnd)
         return 0;
 
-    auto divideSampleIfPossibleAtPresentationTime = [&] (const MediaTime& time, bool dropFirstPart) -> int64_t  {
-        auto sampleIterator = m_samples.presentationOrder().findSampleContainingPresentationTime(time);
-        if (sampleIterator == m_samples.presentationOrder().end())
-            return 0;
-        Ref sample = sampleIterator->second;
-        if (!sample->isDivisable())
-            return 0;
-        MediaTime microsecond(1, 1000000);
-        MediaTime roundedTime = roundTowardsTimeScaleWithRoundingMargin(time, sample->presentationTime().timeScale(), microsecond);
-        std::pair<RefPtr<MediaSample>, RefPtr<MediaSample>> replacementSamples = sample->divide(roundedTime);
-        if (!replacementSamples.first || !replacementSamples.second)
-            return 0;
-        return dropFirstPart ? Ref { *replacementSamples.first }->sizeInBytes() : Ref { *replacementSamples.second }->sizeInBytes();
-    };
-
     int64_t framesSize = 0;
-    framesSize -= divideSampleIfPossibleAtPresentationTime(start, true);
-    framesSize -= divideSampleIfPossibleAtPresentationTime(end, false);
+    // Subtract the "before" piece at start (kept) and the "after" piece at end (kept) from the
+    // total below; everything between is summed.
+    framesSize -= splitAtStart.beforeSplitSize;
+    framesSize -= splitAtEnd.afterSplitSize;
 
     auto minmaxDecodeTimeIterPair = std::minmax_element(removePresentationStart, removePresentationEnd, decodeTimeComparator);
     Ref firstSample = minmaxDecodeTimeIterPair.first->second.get();
@@ -521,6 +527,33 @@ int64_t TrackBuffer::codedFramesIntervalSize(const MediaTime& start, const Media
         framesSize += Ref { erasedPair.second }->sizeInBytes();
 
     return framesSize;
+}
+
+TrackBuffer::DivideResult TrackBuffer::tryDivideSampleAtTime(const MediaTime& time, ApplyDivide applyDivide)
+{
+    auto sampleIterator = m_samples.presentationOrder().findSampleContainingPresentationTime(time);
+    if (sampleIterator == m_samples.presentationOrder().end())
+        return { };
+    Ref sample = sampleIterator->second;
+    if (!sample->isDivisable())
+        return { };
+    MediaTime microsecond(1, 1000000);
+    MediaTime roundedTime = roundTowardsTimeScaleWithRoundingMargin(time, sample->presentationTime().timeScale(), microsecond);
+    std::pair<RefPtr<MediaSample>, RefPtr<MediaSample>> replacementSamples = sample->divide(roundedTime);
+    if (!replacementSamples.first || !replacementSamples.second)
+        return { };
+    DivideResult result {
+        .afterSplitPresentationTime = protect(replacementSamples.second)->presentationTime(),
+        .beforeSplitSize = static_cast<int64_t>(protect(replacementSamples.first)->sizeInBytes()),
+        .afterSplitSize = static_cast<int64_t>(protect(replacementSamples.second)->sizeInBytes()),
+    };
+    if (applyDivide == ApplyDivide::Yes) {
+        DEBUG_LOG_IF(m_logger, LOGIDENTIFIER, "splitting sample ", sample.get(), " into ", Ref { *replacementSamples.first }.get(), " and ", Ref { *replacementSamples.second }.get());
+        m_samples.removeSample(sample);
+        m_samples.addSample(replacementSamples.first.releaseNonNull());
+        m_samples.addSample(replacementSamples.second.releaseNonNull());
+    }
+    return result;
 }
 
 void TrackBuffer::resetTimestampOffset()

--- a/Source/WebCore/platform/graphics/TrackBuffer.h
+++ b/Source/WebCore/platform/graphics/TrackBuffer.h
@@ -128,6 +128,20 @@ private:
     void updateMinimumUpcomingPresentationTime();
     void clearDecodeQueue();
 
+    // Result of attempting to split the sample whose presentation range contains a given time.
+    struct DivideResult {
+        // Presentation timestamp of the "after" piece (the piece whose range starts at the split
+        // point). Invalid if no split happened (no containing sample, not divisible, or
+        // MediaSample::divide returned null halves).
+        MediaTime afterSplitPresentationTime { MediaTime::invalidTime() };
+        // Byte sizes of the pieces produced by the split, valid only when
+        // afterSplitPresentationTime is valid.
+        int64_t beforeSplitSize { 0 };
+        int64_t afterSplitSize { 0 };
+    };
+    enum class ApplyDivide : bool { No, Yes };
+    DivideResult tryDivideSampleAtTime(const MediaTime&, ApplyDivide);
+
     SampleMap m_samples;
     DecodeOrderSampleMap::MapType m_decodeQueue;
     RefPtr<MediaDescription> m_description;


### PR DESCRIPTION
#### 902e82002ac411277b6a22e9243898a80fd59afb
<pre>
[MSE] SourceBuffer.remove() removes one extra sample, and buffered trims coverage still backed by retained samples
<a href="https://bugs.webkit.org/show_bug.cgi?id=222422">https://bugs.webkit.org/show_bug.cgi?id=222422</a>
<a href="https://rdar.apple.com/176599938">rdar://176599938</a>

Reviewed by NOBODY (OOPS!).

Two defects along the SourceBuffer.remove() path:

1. Per MSE spec 3.5.9 step 3.3, only coded frames whose starting
   timestamp is &quot;greater than or equal to start&quot; should be removed.
   TrackBuffer::removeCodedFrames was using
   findSampleContainingOrAfterPresentationTime(start), which for
   non-divisible samples (video frames) returns the sample whose
   presentation range *contains* start - i.e. a sample with PTS &lt;
   start - and erased it. Switch to
   findSampleStartingOnOrAfterPresentationTime to match the spec
   exactly. Divisible samples are still split at start by the prior
   divideSampleIfPossibleAtPresentationTime call, and the resulting
   &quot;after&quot; piece (whose PTS == start) is then correctly picked up by
   findSampleStartingOnOrAfter. Apply the same change in
   codedFramesIntervalSize so the eviction-size estimator stays
   consistent with the actual remove behaviour.

2. TrackBuffer::removeSamples&apos; neighbour-sample handling already
   padded erasedRanges on either side when the adjacent retained
   sample left a gap (prevSample.end &lt; erasedStart, or nextSample.PT
   &gt; erasedEnd). The symmetric overlap cases were never handled, so
   when a retained sample&apos;s presentation interval extended into the
   erased range - which happens for WebM sub-millisecond overlaps
   allowed by contiguousFrameTolerance, and can also be manufactured
   by tests via abort()+append - erasedRanges included coverage that
   was still backed by a retained sample, and the caller&apos;s
   intersection trimmed m_buffered accordingly. The old &quot;containing&quot;
   remove semantics papered over this in a subsequent remove by
   aggressively pulling the overlap sample in; spec-strict remove
   does not, so the inconsistency is now observable. Extend the same
   neighbour check with overlap branches: if the previous retained
   sample ends past erasedStart, clip erasedStart to its end; if the
   next retained sample starts before erasedEnd, clip erasedEnd to
   its PTS. No extra map scans - reuses the iterators already fetched
   for the gap case.

* LayoutTests/media/media-source/media-source-remove-decodeorder-crash.html:
Change remove(1.9, 2) to remove(1, 2). This test doesn&apos;t involve
buffered-range math; the original call relied on the old &quot;containing&quot;
removal to erase the [1, 2) sample. Under spec-strict no sample has
PTS in [1.9, 2). remove(1, 2) still drives the decode-order
extraction path (PTS=1 has DTS=2, last in decode order) and produces
the existing expected output.

* Source/WebCore/platform/graphics/TrackBuffer.cpp:
(WebCore::TrackBuffer::removeSamples):
(WebCore::TrackBuffer::removeCodedFrames):
(WebCore::TrackBuffer::codedFramesIntervalSize):
(WebCore::TrackBuffer::tryDivideSampleAtTime):
* Source/WebCore/platform/graphics/TrackBuffer.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/902e82002ac411277b6a22e9243898a80fd59afb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162548 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36024 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29187 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171486 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118993 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164417 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36128 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36028 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126147 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165507 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28502 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146067 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106725 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8d6389ad-2c54-4771-bdf5-e9e4f5547319) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27548 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26072 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19186 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137252 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23797 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173990 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21303 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25442 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134456 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35698 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30164 "Found 1 new test failure: imported/w3c/web-platform-tests/IndexedDB/interleaved-cursors-small.any.serviceworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134454 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35682 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145593 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98001 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28992 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22427 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35192 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102943 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34693 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34938 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34841 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->