### PR TITLE
Web Inspector: Show a Node associated with layout and rendering events in a separate column

### DIFF
--- a/LayoutTests/inspector/timeline/resources/timeline-event-utilities.js
+++ b/LayoutTests/inspector/timeline/resources/timeline-event-utilities.js
@@ -5,7 +5,7 @@ function savePageData(data) {
 TestPage.registerInitializer(() => {
     InspectorTest.TimelineEvent = {};
 
-    InspectorTest.TimelineEvent.captureTimelineWithScript = function({expression, eventType, timelineType}) {
+    InspectorTest.TimelineEvent.captureTimelineWithScript = function({expression, eventType, timelineType, silent = false}) {
         let savePageDataPromise = InspectorTest.awaitEvent("SavePageData").then((event) => event.data);
 
         let promise = new Promise((resolve, reject) => {
@@ -21,11 +21,13 @@ TestPage.registerInitializer(() => {
 
                         timeline.removeEventListener(WI.Timeline.Event.RecordAdded, recordAddedListener);
 
-                        InspectorTest.log("Stopping Capture...");
+                        if (!silent)
+                            InspectorTest.log("Stopping Capture...");
                         WI.timelineManager.stopCapturing();
                     });
 
-                    InspectorTest.log("Evaluating...");
+                    if (!silent)
+                        InspectorTest.log("Evaluating...");
                     InspectorTest.evaluateInPage(expression).catch(reject);
                     return;
                 }
@@ -39,14 +41,15 @@ TestPage.registerInitializer(() => {
             });
         });
 
-        InspectorTest.log("Starting Capture...");
+        if (!silent)
+            InspectorTest.log("Starting Capture...");
         const newRecording = true;
         WI.timelineManager.startCapturing(newRecording);
 
         return promise;
     }
 
-    InspectorTest.TimelineEvent.captureTimelineWithMarker = function({expression, markerType, timelineType}) {
+    InspectorTest.TimelineEvent.captureTimelineWithMarker = function({expression, markerType, timelineType, silent = false}) {
         let savePageDataPromise = InspectorTest.awaitEvent("SavePageData").then((event) => event.data);
 
         let promise = new Promise((resolve, reject) => {
@@ -61,11 +64,13 @@ TestPage.registerInitializer(() => {
 
                         recording.removeEventListener(WI.TimelineRecording.Event.MarkerAdded, markerAddedListener);
 
-                        InspectorTest.log("Stopping Capture...");
+                        if (!silent)
+                            InspectorTest.log("Stopping Capture...");
                         WI.timelineManager.stopCapturing();
                     });
 
-                    InspectorTest.log("Evaluating...");
+                    if (!silent)
+                        InspectorTest.log("Evaluating...");
                     InspectorTest.evaluateInPage(expression).catch(reject);
                     return;
                 }
@@ -79,7 +84,8 @@ TestPage.registerInitializer(() => {
             });
         });
 
-        InspectorTest.log("Starting Capture...");
+        if (!silent)
+            InspectorTest.log("Starting Capture...");
         const newRecording = true;
         WI.timelineManager.startCapturing(newRecording);
 

--- a/LayoutTests/inspector/timeline/timeline-layout-events-expected.txt
+++ b/LayoutTests/inspector/timeline/timeline-layout-events-expected.txt
@@ -1,0 +1,20 @@
+Tests Layout Timeline event records.
+
+PASS: Should have 4 Layout record.
+PASS: Record 0 should be invalidate-styles.
+PASS: Record 0 should have a DOM node.
+PASS: Record 0 should have a document node.
+PASS: Record 0 should have the main document node.
+PASS: Record 1 should be recalculate-styles.
+PASS: Record 1 should have a DOM node.
+PASS: Record 1 should have a document node.
+PASS: Record 1 should have the main document node.
+PASS: Record 2 should be invalidate-layout.
+PASS: Record 2 should have a DOM node.
+PASS: Record 2 should have a document node.
+PASS: Record 2 should have the main document node.
+PASS: Record 3 should be layout.
+PASS: Record 3 should have a DOM node.
+PASS: Record 3 should have a document node.
+PASS: Record 3 should have the main document node.
+

--- a/LayoutTests/inspector/timeline/timeline-layout-events-iframe-expected.txt
+++ b/LayoutTests/inspector/timeline/timeline-layout-events-iframe-expected.txt
@@ -1,0 +1,21 @@
+Tests Layout Timeline event records in an iframe.
+
+
+PASS: Should have 4 Layout record.
+PASS: Record 0 should be invalidate-styles.
+PASS: Record 0 should have a DOM node.
+PASS: Record 0 should have a document node.
+PASS: Record 0 should have the iframe's document node.
+PASS: Record 1 should be recalculate-styles.
+PASS: Record 1 should have a DOM node.
+PASS: Record 1 should have a document node.
+PASS: Record 1 should have the iframe's document node.
+PASS: Record 2 should be invalidate-layout.
+PASS: Record 2 should have a DOM node.
+PASS: Record 2 should have a document node.
+PASS: Record 2 should have the iframe's document node.
+PASS: Record 3 should be layout.
+PASS: Record 3 should have a DOM node.
+PASS: Record 3 should have a document node.
+PASS: Record 3 should have the iframe's document node.
+

--- a/LayoutTests/inspector/timeline/timeline-layout-events-iframe.html
+++ b/LayoutTests/inspector/timeline/timeline-layout-events-iframe.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script src="./resources/timeline-event-utilities.js"></script>
+<script>
+
+function invalidateLayout() {
+    let iframe = document.getElementById("iframe");
+    iframe.contentDocument.getElementById("test").style.width = "200px";
+
+    savePageData({invalidatedLayout: true});
+}
+
+async function test()
+{
+    WI.timelineManager.enabledTimelineTypes = [WI.TimelineRecord.Type.Layout];
+
+    let pageRecordingData = await InspectorTest.TimelineEvent.captureTimelineWithScript({
+        expression: `invalidateLayout()`,
+        timelineType: WI.TimelineRecord.Type.Layout,
+        eventType: WI.LayoutTimelineRecord.EventType.Layout,
+        silent: true,
+    });
+    InspectorTest.assert(pageRecordingData.invalidatedLayout);
+
+    let recording = WI.timelineManager.activeRecording;
+    let layoutTimeline = recording.timelines.get(WI.TimelineRecord.Type.Layout);
+
+    let expectedEventTypes = [
+        WI.LayoutTimelineRecord.EventType.InvalidateStyles,
+        WI.LayoutTimelineRecord.EventType.RecalculateStyles,
+        WI.LayoutTimelineRecord.EventType.InvalidateLayout,
+        WI.LayoutTimelineRecord.EventType.Layout,
+    ];
+    let records = layoutTimeline.records.filter((x) => expectedEventTypes.includes(x.eventType));
+
+    InspectorTest.expectEqual(records.length, 4, "Should have 4 Layout record.");
+
+    for (let i = 0; i < expectedEventTypes.length; ++i) {
+        let record = records[i];
+        let expectedEventType = expectedEventTypes[i];
+        InspectorTest.expectEqual(record.eventType, expectedEventType, `Record ${i} should be ${expectedEventType}.`);
+        InspectorTest.expectNotNull(record.domNode, `Record ${i} should have a DOM node.`);
+        InspectorTest.expectEqual(record.domNode.nodeType(), Node.DOCUMENT_NODE, `Record ${i} should have a document node.`);
+        InspectorTest.expectNotEqual(record.domNode.frame, WI.networkManager.mainFrame, `Record ${i} should have the iframe's document node.`);
+    }
+
+    InspectorTest.completeTest();
+}
+
+</script>
+</head>
+<body onload="runTest()">
+    <p>Tests Layout Timeline event records in an iframe.</p>
+
+    <iframe id="iframe" srcdoc="
+    <div id='test' style='width: 100px; height: 100px; background: green'></div>
+    "></iframe>
+</body>
+</html>

--- a/LayoutTests/inspector/timeline/timeline-layout-events.html
+++ b/LayoutTests/inspector/timeline/timeline-layout-events.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/inspector-test.js"></script>
+<script src="./resources/timeline-event-utilities.js"></script>
+<script>
+
+function invalidateLayout() {
+    document.getElementById("test").style.width = "200px";
+
+    savePageData({invalidatedLayout: true});
+}
+
+async function test()
+{
+    WI.timelineManager.enabledTimelineTypes = [WI.TimelineRecord.Type.Layout];
+
+    let pageRecordingData = await InspectorTest.TimelineEvent.captureTimelineWithScript({
+        expression: `invalidateLayout()`,
+        timelineType: WI.TimelineRecord.Type.Layout,
+        eventType: WI.LayoutTimelineRecord.EventType.Layout,
+        silent: true,
+    });
+    InspectorTest.assert(pageRecordingData.invalidatedLayout);
+
+    let recording = WI.timelineManager.activeRecording;
+    let layoutTimeline = recording.timelines.get(WI.TimelineRecord.Type.Layout);
+
+    let expectedEventTypes = [
+        WI.LayoutTimelineRecord.EventType.InvalidateStyles,
+        WI.LayoutTimelineRecord.EventType.RecalculateStyles,
+        WI.LayoutTimelineRecord.EventType.InvalidateLayout,
+        WI.LayoutTimelineRecord.EventType.Layout,
+    ];
+    let records = layoutTimeline.records.filter((x) => expectedEventTypes.includes(x.eventType));
+
+    InspectorTest.expectEqual(records.length, 4, "Should have 4 Layout record.");
+
+    for (let i = 0; i < expectedEventTypes.length; ++i) {
+        let record = records[i];
+        let expectedEventType = expectedEventTypes[i];
+        InspectorTest.expectEqual(record.eventType, expectedEventType, `Record ${i} should be ${expectedEventType}.`);
+        InspectorTest.expectNotNull(record.domNode, `Record ${i} should have a DOM node.`);
+        InspectorTest.expectEqual(record.domNode.nodeType(), Node.DOCUMENT_NODE, `Record ${i} should have a document node.`);
+        InspectorTest.expectEqual(record.domNode.frame, WI.networkManager.mainFrame, `Record ${i} should have the main document node.`);
+    }
+
+    InspectorTest.completeTest();
+}
+
+</script>
+</head>
+<body onload="runTest()">
+    <p>Tests Layout Timeline event records.</p>
+
+    <div id="test" style='width: 100px; height: 100px; background: green'></div>
+</body>
+</html>

--- a/Source/WebCore/inspector/InspectorInstrumentation.cpp
+++ b/Source/WebCore/inspector/InspectorInstrumentation.cpp
@@ -539,10 +539,10 @@ void InspectorInstrumentation::didFireTimerImpl(InstrumentingAgents& instrumenti
         timelineAgent->didFireTimer();
 }
 
-void InspectorInstrumentation::didInvalidateLayoutImpl(InstrumentingAgents& instrumentingAgents)
+void InspectorInstrumentation::didInvalidateLayoutImpl(InstrumentingAgents& instrumentingAgents, const RenderElement& layoutRoot)
 {
     if (CheckedPtr pageTimelineAgent = instrumentingAgents.trackingPageTimelineAgent())
-        pageTimelineAgent->didInvalidateLayout();
+        pageTimelineAgent->didInvalidateLayout(layoutRoot);
 }
 
 void InspectorInstrumentation::willLayoutImpl(InstrumentingAgents& instrumentingAgents)
@@ -565,10 +565,10 @@ void InspectorInstrumentation::willCompositeImpl(InstrumentingAgents& instrument
         pageTimelineAgent->willComposite();
 }
 
-void InspectorInstrumentation::didCompositeImpl(InstrumentingAgents& instrumentingAgents)
+void InspectorInstrumentation::didCompositeImpl(InstrumentingAgents& instrumentingAgents, const LocalFrame& frame)
 {
     if (CheckedPtr pageTimelineAgent = instrumentingAgents.trackingPageTimelineAgent())
-        pageTimelineAgent->didComposite();
+        pageTimelineAgent->didComposite(frame);
 }
 
 void InspectorInstrumentation::willPaintImpl(InstrumentingAgents& instrumentingAgents)
@@ -594,10 +594,10 @@ void InspectorInstrumentation::willRecalculateStyleImpl(InstrumentingAgents& ins
         networkAgent->willRecalculateStyle();
 }
 
-void InspectorInstrumentation::didRecalculateStyleImpl(InstrumentingAgents& instrumentingAgents)
+void InspectorInstrumentation::didRecalculateStyleImpl(InstrumentingAgents& instrumentingAgents, Document& document)
 {
     if (CheckedPtr pageTimelineAgent = instrumentingAgents.trackingPageTimelineAgent())
-        pageTimelineAgent->didRecalculateStyle();
+        pageTimelineAgent->didRecalculateStyle(document);
     if (CheckedPtr networkAgent = instrumentingAgents.enabledNetworkAgent())
         networkAgent->didRecalculateStyle();
     if (CheckedPtr pageAgent = instrumentingAgents.enabledPageAgent())
@@ -607,7 +607,7 @@ void InspectorInstrumentation::didRecalculateStyleImpl(InstrumentingAgents& inst
 void InspectorInstrumentation::didScheduleStyleRecalculationImpl(InstrumentingAgents& instrumentingAgents, Document& document)
 {
     if (CheckedPtr pageTimelineAgent = instrumentingAgents.trackingPageTimelineAgent())
-        pageTimelineAgent->didScheduleStyleRecalculation();
+        pageTimelineAgent->didScheduleStyleRecalculation(document);
     if (CheckedPtr networkAgent = instrumentingAgents.enabledNetworkAgent())
         networkAgent->didScheduleStyleRecalculation(document);
 }
@@ -862,10 +862,10 @@ void InspectorInstrumentation::frameStartedLoadingImpl(InstrumentingAgents& inst
     }
 }
 
-void InspectorInstrumentation::didCompleteRenderingFrameImpl(InstrumentingAgents& instrumentingAgents)
+void InspectorInstrumentation::didCompleteRenderingFrameImpl(InstrumentingAgents& instrumentingAgents, LocalFrame& frame)
 {
     if (CheckedPtr pageTimelineAgent = instrumentingAgents.enabledPageTimelineAgent())
-        pageTimelineAgent->didCompleteRenderingFrame();
+        pageTimelineAgent->didCompleteRenderingFrame(frame);
 }
 
 void InspectorInstrumentation::frameStoppedLoadingImpl(InstrumentingAgents& instrumentingAgents, LocalFrame& frame)

--- a/Source/WebCore/inspector/InspectorInstrumentation.h
+++ b/Source/WebCore/inspector/InspectorInstrumentation.h
@@ -192,7 +192,7 @@ public:
     static void didEvaluateScript(WorkerOrWorkletGlobalScope&);
     static void willFireTimer(ScriptExecutionContext&, int timerId, bool oneShot);
     static void didFireTimer(ScriptExecutionContext&, int timerId, bool oneShot);
-    static void didInvalidateLayout(LocalFrame&);
+    static void didInvalidateLayout(LocalFrame&, const RenderElement&);
     static void willLayout(LocalFrame&);
     static void didLayout(LocalFrame&, const RenderElement&, const Vector<FloatQuad>&);
     static void didScroll(Page&);
@@ -422,16 +422,16 @@ private:
     static void didEvaluateScriptImpl(InstrumentingAgents&);
     static void willFireTimerImpl(InstrumentingAgents&, int timerId, bool oneShot);
     static void didFireTimerImpl(InstrumentingAgents&, int timerId, bool oneShot);
-    static void didInvalidateLayoutImpl(InstrumentingAgents&);
+    static void didInvalidateLayoutImpl(InstrumentingAgents&, const RenderElement&);
     static void willLayoutImpl(InstrumentingAgents&);
     static void didLayoutImpl(InstrumentingAgents&, const RenderElement&, const Vector<FloatQuad>&);
     static void didScrollImpl(InstrumentingAgents&);
     static void willCompositeImpl(InstrumentingAgents&);
-    static void didCompositeImpl(InstrumentingAgents&);
+    static void didCompositeImpl(InstrumentingAgents&, const LocalFrame&);
     static void willPaintImpl(InstrumentingAgents&);
     static void didPaintImpl(InstrumentingAgents&, RenderObject&, const LayoutRect&);
     static void willRecalculateStyleImpl(InstrumentingAgents&);
-    static void didRecalculateStyleImpl(InstrumentingAgents&);
+    static void didRecalculateStyleImpl(InstrumentingAgents&, Document&);
     static void didScheduleStyleRecalculationImpl(InstrumentingAgents&, Document&);
     static void applyUserAgentOverrideImpl(InstrumentingAgents&, String&);
     static void applyEmulatedMediaImpl(InstrumentingAgents&, AtomString&);
@@ -460,7 +460,7 @@ private:
     static void frameDocumentUpdatedImpl(InstrumentingAgents&, LocalFrame&);
     static void loaderDetachedFromFrameImpl(InstrumentingAgents&, DocumentLoader&);
     static void frameStartedLoadingImpl(InstrumentingAgents&, LocalFrame&);
-    static void didCompleteRenderingFrameImpl(InstrumentingAgents&);
+    static void didCompleteRenderingFrameImpl(InstrumentingAgents&, LocalFrame&);
     static void frameStoppedLoadingImpl(InstrumentingAgents&, LocalFrame&);
     static void accessibilitySettingsDidChangeImpl(InstrumentingAgents&);
 #if ENABLE(DARK_MODE_CSS)
@@ -1003,10 +1003,10 @@ inline void InspectorInstrumentation::didFireTimer(ScriptExecutionContext& conte
         didFireTimerImpl(*agents, timerId, oneShot);
 }
 
-inline void InspectorInstrumentation::didInvalidateLayout(LocalFrame& frame)
+inline void InspectorInstrumentation::didInvalidateLayout(LocalFrame& frame, const RenderElement& layoutRoot)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    didInvalidateLayoutImpl(instrumentingAgents(frame));
+    didInvalidateLayoutImpl(instrumentingAgents(frame), layoutRoot);
 }
 
 inline void InspectorInstrumentation::willLayout(LocalFrame& frame)
@@ -1036,7 +1036,7 @@ inline void InspectorInstrumentation::willComposite(LocalFrame& frame)
 inline void InspectorInstrumentation::didComposite(LocalFrame& frame)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    didCompositeImpl(instrumentingAgents(frame));
+    didCompositeImpl(instrumentingAgents(frame), frame);
 }
 
 inline void InspectorInstrumentation::willPaint(RenderObject& renderer)
@@ -1062,7 +1062,7 @@ inline void InspectorInstrumentation::didRecalculateStyle(Document& document)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
     if (RefPtr agents = instrumentingAgents(document))
-        didRecalculateStyleImpl(*agents);
+        didRecalculateStyleImpl(*agents, document);
 }
 
 inline void InspectorInstrumentation::didScheduleStyleRecalculation(Document& document)
@@ -1274,7 +1274,7 @@ inline void InspectorInstrumentation::frameStartedLoading(LocalFrame& frame)
 inline void InspectorInstrumentation::didCompleteRenderingFrame(LocalFrame& frame)
 {
     FAST_RETURN_IF_NO_FRONTENDS(void());
-    didCompleteRenderingFrameImpl(instrumentingAgents(frame));
+    didCompleteRenderingFrameImpl(instrumentingAgents(frame), frame);
 }
 
 inline void InspectorInstrumentation::frameStoppedLoading(LocalFrame& frame)

--- a/Source/WebCore/inspector/TimelineRecordFactory.cpp
+++ b/Source/WebCore/inspector/TimelineRecordFactory.cpp
@@ -177,10 +177,14 @@ Ref<JSON::Object> TimelineRecordFactory::createScreenshotData(const String& imag
     return data;
 }
 
-void TimelineRecordFactory::appendLayoutRoot(JSON::Object& data, Inspector::Protocol::DOM::NodeId nodeId, const FloatQuad& quad)
+void TimelineRecordFactory::appendLayoutRoot(JSON::Object& data, const FloatQuad& quad)
+{
+    data.setArray("root"_s, createQuad(quad));
+}
+
+void TimelineRecordFactory::appendNodeId(JSON::Object& data, Inspector::Protocol::DOM::NodeId nodeId)
 {
     data.setInteger("nodeId"_s, nodeId);
-    data.setArray("root"_s, createQuad(quad));
 }
 
 } // namespace WebCore

--- a/Source/WebCore/inspector/TimelineRecordFactory.h
+++ b/Source/WebCore/inspector/TimelineRecordFactory.h
@@ -62,7 +62,8 @@ public:
     static Ref<JSON::Object> createPaintData(const FloatQuad&);
     static Ref<JSON::Object> createScreenshotData(const String& imageData);
 
-    static void appendLayoutRoot(JSON::Object& data, Inspector::Protocol::DOM::NodeId, const FloatQuad&);
+    static void appendLayoutRoot(JSON::Object& data, const FloatQuad&);
+    static void appendNodeId(JSON::Object& data, Inspector::Protocol::DOM::NodeId);
 
 private:
     TimelineRecordFactory() { }

--- a/Source/WebCore/inspector/agents/page/PageTimelineAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageTimelineAgent.cpp
@@ -148,8 +148,10 @@ void PageTimelineAgent::internalStart(std::optional<int>&& maxCallStackDepth)
             checkedThis->pushCurrentRecord(TimelineRecordFactory::createRenderingFrameData(name), TimelineRecordType::RenderingFrame, false);
             break;
         case RunLoop::Event::DidDispatch:
-            if (checkedThis->m_startedComposite)
-                checkedThis->didComposite();
+            if (checkedThis->m_startedComposite) {
+                ASSERT(checkedThis->m_inspectedPage->localMainFrame());
+                checkedThis->didComposite(*checkedThis->m_inspectedPage->localMainFrame());
+            }
             checkedThis->didCompleteCurrentRecord(TimelineRecordType::RenderingFrame);
             break;
         }
@@ -190,9 +192,14 @@ Inspector::Protocol::ErrorStringOr<void> PageTimelineAgent::setAutoCaptureEnable
     return { };
 }
 
-void PageTimelineAgent::didInvalidateLayout()
+void PageTimelineAgent::didInvalidateLayout(const RenderElement& layoutRoot)
 {
-    appendRecord(JSON::Object::create(), TimelineRecordType::InvalidateLayout, true);
+    auto data = JSON::Object::create();
+
+    if (auto nodeId = nodeIdForRenderer(layoutRoot))
+        TimelineRecordFactory::appendNodeId(data.get(), nodeId);
+
+    appendRecord(WTF::move(data), TimelineRecordType::InvalidateLayout, true);
 }
 
 void PageTimelineAgent::willLayout()
@@ -207,30 +214,24 @@ void PageTimelineAgent::didLayout(const RenderElement& layoutRoot, const Vector<
         return;
 
     ASSERT(entry->type == TimelineRecordType::Layout);
-    ASSERT(!layoutAreas.isEmpty());
 
-    RefPtr<Node> node = layoutRoot.element();
+    if (!layoutAreas.isEmpty())
+        TimelineRecordFactory::appendLayoutRoot(entry->data.get(), layoutAreas[0]);
 
-    if (layoutRoot.isRenderView())
-        node = &layoutRoot.document();
-    else if (layoutRoot.isBeforeOrAfterContent())
-        node = layoutRoot.generatingElement();
-    else if (layoutRoot.isAnonymous())
-        node = layoutRoot.parent()->element();
-
-    Inspector::Protocol::DOM::NodeId nodeID = 0;
-    if (CheckedPtr domAgent = Ref { m_instrumentingAgents.get() }->persistentDOMAgent())
-        nodeID = domAgent->pushNodeToFrontend(node);
-
-    if (nodeID && !layoutAreas.isEmpty())
-        TimelineRecordFactory::appendLayoutRoot(entry->data.get(), nodeID, layoutAreas[0]);
+    if (auto nodeId = nodeIdForRenderer(layoutRoot))
+        TimelineRecordFactory::appendNodeId(entry->data.get(), nodeId);
 
     didCompleteCurrentRecord(TimelineRecordType::Layout);
 }
 
-void PageTimelineAgent::didScheduleStyleRecalculation()
+void PageTimelineAgent::didScheduleStyleRecalculation(Document& document)
 {
-    appendRecord(JSON::Object::create(), TimelineRecordType::ScheduleStyleRecalculation, true);
+    auto data = JSON::Object::create();
+
+    if (auto nodeId = nodeIdForDocument(document))
+        TimelineRecordFactory::appendNodeId(data.get(), nodeId);
+
+    appendRecord(WTF::move(data), TimelineRecordType::ScheduleStyleRecalculation, true);
 }
 
 void PageTimelineAgent::willRecalculateStyle()
@@ -238,8 +239,17 @@ void PageTimelineAgent::willRecalculateStyle()
     pushCurrentRecord(JSON::Object::create(), TimelineRecordType::RecalculateStyles, true);
 }
 
-void PageTimelineAgent::didRecalculateStyle()
+void PageTimelineAgent::didRecalculateStyle(Document& document)
 {
+    auto* entry = lastRecordEntry();
+    if (!entry)
+        return;
+
+    ASSERT(entry->type == TimelineRecordType::RecalculateStyles);
+
+    if (auto nodeId = nodeIdForDocument(document))
+        TimelineRecordFactory::appendNodeId(entry->data.get(), nodeId);
+
     didCompleteCurrentRecord(TimelineRecordType::RecalculateStyles);
 }
 
@@ -250,10 +260,22 @@ void PageTimelineAgent::willComposite()
     m_startedComposite = true;
 }
 
-void PageTimelineAgent::didComposite()
+void PageTimelineAgent::didComposite(const LocalFrame& frame)
 {
-    if (m_startedComposite)
+    if (m_startedComposite) {
+        auto* entry = lastRecordEntry();
+        if (!entry)
+            return;
+
+        ASSERT(entry->type == TimelineRecordType::Composite);
+
+        ASSERT(frame.document());
+        Ref document = *frame.document();
+        if (auto nodeId = nodeIdForDocument(document.get()))
+            TimelineRecordFactory::appendNodeId(entry->data.get(), nodeId);
+
         didCompleteCurrentRecord(TimelineRecordType::Composite);
+    }
     m_startedComposite = false;
 
     if (instruments().contains(Inspector::Protocol::Timeline::Instrument::Screenshot))
@@ -281,6 +303,9 @@ void PageTimelineAgent::didPaint(RenderObject& renderer, const LayoutRect& clipR
 
     auto clipQuadInRootView = protect(renderer.view().frameView())->contentsToRootView(renderer.localToAbsoluteQuad({ clipRect }));
     entry->data = TimelineRecordFactory::createPaintData(clipQuadInRootView);
+
+    if (auto nodeId = nodeIdForRenderer(renderer))
+        TimelineRecordFactory::appendNodeId(entry->data.get(), nodeId);
 
     didCompleteCurrentRecord(TimelineRecordType::Paint);
 }
@@ -317,7 +342,7 @@ void PageTimelineAgent::mainFrameNavigated()
     }
 }
 
-void PageTimelineAgent::didCompleteRenderingFrame()
+void PageTimelineAgent::didCompleteRenderingFrame(const LocalFrame& frame)
 {
 #if PLATFORM(COCOA)
     if (!tracking() || protect(environment())->debugger()->isPaused())
@@ -329,9 +354,11 @@ void PageTimelineAgent::didCompleteRenderingFrame()
         return;
 
     if (m_startedComposite)
-        didComposite();
+        didComposite(frame);
 
     didCompleteCurrentRecord(TimelineRecordType::RenderingFrame);
+#else
+    UNUSED_PARAM(frame);
 #endif
 }
 
@@ -362,6 +389,54 @@ void PageTimelineAgent::captureScreenshot()
         pushCurrentRecord(WTF::move(snapshotRecord), TimelineRecordType::Screenshot, false, snapshotStartTime);
         didCompleteCurrentRecord(TimelineRecordType::Screenshot);
     }
+}
+
+Inspector::Protocol::DOM::NodeId PageTimelineAgent::nodeIdForDocument(Document& document) const
+{
+    CheckedPtr domAgent = Ref { m_instrumentingAgents.get() }->persistentDOMAgent();
+    if (!domAgent)
+        return 0;
+
+    if (document.isTopDocument())
+        return domAgent->boundNodeId(&document);
+
+    return domAgent->pushNodePathToFrontend(&document);
+}
+
+Inspector::Protocol::DOM::NodeId PageTimelineAgent::nodeIdForRenderer(const RenderObject& renderer) const
+{
+    CheckedPtr domAgent = Ref { m_instrumentingAgents.get() }->persistentDOMAgent();
+    if (!domAgent)
+        return 0;
+
+    if (renderer.isRenderView()) {
+        RefPtr document = renderer.document();
+        if (document->isTopDocument())
+            return domAgent->boundNodeId(document);
+        return domAgent->pushNodePathToFrontend(document);
+    }
+
+    if (renderer.isAnonymous()) {
+        for (CheckedPtr ancestor = renderer.parent(); ancestor; ancestor = ancestor->parent()) {
+            if (RefPtr element = ancestor->element())
+                return domAgent->pushNodeToFrontend(element);
+        }
+        ASSERT_NOT_REACHED();
+        return 0;
+    }
+
+    if (CheckedPtr renderElement = dynamicDowncast<RenderElement>(renderer)) {
+        if (renderElement->isPseudoElement()) {
+            RefPtr generatingElement = renderElement->generatingElement();
+            return domAgent->pushNodeToFrontend(generatingElement);
+        }
+
+        RefPtr element = renderElement->element();
+        return domAgent->pushNodeToFrontend(element);
+    }
+
+    RefPtr node = renderer.node();
+    return domAgent->pushNodeToFrontend(node);
 }
 
 } // namespace WebCore

--- a/Source/WebCore/inspector/agents/page/PageTimelineAgent.h
+++ b/Source/WebCore/inspector/agents/page/PageTimelineAgent.h
@@ -49,19 +49,19 @@ public:
     Inspector::Protocol::ErrorStringOr<void> setAutoCaptureEnabled(bool) override;
 
     // InspectorInstrumentation
-    void didInvalidateLayout();
+    void didInvalidateLayout(const RenderElement&);
     void willLayout();
     void didLayout(const RenderElement&, const Vector<FloatQuad>&);
     void willComposite();
-    void didComposite();
+    void didComposite(const LocalFrame&);
     void willPaint();
     void didPaint(RenderObject&, const LayoutRect&);
     void willRecalculateStyle();
-    void didRecalculateStyle();
-    void didScheduleStyleRecalculation();
+    void didRecalculateStyle(Document&);
+    void didScheduleStyleRecalculation(Document&);
     void mainFrameStartedLoading();
     void mainFrameNavigated();
-    void didCompleteRenderingFrame();
+    void didCompleteRenderingFrame(const LocalFrame&);
 
 private:
     bool enabled() const override;
@@ -75,6 +75,9 @@ private:
     bool shouldStartHeapInstrument() const override;
 
     void captureScreenshot();
+
+    Inspector::Protocol::DOM::NodeId nodeIdForDocument(Document&) const;
+    Inspector::Protocol::DOM::NodeId nodeIdForRenderer(const RenderObject&) const;
 
     WeakRef<Page> m_inspectedPage;
 

--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -677,7 +677,9 @@ void LocalFrameViewLayoutContext::scheduleLayout()
         LOG(Layout, "LocalFrameView %p layout timer scheduled at %.3fs", this, document->timeSinceDocumentCreation().value());
 #endif
 
-    InspectorInstrumentation::didInvalidateLayout(protect(frame()));
+    ASSERT(renderView());
+    InspectorInstrumentation::didInvalidateLayout(protect(frame()), *renderView());
+
     m_layoutTimer.startOneShot(0_s);
 }
 
@@ -714,7 +716,7 @@ void LocalFrameViewLayoutContext::scheduleSubtreeLayout(RenderElement& layoutRoo
     if (!isLayoutPending() && isLayoutSchedulingEnabled()) {
         ASSERT(!layoutRoot.container() || is<RenderView>(layoutRoot.container()) || !layoutRoot.container()->needsLayout());
         setSubtreeLayoutRoot(layoutRoot);
-        InspectorInstrumentation::didInvalidateLayout(protect(frame()));
+        InspectorInstrumentation::didInvalidateLayout(protect(frame()), layoutRoot);
         m_layoutTimer.startOneShot(0_s);
         return;
     }
@@ -726,7 +728,7 @@ void LocalFrameViewLayoutContext::scheduleSubtreeLayout(RenderElement& layoutRoo
     if (!subtreeLayoutRoot) {
         // We already have a pending (full) layout. Just mark the subtree for layout.
         layoutRoot.markContainingBlocksForLayout(renderView.ptr());
-        InspectorInstrumentation::didInvalidateLayout(protect(frame()));
+        InspectorInstrumentation::didInvalidateLayout(protect(frame()), renderView.get());
         return;
     }
 
@@ -742,13 +744,13 @@ void LocalFrameViewLayoutContext::scheduleSubtreeLayout(RenderElement& layoutRoo
         subtreeLayoutRoot->markContainingBlocksForLayout(&layoutRoot);
         setSubtreeLayoutRoot(layoutRoot);
         ASSERT(!layoutRoot.container() || is<RenderView>(layoutRoot.container()) || !layoutRoot.container()->needsLayout());
-        InspectorInstrumentation::didInvalidateLayout(protect(frame()));
+        InspectorInstrumentation::didInvalidateLayout(protect(frame()), layoutRoot);
         return;
     }
     // Two disjoint subtrees need layout. Mark both of them and issue a full layout instead.
     convertSubtreeLayoutToFullLayout();
     layoutRoot.markContainingBlocksForLayout(renderView.ptr());
-    InspectorInstrumentation::didInvalidateLayout(protect(frame()));
+    InspectorInstrumentation::didInvalidateLayout(protect(frame()), renderView.get());
 }
 
 void LocalFrameViewLayoutContext::layoutTimerFired()

--- a/Source/WebInspectorUI/UserInterface/Controllers/TimelineManager.js
+++ b/Source/WebInspectorUI/UserInterface/Controllers/TimelineManager.js
@@ -843,16 +843,22 @@ WI.TimelineManager = class TimelineManager extends WI.Object
             console.assert(isNaN(endTime));
 
             // Pass the startTime as the endTime since this record type has no duration.
-            return new WI.LayoutTimelineRecord(WI.LayoutTimelineRecord.EventType.InvalidateStyles, startTime, startTime, stackTrace, sourceCodeLocation);
+            return new WI.LayoutTimelineRecord(WI.LayoutTimelineRecord.EventType.InvalidateStyles, startTime, startTime, stackTrace, sourceCodeLocation, {
+                domNode: WI.domManager.nodeForId(recordPayload.data.nodeId),
+            });
 
         case InspectorBackend.Enum.Timeline.EventType.RecalculateStyles:
-            return new WI.LayoutTimelineRecord(WI.LayoutTimelineRecord.EventType.RecalculateStyles, startTime, endTime, stackTrace, sourceCodeLocation);
+            return new WI.LayoutTimelineRecord(WI.LayoutTimelineRecord.EventType.RecalculateStyles, startTime, endTime, stackTrace, sourceCodeLocation, {
+                domNode: WI.domManager.nodeForId(recordPayload.data.nodeId),
+            });
 
         case InspectorBackend.Enum.Timeline.EventType.InvalidateLayout:
             console.assert(isNaN(endTime));
 
             // Pass the startTime as the endTime since this record type has no duration.
-            return new WI.LayoutTimelineRecord(WI.LayoutTimelineRecord.EventType.InvalidateLayout, startTime, startTime, stackTrace, sourceCodeLocation);
+            return new WI.LayoutTimelineRecord(WI.LayoutTimelineRecord.EventType.InvalidateLayout, startTime, startTime, stackTrace, sourceCodeLocation, {
+                domNode: WI.domManager.nodeForId(recordPayload.data.nodeId),
+            });
 
         case InspectorBackend.Enum.Timeline.EventType.Layout:
             var layoutRecordType = sourceCodeLocation ? WI.LayoutTimelineRecord.EventType.ForcedLayout : WI.LayoutTimelineRecord.EventType.Layout;
@@ -864,10 +870,13 @@ WI.TimelineManager = class TimelineManager extends WI.Object
         case InspectorBackend.Enum.Timeline.EventType.Paint:
             return new WI.LayoutTimelineRecord(WI.LayoutTimelineRecord.EventType.Paint, startTime, endTime, stackTrace, sourceCodeLocation, {
                 quad: new WI.Quad(recordPayload.data.clip),
+                domNode: WI.domManager.nodeForId(recordPayload.data.nodeId),
             });
 
         case InspectorBackend.Enum.Timeline.EventType.Composite:
-            return new WI.LayoutTimelineRecord(WI.LayoutTimelineRecord.EventType.Composite, startTime, endTime, stackTrace, sourceCodeLocation);
+            return new WI.LayoutTimelineRecord(WI.LayoutTimelineRecord.EventType.Composite, startTime, endTime, stackTrace, sourceCodeLocation, {
+                domNode: WI.domManager.nodeForId(recordPayload.data.nodeId),
+            });
 
         case InspectorBackend.Enum.Timeline.EventType.FirstContentfulPaint:
             return new WI.LayoutTimelineRecord(WI.LayoutTimelineRecord.EventType.FirstContentfulPaint, startTime, startTime, stackTrace, sourceCodeLocation);

--- a/Source/WebInspectorUI/UserInterface/Views/LayoutTimelineDataGridNode.js
+++ b/Source/WebInspectorUI/UserInterface/Views/LayoutTimelineDataGridNode.js
@@ -42,6 +42,7 @@ WI.LayoutTimelineDataGridNode = class LayoutTimelineDataGridNode extends WI.Time
         this._cachedData = super.data;
         this._cachedData.type = this.record.eventType;
         this._cachedData.name = this.displayName();
+        this._cachedData.node = this.record.domNode;
         this._cachedData.width = this.record.width;
         this._cachedData.height = this.record.height;
         this._cachedData.area = this.record.area;
@@ -60,20 +61,6 @@ WI.LayoutTimelineDataGridNode = class LayoutTimelineDataGridNode extends WI.Time
         switch (columnIdentifier) {
         case "name":
             cell.classList.add(...this.iconClassNames());
-
-            if (this.record.eventType == WI.LayoutTimelineRecord.EventType.Layout || this.record.eventType == WI.LayoutTimelineRecord.EventType.LargestContentfulPaint) {
-                let fragment = document.createDocumentFragment();
-                fragment.append(value);
-
-                if (this.record.domNode) {
-                    let goToArrow = fragment.appendChild(WI.createGoToArrowButton());
-                    goToArrow.addEventListener("click", (event) => {
-                        WI.showMainFrameDOMTree(this.record.domNode, {ignoreSearchTab: true});
-                    });
-                }
-
-                return fragment;
-            }
             return value;
 
         case "width":
@@ -91,6 +78,12 @@ WI.LayoutTimelineDataGridNode = class LayoutTimelineDataGridNode extends WI.Time
 
         case "source": // Timeline Overview
             return super.createCellContent("initiator", cell);
+
+        case "node":
+            if (!value)
+                return emDash;
+            cell.classList.add(WI.DOMTreeElementPathComponent.iconClassNameForNode(value));
+            return WI.linkifyNodeReference(value);
         }
 
         return super.createCellContent(columnIdentifier, cell);

--- a/Source/WebInspectorUI/UserInterface/Views/LayoutTimelineView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/LayoutTimelineView.js
@@ -31,7 +31,7 @@ WI.LayoutTimelineView = class LayoutTimelineView extends WI.TimelineView
 
         console.assert(timeline.type === WI.TimelineRecord.Type.Layout, timeline);
 
-        let columns = {type: {}, name: {}, initiator: {}, area: {}, width: {}, height: {}, startTime: {}, totalTime: {}};
+        let columns = {type: {}, name: {}, node: {}, initiator: {}, area: {}, width: {}, height: {}, startTime: {}, totalTime: {}};
 
         columns.name.title = WI.UIString("Type");
         columns.name.width = "15%";
@@ -52,8 +52,11 @@ WI.LayoutTimelineView = class LayoutTimelineView extends WI.TimelineView
 
         this._scopeBar = columns.type.scopeBar;
 
+        columns.node.title = WI.UIString("Node");
+        columns.node.width = "10%";
+
         columns.initiator.title = WI.UIString("Initiator");
-        columns.initiator.width = "25%";
+        columns.initiator.width = "15%";
 
         columns.area.title = WI.UIString("Area");
         columns.area.width = "8%";


### PR DESCRIPTION
#### f7dd925a68af3c39406f6942a728e1428d00f802
<pre>
Web Inspector: Show a Node associated with layout and rendering events in a separate column
<a href="https://bugs.webkit.org/show_bug.cgi?id=314816">https://bugs.webkit.org/show_bug.cgi?id=314816</a>

Reviewed by Devin Rousso.

`Layout` and `Largest Contentful Paint` events in the Timeline panel
have associated Nodes. For these events, a little arrow is shown next
to the name of the event. While this lets navigate to the Node in the
Elements panel, it is not very discoverable.

This patch adds a separate column for the Node in the Timeline panel,
making it more visible and navigatable. It also adds a Node to other
layout and rendering events.

* LayoutTests/inspector/timeline/resources/timeline-event-utilities.js:
(TestPage.registerInitializer.InspectorTest.TimelineEvent.captureTimelineWithScript):
(TestPage.registerInitializer.InspectorTest.TimelineEvent.captureTimelineWithMarker):
(TestPage.registerInitializer):
* LayoutTests/inspector/timeline/timeline-layout-events-expected.txt: Added.
* LayoutTests/inspector/timeline/timeline-layout-events-iframe-expected.txt: Added.
* LayoutTests/inspector/timeline/timeline-layout-events-iframe.html: Added.
* LayoutTests/inspector/timeline/timeline-layout-events.html: Added.
* Source/WebCore/inspector/InspectorInstrumentation.cpp:
(WebCore::InspectorInstrumentation::didInvalidateLayoutImpl):
(WebCore::InspectorInstrumentation::didCompositeImpl):
(WebCore::InspectorInstrumentation::didRecalculateStyleImpl):
(WebCore::InspectorInstrumentation::didScheduleStyleRecalculationImpl):
(WebCore::InspectorInstrumentation::didCompleteRenderingFrameImpl):
* Source/WebCore/inspector/InspectorInstrumentation.h:
(WebCore::InspectorInstrumentation::didInvalidateLayout):
(WebCore::InspectorInstrumentation::didComposite):
(WebCore::InspectorInstrumentation::didRecalculateStyle):
(WebCore::InspectorInstrumentation::didCompleteRenderingFrame):
* Source/WebCore/inspector/TimelineRecordFactory.cpp:
(WebCore::TimelineRecordFactory::appendLayoutRoot):
(WebCore::TimelineRecordFactory::appendNodeId):
* Source/WebCore/inspector/TimelineRecordFactory.h:
* Source/WebCore/inspector/agents/page/PageTimelineAgent.cpp:
(WebCore::PageTimelineAgent::internalStart):
(WebCore::PageTimelineAgent::didInvalidateLayout):
(WebCore::PageTimelineAgent::didLayout):
(WebCore::PageTimelineAgent::didScheduleStyleRecalculation):
(WebCore::PageTimelineAgent::didRecalculateStyle):
(WebCore::PageTimelineAgent::didComposite):
(WebCore::PageTimelineAgent::didPaint):
(WebCore::PageTimelineAgent::didCompleteRenderingFrame):
(WebCore::PageTimelineAgent::nodeIdForDocument const):
(WebCore::PageTimelineAgent::nodeIdForRenderer const):
* Source/WebCore/inspector/agents/page/PageTimelineAgent.h:
* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::LocalFrameViewLayoutContext::scheduleLayout):
(WebCore::LocalFrameViewLayoutContext::scheduleSubtreeLayout):
* Source/WebInspectorUI/UserInterface/Controllers/TimelineManager.js:
(WI.TimelineManager.prototype._processRecord):
* Source/WebInspectorUI/UserInterface/Views/LayoutTimelineDataGridNode.js:
(WI.LayoutTimelineDataGridNode.prototype.get data):
(WI.LayoutTimelineDataGridNode.prototype.createCellContent):
(WI.LayoutTimelineDataGridNode):
* Source/WebInspectorUI/UserInterface/Views/LayoutTimelineView.js:
(WI.LayoutTimelineView):

Canonical link: <a href="https://commits.webkit.org/314460@main">https://commits.webkit.org/314460@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/140f05d49c80e0c8d65f86ce995e0e394394efa7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165895 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39385 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32966 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174938 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123150 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167761 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39811 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39389 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128932 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90817 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168854 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31300 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149040 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109459 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30277 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28957 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23082 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140245 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26739 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177471 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30377 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28445 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137271 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39454 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33104 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137198 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37027 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40142 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148534 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102708 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32485 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25401 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38653 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111726 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38050 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3483 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38295 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38193 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->