### PR TITLE
Reduce power cost of VideoPlaybackQualityMetrics

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
@@ -857,13 +857,7 @@ std::optional<VideoPlaybackQualityMetrics> AudioVideoRendererAVFObjC::videoPlayb
     if (!videoRenderer)
         return std::nullopt;
 
-    return VideoPlaybackQualityMetrics {
-        videoRenderer->totalVideoFrames(),
-        videoRenderer->droppedVideoFrames(),
-        videoRenderer->corruptedVideoFrames(),
-        videoRenderer->totalFrameDelay().toDouble(),
-        videoRenderer->totalDisplayedFrames()
-    };
+    return videoRenderer->videoPlaybackQualityMetrics();
 }
 
 PlatformLayer* AudioVideoRendererAVFObjC::platformVideoLayer() const

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h
@@ -30,6 +30,7 @@
 #include "MediaReorderQueue.h"
 #include "ProcessIdentity.h"
 #include "SampleMap.h"
+#include "VideoPlaybackQualityMetrics.h"
 #include "WebAVSampleBufferListener.h"
 #include <wtf/Deque.h>
 #include <wtf/Forward.h>
@@ -116,10 +117,7 @@ public:
     DisplayedPixelBufferEntry copyDisplayedPixelBuffer();
 
     unsigned NODELETE totalDisplayedFrames() const;
-    unsigned totalVideoFrames() const;
-    unsigned droppedVideoFrames() const;
-    unsigned corruptedVideoFrames() const;
-    MediaTime totalFrameDelay() const;
+    std::optional<VideoPlaybackQualityMetrics> videoPlaybackQualityMetrics() const;
 
     void setResourceOwner(const ProcessIdentity&);
 

--- a/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm
@@ -1116,55 +1116,31 @@ unsigned VideoMediaSampleRenderer::totalDisplayedFrames() const
     return isUsingDecompressionSession() ? m_presentedVideoFrames.load() : ++m_sampleCount;
 }
 
-unsigned VideoMediaSampleRenderer::totalVideoFrames() const
+std::optional<VideoPlaybackQualityMetrics> VideoMediaSampleRenderer::videoPlaybackQualityMetrics() const
 {
     assertIsMainThread();
 
-    if (isUsingDecompressionSession() && !m_decompressionSessionBlocked)
-        return m_totalVideoFrames;
+    if (isUsingDecompressionSession() && !m_decompressionSessionBlocked) {
+        return VideoPlaybackQualityMetrics {
+            m_totalVideoFrames.load(),
+            m_droppedVideoFrames.load(),
+            m_corruptedVideoFrames.load(),
+            m_totalFrameDelay.toDouble(),
+            m_presentedVideoFrames.load()
+        };
+    }
 #if PLATFORM(WATCHOS)
-    return 0;
+    return std::nullopt;
 #else
-    return [renderer() videoPerformanceMetrics].totalNumberOfVideoFrames;
-#endif
-}
-
-unsigned VideoMediaSampleRenderer::droppedVideoFrames() const
-{
-    assertIsMainThread();
-
-    if (isUsingDecompressionSession() && !m_decompressionSessionBlocked)
-        return m_droppedVideoFrames;
-#if PLATFORM(WATCHOS)
-    return 0;
-#else
-    return [renderer() videoPerformanceMetrics].numberOfDroppedVideoFrames + m_droppedVideoFramesOffset;
-#endif
-}
-
-unsigned VideoMediaSampleRenderer::corruptedVideoFrames() const
-{
-    assertIsMainThread();
-
-    if (isUsingDecompressionSession() && !m_decompressionSessionBlocked)
-        return m_corruptedVideoFrames;
-#if PLATFORM(WATCHOS)
-    return 0;
-#else
-    return [renderer() videoPerformanceMetrics].numberOfCorruptedVideoFrames + m_corruptedVideoFrames;
-#endif
-}
-
-MediaTime VideoMediaSampleRenderer::totalFrameDelay() const
-{
-    assertIsMainThread();
-
-    if (isUsingDecompressionSession() && !m_decompressionSessionBlocked)
-        return m_totalFrameDelay;
-#if PLATFORM(WATCHOS)
-    return MediaTime::invalidTime();
-#else
-    return MediaTime::createWithDouble([renderer() videoPerformanceMetrics].totalFrameDelay);
+    RetainPtr renderer = this->renderer();
+    RetainPtr metrics = [renderer videoPerformanceMetrics];
+    return VideoPlaybackQualityMetrics {
+        static_cast<uint32_t>([metrics totalNumberOfVideoFrames]),
+        static_cast<uint32_t>([metrics numberOfDroppedVideoFrames] + m_droppedVideoFramesOffset),
+        static_cast<uint32_t>([metrics numberOfCorruptedVideoFrames] + m_corruptedVideoFrames.load()),
+        [metrics totalFrameDelay],
+        totalDisplayedFrames()
+    };
 #endif
 }
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
@@ -165,8 +165,10 @@ void RemoteAudioVideoRendererProxyManager::create(RemoteAudioVideoRendererIdenti
     });
 
     context.renderer->setTimeObserver(remoteAudioVideoRendererUpdateInterval, [weakThis = WeakPtr { *this }, identifier](const MediaTime&) {
-        if (RefPtr protectedThis = weakThis.get(); protectedThis && protectedThis->m_renderers.contains(identifier))
+        if (RefPtr protectedThis = weakThis.get(); protectedThis && protectedThis->m_renderers.contains(identifier)) {
+            protectedThis->maybeUpdateCachedVideoMetrics(identifier);
             protectedThis->m_gpuConnectionToWebProcess.get()->connection().send(Messages::AudioVideoRendererRemoteMessageReceiver::StateUpdate(protectedThis->stateFor(identifier)), identifier);
+        }
     });
 
 #if ENABLE(LINEAR_MEDIA_PLAYER)
@@ -491,13 +493,21 @@ void RemoteAudioVideoRendererProxyManager::notifyWhenHasAvailableVideoFrame(WebK
     RefPtr renderer = rendererFor(identifier);
     if (!renderer)
         return;
+    contextFor(identifier).isGatheringVideoFrameMetadata = notify;
     if (!notify) {
         renderer->notifyWhenHasAvailableVideoFrame({ });
         return;
     }
     renderer->notifyWhenHasAvailableVideoFrame([weakThis = WeakPtr { *this }, identifier](auto presentationTime, auto clockTime) {
-        if (RefPtr protectedThis = weakThis.get(); protectedThis && protectedThis->m_renderers.contains(identifier))
-            protectedThis->m_gpuConnectionToWebProcess.get()->connection().send(Messages::AudioVideoRendererRemoteMessageReceiver::HasAvailableVideoFrame(presentationTime, clockTime, protectedThis->stateFor(identifier)), identifier);
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis || !protectedThis->m_renderers.contains(identifier))
+            return;
+        // Per-frame consumers (e.g. requestVideoFrameCallback) need the metrics
+        // for this exact frame. Fetch them and ship them with the IPC so the
+        // receiver doesn't have to read a stale shared cache. This path is
+        // independent of the cadence-based metrics push.
+        auto metrics = protectedThis->contextFor(identifier).renderer->videoPlaybackQualityMetrics();
+        protectedThis->m_gpuConnectionToWebProcess.get()->connection().send(Messages::AudioVideoRendererRemoteMessageReceiver::HasAvailableVideoFrame(presentationTime, clockTime, protectedThis->stateFor(identifier), WTF::move(metrics)), identifier);
     });
 }
 
@@ -523,6 +533,52 @@ void RemoteAudioVideoRendererProxyManager::setResourceOwner(RemoteAudioVideoRend
 {
     if (RefPtr renderer = rendererFor(identifier))
         renderer->setResourceOwner(resourceOwner);
+}
+
+void RemoteAudioVideoRendererProxyManager::setVideoPlaybackMetricsUpdateInterval(RemoteAudioVideoRendererIdentifier identifier, double interval)
+{
+    DEBUG_LOG(LOGIDENTIFIER, identifier.loggingString(), " interval=", interval, "s");
+    MESSAGE_CHECK(m_renderers.contains(identifier));
+    auto iterator = m_renderers.find(identifier);
+    if (iterator == m_renderers.end())
+        return;
+    auto& context = iterator->value;
+    static const Seconds metricsAdvanceUpdate = 0.25_s;
+    updateCachedVideoMetrics(identifier);
+    context.videoPlaybackMetricsUpdateInterval = Seconds(interval);
+    context.nextPlaybackQualityMetricsUpdateTime = MonotonicTime::now() + Seconds(interval) - metricsAdvanceUpdate;
+}
+
+void RemoteAudioVideoRendererProxyManager::maybeUpdateCachedVideoMetrics(RemoteAudioVideoRendererIdentifier identifier)
+{
+    auto iterator = m_renderers.find(identifier);
+    if (iterator == m_renderers.end())
+        return;
+    auto& context = iterator->value;
+    // While rVFC is gathering metadata the WebContent cache is refreshed per
+    // frame via HasAvailableVideoFrame; the cadence-based push would just
+    // duplicate work, so skip it.
+    if (context.isGatheringVideoFrameMetadata)
+        return;
+    if (context.renderer->paused() || !context.videoPlaybackMetricsUpdateInterval || MonotonicTime::now() < context.nextPlaybackQualityMetricsUpdateTime)
+        return;
+    updateCachedVideoMetrics(identifier);
+}
+
+void RemoteAudioVideoRendererProxyManager::updateCachedVideoMetrics(RemoteAudioVideoRendererIdentifier identifier)
+{
+    auto iterator = m_renderers.find(identifier);
+    if (iterator == m_renderers.end())
+        return;
+    auto& context = iterator->value;
+    context.nextPlaybackQualityMetricsUpdateTime = MonotonicTime::now() + context.videoPlaybackMetricsUpdateInterval;
+    auto metrics = context.renderer->videoPlaybackQualityMetrics();
+    if (!metrics) {
+        DEBUG_LOG(LOGIDENTIFIER, identifier.loggingString(), " no metrics available");
+        return;
+    }
+    DEBUG_LOG(LOGIDENTIFIER, identifier.loggingString(), " total=", metrics->totalVideoFrames, " dropped=", metrics->droppedVideoFrames, " corrupted=", metrics->corruptedVideoFrames, " displayComposited=", metrics->displayCompositedVideoFrames, " frameDelay=", metrics->totalFrameDelay);
+    m_gpuConnectionToWebProcess.get()->connection().send(Messages::AudioVideoRendererRemoteMessageReceiver::UpdatePlaybackQualityMetrics(WTF::move(*metrics)), identifier);
 }
 
 void RemoteAudioVideoRendererProxyManager::flushAndRemoveImage(RemoteAudioVideoRendererIdentifier identifier)
@@ -596,7 +652,6 @@ RemoteAudioVideoRendererState RemoteAudioVideoRendererProxyManager::stateFor(Rem
     return {
         .timeUpdateData = timeUpdateDataFor(*renderer),
         .paused = renderer->paused(),
-        .videoPlaybackQualityMetrics = renderer->videoPlaybackQualityMetrics()
     };
 }
 

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
@@ -46,6 +46,7 @@
 #include <wtf/Forward.h>
 #include <wtf/Logger.h>
 #include <wtf/MediaTime.h>
+#include <wtf/MonotonicTime.h>
 #include <wtf/ObjectIdentifier.h>
 #include <wtf/RefCounted.h>
 #include <wtf/TZoneMalloc.h>
@@ -140,6 +141,7 @@ private:
     void setShouldDisableHDR(RemoteAudioVideoRendererIdentifier, bool);
     void setPlatformDynamicRangeLimit(RemoteAudioVideoRendererIdentifier, const WebCore::PlatformDynamicRangeLimit&);
     void setResourceOwner(RemoteAudioVideoRendererIdentifier, const WebCore::ProcessIdentity& resourceOwner);
+    void setVideoPlaybackMetricsUpdateInterval(RemoteAudioVideoRendererIdentifier, double);
     void flushAndRemoveImage(RemoteAudioVideoRendererIdentifier);
     void currentVideoFrame(RemoteAudioVideoRendererIdentifier, CompletionHandler<void(std::optional<RemoteVideoFrameProxy::Properties>)>&&) const;
     void currentBitmapImage(RemoteAudioVideoRendererIdentifier, CompletionHandler<void(std::optional<WebCore::ShareableBitmap::Handle>&&)>&&) const;
@@ -170,12 +172,17 @@ private:
 #endif
         HashMap<TrackIdentifier, WebCore::MediaSampleConverter> converters { };
         WebCore::VideoRendererPreferences preferences { };
+        Seconds videoPlaybackMetricsUpdateInterval { };
+        MonotonicTime nextPlaybackQualityMetricsUpdateTime { };
+        bool isGatheringVideoFrameMetadata { false };
     };
     RefPtr<WebCore::AudioVideoRenderer> createRenderer();
     RefPtr<WebCore::AudioVideoRenderer> rendererFor(RemoteAudioVideoRendererIdentifier) const;
     RemoteAudioVideoRendererState stateFor(RemoteAudioVideoRendererIdentifier) const;
     RendererContext& NODELETE contextFor(RemoteAudioVideoRendererIdentifier);
     void rendereringModeChanged(RemoteAudioVideoRendererIdentifier);
+    void updateCachedVideoMetrics(RemoteAudioVideoRendererIdentifier);
+    void maybeUpdateCachedVideoMetrics(RemoteAudioVideoRendererIdentifier);
     using LayerHostingContextCallback = CompletionHandler<void(WebCore::HostingContext)>;
     void requestHostingContext(RemoteAudioVideoRendererIdentifier, LayerHostingContextCallback&&);
     WebCore::MediaSampleConverter& converterFor(RendererContext&, TrackIdentifier);

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in
@@ -79,6 +79,7 @@ messages -> RemoteAudioVideoRendererProxyManager {
     SetShouldDisableHDR(WebKit::RemoteAudioVideoRendererIdentifier identifier, bool disable)
     SetPlatformDynamicRangeLimit(WebKit::RemoteAudioVideoRendererIdentifier identifier, WebCore::PlatformDynamicRangeLimit limit)
     SetResourceOwner(WebKit::RemoteAudioVideoRendererIdentifier identifier, WebCore::ProcessIdentity resourceOwner)
+    SetVideoPlaybackMetricsUpdateInterval(WebKit::RemoteAudioVideoRendererIdentifier identifier, double interval)
     FlushAndRemoveImage(WebKit::RemoteAudioVideoRendererIdentifier identifier)
     CurrentVideoFrame(WebKit::RemoteAudioVideoRendererIdentifier identifier) -> (struct std::optional<WebKit::RemoteVideoFrameProxyProperties> videoFrame) Synchronous
     CurrentBitmapImage(WebKit::RemoteAudioVideoRendererIdentifier identifier) -> (std::optional<WebCore::ShareableBitmapHandle> image)

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
@@ -425,8 +425,39 @@ Ref<AudioVideoRenderer::BitmapImagePromise> AudioVideoRendererRemote::currentBit
 
 std::optional<VideoPlaybackQualityMetrics> AudioVideoRendererRemote::videoPlaybackQualityMetrics()
 {
-    Locker locker { m_lock };
-    return m_cachedState.videoPlaybackQualityMetrics;
+    constexpr Seconds maximumPlaybackQualityMetricsSampleTimeDelta = 250_ms;
+    constexpr Seconds minimumPlaybackQualityMetricsUpdateInterval = 250_ms;
+
+    std::optional<Seconds> newInterval;
+    std::optional<VideoPlaybackQualityMetrics> cached;
+    Seconds timeSinceLastQuery;
+    Seconds currentInterval;
+    {
+        Locker locker { m_lock };
+        auto now = MonotonicTime::now();
+        timeSinceLastQuery = now - m_lastPlaybackQualityMetricsQueryTime;
+        if (!m_videoPlaybackMetricsUpdateInterval)
+            newInterval = 1_s;
+        else if (std::abs((timeSinceLastQuery - m_videoPlaybackMetricsUpdateInterval).value()) > maximumPlaybackQualityMetricsSampleTimeDelta.value())
+            newInterval = std::max(timeSinceLastQuery, minimumPlaybackQualityMetricsUpdateInterval);
+        m_lastPlaybackQualityMetricsQueryTime = now;
+        if (newInterval)
+            m_videoPlaybackMetricsUpdateInterval = *newInterval;
+        currentInterval = m_videoPlaybackMetricsUpdateInterval;
+        cached = m_cachedState.videoPlaybackQualityMetrics;
+    }
+    DEBUG_LOG(LOGIDENTIFIER, "timeSinceLastQuery=", timeSinceLastQuery.value(), "s interval=", currentInterval.value(), "s", newInterval ? " (interval updated)" : "", cached ? " cached=yes" : " cached=no");
+    if (newInterval)
+        updateVideoPlaybackMetricsUpdateInterval(*newInterval);
+    return cached;
+}
+
+void AudioVideoRendererRemote::updateVideoPlaybackMetricsUpdateInterval(const Seconds& interval)
+{
+    DEBUG_LOG(LOGIDENTIFIER, "interval=", interval.value(), "s");
+    ensureOnDispatcherWithConnection([identifier = m_identifier, interval](AudioVideoRendererRemote&, IPC::Connection& connection) {
+        connection.send(Messages::RemoteAudioVideoRendererProxyManager::SetVideoPlaybackMetricsUpdateInterval(identifier, interval.value()), 0);
+    });
 }
 
 PlatformLayer* AudioVideoRendererRemote::platformVideoLayer() const
@@ -877,10 +908,19 @@ WTFLogChannel& AudioVideoRendererRemote::logChannel() const
 
 void AudioVideoRendererRemote::updateCacheState(const RemoteAudioVideoRendererState& state)
 {
+    constexpr Seconds playbackQualityMetricsTimeout = 30_s;
     m_timeEstimator.setTime(state.timeUpdateData);
-    Locker locker { m_lock };
-    m_cachedState.paused = state.paused;
-    m_cachedState.videoPlaybackQualityMetrics = state.videoPlaybackQualityMetrics;
+    bool shouldDisableMetrics = false;
+    {
+        Locker locker { m_lock };
+        m_cachedState.paused = state.paused;
+        if (m_videoPlaybackMetricsUpdateInterval && (MonotonicTime::now() - m_lastPlaybackQualityMetricsQueryTime) > playbackQualityMetricsTimeout) {
+            m_videoPlaybackMetricsUpdateInterval = 0_s;
+            shouldDisableMetrics = true;
+        }
+    }
+    if (shouldDisableMetrics)
+        updateVideoPlaybackMetricsUpdateInterval(0_s);
 }
 
 AudioVideoRendererRemote::ReadyForMoreDataState& AudioVideoRendererRemote::readyForMoreDataState(TrackIdentifier trackIdentifier)
@@ -1097,11 +1137,15 @@ void AudioVideoRendererRemote::MessageReceiver::firstFrameAvailable(RemoteAudioV
     }
 }
 
-void AudioVideoRendererRemote::MessageReceiver::hasAvailableVideoFrame(MediaTime time, double clockTime, RemoteAudioVideoRendererState state)
+void AudioVideoRendererRemote::MessageReceiver::hasAvailableVideoFrame(MediaTime time, double clockTime, RemoteAudioVideoRendererState state, std::optional<VideoPlaybackQualityMetrics> metrics)
 {
     if (RefPtr parent = m_parent.get()) {
         assertIsCurrent(queueSingleton());
         parent->updateCacheState(state);
+        if (metrics) {
+            Locker locker { parent->m_lock };
+            parent->m_cachedState.videoPlaybackQualityMetrics = WTF::move(metrics);
+        }
         if (parent->m_hasAvailableVideoFrameCallback)
             parent->m_hasAvailableVideoFrameCallback(time, clockTime);
     }
@@ -1208,6 +1252,15 @@ void AudioVideoRendererRemote::MessageReceiver::stateUpdate(RemoteAudioVideoRend
 {
     if (RefPtr parent = m_parent.get())
         parent->updateCacheState(state);
+}
+
+void AudioVideoRendererRemote::MessageReceiver::updatePlaybackQualityMetrics(WebCore::VideoPlaybackQualityMetrics metrics)
+{
+    if (RefPtr parent = m_parent.get()) {
+        DEBUG_LOG_WITH_THIS(parent.get(), LOGIDENTIFIER_WITH_THIS(parent.get()), "total=", metrics.totalVideoFrames, " dropped=", metrics.droppedVideoFrames, " corrupted=", metrics.corruptedVideoFrames, " displayComposited=", metrics.displayCompositedVideoFrames, " frameDelay=", metrics.totalFrameDelay);
+        Locker locker { parent->m_lock };
+        parent->m_cachedState.videoPlaybackQualityMetrics = WTF::move(metrics);
+    }
 }
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
@@ -38,6 +38,7 @@
 #include <WebCore/MediaPlayerIdentifier.h>
 #include <WebCore/MediaSampleConverter.h>
 #include <WebCore/MediaTimeUpdateData.h>
+#include <WebCore/VideoPlaybackQualityMetrics.h>
 #include <wtf/Forward.h>
 #include <wtf/LoggerHelper.h>
 #include <wtf/RefPtr.h>
@@ -83,7 +84,7 @@ public:
         void didReceiveMessage(IPC::Connection&, IPC::Decoder&) final;
 
         void firstFrameAvailable(RemoteAudioVideoRendererState);
-        void hasAvailableVideoFrame(MediaTime, double, RemoteAudioVideoRendererState);
+        void hasAvailableVideoFrame(MediaTime, double, RemoteAudioVideoRendererState, std::optional<WebCore::VideoPlaybackQualityMetrics>);
         void requiresFlushToResume(RemoteAudioVideoRendererState);
         void renderingModeChanged(RemoteAudioVideoRendererState);
         void sizeChanged(MediaTime, WebCore::FloatSize, RemoteAudioVideoRendererState);
@@ -94,6 +95,7 @@ public:
         void errorOccurred(WebCore::PlatformMediaError);
         void readyForMoreMediaData(WebCore::SamplesRendererTrackIdentifier);
         void stateUpdate(RemoteAudioVideoRendererState);
+        void updatePlaybackQualityMetrics(WebCore::VideoPlaybackQualityMetrics);
 
 #if PLATFORM(COCOA)
         void layerHostingContextChanged(RemoteAudioVideoRendererState, WebCore::HostingContext&&, const WebCore::FloatSize&);
@@ -244,6 +246,7 @@ private:
     bool isGPURunning() const { return !m_shutdown; }
 
     void updateCacheState(const RemoteAudioVideoRendererState&);
+    void updateVideoPlaybackMetricsUpdateInterval(const Seconds&);
     class ReadyForMoreDataState {
     public:
         static constexpr size_t kMaxPendingSample = 20;
@@ -273,6 +276,8 @@ private:
         std::optional<WebCore::VideoPlaybackQualityMetrics> videoPlaybackQualityMetrics;
     };
     CachedState m_cachedState WTF_GUARDED_BY_LOCK(m_lock);
+    MonotonicTime m_lastPlaybackQualityMetricsQueryTime WTF_GUARDED_BY_LOCK(m_lock);
+    Seconds m_videoPlaybackMetricsUpdateInterval WTF_GUARDED_BY_LOCK(m_lock);
     TimeProgressEstimator m_timeEstimator;
 
     Function<void(WebCore::PlatformMediaError)> m_errorCallback WTF_GUARDED_BY_CAPABILITY(queueSingleton());

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemoteMessageReceiver.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemoteMessageReceiver.messages.in
@@ -32,7 +32,7 @@
 messages -> AudioVideoRendererRemoteMessageReceiver {
     ReadyForMoreMediaData(WebCore::SamplesRendererTrackIdentifier identifier)
     FirstFrameAvailable(struct WebKit::RemoteAudioVideoRendererState state)
-    HasAvailableVideoFrame(MediaTime time, double clockTime, struct WebKit::RemoteAudioVideoRendererState state)
+    HasAvailableVideoFrame(MediaTime time, double clockTime, struct WebKit::RemoteAudioVideoRendererState state, struct std::optional<WebCore::VideoPlaybackQualityMetrics> metrics)
     RequiresFlushToResume(struct WebKit::RemoteAudioVideoRendererState state)
     RenderingModeChanged(struct WebKit::RemoteAudioVideoRendererState state)
     SizeChanged(MediaTime time, WebCore::FloatSize size, struct WebKit::RemoteAudioVideoRendererState state)
@@ -42,6 +42,7 @@ messages -> AudioVideoRendererRemoteMessageReceiver {
     TaskTimeReached(MediaTime time, struct WebKit::RemoteAudioVideoRendererState state)
     ErrorOccurred(WebCore::PlatformMediaError error)
     StateUpdate(struct WebKit::RemoteAudioVideoRendererState state)
+    UpdatePlaybackQualityMetrics(struct WebCore::VideoPlaybackQualityMetrics metrics)
 
 #if PLATFORM(COCOA)
     LayerHostingContextChanged(struct WebKit::RemoteAudioVideoRendererState state, struct WebCore::HostingContext hostingContext, WebCore::FloatSize presentationSize);

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioVideoRendererState.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioVideoRendererState.h
@@ -27,7 +27,6 @@
 
 #include <WebCore/FloatSize.h>
 #include <WebCore/MediaTimeUpdateData.h>
-#include <WebCore/VideoPlaybackQualityMetrics.h>
 #include <wtf/MediaTime.h>
 #include <wtf/Seconds.h>
 
@@ -41,7 +40,6 @@ constexpr Seconds remoteAudioVideoRendererUpdateInterval = 250_ms;
 struct RemoteAudioVideoRendererState {
     WebCore::MediaTimeUpdateData timeUpdateData { };
     bool paused { false };
-    std::optional<WebCore::VideoPlaybackQualityMetrics> videoPlaybackQualityMetrics { };
 };
 
 }

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioVideoRendererState.serialization.in
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioVideoRendererState.serialization.in
@@ -24,6 +24,5 @@
 struct WebKit::RemoteAudioVideoRendererState {
     WebCore::MediaTimeUpdateData timeUpdateData;
     bool paused;
-    std::optional<WebCore::VideoPlaybackQualityMetrics> videoPlaybackQualityMetrics;
 }
 #endif


### PR DESCRIPTION
#### 2b092c252762a5a9a301b99d25b300b450cc28c5
<pre>
Reduce power cost of VideoPlaybackQualityMetrics
<a href="https://bugs.webkit.org/show_bug.cgi?id=314796">https://bugs.webkit.org/show_bug.cgi?id=314796</a>
<a href="https://rdar.apple.com/176487081">rdar://176487081</a>

Reviewed by Jer Noble.

On the protected-content path — where no WebCoreDecompressionSession is
in use — VideoMediaSampleRenderer&apos;s four per-metric accessors each issued
a separate [renderer videoPerformanceMetrics] synchronous XPC, and the
GPU-side RemoteAudioVideoRendererProxyManager eagerly bundled the resulting
VideoPlaybackQualityMetrics into every RemoteAudioVideoRendererState push
back to WebContent. Each such push therefore fanned into four XPCs, and
they fired on every state-carrying event plus the 250ms periodic StateUpdate,
even when no script was asking for the metrics. Plain MSE / WebM playback
services these accessors from in-process atomics and was unaffected.

Consolidate the fetch into a single [renderer videoPerformanceMetrics]
call and move metrics delivery to a pull model matching
MediaPlayerPrivateRemote / RemoteMediaPlayerProxy:

  1. VideoMediaSampleRenderer exposes videoPlaybackQualityMetrics() that
     builds the full struct from one videoPerformanceMetrics read (or
     from the internal decompression-session counters when applicable).
     The four per-metric getters are removed; AudioVideoRendererAVFObjC
     delegates to the new single-call method.

  2. RemoteAudioVideoRendererState no longer carries a metrics payload.
     stateFor() returns only timeUpdateData + paused, so on the
     protected-content path the frequent state pushes no longer XPC
     into mediaserverd.

  3. AudioVideoRendererRemote::videoPlaybackQualityMetrics() now
     estimates client query cadence and forwards it to the GPU via a new
     SetVideoPlaybackMetricsUpdateInterval IPC, mirroring
     MediaPlayerPrivateRemote::updateVideoPlaybackMetricsUpdateInterval.
     The interval seeds at 1s on the first query and retunes when the
     observed delta drifts by more than 250ms, clamped to a 250ms floor
     so rapid bursts of queries cannot drive the GPU into a sub-ms push
     cadence. If the client stops polling for more than 30s,
     updateCacheState tells the GPU to stop pushing (interval=0); the
     next query re-seeds. The method returns the last cached struct
     pushed from the GPU.

  4. RemoteAudioVideoRendererProxyManager piggybacks metrics collection
     on its existing setTimeObserver tick (every
     remoteAudioVideoRendererUpdateInterval), matching the structure of
     RemoteMediaPlayerProxy::maybeUpdateCachedVideoMetrics. Each tick
     calls maybeUpdateCachedVideoMetrics(), which early-returns while
     the renderer is paused, when no interval has been negotiated, or
     when the scheduled nextPlaybackQualityMetricsUpdateTime has not
     elapsed yet. When it does fire, updateCachedVideoMetrics() reads
     [renderer videoPerformanceMetrics] once, sends
     UpdatePlaybackQualityMetrics to the WebContent, and anchors the
     next tick at now + interval. SetVideoPlaybackMetricsUpdateInterval
     primes the cache immediately and anchors the first next-tick at
     now + interval - 0.25s (metricsAdvanceUpdate) so the GPU refreshes
     just before the client&apos;s expected next query. No dedicated
     RunLoop::Timer is needed: the time observer naturally stops firing
     when media time stops advancing, so paused / stalled playback
     incurs no additional wake-ups.

Debug logging is added on both sides to trace query cadence, interval
retuning, and the metrics values flowing over the new IPC.

[renderer videoPerformanceMetrics] performs a sync XP dispatch and is
called from the main thread, blocking it until completion. A future
update could run this operation on the AVSampleBufferDisplayLayer&apos;s
AVSampleBufferVideoRenderer in a secondary WorkQueue. But as this
commit only affects protected content which occurs on the main thread,
additional work is required.

* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::videoPlaybackQualityMetrics): Delegate
to VideoMediaSampleRenderer&apos;s single-call method.

* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.h:
* Source/WebCore/platform/graphics/cocoa/VideoMediaSampleRenderer.mm:
(WebCore::VideoMediaSampleRenderer::videoPlaybackQualityMetrics): New.
Builds the full VideoPlaybackQualityMetrics from one videoPerformanceMetrics
read (or internal counters on the decompression-session path). The four
per-metric accessors are removed.

* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp:
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h:
(WebKit::RemoteAudioVideoRendererProxyManager::create): Call
maybeUpdateCachedVideoMetrics from the existing setTimeObserver tick
so metrics refresh on the same cadence that already drives the state
pushes.
(WebKit::RemoteAudioVideoRendererProxyManager::stateFor): Drop the
metrics fetch; return only timeUpdateData and paused.
(WebKit::RemoteAudioVideoRendererProxyManager::setVideoPlaybackMetricsUpdateInterval):
New IPC handler. Pushes current metrics immediately, stores the interval
on the RendererContext, and anchors nextPlaybackQualityMetricsUpdateTime
with the 250ms metricsAdvanceUpdate nudge so the first refresh lands
just before the client&apos;s next expected query.
(WebKit::RemoteAudioVideoRendererProxyManager::maybeUpdateCachedVideoMetrics):
New. Gate-check for the time-observer callsite: skips while the renderer
is paused, when no interval is negotiated, or when the scheduled update
time has not yet elapsed.
(WebKit::RemoteAudioVideoRendererProxyManager::updateCachedVideoMetrics):
Fetches metrics in a single call, sends UpdatePlaybackQualityMetrics to
the WebContent, and advances nextPlaybackQualityMetricsUpdateTime by
the current interval.

* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in:
Declare SetVideoPlaybackMetricsUpdateInterval.

* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp:
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h:
(WebKit::AudioVideoRendererRemote::videoPlaybackQualityMetrics): Estimate
client query cadence, clamp retunes to a 250ms floor, and send
SetVideoPlaybackMetricsUpdateInterval when the interval changes. Returns
the cached struct from the GPU.
(WebKit::AudioVideoRendererRemote::updateVideoPlaybackMetricsUpdateInterval):
New. Dispatches the interval IPC on queueSingleton().
(WebKit::AudioVideoRendererRemote::updateCacheState): No longer copies
videoPlaybackQualityMetrics out of the state struct. Auto-disables GPU
metrics pushes (interval=0) when the client has not queried for 30s,
mirroring MediaPlayerPrivateRemote::updateCachedState.
(WebKit::AudioVideoRendererRemote::MessageReceiver::updatePlaybackQualityMetrics):
New receiver for the GPU-pushed metrics. Stores into m_cachedState.

* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemoteMessageReceiver.messages.in:
Declare UpdatePlaybackQualityMetrics.

* Source/WebKit/WebProcess/GPU/media/RemoteAudioVideoRendererState.h:
* Source/WebKit/WebProcess/GPU/media/RemoteAudioVideoRendererState.serialization.in:
Remove the videoPlaybackQualityMetrics field.

Canonical link: <a href="https://commits.webkit.org/313304@main">https://commits.webkit.org/313304@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8bb6f0924c3db50e9b3fced60a1762ca67870d56

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162720 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36196 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29342 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171658 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119166 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164589 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36300 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36200 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126297 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88943 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165679 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28648 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146205 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106874 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f588f814-0fbb-4390-b873-eadfbaba4aa4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27694 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26226 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19358 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137402 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23934 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174162 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21475 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25579 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134608 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35870 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30325 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134603 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36316 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35854 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145730 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98236 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/29144 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22566 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35364 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/103115 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34865 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35110 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35013 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->