### PR TITLE
[JSC] Support double arrays in DFG / FTL inline `Array.prototype.sort`

### DIFF
--- a/JSTests/microbenchmarks/array-prototype-sort-small-array-comparator-double.js
+++ b/JSTests/microbenchmarks/array-prototype-sort-small-array-comparator-double.js
@@ -1,0 +1,6 @@
+var comparator = (a, b) => a - b;
+var source = [0.5, 1.5, 2.5, 3.5, 7.5, 6.5, 5.5, 4.5];
+
+for (var i = 0; i < 1e6; ++i) {
+    Array.from(source).sort(comparator);
+}

--- a/JSTests/stress/array-sort-inline-double-holey.js
+++ b/JSTests/stress/array-sort-inline-double-holey.js
@@ -1,0 +1,36 @@
+// Verifies the DFG ArraySortIntrinsic's hole handling for ArrayWithDouble arrays.
+// Double butterflies represent holes as PNaN; ArraySortCompact must detect that bit pattern
+// (via a NaN self-compare) and bail to the slow-path DirectCall to arrayProtoFuncSort.
+
+function cmp(a, b) { return a - b; }
+function sortIt(a) { return a.sort(cmp); }
+noInline(sortIt);
+
+// Warm up the DFG/FTL compile of sortIt with dense Double arrays.
+for (let w = 0; w < testLoopCount; w++) {
+    const a = [5.5, 3.5, 1.5, 4.5, 2.5];
+    const r = sortIt(a);
+    if (r[0] !== 1.5 || r[4] !== 5.5)
+        throw new Error("dense warm-up wrong: " + JSON.stringify(r));
+}
+
+// Now feed in a holey Double array. ArraySortCompact returns the sentinel and the parser's
+// branch routes to the slow path which sorts correctly.
+function runHoley(iter) {
+    const a = [5.5, , 3.5, , 1.5, , 4.5, , 2.5];
+    const r = sortIt(a);
+    if (r.length !== 9)
+        throw new Error("iter " + iter + " wrong length " + r.length);
+    let multiset = new Map();
+    for (let i = 0; i < r.length; i++) {
+        if (i in r)
+            multiset.set(r[i], (multiset.get(r[i]) || 0) + 1);
+    }
+    for (const v of [1.5, 2.5, 3.5, 4.5, 5.5]) {
+        if (multiset.get(v) !== 1)
+            throw new Error("iter " + iter + " missing " + v + " (multiset = " + JSON.stringify([...multiset]) + ")");
+    }
+}
+
+for (let i = 0; i < testLoopCount; i++)
+    runHoley(i);

--- a/JSTests/stress/array-sort-inline-double.js
+++ b/JSTests/stress/array-sort-inline-double.js
@@ -1,0 +1,76 @@
+// Verifies the DFG ArraySortIntrinsic's fast path handles ArrayWithDouble arrays.
+// ArraySortCompact loads raw doubles from the butterfly, boxes them into the JSCellButterfly
+// scratch, and ArraySortCommit unboxes them back to raw doubles when committing.
+
+function sortIt(a, cmp) { return a.sort(cmp); }
+noInline(sortIt);
+
+function assertSameOrder(actual, expected, label, iter) {
+    if (actual.length !== expected.length)
+        throw new Error(`${label} iter ${iter}: length mismatch ${actual.length} != ${expected.length}`);
+    for (let i = 0; i < expected.length; i++) {
+        if (!Object.is(actual[i], expected[i]))
+            throw new Error(`${label} iter ${iter} index ${i}: got ${actual[i]} expected ${expected[i]}`);
+    }
+}
+
+// Plain double array, ascending sort.
+{
+    const input = [3.5, 1.2, 2.8, 0.4, 4.1, -1.5, 2.2];
+    const expected = [-1.5, 0.4, 1.2, 2.2, 2.8, 3.5, 4.1];
+    for (let w = 0; w < testLoopCount; w++) {
+        const a = input.slice();
+        const r = sortIt(a, (x, y) => x - y);
+        assertSameOrder(r, expected, "asc", w);
+        if (r !== a)
+            throw new Error("asc iter " + w + ": result is not the same array");
+    }
+}
+
+// Plain double array, descending sort.
+{
+    const input = [3.5, 1.2, 2.8, 0.4, 4.1, -1.5, 2.2];
+    const expected = [4.1, 3.5, 2.8, 2.2, 1.2, 0.4, -1.5];
+    for (let w = 0; w < testLoopCount; w++) {
+        const a = input.slice();
+        const r = sortIt(a, (x, y) => y - x);
+        assertSameOrder(r, expected, "desc", w);
+    }
+}
+
+// Doubles with integral values (still a Double butterfly because of the mixed literal).
+{
+    const input = [5.0, 3.5, 1.0, 4.0, 2.5];
+    const expected = [1.0, 2.5, 3.5, 4.0, 5.0];
+    for (let w = 0; w < testLoopCount; w++) {
+        const a = input.slice();
+        const r = sortIt(a, (x, y) => x - y);
+        assertSameOrder(r, expected, "int-like", w);
+    }
+}
+
+// Negative zero and signed-ness round-trip through box/unbox.
+{
+    const input = [1.5, -0.0, 0.0, -1.5];
+    for (let w = 0; w < testLoopCount; w++) {
+        const a = input.slice();
+        const r = sortIt(a, (x, y) => x - y);
+        // Comparator treats -0 and +0 as equal; insertion sort is stable so original order is kept.
+        if (!(r[0] === -1.5 && Object.is(r[1], -0.0) && Object.is(r[2], 0.0) && r[3] === 1.5))
+            throw new Error("zero iter " + w + ": got " + r.map(x => Object.is(x, -0) ? "-0" : x).join(","));
+    }
+}
+
+// Stability check: equal-key elements preserve their relative order.
+{
+    function buildPairs() {
+        // Encode (key, tag) as key + tag/100 -> still a double, integer key part repeats.
+        return [3.01, 1.01, 2.01, 1.02, 3.02, 2.02, 1.03];
+    }
+    const expected = [1.01, 1.02, 1.03, 2.01, 2.02, 3.01, 3.02];
+    for (let w = 0; w < testLoopCount; w++) {
+        const a = buildPairs();
+        const r = sortIt(a, (x, y) => Math.floor(x) - Math.floor(y));
+        assertSameOrder(r, expected, "stable", w);
+    }
+}

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -3844,6 +3844,9 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         case Array::Int32:
             setNonCellTypeForNode(node, SpecInt32Only);
             break;
+        case Array::Double:
+            setNonCellTypeForNode(node, SpecDoubleReal);
+            break;
         default:
             makeBytecodeTopForNode(node);
             break;

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -11606,12 +11606,12 @@ template<typename ChecksFunctor, typename SetResultFunctor>
 auto ByteCodeParser::handleArraySort(Node* callee, Operand resultOperand, CallVariant variant, int registerOffset, int argumentCountIncludingThis, BytecodeIndex osrExitIndex, SpeculatedType prediction, const ChecksFunctor& insertChecks, const SetResultFunctor& setResult) -> CallOptimizationResult
 {
     // Inline Array.prototype.sort(comparator) when:
-    //   - receiver is an original-structure JSArray with Undecided / Int32 / Contiguous indexing, and
+    //   - receiver is an original-structure JSArray with Undecided / Int32 / Double / Contiguous indexing, and
     //   - comparator is callable (CellUse speculation; non-callable cells throw TypeError from the Call just like the spec requires).
     //
     // Strategy:
     //   * ArrayWithUndecided -> length is 0, return the receiver.
-    //   * Int32 / Contiguous -> dispatch on runtime length:
+    //   * Int32 / Double / Contiguous -> dispatch on runtime length:
     //       length > 16  -> fallback DirectCall to arrayProtoFuncSort. Avoids re-deopt loops
     //         or hot sort sites with large arrays.
     //       length <= 16 -> three-phase pipeline over a 16-slot JSCellButterfly scratch:
@@ -11657,6 +11657,9 @@ auto ByteCodeParser::handleArraySort(Node* callee, Operand resultOperand, CallVa
         break;
     case Array::Int32:
         indexingType = ArrayWithInt32;
+        break;
+    case Array::Double:
+        indexingType = ArrayWithDouble;
         break;
     case Array::Contiguous:
         indexingType = ArrayWithContiguous;

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -1979,6 +1979,9 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         case Array::Int32:
             sourceHeap = IndexedInt32Properties;
             break;
+        case Array::Double:
+            sourceHeap = IndexedDoubleProperties;
+            break;
         case Array::Contiguous:
             sourceHeap = IndexedContiguousProperties;
             break;
@@ -2000,6 +2003,9 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         switch (node->arrayMode().type()) {
         case Array::Int32:
             targetHeap = IndexedInt32Properties;
+            break;
+        case Array::Double:
+            targetHeap = IndexedDoubleProperties;
             break;
         case Array::Contiguous:
             targetHeap = IndexedContiguousProperties;

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1340,6 +1340,9 @@ private:
             case Array::Int32:
                 setPrediction(SpecInt32Only);
                 break;
+            case Array::Double:
+                setPrediction(SpecDoubleReal);
+                break;
             default:
                 setPrediction(SpecBytecodeTop);
                 break;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -15482,6 +15482,8 @@ void SpeculativeJIT::compilePutCellButterflySlot(Node* node)
 
 void SpeculativeJIT::compileArraySortCompact(Node* node)
 {
+    bool isDouble = node->arrayMode().type() == Array::Double;
+
     SpeculateCellOperand array(this, node->child1());
     SpeculateInt32Operand length(this, node->child2());
 
@@ -15498,6 +15500,13 @@ void SpeculativeJIT::compileArraySortCompact(Node* node)
     GPRReg valueGPR = value.gpr();
     GPRReg butterflyGPR = butterfly.gpr();
 
+    std::optional<FPRTemporary> fp;
+    FPRReg fpReg = InvalidFPRReg;
+    if (isDouble) {
+        fp.emplace(this);
+        fpReg = fp->fpr();
+    }
+
     loadPtr(&vm().m_cachedSortScratch, scratchGPR);
     move(TrustedImmPtr(nullptr), butterflyGPR);
     storePtr(butterflyGPR, &vm().m_cachedSortScratch);
@@ -15511,11 +15520,17 @@ void SpeculativeJIT::compileArraySortCompact(Node* node)
     move(lengthGPR, counterGPR);
     auto loop = label();
     auto done = branchSub32(Signed, counterGPR, TrustedImm32(1), counterGPR);
-    load64(BaseIndex(butterflyGPR, counterGPR, TimesEight, 0), valueGPR);
     JumpList holes;
-    holes.append(branchTest64(Zero, valueGPR));
-    if (node->arrayMode().type() == Array::Contiguous)
-        holes.append(branch64(Equal, valueGPR, TrustedImm64(JSValue::encode(jsUndefined()))));
+    if (isDouble) {
+        loadDouble(BaseIndex(butterflyGPR, counterGPR, TimesEight, 0), fpReg);
+        holes.append(branchIfNaN(fpReg));
+        boxDouble(fpReg, valueGPR);
+    } else {
+        load64(BaseIndex(butterflyGPR, counterGPR, TimesEight, 0), valueGPR);
+        holes.append(branchTest64(Zero, valueGPR));
+        if (node->arrayMode().type() == Array::Contiguous)
+            holes.append(branch64(Equal, valueGPR, TrustedImm64(JSValue::encode(jsUndefined()))));
+    }
     store64(valueGPR, BaseIndex(scratchGPR, counterGPR, TimesEight, JSCellButterfly::offsetOfData()));
     jump().linkTo(loop, this);
 
@@ -15528,6 +15543,8 @@ void SpeculativeJIT::compileArraySortCompact(Node* node)
 
 void SpeculativeJIT::compileArraySortCommit(Node* node)
 {
+    bool isDouble = node->arrayMode().type() == Array::Double;
+
     SpeculateCellOperand array(this, node->child1());
     SpeculateCellOperand storage(this, node->child2());
     SpeculateInt32Operand length(this, node->child3());
@@ -15542,6 +15559,17 @@ void SpeculativeJIT::compileArraySortCommit(Node* node)
     GPRReg counterGPR = counter.gpr();
     GPRReg butterflyGPR = butterfly.gpr();
 
+    std::optional<GPRTemporary> value;
+    GPRReg valueGPR = InvalidGPRReg;
+    std::optional<FPRTemporary> fp;
+    FPRReg fpReg = InvalidFPRReg;
+    if (isDouble) {
+        value.emplace(this);
+        valueGPR = value->gpr();
+        fp.emplace(this);
+        fpReg = fp->fpr();
+    }
+
     // If array.length gets modified during sorting, let's reject commit and do OSR exit.
     loadPtr(Address(arrayGPR, JSObject::butterflyOffset()), butterflyGPR);
     speculationCheck(BadIndexingType, JSValueRegs(), node, branch32(NotEqual, Address(butterflyGPR, Butterfly::offsetOfPublicLength()), lengthGPR));
@@ -15549,7 +15577,12 @@ void SpeculativeJIT::compileArraySortCommit(Node* node)
     move(lengthGPR, counterGPR);
     auto loop = label();
     auto done = branchSub32(Signed, counterGPR, TrustedImm32(1), counterGPR);
-    transfer64(BaseIndex(storageGPR, counterGPR, TimesEight, JSCellButterfly::offsetOfData()), BaseIndex(butterflyGPR, counterGPR, TimesEight, 0));
+    if (isDouble) {
+        load64(BaseIndex(storageGPR, counterGPR, TimesEight, JSCellButterfly::offsetOfData()), valueGPR);
+        unboxDouble(valueGPR, valueGPR, fpReg);
+        storeDouble(fpReg, BaseIndex(butterflyGPR, counterGPR, TimesEight, 0));
+    } else
+        transfer64(BaseIndex(storageGPR, counterGPR, TimesEight, JSCellButterfly::offsetOfData()), BaseIndex(butterflyGPR, counterGPR, TimesEight, 0));
     jump().linkTo(loop, this);
 
     done.link(this);

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -10586,7 +10586,17 @@ IGNORE_CLANG_WARNINGS_END
         LValue array = lowCell(m_node->child1());
         LValue length = m_out.zeroExt(lowInt32(m_node->child2()), pointerType());
 
-        IndexedAbstractHeap& sourceHeap = m_node->arrayMode().type() == Array::Int32 ? m_heaps.indexedInt32Properties : m_heaps.indexedContiguousProperties;
+        Array::Type arrayType = m_node->arrayMode().type();
+        IndexedAbstractHeap& sourceHeap = [&]() -> IndexedAbstractHeap& {
+            switch (arrayType) {
+            case Array::Int32:
+                return m_heaps.indexedInt32Properties;
+            case Array::Double:
+                return m_heaps.indexedDoubleProperties;
+            default:
+                return m_heaps.indexedContiguousProperties;
+            }
+        }();
 
         LBasicBlock slowCase = m_out.newBlock();
         LBasicBlock acquired = m_out.newBlock();
@@ -10616,11 +10626,19 @@ IGNORE_CLANG_WARNINGS_END
         m_out.branch(m_out.aboveOrEqual(index, length), unsure(continuation), unsure(loopBody));
 
         m_out.appendTo(loopBody, storeSlot);
-        LValue value = m_out.load64(m_out.baseIndex(sourceHeap, butterfly, index));
+        LValue value;
+        LValue isHole;
+        if (arrayType == Array::Double) {
+            LValue doubleValue = m_out.loadDouble(m_out.baseIndex(sourceHeap, butterfly, index));
+            isHole = m_out.doubleNotEqualOrUnordered(doubleValue, doubleValue);
+            value = boxDouble(doubleValue);
+        } else {
+            value = m_out.load64(m_out.baseIndex(sourceHeap, butterfly, index));
+            isHole = m_out.isZero64(value);
+            if (arrayType == Array::Contiguous)
+                isHole = m_out.bitOr(isHole, m_out.equal(value, m_out.constInt64(JSValue::encode(jsUndefined()))));
+        }
         ValueFromBlock holeResult = m_out.anchor(m_out.constIntPtr(std::bit_cast<void*>(vm().m_sortScratchSentinel.get())));
-        LValue isHole = m_out.isZero64(value);
-        if (m_node->arrayMode().type() == Array::Contiguous)
-            isHole = m_out.bitOr(isHole, m_out.equal(value, m_out.constInt64(JSValue::encode(jsUndefined()))));
         m_out.branch(isHole, rarely(continuation), usually(storeSlot));
 
         m_out.appendTo(storeSlot, continuation);
@@ -10639,7 +10657,17 @@ IGNORE_CLANG_WARNINGS_END
         LValue scratch = lowCell(m_node->child2());
         LValue length = m_out.zeroExt(lowInt32(m_node->child3()), pointerType());
 
-        IndexedAbstractHeap& targetHeap = m_node->arrayMode().type() == Array::Int32 ? m_heaps.indexedInt32Properties : m_heaps.indexedContiguousProperties;
+        Array::Type arrayType = m_node->arrayMode().type();
+        IndexedAbstractHeap& targetHeap = [&]() -> IndexedAbstractHeap& {
+            switch (arrayType) {
+            case Array::Int32:
+                return m_heaps.indexedInt32Properties;
+            case Array::Double:
+                return m_heaps.indexedDoubleProperties;
+            default:
+                return m_heaps.indexedContiguousProperties;
+            }
+        }();
 
         LBasicBlock commitHeader = m_out.newBlock();
         LBasicBlock commitBody = m_out.newBlock();
@@ -10658,7 +10686,10 @@ IGNORE_CLANG_WARNINGS_END
 
         m_out.appendTo(commitBody, continuation);
         LValue value = m_out.load64(m_out.baseIndex(m_heaps.indexedContiguousProperties, scratch, index, JSValue(), JSCellButterfly::offsetOfData()));
-        m_out.store64(value, m_out.baseIndex(targetHeap, butterfly, index));
+        if (arrayType == Array::Double)
+            m_out.storeDouble(unboxDouble(value), m_out.baseIndex(targetHeap, butterfly, index));
+        else
+            m_out.store64(value, m_out.baseIndex(targetHeap, butterfly, index));
         LValue nextIndex = m_out.add(index, m_out.intPtrOne);
         m_out.addIncomingToPhi(index, m_out.anchor(nextIndex));
         m_out.jump(commitHeader);


### PR DESCRIPTION
#### ffeb1bb68a491465a5b514ef55168a4b6d98f7ce
<pre>
[JSC] Support double arrays in DFG / FTL inline `Array.prototype.sort`
<a href="https://bugs.webkit.org/show_bug.cgi?id=314818">https://bugs.webkit.org/show_bug.cgi?id=314818</a>

Reviewed by NOBODY (OOPS!).

This patch extends the inline Array.prototype.sort fast path added in
<a href="https://commits.webkit.org/312983@main">312983@main</a> to ArrayWithDouble arrays.

The scratch JSCellButterfly always holds boxed EncodedJSValues, so the
insertion sort and comparator call codegen are unchanged. We adapt the
boundary conversions instead:

1. ArraySortCompact loads each raw double from the Double butterfly and
   boxes it into the scratch slot. A NaN read identifies a hole.
2. ArraySortCommit unboxes each scratch slot back to a raw double before
   storing it into the Double butterfly.
3. GetCellButterflySlot&apos;s result type for Array::Double is SpecDoubleReal
   in AbstractInterpreter / PredictionPropagation.
4. Clobberize tracks IndexedDoubleProperties read in Compact and write in
   Commit for Array::Double.

This makes array-prototype-sort-small-array-comparator-double 3.3x
faster.

Tests: JSTests/microbenchmarks/array-prototype-sort-small-array-comparator-double.js
       JSTests/stress/array-sort-inline-double-holey.js
       JSTests/stress/array-sort-inline-double.js

* JSTests/microbenchmarks/array-prototype-sort-small-array-comparator-double.js: Added.
* JSTests/stress/array-sort-inline-double-holey.js: Added.
(cmp):
(sortIt):
(runHoley):
* JSTests/stress/array-sort-inline-double.js: Added.
(sortIt):
(assertSameOrder):
(throw.new.Error):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleArraySort):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileArraySortCompact):
(JSC::FTL::DFG::LowerDFGToB3::compileArraySortCommit):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ffeb1bb68a491465a5b514ef55168a4b6d98f7ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162550 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36026 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29155 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171488 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/118995 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36130 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36030 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126150 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88862 "17 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165509 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28499 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146034 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106728 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27545 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26075 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19188 "Built successfully") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137249 "Found 1 new API test failure: TestWebKitAPI.WKAttachmentTestsIOS.PasteRichTextCopiedFromNotes (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23764 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/173992 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23389 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21305 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25409 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134458 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35700 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30167 "Found 1 new test failure: imported/w3c/web-platform-tests/IndexedDB/interleaved-cursors-small.any.serviceworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134456 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35684 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145560 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98003 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/28996 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22394 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/194951 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35194 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/102945 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50389 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34695 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/34940 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34843 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->