### PR TITLE
Regression(307371@main): SVG overflows edge when offset by fraction

### DIFF
--- a/LayoutTests/svg/in-html/hidpi-legacy-svg-root-fractional-clip-expected.html
+++ b/LayoutTests/svg/in-html/hidpi-legacy-svg-root-fractional-clip-expected.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ deviceScaleFactor=2.0 ] -->
+<style>
+    :root {
+        --margin: .6px;
+    }
+
+    .m4 {
+        --margin: .4px;
+    }
+
+    .case {
+        display: inline-block;
+        height: 110px;
+        width: 110px;
+        position: relative;
+        vertical-align: top;
+        margin: 2px;
+        background-color: hotpink;
+    }
+
+    svg {
+        /* The circles should not be overflowing */
+        overflow: visible;
+        position: absolute;
+    }
+
+    .left {
+        left: 0;
+        margin-left: var(--margin);
+        top: 0;
+    }
+
+    .right {
+        margin-right: var(--margin);
+        right: 0;
+        top: 0;
+    }
+
+    .top {
+        left: 0;
+        margin-top: var(--margin);
+        top: 0;
+    }
+
+    .bottom {
+        bottom: 0;
+        left: 0;
+        margin-bottom: var(--margin);
+    }
+</style>
+<div class="case">
+    <svg class="left" xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">
+        <circle cx="50" cy="50" r="50" fill="black" />
+    </svg>
+</div>
+<div class="case">
+    <svg class="right" xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">
+        <circle cx="50" cy="50" r="50" fill="black" />
+    </svg>
+</div>
+<div class="case">
+    <svg class="top" xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">
+        <circle cx="50" cy="50" r="50" fill="black" />
+    </svg>
+</div>
+<div class="case">
+    <svg class="bottom" xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">
+        <circle cx="50" cy="50" r="50" fill="black" />
+    </svg>
+</div>
+
+<div class="m4">
+    <div class="case">
+        <svg class="left" xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">
+            <circle cx="50" cy="50" r="50" fill="black" />
+        </svg>
+    </div>
+    <div class="case">
+        <svg class="right" xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">
+            <circle cx="50" cy="50" r="50" fill="black" />
+        </svg>
+    </div>
+    <div class="case">
+        <svg class="top" xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">
+            <circle cx="50" cy="50" r="50" fill="black" />
+        </svg>
+    </div>
+    <div class="case">
+        <svg class="bottom" xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">
+            <circle cx="50" cy="50" r="50" fill="black" />
+        </svg>
+    </div>
+</div>

--- a/LayoutTests/svg/in-html/hidpi-legacy-svg-root-fractional-clip.html
+++ b/LayoutTests/svg/in-html/hidpi-legacy-svg-root-fractional-clip.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ deviceScaleFactor=2.0 ] -->
+<style>
+    :root {
+        --margin: .6px;
+    }
+
+    .m4 {
+        --margin: .4px;
+    }
+
+    .case {
+        display: inline-block;
+        height: 110px;
+        width: 110px;
+        position: relative;
+        vertical-align: top;
+        margin: 2px;
+        background-color: hotpink;
+    }
+
+    svg {
+        /* The circles should not be overflowing */
+        overflow: hidden;
+        position: absolute;
+    }
+
+    .left {
+        left: 0;
+        margin-left: var(--margin);
+        top: 0;
+    }
+
+    .right {
+        margin-right: var(--margin);
+        right: 0;
+        top: 0;
+    }
+
+    .top {
+        left: 0;
+        margin-top: var(--margin);
+        top: 0;
+    }
+
+    .bottom {
+        bottom: 0;
+        left: 0;
+        margin-bottom: var(--margin);
+    }
+</style>
+<div class="case">
+    <svg class="left" xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">
+        <circle cx="50" cy="50" r="50" fill="black" />
+    </svg>
+</div>
+<div class="case">
+    <svg class="right" xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">
+        <circle cx="50" cy="50" r="50" fill="black" />
+    </svg>
+</div>
+<div class="case">
+    <svg class="top" xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">
+        <circle cx="50" cy="50" r="50" fill="black" />
+    </svg>
+</div>
+<div class="case">
+    <svg class="bottom" xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">
+        <circle cx="50" cy="50" r="50" fill="black" />
+    </svg>
+</div>
+
+<div class="m4">
+    <div class="case">
+        <svg class="left" xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">
+            <circle cx="50" cy="50" r="50" fill="black" />
+        </svg>
+    </div>
+    <div class="case">
+        <svg class="right" xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">
+            <circle cx="50" cy="50" r="50" fill="black" />
+        </svg>
+    </div>
+    <div class="case">
+        <svg class="top" xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">
+            <circle cx="50" cy="50" r="50" fill="black" />
+        </svg>
+    </div>
+    <div class="case">
+        <svg class="bottom" xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 100 100">
+            <circle cx="50" cy="50" r="50" fill="black" />
+        </svg>
+    </div>
+</div>

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp
@@ -327,10 +327,10 @@ void LegacyRenderSVGRoot::paintReplaced(PaintInfo& paintInfo, const LayoutPoint&
 
     // Apply initial viewport clip
     if (clipViewport) {
-        auto clipRect = snappedIntRect(overflowClipRect(paintOffset));
+        auto clipRect = snapRectToDevicePixels(overflowClipRect(paintOffset), document().deviceScaleFactor());
         childPaintInfo.context().clip(clipRect);
         if (paintInfo.phase == PaintPhase::EventRegion && childPaintInfo.eventRegionContext())
-            childPaintInfo.eventRegionContext()->pushClip(clipRect);
+            childPaintInfo.eventRegionContext()->pushClip(enclosingIntRect(clipRect));
     }
 
     // Convert from container offsets (html renderers) to a relative transform (svg renderers).


### PR DESCRIPTION
#### f77c54c24879e2f2311420175ff5a01d0493ca7e
<pre>
Regression(307371@main): SVG overflows edge when offset by fraction
<a href="https://bugs.webkit.org/show_bug.cgi?id=314825">https://bugs.webkit.org/show_bug.cgi?id=314825</a>

Reviewed by Alan Baradlay.

When a SVG is offset by between 0.25 and 0.75 pixels, there is a
a mismatch between the overflow clip and the paintOffset, leading to slight
clipping around the edge.

Regression from <a href="https://commits.webkit.org/307371@main">https://commits.webkit.org/307371@main</a>, which made
`adjustedPaintOffset` use subpixel snapping, but did not also update
`clipRect` to do the same.

Example: content is calculated to be in [0 + offset, 100 + offset],
For an offset between 0.5 and 0.75, which snaps to 0.5, so the content
is at [0.5, 100.5], the overflow  clip is rounded up to [1, 101],
which clips at the start.

With a offset between 0.25 and 0.5, the content still clips to [0.5, 100.5]
but the clip is rounded down to [0, 100], clipping the end.

This fix is to make `clipRect` snap to device pixels, such that the
overflow clip in both cases ends up as the expected [0.5, 100.5],
and the circle does not overflow.

Test by asserting that `overflow: hidden` has no effect, as the SVGs
should not be overflowing.

GPT 5.5 was used both in generating the test-cases and bug fix.

Test: svg/in-html/hidpi-legacy-svg-root-fractional-clip.html

* LayoutTests/svg/in-html/hidpi-legacy-svg-root-fractional-clip-expected.html: Added.
* LayoutTests/svg/in-html/hidpi-legacy-svg-root-fractional-clip.html: Added.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGRoot.cpp:
(WebCore::LegacyRenderSVGRoot::paintReplaced):

Canonical link: <a href="https://commits.webkit.org/313886@main">https://commits.webkit.org/313886@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/189922ca9650a7c2c2cf220c3d79222a83c373bd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164428 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37912 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31483 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173457 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121680 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166297 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38246 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37914 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127758 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89932 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167387 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30057 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Running apply-patch; Checked out pull request; Passed layout tests; Ignored 4 pre-existing failure based on results-db; Uploaded test results") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147793 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108303 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29104 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27731 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21221 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139006 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25509 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175983 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28806 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27177 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136071 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/37904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31851 "Found 1 new test failure: http/tests/storage/storage-map-leaking.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136039 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/38615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147304 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/100799 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25032 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/38615 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24160 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37179 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110223 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36576 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2218 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36825 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36725 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->