### PR TITLE
Correct some outdated SPI header declarations

### DIFF
--- a/Source/WebCore/PAL/pal/spi/cf/CFNetworkSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cf/CFNetworkSPI.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2014-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2014-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -581,9 +581,11 @@ WTF_EXTERN_C_END
 - (void)_setExplicitCookieStorage:(CFHTTPCookieStorageRef)storage;
 @end
 
+#if !__has_include(<CFNetwork/CFNSURLConnection.h>)
 @interface NSURLSessionWebSocketTask (SPI)
-- (void)_sendCloseCode:(NSURLSessionWebSocketCloseCode)closeCode reason:(NSData *)reason;
+- (void)_sendCloseCode:(NSURLSessionWebSocketCloseCode)closeCode reason:(NSData * _Nullable)reason;
 @end
+#endif
 
 @interface NSMutableURLRequest (Staging_88972294)
 @property (setter=_setPrivacyProxyFailClosedForUnreachableNonMainHosts:) BOOL _privacyProxyFailClosedForUnreachableNonMainHosts;
@@ -611,7 +613,7 @@ WTF_EXTERN_C_END
 #endif
 
 @interface NSURLProtectionSpace (SPI)
-- (void)_setServerTrust:(SecTrustRef)serverTrust;
+- (void)_setServerTrust:(SecTrustRef _Nullable)serverTrust;
 @end
 
 #endif // defined(__OBJC__)

--- a/Source/WebCore/PAL/pal/spi/cocoa/NetworkSPI.h
+++ b/Source/WebCore/PAL/pal/spi/cocoa/NetworkSPI.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2021-2025 Apple Inc. All rights reserved.
+ * Copyright (C) 2021-2026 Apple Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
@@ -37,15 +37,6 @@ typedef void (^nw_webtransport_receive_error_handler_t)(uint64_t receive_error_c
 typedef void (^nw_webtransport_send_error_handler_t)(uint64_t send_error_code);
 typedef void (^nw_http_optional_string_accessor_t)(const char * _Nullable string);
 
-#if OS_OBJECT_USE_OBJC
-NW_OBJECT_DECL(nw_http_fields);
-NW_OBJECT_DECL_SUBCLASS(nw_http_response, nw_http_fields);
-#else
-struct nw_http_fields;
-typedef struct nw_http_fields *nw_http_fields_t;
-typedef nw_http_fields_t nw_http_response_t;
-#endif // OS_OBJECT_USE_OBJC
-
 #if USE(APPLE_INTERNAL_SDK)
 
 #import <nw/private.h>
@@ -63,6 +54,17 @@ typedef nw_http_fields_t nw_http_response_t;
 // Only needed for running tests.
 #import <NetworkExtension/NEPolicySession.h>
 #endif
+
+#else // !USE(APPLE_INTERNAL_SDK)
+
+#if OS_OBJECT_USE_OBJC
+NW_OBJECT_DECL(nw_http_fields);
+NW_OBJECT_DECL_SUBCLASS(nw_http_response, nw_http_fields);
+#else
+struct nw_http_fields;
+typedef struct nw_http_fields *nw_http_fields_t;
+typedef nw_http_fields_t nw_http_response_t;
+#endif // OS_OBJECT_USE_OBJC
 
 #endif // USE(APPLE_INTERNAL_SDK)
 


### PR DESCRIPTION
#### 13a37239ea7b2b670bca296d44029c3977003ba2
<pre>
Correct some outdated SPI header declarations
<a href="https://bugs.webkit.org/show_bug.cgi?id=314828">https://bugs.webkit.org/show_bug.cgi?id=314828</a>
<a href="https://rdar.apple.com/177084325">rdar://177084325</a>

Reviewed by Elliott Williams and Dan Glastonbury.

This change corrects some forward declarations to avoid duplicates when building with
the Internal SDK. It also corrects nullability declarations (or adds _Null_unspecified)
to reduce warning output in our build logs.

* Source/WebCore/PAL/pal/spi/cf/CFNetworkSPI.h:
* Source/WebCore/PAL/pal/spi/cocoa/NetworkSPI.h:

Canonical link: <a href="https://commits.webkit.org/313343@main">https://commits.webkit.org/313343@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba55812fc0c3d1642d283df18b01e83048096b95

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162826 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36303 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29460 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171764 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/119272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1a00ef4e-abd8-42b9-b48e-bd93ac3caf05) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164695 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36407 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36306 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126391 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/119272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/37ffe2d8-ae1b-4f1e-ac38-0285963304a7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165785 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28740 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146312 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106968 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/976777d0-0efb-44f1-9b30-32c51b3dc7ef) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26317 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19464 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137495 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24041 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174268 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21791 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25686 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134698 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35976 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30420 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134693 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36338 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35961 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145837 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98381 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/29230 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22673 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35470 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/103510 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34971 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35216 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35119 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->