### PR TITLE
[JSC] Cache result of Symbol.prototype.toString

### DIFF
--- a/JSTests/stress/symbol-prototype-to-string-intrinsic.js
+++ b/JSTests/stress/symbol-prototype-to-string-intrinsic.js
@@ -1,0 +1,160 @@
+function shouldBe(actual, expected)
+{
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' (expected: ' + expected + ')');
+}
+
+function shouldThrow(func, errorType)
+{
+    let threw = false;
+    try {
+        func();
+    } catch (e) {
+        threw = true;
+        if (!(e instanceof errorType))
+            throw new Error('unexpected error: ' + e);
+    }
+    if (!threw)
+        throw new Error('did not throw');
+}
+
+// 1. SymbolUse fast path: repeated .toString() on a Symbol with a description.
+(function () {
+    function test(sym) {
+        return sym.toString();
+    }
+    noInline(test);
+
+    const sym = Symbol("cocoa");
+    for (let i = 0; i < testLoopCount; ++i)
+        shouldBe(test(sym), "Symbol(cocoa)");
+}());
+
+// 2. SymbolUse fast path: Symbol with no description must stringify as "Symbol()".
+(function () {
+    function test(sym) {
+        return sym.toString();
+    }
+    noInline(test);
+
+    const sym = Symbol();
+    for (let i = 0; i < testLoopCount; ++i)
+        shouldBe(test(sym), "Symbol()");
+}());
+
+// 3. Well-known symbols should tier up and return "Symbol(Symbol.iterator)" etc.
+(function () {
+    function test(sym) {
+        return sym.toString();
+    }
+    noInline(test);
+
+    for (let i = 0; i < testLoopCount; ++i) {
+        shouldBe(test(Symbol.iterator), "Symbol(Symbol.iterator)");
+        shouldBe(test(Symbol.asyncIterator), "Symbol(Symbol.asyncIterator)");
+        shouldBe(test(Symbol.hasInstance), "Symbol(Symbol.hasInstance)");
+    }
+}());
+
+// 4. Cached result must be stable across many invocations (same observable value).
+(function () {
+    function test(sym) {
+        return sym.toString();
+    }
+    noInline(test);
+
+    const sym = Symbol("stable");
+    const first = test(sym);
+    for (let i = 0; i < testLoopCount; ++i)
+        shouldBe(test(sym), first);
+}());
+
+// 5. String(symbol) goes through stringConstructor's symbol fast path and should
+//    match Symbol.prototype.toString.call(symbol).
+(function () {
+    function viaString(sym) {
+        return String(sym);
+    }
+    function viaToString(sym) {
+        return sym.toString();
+    }
+    noInline(viaString);
+    noInline(viaToString);
+
+    const sym = Symbol("matcha");
+    for (let i = 0; i < testLoopCount; ++i) {
+        shouldBe(viaString(sym), "Symbol(matcha)");
+        shouldBe(viaString(sym), viaToString(sym));
+    }
+}());
+
+// 6. Symbol.prototype.description must return undefined (not null) for a
+//    descriptionless Symbol, per ECMA-262 20.4.3.2.
+(function () {
+    function desc(sym) {
+        return sym.description;
+    }
+    noInline(desc);
+
+    const withDesc = Symbol("rize");
+    const withoutDesc = Symbol();
+    for (let i = 0; i < testLoopCount; ++i) {
+        shouldBe(desc(withDesc), "rize");
+        shouldBe(desc(withoutDesc), undefined);
+    }
+}());
+
+// 7. Symbol.prototype.toString.call on a non-Symbol must throw TypeError.
+//    Exercises the generic (non-intrinsified) path and its OSR behavior.
+(function () {
+    const toString = Symbol.prototype.toString;
+    function test(receiver) {
+        return toString.call(receiver);
+    }
+    noInline(test);
+
+    for (let i = 0; i < testLoopCount; ++i) {
+        shouldThrow(() => test({}), TypeError);
+        shouldThrow(() => test("not a symbol"), TypeError);
+        shouldThrow(() => test(42), TypeError);
+        shouldThrow(() => test(undefined), TypeError);
+    }
+}());
+
+// 8. Symbol created from a non-string description (coerced via toString) should
+//    preserve the coerced description across repeated toString() calls.
+(function () {
+    function test(sym) {
+        return sym.toString();
+    }
+    noInline(test);
+
+    const descriptor = { toString() { return "coerced"; } };
+    const sym = Symbol(descriptor);
+    for (let i = 0; i < testLoopCount; ++i)
+        shouldBe(test(sym), "Symbol(coerced)");
+}());
+
+// 9. OSR-exit path: feed a non-Symbol to a function that has tiered up on
+//    Symbols. The SymbolUse speculation must fail cleanly and the call must
+//    fall back to the generic toString (which throws TypeError for non-Symbol
+//    receivers when invoked via Symbol.prototype.toString.call).
+(function () {
+    const toString = Symbol.prototype.toString;
+    function test(receiver) {
+        return toString.call(receiver);
+    }
+    noInline(test);
+
+    const sym = Symbol("kilimanjaro");
+    // Warm up on Symbol to encourage speculation.
+    for (let i = 0; i < testLoopCount; ++i)
+        shouldBe(test(sym), "Symbol(kilimanjaro)");
+
+    // Now hit the non-Symbol path.
+    shouldThrow(() => test({}), TypeError);
+
+    // And make sure the Symbol path still works after OSR exit.
+    for (let i = 0; i < testLoopCount; ++i)
+        shouldBe(test(sym), "Symbol(kilimanjaro)");
+}());

--- a/Source/JavaScriptCore/b3/B3AbstractHeapRepository.h
+++ b/Source/JavaScriptCore/b3/B3AbstractHeapRepository.h
@@ -209,7 +209,9 @@ namespace JSC::B3 {
     macro(WebAssemblyFunctionBase_targetInstance, WebAssemblyFunctionBase::offsetOfTargetInstance(), Mutability::Immutable) \
     macro(WebAssemblyGCStructure_rtt, WebAssemblyGCStructure::offsetOfRTT(), Mutability::Immutable) \
     macro(WebAssemblyModuleRecord_exportsObject, WebAssemblyModuleRecord::offsetOfExportsObject(), Mutability::Mutable) \
+    macro(Symbol_description, Symbol::offsetOfDescription(), Mutability::Mutable) \
     macro(Symbol_symbolImpl, Symbol::offsetOfSymbolImpl(), Mutability::Immutable) \
+    macro(Symbol_string, Symbol::offsetOfString(), Mutability::Mutable) \
 
 #define FOR_EACH_INDEXED_ABSTRACT_HEAP(macro) \
     macro(ArrayStorage_vector, ArrayStorage::vectorOffset(), sizeof(WriteBarrier<Unknown>)) \

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -4129,6 +4129,11 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         break;
     }
 
+    case SymbolToString: {
+        setTypeForNode(node, SpecStringResolved);
+        break;
+    }
+
     case ToObject:
     case CallObjectConstructor: {
         AbstractValue& source = forNode(node->child1());

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -3683,7 +3683,20 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             setResult(resultNode);
             return CallOptimizationResult::Inlined;
         }
-            
+
+        case SymbolPrototypeToStringIntrinsic: {
+            if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadType))
+                return CallOptimizationResult::DidNothing;
+            if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadConstantValue))
+                return CallOptimizationResult::DidNothing;
+            if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadCache))
+                return CallOptimizationResult::DidNothing;
+
+            insertChecks();
+            setResult(addToGraph(SymbolToString, Edge(get(virtualRegisterForArgumentIncludingThis(0, registerOffset)), SymbolUse)));
+            return CallOptimizationResult::Inlined;
+        }
+
         case RoundIntrinsic:
         case FloorIntrinsic:
         case CeilIntrinsic:

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -271,6 +271,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
     case GetExecutable:
     case BottomValue:
     case TypeOf:
+    case SymbolToString:
         def(PureValue(node));
         return;
 

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -409,6 +409,7 @@ bool doesGC(Graph& graph, Node* node)
     case ObjectGetOwnPropertyNames:
     case ObjectGetOwnPropertySymbols:
     case ObjectToString:
+    case SymbolToString:
     case ReflectOwnKeys:
     case AllocatePropertyStorage:
     case ReallocatePropertyStorage:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -2494,6 +2494,11 @@ private:
             break;
         }
 
+        case SymbolToString: {
+            fixEdge<SymbolUse>(node->child1());
+            break;
+        }
+
         case CheckIdent: {
             if (node->uidOperand()->isSymbol())
                 fixEdge<SymbolUse>(node->child1());

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -327,6 +327,7 @@ namespace JSC { namespace DFG {
     macro(ObjectGetOwnPropertySymbols, NodeMustGenerate | NodeResultJS) \
     macro(ObjectToString, NodeMustGenerate | NodeResultJS) \
     macro(ReflectOwnKeys, NodeMustGenerate | NodeResultJS) \
+    macro(SymbolToString, NodeResultJS) \
     \
     /* Atomics object functions. */\
     macro(AtomicsAdd, NodeResultJS | NodeMustGenerate | NodeHasVarArgs) \

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -4202,11 +4202,9 @@ JSC_DEFINE_JIT_OPERATION(operationNewSymbolWithStringDescription, Symbol*, (JSGl
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
-
-    auto string = description->value(globalObject);
+    auto value = description->value(globalObject);
     OPERATION_RETURN_IF_EXCEPTION(scope, nullptr);
-
-    OPERATION_RETURN(scope, Symbol::createWithDescription(vm, WTF::move(string)));
+    OPERATION_RETURN(scope, Symbol::createWithDescription(vm, value, description));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationNewSymbolWithDescription, Symbol*, (JSGlobalObject* globalObject, EncodedJSValue encodedDescription))
@@ -4220,10 +4218,22 @@ JSC_DEFINE_JIT_OPERATION(operationNewSymbolWithDescription, Symbol*, (JSGlobalOb
     if (description.isUndefined())
         OPERATION_RETURN(scope, Symbol::create(vm));
 
-    String string = description.toWTFString(globalObject);
+    auto* string = description.toString(globalObject);
     OPERATION_RETURN_IF_EXCEPTION(scope, nullptr);
 
-    OPERATION_RETURN(scope, Symbol::createWithDescription(vm, string));
+    auto value = string->value(globalObject);
+    OPERATION_RETURN_IF_EXCEPTION(scope, nullptr);
+
+    OPERATION_RETURN(scope, Symbol::createWithDescription(vm, value, string));
+}
+
+JSC_DEFINE_JIT_OPERATION(operationSymbolToString, JSString*, (JSGlobalObject* globalObject, Symbol* symbol))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    OPERATION_RETURN(scope, symbol->toString(globalObject));
 }
 
 JSC_DEFINE_JIT_OPERATION(operationNewStringObject, JSCell*, (VM* vmPointer, JSString* string, Structure* structure))

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -374,6 +374,7 @@ JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationPerformPromiseThenOneHandler, void, 
 JSC_DECLARE_JIT_OPERATION(operationNewSymbol, Symbol*, (VM*));
 JSC_DECLARE_JIT_OPERATION(operationNewSymbolWithStringDescription, Symbol*, (JSGlobalObject*, JSString*));
 JSC_DECLARE_JIT_OPERATION(operationNewSymbolWithDescription, Symbol*, (JSGlobalObject*, EncodedJSValue));
+JSC_DECLARE_JIT_OPERATION(operationSymbolToString, JSString*, (JSGlobalObject*, Symbol*));
 JSC_DECLARE_JIT_OPERATION(operationNewStringObject, JSCell*, (VM*, JSString*, Structure*));
 JSC_DECLARE_JIT_OPERATION(operationToStringOnCell, JSString*, (JSGlobalObject*, JSCell*));
 JSC_DECLARE_JIT_OPERATION(operationToString, JSString*, (JSGlobalObject*, EncodedJSValue));

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1413,6 +1413,10 @@ private:
             setPrediction(SpecString);
             break;
 
+        case SymbolToString:
+            setPrediction(SpecStringResolved);
+            break;
+
         case Spread:
             setPrediction(SpecCellOther);
             break;

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -582,6 +582,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case ObjectGetOwnPropertyNames:
     case ObjectGetOwnPropertySymbols:
     case ObjectToString:
+    case SymbolToString:
     case ReflectOwnKeys:
     case SetLocal:
     case SetCallee:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -15993,6 +15993,25 @@ void SpeculativeJIT::compileObjectToString(Node* node)
     }
 }
 
+void SpeculativeJIT::compileSymbolToString(Node* node)
+{
+    SpeculateCellOperand argument(this, node->child1());
+    GPRTemporary result(this);
+
+    GPRReg argumentGPR = argument.gpr();
+    GPRReg resultGPR = result.gpr();
+
+    speculateSymbol(node->child1(), argumentGPR);
+
+    JumpList slowCases;
+    loadPtr(Address(argumentGPR, Symbol::offsetOfString()), resultGPR);
+    slowCases.append(branchTestPtr(Zero, resultGPR));
+
+    addSlowPathGenerator(slowPathCall(slowCases, this, operationSymbolToString, resultGPR, LinkableConstant::globalObject(*this, node), argumentGPR));
+
+    cellResult(resultGPR, node);
+}
+
 void SpeculativeJIT::compileCreateThis(Node* node)
 {
     // Note that there is not so much profit to speculate here. The only things we

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1779,6 +1779,7 @@ public:
     void compileObjectAssign(Node*);
     void compileObjectCreate(Node*);
     void compileObjectToString(Node*);
+    void compileSymbolToString(Node*);
     void compileCreateThis(Node*);
     void compileCreatePromise(Node*);
     void compileCreateGenerator(Node*);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -3313,6 +3313,11 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case SymbolToString: {
+        compileSymbolToString(node);
+        break;
+    }
+
     case CreateThis: {
         compileCreateThis(node);
         break;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -4685,6 +4685,11 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case SymbolToString: {
+        compileSymbolToString(node);
+        break;
+    }
+
     case CreateThis: {
         compileCreateThis(node);
         break;

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -250,6 +250,7 @@ inline CapabilityLevel canCompile(Node* node)
     case ObjectGetOwnPropertyNames:
     case ObjectGetOwnPropertySymbols:
     case ObjectToString:
+    case SymbolToString:
     case ReflectOwnKeys:
     case MakeRope:
     case MakeAtomString:

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -1239,6 +1239,9 @@ private:
         case ObjectToString:
             compileObjectToString();
             break;
+        case SymbolToString:
+            compileSymbolToString();
+            break;
         case NewObject:
             compileNewObject();
             break;
@@ -9512,6 +9515,27 @@ IGNORE_CLANG_WARNINGS_END
             RELEASE_ASSERT_NOT_REACHED();
             break;
         }
+    }
+
+    void compileSymbolToString()
+    {
+        JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
+
+        LBasicBlock slowCase = m_out.newBlock();
+        LBasicBlock continuation = m_out.newBlock();
+
+        auto symbol = lowSymbol(m_node->child1());
+        auto cached = m_out.loadPtr(symbol, m_heaps.Symbol_string);
+        ValueFromBlock fastResult = m_out.anchor(cached);
+        m_out.branch(m_out.notNull(cached), usually(continuation), rarely(slowCase));
+
+        LBasicBlock lastNext = m_out.appendTo(slowCase, continuation);
+        auto slowResultValue = vmCall(pointerType(), operationSymbolToString, weakPointer(globalObject), symbol);
+        ValueFromBlock slowResult = m_out.anchor(slowResultValue);
+        m_out.jump(continuation);
+
+        m_out.appendTo(continuation, lastNext);
+        setJSValue(m_out.phi(pointerType(), fastResult, slowResult));
     }
 
     void compileObjectAssign()

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -137,6 +137,7 @@ namespace JSC {
     macro(StringPrototypeSubstringIntrinsic) \
     macro(StringPrototypeToLowerCaseIntrinsic) \
     macro(StringPrototypeToUpperCaseIntrinsic) \
+    macro(SymbolPrototypeToStringIntrinsic) \
     macro(NumberPrototypeToStringIntrinsic) \
     macro(NumberIsFiniteIntrinsic) \
     macro(NumberIsNaNIntrinsic) \

--- a/Source/JavaScriptCore/runtime/StringConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/StringConstructor.cpp
@@ -163,19 +163,9 @@ JSC_DEFINE_HOST_FUNCTION(constructWithStringConstructor, (JSGlobalObject* global
 
 JSString* stringConstructor(JSGlobalObject* globalObject, JSValue argument)
 {
-    VM& vm = globalObject->vm();
-    auto scope = DECLARE_THROW_SCOPE(vm);
-
-    if (argument.isSymbol()) {
-        auto description = asSymbol(argument)->tryGetDescriptiveString();
-        if (!description) [[unlikely]] {
-            ASSERT(description.error() == ErrorTypeWithExtension::OutOfMemoryError);
-            throwOutOfMemoryError(globalObject, scope);
-            return nullptr;
-        }
-        return jsNontrivialString(vm, description.value());
-    }
-    RELEASE_AND_RETURN(scope, argument.toString(globalObject));
+    if (argument.isSymbol())
+        return asSymbol(argument)->toString(globalObject);
+    return argument.toString(globalObject);
 }
 
 JSC_DEFINE_HOST_FUNCTION(callStringConstructor, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/JavaScriptCore/runtime/Symbol.cpp
+++ b/Source/JavaScriptCore/runtime/Symbol.cpp
@@ -53,6 +53,13 @@ Symbol::Symbol(VM& vm, SymbolImpl& uid)
 {
 }
 
+Symbol::Symbol(VM& vm, const String& string, JSString* description)
+    : Base(vm, vm.symbolStructure.get())
+    , m_privateName(PrivateName::Description, string)
+    , m_description(description, WriteBarrierEarlyInit)
+{
+}
+
 void Symbol::finishCreation(VM& vm)
 {
     Base::finishCreation(vm);
@@ -79,10 +86,39 @@ double Symbol::toNumber(JSGlobalObject* globalObject) const
     return 0.0;
 }
 
+JSString* Symbol::toString(JSGlobalObject* globalObject)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    if (auto* string = m_string.get())
+        return string;
+
+    auto description = tryGetDescriptiveString();
+    if (!description) [[unlikely]] {
+        throwOutOfMemoryError(globalObject, scope);
+        return nullptr;
+    }
+    auto* string = jsNontrivialString(vm, description.value());
+    m_string.set(vm, this, string);
+    ASSERT(!string->isRope());
+    return string;
+}
+
 void Symbol::destroy(JSCell* cell)
 {
     static_cast<Symbol*>(cell)->Symbol::~Symbol();
 }
+
+template<typename Visitor>
+void Symbol::visitChildrenImpl(JSCell* cell, Visitor& visitor)
+{
+    auto* thisCell = uncheckedDowncast<Symbol>(cell);
+    ASSERT_GC_OBJECT_INHERITS(thisCell, info());
+    Base::visitChildren(thisCell, visitor);
+    visitor.append(thisCell->m_description);
+    visitor.append(thisCell->m_string);
+}
+DEFINE_VISIT_CHILDREN(Symbol);
 
 Expected<String, ErrorTypeWithExtension> Symbol::tryGetDescriptiveString() const
 {
@@ -92,10 +128,18 @@ Expected<String, ErrorTypeWithExtension> Symbol::tryGetDescriptiveString() const
     return description;
 }
 
-String Symbol::description() const
+JSString* Symbol::description(VM& vm)
 {
+    if (auto* string = m_description.get())
+        return string;
+
     auto& uid = m_privateName.uid();
-    return uid.isNullSymbol() ? String() : uid;
+    if (uid.isNullSymbol())
+        return nullptr;
+
+    auto* string = jsString(vm, String(uid));
+    m_description.set(vm, this, string);
+    return string;
 }
 
 Symbol* Symbol::create(VM& vm)
@@ -108,6 +152,13 @@ Symbol* Symbol::create(VM& vm)
 Symbol* Symbol::createWithDescription(VM& vm, const String& description)
 {
     Symbol* symbol = new (NotNull, allocateCell<Symbol>(vm)) Symbol(vm, description);
+    symbol->finishCreation(vm);
+    return symbol;
+}
+
+Symbol* Symbol::createWithDescription(VM& vm, const String& description, JSString* string)
+{
+    Symbol* symbol = new (NotNull, allocateCell<Symbol>(vm)) Symbol(vm, description, string);
     symbol->finishCreation(vm);
     return symbol;
 }

--- a/Source/JavaScriptCore/runtime/Symbol.h
+++ b/Source/JavaScriptCore/runtime/Symbol.h
@@ -53,33 +53,42 @@ public:
 
     static Symbol* create(VM&);
     static Symbol* createWithDescription(VM&, const String&);
+    static Symbol* createWithDescription(VM&, const String&, JSString*);
     JS_EXPORT_PRIVATE static Symbol* create(VM&, SymbolImpl& uid);
 
     SymbolImpl& uid() const { return m_privateName.uid(); }
     PrivateName privateName() const { return m_privateName; }
-    String NODELETE description() const;
-    Expected<String, ErrorTypeWithExtension> tryGetDescriptiveString() const;
+    JSString* description(VM&);
 
     JSValue NODELETE toPrimitive(JSGlobalObject*, PreferredPrimitiveType) const;
     JSObject* toObject(JSGlobalObject*) const;
     double toNumber(JSGlobalObject*) const;
+    JSString* toString(JSGlobalObject*);
 
     static constexpr ptrdiff_t offsetOfSymbolImpl()
     {
         // PrivateName is just a Ref<SymbolImpl> which can just be used as a SymbolImpl*.
         return OBJECT_OFFSETOF(Symbol, m_privateName);
     }
+    static constexpr ptrdiff_t offsetOfString() { return OBJECT_OFFSETOF(Symbol, m_string); }
+    static constexpr ptrdiff_t offsetOfDescription() { return OBJECT_OFFSETOF(Symbol, m_description); }
+
+    DECLARE_VISIT_CHILDREN;
+
+    Expected<String, ErrorTypeWithExtension> tryGetDescriptiveString() const;
 
 private:
-    static void destroy(JSCell*);
-
     Symbol(VM&);
     Symbol(VM&, const String&);
+    Symbol(VM&, const String&, JSString*);
     Symbol(VM&, SymbolImpl& uid);
 
+    static void destroy(JSCell*);
     void finishCreation(VM&);
 
     PrivateName m_privateName;
+    WriteBarrier<JSString> m_description;
+    WriteBarrier<JSString> m_string;
 };
 
 Symbol* asSymbol(JSValue);

--- a/Source/JavaScriptCore/runtime/SymbolConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/SymbolConstructor.cpp
@@ -86,9 +86,13 @@ JSC_DEFINE_HOST_FUNCTION(callSymbol, (JSGlobalObject* globalObject, CallFrame* c
     if (description.isUndefined())
         return JSValue::encode(Symbol::create(vm));
 
-    String string = description.toWTFString(globalObject);
+    auto* string = description.toString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
-    return JSValue::encode(Symbol::createWithDescription(vm, string));
+
+    auto value = string->value(globalObject);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    return JSValue::encode(Symbol::createWithDescription(vm, value, string));
 }
 
 JSC_DEFINE_HOST_FUNCTION(constructSymbol, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/JavaScriptCore/runtime/SymbolPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/SymbolPrototype.cpp
@@ -48,7 +48,7 @@ const ClassInfo SymbolPrototype::s_info = { "Symbol"_s, &Base::s_info, &symbolPr
 /* Source for SymbolPrototype.lut.h
 @begin symbolPrototypeTable
   description       symbolProtoGetterDescription    DontEnum|ReadOnly|CustomAccessor
-  toString          symbolProtoFuncToString         DontEnum|Function 0
+  toString          symbolProtoFuncToString         DontEnum|Function 0 SymbolPrototypeToStringIntrinsic
   valueOf           symbolProtoFuncValueOf          DontEnum|Function 0
 @end
 */
@@ -98,8 +98,9 @@ JSC_DEFINE_CUSTOM_GETTER(symbolProtoGetterDescription, (JSGlobalObject* globalOb
         return throwVMTypeError(globalObject, scope, SymbolDescriptionTypeError);
     scope.release();
     Integrity::auditStructureID(symbol->structureID());
-    auto description = symbol->description();
-    return JSValue::encode(description.isNull() ? jsUndefined() : jsString(vm, WTF::move(description)));
+    if (auto* string = symbol->description(vm))
+        return JSValue::encode(string);
+    return JSValue::encode(jsUndefined());
 }
 
 JSC_DEFINE_HOST_FUNCTION(symbolProtoFuncToString, (JSGlobalObject* globalObject, CallFrame* callFrame))
@@ -111,13 +112,7 @@ JSC_DEFINE_HOST_FUNCTION(symbolProtoFuncToString, (JSGlobalObject* globalObject,
     if (!symbol)
         return throwVMTypeError(globalObject, scope, SymbolToStringTypeError);
     Integrity::auditStructureID(symbol->structureID());
-    auto description = symbol->tryGetDescriptiveString();
-    if (!description) [[unlikely]] {
-        ASSERT(description.error() == ErrorTypeWithExtension::OutOfMemoryError);
-        throwOutOfMemoryError(globalObject, scope);
-        return { };
-    }
-    RELEASE_AND_RETURN(scope, JSValue::encode(jsNontrivialString(vm, description.value())));
+    RELEASE_AND_RETURN(scope, JSValue::encode(symbol->toString(globalObject)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(symbolProtoFuncValueOf, (JSGlobalObject* globalObject, CallFrame* callFrame))


### PR DESCRIPTION
#### 5e57a5812ef4218e611a1f7601bf20544267394c
<pre>
[JSC] Cache result of Symbol.prototype.toString
<a href="https://bugs.webkit.org/show_bug.cgi?id=314842">https://bugs.webkit.org/show_bug.cgi?id=314842</a>
<a href="https://rdar.apple.com/177099930">rdar://177099930</a>

Reviewed by Yijia Huang.

We found that this is relatively frequently called and we are generating
JSString each time. This patch adds some fields to cache the idempotent
string results from Symbol. As we already hash-consing Symbols, this
cache works well for the same Symbol globally.

We also added SymbolToString DFG node to handle this efficiently, and
the fast path is just loading a value from the cached field of Symbol.

Test: JSTests/stress/symbol-prototype-to-string-intrinsic.js

* JSTests/stress/symbol-prototype-to-string-intrinsic.js: Added.
(shouldBe):
(shouldThrow):
(test):
(viaString):
(viaToString):
(desc):
(const.descriptor.toString):
* Source/JavaScriptCore/b3/B3AbstractHeapRepository.h:
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileSymbolToString):
* Source/JavaScriptCore/runtime/Intrinsic.h:
* Source/JavaScriptCore/runtime/StringConstructor.cpp:
(JSC::stringConstructor):
* Source/JavaScriptCore/runtime/Symbol.cpp:
(JSC::Symbol::Symbol):
(JSC::Symbol::toString):
(JSC::Symbol::visitChildrenImpl):
(JSC::Symbol::description):
(JSC::Symbol::createWithDescription):
(JSC::Symbol::description const): Deleted.
* Source/JavaScriptCore/runtime/Symbol.h:
* Source/JavaScriptCore/runtime/SymbolConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/SymbolPrototype.cpp:
(JSC::JSC_DEFINE_CUSTOM_GETTER):
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/313284@main">https://commits.webkit.org/313284@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/da00e923b21381c5e967016ce6667e80b73bdeae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162644 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36120 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29260 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171582 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/119090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7e8ef261-f904-4dc2-a63c-a10b5797203f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36224 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36124 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126231 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/119090 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5790d73a-fa9f-42e4-9f70-78a03f5c47f3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165603 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28587 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146134 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106809 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/13e42749-d480-4fc6-976b-db8224adf8c2) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19282 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137339 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23864 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174086 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23483 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21399 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25509 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134540 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35794 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134536 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35778 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145660 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98130 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24725 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/29077 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22494 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195045 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35288 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/103039 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/50442 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34789 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35034 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34937 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->