### PR TITLE
Introduce FontSettings and MDC-specific equality path for future cross-document style reuse

### DIFF
--- a/Source/WebCore/css/CSSFontSelector.cpp
+++ b/Source/WebCore/css/CSSFontSelector.cpp
@@ -60,6 +60,20 @@ namespace WebCore {
 
 using namespace WebKitFontFamilyNames;
 
+FontSettings::FontSettings(const SettingsValues& settings)
+    : fontGenericFamilies(settings.fontGenericFamilies)
+    , fontFallbackPrefersPictographs(settings.fontFallbackPrefersPictographs)
+    , webAPIStatisticsEnabled(settings.webAPIStatisticsEnabled)
+{
+}
+
+bool FontSettings::operator==(const FontSettings& other) const
+{
+    return fontFallbackPrefersPictographs == other.fontFallbackPrefersPictographs
+        && webAPIStatisticsEnabled == other.webAPIStatisticsEnabled
+        && fontGenericFamilies == other.fontGenericFamilies;
+}
+
 static unsigned fontSelectorId;
 
 Ref<CSSFontSelector> CSSFontSelector::create(ScriptExecutionContext& context)
@@ -79,6 +93,7 @@ CSSFontSelector::CSSFontSelector(ScriptExecutionContext& context)
     }))
     , m_uniqueId(++fontSelectorId)
     , m_version(0)
+    , m_fontSettings(context.settingsValues())
 {
     if (is<Document>(context)) {
         m_fontFamilyNames.reserveInitialCapacity(familyNames->size());
@@ -331,6 +346,14 @@ void CSSFontSelector::fontCacheInvalidated()
     dispatchInvalidationCallbacks();
 }
 
+void CSSFontSelector::refreshFontSettings()
+{
+    RefPtr context = m_context.get();
+    if (!context)
+        return;
+    m_fontSettings = FontSettings(context->settingsValues());
+}
+
 std::optional<AtomString> CSSFontSelector::resolveGenericFamily(const FontDescription& fontDescription, const AtomString& familyName)
 {
     auto platformResult = FontDescription::platformResolveGenericFamily(fontDescription.script(), fontDescription.computedLocale(), familyName);
@@ -340,12 +363,10 @@ std::optional<AtomString> CSSFontSelector::resolveGenericFamily(const FontDescri
     if (!m_context)
         return std::nullopt;
 
-    const auto& settings = protect(scriptExecutionContext())->settingsValues();
-
     UScriptCode script = fontDescription.script();
     auto familyNameIndex = m_fontFamilyNames.find(familyName);
     if (familyNameIndex != notFound) {
-        if (auto familyString = settings.fontGenericFamilies.fontFamily(static_cast<FamilyNamesIndex>(familyNameIndex), script))
+        if (auto familyString = m_fontSettings.fontGenericFamilies.fontFamily(static_cast<FamilyNamesIndex>(familyNameIndex), script))
             return AtomString(*familyString);
     }
 
@@ -456,8 +477,7 @@ FontRanges CSSFontSelector::fontRangesForFamily(const FontDescription& fontDescr
     // Handle the generic math font family a bit differently.
     if (fontFamily.isGeneric() && familyName == m_fontFamilyNames.at(FamilyNamesIndex::MathFamily)) {
         // First check if the user has defined a preference.
-        const auto& settings = protect(scriptExecutionContext())->settingsValues();
-        const String& preferredMathFamily = settings.fontGenericFamilies.mathFontFamily(fontDescription.script());
+        const String& preferredMathFamily = m_fontSettings.fontGenericFamilies.mathFontFamily(fontDescription.script());
         if (!preferredMathFamily.isEmpty() && familyName != preferredMathFamily) {
             auto ranges = fontRangesForFamily(fontDescription, FontFamily { AtomString(preferredMathFamily), FontFamilyKind::Specified });
             if (!ranges.isNull())
@@ -476,7 +496,7 @@ FontRanges CSSFontSelector::fontRangesForFamily(const FontDescription& fontDescr
         resolveAndAssignGenericFamily();
     RefPtr document = dynamicDowncast<Document>(m_context.get());
     if (RefPtr face = m_cssFontFaceSet->fontFace(fontDescriptionForLookup->fontSelectionRequest(), familyForLookup)) {
-        if (document && document->settings().webAPIStatisticsEnabled())
+        if (document && m_fontSettings.webAPIStatisticsEnabled)
             ResourceLoadObserver::singleton().logFontLoad(*document, familyForLookup.string(), true);
         return { face->fontRanges(*fontDescriptionForLookup, fontPaletteValues, fontFeatureValues), isGenericFontFamily };
     }
@@ -485,7 +505,7 @@ FontRanges CSSFontSelector::fontRangesForFamily(const FontDescription& fontDescr
         resolveAndAssignGenericFamily();
 
     auto font = protect(FontCache::forCurrentThread())->fontForFamily(*fontDescriptionForLookup, familyForLookup, { { }, { }, fontPaletteValues, fontFeatureValues, 1.0 });
-    if (document && document->settings().webAPIStatisticsEnabled())
+    if (document && m_fontSettings.webAPIStatisticsEnabled)
         ResourceLoadObserver::singleton().logFontLoad(*document, familyForLookup.string(), !!font);
     return { FontRanges { WTF::move(font) }, isGenericFontFamily };
 }
@@ -502,7 +522,7 @@ size_t CSSFontSelector::fallbackFontCount()
     if (m_isStopped)
         return 0;
 
-    return protect(scriptExecutionContext())->settingsValues().fontFallbackPrefersPictographs ? 1 : 0;
+    return m_fontSettings.fontFallbackPrefersPictographs ? 1 : 0;
 }
 
 RefPtr<Font> CSSFontSelector::fallbackFontAt(const FontDescription& fontDescription, size_t index)
@@ -512,12 +532,11 @@ RefPtr<Font> CSSFontSelector::fallbackFontAt(const FontDescription& fontDescript
     if (m_isStopped)
         return nullptr;
 
-    RefPtr context = m_context.get();
-    if (!context->settingsValues().fontFallbackPrefersPictographs)
+    if (!m_fontSettings.fontFallbackPrefersPictographs)
         return nullptr;
-    auto& pictographFontFamily = context->settingsValues().fontGenericFamilies.pictographFontFamily();
+    auto& pictographFontFamily = m_fontSettings.fontGenericFamilies.pictographFontFamily();
     RefPtr font = protect(FontCache::forCurrentThread())->fontForFamily(fontDescription, pictographFontFamily);
-    if (RefPtr document = dynamicDowncast<Document>(context.get()); document && document->settingsValues().webAPIStatisticsEnabled)
+    if (RefPtr document = dynamicDowncast<Document>(m_context.get()); document && m_fontSettings.webAPIStatisticsEnabled)
         ResourceLoadObserver::singleton().logFontLoad(*document, pictographFontFamily, !!font);
 
     return font;
@@ -536,6 +555,16 @@ bool CSSFontSelector::isSimpleFontSelectorForDescription() const
     }
 
     return !m_cssFontFaceSet->faceCount() && m_featureValues.isEmpty() && m_paletteMap.isEmpty();
+}
+
+bool CSSFontSelector::isSimpleFontResolutionEquivalentTo(const FontSelector& other) const
+{
+    if (!isSimpleFontSelectorForDescription())
+        return false;
+    auto* otherCSS = dynamicDowncast<CSSFontSelector>(other);
+    if (!otherCSS || !otherCSS->isSimpleFontSelectorForDescription())
+        return false;
+    return m_fontSettings == otherCSS->m_fontSettings;
 }
 
 }

--- a/Source/WebCore/css/CSSFontSelector.h
+++ b/Source/WebCore/css/CSSFontSelector.h
@@ -30,6 +30,7 @@
 #include "CSSFontFaceSet.h"
 #include "CachedResourceHandle.h"
 #include "Font.h"
+#include "FontGenericFamilies.h"
 #include "FontSelector.h"
 #include "ScriptExecutionContext.h"
 #include "StyleRule.h"
@@ -48,6 +49,25 @@ class CSSSegmentedFontFace;
 class CSSValueList;
 class CachedFont;
 class ScriptExecutionContext;
+struct SettingsValues;
+
+// Snapshot of the Settings subset that CSSFontSelector consults during font
+// resolution. Captured per-CSSFontSelector at construction and refreshed when
+// any of these settings change. Designed to serve as an equality key for
+// cross-document MatchedDeclarationsCache sharing (rdar://173598541).
+struct FontSettings {
+    FontSettings() = default;
+    explicit FontSettings(const SettingsValues&);
+
+    bool operator==(const FontSettings&) const;
+
+    FontGenericFamilies fontGenericFamilies;
+    bool fontFallbackPrefersPictographs { false };
+    // FIXME (rdar://173598541): webAPIStatisticsEnabled has no webcoreOnChange
+    // hook so this snapshot is not refreshed if the setting is toggled at
+    // runtime. Acceptable for now (research-only flag, defaults off).
+    bool webAPIStatisticsEnabled { false };
+};
 
 class CSSFontSelector final : public FontSelector, public CSSFontFaceClient, public ActiveDOMObject {
 public:
@@ -88,6 +108,13 @@ public:
     bool isCSSFontSelector() const final { return true; }
 
     ScriptExecutionContext* scriptExecutionContext() const { return m_context.get(); }
+
+    // Snapshot of the Settings subset consumed by font resolution. Refreshed
+    // whenever any of those settings change (see SettingsBase.cpp). Reads on
+    // the resolution path go through this rather than touching m_context.
+    const FontSettings& fontSettings() const LIFETIME_BOUND { return m_fontSettings; }
+    bool isSimpleFontResolutionEquivalentTo(const FontSelector&) const final;
+    void refreshFontSettings();
 
     FontFaceSet* NODELETE fontFaceSetIfExists();
     FontFaceSet& fontFaceSet();
@@ -156,6 +183,8 @@ private:
     bool m_isStopped { false };
 
     WebKitFontFamilyNames::FamilyNamesList<AtomString> m_fontFamilyNames;
+
+    FontSettings m_fontSettings;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/page/SettingsBase.cpp
+++ b/Source/WebCore/page/SettingsBase.cpp
@@ -27,9 +27,11 @@
 #include "SettingsBase.h"
 
 #include "BackForwardCache.h"
+#include "CSSFontSelector.h"
 #include "Chrome.h"
 #include "ChromeClient.h"
 #include "DOMTimer.h"
+#include "Document.h"
 #include "DocumentResourceLoader.h"
 #include "DocumentView.h"
 #include "FontCache.h"
@@ -59,8 +61,17 @@ static void invalidateAfterGenericFamilyChange(Page* page)
     FontCascadeCache::forCurrentThread().invalidate();
     SystemFontDatabase::singleton().invalidate();
 
-    if (page)
-        page->setNeedsRecalcStyleInAllFrames();
+    if (!page)
+        return;
+
+    // Refresh per-document FontSettings snapshots before triggering restyle so
+    // CSSFontSelector reads see the new values during the recalc.
+    page->forEachDocument([](Document& document) {
+        if (RefPtr selector = document.fontSelectorIfExists())
+            selector->refreshFontSettings();
+    });
+
+    page->setNeedsRecalcStyleInAllFrames();
 }
 
 SettingsBase::SettingsBase(Page* page)

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -31,6 +31,7 @@
 #include "FontCache.h"
 #include "FontCascadeInlines.h"
 #include "FontInlines.h"
+#include "FontSelector.h"
 #include "GlyphBuffer.h"
 #include "GraphicsContext.h"
 #include "LayoutRect.h"
@@ -138,6 +139,34 @@ bool FontCascade::operator==(const FontCascade& other) const
     if (fontSelectorVersion() != other.fontSelectorVersion())
         return false;
 
+    if (m_fonts->generation() != other.m_fonts->generation())
+        return false;
+
+    return true;
+}
+
+bool FontCascade::equalsForMDC(const FontCascade& other) const
+{
+    if (m_fontDescription != other.m_fontDescription || m_spacing != other.m_spacing)
+        return false;
+
+    if (m_fonts != other.m_fonts)
+        return false;
+
+    if (!m_fonts)
+        return true;
+
+    // Cross-document shortcut: if both sides are simple CSSFontSelectors with
+    // equal FontSettings, font resolution is identical regardless of per-doc
+    // selector identity/version/generation. This is what lets MDC entries
+    // cached in one document be reused in another.
+    if (RefPtr a = fontSelector(), b = other.fontSelector(); a && b && a->isSimpleFontResolutionEquivalentTo(*b))
+        return true;
+
+    if (fontSelector() != other.fontSelector())
+        return false;
+    if (fontSelectorVersion() != other.fontSelectorVersion())
+        return false;
     if (m_fonts->generation() != other.m_fonts->generation())
         return false;
 

--- a/Source/WebCore/platform/graphics/FontCascade.h
+++ b/Source/WebCore/platform/graphics/FontCascade.h
@@ -101,6 +101,13 @@ public:
 
     WEBCORE_EXPORT bool operator==(const FontCascade& other) const;
 
+    // Equality used by MatchedDeclarationsCache lookup. Relaxes the
+    // per-document selector identity / version / generation checks at the
+    // bottom of operator== when both selectors are simple and their
+    // FontSettings compare equal. Enables cross-document RenderStyle reuse
+    // without requiring shared selector identity. See rdar://173598541.
+    WEBCORE_EXPORT bool equalsForMDC(const FontCascade& other) const;
+
     const FontCascadeDescription& fontDescription() const LIFETIME_BOUND { return m_fontDescription; }
     FontCascadeDescription& mutableFontDescription() const LIFETIME_BOUND { return m_fontDescription; }
 

--- a/Source/WebCore/platform/graphics/FontGenericFamilies.cpp
+++ b/Source/WebCore/platform/graphics/FontGenericFamilies.cpp
@@ -94,6 +94,18 @@ FontGenericFamilies FontGenericFamilies::isolatedCopy() &&
     return copy;
 }
 
+bool FontGenericFamilies::operator==(const FontGenericFamilies& other) const
+{
+    return m_standardFontFamilyMap == other.m_standardFontFamilyMap
+        && m_serifFontFamilyMap == other.m_serifFontFamilyMap
+        && m_fixedFontFamilyMap == other.m_fixedFontFamilyMap
+        && m_sansSerifFontFamilyMap == other.m_sansSerifFontFamilyMap
+        && m_cursiveFontFamilyMap == other.m_cursiveFontFamilyMap
+        && m_fantasyFontFamilyMap == other.m_fantasyFontFamilyMap
+        && m_pictographFontFamilyMap == other.m_pictographFontFamilyMap
+        && m_mathFontFamilyMap == other.m_mathFontFamilyMap;
+}
+
 const String& FontGenericFamilies::standardFontFamily(UScriptCode script) const
 {
     return genericFontFamilyForScript(m_standardFontFamilyMap, script);

--- a/Source/WebCore/platform/graphics/FontGenericFamilies.h
+++ b/Source/WebCore/platform/graphics/FontGenericFamilies.h
@@ -53,6 +53,8 @@ public:
     FontGenericFamilies isolatedCopy() const &;
     FontGenericFamilies isolatedCopy() &&;
 
+    bool operator==(const FontGenericFamilies&) const;
+
     const String& standardFontFamily(UScriptCode = USCRIPT_COMMON) const;
     const String& fixedFontFamily(UScriptCode = USCRIPT_COMMON) const;
     const String& serifFontFamily(UScriptCode = USCRIPT_COMMON) const;

--- a/Source/WebCore/platform/graphics/FontSelector.h
+++ b/Source/WebCore/platform/graphics/FontSelector.h
@@ -73,6 +73,12 @@ public:
 
     virtual bool isSimpleFontSelectorForDescription() const = 0;
 
+    // True when both this selector and `other` are simple selectors that
+    // produce identical font resolution. Enables MatchedDeclarationsCache
+    // entries to be reused across documents without requiring shared
+    // selector identity. Non-CSS subclasses return false. See rdar://173598541.
+    virtual bool isSimpleFontResolutionEquivalentTo(const FontSelector&) const { return false; }
+
     virtual bool isCSSFontSelector() const { return false; }
 
 };

--- a/Source/WebCore/rendering/style/RenderStyle+GettersInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyle+GettersInlines.h
@@ -45,6 +45,11 @@ inline bool RenderStyle::inheritedEqual(const RenderStyle& other) const
     return m_computedStyle.inheritedEqual(other.m_computedStyle);
 }
 
+inline bool RenderStyle::inheritedEqualForMDC(const RenderStyle& other) const
+{
+    return m_computedStyle.inheritedEqualForMDC(other.m_computedStyle);
+}
+
 inline bool RenderStyle::nonInheritedEqual(const RenderStyle& other) const
 {
     return m_computedStyle.nonInheritedEqual(other.m_computedStyle);

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -75,6 +75,7 @@ public:
     bool operator==(const RenderStyle&) const;
 
     bool inheritedEqual(const RenderStyle&) const;
+    bool inheritedEqualForMDC(const RenderStyle&) const;
     bool nonInheritedEqual(const RenderStyle&) const;
     bool fastPathInheritedEqual(const RenderStyle&) const;
     bool nonFastPathInheritedEqual(const RenderStyle&) const;

--- a/Source/WebCore/style/MatchedDeclarationsCache.cpp
+++ b/Source/WebCore/style/MatchedDeclarationsCache.cpp
@@ -153,7 +153,7 @@ std::optional<MatchedDeclarationsCache::Result> MatchedDeclarationsCache::find(u
         if (&entry.parentRenderStyle->inheritedCustomProperties() != &inheritedCustomProperties)
             continue;
 
-        if (parentStyle.inheritedEqual(*entry.parentRenderStyle))
+        if (parentStyle.inheritedEqualForMDC(*entry.parentRenderStyle))
             return std::make_optional(Result { .entry = entry, .inheritedEqual = true });
         partiallyMatchingEntry = &entry;
     }

--- a/Source/WebCore/style/computed/StyleComputedStyle.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyle.cpp
@@ -147,6 +147,23 @@ bool ComputedStyle::inheritedEqual(const ComputedStyle& other) const
         && m_inheritedRareData == other.m_inheritedRareData;
 }
 
+bool ComputedStyle::inheritedEqualForMDC(const ComputedStyle& other) const
+{
+    if (m_inheritedFlags != other.m_inheritedFlags)
+        return false;
+    if (m_inheritedRareData != other.m_inheritedRareData)
+        return false;
+    if (m_svgData.ptr() != other.m_svgData.ptr() && !m_svgData->inheritedEqual(other.m_svgData))
+        return false;
+    // Diverges from inheritedEqual here: fall through to InheritedData's
+    // MDC-specific equality, which treats two simple-selector FontCascades
+    // with equal FontSettings as equivalent. All other fields compared
+    // identically to inheritedEqual.
+    if (m_inheritedData.ptr() == other.m_inheritedData.ptr())
+        return true;
+    return m_inheritedData->inheritedEqualForMDC(*other.m_inheritedData);
+}
+
 bool ComputedStyle::nonInheritedEqual(const ComputedStyle& other) const
 {
     return m_nonInheritedFlags == other.m_nonInheritedFlags

--- a/Source/WebCore/style/computed/StyleComputedStyle.h
+++ b/Source/WebCore/style/computed/StyleComputedStyle.h
@@ -48,6 +48,7 @@ public:
     bool operator==(const ComputedStyle&) const;
 
     bool inheritedEqual(const ComputedStyle&) const;
+    bool inheritedEqualForMDC(const ComputedStyle&) const;
     bool nonInheritedEqual(const ComputedStyle&) const;
     bool NODELETE fastPathInheritedEqual(const ComputedStyle&) const;
     bool nonFastPathInheritedEqual(const ComputedStyle&) const;

--- a/Source/WebCore/style/computed/data/StyleFontData.cpp
+++ b/Source/WebCore/style/computed/data/StyleFontData.cpp
@@ -62,6 +62,13 @@ bool FontData::operator==(const FontData& o) const
         && fontCascade == o.fontCascade;
 }
 
+bool FontData::equalsForMDC(const FontData& o) const
+{
+    return letterSpacing == o.letterSpacing
+        && wordSpacing == o.wordSpacing
+        && fontCascade.equalsForMDC(o.fontCascade);
+}
+
 #if !LOG_DISABLED
 void FontData::dumpDifferences(TextStream& ts, const FontData& other) const
 {

--- a/Source/WebCore/style/computed/data/StyleFontData.h
+++ b/Source/WebCore/style/computed/data/StyleFontData.h
@@ -43,6 +43,7 @@ public:
     Ref<FontData> copy() const;
 
     bool operator==(const FontData&) const;
+    bool equalsForMDC(const FontData&) const;
 
 #if !LOG_DISABLED
     void dumpDifferences(TextStream&, const FontData&) const;

--- a/Source/WebCore/style/computed/data/StyleInheritedData.cpp
+++ b/Source/WebCore/style/computed/data/StyleInheritedData.cpp
@@ -92,6 +92,28 @@ bool InheritedData::nonFastPathInheritedEqual(const InheritedData& other) const
         && borderVerticalSpacing == other.borderVerticalSpacing;
 }
 
+bool InheritedData::inheritedEqualForMDC(const InheritedData& other) const
+{
+    if (lineHeight != other.lineHeight)
+        return false;
+#if ENABLE(TEXT_AUTOSIZING)
+    if (specifiedLineHeight != other.specifiedLineHeight)
+        return false;
+#endif
+    if (borderHorizontalSpacing != other.borderHorizontalSpacing || borderVerticalSpacing != other.borderVerticalSpacing)
+        return false;
+    if (color != other.color || visitedLinkColor != other.visitedLinkColor)
+        return false;
+    // FontData comparison is the only difference vs. InheritedData::operator==:
+    // we fall through to fontCascade.equalsForMDC, which treats two simple
+    // FontCascades with equal FontSettings as equivalent.
+    if (fontData.ptr() == other.fontData.ptr())
+        return true;
+    Ref myFontData { *fontData };
+    Ref otherFontData { *other.fontData };
+    return myFontData->equalsForMDC(otherFontData);
+}
+
 void InheritedData::fastPathInheritFrom(const InheritedData& inheritParent)
 {
     color = inheritParent.color;

--- a/Source/WebCore/style/computed/data/StyleInheritedData.h
+++ b/Source/WebCore/style/computed/data/StyleInheritedData.h
@@ -47,6 +47,8 @@ public:
 
     bool operator==(const InheritedData&) const;
 
+    bool inheritedEqualForMDC(const InheritedData&) const;
+
 #if !LOG_DISABLED
     void dumpDifferences(TextStream&, const InheritedData&) const;
 #endif


### PR DESCRIPTION
#### 1ab31867e745c97f647adb5648162e7581d25156
<pre>
Introduce FontSettings and MDC-specific equality path for future cross-document style reuse
<a href="https://bugs.webkit.org/show_bug.cgi?id=314843">https://bugs.webkit.org/show_bug.cgi?id=314843</a>
<a href="https://rdar.apple.com/177100844">rdar://177100844</a>

Reviewed by NOBODY (OOPS!).

* Source/WebCore/Sources.txt:
* Source/WebCore/css/CSSFontSelector.cpp:
(WebCore::m_fontSettings):
(WebCore::CSSFontSelector::refreshFontSettings):
(WebCore::CSSFontSelector::resolveGenericFamily):
(WebCore::CSSFontSelector::fontRangesForFamily):
(WebCore::CSSFontSelector::fallbackFontCount):
(WebCore::CSSFontSelector::fallbackFontAt):
(WebCore::CSSFontSelector::isSimpleFontResolutionEquivalentTo const):
(WebCore::m_version): Deleted.
* Source/WebCore/css/CSSFontSelector.h:
* Source/WebCore/css/FontSettings.cpp: Copied from Source/WebCore/style/computed/data/StyleFontData.h.
(WebCore::FontSettings::FontSettings):
(WebCore::FontSettings::operator== const):
* Source/WebCore/css/FontSettings.h: Copied from Source/WebCore/style/computed/data/StyleFontData.h.
* Source/WebCore/page/SettingsBase.cpp:
(WebCore::invalidateAfterGenericFamilyChange):
* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::simpleSelectorsProduceEquivalentResolution):
(WebCore::FontCascade::equalsForMDC const):
* Source/WebCore/platform/graphics/FontCascade.h:
* Source/WebCore/platform/graphics/FontGenericFamilies.cpp:
(WebCore::FontGenericFamilies::operator== const):
* Source/WebCore/platform/graphics/FontGenericFamilies.h:
* Source/WebCore/platform/graphics/FontSelector.h:
(WebCore::FontSelector::isSimpleFontResolutionEquivalentTo const):
* Source/WebCore/rendering/style/RenderStyle+GettersInlines.h:
(WebCore::RenderStyle::inheritedEqualForMDC const):
* Source/WebCore/rendering/style/RenderStyle.h:
* Source/WebCore/style/MatchedDeclarationsCache.cpp:
(WebCore::Style::MatchedDeclarationsCache::find):
* Source/WebCore/style/computed/StyleComputedStyle.cpp:
(WebCore::Style::ComputedStyle::inheritedEqualForMDC const):
* Source/WebCore/style/computed/StyleComputedStyle.h:
* Source/WebCore/style/computed/data/StyleFontData.cpp:
(WebCore::Style::FontData::equalsForMDC const):
* Source/WebCore/style/computed/data/StyleFontData.h:
* Source/WebCore/style/computed/data/StyleInheritedData.cpp:
(WebCore::Style::InheritedData::inheritedEqualForMDC const):
* Source/WebCore/style/computed/data/StyleInheritedData.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ab31867e745c97f647adb5648162e7581d25156

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162703 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36179 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29324 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171641 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119149 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164572 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36283 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36183 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126282 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88931 "17 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fd7d3953-e016-44a6-902f-fc83e570baf4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165662 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28634 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146188 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106859 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/04dc9220-5409-4055-9b8f-587034425152) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27680 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26208 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19341 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137388 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23917 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174145 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21458 "Found 1 new failure in style/computed/data/StyleFontData.cpp") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25562 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134591 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35853 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30305 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134587 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35837 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145713 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98219 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/29128 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22549 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35347 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/103098 "Found 1 new failure in style/computed/data/StyleFontData.cpp") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34848 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35093 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34996 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->