### PR TITLE
[claude] Add harness for testing files

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/skill_testing/skill_test.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/skill_testing/skill_test.py
@@ -23,6 +23,7 @@
 import json
 import logging
 import os
+import shutil
 import subprocess
 
 from webkitcorepy import AutoInstall
@@ -70,6 +71,20 @@ class SkillTest(object):
         log.debug('\nRunning: %s', ' '.join(cmd))
         return subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
 
+    def _setup_files(self, cwd):
+        tests_dir = os.path.dirname(self.path)
+        for filename in self.files:
+            source = os.path.join(tests_dir, filename)
+            if not os.path.exists(source):
+                continue
+            dest = os.path.join(cwd, filename)
+            if os.path.isdir(source):
+                if os.path.exists(dest):
+                    shutil.rmtree(dest)
+                shutil.copytree(source, dest)
+            else:
+                shutil.copy2(source, dest)
+
     def _cleanup_files(self, cwd):
         for filename in self.files:
             filepath = os.path.join(cwd, filename)
@@ -77,7 +92,6 @@ class SkillTest(object):
                 if os.path.isfile(filepath):
                     os.remove(filepath)
                 elif os.path.isdir(filepath):
-                    import shutil
                     shutil.rmtree(filepath)
             except OSError:
                 pass
@@ -127,6 +141,7 @@ class SkillTest(object):
     def run(self, cwd):
         dump_path = os.path.join(cwd, '.llm_test_dump.txt')
         try:
+            self._setup_files(cwd)
             test_result = self._invoke_claude(self.test_prompt, self.test_args, cwd)
 
             with open(dump_path, 'w') as f:

--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/skill_testing/skill_test_unittest.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/skill_testing/skill_test_unittest.py
@@ -21,6 +21,7 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import os
+import tempfile
 import unittest
 
 from webkitcorepy import testing
@@ -183,3 +184,62 @@ class SkillTestDiscoverTest(testing.PathTestCase):
         skill = SkillFile(os.path.join(skill_dir, 'SKILL.md'))
         tests = SkillTest.discover(skill)
         self.assertEqual(len(tests), 0)
+
+
+class SkillTestSetupFilesTest(testing.PathTestCase):
+    basepath = 'mock/skills/my-skill/tests'
+
+    def _make_test(self, files):
+        path = os.path.join(self.path, 'basic.yaml')
+        with open(path, 'w') as f:
+            f.write(
+                'name: setup-test\n'
+                'test:\n'
+                '  prompt: "do thing"\n'
+                'validation:\n'
+                '  prompt: "check"\n'
+                'files: {}\n'.format(files)
+            )
+        return SkillTest(path)
+
+    def test_copies_file_from_tests_dir(self):
+        with open(os.path.join(self.path, 'fixture.py'), 'w') as f:
+            f.write('print("hi")\n')
+        st = self._make_test('["fixture.py"]')
+        with tempfile.TemporaryDirectory() as cwd:
+            st._setup_files(cwd)
+            with open(os.path.join(cwd, 'fixture.py'), 'r') as f:
+                self.assertEqual(f.read(), 'print("hi")\n')
+
+    def test_skips_files_not_in_tests_dir(self):
+        st = self._make_test('["output.txt"]')
+        with tempfile.TemporaryDirectory() as cwd:
+            st._setup_files(cwd)
+            self.assertFalse(os.path.exists(os.path.join(cwd, 'output.txt')))
+
+    def test_copies_directory(self):
+        src = os.path.join(self.path, 'fixture_dir')
+        os.makedirs(src)
+        with open(os.path.join(src, 'a.txt'), 'w') as f:
+            f.write('a\n')
+        st = self._make_test('["fixture_dir"]')
+        with tempfile.TemporaryDirectory() as cwd:
+            st._setup_files(cwd)
+            with open(os.path.join(cwd, 'fixture_dir', 'a.txt'), 'r') as f:
+                self.assertEqual(f.read(), 'a\n')
+
+    def test_overwrites_existing_directory(self):
+        src = os.path.join(self.path, 'fixture_dir')
+        os.makedirs(src)
+        with open(os.path.join(src, 'a.txt'), 'w') as f:
+            f.write('new\n')
+        st = self._make_test('["fixture_dir"]')
+        with tempfile.TemporaryDirectory() as cwd:
+            stale = os.path.join(cwd, 'fixture_dir')
+            os.makedirs(stale)
+            with open(os.path.join(stale, 'old.txt'), 'w') as f:
+                f.write('old\n')
+            st._setup_files(cwd)
+            self.assertFalse(os.path.exists(os.path.join(stale, 'old.txt')))
+            with open(os.path.join(stale, 'a.txt'), 'r') as f:
+                self.assertEqual(f.read(), 'new\n')


### PR DESCRIPTION
#### 7e7010ec9c9ca622b6ef5c73c2d378adef115508
<pre>
[claude] Add harness for testing files
<a href="https://bugs.webkit.org/show_bug.cgi?id=314847">https://bugs.webkit.org/show_bug.cgi?id=314847</a>
<a href="https://rdar.apple.com/177102326">rdar://177102326</a>

Reviewed by NOBODY (OOPS!).

When testing LLM skills, take files from the test directory which are listed in the test manifest
and copy them into the current working directory before running tests.

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/skill_testing/skill_test.py:
(SkillTest._setup_files):
(SkillTest._cleanup_files):
(SkillTest.run):
* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/tests/skill_testing/skill_test_unittest.py:
(SkillTestSetupFilesTest): Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e7010ec9c9ca622b6ef5c73c2d378adef115508

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162626 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36102 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29241 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171564 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119072 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164495 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36206 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36106 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126213 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88893 "18 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5528feb9-3e00-4b0f-8473-a69743d2e95b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165585 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28566 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146114 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106791 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/678135f6-80b4-47fc-9bc5-9fa7ab8d0b0d) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/161946 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27612 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26140 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19264 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137318 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23844 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174068 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25489 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134523 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/162023 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35776 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30237 "Found 2 new test failures: http/tests/ssl/ping-with-unsafe-redirect.html imported/w3c/web-platform-tests/IndexedDB/interleaved-cursors-small.any.sharedworker.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134519 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35760 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145640 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98112 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/29060 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22474 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35270 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34771 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35016 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34919 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->