### PR TITLE
[JSC][Temporal] Fix fractionToDouble for large denominators and consolidate ZonedDateTime diff

### DIFF
--- a/Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp
+++ b/Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp
@@ -3010,8 +3010,7 @@ static void testNudgeFunctions()
     }
 
     // --- nudgeToCalendarUnit: P0DT1H with unit=Day relative to 2020-01-15 ---
-    // Using Day (not Year) to keep denominator (1 day = 8.64e13 ns) within fractionToDouble's safe range.
-    // Year-level denominators (~3e16 ns) exceed safe integer range and require __float128 per spec NOTE.
+    // Using Day unit; Year-scale denominators (≈3e16 ns > 2^53) now handled correctly via Int128 fractionToDouble.
     {
         ISO8601::PlainDate date { 2020, 1, 15 };
         ISO8601::PlainTime time;
@@ -3076,10 +3075,10 @@ static void testRoundRelativeToZonedDateTime()
     Int128 startNs = Int128(1000000000000000000LL);
     Int128 endNs = startNs + Int128(90000000000000LL); // +25h
 
-    // differenceZonedDateTimeForDuration(start, end, tz, Day, iso8601)
-    auto diff = differenceZonedDateTimeForDuration(
+    // differenceZonedDateTimeWithRounding(start, end, tz, Day, Nanosecond, Trunc, 1, iso8601)
+    auto diff = differenceZonedDateTimeWithRounding(
         ISO8601::ExactTime(startNs), ISO8601::ExactTime(endNs),
-        tz, TemporalUnit::Day, calendarIDFromString("iso8601"_s));
+        tz, TemporalUnit::Day, TemporalUnit::Nanosecond, RoundingMode::Trunc, 1.0, calendarIDFromString("iso8601"_s));
     TCHECK_TRUE(diff.has_value(), "roundRelZDT: diff ok");
     // 25h with +04:30 (no DST) = 1 day + 1 hour
     TCHECK_EQ(static_cast<int64_t>(diff->dateDuration().days()), 1LL, "roundRelZDT: days=1");
@@ -3105,10 +3104,10 @@ static void testDurationTotalZDT()
     Int128 p2756h = Int128(2756LL) * Int128(3600000000000LL);
     Int128 endNs = startR->epochNanoseconds() + p2756h;
 
-    // differenceZonedDateTimeForDuration(start, end, Rome, Month)
-    auto diff = differenceZonedDateTimeForDuration(
+    // differenceZonedDateTimeWithRounding(start, end, Rome, Month, Nanosecond, Trunc, 1)
+    auto diff = differenceZonedDateTimeWithRounding(
         *startR, ISO8601::ExactTime(endNs),
-        romeTz, TemporalUnit::Month, calendarIDFromString("iso8601"_s));
+        romeTz, TemporalUnit::Month, TemporalUnit::Nanosecond, RoundingMode::Trunc, 1.0, calendarIDFromString("iso8601"_s));
     TCHECK_TRUE(diff.has_value(), "totalZDT: diff ok");
 
     // Convert to total months: months + remaining time as fraction
@@ -3149,9 +3148,9 @@ static void testNudgePastEnd()
     // Verify a normal diff near max succeeds (the out-of-range error is in getStartOfDay above).
     Int128 nearMax = maxEpoch - Int128(3600000000000LL); // 1h before max
     Int128 nearMaxEnd = nearMax + Int128(60000000000LL); // +1min
-    auto diffNear = differenceZonedDateTimeForDuration(
+    auto diffNear = differenceZonedDateTimeWithRounding(
         ISO8601::ExactTime(nearMax), ISO8601::ExactTime(nearMaxEnd),
-        utc, TemporalUnit::Hour, calendarIDFromString("iso8601"_s));
+        utc, TemporalUnit::Hour, TemporalUnit::Nanosecond, RoundingMode::Trunc, 1.0, calendarIDFromString("iso8601"_s));
     TCHECK_TRUE(diffNear.has_value(), "nudgePast: normal diff near max ok");
 }
 
@@ -3168,7 +3167,7 @@ static void testRoundZeroDurationZDT()
 
     // Start and end are the same (zero duration) -> diff = zero
     ISO8601::ExactTime epoch(Int128(0LL));
-    auto diff = differenceZonedDateTimeForDuration(epoch, epoch, utc, TemporalUnit::Day, calendarIDFromString("iso8601"_s));
+    auto diff = differenceZonedDateTimeWithRounding(epoch, epoch, utc, TemporalUnit::Day, TemporalUnit::Nanosecond, RoundingMode::Trunc, 1.0, calendarIDFromString("iso8601"_s));
     TCHECK_TRUE(diff.has_value(), "roundZeroZDT: zero diff ok");
     TCHECK_EQ(static_cast<int64_t>(diff->dateDuration().days()), 0LL, "roundZeroZDT: days=0");
     TCHECK_EQ(diff->time(), Int128(0LL), "roundZeroZDT: time=0");
@@ -3189,7 +3188,7 @@ static void testRoundIncrementRegressionZDT()
     // P48H = 2 * 86400000000000 ns from epoch 0
     ISO8601::ExactTime start(Int128(0LL));
     ISO8601::ExactTime end(Int128(172800000000000LL)); // 48h
-    auto diff = differenceZonedDateTimeForDuration(start, end, utc, TemporalUnit::Day, calendarIDFromString("iso8601"_s));
+    auto diff = differenceZonedDateTimeWithRounding(start, end, utc, TemporalUnit::Day, TemporalUnit::Nanosecond, RoundingMode::Trunc, 1.0, calendarIDFromString("iso8601"_s));
     TCHECK_TRUE(diff.has_value(), "roundIncZDT: 48h diff ok");
     TCHECK_EQ(static_cast<int64_t>(diff->dateDuration().days()), 2LL, "roundIncZDT: days=2");
     TCHECK_EQ(diff->time(), Int128(0LL), "roundIncZDT: time=0");

--- a/Source/JavaScriptCore/runtime/FractionToDouble.cpp
+++ b/Source/JavaScriptCore/runtime/FractionToDouble.cpp
@@ -145,4 +145,61 @@ double fractionToDouble(const Int128& numerator, double denominator)
     return fractionToDoubleSlow(numerator, denominator);
 }
 
+// Extends section 3.5 of the Hida-Li-Bailey paper to an Int128 denominator.
+static double fractionToDoubleSlow(const Int128& numerator, const Int128& denominator)
+{
+    // n0 + n1 = N exactly, d0 + d1 = D exactly.
+    DD n = int128ToDD(numerator);
+    DD d = int128ToDD(denominator);
+
+    // We want Q = N / D, where Q = q0 + q1.
+    // => (q0 + q1) * D = N
+    // => residual = q1 * D = N - q0 * D
+    // => q1 = (N - q0 * D) / D
+
+    // Step 1: q0 = first approximation of Q.
+    // n0 and d0 are the best doubles for N and D; n0/d0 is the best
+    // double approximation of N/D using regular double division.
+    // (Can't divide N/D directly — both may exceed 2^53 as Int128.)
+    double q0 = n[0] / d[0];
+
+    // Step 2: residual = N - q0 * D, split as r0 + error.
+    //
+    // Expand: N - q0 * D
+    // => (n0 + n1) - q0 * (d0 + d1)
+    // => (n0 - q0 * d0) + n1 - q0 * d1
+    //
+    DD p = ddProduct(q0, d[0]); // p0 + p1 = q0 * d0
+    DD r = ddSum(n[0], -p[0]); // r0 + r1 = n0 - p0
+    // Expand: n0 - q0 * d0
+    // => n0 - p0 - p1
+    // => r0 + r1 - p1
+    //
+    // Substituting back:
+    //   residual = r0 + r1 - p1 + n1 - q0 * d1
+    //            = r0 + error
+    double error = r[1] + n[1] - p[1] - q0 * d[1];
+
+    // Step 3: q1 = residual / D ≈ (r[0] + error) / d0.
+    // Using d0 instead of D: error ≈ q1 * (d1 / d0) ≈ Q*2^-104, negligible.
+    double q1 = (r[0] + error) / d[0];
+
+    // Discard DD renormalization (Shewchuk Fast-Two-Sum, theorem 6):
+    // single-precision result is sufficient here.
+    return q0 + q1;
+}
+
+double fractionToDouble(const Int128& numerator, const Int128& denominator)
+{
+    ASSERT(denominator > 0);
+
+    if (!numerator)
+        return 0;
+    if (denominator == 1)
+        return static_cast<double>(numerator);
+    if (isSafeInteger(static_cast<double>(numerator)) && isSafeInteger(static_cast<double>(denominator))) [[likely]]
+        return static_cast<double>(numerator) / static_cast<double>(denominator);
+    return fractionToDoubleSlow(numerator, denominator);
+}
+
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/FractionToDouble.h
+++ b/Source/JavaScriptCore/runtime/FractionToDouble.h
@@ -36,6 +36,14 @@ static constexpr Int128 absInt128(const Int128& value)
     return value;
 }
 
+// Denominator is a double — caller must ensure isSafeInteger(denominator).
+// Use when spec guarantees the divisor fits in 53 bits (e.g. TotalTimeDuration:
+// all unit lengths ≤ nsPerDay = 8.64e13 < 2^53).
 double fractionToDouble(const Int128& numerator, double denominator);
+
+// Denominator is an Int128 — handles denominators that exceed 2^53.
+// Use when the denominator may be year-scale epoch-ns (e.g. NudgeToCalendarUnit:
+// endEpochNs - startEpochNs ≈ 3.15e16 > 2^53 for year unit).
+double fractionToDouble(const Int128& numerator, const Int128& denominator);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/temporal/core/DurationArithmetic.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/DurationArithmetic.cpp
@@ -213,12 +213,16 @@ ISO8601::PlainTime plainTimeFromSubdayNs(Int128 ns)
 }
 
 // totalTimeDuration — temporal_rs: TimeDuration::total (src/builtins/core/duration/normalized.rs)
+// https://tc39.es/proposal-temporal/#sec-temporal-totaltimeduration
 // Returns the total time portion of a duration as a fractional count of the given unit.
 double totalTimeDuration(Int128 timeDuration, TemporalUnit unit)
 {
-    double divisor = static_cast<double>(lengthInNanoseconds(unit));
-    ASSERT(isSafeInteger(divisor));
-    return fractionToDouble(timeDuration, divisor);
+    Int128 unitLength = lengthInNanoseconds(unit);
+    // All "Length in Nanoseconds" values in spec Table 21 are ≤ nsPerDay = 8.64e13 < 2^53.
+    ASSERT(isSafeInteger(static_cast<double>(unitLength)));
+    // Spec NOTE: timeDuration may exceed safe integer range; fractionToDouble
+    // implements the required software emulation (double-double arithmetic).
+    return fractionToDouble(timeDuration, static_cast<double>(unitLength));
 }
 
 // toInternalDuration — temporal_rs: Duration::to_internal_duration_record (src/builtins/core/duration.rs)
@@ -664,7 +668,7 @@ TemporalResult<Nudged> nudgeToCalendarUnit(int32_t sign,
     // Step 15: Let total be r1 + progress × increment × sign.
     // (NOTE: computed via integer arithmetic before the final float division per spec note.)
     Int128 totalNumerator = Int128(static_cast<int64_t>(nudgeWindow.r1)) * progressDenominator + progressNumerator * Int128(static_cast<int64_t>(increment)) * Int128(sign);
-    double total = fractionToDouble(totalNumerator, static_cast<double>(absInt128(progressDenominator))) * (progressDenominator < 0 ? -1.0 : 1.0);
+    double total = fractionToDouble(totalNumerator, absInt128(progressDenominator)) * (progressDenominator < 0 ? -1.0 : 1.0);
     Int128 progress = progressNumerator / progressDenominator;
     // Step 16: Assert: 0 ≤ progress ≤ 1.
     ASSERT(0 <= progress && progress <= 1);
@@ -924,106 +928,6 @@ TemporalResult<void> roundRelativeDuration(ISO8601::InternalDuration& duration,
     }
     // Step 10: Return duration.
     return { };
-}
-
-// differenceZonedDateTimeForDuration — temporal_rs: ZonedDateTime::diff_zoned_datetime (src/builtins/core/zoned_date_time.rs)
-// https://tc39.es/proposal-temporal/#sec-temporal-differencezoneddatetime
-TemporalResult<ISO8601::InternalDuration> differenceZonedDateTimeForDuration(
-    ISO8601::ExactTime startExact, ISO8601::ExactTime endExact,
-    const TimeZone& timeZone, TemporalUnit largestUnit, CalendarID calendarId)
-{
-    Int128 nsA = startExact.epochNanoseconds();
-    Int128 nsB = endExact.epochNanoseconds();
-    // Step 1: If ns1 = ns2, return CombineDateAndTimeDuration(ZeroDateDuration(), 0).
-    if (nsA == nsB)
-        return ISO8601::InternalDuration::combineDateAndTimeDuration(ISO8601::Duration(), Int128(0));
-    // Step 2: Let startDateTime be GetISODateTimeFor(timeZone, ns1).
-    // Step 3: Let endDateTime be GetISODateTimeFor(timeZone, ns2).
-    // (Each GetISODateTimeFor is split: getOffsetNanosecondsFor computes the offset,
-    //  exactTimeToLocalDateAndTime completes the date/time extraction.)
-    auto offset1Result = getOffsetNanosecondsFor(timeZone, startExact);
-    if (!offset1Result)
-        return makeUnexpected(offset1Result.error());
-    auto offset2Result = getOffsetNanosecondsFor(timeZone, endExact);
-    if (!offset2Result)
-        return makeUnexpected(offset2Result.error());
-
-    ISO8601::PlainDate startDate, endDate;
-    ISO8601::PlainTime startTime, endTime;
-    exactTimeToLocalDateAndTime(startExact, *offset1Result, startDate, startTime);
-    exactTimeToLocalDateAndTime(endExact, *offset2Result, endDate, endTime);
-
-    // Step 4: If CompareISODate(startDateTime.[[ISODate]], endDateTime.[[ISODate]]) = 0, return CombineDateAndTimeDuration(ZeroDateDuration(), ns2 - ns1).
-    if (!isoDateCompare(startDate, endDate))
-        return ISO8601::InternalDuration::combineDateAndTimeDuration(ISO8601::Duration(), nsB - nsA);
-
-    // Step 5: If ns2 - ns1 < 0, let sign be 1; else let sign be -1.
-    int32_t diffSign = (nsB - nsA < Int128 { 0 }) ? 1 : -1;
-    // Step 6: If sign = -1, let maxDayCorrection be 2; else let maxDayCorrection be 1.
-    int32_t maxDayCorrection = (diffSign == -1) ? 2 : 1;
-    // Step 7: Let dayCorrection be 0.
-    int32_t dayCorrection = 0;
-    // Step 8: Let timeDuration be DifferenceTime(startDateTime.[[Time]], endDateTime.[[Time]]).
-    Int128 timeDiff = timeDurationFromComponents(
-        static_cast<double>(endTime.hour()) - static_cast<double>(startTime.hour()),
-        static_cast<double>(endTime.minute()) - static_cast<double>(startTime.minute()),
-        static_cast<double>(endTime.second()) - static_cast<double>(startTime.second()),
-        static_cast<double>(endTime.millisecond()) - static_cast<double>(startTime.millisecond()),
-        static_cast<double>(endTime.microsecond()) - static_cast<double>(startTime.microsecond()),
-        static_cast<double>(endTime.nanosecond()) - static_cast<double>(startTime.nanosecond()));
-    int32_t timeSign = (timeDiff < 0) ? -1 : (timeDiff > 0) ? 1 : 0;
-    // Step 9: If timeSign = sign, set dayCorrection to dayCorrection + 1.
-    if (timeSign == diffSign)
-        dayCorrection++;
-
-    // Step 10: Let success be false.
-    ISO8601::PlainDate intermediateDate = endDate;
-    Int128 adjustedTimeDiff = timeDiff;
-    bool success = false;
-    // Step 11: Repeat, while dayCorrection ≤ maxDayCorrection and success is false,
-    while (dayCorrection <= maxDayCorrection && !success) {
-        // Step 11.a: Let intermediateDate be AddDaysToISODate(endDateTime.[[ISODate]], dayCorrection × sign).
-        intermediateDate = balanceISODate(endDate.year(), static_cast<int32_t>(endDate.month()), static_cast<int64_t>(endDate.day()) + dayCorrection * diffSign);
-        // Step 11.b: intermediateDateTime = CombineISODateAndTimeRecord(intermediateDate, startDateTime.[[Time]]).
-        // Step 11.c: intermediateNs = GetEpochNanosecondsFor(timeZone, intermediateDateTime, ~compatible~). (11.b+11.c fused)
-        auto intermediateNsResult = getEpochNanosecondsFor(timeZone, intermediateDate, startTime, TemporalDisambiguation::Compatible);
-        if (!intermediateNsResult)
-            return makeUnexpected(intermediateNsResult.error());
-        // Step 11.d: Set timeDuration to TimeDurationFromEpochNanosecondsDifference(ns2, intermediateNs).
-        adjustedTimeDiff = nsB - intermediateNsResult->epochNanoseconds();
-        // Step 11.e: Let timeSign be TimeDurationSign(timeDuration).
-        int32_t adjTimeSign = (adjustedTimeDiff < 0) ? -1 : (adjustedTimeDiff > 0) ? 1 : 0;
-        // Step 11.f: If sign ≠ timeSign, set success to true.
-        if (diffSign != adjTimeSign)
-            success = true;
-        // Step 11.g: Set dayCorrection to dayCorrection + 1.
-        dayCorrection++;
-    }
-    // Step 12: Assert: success is true.
-    ASSERT(success);
-
-    // Step 13: Let dateLargestUnit be LargerOfTwoTemporalUnits(largestUnit, ~day~).
-    TemporalUnit dateLargestUnit = (largestUnit > TemporalUnit::Day) ? TemporalUnit::Day : largestUnit;
-    // Step 14: Let dateDifference be CalendarDateUntil(calendar, startDateTime.[[ISODate]], intermediateDate, dateLargestUnit).
-    // (Note: intermediateDateTime.[[ISODate]] = intermediateDate computed above.)
-    auto dateDiffResult = TemporalCore::calendarDateUntil(calendarId, startDate, intermediateDate, dateLargestUnit);
-    if (!dateDiffResult)
-        return makeUnexpected(dateDiffResult.error());
-    ISO8601::Duration dateDiff = *dateDiffResult;
-
-    // Step 15: Return CombineDateAndTimeDuration(dateDifference, timeDuration).
-    // (Implementation folds days into time when largestUnit > day.)
-    constexpr Int128 nsPerDay = ISO8601::ExactTime::nsPerDay;
-    double remainingDays = 0;
-    Int128 timeDuration = adjustedTimeDiff;
-    if (largestUnit != dateLargestUnit)
-        timeDuration = adjustedTimeDiff + Int128(dateDiff.days()) * nsPerDay;
-    else
-        remainingDays = static_cast<double>(dateDiff.days());
-
-    ISO8601::Duration datePart(dateDiff.years(), dateDiff.months(),
-        dateDiff.weeks(), static_cast<int64_t>(remainingDays), 0, 0, 0, 0, Int128(0), Int128(0));
-    return ISO8601::InternalDuration::combineDateAndTimeDuration(datePart, timeDuration);
 }
 
 } // namespace TemporalCore

--- a/Source/JavaScriptCore/runtime/temporal/core/DurationArithmetic.h
+++ b/Source/JavaScriptCore/runtime/temporal/core/DurationArithmetic.h
@@ -138,9 +138,5 @@ TemporalResult<void> JS_EXPORT_PRIVATE roundRelativeDuration(ISO8601::InternalDu
     TemporalUnit largestUnit, double increment, TemporalUnit smallestUnit,
     RoundingMode, const TimeZone*, CalendarID);
 
-TemporalResult<ISO8601::InternalDuration> JS_EXPORT_PRIVATE differenceZonedDateTimeForDuration(
-    ISO8601::ExactTime startExact, ISO8601::ExactTime endExact,
-    const TimeZone&, TemporalUnit largestUnit, CalendarID = iso8601CalendarID());
-
 } // namespace TemporalCore
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/temporal/core/ZonedDateTimeCore.cpp
+++ b/Source/JavaScriptCore/runtime/temporal/core/ZonedDateTimeCore.cpp
@@ -200,7 +200,8 @@ static TemporalResult<ISO8601::InternalDuration> differenceZonedDateTime(ISO8601
     if (timeSign == sign)
         dayCorrection++;
 
-    // Steps 10-12: day-correction loop.
+    // Step 10: success = false.
+    // Step 11: Repeat while dayCorrection ≤ maxDayCorrection and success = false.
     ISO8601::PlainDate intermediateDate = endDate;
     Int128 adjustedTimeDiff = timeDiff;
     bool success = false;
@@ -208,30 +209,33 @@ static TemporalResult<ISO8601::InternalDuration> differenceZonedDateTime(ISO8601
         // Step 11.a: intermediateDate = AddDaysToISODate(endDate, dayCorrection × sign).
         intermediateDate = balanceISODate(endDate.year(), static_cast<int32_t>(endDate.month()),
             static_cast<int64_t>(endDate.day()) + dayCorrection * sign);
-        // Step 11.c: intermediateNs = GetEpochNanosecondsFor(timeZone, intermediateDateTime, compatible).
+        // Step 11.b: intermediateDateTime = CombineISODateAndTimeRecord(intermediateDate, startTime).
+        // Step 11.c: intermediateNs = GetEpochNanosecondsFor(timeZone, intermediateDateTime, compatible). (11.b+11.c fused)
         auto intermediateNsResult = getEpochNanosecondsFor(timeZone, intermediateDate, startTime, TemporalDisambiguation::Compatible);
         if (!intermediateNsResult)
             return makeUnexpected(intermediateNsResult.error());
-        // Step 11.d: timeDuration = ns2 - intermediateNs.
+        // Step 11.d: timeDuration = TimeDurationFromEpochNanosecondsDifference(ns2, intermediateNs).
         adjustedTimeDiff = nsB - intermediateNsResult->epochNanoseconds();
+        // Step 11.e: timeSign = TimeDurationSign(timeDuration).
         int32_t adjTimeSign = (adjustedTimeDiff < 0) ? -1 : (adjustedTimeDiff > 0) ? 1 : 0;
-        // Step 11.f: If sign ≠ timeSign -> success.
+        // Step 11.f: If sign ≠ timeSign, success = true.
         if (sign != adjTimeSign)
             success = true;
+        // Step 11.g: dayCorrection++.
         dayCorrection++;
     }
-    // Step 13: Assert success.
+    // Step 12: Assert: success is true.
     ASSERT(success);
 
-    // Step 14: dateLargestUnit = max(largestUnit, day).
+    // Step 13: dateLargestUnit = LargerOfTwoTemporalUnits(largestUnit, day).
     TemporalUnit dateLargestUnit = (largestUnit > TemporalUnit::Day) ? TemporalUnit::Day : largestUnit;
-    // Step 15: dateDifference = CalendarDateUntil(startDate, intermediateDate, dateLargestUnit).
+    // Step 14: dateDifference = CalendarDateUntil(startDate, intermediateDate, dateLargestUnit).
     auto dateDiffResult = TemporalCore::calendarDateUntil(calendarId, startDate, intermediateDate, dateLargestUnit);
     if (!dateDiffResult)
         return makeUnexpected(dateDiffResult.error());
     auto& dateDiff = *dateDiffResult;
 
-    // Step 16: Return CombineDateAndTimeDuration(dateDifference, timeDuration).
+    // Step 15: Return CombineDateAndTimeDuration(dateDifference, timeDuration).
     ISO8601::Duration datePart(static_cast<double>(dateDiff.years()), static_cast<double>(dateDiff.months()),
         static_cast<double>(dateDiff.weeks()), static_cast<double>(dateDiff.days()), 0, 0, 0, 0, 0, 0);
     return ISO8601::InternalDuration::combineDateAndTimeDuration(datePart, adjustedTimeDiff);
@@ -239,7 +243,7 @@ static TemporalResult<ISO8601::InternalDuration> differenceZonedDateTime(ISO8601
 
 // DifferenceZonedDateTimeWithRounding — temporal_rs: ZonedDateTime::diff_zoned_datetime (src/builtins/core/zoned_date_time.rs)
 // https://tc39.es/proposal-temporal/#sec-temporal-differencezoneddatetimewithrounding
-TemporalResult<ISO8601::Duration> differenceZonedDateTimeWithRounding(
+TemporalResult<ISO8601::InternalDuration> differenceZonedDateTimeWithRounding(
     ISO8601::ExactTime ns1,
     ISO8601::ExactTime ns2,
     const TimeZone& timeZone,
@@ -262,7 +266,7 @@ TemporalResult<ISO8601::Duration> differenceZonedDateTimeWithRounding(
                 lengthInNanoseconds(smallestUnit) * (Int128)std::trunc(increment), roundingMode);
             internalDuration = ISO8601::InternalDuration::combineDateAndTimeDuration(ISO8601::Duration(), roundedTime);
         }
-        return temporalDurationFromInternal(internalDuration, largestUnit);
+        return internalDuration;
     }
 
     // Step 2: difference = DifferenceZonedDateTime(ns1, ns2, timeZone, calendar, largestUnit).
@@ -273,7 +277,7 @@ TemporalResult<ISO8601::Duration> differenceZonedDateTimeWithRounding(
 
     // Step 3: If smallestUnit=nanosecond and increment=1 -> return difference.
     if (smallestUnit == TemporalUnit::Nanosecond && increment == 1)
-        return temporalDurationFromInternal(internalDuration, largestUnit);
+        return internalDuration;
 
     // Step 4: dateTime = GetISODateTimeFor(timeZone, ns1). (split: getOffsetNanosecondsFor + exactTimeToLocalDateAndTime)
     auto offset1 = getOffsetNanosecondsFor(timeZone, ns1);
@@ -288,7 +292,7 @@ TemporalResult<ISO8601::Duration> differenceZonedDateTimeWithRounding(
         largestUnit, increment, smallestUnit, roundingMode, &timeZone, calendarId);
     if (!roundResult)
         return makeUnexpected(roundResult.error());
-    return temporalDurationFromInternal(internalDuration, largestUnit);
+    return internalDuration;
 }
 
 } // namespace TemporalCore

--- a/Source/JavaScriptCore/runtime/temporal/core/ZonedDateTimeCore.h
+++ b/Source/JavaScriptCore/runtime/temporal/core/ZonedDateTimeCore.h
@@ -51,7 +51,7 @@ TemporalResult<ISO8601::ExactTime> JS_EXPORT_PRIVATE interpretISODateTimeOffset(
 
 TemporalResult<ISO8601::ExactTime> JS_EXPORT_PRIVATE getStartOfDay(const TimeZone&, ISO8601::PlainDate);
 
-TemporalResult<ISO8601::Duration> JS_EXPORT_PRIVATE differenceZonedDateTimeWithRounding(
+TemporalResult<ISO8601::InternalDuration> JS_EXPORT_PRIVATE differenceZonedDateTimeWithRounding(
     ISO8601::ExactTime ns1,
     ISO8601::ExactTime ns2,
     const TimeZone&,


### PR DESCRIPTION
#### 7f9fbe74e49215f831e45d4026ba4b37c9492ef6
<pre>
[JSC][Temporal] Fix fractionToDouble for large denominators and consolidate ZonedDateTime diff
<a href="https://bugs.webkit.org/show_bug.cgi?id=314848">https://bugs.webkit.org/show_bug.cgi?id=314848</a>
<a href="https://rdar.apple.com/177102646">rdar://177102646</a>

Reviewed by Yusuke Suzuki.

Add an Int128-denominator overload of fractionToDouble to handle year-scale
epoch-ns windows (~3.15e16 ns &gt; 2^53) in nudgeToCalendarUnit without
triggering the isSafeInteger assertion. The Int128 overload extends the
Hida-Li-Bailey section 3.5 algorithm by representing the denominator in
double-double form, giving a more precise result than casting to double.

Move differenceZonedDateTimeForDuration out of DurationArithmetic into
ZonedDateTimeCore where it belongs alongside other timezone operations.
Change differenceZonedDateTimeWithRounding to return InternalDuration
instead of Duration, deferring conversion to the JS-layer caller. Fix
spec step annotations in differenceZonedDateTime (steps 12-15 were off
by 1, sub-steps 11.b/11.e/11.g were missing).

Test: Source/JavaScriptCore/API/tests/TemporalCoreTest.cpp
Canonical link: <a href="https://commits.webkit.org/313276@main">https://commits.webkit.org/313276@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/244fc88cadb384b0095bc8971cbcbf60e9de8db7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162633 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36109 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29249 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171571 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/119079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36213 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36113 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126219 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/119079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165592 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28575 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/146113 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106797 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27621 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19271 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137327 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23843 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174075 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23472 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21388 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25488 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134530 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35783 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134526 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35767 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145639 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98119 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24720 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/29066 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/22473 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195034 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35277 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/103028 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/50432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34778 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35023 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34926 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->