### PR TITLE
[export-w3c-test-changes] Remove support for exporting Bugzilla attachments

### DIFF
--- a/Tools/Scripts/webkitpy/w3c/test_exporter.py
+++ b/Tools/Scripts/webkitpy/w3c/test_exporter.py
@@ -26,22 +26,19 @@
 
 import argparse
 import logging
-import os
 import sys
 import subprocess
 
 from webkitcorepy import string_utils, run
-from webkitbugspy import Tracker, bugzilla
+from webkitbugspy import bugzilla
 from webkitscmpy import local
 
 from webkitpy.common.host import Host
-from webkitpy.common.net.bugzilla import Bugzilla
 from webkitpy.common.webkit_finder import WebKitFinder
 from webkitpy.w3c.wpt_linter import WPTLinter
 from webkitpy.w3c.common import WPT_GH_ORG, WPT_GH_REPO_NAME, WPT_GH_URL, WPTPaths
 from webkitpy.common.memoized import memoized
 
-from urllib.error import HTTPError
 
 _log = logging.getLogger(__name__)
 
@@ -53,46 +50,28 @@ EXCLUDED_FILE_SUFFIXES = ['-expected.txt', '-expected.html', '-expected.xht', '-
 
 
 class WebPlatformTestExporter(object):
-    def __init__(self, host, options, bugzillaClass=Bugzilla, WPTLinterClass=WPTLinter, WKRepository=None):
+    def __init__(self, host, options):
         self._host = host
         self._filesystem = host.filesystem
         self._options = options
-        self._linter = WPTLinterClass
 
         self._host.initialize_scm()
 
-        self._bugzilla = bugzillaClass()
-        self._bug_id = options.bug_id
-        self._bug = None
-
-        issue = None
         repo_path = WebKitFinder(self._filesystem).webkit_base()
-        self._repository = WKRepository or local.Git(repo_path)
+        self._repository = local.Git(repo_path)
 
-        if not self._bug_id:
-            if options.attachment_id:
-                self._bug_id = self._bugzilla.bug_id_for_attachment_id(options.attachment_id)  # FIXME: Dependency on webkitpy.bugzilla should be removed when patch workflow is disabled
-            elif options.git_commit:
-                commit = self._repository.find(options.git_commit)
-                issue = next((issue for issue in commit.issues if isinstance(issue.tracker, bugzilla.Tracker)), None)
-                if not issue:
-                    raise ValueError('Unable to find associated bug. Please provide a bug id using `--bug`.')
-                self._bug_id = issue.id
-                self._options.git_commit = commit.hash
+        if not options.git_commit:
+            raise ValueError('A git commit must be provided using `--git-commit`.')
 
-        if not self._bug_id:
-            raise ValueError('Unable to find associated bug. Please provide a bug id using `--bug`.')
-        elif Tracker.instance() and (isinstance(self._bug_id, int) or string_utils.decode(self._bug_id).isnumeric()):
-            issue = Tracker.instance().issue(int(self._bug_id))
-        else:
-            issue = Tracker.from_string(self._bug_id)
-        if issue:
-            self._bug_id = issue.id
-            self._bug = issue
+        commit = self._repository.find(options.git_commit)
+        issue = next((issue for issue in commit.issues if isinstance(issue.tracker, bugzilla.Tracker)), None)
+        if not issue:
+            raise ValueError('Unable to find associated bug from commit.')
+        self._bug_id = issue.id
+        self._bug = issue
+        self._options.git_commit = commit.hash
 
-        self._commit_message = options.message
-        if not self._commit_message:
-            self._commit_message = f'WebKit export of {issue.link}' if issue else 'Export made from a WebKit repository'
+        self._commit_message = options.message or f'WebKit export of {issue.link}'
 
     @property
     def username(self):
@@ -128,10 +107,7 @@ class WebPlatformTestExporter(object):
     @property
     @memoized
     def _branch_name(self):
-        if not self._bug_id:
-            commit = self._repository.find(self._options.git_commit)
-            commit_hash = commit.hash[:7] if commit else '0'
-        return f"wpt-export-for-webkit-{(str(self._bug_id) if self._bug_id else commit_hash)}"
+        return f"wpt-export-for-webkit-{self._bug_id}"
 
     @property
     @memoized
@@ -223,7 +199,7 @@ class WebPlatformTestExporter(object):
         self._remote = self._init_wpt_remote()
         if not self._remote:
             return 1
-        self._linter = self._linter(repository_directory)
+        self._linter = WPTLinter(repository_directory)
         return True
 
     def clean(self):
@@ -245,7 +221,7 @@ class WebPlatformTestExporter(object):
         try:
             output = self._run_wpt_git(['apply', '--index', patch, '-3'], stderr=subprocess.STDOUT)
             if output.returncode:
-                _log.error(f'Failed to apply patch!')
+                _log.error('Failed to apply patch!')
                 _log.error(f"{output.stdout.decode('utf-8', 'replace')}")
                 return False
         except Exception as e:
@@ -346,7 +322,7 @@ class WebPlatformTestExporter(object):
             return 1
 
         if not self._get_wpt_repository():
-            _log.error(f'Could not find WPT repository')
+            _log.error('Could not find WPT repository')
             return 1
 
         _log.info('Fetching web-platform-tests repository')
@@ -403,10 +379,10 @@ class WebPlatformTestExporter(object):
 
 def parse_args(args):
     description = f"""Script to generate a pull request to W3C web-platform-tests repository
-    'Tools/Scripts/export-w3c-test-changes -c -g HEAD -b XYZ' will do the following:
+    'Tools/Scripts/export-w3c-test-changes -c -g HEAD' will do the following:
     - Clone web-platform-tests repository if not done already and set it up for pushing branches. By default, the repository will be cloned into the parent directory of your WebKit checkout (e.g. ~/WebKit/../wpt).
-    - Gather WebKit bug id XYZ bug and changes to apply to web-platform-tests repository based on the HEAD commit
-    - Create a remote branch named webkit-XYZ on https://github.com/USERNAME/{WPT_GH_REPO_NAME}.git repository based on the locally applied patch.
+    - Gather the bug and changes to apply to web-platform-tests repository based on the HEAD commit
+    - Create a remote branch on https://github.com/USERNAME/{WPT_GH_REPO_NAME}.git repository based on the locally applied patch.
        * {WPT_GH_URL}.git should have already been cloned to https://github.com/USERNAME/{WPT_GH_REPO_NAME}.git.
     - Make the related pull request on {WPT_GH_URL}.git repository.
     - Clean the local Git repository
@@ -420,8 +396,6 @@ def parse_args(args):
     parser = argparse.ArgumentParser(prog='export-w3c-test-changes ...', description=description, formatter_class=argparse.RawDescriptionHelpFormatter)
 
     parser.add_argument('-g', '--git-commit', dest='git_commit', default=None, help='Git commit to apply')
-    parser.add_argument('-b', '--bug', dest='bug_id', default=None, help='Bug ID or URL to search for patch')
-    parser.add_argument('-a', '--attachment', dest='attachment_id', default=None, help='Attachment ID to search for patch')
     parser.add_argument('-bn', '--branch-name', dest='public_branch_name', default=None, help='Branch name to push to')
     parser.add_argument('-m', '--message', dest='message', default=None, help='Commit message')
     parser.add_argument('-r', '--remote', dest='repository_remote', default=None, help='repository origin to use to push')

--- a/Tools/Scripts/webkitpy/w3c/test_exporter_unittest.py
+++ b/Tools/Scripts/webkitpy/w3c/test_exporter_unittest.py
@@ -42,20 +42,6 @@ class TestExporterTest(testing.PathTestCase):
         super().setUp()
         os.mkdir(os.path.join(self.path, '.git'))
 
-    class MockBugzilla(object):
-        def __init__(self):
-            self.calls = []
-
-        def fetch_bug_dictionary(self, id):
-            self.calls.append('fetch bug ' + id)
-            return {"title": "my bug title"}
-
-        def post_comment_to_bug(self, id, comment, see_also=None):
-            if see_also:
-                self.calls.append("Append %s to see also list" % ", ".join(see_also))
-            self.calls.append('post comment to bug ' + id + ' : ' + comment)
-            return True
-
     class MockGit(object):
         mock_format_patch_result = b'my patch containing some diffs'
 
@@ -85,17 +71,22 @@ class TestExporterTest(testing.PathTestCase):
         }) as wpt_remote, mocks.local.Git(
             self.path,
             remote='https://{}'.format(wpt_remote.remote)
-        ), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)]), patch(
+        ) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
             'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
         ) as mock_linter_class:
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
             host = TestExporterTest.MyMockHost()
             host.filesystem.maybe_make_directory(self.path)
             host.filesystem.write_binary_file(f'{self.path}/resources/testharness.js', '')
             host.filesystem.write_binary_file(f'{self.path}/wpt', '')
 
             host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
-            options = parse_args(['test_exporter.py', '-g', '1@main', '-b', '1', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
-            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, mock_linter_class, 1)
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+            exporter = WebPlatformTestExporter(host, options)
             exporter.do_export()
 
             issue = Tracker.from_string('{}/show_bug.cgi?id=1'.format(self.BUGZILLA_URL))
@@ -107,7 +98,7 @@ class TestExporterTest(testing.PathTestCase):
 
         self.assertEqual(
             captured.stdout.getvalue(),
-            f"Created 'PR 1 | WebKit export of https://bugs.example.com/show_bug.cgi?id=1'!\n",
+            "Created 'PR 1 | WebKit export of https://bugs.example.com/show_bug.cgi?id=1'!\n",
         )
         self.assertEqual(captured.stderr.getvalue(), '')
         log = captured.root.log.getvalue().splitlines()
@@ -125,6 +116,31 @@ class TestExporterTest(testing.PathTestCase):
                 'WPT Pull Request: https://github.com/web-platform-tests/wpt/pull/1'],
         )
 
+    def test_export_no_git_commit(self):
+        with mocks.local.Git(self.path), patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ):
+            host = TestExporterTest.MyMockHost()
+            host.filesystem.maybe_make_directory(self.path)
+            options = parse_args(['test_exporter.py', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+            with self.assertRaises(ValueError) as context:
+                WebPlatformTestExporter(host, options)
+            self.assertIn('--git-commit', str(context.exception))
+
+    def test_export_no_bugzilla_issue_in_commit(self):
+        with mocks.local.Git(self.path) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ):
+            git_mock.head.message = 'Commit with no bug reference\n'
+            host = TestExporterTest.MyMockHost()
+            host.filesystem.maybe_make_directory(self.path)
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+            with self.assertRaises(ValueError) as context:
+                WebPlatformTestExporter(host, options)
+            self.assertIn('Unable to find associated bug', str(context.exception))
+
     def test_export_with_specific_branch(self):
         with OutputCapture(level=logging.INFO) as captured, bmocks.Bugzilla(self.BUGZILLA_URL.split('://')[1], issues=bmocks.ISSUES, environment=wkmocks.Environment(
             BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
@@ -134,16 +150,21 @@ class TestExporterTest(testing.PathTestCase):
         }) as wpt_remote, mocks.local.Git(
             self.path,
             remote='https://{}'.format(wpt_remote.remote)
-        ), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)]), patch(
+        ) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
             'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
         ) as mock_linter_class:
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
             host = TestExporterTest.MyMockHost()
             host.filesystem.maybe_make_directory(self.path)
             host.filesystem.write_binary_file(f'{self.path}/resources/testharness.js', '')
             host.filesystem.write_binary_file(f'{self.path}/wpt', '')
             host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
-            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-b', '1', '-c', '-n', 'USER', '-t', 'TOKEN', '-bn', 'wpt-export-branch', '-d', self.path])
-            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, mock_linter_class, 1)
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-bn', 'wpt-export-branch', '-d', self.path])
+            exporter = WebPlatformTestExporter(host, options)
             exporter.do_export()
             issue = Tracker.from_string('{}/show_bug.cgi?id=1'.format(self.BUGZILLA_URL))
             self.assertEqual(issue.comments[-1].content, 'Submitted web-platform-tests pull request: https://github.com/web-platform-tests/wpt/pull/1')
@@ -154,7 +175,7 @@ class TestExporterTest(testing.PathTestCase):
 
         self.assertEqual(
             captured.stdout.getvalue(),
-            f"Created 'PR 1 | WebKit export of https://bugs.example.com/show_bug.cgi?id=1'!\n",
+            "Created 'PR 1 | WebKit export of https://bugs.example.com/show_bug.cgi?id=1'!\n",
         )
         self.assertEqual(captured.stderr.getvalue(), '')
         log = captured.root.log.getvalue().splitlines()
@@ -181,16 +202,21 @@ class TestExporterTest(testing.PathTestCase):
         }) as wpt_remote, mocks.local.Git(
             self.path,
             remote='https://{}'.format(wpt_remote.remote)
-        ), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)]), patch(
+        ) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
             'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
         ) as mock_linter_class:
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
             host = TestExporterTest.MyMockHost()
             host.filesystem.maybe_make_directory(self.path)
             host.filesystem.write_binary_file(f'{self.path}/resources/testharness.js', '')
             host.filesystem.write_binary_file(f'{self.path}/wpt', '')
             host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
-            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-b', '1', '-c', '-n', 'USER', '-t', 'TOKEN', '--no-clean', '-d', self.path])
-            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, mock_linter_class, 1)
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '--no-clean', '-d', self.path])
+            exporter = WebPlatformTestExporter(host, options)
             exporter.do_export()
             issue = Tracker.from_string('{}/show_bug.cgi?id=1'.format(self.BUGZILLA_URL))
             self.assertEqual(issue.comments[-1].content, 'Submitted web-platform-tests pull request: https://github.com/web-platform-tests/wpt/pull/1')
@@ -201,7 +227,7 @@ class TestExporterTest(testing.PathTestCase):
 
         self.assertEqual(
             captured.stdout.getvalue(),
-            f"Created 'PR 1 | WebKit export of https://bugs.example.com/show_bug.cgi?id=1'!\n",
+            "Created 'PR 1 | WebKit export of https://bugs.example.com/show_bug.cgi?id=1'!\n",
         )
         self.assertEqual(captured.stderr.getvalue(), '')
         log = captured.root.log.getvalue().splitlines()
@@ -220,7 +246,7 @@ class TestExporterTest(testing.PathTestCase):
         )
 
     def test_export_interactive_mode(self):
-        with OutputCapture(level=logging.INFO) as captured, bmocks.Bugzilla(self.BUGZILLA_URL.split('://')[1], issues=bmocks.ISSUES, environment=wkmocks.Environment(
+        with OutputCapture(level=logging.INFO), bmocks.Bugzilla(self.BUGZILLA_URL.split('://')[1], issues=bmocks.ISSUES, environment=wkmocks.Environment(
             BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
             BUGS_EXAMPLE_COM_PASSWORD='password',
         )), mocks.remote.GitHub(remote='github.com/web-platform-tests/wpt', labels={
@@ -228,30 +254,40 @@ class TestExporterTest(testing.PathTestCase):
         }) as wpt_remote, mocks.local.Git(
             self.path,
             remote='https://{}'.format(wpt_remote.remote)
-        ), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)]), patch(
+        ) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
             'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
-        ) as mock_linter_class:
+        ):
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
             host = TestExporterTest.MyMockHost()
             host.filesystem.maybe_make_directory(self.path)
             host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
-            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-b', '1', '-c', '-n', 'USER', '-t', 'TOKEN', '--interactive', '-d', self.path])
-            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, mock_linter_class, 1)
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '--interactive', '-d', self.path])
+            exporter = WebPlatformTestExporter(host, options)
             exporter.do_export()
 
     def test_export_invalid_token(self):
         host = TestExporterTest.MyMockHost()
         host.filesystem.maybe_make_directory(self.path)
         host.web.responses.append({'status_code': 401})
-        options = parse_args(['test_exporter.py', '-g', 'HEAD', '-b', '1', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
-        with OutputCapture(level=logging.INFO) as captured, mocks.remote.GitHub(remote='github.com/web-platform-tests/wpt', labels={
+        options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+        with OutputCapture(level=logging.INFO), mocks.remote.GitHub(remote='github.com/web-platform-tests/wpt', labels={
             'webkit-export': dict(color='00000', description=''),
         }) as wpt_remote, mocks.local.Git(
             self.path,
             remote='https://{}'.format(wpt_remote.remote)
-        ), self.assertRaises(Exception) as context, patch('webkitpy.w3c.test_exporter.WPTLinter',
-            autospec=True, spec_set=True,
-        ) as mock_linter_class:
-            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, mock_linter_class, 1)
+        ) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), self.assertRaises(Exception) as context, patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ):
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
+            exporter = WebPlatformTestExporter(host, options)
             exporter.do_export()
             self.assertIn('OAuth token is not valid', str(context.exception))
 
@@ -259,43 +295,58 @@ class TestExporterTest(testing.PathTestCase):
         host = TestExporterTest.MyMockHost()
         host.filesystem.maybe_make_directory(self.path)
         host.web.responses.append({'status_code': 200, 'body': '{"login": "DIFF_USER"}'})
-        options = parse_args(['test_exporter.py', '-g', 'HEAD', '-b', '1', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
-        with OutputCapture(level=logging.INFO) as captured, mocks.remote.GitHub(remote='github.com/web-platform-tests/wpt', labels={
+        options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+        with OutputCapture(level=logging.INFO), mocks.remote.GitHub(remote='github.com/web-platform-tests/wpt', labels={
             'webkit-export': dict(color='00000', description=''),
         }) as wpt_remote, mocks.local.Git(
             self.path,
             remote='https://{}'.format(wpt_remote.remote)
-        ), self.assertRaises(Exception) as context, patch('webkitpy.w3c.test_exporter.WPTLinter',
-            autospec=True, spec_set=True,
-        ) as mock_linter_class:
-            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, mock_linter_class, 1)
+        ) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), self.assertRaises(Exception) as context, patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ):
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
+            exporter = WebPlatformTestExporter(host, options)
             exporter.do_export()
             self.assertIn('OAuth token does not match the provided username', str(context.exception))
 
     def test_has_wpt_changes(self):
         host = TestExporterTest.MyMockHost()
         host.filesystem.maybe_make_directory(self.path)
-        options = parse_args(['test_exporter.py', '-g', 'HEAD', '-b', '1', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
-        with mocks.local.Git(self.path), patch('webkitpy.w3c.test_exporter.WPTLinter',
-            autospec=True, spec_set=True,
-        ) as mock_linter_class:
-            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, mock_linter_class, 1)
+        options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+        with mocks.local.Git(self.path) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ):
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
+            exporter = WebPlatformTestExporter(host, options)
             self.assertTrue(exporter.has_wpt_changes())
 
     def test_has_no_wpt_changes_for_no_diff(self):
         host = TestExporterTest.MyMockHost()
         host.filesystem.maybe_make_directory(self.path)
         host._mockSCM.mock_format_patch_result = None
-        options = parse_args(['test_exporter.py', '-g', 'HEAD', '-b', '1', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+        options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
         with mocks.remote.GitHub(remote='github.com/web-platform-tests/wpt', labels={
             'webkit-export': dict(color='00000', description=''),
         }) as wpt_remote, mocks.local.Git(
             self.path,
             remote='https://{}'.format(wpt_remote.remote)
-        ), patch('webkitpy.w3c.test_exporter.WPTLinter',
-            autospec=True, spec_set=True,
-        ) as mock_linter_class:
-            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, mock_linter_class, 1)
+        ) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ):
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
+            exporter = WebPlatformTestExporter(host, options)
             self.assertFalse(exporter.has_wpt_changes())
 
     def test_ignore_changes_to_expected_file(self):
@@ -319,11 +370,16 @@ diff --git a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/headers/heade
 
 +change to any.sharedworker
 """
-        options = parse_args(['test_exporter.py', '-g', 'HEAD', '-b', '1', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
-        with mocks.local.Git(self.path), patch('webkitpy.w3c.test_exporter.WPTLinter',
-            autospec=True, spec_set=True,
-        ) as mock_linter_class:
-            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, mock_linter_class, 1)
+        options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+        with mocks.local.Git(self.path) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ):
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
+            exporter = WebPlatformTestExporter(host, options)
         self.assertFalse(exporter.has_wpt_changes())
 
     def test_ignore_changes_to_expected_mismatch_file(self):
@@ -335,11 +391,16 @@ diff --git a/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/
 
 +change to expected-mismatch
 """
-        options = parse_args(['test_exporter.py', '-g', 'HEAD', '-b', '1', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
-        with mocks.local.Git(self.path), patch('webkitpy.w3c.test_exporter.WPTLinter',
-            autospec=True, spec_set=True,
-        ) as mock_linter_class:
-            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, mock_linter_class, 1)
+        options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+        with mocks.local.Git(self.path) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ):
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
+            exporter = WebPlatformTestExporter(host, options)
         self.assertFalse(exporter.has_wpt_changes())
 
     def test_ignore_changes_to_w3c_import_log(self):
@@ -351,9 +412,14 @@ diff --git a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/headers/w3c-i
 
 +change to w3c import
 """
-        options = parse_args(['test_exporter.py', '-g', 'HEAD', '-b', '1', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
-        with mocks.local.Git(self.path), patch('webkitpy.w3c.test_exporter.WPTLinter',
-            autospec=True, spec_set=True,
-        ) as mock_linter_class:
-            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, mock_linter_class, 1)
+        options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+        with mocks.local.Git(self.path) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ):
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
+            exporter = WebPlatformTestExporter(host, options)
         self.assertFalse(exporter.has_wpt_changes())


### PR DESCRIPTION
#### beb1d4628418c5bc008f795e1ae5aed9680fd30f
<pre>
[export-w3c-test-changes] Remove support for exporting Bugzilla attachments
<a href="https://bugs.webkit.org/show_bug.cgi?id=297919">https://bugs.webkit.org/show_bug.cgi?id=297919</a>
<a href="https://rdar.apple.com/159206512">rdar://159206512</a>

Reviewed by Elliott Williams.

The Bugzilla attachment and bug-id paths are practically unused, and
make related improvements harder because they lack the full context of
a git commit. Remove them so that the exporter always derives the bug
from the git commit. Simplify the constructor by removing the
dependency-injection parameters that only existed to support the
removed paths.

Drive-by: remove the WPTLinterClass parameter from
WebPlatformTestExporter, the last dependency-injection paramter, since
the tests already patch the module-level name.

* Tools/Scripts/webkitpy/tool/steps/wptchangeexport.py:
(WPTChangeExport.run): Require git_commit instead of bug_id, and
build args without --bug.
* Tools/Scripts/webkitpy/w3c/test_exporter.py:
(WebPlatformTestExporter.__init__): Remove bugzillaClass,
WPTLinterClass, and WKRepository parameters. Remove bug_id and
attachment_id handling; always derive the bug from the git commit.
(WebPlatformTestExporter._branch_name): Simplify now that bug_id is
always set.
(WebPlatformTestExporter._get_wpt_repository): Use WPTLinter directly
instead of indirecting through self._linter class reference.
(WebPlatformTestExporter.create_branch_with_patch):
(WebPlatformTestExporter.do_export):
(parse_args): Remove -b/--bug and -a/--attachment arguments. Update
usage description.
* Tools/Scripts/webkitpy/w3c/test_exporter_unittest.py:
(TestExporterTest.setUp):
(TestExporterTest.test_export):
(TestExporterTest.test_export_with_specific_branch):
(TestExporterTest.test_export_no_clean):
(TestExporterTest.test_export_interactive_mode):
(TestExporterTest.test_export_invalid_token):
(TestExporterTest.test_export_wrong_token):
(TestExporterTest.test_has_wpt_changes):
(TestExporterTest.test_has_no_wpt_changes_for_no_diff):
(TestExporterTest.MockBugzilla): Removed.
(TestExporterTest.MockBugzilla.__init__): Deleted.
(TestExporterTest.MockBugzilla.fetch_bug_dictionary): Deleted.
(TestExporterTest.MockBugzilla.post_comment_to_bug): Deleted.

Canonical link: <a href="https://commits.webkit.org/314677@main">https://commits.webkit.org/314677@main</a>
</pre>
