### PR TITLE
[AppKit Gestures] Add a test that AppKit gesture driven scrolls propagate upwards to outer scrollviews

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift
@@ -24,7 +24,7 @@
 #if HAVE_APPKIT_GESTURES_SUPPORT
 
 import Foundation
-@_spi(WebKitAdditions_Testing) @_spi(Testing) import WebKit
+@_spi(WebKitAdditions_Testing) @_spi(Testing) @_spi(CrossImportOverlay) import WebKit
 import SwiftUI
 import struct Swift.String
 import struct _Concurrency.Task
@@ -234,6 +234,72 @@ struct AppKitGesturesTests {
         #expect(newSelection == .collapsed(.init(in: "div", at: offset)))
     }
 
+    @Test(.bug("rdar://170502266"))
+    func scrollOverNonScrollableWebViewPropagatesToEnclosingScrollView() async throws {
+        let windowSize = NSSize(width: 800, height: 600)
+        let documentHeight: CGFloat = 2000
+        let page = WebPage()
+        let webView = page.backingWebView
+        webView.frame = NSRect(x: 0, y: 0, width: windowSize.width, height: windowSize.height)
+
+        let documentView = FlippedDocumentView(
+            frame: NSRect(x: 0, y: 0, width: windowSize.width, height: documentHeight)
+        )
+        documentView.addSubview(webView)
+
+        let scrollView = NSScrollView(frame: NSRect(origin: .zero, size: windowSize))
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = false
+        scrollView.documentView = documentView
+
+        let scrollViewController = NSViewController()
+        scrollViewController.view = scrollView
+        let scrollWindow = NSWindow(contentViewController: scrollViewController)
+        scrollWindow.setContentSize(windowSize)
+        scrollWindow.setFrameOrigin(.zero)
+        NSApp.activate(ignoringOtherApps: true)
+        scrollWindow.makeKeyAndOrderFront(nil)
+
+        try await page.load(html: "<body style='margin:0'>not scrollable</body>").wait()
+        await page.waitForNextPresentationUpdate()
+
+        // Recap requires this test to be ran within an app host.
+        guard NSApp.isActive else {
+            return
+        }
+
+        let viewportInDOMCoords = try #require(
+            DOMRect(decodedRepresentation: [
+                "x": 0.0,
+                "y": 0.0,
+                "width": Double(webView.frame.width),
+                "height": Double(webView.frame.height),
+            ])
+        )
+        let viewportInCGScreen = convertToCoreGraphicsScreenCoordinates(
+            rectInViewportCoordinates: viewportInDOMCoords,
+            window: scrollWindow
+        )
+
+        let dragDistance: CGFloat = 100
+        let center = viewportInCGScreen.center
+        let startPoint = CGPoint(x: center.x, y: center.y + dragDistance / 2)
+        let endPoint = CGPoint(x: center.x, y: center.y - dragDistance / 2)
+
+        let initialDocumentVisibleRect = scrollView.documentVisibleRect
+
+        await recap.play { composer in
+            composer.drag(withStart: startPoint, end: endPoint, duration: 0.5)
+            composer.advanceTime(0.1)
+            composer._wk_mouseUp()
+        }
+
+        await page.waitForNextPresentationUpdate()
+
+        // The test passes if the outer scroller scrolled.
+        #expect(scrollView.documentVisibleRect.origin != initialDocumentVisibleRect.origin)
+    }
+
     @Test
     func clickingChangesSelection() async throws {
         try await loadHTML(contentEditable: true)
@@ -337,6 +403,10 @@ extension AppKitGesturesTests {
 
         return screenCoordinates
     }
+}
+
+private final class FlippedDocumentView: NSView {
+    override var isFlipped: Bool { true }
 }
 
 #endif // HAVE_APPKIT_GESTURES_SUPPORT


### PR DESCRIPTION
#### 45a2c925bb5fce393684d6dd0e16bc1bb5b432f8
<pre>
[AppKit Gestures] Add a test that AppKit gesture driven scrolls propagate upwards to outer scrollviews
<a href="https://bugs.webkit.org/show_bug.cgi?id=314854">https://bugs.webkit.org/show_bug.cgi?id=314854</a>
<a href="https://rdar.apple.com/177109678">rdar://177109678</a>

Reviewed by NOBODY (OOPS!).

* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift:
(AppKitGesturesTests.scrollOverNonScrollableWebViewPropagatesToEnclosingScrollView):
Add a test for <a href="https://commits.webkit.org/313208@main">313208@main</a>.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45a2c925bb5fce393684d6dd0e16bc1bb5b432f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162654 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36130 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29270 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171592 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119100 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3329a14b-3cf6-46e7-96d3-c93472981af6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164523 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36234 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36134 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126239 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88902 "1 flakes 18 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f4bdd24f-0e91-48ac-bee0-b1eed5fdbf53) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165613 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28588 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146140 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106817 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27634 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26166 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19292 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137340 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23870 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174096 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25515 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134550 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35804 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30263 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134546 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35788 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145666 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98140 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/29085 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22500 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35298 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34799 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35044 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34947 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->