### PR TITLE
[JSC] Optimize stricteq with non-String / non-HeapBigInt cells

### DIFF
--- a/Source/JavaScriptCore/jit/JITOpcodes.cpp
+++ b/Source/JavaScriptCore/jit/JITOpcodes.cpp
@@ -858,19 +858,29 @@ void JIT::compileOpStrictEq(const JSInstruction* currentInstruction)
     boxBoolean(regT5, JSValueRegs { regT5 });
     emitPutVirtualRegister(dst, regT5);
 #else // if !USE(BIGINT32)
-    // Jump slow if both are cells (to cover strings).
+    // Cells are slow only when they actually need value-based equality (Strings, HeapBigInts).
+    // For other cell pairs we can answer with a pointer compare directly.
     or64(regT1, regT0, regT2);
-    addSlowCase(branchIfCell(regT2));
+    Jump includesNonCell = branchIfNotCell(regT2);
+
+    // Now both are cells. Cell comparison is complicated only when they are Strings / HeapBigInts.
+    // If either cell is something else, the pointer compare answers correctly. Check the first cell and if it's already a high
+    // type we can skip the second check entirely.
+    JumpList comparePointers;
+    comparePointers.append(branch8(Above, Address(regT0, JSCell::typeInfoTypeOffset()), TrustedImm32(LastValueCompareCellType)));
+    comparePointers.append(branch8(Above, Address(regT1, JSCell::typeInfoTypeOffset()), TrustedImm32(LastValueCompareCellType)));
+    addSlowCase(jump());
 
     // Jump slow if either is a double. First test if it's an integer, which is fine, and then test
     // if it's a double.
+    includesNonCell.link(this);
     Jump leftOK = branchIfInt32(regT0);
     addSlowCase(branchIfNumber(regT0));
     leftOK.link(this);
     Jump rightOK = branchIfInt32(regT1);
     addSlowCase(branchIfNumber(regT1));
     rightOK.link(this);
-
+    comparePointers.link(this);
     if constexpr (std::is_same_v<Op, OpStricteq>)
         compare64(Equal, regT1, regT0, regT0);
     else
@@ -1026,22 +1036,51 @@ void JIT::compileOpStrictEqJump(const JSInstruction* currentInstruction)
         areEqual.link(this);
     }
 #else // if !USE(BIGINT32)
-    // Jump slow if both are cells (to cover strings).
+    JumpList taken;
+    JumpList notTaken;
+
+    // Cells are slow only when they actually need value-based equality (Strings, HeapBigInts).
+    // For other cell pairs we can answer with a pointer compare directly.
     or64(regT1, regT0, regT2);
-    addSlowCase(branchIfCell(regT2));
+    Jump includesNonCell = branchIfNotCell(regT2);
+
+    // Now both are cells. Identical pointers mean the same cell, which is strictly equal
+    // (cells never carry the NaN bit pattern that breaks pointer-based equality for doubles).
+    if constexpr (std::same_as<Op, OpJstricteq>)
+        taken.append(branch64(Equal, regT1, regT0));
+    else
+        notTaken.append(branch64(Equal, regT1, regT0));
+
+    // Pointers differ. Cell comparison is complicated only when they are Strings / HeapBigInts /
+    // HeapDoubles / HeapInt32s. If either cell is something else, the pointer compare answers correctly.
+    if constexpr (std::same_as<Op, OpJstricteq>) {
+        notTaken.append(branch8(Above, Address(regT0, JSCell::typeInfoTypeOffset()), TrustedImm32(LastValueCompareCellType)));
+        notTaken.append(branch8(Above, Address(regT1, JSCell::typeInfoTypeOffset()), TrustedImm32(LastValueCompareCellType)));
+    } else {
+        taken.append(branch8(Above, Address(regT0, JSCell::typeInfoTypeOffset()), TrustedImm32(LastValueCompareCellType)));
+        taken.append(branch8(Above, Address(regT1, JSCell::typeInfoTypeOffset()), TrustedImm32(LastValueCompareCellType)));
+    }
+    addSlowCase(jump());
 
     // Jump slow if either is a double. First test if it's an integer, which is fine, and then test
-    // if it's a double.
+    // if it's a double. We must filter doubles before doing the bitwise identity check below,
+    // since NaN === NaN must be false even when both sides have identical encoded bits.
+    includesNonCell.link(this);
     Jump leftOK = branchIfInt32(regT0);
     addSlowCase(branchIfNumber(regT0));
     leftOK.link(this);
     Jump rightOK = branchIfInt32(regT1);
     addSlowCase(branchIfNumber(regT1));
     rightOK.link(this);
+
+    // No doubles. At least one operand is a non-cell, so identical encoded bits imply strict equality.
     if constexpr (std::same_as<Op, OpJstricteq>)
         addJump(branch64(Equal, regT1, regT0), target);
     else
         addJump(branch64(NotEqual, regT1, regT0), target);
+
+    notTaken.link(this);
+    addJump(taken, target);
 #endif
 }
 

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter64.asm
@@ -995,7 +995,9 @@ macro strictEqOp(opcodeName, opcodeStruct, createBoolean)
         # result = (left == right);
         # if (result)
         #     goto done;
-        # if (left is Cell || right is Cell)
+        # if (left is non-cell || right is non-cell)
+        #     done (result is already false)
+        # if (left is empty || right is empty || either is String/HeapBigInt)
         #     goto slowPath;
         # done:
         # return result;
@@ -1016,10 +1018,15 @@ macro strictEqOp(opcodeName, opcodeStruct, createBoolean)
         cqeq t0, t1, t5
         btqnz t5, t5, .done #is there a better way of checking t5 != 0 ?
 
-        move t0, t2
-        # This andq could be an 'or' if not for BigInt32 (since it makes it possible for a Cell to be strictEqual to a non-Cell)
-        andq t1, t2
-        btqz t2, notCellMask, .slow
+        # Pointer-equal failed. Doubles were filtered above, so any non-cell here is
+        # Int32 / Null / Undefined / true / false, and a non-cell on either side means
+        # strict equality is already known to be false.
+        btqnz t0, notCellMask, .done
+        btqnz t1, notCellMask, .done
+        # Both are cells. Only String / HeapBigInt have value-based equality, so if either
+        # cell is something else the pointer compare result (false) is correct.
+        bba JSCell::m_type[t0], constexpr LastValueCompareCellType, .done
+        bbbeq JSCell::m_type[t1], constexpr LastValueCompareCellType, .slow
 
     .done:
         createBoolean(t5)
@@ -1052,7 +1059,9 @@ macro strictEqualityJumpOp(opcodeName, opcodeStruct, jumpIfEqual, jumpIfNotEqual
         #     goto slowPath;
         # if (left == right)
         #     goto jumpTarget;
-        # if (left is Cell || right is Cell)
+        # if (left is non-cell || right is non-cell)
+        #     goto otherJumpTarget (result is already not equal)
+        # if (left is empty || right is empty || either is String/HeapBigInt)
         #     goto slowPath;
         # goto otherJumpTarget
 
@@ -1071,11 +1080,17 @@ macro strictEqualityJumpOp(opcodeName, opcodeStruct, jumpIfEqual, jumpIfNotEqual
 
         bqeq t0, t1, .equal
 
-        move t0, t2
-        # This andq could be an 'or' if not for BigInt32 (since it makes it possible for a Cell to be strictEqual to a non-Cell)
-        andq t1, t2
-        btqz t2, notCellMask, .slow
+        # Pointer-equal failed. Doubles were filtered above, so any non-cell here is
+        # Int32 / Null / Undefined / true / false, and a non-cell on either side means
+        # strict equality is already known to be false.
+        btqnz t0, notCellMask, .notEqual
+        btqnz t1, notCellMask, .notEqual
+        # Both are cells. Only String / HeapBigInt have value-based equality, so if either
+        # cell is something else the pointer compare result (false) is correct.
+        bba JSCell::m_type[t0], constexpr LastValueCompareCellType, .notEqual
+        bbbeq JSCell::m_type[t1], constexpr LastValueCompareCellType, .slow
 
+    .notEqual:
         jumpIfNotEqual(jump, m_targetLabel, dispatch)
 
     .equal:
@@ -2129,7 +2144,7 @@ macro llintJumpTrueOrFalseOp(opcodeName, opcodeStruct, miscConditionOp, truthyCe
 
     .maybeCell:
         btqnz t0, notCellMask, .slow
-        bbbeq JSCell::m_type[t0], constexpr LastMaybeFalsyCellPrimitive, .slow
+        bbbeq JSCell::m_type[t0], constexpr LastValueCompareCellType, .slow
         btbnz JSCell::m_flags[t0], constexpr MasqueradesAsUndefined, .slow
         truthyCellConditionOp(dispatch)
 

--- a/Source/JavaScriptCore/runtime/JSType.h
+++ b/Source/JavaScriptCore/runtime/JSType.h
@@ -31,10 +31,14 @@ namespace JSC {
     /* The CellType value must come before any JSType that is a JSCell. */ \
     macro(CellType, SpecCellOther) \
     macro(StructureType, SpecCellOther) \
+    \
+    /* These JSCells require non-pointer-comparison identity check */ \
+    /* (e.g. String value comparison). Keep in sync with LastValueCompareCellType. */ \
     macro(StringType, SpecString) \
     macro(HeapBigIntType, SpecHeapBigInt) \
     macro(HeapDoubleType, SpecCellOther) \
     macro(HeapInt32Type, SpecCellOther) \
+    \
     macro(SymbolType, SpecSymbol) \
     \
     macro(GetterSetterType, SpecCellOther) \
@@ -168,7 +172,7 @@ enum JSType : uint8_t {
 
 static constexpr uint8_t EmbedderArrayLikeType = 0b11101101;
 
-static constexpr uint32_t LastMaybeFalsyCellPrimitive = HeapBigIntType;
+static constexpr uint32_t LastValueCompareCellType = HeapInt32Type;
 
 static constexpr uint32_t FirstTypedArrayType = Int8ArrayType;
 static constexpr uint32_t LastTypedArrayType = DataViewType;


### PR DESCRIPTION
#### 8f52a29461caf12d63f04167bafd44c7746613b6
<pre>
[JSC] Optimize stricteq with non-String / non-HeapBigInt cells
<a href="https://bugs.webkit.org/show_bug.cgi?id=314855">https://bugs.webkit.org/show_bug.cgi?id=314855</a>
<a href="https://rdar.apple.com/177111037">rdar://177111037</a>

Reviewed by Sosuke Suzuki and Keith Miller.

In LLInt / Baseline, we are calling a slow path function when both sides
are cells since we need to perform String / HeapBigInt comparisons. But
String and HeapBigInt are the only cells which require value comparison,
and the other cells can use pointer comparison check. We add quick
pointer comparison check + JSCell type check before going to the slow
path in LLInt and Baseline. We are not particularly changing DFG and FTL
as we specialize CompareStrictEq with type speculations.

* Source/JavaScriptCore/jit/JITOpcodes.cpp:
(JSC::JIT::compileOpStrictEq):
(JSC::JIT::compileOpStrictEqJump):
* Source/JavaScriptCore/llint/LowLevelInterpreter64.asm:
* Source/JavaScriptCore/runtime/JSType.h:

Canonical link: <a href="https://commits.webkit.org/313295@main">https://commits.webkit.org/313295@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65e00c4331872244e9b03a8708872f343ac70a71

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162683 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36159 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29302 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171621 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119129 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36263 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36163 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126267 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88919 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/034b491f-7051-4f31-a9b6-48f35fed5544) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165642 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28618 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146173 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106844 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b756023a-4622-4f6e-b29d-d9de9842e4ed) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27664 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19321 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137372 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23902 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174125 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23522 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21438 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25547 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134577 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35833 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30291 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134573 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35817 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145698 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98182 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24730 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/29113 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22532 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195084 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35327 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/103078 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/50478 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34828 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35073 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34976 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->