### PR TITLE
claude.com: Selection highlight in the search field moves up as you scroll the page on iPhone

### DIFF
--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -2483,6 +2483,12 @@ bool Quirks::needsClaudeSidebarViewportUnitQuirk(Element& element, const RenderS
 
     return false;
 }
+
+bool Quirks::needsHideSelectionDuringOverflowScrollQuirk() const
+{
+    QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
+    return m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::NeedsHideSelectionDuringOverflowScrollQuirk);
+}
 #endif
 
 bool Quirks::needsLimitedMatroskaSupport() const
@@ -3068,18 +3074,23 @@ static void handleDailyMailCoUkQuirks(QuirksData& quirksData, const URL& /* quir
 
 static void handleClaudeQuirks(QuirksData& quirksData, const URL& /* quirksURL */, const String& quirksDomainString, const URL&  /* documentURL */)
 {
-    QUIRKS_EARLY_RETURN_IF_NOT_DOMAIN("claude.ai"_s);
-
+    if (quirksDomainString == "claude.ai"_s) {
 #if PLATFORM(IOS_FAMILY)
-    quirksData.enableQuirk(QuirksData::SiteSpecificQuirk::NeedsClaudeSidebarViewportUnitQuirk);
+        quirksData.enableQuirk(QuirksData::SiteSpecificQuirk::NeedsClaudeSidebarViewportUnitQuirk);
 #endif
 
-    // rdar://174779259.
-    // The Claude SPA's logout flow leaves some identification cookies behind.
-    // On the next /chat boot those cookies cause the SPA to enter an unauthenticated boot path
-    // that 403s and triggers a /chat -> /logout redirect loop. See
-    // Quirks::clearLogoutSurvivingIdentityCookiesIfNeeded() for the cleanup hook.
-    quirksData.enableQuirk(QuirksData::SiteSpecificQuirk::NeedsLogoutCookieCleanupQuirk);
+        // rdar://174779259.
+        // The Claude SPA's logout flow leaves some identification cookies behind.
+        // On the next /chat boot those cookies cause the SPA to enter an unauthenticated boot path
+        // that 403s and triggers a /chat -> /logout redirect loop. See
+        // Quirks::clearLogoutSurvivingIdentityCookiesIfNeeded() for the cleanup hook.
+        quirksData.enableQuirk(QuirksData::SiteSpecificQuirk::NeedsLogoutCookieCleanupQuirk);
+    }
+
+#if PLATFORM(IOS_FAMILY)
+    if (quirksDomainString == "claude.ai"_s || quirksDomainString == "claude.com"_s)
+        quirksData.enableQuirk(QuirksData::SiteSpecificQuirk::NeedsHideSelectionDuringOverflowScrollQuirk);
+#endif
 }
 
 #if ENABLE(TEXT_AUTOSIZING)

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -288,6 +288,7 @@ public:
     WEBCORE_EXPORT bool shouldHideSoftTopScrollEdgeEffectDuringFocus(const Element&) const;
 
     bool needsClaudeSidebarViewportUnitQuirk(Element&, const RenderStyle&) const;
+    WEBCORE_EXPORT bool needsHideSelectionDuringOverflowScrollQuirk() const;
     bool needsChromeOSNavigatorUserAgentQuirk(const Document&) const;
 #endif
 

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -84,6 +84,7 @@ struct QuirksData {
         NeedsLogoutCookieCleanupQuirk,
 #if PLATFORM(IOS_FAMILY)
         NeedsClaudeSidebarViewportUnitQuirk,
+        NeedsHideSelectionDuringOverflowScrollQuirk,
 #endif
         NeedsCustomUserAgentData,
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/Shared/EditorState.h
+++ b/Source/WebKit/Shared/EditorState.h
@@ -164,6 +164,7 @@ struct EditorState {
         std::optional<WebCore::ScrollingNodeID> scrollingNodeIDAtEnd;
         WebCore::ScrollOffset enclosingScrollOffset;
         bool enclosingLayerUsesContentsLayer { false };
+        bool needsHideSelectionDuringOverflowScrollQuirk { false };
 #endif // PLATFORM(IOS_FAMILY)
     };
 

--- a/Source/WebKit/Shared/EditorState.serialization.in
+++ b/Source/WebKit/Shared/EditorState.serialization.in
@@ -135,6 +135,7 @@ using WebCore::ScrollOffset = WebCore::IntPoint;
     std::optional<WebCore::ScrollingNodeID> scrollingNodeIDAtEnd;
     WebCore::ScrollOffset enclosingScrollOffset;
     bool enclosingLayerUsesContentsLayer;
+    bool needsHideSelectionDuringOverflowScrollQuirk;
 #endif
 };
 

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -14528,6 +14528,9 @@ static inline WKTextAnimationType toWKTextAnimationType(WebCore::TextAnimationTy
     if (!state.hasVisualData())
         return NO;
 
+    if (state.visualData->needsHideSelectionDuringOverflowScrollQuirk)
+        return YES;
+
     auto enclosingScrollingNodeID = state.visualData->enclosingScrollingNodeID;
     RetainPtr enclosingScroller = [self _scrollViewForScrollingNodeID:enclosingScrollingNodeID] ?: self._scroller;
     if (!enclosingScroller || ![enclosingScroller _wk_isAncestorOf:scrollView])

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -355,6 +355,9 @@ void WebPage::getPlatformEditorState(LocalFrame& frame, EditorState& result) con
     auto& postLayoutData = *result.postLayoutData;
     auto& visualData = *result.visualData;
 
+    if (RefPtr document = frame.document())
+        visualData.needsHideSelectionDuringOverflowScrollQuirk = document->quirks().needsHideSelectionDuringOverflowScrollQuirk();
+
     Ref view = *frame.view();
 
     if (frame.editor().hasComposition()) {


### PR DESCRIPTION
#### a89e5daa466bf4e8e3bc61ac1208ef6019465133
<pre>
claude.com: Selection highlight in the search field moves up as you scroll the page on iPhone
<a href="https://bugs.webkit.org/show_bug.cgi?id=314856">https://bugs.webkit.org/show_bug.cgi?id=314856</a>
<a href="https://rdar.apple.com/171039225">rdar://171039225</a>

Reviewed by Wenson Hsieh.

The problem: claude.ai&apos;s chat input is a position:sticky contenteditable
inside an overflow:auto scroller. The selection markers are positioned in
root view coordinates that get computed when the EditorState snapshot is
taken, and EditorState updates are throttled during an active overflow scroll.
So during scroll the markers are drawn against stale coordinates while
the underlying text is at a fresh sticky position. Thus we see the visible
drift in the chat input.

The fix: A quirk for claude.ai and claude.com
that forces _shouldHideSelectionDuringOverflowScroll: to return YES.
That&apos;s the existing mechanism for masking scroll window staleness.
This pattern (sticky positioned editable inside an overflow scroller)
could allude a broader WebKit issue around how selection markers track during
scroll. However, that would warrant its own investigation, a follow up will
be filed.

* Source/WebCore/page/Quirks.cpp:
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:
* Source/WebKit/Shared/EditorState.h:
* Source/WebKit/Shared/EditorState.serialization.in:
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView _shouldHideSelectionDuringOverflowScroll:]):
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::getPlatformEditorState const):

Canonical link: <a href="https://commits.webkit.org/313739@main">https://commits.webkit.org/313739@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9fc7ba75624eb70a8997a34ac25bb361ccfb3e7a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163827 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37311 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30530 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172855 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a8673096-2ba8-442b-a134-8c7cb50ee7c7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165696 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37643 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37378 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127264 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9a920feb-3009-4e4b-b1bc-936b778dc09a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166786 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29542 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147271 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107813 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cf6f01a4-b954-4145-a3e2-c2b904772e7c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28589 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27267 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20620 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138488 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24988 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175377 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28203 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26656 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135566 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36981 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31378 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135542 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36561 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37766 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146783 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99903 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30852 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23637 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36477 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109622 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35974 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1671 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36224 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36121 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->