### PR TITLE
REGRESSION (296844@main): drop-shadow and translation transforms render incorrectly clipped

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-overflow-transformed-child-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-overflow-transformed-child-001-expected.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<title>CSS Filters: filter should not clip transformed overflow children (reference)</title>
+<style>
+body { margin: 0; }
+</style>
+<div style="position: absolute; left: 50px; top: 50px; width: 150px; height: 150px; filter: saturate(50%);">
+  <div style="position: absolute; left: 50px; top: 50px; width: 40px; height: 40px; background-color: green;"></div>
+  <div style="position: absolute; width: 150px; height: 150px; background-color: rgba(0, 255, 0, 0.5);"></div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-overflow-transformed-child-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-overflow-transformed-child-001.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<title>CSS Filters: filter should not clip transformed overflow children</title>
+<link rel="help" href="https://drafts.fxtf.org/filter-effects-1/#FilterProperty">
+<link rel="match" href="reference/filter-overflow-transformed-child-001-ref.html">
+<meta name="assert" content="A child element with a CSS transform that overflows the filtered parent should not be clipped by the filter.">
+<style>
+body { margin: 0; }
+</style>
+<div style="margin: 100px; width: 40px; height: 40px; background-color: green; filter: saturate(50%);">
+  <div>
+    <div style="background-color: rgba(0, 255, 0, 0.5); width: 150px; height: 150px; transform: translate(-50px, -50px);"></div>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference/filter-overflow-transformed-child-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference/filter-overflow-transformed-child-001-ref.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<title>CSS Filters: filter should not clip transformed overflow children (reference)</title>
+<style>
+body { margin: 0; }
+</style>
+<div style="position: absolute; left: 50px; top: 50px; width: 150px; height: 150px; filter: saturate(50%);">
+  <div style="position: absolute; left: 50px; top: 50px; width: 40px; height: 40px; background-color: green;"></div>
+  <div style="position: absolute; width: 150px; height: 150px; background-color: rgba(0, 255, 0, 0.5);"></div>
+</div>

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -3627,7 +3627,7 @@ GraphicsContext* RenderLayer::setupFilters(GraphicsContext& destinationContext, 
     LayoutRect filterRepaintRect = paintingFilters->dirtySourceRect();
     filterRepaintRect.move(offsetFromRoot);
 
-    auto rootRelativeBounds = calculateLayerBounds(paintingInfo.rootLayer, offsetFromRoot, { RenderLayer::PreserveAncestorFlags });
+    auto rootRelativeBounds = calculateLayerBounds(paintingInfo.rootLayer, offsetFromRoot, { });
 
     // When the filter is applied via a transparency layer directly on the destination context (e.g. CG drop-shadow),
     // the switcher doesn't consult applyFilters's clipToRect path, so the ancestor border-radius clip would be lost.


### PR DESCRIPTION
#### 42cae1dc020ad35cbed9c56a8fd7a0c06f4904b7
<pre>
REGRESSION (296844@main): drop-shadow and translation transforms render incorrectly clipped
<a href="https://bugs.webkit.org/show_bug.cgi?id=313665">https://bugs.webkit.org/show_bug.cgi?id=313665</a>
<a href="https://rdar.apple.com/175905543">rdar://175905543</a>

Reviewed by Brent Fulgham.

In setupFilters, calculateLayerBounds was called with { PreserveAncestorFlags }. This flag causes
descendant layers to inherit the parent&apos;s empty flags, which crucially omits IncludeSelfTransform.
Without that flag, CSS transforms on descendant layers (like the inner circle&apos;s transform) are
ignored when computing the filter source image bounds. This makes the filter source image buffer
positioned incorrectly, clipping parts of the painted content.

Fix by passing empty flags.

Tests: imported/w3c/web-platform-tests/css/filter-effects/filter-overflow-transformed-child-001.html
       imported/w3c/web-platform-tests/css/filter-effects/reference/filter-overflow-transformed-child-001-ref.html

* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-overflow-transformed-child-001-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/filter-overflow-transformed-child-001.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/reference/filter-overflow-transformed-child-001-ref.html: Added.
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::setupFilters):

Canonical link: <a href="https://commits.webkit.org/313316@main">https://commits.webkit.org/313316@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d341d2a8f7d8c5efc6766411dc248748861961f6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162679 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36155 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29298 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171617 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119125 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cbe7526f-c788-4c79-a06c-4f5e18a622df) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164548 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36259 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36159 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126263 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f1cbc1f7-8f75-4c19-9de0-39fe0ce9eb2c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165638 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28613 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146167 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106840 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27659 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26189 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19317 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137367 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23896 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174121 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21434 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25541 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134571 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35829 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30286 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134567 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36322 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35813 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145692 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98168 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/29109 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22526 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35323 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/103074 "Found 1 new failure in wasm/WasmConstExprGenerator.cpp") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34824 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35069 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34972 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->