### PR TITLE
[JSC] Avoid per-element `JSPromiseCombinatorsContext` allocation in Promise combinators

### DIFF
--- a/Source/JavaScriptCore/interpreter/Interpreter.cpp
+++ b/Source/JavaScriptCore/interpreter/Interpreter.cpp
@@ -60,7 +60,6 @@
 #include "JSModuleRecord.h"
 #include "JSObject.h"
 #include "JSPromise.h"
-#include "JSPromiseCombinatorsContext.h"
 #include "JSPromiseCombinatorsGlobalContext.h"
 #include "JSPromiseReaction.h"
 #include "JSRemoteFunction.h"
@@ -473,15 +472,13 @@ void Interpreter::getAsyncStackTrace(JSCell* owner, Vector<StackFrame>& results,
             return generator;
 
         // handle `Promise.all`, `Promise.allSettled`, and `Promise.any`
-        if (auto* promiseCombinatorsContext = dynamicDowncast<JSPromiseCombinatorsContext>(promiseContext)) {
-            if (auto* globalContext = promiseCombinatorsContext->globalContext()) {
-                JSValue promiseValue = globalContext->promise();
-                ASSERT(promiseValue);
-                if (auto* promise = dynamicDowncast<JSPromise>(promiseValue)) {
-                    if (JSValue promiseContext = getContextValueFromPromise(promise)) {
-                        if (auto* generator = dynamicDowncast<JSGenerator>(promiseContext))
-                            return generator;
-                    }
+        if (auto* globalContext = dynamicDowncast<JSPromiseCombinatorsGlobalContext>(promiseContext)) {
+            JSValue promiseValue = globalContext->promise();
+            ASSERT(promiseValue);
+            if (auto* promise = dynamicDowncast<JSPromise>(promiseValue)) {
+                if (JSValue promiseContext = getContextValueFromPromise(promise)) {
+                    if (auto* generator = dynamicDowncast<JSGenerator>(promiseContext))
+                        return generator;
                 }
             }
         }

--- a/Source/JavaScriptCore/runtime/JSMicrotask.cpp
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.cpp
@@ -47,7 +47,6 @@
 #include "JSModuleNamespaceObject.h"
 #include "JSModuleRecord.h"
 #include "JSPromise.h"
-#include "JSPromiseCombinatorsContext.h"
 #include "JSPromiseCombinatorsGlobalContext.h"
 #include "JSPromiseConstructor.h"
 #include "JSPromisePrototype.h"
@@ -359,11 +358,10 @@ static void promiseRaceResolveJob(JSGlobalObject* globalObject, VM& vm, JSPromis
     }
 }
 
-static void promiseAllResolveJob(JSGlobalObject* globalObject, VM& vm, JSPromise* promise, JSValue resolution, JSPromiseCombinatorsContext* context, JSPromise::Status status)
+static void promiseAllResolveJob(JSGlobalObject* globalObject, VM& vm, JSPromiseCombinatorsGlobalContext* globalContext, JSValue resolution, uint64_t index, JSPromise::Status status)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* globalContext = context->globalContext();
     switch (status) {
     case JSPromise::Status::Pending: {
         RELEASE_ASSERT_NOT_REACHED();
@@ -371,7 +369,6 @@ static void promiseAllResolveJob(JSGlobalObject* globalObject, VM& vm, JSPromise
     }
     case JSPromise::Status::Fulfilled: {
         auto* values = uncheckedDowncast<JSArray>(globalContext->values());
-        uint64_t index = context->index();
 
         values->putDirectIndex(globalObject, index, resolution);
         RETURN_IF_EXCEPTION(scope, void());
@@ -382,12 +379,14 @@ static void promiseAllResolveJob(JSGlobalObject* globalObject, VM& vm, JSPromise
         --count;
         globalContext->setRemainingElementsCount(vm, jsNumber(count));
         if (!count) {
+            auto* promise = uncheckedDowncast<JSPromise>(globalContext->promise());
             scope.release();
             promise->resolve(globalObject, vm, values);
         }
         break;
     }
     case JSPromise::Status::Rejected: {
+        auto* promise = uncheckedDowncast<JSPromise>(globalContext->promise());
         scope.release();
         promise->reject(vm, globalObject, resolution);
         break;
@@ -395,13 +394,11 @@ static void promiseAllResolveJob(JSGlobalObject* globalObject, VM& vm, JSPromise
     }
 }
 
-static void promiseAllSettledResolveJob(JSGlobalObject* globalObject, VM& vm, JSPromise* promise, JSValue resolution, JSPromiseCombinatorsContext* context, JSPromise::Status status)
+static void promiseAllSettledResolveJob(JSGlobalObject* globalObject, VM& vm, JSPromiseCombinatorsGlobalContext* globalContext, JSValue resolution, uint64_t index, JSPromise::Status status)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
 
-    auto* globalContext = context->globalContext();
     auto* values = uncheckedDowncast<JSArray>(globalContext->values());
-    uint64_t index = context->index();
 
     JSObject* resultObject = nullptr;
     switch (status) {
@@ -428,16 +425,15 @@ static void promiseAllSettledResolveJob(JSGlobalObject* globalObject, VM& vm, JS
     --count;
     globalContext->setRemainingElementsCount(vm, jsNumber(count));
     if (!count) {
+        auto* promise = uncheckedDowncast<JSPromise>(globalContext->promise());
         scope.release();
         promise->resolve(globalObject, vm, values);
     }
 }
 
-static void promiseAnyResolveJob(JSGlobalObject* globalObject, VM& vm, JSPromise* promise, JSValue resolution, JSPromiseCombinatorsContext* context, JSPromise::Status status)
+static void promiseAnyResolveJob(JSGlobalObject* globalObject, VM& vm, JSPromiseCombinatorsGlobalContext* globalContext, JSValue resolution, uint64_t index, JSPromise::Status status)
 {
     auto scope = DECLARE_THROW_SCOPE(vm);
-
-    auto* globalContext = context->globalContext();
 
     switch (status) {
     case JSPromise::Status::Pending: {
@@ -445,13 +441,13 @@ static void promiseAnyResolveJob(JSGlobalObject* globalObject, VM& vm, JSPromise
         break;
     }
     case JSPromise::Status::Fulfilled: {
+        auto* promise = uncheckedDowncast<JSPromise>(globalContext->promise());
         scope.release();
         promise->resolve(globalObject, vm, resolution);
         break;
     }
     case JSPromise::Status::Rejected: {
         auto* errors = uncheckedDowncast<JSArray>(globalContext->values());
-        uint64_t index = context->index();
 
         errors->putDirectIndex(globalObject, index, resolution);
         RETURN_IF_EXCEPTION(scope, void());
@@ -462,6 +458,7 @@ static void promiseAnyResolveJob(JSGlobalObject* globalObject, VM& vm, JSPromise
         --count;
         globalContext->setRemainingElementsCount(vm, jsNumber(count));
         if (!count) {
+            auto* promise = uncheckedDowncast<JSPromise>(globalContext->promise());
             auto* aggregateError = createAggregateError(vm, globalObject->errorStructure(ErrorType::AggregateError), errors, String(), jsUndefined());
             scope.release();
             promise->reject(vm, globalObject, aggregateError);
@@ -1489,13 +1486,13 @@ void runInternalMicrotask(JSGlobalObject* globalObject, VM& vm, InternalMicrotas
         RELEASE_AND_RETURN(scope, promiseRaceResolveJob(globalObject, vm, uncheckedDowncast<JSPromise>(arguments[0]), arguments[1], static_cast<JSPromise::Status>(payload)));
 
     case InternalMicrotask::PromiseAllResolveJob:
-        RELEASE_AND_RETURN(scope, promiseAllResolveJob(globalObject, vm, uncheckedDowncast<JSPromise>(arguments[0]), arguments[1], uncheckedDowncast<JSPromiseCombinatorsContext>(arguments[2]), static_cast<JSPromise::Status>(payload)));
+        RELEASE_AND_RETURN(scope, promiseAllResolveJob(globalObject, vm, uncheckedDowncast<JSPromiseCombinatorsGlobalContext>(arguments[0]), arguments[1], static_cast<uint64_t>(arguments[2].asAnyInt()), static_cast<JSPromise::Status>(payload)));
 
     case InternalMicrotask::PromiseAllSettledResolveJob:
-        RELEASE_AND_RETURN(scope, promiseAllSettledResolveJob(globalObject, vm, uncheckedDowncast<JSPromise>(arguments[0]), arguments[1], uncheckedDowncast<JSPromiseCombinatorsContext>(arguments[2]), static_cast<JSPromise::Status>(payload)));
+        RELEASE_AND_RETURN(scope, promiseAllSettledResolveJob(globalObject, vm, uncheckedDowncast<JSPromiseCombinatorsGlobalContext>(arguments[0]), arguments[1], static_cast<uint64_t>(arguments[2].asAnyInt()), static_cast<JSPromise::Status>(payload)));
 
     case InternalMicrotask::PromiseAnyResolveJob:
-        RELEASE_AND_RETURN(scope, promiseAnyResolveJob(globalObject, vm, uncheckedDowncast<JSPromise>(arguments[0]), arguments[1], uncheckedDowncast<JSPromiseCombinatorsContext>(arguments[2]), static_cast<JSPromise::Status>(payload)));
+        RELEASE_AND_RETURN(scope, promiseAnyResolveJob(globalObject, vm, uncheckedDowncast<JSPromiseCombinatorsGlobalContext>(arguments[0]), arguments[1], static_cast<uint64_t>(arguments[2].asAnyInt()), static_cast<JSPromise::Status>(payload)));
 
     case InternalMicrotask::PromiseReactionJob: {
         JSValue promiseOrCapability = arguments[0];

--- a/Source/JavaScriptCore/runtime/JSPromise.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromise.cpp
@@ -237,7 +237,7 @@ JSPromise* JSPromise::rejectWithCaughtException(JSGlobalObject* globalObject, Th
     return this;
 }
 
-void JSPromise::setInlineMicrotaskReaction(VM& vm, InternalMicrotask task, JSPromise* promise, JSValue context)
+void JSPromise::setInlineMicrotaskReaction(VM& vm, InternalMicrotask task, JSCell* cell, JSValue context)
 {
     ASSERT(status() == Status::Pending);
     ASSERT(inlineReactionKind() == InlineReactionKind::None);
@@ -249,7 +249,7 @@ void JSPromise::setInlineMicrotaskReaction(VM& vm, InternalMicrotask task, JSPro
         | (static_cast<uint16_t>(InlineReactionKind::InternalMicrotask) << inlineReactionKindShift)
         | (static_cast<uint16_t>(task) << inlineReactionMicrotaskShift);
     setSlot(vm, context);
-    setPackedCell(vm, newFlags, promise);
+    setPackedCell(vm, newFlags, cell);
 }
 
 void JSPromise::setInlineHandlerReaction(VM& vm, InlineReactionKind kind, JSPromise* resultPromise, JSValue handler)
@@ -275,8 +275,8 @@ JSPromiseReaction* JSPromise::spillInlineReaction(VM& vm)
     case InlineReactionKind::InternalMicrotask: {
         InternalMicrotask task = inlineReactionMicrotask();
         JSValue context = m_slot.get();
-        auto* promise = uncheckedDowncast<JSPromise>(payloadCell());
-        reaction = JSSlimPromiseReaction::create(vm, promise ? JSValue(promise) : jsUndefined(), task, context, nullptr);
+        JSCell* cell = payloadCell();
+        reaction = JSSlimPromiseReaction::create(vm, cell ? JSValue(cell) : jsUndefined(), task, context, nullptr);
         break;
     }
     case InlineReactionKind::FulfillHandler:
@@ -313,8 +313,13 @@ JSValue JSPromise::asyncStackTraceContext() const
         auto* head = uncheckedDowncast<JSPromiseReaction>(payloadCell());
         return head ? JSPromiseReaction::tryGetContext(head) : JSValue();
     }
-    case InlineReactionKind::InternalMicrotask:
+    case InlineReactionKind::InternalMicrotask: {
+        if (promiseReactionPacksGlobalContextAndIndex(inlineReactionMicrotask())) {
+            ASSERT(payloadCell());
+            return JSValue(payloadCell());
+        }
         return m_slot.get();
+    }
     case InlineReactionKind::FulfillHandler:
     case InlineReactionKind::RejectHandler:
         return { };
@@ -374,17 +379,17 @@ void JSPromise::performPromiseThen(VM& vm, JSGlobalObject* globalObject, JSValue
     }
 }
 
-void JSPromise::performPromiseThenWithInternalMicrotask(VM& vm, JSGlobalObject* globalObject, InternalMicrotask task, JSPromise* promise, JSValue context)
+void JSPromise::performPromiseThenWithInternalMicrotask(VM& vm, JSGlobalObject* globalObject, InternalMicrotask task, JSCell* cell, JSValue context)
 {
-    JSValue promiseValue = promise ? JSValue(promise) : jsUndefined();
+    JSValue cellValue = cell ? JSValue(cell) : jsUndefined();
     switch (status()) {
     case JSPromise::Status::Pending: {
         if (inlineReactionKind() == InlineReactionKind::None && !payloadCell()) [[likely]] {
-            setInlineMicrotaskReaction(vm, task, promise, context);
+            setInlineMicrotaskReaction(vm, task, cell, context);
             break;
         }
         JSPromiseReaction* existing = reactionHead(vm);
-        auto* reaction = JSSlimPromiseReaction::create(vm, promiseValue, task, context, existing);
+        auto* reaction = JSSlimPromiseReaction::create(vm, cellValue, task, context, existing);
         setPackedCell(vm, flags() | isHandledFlag, reaction);
         break;
     }
@@ -392,13 +397,13 @@ void JSPromise::performPromiseThenWithInternalMicrotask(VM& vm, JSGlobalObject* 
         JSValue settled = settlementValue();
         if (!isHandled())
             globalObject->globalObjectMethodTable()->promiseRejectionTracker(globalObject, this, JSPromiseRejectionOperation::Handle);
-        globalObject->queueMicrotask(vm, task, static_cast<uint8_t>(Status::Rejected), promiseValue, settled, context);
+        globalObject->queueMicrotask(vm, task, static_cast<uint8_t>(Status::Rejected), cellValue, settled, context);
         markAsHandled();
         break;
     }
     case JSPromise::Status::Fulfilled: {
         JSValue settled = settlementValue();
-        globalObject->queueMicrotask(vm, task, static_cast<uint8_t>(Status::Fulfilled), promiseValue, settled, context);
+        globalObject->queueMicrotask(vm, task, static_cast<uint8_t>(Status::Fulfilled), cellValue, settled, context);
         break;
     }
     }
@@ -459,12 +464,12 @@ ALWAYS_INLINE void JSPromise::settleInlineInternalMicrotask(VM& vm, JSGlobalObje
     ASSERT(flagsSnapshot & isHandledFlag);
     InternalMicrotask task = static_cast<InternalMicrotask>((flagsSnapshot & inlineReactionMicrotaskMask) >> inlineReactionMicrotaskShift);
     JSValue context = m_slot.get();
-    auto* promise = uncheckedDowncast<JSPromise>(payloadCell());
-    JSValue promiseValue = promise ? JSValue(promise) : jsUndefined();
+    JSCell* cell = payloadCell();
+    JSValue cellValue = cell ? JSValue(cell) : jsUndefined();
     uint16_t settledFlags = (flagsSnapshot & ~(inlineReactionKindMask | inlineReactionMicrotaskMask)) | static_cast<uint16_t>(newStatus);
     setSlot(vm, argument);
     setPackedCell(vm, settledFlags, nullptr);
-    globalObject->queueMicrotask(vm, task, static_cast<uint8_t>(newStatus), promiseValue, argument, context);
+    globalObject->queueMicrotask(vm, task, static_cast<uint8_t>(newStatus), cellValue, argument, context);
 }
 
 ALWAYS_INLINE void JSPromise::settleInlineHandler(VM& vm, JSGlobalObject* globalObject, Status newStatus, JSValue argument, uint16_t flagsSnapshot)

--- a/Source/JavaScriptCore/runtime/JSPromise.h
+++ b/Source/JavaScriptCore/runtime/JSPromise.h
@@ -155,7 +155,7 @@ public:
     static void rejectWithInternalMicrotask(VM&, JSGlobalObject*, JSValue argument, InternalMicrotask, JSValue context);
     static void fulfillWithInternalMicrotask(VM&, JSGlobalObject*, JSValue argument, InternalMicrotask, JSValue context);
 
-    void performPromiseThenWithInternalMicrotask(VM&, JSGlobalObject*, InternalMicrotask, JSPromise*, JSValue context);
+    void performPromiseThenWithInternalMicrotask(VM&, JSGlobalObject*, InternalMicrotask, JSCell*, JSValue context);
 
     bool isThenFastAndNonObservable();
 
@@ -218,7 +218,7 @@ private:
     void setSlot(VM& vm, JSValue value) { m_slot.set(vm, this, value); }
     void clearSlot() { m_slot.clear(); }
 
-    void setInlineMicrotaskReaction(VM&, InternalMicrotask, JSPromise*, JSValue context);
+    void setInlineMicrotaskReaction(VM&, InternalMicrotask, JSCell*, JSValue context);
     void setInlineHandlerReaction(VM&, InlineReactionKind, JSPromise*, JSValue handler);
     JSPromiseReaction* spillInlineReaction(VM&);
     JSPromiseReaction* reactionHead(VM&);

--- a/Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp
@@ -486,14 +486,12 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAll, (JSGlobalObject* globalObjec
         RETURN_IF_EXCEPTION(scope, void());
         globalContext->setRemainingElementsCount(vm, jsNumber(count + 1));
 
-        JSPromiseCombinatorsContext* context = JSPromiseCombinatorsContext::create(vm, globalContext, index);
-
         if (nextPromise->isThenFastAndNonObservable()) [[likely]] {
             auto* constructor = promiseSpeciesConstructor(globalObject, nextPromise);
             RETURN_IF_EXCEPTION(scope, void());
             if (constructor == globalObject->promiseConstructor()) [[likely]] {
                 scope.release();
-                nextPromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::PromiseAllResolveJob, promise, context);
+                nextPromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::PromiseAllResolveJob, globalContext, jsNumber(index));
                 ++index;
                 return;
             }
@@ -509,6 +507,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAll, (JSGlobalObject* globalObjec
             return;
         }
 
+        JSPromiseCombinatorsContext* context = JSPromiseCombinatorsContext::create(vm, globalContext, index);
         auto* onFulfilled = JSFunctionWithFields::create(vm, globalObject, vm.promiseAllFulfillFunctionExecutable(), 1, emptyString());
         onFulfilled->setField(vm, JSFunctionWithFields::Field::PromiseAllContext, context);
 
@@ -809,19 +808,18 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAllSettled, (JSGlobalObject* glob
         RETURN_IF_EXCEPTION(scope, void());
         globalContext->setRemainingElementsCount(vm, jsNumber(count + 1));
 
-        JSPromiseCombinatorsContext* context = JSPromiseCombinatorsContext::create(vm, globalContext, index);
-
         if (nextPromise->isThenFastAndNonObservable()) [[likely]] {
             auto* constructor = promiseSpeciesConstructor(globalObject, nextPromise);
             RETURN_IF_EXCEPTION(scope, void());
             if (constructor == globalObject->promiseConstructor()) [[likely]] {
                 scope.release();
-                nextPromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::PromiseAllSettledResolveJob, promise, context);
+                nextPromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::PromiseAllSettledResolveJob, globalContext, jsNumber(index));
                 ++index;
                 return;
             }
         }
 
+        JSPromiseCombinatorsContext* context = JSPromiseCombinatorsContext::create(vm, globalContext, index);
         auto* onFulfilled = JSFunctionWithFields::create(vm, globalObject, vm.promiseAllSettledFulfillFunctionExecutable(), 1, emptyString());
         onFulfilled->setField(vm, JSFunctionWithFields::Field::PromiseAllSettledContext, context);
 
@@ -1283,14 +1281,12 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAny, (JSGlobalObject* globalObjec
         RETURN_IF_EXCEPTION(scope, void());
         globalContext->setRemainingElementsCount(vm, jsNumber(count + 1));
 
-        JSPromiseCombinatorsContext* context = JSPromiseCombinatorsContext::create(vm, globalContext, index);
-
         if (nextPromise->isThenFastAndNonObservable()) [[likely]] {
             auto* constructor = promiseSpeciesConstructor(globalObject, nextPromise);
             RETURN_IF_EXCEPTION(scope, void());
             if (constructor == globalObject->promiseConstructor()) [[likely]] {
                 scope.release();
-                nextPromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::PromiseAnyResolveJob, promise, context);
+                nextPromise->performPromiseThenWithInternalMicrotask(vm, globalObject, InternalMicrotask::PromiseAnyResolveJob, globalContext, jsNumber(index));
                 ++index;
                 return;
             }
@@ -1300,6 +1296,7 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAny, (JSGlobalObject* globalObjec
         if (!resolve)
             resolve = promise->createFirstResolveFunction(vm, globalObject);
 
+        JSPromiseCombinatorsContext* context = JSPromiseCombinatorsContext::create(vm, globalContext, index);
         auto* onRejected = JSFunctionWithFields::create(vm, globalObject, vm.promiseAnyRejectFunctionExecutable(), 1, emptyString());
         onRejected->setField(vm, JSFunctionWithFields::Field::PromiseAnyContext, context);
 

--- a/Source/JavaScriptCore/runtime/JSPromiseReaction.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromiseReaction.cpp
@@ -48,8 +48,12 @@ DEFINE_VISIT_CHILDREN(JSPromiseReaction);
 JSValue JSPromiseReaction::tryGetContext(JSValue reactionsValue)
 {
     if (auto* slim = dynamicDowncast<JSSlimPromiseReaction>(reactionsValue)) {
-        if (slim->internalMicrotask() != InternalMicrotask::None)
+        InternalMicrotask task = slim->internalMicrotask();
+        if (task != InternalMicrotask::None) {
+            if (promiseReactionPacksGlobalContextAndIndex(task))
+                return slim->promise(); // This is actually JSPromiseCombinatorsGlobalContext.
             return slim->handlerOrContext();
+        }
         return { };
     }
     if (auto* full = dynamicDowncast<JSFullPromiseReaction>(reactionsValue))

--- a/Source/JavaScriptCore/runtime/Microtask.h
+++ b/Source/JavaScriptCore/runtime/Microtask.h
@@ -89,6 +89,15 @@ enum class InternalMicrotask : uint8_t {
 
 constexpr unsigned maxMicrotaskArguments = 3;
 
+// True for Promise.all/allSettled/any element jobs, whose reaction packs
+// (globalContext cell, element index) instead of a single context cell.
+constexpr bool promiseReactionPacksGlobalContextAndIndex(InternalMicrotask task)
+{
+    static_assert(static_cast<uint8_t>(InternalMicrotask::PromiseAllSettledResolveJob) == static_cast<uint8_t>(InternalMicrotask::PromiseAllResolveJob) + 1);
+    static_assert(static_cast<uint8_t>(InternalMicrotask::PromiseAnyResolveJob) == static_cast<uint8_t>(InternalMicrotask::PromiseAllSettledResolveJob) + 1);
+    return task >= InternalMicrotask::PromiseAllResolveJob && task <= InternalMicrotask::PromiseAnyResolveJob;
+}
+
 enum class QueuedTaskResult : uint8_t {
     Executed,
     Discard,


### PR DESCRIPTION
#### 0f6a35669fa8e3e9b3aa37e9778611a5eadaf674
<pre>
[JSC] Avoid per-element `JSPromiseCombinatorsContext` allocation in Promise combinators
<a href="https://bugs.webkit.org/show_bug.cgi?id=314861">https://bugs.webkit.org/show_bug.cgi?id=314861</a>

Reviewed by Yusuke Suzuki.

After 313230@main, an element promise in Promise.all/allSettled/any stores its inline
internal-microtask reaction as (m_packed.pointer() = outerPromise, m_slot =
JSPromiseCombinatorsContext). The JSPromiseCombinatorsContext is a 32-byte heap cell
pairing (globalContext, index), allocated once per element on the fast path. Since the
inline reaction already has two slots, this patch stores globalContext directly as the
payload cell and the element index as jsNumber() in the slot, eliminating the per-element
allocation. The outer promise is recovered from globalContext-&gt;promise() on settlement,
and the index store needs no write barrier since it is not a cell.

The PromiseAll*ResolveJob microtasks are reached only from the fast path (slow paths use
JSFunctionWithFields and a separate JSPromiseCombinatorsContext), so they are switched
unconditionally to take (globalContext, resolution, index). Spilled JSSlimPromiseReactions
follow the same shape, so no materialization is needed when the inline reaction is spilled.
Async stack traces continue to work by anchoring on the global context directly.

With 500,000 pending element reactions (Promise.allSettled([100 resolved promises]) called
5,000 times before draining the microtask queue), peak process footprint drops from
91.6 MiB to 75.3 MiB, matching the expected 500,000 × 32 bytes for the eliminated
JSPromiseCombinatorsContext cells. Promise.all and Promise.any show similar reductions.

* Source/JavaScriptCore/interpreter/Interpreter.cpp:
(JSC::Interpreter::getAsyncStackTrace):
* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::promiseAllResolveJob):
(JSC::promiseAllSettledResolveJob):
(JSC::promiseAnyResolveJob):
(JSC::runInternalMicrotask):
* Source/JavaScriptCore/runtime/JSPromise.cpp:
(JSC::JSPromise::setInlineMicrotaskReaction):
(JSC::JSPromise::spillInlineReaction):
(JSC::JSPromise::asyncStackTraceContext const):
(JSC::JSPromise::performPromiseThenWithInternalMicrotask):
(JSC::JSPromise::settleInlineInternalMicrotask):
* Source/JavaScriptCore/runtime/JSPromise.h:
* Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/JSPromiseReaction.cpp:
(JSC::JSPromiseReaction::tryGetContext):
* Source/JavaScriptCore/runtime/Microtask.h:
(JSC::isPromiseCombinatorElementTask):

Canonical link: <a href="https://commits.webkit.org/313361@main">https://commits.webkit.org/313361@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ffa39c907b30460a53700f40fb112f9f8834c02f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162733 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36209 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29358 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171671 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119179 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36313 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36213 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126308 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88952 "1 flakes 18 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165692 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28660 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146222 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106885 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27706 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26238 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19371 "Built successfully") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137414 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23951 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174175 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23572 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21488 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25596 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134617 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35883 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30338 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134612 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36349 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35867 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145747 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98259 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/29154 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22583 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195134 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35377 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/103128 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50507 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34878 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35123 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35026 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->