### PR TITLE
[JSC] Inline allocation for `Promise.resolve()` of a non-thenable object

### DIFF
--- a/JSTests/microbenchmarks/promise-resolve-non-thenable-object.js
+++ b/JSTests/microbenchmarks/promise-resolve-non-thenable-object.js
@@ -1,0 +1,2 @@
+for (var i = 0; i < 1e6; ++i)
+    Promise.resolve({ a: i, b: i + 1, c: i + 2 });

--- a/JSTests/stress/dfg-promise-resolve-fulfilled-object.js
+++ b/JSTests/stress/dfg-promise-resolve-fulfilled-object.js
@@ -1,0 +1,117 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' (expected ' + expected + ')');
+}
+
+// Each scenario uses its own noInline helper so the PromiseResolve call site stays
+// monomorphic and the intended ConstantFoldingPhase branch is actually exercised.
+
+// Branch 3: plain non-thenable object with a single watched structure -> folds to
+// NewResolvedPromise(isResolvedValueKnownNonThenable), inline-allocated fulfilled.
+function resolveObject(o) {
+    return Promise.resolve(o);
+}
+noInline(resolveObject);
+
+// Branch 1: non-object argument -> trivially non-thenable.
+function resolveValue(v) {
+    return Promise.resolve(v);
+}
+noInline(resolveValue);
+
+// `then` present -> tryEnsureAbsence fails, no fold, object must be adopted.
+function resolveThenable(o) {
+    return Promise.resolve(o);
+}
+noInline(resolveThenable);
+
+// Non-default constructor -> not folded, goes through the species path.
+class MyPromise extends Promise { }
+function resolveSubclass(o) {
+    return Promise.resolve.call(MyPromise, o);
+}
+noInline(resolveSubclass);
+
+// Dedicated monomorphic site for the watchpoint-invalidation scenario.
+function Proto() { }
+function resolveProto(o) {
+    return Promise.resolve(o);
+}
+noInline(resolveProto);
+
+async function main() {
+    // 1. Plain object: fulfilled with the object itself, distinct promise cell.
+    for (let i = 0; i < testLoopCount; ++i) {
+        let o = { a: i, b: i + 1 };
+        let p = resolveObject(o);
+        shouldBe(p instanceof Promise, true);
+        shouldBe(p !== o, true);
+        shouldBe(await p, o);
+    }
+
+    // 2. .then() handler receives the object; chaining and microtask ordering.
+    for (let i = 0; i < testLoopCount; ++i) {
+        let o = { x: i };
+        let order = [];
+        let q = resolveObject(o).then(v => { order.push("then"); return v.x; });
+        order.push("sync");
+        shouldBe(await q, i);
+        shouldBe(order.join(","), "sync,then");
+    }
+
+    // 3. Branch 1: non-object values are non-thenable.
+    for (let i = 0; i < testLoopCount; ++i) {
+        shouldBe(await resolveValue(i), i);
+        shouldBe(await resolveValue(undefined), undefined);
+        shouldBe(await resolveValue("s" + (i & 7)), "s" + (i & 7));
+        shouldBe(await resolveValue(null), null);
+        shouldBe(await resolveValue(i & 1 ? true : false), !!(i & 1));
+    }
+
+    // 4. GC stress: the inline-allocated promise must keep its slot value alive.
+    {
+        let promises = [];
+        let objects = [];
+        for (let i = 0; i < testLoopCount; ++i) {
+            let o = { g: i };
+            objects.push(o);
+            promises.push(resolveObject(o));
+        }
+        gc();
+        for (let i = 0; i < promises.length; ++i) {
+            shouldBe(promises[i] !== objects[i], true);
+            shouldBe(await promises[i], objects[i]);
+        }
+    }
+
+    // 5. Subclass constructor: not folded, still correct, produces a MyPromise.
+    for (let i = 0; i < testLoopCount; ++i) {
+        let o = { s: i };
+        let p = resolveSubclass(o);
+        shouldBe(p instanceof MyPromise, true);
+        shouldBe(await p, o);
+    }
+
+    // 6. `then` as an own property: object IS thenable, must be adopted (no fold).
+    for (let i = 0; i < testLoopCount; ++i) {
+        let adopted = false;
+        let o = { then(resolve) { adopted = true; resolve("own-then-" + (i & 15)); } };
+        shouldBe(await resolveThenable(o), "own-then-" + (i & 15));
+        shouldBe(adopted, true);
+    }
+
+    // 7. Watchpoint invalidation: after tiering up on a non-thenable structure,
+    //    adding a callable `then` to the prototype must invalidate the fast path
+    //    so later calls adopt the now-thenable object instead of fulfilling with it.
+    for (let i = 0; i < testLoopCount; ++i) {
+        let o = new Proto();
+        shouldBe(await resolveProto(o), o);
+    }
+    Proto.prototype.then = function (resolve) { resolve("via-proto-then"); };
+    for (let i = 0; i < testLoopCount; ++i) {
+        let o = new Proto();
+        shouldBe(await resolveProto(o), "via-proto-then");
+    }
+}
+
+main().catch($vm.abort);

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -4012,6 +4012,11 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
     }
 
     case NewResolvedPromise:
+        if (!node->isResolvedValueKnownNonThenable())
+            clobberWorld();
+        setTypeForNode(node, SpecPromiseObject);
+        break;
+
     case NewRejectedPromise: {
         clobberWorld();
         setTypeForNode(node, SpecPromiseObject);

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -2618,6 +2618,14 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         return;
 
     case NewResolvedPromise:
+        if (node->isResolvedValueKnownNonThenable()) {
+            read(HeapObjectCount);
+            write(HeapObjectCount);
+            return;
+        }
+        clobberTop();
+        return;
+
     case NewRejectedPromise:
         clobberTop();
         return;

--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -2009,7 +2009,7 @@ private:
                         if (argument.isType(~SpecObject)) {
                             m_interpreter.execute(indexInBlock); // Push CFA over this node after we get the state before.
                             alreadyHandled = true; // Don't allow the default constant folder to do things to this.
-                            node->convertToNewResolvedPromise(node->child2());
+                            node->convertToNewResolvedPromise(node->child2(), /* isResolvedValueKnownNonThenable */ true);
                             changed = true;
                             break;
                         }
@@ -2035,7 +2035,7 @@ private:
                                     if (m_graph.watchConditions(conditionSet)) {
                                         m_interpreter.execute(indexInBlock); // Push CFA over this node after we get the state before.
                                         alreadyHandled = true; // Don't allow the default constant folder to do things to this.
-                                        node->convertToNewResolvedPromise(node->child2());
+                                        node->convertToNewResolvedPromise(node->child2(), /* isResolvedValueKnownNonThenable */ true);
                                         changed = true;
                                         break;
                                     }

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -931,13 +931,19 @@ public:
         children = AdjacencyList();
     }
 
-    void convertToNewResolvedPromise(Edge argument)
+    void convertToNewResolvedPromise(Edge argument, bool isResolvedValueKnownNonThenable)
     {
         ASSERT(m_op == PromiseResolve);
         setOpAndDefaultFlags(NewResolvedPromise);
         children = AdjacencyList(AdjacencyList::Fixed, argument);
-        m_opInfo = OpInfoWrapper();
+        m_opInfo = static_cast<uint32_t>(isResolvedValueKnownNonThenable);
         m_opInfo2 = OpInfoWrapper();
+    }
+
+    bool isResolvedValueKnownNonThenable()
+    {
+        ASSERT(op() == NewResolvedPromise);
+        return m_opInfo.as<bool>();
     }
 
     void NODELETE convertToNewArrayBuffer(FrozenValue* immutableButterfly);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -8811,7 +8811,7 @@ void SpeculativeJIT::compileNewPromise(Node* node)
 void SpeculativeJIT::compileNewResolvedPromise(Node* node)
 {
     JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);
-    if (!(m_state.forNode(node->child1()).m_type & SpecObject)) {
+    if (node->isResolvedValueKnownNonThenable() || !(m_state.forNode(node->child1()).m_type & SpecObject)) {
         JSValueOperand argument(this, node->child1());
 
         GPRTemporary result(this);

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -21070,7 +21070,7 @@ IGNORE_CLANG_WARNINGS_END
     {
         auto* globalObject = m_graph.globalObjectFor(m_origin.semantic);
 
-        if (!(abstractValue(m_node->child1()).m_type & SpecObject)) {
+        if (m_node->isResolvedValueKnownNonThenable() || !(abstractValue(m_node->child1()).m_type & SpecObject)) {
             LValue argument = lowJSValue(m_node->child1());
 
             LBasicBlock slowCase = m_out.newBlock();


### PR DESCRIPTION
#### b1a624172673ac28c2d4882c0f8a95260d80d457
<pre>
[JSC] Inline allocation for `Promise.resolve()` of a non-thenable object
<a href="https://bugs.webkit.org/show_bug.cgi?id=314865">https://bugs.webkit.org/show_bug.cgi?id=314865</a>

Reviewed by Yusuke Suzuki.

313220@main rewrote how ConstantFoldingPhase folds the PromiseResolve node: when
the resolved value is proven non-thenable it now emits NewResolvedPromise instead
of an inline NewInternalFieldObject. But NewResolvedPromise only inline-allocates
for a statically non-object argument; for an object argument it falls back to the
operationNewResolvedPromise C call and clobberTop(). The common
Promise.resolve({ ... }) pattern -- where ConstantFoldingPhase has already proven
the argument non-thenable via a watched &quot;then&quot;-absence condition set -- thus
regressed from an inline allocation into a clobbering C call.

Carry that fact on the node via an isResolvedValueKnownNonThenable flag. When set,
compileNewResolvedPromise inline-allocates the fulfilled promise even for an
object argument, and clobberize / AbstractInterpreter model it as a pure
allocation (HeapObjectCount) like NewPromise. Nodes created from the
NewResolvedPromiseIntrinsic keep the flag clear and the previous behavior.

promise-resolve-non-thenable-object       10.5459+-0.1503     ^      6.8783+-0.1186        ^ definitely 1.5332x faster

Tests: JSTests/microbenchmarks/promise-resolve-non-thenable-object.js
       JSTests/stress/dfg-promise-resolve-fulfilled-object.js

* JSTests/microbenchmarks/promise-resolve-non-thenable-object.js: Added.
* JSTests/stress/dfg-promise-resolve-fulfilled-object.js: Added.
(shouldBe):
(resolveObject):
(resolveValue):
(resolveThenable):
(MyPromise):
(resolveSubclass):
(Proto):
(resolveProto):
(async main.Proto.prototype.then):
(async main):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp:
(JSC::DFG::ConstantFoldingPhase::foldConstants):
* Source/JavaScriptCore/dfg/DFGNode.h:
(JSC::DFG::Node::convertToNewResolvedPromise):
(JSC::DFG::Node::isResolvedValueKnownNonThenable):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compileNewResolvedPromise):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):

Canonical link: <a href="https://commits.webkit.org/313301@main">https://commits.webkit.org/313301@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1d224244e7a4f780a3a4c465819014b0a24e13e5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162685 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36161 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29305 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171623 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119131 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36265 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36165 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126268 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88921 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165644 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28619 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146175 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106845 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27665 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26197 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19323 "Built successfully") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137373 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23904 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174127 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23524 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21440 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25549 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134578 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35835 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30294 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134574 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36314 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35819 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145700 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98192 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/29114 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22534 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195086 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35329 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/103080 "Found 1 new failure in wasm/WasmConstExprGenerator.cpp") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50483 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34830 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35075 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34978 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->