### PR TITLE
[Swift in WebKit] Adopt `emit-clang-header-min-access` flag in WebGPU

### DIFF
--- a/Source/WebGPU/Configurations/WebGPU.xcconfig
+++ b/Source/WebGPU/Configurations/WebGPU.xcconfig
@@ -131,7 +131,7 @@ WK_SWIFT_OBJC_INTEROP_MODE_ENABLE_WEBGPU_SWIFT = objcxx;
 SWIFT_LIBRARY_LEVEL = spi;
 
 // FIXME: broaden SafeInteropWrappers to all of WebKit; rdar://159439903
-OTHER_SWIFT_FLAGS = $(inherited) @$(BUILT_PRODUCTS_DIR)/DerivedSources/WebGPU/platform-enabled-swift-args.$(arch).resp -Xcc -std=c++2b -Xcc -DUCHAR_TYPE=char16_t -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature LifetimeDependence -no-verify-emitted-module-interface;
+OTHER_SWIFT_FLAGS = $(inherited) @$(BUILT_PRODUCTS_DIR)/DerivedSources/WebGPU/platform-enabled-swift-args.$(arch).resp -Xcc -std=c++2b -Xcc -DUCHAR_TYPE=char16_t -enable-experimental-feature SafeInteropWrappers -enable-experimental-feature LifetimeDependence -no-verify-emitted-module-interface  -Xfrontend -clang-header-expose-decls=has-expose-attr-or-stdlib -Xfrontend -emit-clang-header-min-access -Xfrontend internal;
 
 EXCLUDED_SOURCE_FILE_NAMES = $(EXCLUDED_SOURCE_FILE_NAMES_$(ENABLE_WEBGPU_SWIFT));
 EXCLUDED_SOURCE_FILE_NAMES_ENABLE_WEBGPU_SWIFT =;

--- a/Source/WebGPU/WebGPU/Buffer.h
+++ b/Source/WebGPU/WebGPU/Buffer.h
@@ -78,6 +78,7 @@ public:
 
     void destroy();
     std::span<uint8_t> getMappedRange(size_t offset, size_t) HAS_SWIFTCXX_THUNK;
+    void bufferCopy(std::span<const uint8_t>, size_t offset);
     void mapAsync(WGPUMapModeFlags, size_t offset, size_t, CompletionHandler<void(WGPUBufferMapAsyncStatus)>&& callback);
     void unmap();
     void setLabel(String&&);
@@ -126,9 +127,6 @@ public:
 
     void indirectBufferInvalidated(CommandEncoder* = nullptr);
     void indirectBufferInvalidated(CommandEncoder&);
-#if ENABLE(WEBGPU_SWIFT)
-    void copyFrom(const std::span<const uint8_t>, const size_t offset) HAS_SWIFTCXX_THUNK;
-#endif
     void removeSkippedValidationCommandEncoder(uint64_t);
     bool mustTakeSlowIndexValidationPath() const { return m_mustTakeSlowIndexValidationPath; }
     void clearMustTakeSlowIndexValidationPath() { m_mustTakeSlowIndexValidationPath = false; }

--- a/Source/WebGPU/WebGPU/Buffer.mm
+++ b/Source/WebGPU/WebGPU/Buffer.mm
@@ -41,8 +41,6 @@
 #import <WebGPU/WGPUTextureImpl.h>
 #import <WebGPU/WebGPU.h>
 #import "WebGPUSwift-Generated.h"
-
-DEFINE_SWIFTCXX_THUNK(WebGPU::Buffer, copyFrom, void, const std::span<const uint8_t>, const size_t);
 #endif
 
 namespace WebGPU {
@@ -299,7 +297,7 @@ std::span<uint8_t> Buffer::getMappedRange(size_t offset, size_t size)
 {
 #if ENABLE(WEBGPU_SWIFT)
     if (isWebGPUSwiftEnabled())
-        return Buffer_getMappedRange_thunk(this, offset, size);
+        return bufferGetMappedRange(this, offset, size);
 #endif
 
     // https://gpuweb.github.io/gpuweb/#dom-gpubuffer-getmappedrange
@@ -324,6 +322,16 @@ std::span<uint8_t> Buffer::getMappedRange(size_t offset, size_t size)
 std::span<uint8_t> Buffer::getBufferContents()
 {
     return span<uint8_t>(m_buffer);
+}
+
+void Buffer::bufferCopy(std::span<const uint8_t> data, size_t offset)
+{
+#if ENABLE(WEBGPU_SWIFT)
+    bufferCopyFrom(this, data, offset);
+#else
+    UNUSED_PARAM(data);
+    UNUSED_PARAM(offset);
+#endif
 }
 
 NSString *Buffer::errorValidatingMapAsync(WGPUMapModeFlags mode, size_t offset, size_t rangeSize) const
@@ -873,7 +881,7 @@ WGPUBufferUsageFlags wgpuBufferGetUsage(WGPUBuffer buffer)
 void NODELETE wgpuBufferCopy(WGPUBuffer buffer, std::span<const uint8_t> data, size_t offset)
 {
 #if ENABLE(WEBGPU_SWIFT)
-    protect(WebGPU::fromAPI(buffer))->copyFrom(data, offset);
+    protect(WebGPU::fromAPI(buffer))->bufferCopy(data, offset);
 #else
     UNUSED_PARAM(buffer);
     UNUSED_PARAM(data);

--- a/Source/WebGPU/WebGPU/Buffer.swift
+++ b/Source/WebGPU/WebGPU/Buffer.swift
@@ -34,20 +34,13 @@ extension WebGPU.Buffer {
     }
 }
 
-// FIXME(emw): Find a way to generate thunks like these, maybe via a macro?
-// FIXME: Eventually all these "thunks" should be removed.
-// swift-format-ignore: AlwaysUseLowerCamelCase
-// swift-format-ignore: AllPublicDeclarationsHaveDocumentation
 @_expose(Cxx)
-public func Buffer_copyFrom_thunk(_ buffer: WebGPU.Buffer, from data: WebGPU.SpanConstUInt8, offset: Int) {
+func bufferCopyFrom(_ buffer: WebGPU.Buffer, from data: WebGPU.SpanConstUInt8, offset: Int) {
     buffer.copy(from: unsafe Span<UInt8>(_unsafeCxxSpan: data), offset: offset)
 }
 
-// FIXME: Eventually all these "thunks" should be removed.
-// swift-format-ignore: AlwaysUseLowerCamelCase
-// swift-format-ignore: AllPublicDeclarationsHaveDocumentation
 @_expose(Cxx)
-public func Buffer_getMappedRange_thunk(_ buffer: WebGPU.Buffer, offset: Int, size: Int) -> WebGPU.SpanUInt8 {
+func bufferGetMappedRange(_ buffer: WebGPU.Buffer, offset: Int, size: Int) -> WebGPU.SpanUInt8 {
     unsafe buffer.getMappedRange(offset: offset, size: size)
 }
 

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -264,7 +264,7 @@ Ref<ComputePassEncoder> CommandEncoder::beginComputePass(const WGPUComputePassDe
 {
 #if ENABLE(WEBGPU_SWIFT)
     if (isWebGPUSwiftEnabled())
-        return CommandEncoder_beginComputePass_thunk(this, descriptor);
+        return commandEncoderBeginComputePass(this, descriptor);
 #endif
 
     if (!prepareTheEncoderState()) {
@@ -441,7 +441,7 @@ void CommandEncoder::runClearEncoder(NSMutableDictionary<NSNumber*, TextureAndCl
 {
 #if ENABLE(WEBGPU_SWIFT)
     if (isWebGPUSwiftEnabled()) {
-        CommandEncoder_runClearEncoder_thunk(this, attachmentsToClear, depthStencilAttachmentToClear, depthAttachmentToClear, stencilAttachmentToClear, depthClearValue, stencilClearValue, existingEncoder);
+        commandEncoderRunClearEncoder(this, attachmentsToClear, depthStencilAttachmentToClear, depthAttachmentToClear, stencilAttachmentToClear, depthClearValue, stencilClearValue, existingEncoder);
         return;
     }
 #endif
@@ -532,7 +532,7 @@ Ref<RenderPassEncoder> CommandEncoder::beginRenderPass(const WGPURenderPassDescr
 {
 #if ENABLE(WEBGPU_SWIFT)
     if (isWebGPUSwiftEnabled())
-        return CommandEncoder_beginRenderPass_thunk(this, descriptor);
+        return commandEncoderBeginRenderPass(this, descriptor);
 #endif
 
     auto maxDrawCount = descriptor.maxDrawCount;
@@ -910,7 +910,7 @@ void CommandEncoder::copyBufferToBuffer(const Buffer& source, uint64_t sourceOff
 #if ENABLE(WEBGPU_SWIFT)
     if (isWebGPUSwiftEnabled()) {
         // FIXME: rdar://138047285
-        CommandEncoder_copyBufferToBuffer_thunk(this, &const_cast<Buffer&>(source), sourceOffset, &destination, destinationOffset, size);
+        commandEncoderCopyBufferToBuffer(this, &const_cast<Buffer&>(source), sourceOffset, &destination, destinationOffset, size);
         return;
     }
 #endif
@@ -1025,7 +1025,7 @@ void CommandEncoder::copyBufferToTexture(const WGPUImageCopyBuffer& source, cons
 {
 #if ENABLE(WEBGPU_SWIFT)
     if (isWebGPUSwiftEnabled()) {
-        CommandEncoder_copyBufferToTexture_thunk(this, source, destination, copySize);
+        commandEncoderCopyBufferToTexture(this, source, destination, copySize);
         return;
     }
 #endif
@@ -1336,7 +1336,7 @@ void CommandEncoder::clearTextureIfNeeded(const WGPUImageCopyTexture& destinatio
 {
 #if ENABLE(WEBGPU_SWIFT)
     if (isWebGPUSwiftEnabled()) {
-        CommandEncoder_clearTextureIfNeeded_thunk(this, destination, slice);
+        commandEncoderClearTextureIfNeeded(this, destination, slice);
         return;
     }
 #endif
@@ -1555,7 +1555,7 @@ void CommandEncoder::copyTextureToBuffer(const WGPUImageCopyTexture& source, con
 {
 #if ENABLE(WEBGPU_SWIFT)
     if (isWebGPUSwiftEnabled()) {
-        CommandEncoder_copyTextureToBuffer_thunk(this, source, destination, copySize);
+        commandEncoderCopyTextureToBuffer(this, source, destination, copySize);
         return;
     }
 #endif
@@ -1878,7 +1878,7 @@ void CommandEncoder::copyTextureToTexture(const WGPUImageCopyTexture& source, co
 {
 #if ENABLE(WEBGPU_SWIFT)
     if (isWebGPUSwiftEnabled()) {
-        CommandEncoder_copyTextureToTexture_thunk(this, source, destination, copySize);
+        commandEncoderCopyTextureToTexture(this, source, destination, copySize);
         return;
     }
 #endif
@@ -2059,7 +2059,7 @@ void CommandEncoder::clearBuffer(Buffer& buffer, uint64_t offset, uint64_t size)
     // https://gpuweb.github.io/gpuweb/#dom-gpucommandencoder-clearbuffer
 #if ENABLE(WEBGPU_SWIFT)
     if (isWebGPUSwiftEnabled()) {
-        WebGPU::clearBuffer(this, &buffer, offset, size);
+        commandEncoderClearBuffer(this, &buffer, offset, size);
         return;
     }
 #endif
@@ -2119,7 +2119,7 @@ Ref<CommandBuffer> CommandEncoder::finish(const WGPUCommandBufferDescriptor& des
 {
 #if ENABLE(WEBGPU_SWIFT)
     if (isWebGPUSwiftEnabled())
-        return CommandEncoder_finish_thunk(this, descriptor);
+        return commandEncoderFinish(this, descriptor);
 #endif
 
     if (!isValid() || (m_existingCommandEncoder && m_existingCommandEncoder != m_blitCommandEncoder)) {
@@ -2266,7 +2266,7 @@ void CommandEncoder::resolveQuerySet(const QuerySet& querySet, uint32_t firstQue
 #if ENABLE(WEBGPU_SWIFT)
     // FIXME: rdar://138047285 const_cast is needed as a workaround.
     if (isWebGPUSwiftEnabled()) {
-        WebGPU::resolveQuerySet(this, const_cast<QuerySet*>(&querySet), firstQuery, queryCount, &destination, destinationOffset);
+        commandEncoderResolveQuerySet(this, const_cast<QuerySet*>(&querySet), firstQuery, queryCount, &destination, destinationOffset);
         return;
     }
 #endif

--- a/Source/WebGPU/WebGPU/CommandEncoder.swift
+++ b/Source/WebGPU/WebGPU/CommandEncoder.swift
@@ -22,20 +22,19 @@
 // THE POSSIBILITY OF SUCH DAMAGE.
 
 private import CxxStdlib
-public import Metal
+import Metal
 import WebGPU_Internal.Buffer
 import WebGPU_Internal.CommandEncoder
 import WebGPU_Internal.CxxBridging
 import WebGPU_Internal.QuerySet
 import WebGPU_Internal.TextureOrTextureView
-public import WebGPU_Private.WebGPU
+import WebGPU_Private.WebGPU
 
 typealias String = Swift.String
 
-// FIXME: Eventually all these "thunks" should be removed.
-// swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-public func clearBuffer(
-    commandEncoder: WebGPU.CommandEncoder,
+@_expose(Cxx)
+func commandEncoderClearBuffer(
+    _ commandEncoder: WebGPU.CommandEncoder,
     buffer: WebGPU.Buffer,
     offset: UInt64,
     size: inout UInt64
@@ -43,10 +42,9 @@ public func clearBuffer(
     commandEncoder.clearBuffer(buffer: buffer, offset: offset, size: &size)
 }
 
-// FIXME: Eventually all these "thunks" should be removed.
-// swift-format-ignore: AllPublicDeclarationsHaveDocumentation
-public func resolveQuerySet(
-    commandEncoder: WebGPU.CommandEncoder,
+@_expose(Cxx)
+func commandEncoderResolveQuerySet(
+    _ commandEncoder: WebGPU.CommandEncoder,
     querySet: WebGPU.QuerySet,
     firstQuery: UInt32,
     queryCount: UInt32,
@@ -62,12 +60,9 @@ public func resolveQuerySet(
     )
 }
 
-// FIXME: Eventually all these "thunks" should be removed.
-// swift-format-ignore: AlwaysUseLowerCamelCase
-// swift-format-ignore: AllPublicDeclarationsHaveDocumentation
 @_expose(Cxx)
-public func CommandEncoder_copyBufferToTexture_thunk(
-    commandEncoder: WebGPU.CommandEncoder,
+func commandEncoderCopyBufferToTexture(
+    _ commandEncoder: WebGPU.CommandEncoder,
     source: WGPUImageCopyBuffer,
     destination: WGPUImageCopyTexture,
     copySize: WGPUExtent3D
@@ -75,11 +70,8 @@ public func CommandEncoder_copyBufferToTexture_thunk(
     commandEncoder.copyBufferToTexture(source: source, destination: destination, copySize: copySize)
 }
 
-// FIXME: Eventually all these "thunks" should be removed.
-// swift-format-ignore: AlwaysUseLowerCamelCase
-// swift-format-ignore: AllPublicDeclarationsHaveDocumentation
 @_expose(Cxx)
-public func CommandEncoder_copyTextureToBuffer_thunk(
+func commandEncoderCopyTextureToBuffer(
     commandEncoder: WebGPU.CommandEncoder,
     source: WGPUImageCopyTexture,
     destination: WGPUImageCopyBuffer,
@@ -88,12 +80,9 @@ public func CommandEncoder_copyTextureToBuffer_thunk(
     commandEncoder.copyTextureToBuffer(source: source, destination: destination, copySize: copySize)
 }
 
-// FIXME: Eventually all these "thunks" should be removed.
-// swift-format-ignore: AlwaysUseLowerCamelCase
-// swift-format-ignore: AllPublicDeclarationsHaveDocumentation
 @_expose(Cxx)
-public func CommandEncoder_copyTextureToTexture_thunk(
-    commandEncoder: WebGPU.CommandEncoder,
+func commandEncoderCopyTextureToTexture(
+    _ commandEncoder: WebGPU.CommandEncoder,
     source: WGPUImageCopyTexture,
     destination: WGPUImageCopyTexture,
     copySize: WGPUExtent3D
@@ -101,12 +90,9 @@ public func CommandEncoder_copyTextureToTexture_thunk(
     commandEncoder.copyTextureToTexture(source: source, destination: destination, copySize: copySize)
 }
 
-// FIXME: Eventually all these "thunks" should be removed.
-// swift-format-ignore: AlwaysUseLowerCamelCase
-// swift-format-ignore: AllPublicDeclarationsHaveDocumentation
 @_expose(Cxx)
-public func CommandEncoder_copyBufferToBuffer_thunk(
-    commandEncoder: WebGPU.CommandEncoder,
+func commandEncoderCopyBufferToBuffer(
+    _ commandEncoder: WebGPU.CommandEncoder,
     source: WebGPU.Buffer,
     sourceOffset: UInt64,
     destination: WebGPU.Buffer,
@@ -122,34 +108,25 @@ public func CommandEncoder_copyBufferToBuffer_thunk(
     )
 }
 
-// FIXME: Eventually all these "thunks" should be removed.
-// swift-format-ignore: AlwaysUseLowerCamelCase
-// swift-format-ignore: AllPublicDeclarationsHaveDocumentation
 @_expose(Cxx)
-public func CommandEncoder_beginRenderPass_thunk(
-    commandEncoder: WebGPU.CommandEncoder,
+func commandEncoderBeginRenderPass(
+    _ commandEncoder: WebGPU.CommandEncoder,
     descriptor: WGPURenderPassDescriptor,
 ) -> CxxBridging.RefRenderPassEncoder {
     commandEncoder.beginRenderPass(descriptor: descriptor)
 }
 
-// FIXME: Eventually all these "thunks" should be removed.
-// swift-format-ignore: AlwaysUseLowerCamelCase
-// swift-format-ignore: AllPublicDeclarationsHaveDocumentation
 @_expose(Cxx)
-public func CommandEncoder_beginComputePass_thunk(
-    commandEncoder: WebGPU.CommandEncoder,
+func commandEncoderBeginComputePass(
+    _ commandEncoder: WebGPU.CommandEncoder,
     descriptor: WGPUComputePassDescriptor,
 ) -> CxxBridging.RefComputePassEncoder {
     commandEncoder.beginComputePass(descriptor: descriptor)
 }
 
-// FIXME: Eventually all these "thunks" should be removed.
-// swift-format-ignore: AlwaysUseLowerCamelCase
-// swift-format-ignore: AllPublicDeclarationsHaveDocumentation
 @_expose(Cxx)
-public func CommandEncoder_runClearEncoder_thunk(
-    commandEncoder: WebGPU.CommandEncoder,
+func commandEncoderRunClearEncoder(
+    _ commandEncoder: WebGPU.CommandEncoder,
     attachmentsToClear: NSMutableDictionary,
     depthStencilAttachmentToClear: inout (any MTLTexture)?,
     depthAttachmentToClear: Bool,
@@ -173,21 +150,14 @@ public func CommandEncoder_runClearEncoder_thunk(
     )
 }
 
-// FIXME: Eventually all these "thunks" should be removed.
-// swift-format-ignore: AlwaysUseLowerCamelCase
-// swift-format-ignore: AllPublicDeclarationsHaveDocumentation
 @_expose(Cxx)
-public func CommandEncoder_clearTextureIfNeeded_thunk(commandEncoder: WebGPU.CommandEncoder, destination: WGPUImageCopyTexture, slice: UInt)
-{
+func commandEncoderClearTextureIfNeeded(_ commandEncoder: WebGPU.CommandEncoder, destination: WGPUImageCopyTexture, slice: UInt) {
     commandEncoder.clearTextureIfNeeded(destination: destination, slice: slice)
 }
 
-// FIXME: Eventually all these "thunks" should be removed.
-// swift-format-ignore: AlwaysUseLowerCamelCase
-// swift-format-ignore: AllPublicDeclarationsHaveDocumentation
 @_expose(Cxx)
-public func CommandEncoder_finish_thunk(
-    commandEncoder: WebGPU.CommandEncoder,
+func commandEncoderFinish(
+    _ commandEncoder: WebGPU.CommandEncoder,
     descriptor: WGPUCommandBufferDescriptor
 ) -> CxxBridging.RefCommandBuffer {
     commandEncoder.finish(descriptor: descriptor)

--- a/Source/WebGPU/WebGPU/Queue.mm
+++ b/Source/WebGPU/WebGPU/Queue.mm
@@ -618,7 +618,7 @@ void Queue::writeBuffer(id<MTLBuffer> buffer, uint64_t bufferOffset, std::span<u
 {
 #if ENABLE(WEBGPU_SWIFT)
     if (isWebGPUSwiftEnabled()) {
-        Queue_writeBuffer_thunk(this, buffer, bufferOffset, data);
+        queueWriteBuffer(this, buffer, bufferOffset, data);
         return;
     }
 #endif

--- a/Source/WebGPU/WebGPU/Queue.swift
+++ b/Source/WebGPU/WebGPU/Queue.swift
@@ -21,16 +21,13 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
 // THE POSSIBILITY OF SUCH DAMAGE.
 
-public import Metal
+import Metal
 import WebGPU_Internal.Queue
 
 private let largeBufferSize = 32 * 1024 * 1024
 
-// FIXME: Eventually all these "thunks" should be removed.
-// swift-format-ignore: AlwaysUseLowerCamelCase
-// swift-format-ignore: AllPublicDeclarationsHaveDocumentation
 @_expose(Cxx)
-public func Queue_writeBuffer_thunk(queue: WebGPU.Queue, buffer: any MTLBuffer, bufferOffset: UInt64, data: WebGPU.SpanUInt8) {
+func queueWriteBuffer(_ queue: WebGPU.Queue, buffer: any MTLBuffer, bufferOffset: UInt64, data: WebGPU.SpanUInt8) {
     // FIXME (rdar://161269480): We should be able to declare 'data' as MutableSpan<UInt8>, which will remove this use of 'unsafe'.
     queue.writeBuffer(buffer: buffer, bufferOffset: bufferOffset, data: unsafe MutableSpan(_unsafeCxxSpan: data))
 }


### PR DESCRIPTION
#### 7581588fd861762e6abe201ba15ecf8fe930fa09
<pre>
[Swift in WebKit] Adopt `emit-clang-header-min-access` flag in WebGPU
<a href="https://bugs.webkit.org/show_bug.cgi?id=314869">https://bugs.webkit.org/show_bug.cgi?id=314869</a>
<a href="https://rdar.apple.com/177130998">rdar://177130998</a>

Reviewed by Adrian Taylor and Mike Wyrzykowski.

Adopt the `-clang-header-expose-decls=has-expose-attr-or-stdlib` and
`-emit-clang-header-min-access internal` Swift flag options in WebGPU. The latter makes it so that
`internal` symbols are exposed to C++ instead of just `public` symbols, and the former limits it so
that only symbols annotated with `@_expose(Cxx)` are exposed. This improves encapsulation and makes
WebGPU more aligned with WebKit, and removes the need to have any `public` symbols in WebGPU.

This is also a pre-requisite for being able to adopt internal bridging headers to replace internal modules.

Also clean up all the &quot;thunk&quot; names to be more normally named and simpler.

* Source/WebGPU/Configurations/WebGPU.xcconfig:
* Source/WebGPU/WebGPU/Buffer.h:
* Source/WebGPU/WebGPU/Buffer.mm:
(WebGPU::Buffer::getMappedRange):
(wgpuBufferCopy):
* Source/WebGPU/WebGPU/Buffer.swift:
(bufferCopyFrom(_:from:offset:)):
(bufferGetMappedRange(_:offset:size:)):
(Buffer_copyFrom_thunk(_:from:offset:)): Deleted.
(Buffer_getMappedRange_thunk(_:offset:size:)): Deleted.
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::beginComputePass):
(WebGPU::CommandEncoder::runClearEncoder):
(WebGPU::CommandEncoder::beginRenderPass):
(WebGPU::CommandEncoder::copyBufferToBuffer):
(WebGPU::CommandEncoder::copyBufferToTexture):
(WebGPU::CommandEncoder::clearTextureIfNeeded):
(WebGPU::CommandEncoder::copyTextureToBuffer):
(WebGPU::CommandEncoder::copyTextureToTexture):
(WebGPU::CommandEncoder::clearBuffer):
(WebGPU::CommandEncoder::finish):
(WebGPU::CommandEncoder::resolveQuerySet):
* Source/WebGPU/WebGPU/CommandEncoder.swift:
(commandEncoderClearTextureIfNeeded(_:destination:slice:)):
(CommandEncoder_clearTextureIfNeeded_thunk(_:destination:slice:)): Deleted.
* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::writeBuffer):
* Source/WebGPU/WebGPU/Queue.swift:
(queueWriteBuffer(_:buffer:bufferOffset:data:)):
(Queue_writeBuffer_thunk(_:buffer:bufferOffset:data:)): Deleted.

Canonical link: <a href="https://commits.webkit.org/315833@main">https://commits.webkit.org/315833@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb13489bf529d852f569d7f027325077d71bd93e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169272 "Passed style check") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43194 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/36454 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178628 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126984 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/55175a58-68eb-465d-bfa2-8330f2c96f08) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/43533 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42821 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131842 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92780 "8 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/80598ad2-e058-4cc2-8ca5-d8d8fed6cac8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172231 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/34592 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152134 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112346 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d6acbd64-3100-44cd-aac0-fa1257814d67) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/33575 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31986 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27328 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/143565 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31534 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181228 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33938 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36155 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140297 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42850 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140136 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37957 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43539 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/28509 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/107471 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35406 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115304 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42049 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6599 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41442 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41697 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41585 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->