### PR TITLE
Add isDHTMLDraggable and isColorInput flags to InteractionInformationAtPosition

### DIFF
--- a/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.h
+++ b/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.h
@@ -68,6 +68,8 @@ struct InteractionInformationAtPosition {
         Selectability&&,
         bool isSelected,
         bool prefersDraggingOverTextSelection,
+        bool isDHTMLDraggable,
+        bool isColorInput,
         bool isNearMarkedText,
 #if PLATFORM(IOS_FAMILY)
         bool touchCalloutEnabled,
@@ -134,6 +136,8 @@ struct InteractionInformationAtPosition {
 
     bool isSelected { false };
     bool prefersDraggingOverTextSelection { false };
+    bool isDHTMLDraggable { false };
+    bool isColorInput { false };
     bool isNearMarkedText { false };
 #if PLATFORM(IOS_FAMILY)
     bool touchCalloutEnabled { true };

--- a/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.mm
+++ b/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.mm
@@ -41,6 +41,8 @@ InteractionInformationAtPosition::InteractionInformationAtPosition(
     Selectability&& selectability,
     bool isSelected,
     bool prefersDraggingOverTextSelection,
+    bool isDHTMLDraggable,
+    bool isColorInput,
     bool isNearMarkedText,
 #if PLATFORM(IOS_FAMILY)
     bool touchCalloutEnabled,
@@ -103,6 +105,8 @@ InteractionInformationAtPosition::InteractionInformationAtPosition(
     , selectability(selectability)
     , isSelected(isSelected)
     , prefersDraggingOverTextSelection(prefersDraggingOverTextSelection)
+    , isDHTMLDraggable(isDHTMLDraggable)
+    , isColorInput(isColorInput)
     , isNearMarkedText(isNearMarkedText)
 #if PLATFORM(IOS_FAMILY)
     , touchCalloutEnabled(touchCalloutEnabled)

--- a/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.serialization.in
+++ b/Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.serialization.in
@@ -39,6 +39,8 @@ struct WebKit::InteractionInformationAtPosition {
 
     bool isSelected;
     bool prefersDraggingOverTextSelection;
+    bool isDHTMLDraggable;
+    bool isColorInput;
     bool isNearMarkedText;
 #if PLATFORM(IOS_FAMILY)
     bool touchCalloutEnabled;

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm
@@ -395,16 +395,24 @@ static void selectionPositionInformation(WebPage& page, const InteractionInforma
             info.url = URL::fileURLWithFileSystemPath(attachment->file()->path());
     }
 
-    for (auto* currentNode = hitNode.get(); currentNode; currentNode = currentNode->parentOrShadowHostNode()) {
-        auto* renderer = currentNode->renderer();
+    for (RefPtr currentNode = hitNode; currentNode; currentNode = currentNode->parentOrShadowHostNode()) {
+        CheckedPtr renderer = currentNode->renderer();
         if (!renderer)
             continue;
 
-        auto& style = renderer->style();
-        if (style.usedUserSelect() == WebCore::UserSelect::None && style.userDrag() == WebCore::UserDrag::Element) {
+        CheckedRef style = renderer->style();
+        if (style->userDrag() == WebCore::UserDrag::Element)
+            info.isDHTMLDraggable = true;
+        if (style->usedUserSelect() == WebCore::UserSelect::None && style->userDrag() == WebCore::UserDrag::Element)
             info.prefersDraggingOverTextSelection = true;
-            break;
+
+        if (!info.isColorInput) {
+            if (RefPtr input = dynamicDowncast<WebCore::HTMLInputElement>(currentNode); input && input->isColorControl() && !input->isDisabledFormControl())
+                info.isColorInput = true;
         }
+
+        if (info.prefersDraggingOverTextSelection || info.isDHTMLDraggable || info.isColorInput)
+            break;
     }
 #if PLATFORM(MACCATALYST)
     bool isInsideFixedPosition;


### PR DESCRIPTION
#### 4257db292740bc765680cc5cccae7d2e397ca213
<pre>
Add isDHTMLDraggable and isColorInput flags to InteractionInformationAtPosition
<a href="https://bugs.webkit.org/show_bug.cgi?id=314868">https://bugs.webkit.org/show_bug.cgi?id=314868</a>
<a href="https://rdar.apple.com/177130823">rdar://177130823</a>

Reviewed by Richard Robinson.

This patch teaches InteractionInformationAtPosition a better view of the
signals that DragController consults when deciding what a draggable
element is. This will be requisite in a forthcoming drag-and-drop patch.

Namely, we add two flags:

- isDHTMLDraggable: any node along the hit-test parent chain with
  style.userDrag() == UserDrag::Element.
- isColorInput: a hit-tested HTMLInputElement that is an enabled color
  control.

Drive-by: Also address some SaferCPP errors raised in an earlier EWS
round of this patch.

* Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.h:
* Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.mm:
(WebKit::InteractionInformationAtPosition::InteractionInformationAtPosition):
* Source/WebKit/Shared/Cocoa/InteractionInformationAtPosition.serialization.in:
* Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm:
(WebKit::selectionPositionInformation):

Canonical link: <a href="https://commits.webkit.org/313321@main">https://commits.webkit.org/313321@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1160b5c6f84bd27d3bec75ea9139238b094e8960

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162729 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36205 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29354 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171667 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119175 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a6b2681a-e313-4630-88a1-7eabb5b629d2) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36309 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36209 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126304 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88948 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165688 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28655 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146217 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106881 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/76652233-231d-4f60-a1a0-0c089b6ab264) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27701 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26234 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19367 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137409 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174171 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21484 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25591 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134614 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35879 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30334 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134609 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35863 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145742 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98250 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24740 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/29150 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22578 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35373 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/103124 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34874 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35119 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35022 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->