### PR TITLE
Exempt origins with push subscriptions from time-based website data eviction

### DIFF
--- a/Source/WebCore/Modules/push-api/PushDatabase.cpp
+++ b/Source/WebCore/Modules/push-api/PushDatabase.cpp
@@ -693,6 +693,22 @@ void PushDatabase::getPushSubscriptionSetRecords(CompletionHandler<void(Vector<P
     });
 }
 
+void PushDatabase::getAllPushSubscriptionOrigins(CompletionHandler<void(Vector<String>&&)>&& completionHandler)
+{
+    dispatchOnWorkQueue([this, completionHandler = WTF::move(completionHandler)]() mutable {
+        Vector<String> origins;
+
+        auto sql = cachedStatementOnQueue("SELECT DISTINCT securityOrigin FROM SubscriptionSets WHERE state = 0"_s);
+        if (!sql)
+            return completeOnMainQueue(WTF::move(completionHandler), WTF::move(origins));
+
+        while (sql->step() == SQLITE_ROW)
+            origins.append(sql->columnText(0));
+
+        completeOnMainQueue(WTF::move(completionHandler), WTF::move(origins));
+    });
+}
+
 void PushDatabase::incrementSilentPushCount(const PushSubscriptionSetIdentifier& subscriptionSetIdentifier, const String& securityOrigin, CompletionHandler<void(unsigned)>&& completionHandler)
 {
     dispatchOnWorkQueue([this, subscriptionSetIdentifier = crossThreadCopy(subscriptionSetIdentifier), securityOrigin = crossThreadCopy(securityOrigin), completionHandler = WTF::move(completionHandler)]() mutable {

--- a/Source/WebCore/Modules/push-api/PushDatabase.h
+++ b/Source/WebCore/Modules/push-api/PushDatabase.h
@@ -105,6 +105,7 @@ public:
     WEBCORE_EXPORT void getRecordBySubscriptionSetAndScope(const PushSubscriptionSetIdentifier&, const String& scope, CompletionHandler<void(std::optional<PushRecord>&&)>&&);
     WEBCORE_EXPORT void getIdentifiers(CompletionHandler<void(HashSet<PushSubscriptionIdentifier>&&)>&&);
     WEBCORE_EXPORT void getPushSubscriptionSetRecords(CompletionHandler<void(Vector<PushSubscriptionSetRecord>&&)>&&);
+    WEBCORE_EXPORT void getAllPushSubscriptionOrigins(CompletionHandler<void(Vector<String>&&)>&&);
     WEBCORE_EXPORT void getTopics(CompletionHandler<void(PushTopics&&)>&&);
 
     WEBCORE_EXPORT void incrementSilentPushCount(const PushSubscriptionSetIdentifier&, const String& securityOrigin, CompletionHandler<void(unsigned)>&&);

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -709,6 +709,23 @@ void NetworkProcess::diskCacheOriginAccessTimes(PAL::SessionID sessionID, Comple
     completionHandler({ });
 }
 
+void NetworkProcess::getAllPushSubscriptionOrigins(PAL::SessionID sessionID, CompletionHandler<void(Vector<WebCore::SecurityOriginData>&&)>&& completionHandler)
+{
+    CheckedPtr session = networkSession(sessionID);
+    if (session && !session->mockPushSubscriptionOriginsForTesting().isEmpty()) {
+        completionHandler(Vector { session->mockPushSubscriptionOriginsForTesting() });
+        return;
+    }
+
+#if ENABLE(WEB_PUSH_NOTIFICATIONS)
+    if (session) {
+        session->notificationManager().getAllPushSubscriptionOrigins(WTF::move(completionHandler));
+        return;
+    }
+#endif
+    completionHandler({ });
+}
+
 void NetworkProcess::registrableDomainsExemptFromWebsiteDataDeletion(PAL::SessionID sessionID, CompletionHandler<void(HashSet<RegistrableDomain>)>&& completionHandler)
 {
     if (CheckedPtr session = networkSession(sessionID)) {

--- a/Source/WebKit/NetworkProcess/NetworkProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.h
@@ -243,6 +243,7 @@ public:
 
     void registrableDomainsWithLastAccessedTime(PAL::SessionID, CompletionHandler<void(std::optional<HashMap<RegistrableDomain, WallTime>>&&)>&&);
     void diskCacheOriginAccessTimes(PAL::SessionID, CompletionHandler<void(HashMap<WebCore::RegistrableDomain, WallTime>&&)>&&);
+    void getAllPushSubscriptionOrigins(PAL::SessionID, CompletionHandler<void(Vector<WebCore::SecurityOriginData>&&)>&&);
     void registrableDomainsExemptFromWebsiteDataDeletion(PAL::SessionID, CompletionHandler<void(HashSet<RegistrableDomain>)>&&);
     void clearPrevalentResource(PAL::SessionID, RegistrableDomain&&, CompletionHandler<void()>&&);
     void clearUserInteraction(PAL::SessionID, RegistrableDomain&&, CompletionHandler<void()>&&);

--- a/Source/WebKit/NetworkProcess/NetworkSession.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkSession.cpp
@@ -179,6 +179,7 @@ NetworkSession::NetworkSession(NetworkProcess& networkProcess, const NetworkSess
         ref.set(makeUniqueRef<WebSharedWorkerServer>(session));
     })
     , m_storageManager(createNetworkStorageManager(networkProcess, parameters))
+    , m_mockPushSubscriptionOriginsForTesting(parameters.mockPushSubscriptionOriginsForTesting)
 #if ENABLE(WEB_PUSH_NOTIFICATIONS)
     , m_notificationManager(NetworkNotificationManager::create(parameters.sessionID.isEphemeral() ? String { } : parameters.webPushMachServiceName, configurationWithHostAuditToken(networkProcess, parameters.webPushDaemonConnectionConfiguration), networkProcess))
 #endif

--- a/Source/WebKit/NetworkProcess/NetworkSession.h
+++ b/Source/WebKit/NetworkProcess/NetworkSession.h
@@ -278,6 +278,8 @@ public:
     NetworkNotificationManager& notificationManager() { return m_notificationManager.get(); }
 #endif
 
+    const Vector<WebCore::SecurityOriginData>& mockPushSubscriptionOriginsForTesting() const { return m_mockPushSubscriptionOriginsForTesting; }
+
 #if ENABLE(INSPECTOR_NETWORK_THROTTLING)
     std::optional<int64_t> bytesPerSecondLimit() const { return m_bytesPerSecondLimit; }
     void setEmulatedConditions(std::optional<int64_t>&& bytesPerSecondLimit);
@@ -412,6 +414,7 @@ protected:
     HashMap<WebPageProxyIdentifier, String> m_attributedBundleIdentifierFromPageIdentifiers;
     HashMap<WebPageProxyIdentifier, HashSet<WebCore::RegistrableDomain>> m_trackerBlockingPolicyByPageIdentifier;
 
+    Vector<WebCore::SecurityOriginData> m_mockPushSubscriptionOriginsForTesting;
 #if ENABLE(WEB_PUSH_NOTIFICATIONS)
     const Ref<NetworkNotificationManager> m_notificationManager;
 #endif

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h
@@ -30,6 +30,7 @@
 #include "UnifiedOriginStorageLevel.h"
 #include "WebPushDaemonConnectionConfiguration.h"
 #include <WebCore/NetworkStorageSession.h>
+#include <WebCore/SecurityOriginData.h>
 #include <pal/SessionID.h>
 #include <wtf/Seconds.h>
 #include <wtf/URL.h>
@@ -131,6 +132,7 @@ struct NetworkSessionCreationParameters {
     Seconds timeBasedEvictionThreshold { 180 * 24_h };
     std::optional<Seconds> lastModificationTimeUpdateIntervalOverride;
     std::optional<Seconds> timeBasedEvictionIntervalOverride;
+    Vector<WebCore::SecurityOriginData> mockPushSubscriptionOriginsForTesting;
 #if ENABLE(DECLARATIVE_WEB_PUSH)
     bool isDeclarativeWebPushEnabled { false };
 #endif

--- a/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in
+++ b/Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in
@@ -104,6 +104,7 @@ enum class WebKit::AllowsCellularAccess : bool;
     Seconds timeBasedEvictionThreshold;
     std::optional<Seconds> lastModificationTimeUpdateIntervalOverride;
     std::optional<Seconds> timeBasedEvictionIntervalOverride;
+    Vector<WebCore::SecurityOriginData> mockPushSubscriptionOriginsForTesting;
 #if ENABLE(DECLARATIVE_WEB_PUSH)
     bool isDeclarativeWebPushEnabled;
 #endif

--- a/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp
+++ b/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp
@@ -222,6 +222,17 @@ void NetworkNotificationManager::removePushSubscriptionsForOrigin(WebCore::Secur
     connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::RemovePushSubscriptionsForOrigin(WTF::move(origin)), WTF::move(completionHandler));
 }
 
+void NetworkNotificationManager::getAllPushSubscriptionOrigins(CompletionHandler<void(Vector<WebCore::SecurityOriginData>&&)>&& completionHandler)
+{
+    RefPtr connection = m_connection;
+    if (!connection) {
+        completionHandler({ });
+        return;
+    }
+
+    connection->sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetAllPushSubscriptionOrigins(), WTF::move(completionHandler));
+}
+
 void NetworkNotificationManager::getAppBadgeForTesting(CompletionHandler<void(std::optional<uint64_t>)>&& completionHandler)
 {
     RefPtr connection = m_connection;

--- a/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h
+++ b/Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h
@@ -75,6 +75,7 @@ public:
     void incrementSilentPushCount(WebCore::SecurityOriginData&&, CompletionHandler<void(unsigned)>&&);
     void removeAllPushSubscriptions(CompletionHandler<void(unsigned)>&&);
     void removePushSubscriptionsForOrigin(WebCore::SecurityOriginData&&, CompletionHandler<void(unsigned)>&&);
+    void getAllPushSubscriptionOrigins(CompletionHandler<void(Vector<WebCore::SecurityOriginData>&&)>&&);
 
     void showNotification(const WebCore::NotificationData&, RefPtr<WebCore::NotificationResources>&&, CompletionHandler<void()>&&);
     void getNotifications(const URL& registrationURL, const String& tag, CompletionHandler<void(Expected<Vector<WebCore::NotificationData>, WebCore::ExceptionData>&&)>&&);

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -650,20 +650,32 @@ void NetworkStorageManager::prepareForTimeBasedEviction(TimeBasedEvictionMode mo
             if (!protectedThis || protectedThis->m_closed)
                 return;
 
-            protectedThis->workQueue().dispatch([weakThis = WTF::move(weakThis), mode, threshold, result = crossThreadCopy(WTF::move(result))]() mutable {
-                if (RefPtr protectedThis = weakThis)
-                    protectedThis->donePrepareForTimeBasedEviction(mode, threshold, WTF::move(result));
+            RefPtr process = protectedThis->m_process;
+            if (!process)
+                return;
+
+            process->getAllPushSubscriptionOrigins(protectedThis->m_sessionID, [weakThis = WTF::move(weakThis), mode, threshold, result = WTF::move(result)](Vector<WebCore::SecurityOriginData>&& pushSubscriptionOrigins) mutable {
+                RefPtr protectedThis = weakThis;
+                if (!protectedThis || protectedThis->m_closed)
+                    return;
+
+                protectedThis->workQueue().dispatch([weakThis = WTF::move(weakThis), mode, threshold, result = crossThreadCopy(WTF::move(result)), pushSubscriptionOrigins = crossThreadCopy(WTF::move(pushSubscriptionOrigins))]() mutable {
+                    if (RefPtr protectedThis = weakThis)
+                        protectedThis->donePrepareForTimeBasedEviction(mode, threshold, WTF::move(result), WTF::move(pushSubscriptionOrigins));
+                });
             });
         });
     });
 }
 
-void NetworkStorageManager::donePrepareForTimeBasedEviction(TimeBasedEvictionMode mode, Seconds threshold, HashMap<WebCore::RegistrableDomain, WallTime>&& diskCacheAccessTimes)
+void NetworkStorageManager::donePrepareForTimeBasedEviction(TimeBasedEvictionMode mode, Seconds threshold, HashMap<WebCore::RegistrableDomain, WallTime>&& diskCacheAccessTimes, Vector<WebCore::SecurityOriginData>&& pushSubscriptionOrigins)
 {
     assertIsCurrent(workQueue());
 
     if (m_closed)
         return;
+
+    HashSet<WebCore::SecurityOriginData> pushSubscriptionOriginSet { WTF::move(pushSubscriptionOrigins) };
 
     auto startTime = MonotonicTime::now();
     HashMap<WebCore::SecurityOriginData, AccessRecord> originRecords;
@@ -695,6 +707,11 @@ void NetworkStorageManager::donePrepareForTimeBasedEviction(TimeBasedEvictionMod
 
         if (record.lastAccessTime >= cutoffTime)
             continue;
+
+        if (pushSubscriptionOriginSet.contains(topOrigin)) {
+            RELEASE_LOG(Storage, "%p - NetworkStorageManager::performTimeBasedEviction sessionID=%" PRIu64 " skipping origin %" SENSITIVE_LOG_STRING " with active push subscription", this, m_sessionID.toUInt64(), topOrigin.toString().ascii().data());
+            continue;
+        }
 
         auto types = mode == TimeBasedEvictionMode::ServiceWorkerRegistrationsOnly ? OptionSet<WebsiteDataType> { WebsiteDataType::ServiceWorkerRegistrations } : allManagedTypes();
         performEvictionForOrigin(topOrigin, record, types);

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -298,7 +298,7 @@ private:
     void performQuotaBasedEviction(HashMap<WebCore::SecurityOriginData, AccessRecord>&&);
     void performTimeBasedEviction(TimeBasedEvictionMode, Seconds threshold, std::optional<Seconds> evictionIntervalOverride);
     void prepareForTimeBasedEviction(TimeBasedEvictionMode, Seconds threshold);
-    void donePrepareForTimeBasedEviction(TimeBasedEvictionMode, Seconds threshold, HashMap<WebCore::RegistrableDomain, WallTime>&&);
+    void donePrepareForTimeBasedEviction(TimeBasedEvictionMode, Seconds threshold, HashMap<WebCore::RegistrableDomain, WallTime>&&, Vector<WebCore::SecurityOriginData>&& pushSubscriptionOrigins);
     bool shouldPerformTimeBasedEvictionNow(std::optional<Seconds> intervalOverride);
     void performEvictionForOrigin(const WebCore::SecurityOriginData& topOrigin, const AccessRecord&, OptionSet<WebsiteDataType>);
     const SuspendableWorkQueue& workQueue() const WTF_RETURNS_CAPABILITY(m_queue.get()) { return m_queue; }

--- a/Source/WebKit/Shared/WebPushDaemonConstants.h
+++ b/Source/WebKit/Shared/WebPushDaemonConstants.h
@@ -40,7 +40,7 @@ static constexpr Seconds silentPushTimeoutForProduction { 30_s };
 static constexpr Seconds silentPushTimeoutForTesting { 1_s };
 
 constexpr auto protocolVersionKey = "protocol version"_s;
-constexpr uint64_t protocolVersionValue = 5;
+constexpr uint64_t protocolVersionValue = 6;
 constexpr auto protocolEncodedMessageKey = "encoded message"_s;
 
 // FIXME: ConnectionToMachService traits requires we have a message type, so keep this placeholder here

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h
@@ -63,6 +63,7 @@ WK_CLASS_AVAILABLE(macos(10.13), ios(11.0))
 @property (nonatomic) NSTimeInterval timeBasedEvictionThreshold;
 @property (nonatomic, nullable, copy) NSNumber *lastModificationTimeUpdateIntervalOverride;
 @property (nonatomic, nullable, copy) NSNumber *timeBasedEvictionIntervalOverride;
+@property (nonatomic, nullable, copy) NSArray<NSString *> *mockPushSubscriptionOriginsForTesting;
 @property (nonatomic, nullable, copy) NSNumber *originQuotaRatio WK_API_AVAILABLE(macos(14.0), ios(17.0));
 @property (nonatomic, nullable, copy) NSNumber *totalQuotaRatio WK_API_AVAILABLE(macos(14.0), ios(17.0));
 @property (nonatomic, nullable, copy) NSNumber *standardVolumeCapacity WK_API_AVAILABLE(macos(14.0), ios(17.0));

--- a/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm
@@ -28,6 +28,7 @@
 
 #import "TimeBasedEvictionMode.h"
 #import "UnifiedOriginStorageLevel.h"
+#import <WebCore/SecurityOriginData.h>
 #import <WebCore/WebCoreObjCExtras.h>
 #import <wtf/RetainPtr.h>
 
@@ -572,6 +573,29 @@ static WebKit::UnifiedOriginStorageLevel NODELETE toUnifiedOriginStorageLevel(_W
         _configuration->setTimeBasedEvictionIntervalOverride(Seconds([seconds doubleValue]));
     else
         _configuration->setTimeBasedEvictionIntervalOverride(std::nullopt);
+}
+
+- (NSArray<NSString *> *)mockPushSubscriptionOriginsForTesting
+{
+    auto& origins = _configuration->mockPushSubscriptionOriginsForTesting();
+    RetainPtr result = adoptNS([[NSMutableArray alloc] initWithCapacity:origins.size()]);
+    for (auto& origin : origins)
+        [result addObject:origin.toString().createNSString().get()];
+    return result.autorelease();
+}
+
+- (void)setMockPushSubscriptionOriginsForTesting:(NSArray<NSString *> *)originStrings
+{
+    Vector<WebCore::SecurityOriginData> origins;
+    origins.reserveInitialCapacity(originStrings.count);
+    for (NSString *originString in originStrings) {
+        auto origin = WebCore::SecurityOriginData::fromURL(URL { String { originString } });
+        if (origin.isNull() || origin.isOpaque())
+            continue;
+
+        origins.append(WTF::move(origin));
+    }
+    SUPPRESS_UNCOUNTED_ARG _configuration->setMockPushSubscriptionOriginsForTesting(WTF::move(origins));
 }
 
 - (NSNumber *)originQuotaRatio

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp
@@ -2256,6 +2256,7 @@ WebsiteDataStoreParameters WebsiteDataStore::parameters()
     networkSessionParameters.timeBasedEvictionThreshold = m_configuration->timeBasedEvictionThreshold();
     networkSessionParameters.lastModificationTimeUpdateIntervalOverride = m_configuration->lastModificationTimeUpdateIntervalOverride();
     networkSessionParameters.timeBasedEvictionIntervalOverride = m_configuration->timeBasedEvictionIntervalOverride();
+    networkSessionParameters.mockPushSubscriptionOriginsForTesting = m_configuration->mockPushSubscriptionOriginsForTesting();
 #if ENABLE(DECLARATIVE_WEB_PUSH)
     networkSessionParameters.isDeclarativeWebPushEnabled = m_configuration->isDeclarativeWebPushEnabled();
 #endif

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp
@@ -191,6 +191,7 @@ Ref<WebsiteDataStoreConfiguration> WebsiteDataStoreConfiguration::copy() const
     copy->m_timeBasedEvictionThreshold = this->m_timeBasedEvictionThreshold;
     copy->m_lastModificationTimeUpdateIntervalOverride = this->m_lastModificationTimeUpdateIntervalOverride;
     copy->m_timeBasedEvictionIntervalOverride = this->m_timeBasedEvictionIntervalOverride;
+    copy->m_mockPushSubscriptionOriginsForTesting = this->m_mockPushSubscriptionOriginsForTesting;
     copy->m_defaultTrackingPreventionEnabledOverride = this->m_defaultTrackingPreventionEnabledOverride;
 
     return copy;

--- a/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
+++ b/Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "APIObject.h"
+#include <WebCore/SecurityOriginData.h>
 #include <wtf/Markable.h>
 #include <wtf/URL.h>
 #include <wtf/UUID.h>
@@ -80,6 +81,8 @@ public:
     void setLastModificationTimeUpdateIntervalOverride(std::optional<Seconds> interval) { m_lastModificationTimeUpdateIntervalOverride = interval; }
     std::optional<Seconds> timeBasedEvictionIntervalOverride() const { return m_timeBasedEvictionIntervalOverride; }
     void setTimeBasedEvictionIntervalOverride(std::optional<Seconds> interval) { m_timeBasedEvictionIntervalOverride = interval; }
+    const Vector<WebCore::SecurityOriginData>& mockPushSubscriptionOriginsForTesting() const { return m_mockPushSubscriptionOriginsForTesting; }
+    void setMockPushSubscriptionOriginsForTesting(Vector<WebCore::SecurityOriginData>&& origins) { m_mockPushSubscriptionOriginsForTesting = WTF::move(origins); }
 
     std::optional<double> totalQuotaRatio() const { return m_totalQuotaRatio; }
     void setTotalQuotaRatio(std::optional<double> ratio) { m_totalQuotaRatio = ratio; }
@@ -318,6 +321,7 @@ private:
     Seconds m_timeBasedEvictionThreshold { 180 * 24_h };
     std::optional<Seconds> m_lastModificationTimeUpdateIntervalOverride;
     std::optional<Seconds> m_timeBasedEvictionIntervalOverride;
+    Vector<WebCore::SecurityOriginData> m_mockPushSubscriptionOriginsForTesting;
     std::optional<double> m_totalQuotaRatio;
     std::optional<uint64_t> m_standardVolumeCapacity;
     std::optional<uint64_t> m_volumeCapacityOverride;

--- a/Source/WebKit/webpushd/PushClientConnection.h
+++ b/Source/WebKit/webpushd/PushClientConnection.h
@@ -111,6 +111,7 @@ private:
     void incrementSilentPushCount(WebCore::SecurityOriginData&&, CompletionHandler<void(unsigned)>&&);
     void removeAllPushSubscriptions(CompletionHandler<void(unsigned)>&&);
     void removePushSubscriptionsForOrigin(WebCore::SecurityOriginData&&, CompletionHandler<void(unsigned)>&&);
+    void getAllPushSubscriptionOrigins(CompletionHandler<void(Vector<WebCore::SecurityOriginData>&&)>&&);
     void setPublicTokenForTesting(const String& publicToken, CompletionHandler<void()>&&);
     void initializeConnection(WebPushDaemonConnectionConfiguration&&);
     void getPushPermissionState(WebCore::SecurityOriginData&&, CompletionHandler<void(WebCore::PushPermissionState)>&&);

--- a/Source/WebKit/webpushd/PushClientConnection.messages.in
+++ b/Source/WebKit/webpushd/PushClientConnection.messages.in
@@ -41,6 +41,7 @@ messages -> WebPushD::PushClientConnection NotUsingIPCConnection {
     IncrementSilentPushCount(WebCore::SecurityOriginData origin) -> (unsigned newCount)
     RemoveAllPushSubscriptions()  -> (unsigned removed)
     RemovePushSubscriptionsForOrigin(WebCore::SecurityOriginData origin) -> (unsigned removed)
+    GetAllPushSubscriptionOrigins() -> (Vector<WebCore::SecurityOriginData> origins)
     SetPublicTokenForTesting(String token) -> ()
     GetPushTopicsForTesting() -> (Vector<String> enabled, Vector<String> ignored)
     ShowNotification(struct WebCore::NotificationData notificationData, RefPtr<WebCore::NotificationResources> notificationResources) -> ()

--- a/Source/WebKit/webpushd/PushClientConnection.mm
+++ b/Source/WebKit/webpushd/PushClientConnection.mm
@@ -319,6 +319,11 @@ void PushClientConnection::removePushSubscriptionsForOrigin(WebCore::SecurityOri
     WebPushDaemon::singleton().removePushSubscriptionsForOrigin(*this, WTF::move(origin), WTF::move(replySender));
 }
 
+void PushClientConnection::getAllPushSubscriptionOrigins(CompletionHandler<void(Vector<WebCore::SecurityOriginData>&&)>&& replySender)
+{
+    WebPushDaemon::singleton().getAllPushSubscriptionOrigins(*this, WTF::move(replySender));
+}
+
 void PushClientConnection::setPublicTokenForTesting(const String& publicToken, CompletionHandler<void()>&& replySender)
 {
     WebPushDaemon::singleton().setPublicTokenForTesting(*this, publicToken, WTF::move(replySender));

--- a/Source/WebKit/webpushd/PushService.h
+++ b/Source/WebKit/webpushd/PushService.h
@@ -30,6 +30,7 @@
 #include <WebCore/ExceptionData.h>
 #include <WebCore/PushDatabase.h>
 #include <WebCore/PushSubscriptionData.h>
+#include <WebCore/SecurityOriginData.h>
 #include <wtf/CompletionHandler.h>
 #include <wtf/Deque.h>
 #include <wtf/Expected.h>
@@ -71,6 +72,8 @@ public:
     void unsubscribe(const WebCore::PushSubscriptionSetIdentifier&, const String& scope, std::optional<WebCore::PushSubscriptionIdentifier>, CompletionHandler<void(const Expected<bool, WebCore::ExceptionData>&)>&&);
 
     void incrementSilentPushCount(const WebCore::PushSubscriptionSetIdentifier&, const String& securityOrigin, CompletionHandler<void(unsigned)>&&);
+
+    void getAllPushSubscriptionOrigins(CompletionHandler<void(Vector<WebCore::SecurityOriginData>&&)>&&);
 
     void setPushesEnabledForSubscriptionSetAndOrigin(const WebCore::PushSubscriptionSetIdentifier&, const String& securityOrigin, bool, CompletionHandler<void()>&&);
 

--- a/Source/WebKit/webpushd/PushService.mm
+++ b/Source/WebKit/webpushd/PushService.mm
@@ -748,6 +748,19 @@ void PushService::removeRecordsForBundleIdentifierAndDataStore(const String& bun
     });
 }
 
+void PushService::getAllPushSubscriptionOrigins(CompletionHandler<void(Vector<WebCore::SecurityOriginData>&&)>&& handler)
+{
+    m_database->getAllPushSubscriptionOrigins([handler = WTF::move(handler)](Vector<String>&& originStrings) mutable {
+        auto origins = WTF::compactMap(WTF::move(originStrings), [](String&& originString) -> std::optional<WebCore::SecurityOriginData> {
+            auto origin = WebCore::SecurityOriginData::fromURL(URL { WTF::move(originString) });
+            if (origin.isNull() || origin.isOpaque())
+                return std::nullopt;
+            return origin;
+        });
+        handler(WTF::move(origins));
+    });
+}
+
 #if PLATFORM(IOS)
 
 void PushService::updateSubscriptionSetState(const String& allowedBundleIdentifier, const HashSet<String>& installedWebClipIdentifiers, CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/webpushd/WebPushDaemon.h
+++ b/Source/WebKit/webpushd/WebPushDaemon.h
@@ -106,6 +106,7 @@ public:
     void incrementSilentPushCount(PushClientConnection&, const WebCore::SecurityOriginData&, CompletionHandler<void(unsigned)>&&);
     void removeAllPushSubscriptions(PushClientConnection&, CompletionHandler<void(unsigned)>&&);
     void removePushSubscriptionsForOrigin(PushClientConnection&, const WebCore::SecurityOriginData&, CompletionHandler<void(unsigned)>&&);
+    void getAllPushSubscriptionOrigins(PushClientConnection&, CompletionHandler<void(Vector<WebCore::SecurityOriginData>&&)>&&);
     void setPublicTokenForTesting(PushClientConnection&, const String& publicToken, CompletionHandler<void()>&&);
 
 #if HAVE(FULL_FEATURED_USER_NOTIFICATIONS)

--- a/Source/WebKit/webpushd/WebPushDaemon.mm
+++ b/Source/WebKit/webpushd/WebPushDaemon.mm
@@ -968,6 +968,19 @@ void WebPushDaemon::removePushSubscriptionsForOrigin(PushClientConnection& conne
     });
 }
 
+void WebPushDaemon::getAllPushSubscriptionOrigins(PushClientConnection&, CompletionHandler<void(Vector<WebCore::SecurityOriginData>&&)>&& replySender)
+{
+    runAfterStartingPushService([replySender = WTF::move(replySender)]() mutable {
+        auto& daemon = WebPushDaemon::singleton();
+        if (!daemon.m_pushService) {
+            replySender({ });
+            return;
+        }
+
+        daemon.m_pushService->getAllPushSubscriptionOrigins(WTF::move(replySender));
+    });
+}
+
 void WebPushDaemon::setPublicTokenForTesting(PushClientConnection& connection, const String& publicToken, CompletionHandler<void()>&& replySender)
 {
     if (!connection.hostAppHasPushInjectEntitlement()) {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebsiteDatastore.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebsiteDatastore.mm
@@ -2184,4 +2184,60 @@ TEST(TimeBasedEviction, ServiceWorkerRegistrationsOnlyMode)
     }
 }
 
+TEST(TimeBasedEviction, PushSubscriptionOriginNotEvicted)
+{
+    RetainPtr uuid = adoptNS([[NSUUID alloc] initWithUUIDString:@"68753a44-4d6f-1226-9c60-0050e4c0006f"]);
+    done = false;
+    [WKWebsiteDataStore _removeDataStoreWithIdentifier:uuid.get() completionHandler:^(NSError *error) {
+        done = true;
+    }];
+    TestWebKitAPI::Util::run(&done);
+
+    RetainPtr websiteDataStoreConfiguration = adoptNS([[_WKWebsiteDataStoreConfiguration alloc] initWithIdentifier:uuid.get()]);
+    [websiteDataStoreConfiguration setTimeBasedEvictionMode:_WKTimeBasedEvictionModeAllTypes];
+    [websiteDataStoreConfiguration setTimeBasedEvictionThreshold:0];
+    [websiteDataStoreConfiguration setTimeBasedEvictionIntervalOverride:@0];
+    [websiteDataStoreConfiguration setDefaultTrackingPreventionEnabledOverride:@NO];
+    [websiteDataStoreConfiguration setMockPushSubscriptionOriginsForTesting:@[@"https://example1.com"]];
+
+    NSString *idbHTML = @"<script> \
+        var request = indexedDB.open('testDB'); \
+        request.onupgradeneeded = function(event) { \
+            event.target.result.createObjectStore('store'); \
+        }; \
+        request.onsuccess = function() { \
+            window.webkit.messageHandlers.testHandler.postMessage('done'); \
+        }; \
+        request.onerror = function() { \
+            window.webkit.messageHandlers.testHandler.postMessage('error'); \
+        }; \
+    </script>";
+
+    @autoreleasepool {
+        RetainPtr websiteDataStore = adoptNS([[WKWebsiteDataStore alloc] _initWithConfiguration:websiteDataStoreConfiguration.get()]);
+        RetainPtr handler = adoptNS([[WKWebsiteDataStoreMessageHandler alloc] init]);
+        RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+        [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
+        [configuration setWebsiteDataStore:websiteDataStore.get()];
+        RetainPtr webView = adoptNS([[WKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+
+        // Write data for example1.com (the push-subscribed origin) and example2.com.
+        receivedScriptMessage = false;
+        [webView loadHTMLString:idbHTML baseURL:[NSURL URLWithString:@"https://example1.com/"]];
+        TestWebKitAPI::Util::run(&receivedScriptMessage);
+        EXPECT_WK_STREQ(@"done", [lastScriptMessage body]);
+
+        receivedScriptMessage = false;
+        [webView loadHTMLString:idbHTML baseURL:[NSURL URLWithString:@"https://example2.com/"]];
+        TestWebKitAPI::Util::run(&receivedScriptMessage);
+        EXPECT_WK_STREQ(@"done", [lastScriptMessage body]);
+    }
+
+    // Eviction should remove example2.com but spare example1.com because it has
+    // a push subscription according to the mock.
+    auto evictedDomains = triggerTimeBasedEviction(websiteDataStoreConfiguration.get());
+    EXPECT_EQ(1u, evictedDomains.get().count);
+    EXPECT_WK_STREQ(@"example2.com", evictedDomains.get()[0]);
+}
+
 } // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebPushDaemon.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebPushDaemon.mm
@@ -310,6 +310,28 @@ template<> struct TestArgumentCoder<URL> {
     }
 };
 
+template<> struct TestArgumentCoder<WebCore::SecurityOriginData> {
+    template<typename Encoder> static void encode(Encoder&, const WebCore::SecurityOriginData&)
+    {
+        // Tests only need to decode the reply; encoding is not exercised.
+        ASSERT_NOT_REACHED();
+    }
+    template<typename Decoder> static std::optional<WebCore::SecurityOriginData> decode(Decoder& decoder)
+    {
+        // Wire format mirrors IPC::ArgumentCoder<Variant<Tuple, OpaqueOriginIdentifierProcessQualified>>:
+        // a uint8_t variant index followed by the alternative's payload.
+        auto index = decoder.template decode<uint8_t>();
+        if (!index || *index)
+            return std::nullopt;
+        auto protocol = decoder.template decode<String>();
+        auto host = decoder.template decode<String>();
+        auto port = decoder.template decode<std::optional<uint16_t>>();
+        if (!protocol || !host || !port)
+            return std::nullopt;
+        return WebCore::SecurityOriginData { WTF::move(*protocol), WTF::move(*host), WTF::move(*port) };
+    }
+};
+
 class TestEncoder {
 public:
     template<typename T> void encodeHeader()
@@ -1487,6 +1509,17 @@ TEST_F(WebPushDTest, SubscribeTest)
 
     auto& ignored = topics.second;
     ASSERT_EQ(ignored.size(), 0u);
+
+    auto connection = createAndConfigureConnectionToService("org.webkit.webpushtestdaemon.service");
+    auto sender = WebPushXPCConnectionMessageSender { connection.get() };
+    Vector<WebCore::SecurityOriginData> origins;
+    bool done = false;
+    sender.sendWithAsyncReplyWithoutUsingIPCConnection(Messages::PushClientConnection::GetAllPushSubscriptionOrigins(), [&](Vector<WebCore::SecurityOriginData> result) {
+        origins = WTF::move(result);
+        done = true;
+    });
+    TestWebKitAPI::Util::run(&done);
+    ASSERT_TRUE(origins.contains(WebCore::SecurityOriginData::fromURL(URL { "https://example.com"_s })));
 }
 
 TEST_F(WebPushDTest, SubscribeWithBadIPCVersionRaisesExceptionTest)


### PR DESCRIPTION
#### f6769c8fdb6efaf99bea4ab6caad1c8b13ae3292
<pre>
Exempt origins with push subscriptions from time-based website data eviction
<a href="https://bugs.webkit.org/show_bug.cgi?id=314872">https://bugs.webkit.org/show_bug.cgi?id=314872</a>
<a href="https://rdar.apple.com/176399178">rdar://176399178</a>

Reviewed by Sihui Liu.

There are a number of websites whose only use of persisted website data is a simple service worker
that processes push events for the purposes of Web Push, and who do no other mutations to website
data. These websites could have their service workers (and therefore push subscriptions) cleared by
the time-based eviction path added in 312741@main, which is not desirable.

This exempts all origins with an active push subscription from time-based website data
eviction. This is handled through a new GetAllPushSubscriptionOrigins IPC from NetworkProcess to
webpushd.

Tests: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebsiteDatastore.mm
       Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebPushDaemon.mm

* Source/WebCore/Modules/push-api/PushDatabase.cpp:
(WebCore::PushDatabase::getAllPushSubscriptionOrigins):
* Source/WebCore/Modules/push-api/PushDatabase.h:
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::getAllPushSubscriptionOrigins):
* Source/WebKit/NetworkProcess/NetworkProcess.h:
* Source/WebKit/NetworkProcess/NetworkSession.cpp:
* Source/WebKit/NetworkProcess/NetworkSession.h:
(WebKit::NetworkSession::mockPushSubscriptionOriginsForTesting const):
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.h:
* Source/WebKit/NetworkProcess/NetworkSessionCreationParameters.serialization.in:
* Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.cpp:
(WebKit::NetworkNotificationManager::getAllPushSubscriptionOrigins):
* Source/WebKit/NetworkProcess/Notifications/NetworkNotificationManager.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::prepareForTimeBasedEviction):
(WebKit::NetworkStorageManager::donePrepareForTimeBasedEviction):
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:
* Source/WebKit/Shared/WebPushDaemonConstants.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.h:
* Source/WebKit/UIProcess/API/Cocoa/_WKWebsiteDataStoreConfiguration.mm:
(-[_WKWebsiteDataStoreConfiguration mockPushSubscriptionOriginsForTesting]):
(-[_WKWebsiteDataStoreConfiguration setMockPushSubscriptionOriginsForTesting:]):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStore.cpp:
(WebKit::WebsiteDataStore::parameters):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.cpp:
(WebKit::WebsiteDataStoreConfiguration::copy const):
* Source/WebKit/UIProcess/WebsiteData/WebsiteDataStoreConfiguration.h:
(WebKit::WebsiteDataStoreConfiguration::mockPushSubscriptionOriginsForTesting const):
(WebKit::WebsiteDataStoreConfiguration::setMockPushSubscriptionOriginsForTesting):
* Source/WebKit/webpushd/PushClientConnection.h:
* Source/WebKit/webpushd/PushClientConnection.messages.in:
* Source/WebKit/webpushd/PushClientConnection.mm:
(WebPushD::PushClientConnection::getAllPushSubscriptionOrigins):
* Source/WebKit/webpushd/PushService.h:
* Source/WebKit/webpushd/PushService.mm:
(WebPushD::PushService::getAllPushSubscriptionOrigins):
* Source/WebKit/webpushd/WebPushDaemon.h:
* Source/WebKit/webpushd/WebPushDaemon.mm:
(WebPushD::WebPushDaemon::getAllPushSubscriptionOrigins):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebsiteDatastore.mm:
(TestWebKitAPI::(TimeBasedEviction, PushSubscriptionOriginNotEvicted)):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WebPushDaemon.mm:
(TestWebKitAPI::TestArgumentCoder&lt;WebCore::SecurityOriginData&gt;::encode):
(TestWebKitAPI::TestArgumentCoder&lt;WebCore::SecurityOriginData&gt;::decode):
(TestWebKitAPI::(WebPushDTest, SubscribeTest)):

Canonical link: <a href="https://commits.webkit.org/313457@main">https://commits.webkit.org/313457@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ec803779815dbbdb6585dba1863e30a456b25ff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163172 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36653 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29870 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172111 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119619 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0beb830b-bbf8-451a-8f34-d4245b9b7d2b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165041 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36981 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36654 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126692 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89296 "Passed tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3dee10cd-c7a9-4f2c-acba-1c4c6db57de7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166131 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/28968 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146694 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107261 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0db6cb28-6ed8-43b0-9c7d-3cfdffd084aa) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26643 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19811 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24418 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174614 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/26771 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26073 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135000 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36323 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30745 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134992 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36396 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37109 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146213 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98983 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30299 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23057 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35819 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108180 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35318 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1080 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35565 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35465 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->