### PR TITLE
[AppKit Gestures] WebPage tests cannot verify that an interaction moved the caret

### DIFF
--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm
@@ -2326,24 +2326,45 @@ inline OptionSet<WebKit::FindOptions> toFindOptions(WKFindConfiguration *configu
     });
 }
 
+static RetainPtr<NSDictionary> dictionaryRepresentationForCaretRect(const WebCore::IntRect& rect)
+{
+    return @{
+        @"x": @(rect.x()),
+        @"y": @(rect.y()),
+        @"width": @(rect.width()),
+        @"height": @(rect.height()),
+    };
+}
+
 static RetainPtr<NSDictionary> dictionaryRepresentationForEditorState(const WebKit::EditorState& state)
 {
-    if (!state.hasPostLayoutData())
-        return @{
-            @"post-layout-data" : @NO,
-            @"selection-type": @(static_cast<NSInteger>(state.selectionType)),
-        };
+    RetainPtr<NSMutableDictionary> result = adoptNS([[NSMutableDictionary alloc] init]);
+    [result setObject:@(static_cast<NSInteger>(state.selectionType)) forKey:@"selection-type"];
 
-    auto& postLayoutData = *state.postLayoutData;
-    return @{
-        @"post-layout-data" : @YES,
-        @"selection-type": @(static_cast<NSInteger>(state.selectionType)),
-        @"bold": postLayoutData.typingAttributes.contains(WebKit::TypingAttribute::Bold) ? @YES : @NO,
-        @"italic": postLayoutData.typingAttributes.contains(WebKit::TypingAttribute::Italics) ? @YES : @NO,
-        @"underline": postLayoutData.typingAttributes.contains(WebKit::TypingAttribute::Underline) ? @YES : @NO,
-        @"text-alignment": @(nsTextAlignment(static_cast<WebKit::TextAlignment>(postLayoutData.textAlignment))),
-        @"text-color": serializationForCSS(postLayoutData.textColor).createNSString().get()
-    };
+    if (state.hasPostLayoutData()) {
+        auto& postLayoutData = *state.postLayoutData;
+        [result addEntriesFromDictionary:@{
+            @"post-layout-data": @YES,
+            @"bold": postLayoutData.typingAttributes.contains(WebKit::TypingAttribute::Bold) ? @YES : @NO,
+            @"italic": postLayoutData.typingAttributes.contains(WebKit::TypingAttribute::Italics) ? @YES : @NO,
+            @"underline": postLayoutData.typingAttributes.contains(WebKit::TypingAttribute::Underline) ? @YES : @NO,
+            @"text-alignment": @(nsTextAlignment(static_cast<WebKit::TextAlignment>(postLayoutData.textAlignment))),
+            @"text-color": serializationForCSS(postLayoutData.textColor).createNSString().get(),
+        }];
+    } else
+        [result setObject:@NO forKey:@"post-layout-data"];
+
+    if (state.hasVisualData()) {
+        auto& visualData = *state.visualData;
+        [result addEntriesFromDictionary:@{
+            @"visual-data": @YES,
+            @"caret-rect-at-start": dictionaryRepresentationForCaretRect(visualData.caretRectAtStart).get(),
+            @"caret-rect-at-end": dictionaryRepresentationForCaretRect(visualData.caretRectAtEnd).get(),
+        }];
+    } else
+        [result setObject:@NO forKey:@"visual-data"];
+
+    return result;
 }
 
 static NSTextAlignment NODELETE nsTextAlignment(WebKit::TextAlignment alignment)

--- a/Source/WebKit/UIProcess/API/Swift/WebPage.swift
+++ b/Source/WebKit/UIProcess/API/Swift/WebPage.swift
@@ -851,6 +851,18 @@ extension WebPage {
             public let textColor: Swift.String
         }
 
+        /// The visual data associated with an editor state.
+        @_spi(Testing)
+        public struct VisualData: Sendable, Equatable {
+            /// The caret rect at the start of the current selection, in document coordinates.
+            @_spi(Testing)
+            public let caretRectAtStart: CGRect
+
+            /// The caret rect at the end of the current selection, in document coordinates.
+            @_spi(Testing)
+            public let caretRectAtEnd: CGRect
+        }
+
         /// A type of selection.
         @_spi(Testing)
         public enum SelectionType: Int, Sendable, Equatable {
@@ -871,6 +883,10 @@ extension WebPage {
         /// The post-layout data of the editor state, if any.
         @_spi(Testing)
         public let postLayoutData: PostLayoutData?
+
+        /// The visual data of the editor state, if any.
+        @_spi(Testing)
+        public let visualData: VisualData?
     }
 
     // SPI for testing.
@@ -906,19 +922,42 @@ extension WebPage.EditorStateSnapshot {
         // swift-format-ignore: NeverForceUnwrap
         self.selectionType = SelectionType(rawValue: dictionary["selection-type"] as! SelectionType.RawValue)!
 
-        guard let postLayoutData = dictionary["post-layout-data"] as? Bool, postLayoutData else {
+        if let hasPostLayoutData = dictionary["post-layout-data"] as? Bool, hasPostLayoutData {
+            // The Objective-C interface this is converting from is not able to express at compile-time that these are guaranteed.
+            // swift-format-ignore: NeverForceUnwrap
+            self.postLayoutData = .init(
+                bold: dictionary["bold"] as! Bool,
+                italic: dictionary["italic"] as! Bool,
+                underline: dictionary["underline"] as! Bool,
+                textAlignment: NSTextAlignment(rawValue: dictionary["text-alignment"] as! Int)!,
+                textColor: dictionary["text-color"] as! String
+            )
+        } else {
             self.postLayoutData = nil
-            return
         }
 
+        if let hasVisualData = dictionary["visual-data"] as? Bool, hasVisualData {
+            // The Objective-C interface this is converting from is not able to express at compile-time that these are guaranteed.
+            // swift-format-ignore: NeverForceUnwrap
+            self.visualData = .init(
+                caretRectAtStart: CGRect(caretRectDictionary: dictionary["caret-rect-at-start"] as! [String: NSNumber]),
+                caretRectAtEnd: CGRect(caretRectDictionary: dictionary["caret-rect-at-end"] as! [String: NSNumber])
+            )
+        } else {
+            self.visualData = nil
+        }
+    }
+}
+
+extension CGRect {
+    fileprivate init(caretRectDictionary dictionary: [String: NSNumber]) {
         // The Objective-C interface this is converting from is not able to express at compile-time that these are guaranteed.
         // swift-format-ignore: NeverForceUnwrap
-        self.postLayoutData = .init(
-            bold: dictionary["bold"] as! Bool,
-            italic: dictionary["italic"] as! Bool,
-            underline: dictionary["underline"] as! Bool,
-            textAlignment: NSTextAlignment(rawValue: dictionary["text-alignment"] as! Int)!,
-            textColor: dictionary["text-color"] as! String
+        self.init(
+            x: dictionary["x"]!.doubleValue,
+            y: dictionary["y"]!.doubleValue,
+            width: dictionary["width"]!.doubleValue,
+            height: dictionary["height"]!.doubleValue
         )
     }
 }


### PR DESCRIPTION
#### f9d5b389aefd2b39ff1f9a320f135ad861b9f619
<pre>
[AppKit Gestures] WebPage tests cannot verify that an interaction moved the caret
<a href="https://bugs.webkit.org/show_bug.cgi?id=314871">https://bugs.webkit.org/show_bug.cgi?id=314871</a>
<a href="https://rdar.apple.com/177131763">rdar://177131763</a>

Reviewed by NOBODY (OOPS!).

The Swift WebPage testing SPI surface offers no way to write a test that
asserts &quot;this gesture moved the insertion point.&quot; Tests can observe that
EditorStateSnapshot.selectionType transitioned to .caret, but the
snapshot carries no positional information, so the test cannot tell a
caret that moved from a caret that was already at the destination — or
detect a gesture that should have moved the caret but didn&apos;t.

In this patch, we refactor _dictionaryRepresentationForEditorState() so
post-layout-data and visual-data are emitted independently rather than
via an early-return when post-layout-data is missing, and add an
EditorStateSnapshot.VisualData struct carrying caretRectAtStart and
caretRectAtEnd. The Swift initializer decodes both blocks separately, so
a test can compare caret rects across snapshots.

This patch is a prerequisite for webkit.org/b/314870, since it is not
currently possible to assert the only meaningful expectation for
long-press-drag in editable text, which is that the caret&apos;s on-screen
position changed.

* Source/WebKit/UIProcess/API/Cocoa/WKWebView.mm:
(dictionaryRepresentationForCaretRect):
(dictionaryRepresentationForEditorState):
* Source/WebKit/UIProcess/API/Swift/WebPage.swift:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9d5b389aefd2b39ff1f9a320f135ad861b9f619

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162698 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36174 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29319 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171636 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/119144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36278 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36178 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/126279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/119144 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/01962292-bcc0-40f1-b5e7-6e7d794c7357) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165657 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/28628 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/146185 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/106856 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bc3c5556-a51a-4b4b-947b-e8b916502533) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27674 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19336 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137382 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174140 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21453 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/25559 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/134590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35848 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/134586 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35832 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/145710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98214 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/29124 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/22546 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35342 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/103093 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/34843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35088 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/34991 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->