### PR TITLE
REGRESSION(313207@main): Web Inspector: ProxyingNetworkAgent leaks IPC::MessageReceiver after cross-origin iframe process swap

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2242,8 +2242,6 @@ webkit.org/b/310302 imported/w3c/web-platform-tests/uievents/mouse/mouse_boundar
 http/tests/site-isolation/inspector/debugger/scriptParsed-frame-target.html [ Skip ]
 http/tests/site-isolation/inspector/debugger/pause-in-cross-origin-iframe.html [ Skip ]
 http/tests/site-isolation/inspector/debugger/setBreakpoint-cross-origin-iframe.html [ Skip ]
-http/tests/site-isolation/inspector/runtime/evaluate-in-cross-origin-iframe.html [ Failure Crash ]
-http/tests/site-isolation/inspector/runtime/execution-context-from-frame-target.html [ Failure ]
 http/tests/site-isolation/inspector/runtime/executionContextCreated-frame-target.html [ Failure ]
 http/tests/site-isolation/inspector/page/override-setting-cross-origin-iframe.html [ Pass Failure ]
 webkit.org/b/311836 http/tests/site-isolation/inspector/page/set-emulated-media-cross-origin-iframe.html [ Pass Failure ]

--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
@@ -379,7 +379,7 @@ void WebPageInspectorController::willDestroyProvisionalFrame(const ProvisionalFr
     removeTarget(targetId);
 }
 
-void WebPageInspectorController::didCommitProvisionalFrame(WebFrameProxy& frame, WebCore::ProcessIdentifier oldProcessID, WebCore::ProcessIdentifier newProcessID)
+void WebPageInspectorController::didCommitProvisionalFrame(WebFrameProxy& frame, WebCore::ProcessIdentifier oldProcessID, std::optional<WebCore::PageIdentifier> oldPageID, WebCore::ProcessIdentifier newProcessID)
 {
     if (!shouldManageFrameTargets())
         return;
@@ -397,16 +397,16 @@ void WebPageInspectorController::didCommitProvisionalFrame(WebFrameProxy& frame,
     if (auto oldTarget = m_targets.take(oldTargetID))
         targetAgent->targetDestroyed(protect(*oldTarget));
 
-    // Instrument the new process for network events now that the
-    // frame has committed in its final process.
-    // FIXME: We should also disable instrumentation for the old process that was
-    // hosting this frame before the process swap. Currently the old (processID, pageID)
-    // pair retains a refcount in m_instrumentedProcessPageCounts and the IPC message
-    // receiver stays registered until the old process is torn down.
+    // Instrument the new process for network events now that the frame has
+    // committed in its final process. Also disable instrumentation for the
+    // old process; the frame no longer lives there.
+    RefPtr oldProcess = WebProcessProxy::processForIdentifier(oldProcessID);
     Ref process = frame.process();
 
     RefPtr networkAgent = m_networkAgent;
     if (networkAgent && networkAgent->isEnabled()) {
+        if (oldProcess && oldPageID)
+            networkAgent->disableInstrumentationForProcess(*oldProcess, *oldPageID);
         if (auto pageID = frame.webPageIDInCurrentProcess())
             networkAgent->enableInstrumentationForProcess(process, *pageID);
     }

--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h
@@ -88,7 +88,7 @@ public:
     void willDestroyFrame(const WebFrameProxy&);
     void didCreateProvisionalFrame(ProvisionalFrameProxy&);
     void willDestroyProvisionalFrame(const ProvisionalFrameProxy&);
-    void didCommitProvisionalFrame(WebFrameProxy&, WebCore::ProcessIdentifier oldProcessID, WebCore::ProcessIdentifier newProcessID);
+    void didCommitProvisionalFrame(WebFrameProxy&, WebCore::ProcessIdentifier oldProcessID, std::optional<WebCore::PageIdentifier> oldPageID, WebCore::ProcessIdentifier newProcessID);
 
     InspectorBrowserAgent* NODELETE enabledBrowserAgent() const;
     void setEnabledBrowserAgent(InspectorBrowserAgent*);

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -612,13 +612,14 @@ void WebFrameProxy::commitProvisionalFrame(IPC::Connection& connection, FrameIde
         protect(process())->send(Messages::WebPage::LoadDidCommitInAnotherProcess(frameID, m_layerHostingContextIdentifier, nullptr), *webPageIDInCurrentProcess());
 
         WebCore::ProcessIdentifier oldProcessID = process().coreProcessIdentifier();
+        std::optional<WebCore::PageIdentifier> oldPageID = webPageIDInCurrentProcess();
         WebCore::ProcessIdentifier newProcessID = m_provisionalFrame->process().coreProcessIdentifier();
 
         if (RefPtr process = std::exchange(m_provisionalFrame, nullptr)->takeFrameProcess())
             setProcess(process.releaseNonNull());
 
         if (RefPtr page = m_page.get())
-            page->inspectorController().didCommitProvisionalFrame(*this, oldProcessID, newProcessID);
+            page->inspectorController().didCommitProvisionalFrame(*this, oldProcessID, oldPageID, newProcessID);
     }
 
     protect(page())->didCommitLoadForFrame(connection, frameID, WTF::move(frameInfo), WTF::move(request), navigationID, WTF::move(mimeType), frameHasCustomContentProvider, frameLoadType, certificateInfo, usedLegacyTLS, privateRelayed, WTF::move(proxyName), source, containsPluginDocument, hasInsecureContent, mouseEventPolicy, WTF::move(documentSecurityPolicy), userData);

--- a/Source/WebKit/WebProcess/Inspector/FrameInspectorTarget.cpp
+++ b/Source/WebKit/WebProcess/Inspector/FrameInspectorTarget.cpp
@@ -64,8 +64,10 @@ void FrameInspectorTarget::connect(Inspector::FrontendChannel::ConnectionType co
     m_channel = makeUnique<UIProcessForwardingFrontendChannel>(*page, identifier(), connectionType);
 
     RefPtr coreFrame = frame->provisionalFrame() ?: frame->coreLocalFrame();
-    if (coreFrame)
+    if (coreFrame) {
+        m_inspectedFrame = *coreFrame;
         protect(coreFrame->inspectorController())->connectFrontend(*m_channel);
+    }
 }
 
 void FrameInspectorTarget::disconnect()
@@ -73,11 +75,10 @@ void FrameInspectorTarget::disconnect()
     if (!m_channel)
         return;
 
-    Ref frame = m_frame.get();
-    RefPtr coreFrame = frame->provisionalFrame() ?: frame->coreLocalFrame();
-    if (coreFrame)
-        protect(coreFrame->inspectorController())->disconnectFrontend(*m_channel);
+    if (RefPtr inspectedFrame = m_inspectedFrame.get())
+        protect(inspectedFrame->inspectorController())->disconnectFrontend(*m_channel);
 
+    m_inspectedFrame = nullptr;
     m_channel.reset();
 }
 

--- a/Source/WebKit/WebProcess/Inspector/FrameInspectorTarget.h
+++ b/Source/WebKit/WebProcess/Inspector/FrameInspectorTarget.h
@@ -31,7 +31,12 @@
 #include <memory>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/WeakPtr.h>
 #include <wtf/WeakRef.h>
+
+namespace WebCore {
+class LocalFrame;
+}
 
 namespace WebKit {
 
@@ -59,6 +64,8 @@ public:
 private:
     WeakRef<WebFrame> m_frame;
     std::unique_ptr<UIProcessForwardingFrontendChannel> m_channel;
+    // The WebCore::LocalFrame we registered m_channel with at connect() time.
+    WeakPtr<WebCore::LocalFrame> m_inspectedFrame;
 };
 
 } // namespace WebKit


### PR DESCRIPTION
#### 04f8f8e8059d44ce8129b702dd578c7743e772bc
<pre>
REGRESSION(313207@main): Web Inspector: ProxyingNetworkAgent leaks IPC::MessageReceiver after cross-origin iframe process swap
<a href="https://bugs.webkit.org/show_bug.cgi?id=314808">https://bugs.webkit.org/show_bug.cgi?id=314808</a>
<a href="https://rdar.apple.com/177056433">rdar://177056433</a>

Reviewed by Abrar Rahman Protyasha.

Two distinct teardown bugs surface from the same cross-origin iframe
process swap path under Site Isolation. Both manifest as flaky crashes
attributed to whatever non-SI test runs after a Web Inspector layout
test in WKTR&apos;s run order, which is why
http/tests/ssl/applepay/ApplePayButton.html was the visible victim.

The first issue is that WebPageInspectorController::didCommitProvisionalFrame
re-instruments the new WebContent process for network events but never
removes the old process&apos;s instrumentation. The (oldProcessID, oldPageID)
entry stays in ProxyingNetworkAgent::m_instrumentedProcessPageCounts and
its IPC::MessageReceiver registration on the old WebProcessProxy outlives
the agent. ~ProxyingNetworkAgent then asserts in ~IPC::MessageReceiver
during the next WKWebView teardown. Thread the iframe&apos;s old pageID from
WebFrameProxy::commitProvisionalFrame through to didCommitProvisionalFrame,
and disable instrumentation for the old process before re-enabling on the
new one.

The second issue is that FrameInspectorTarget::connect() chooses
provisionalFrame() ?: coreLocalFrame() and registers the frontend channel
with that frame&apos;s inspector controller. disconnect() makes the same
choice independently. Under Site Isolation those two choices can resolve
to different LocalFrames -- a provisional load can start after connect,
or the previously-provisional frame commits and replaces coreLocalFrame().
Disconnecting from a controller that never registered the channel asserts
in FrontendRouter::disconnectFrontend. Pin a WeakPtr&lt;LocalFrame&gt; at
connect time and disconnect from that same frame&apos;s controller.

Test changes:
- evaluate-in-cross-origin-iframe.html (was [ Failure Crash ]) now passes.
- execution-context-from-frame-target.html (was [ Failure ]) now passes.

* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::commitProvisionalFrame):
* Source/WebKit/UIProcess/Inspector/WebPageInspectorController.h:
* Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp:
(WebKit::WebPageInspectorController::didCommitProvisionalFrame):
* Source/WebKit/WebProcess/Inspector/FrameInspectorTarget.h:
* Source/WebKit/WebProcess/Inspector/FrameInspectorTarget.cpp:
(WebKit::FrameInspectorTarget::connect):
(WebKit::FrameInspectorTarget::disconnect):
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/313318@main">https://commits.webkit.org/313318@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ea5988f58958b6a72e12ab8e1fef44627dd208bd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162704 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36180 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29325 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171642 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119150 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7b5e553b-a544-43f8-8393-2bd022402e5c) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36284 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36184 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126281 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88932 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/86f68998-76d7-4a74-a99e-722e68067746) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165663 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28635 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146189 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106858 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e613791c-1ef7-4da8-8c9c-9a12098f955a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27681 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26209 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19342 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137389 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23918 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174146 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21459 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25563 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134593 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35854 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30306 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134589 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36323 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35838 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145714 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98220 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/29127 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22550 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35348 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/103099 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34849 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35094 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/34997 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->