### PR TITLE
[GFC] Build up remaining skeleton code for grid item sizing.

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayoutUtils.cpp
@@ -136,6 +136,74 @@ static bool NODELETE hasScrollableBlockComputedOverflowValue(const PlacedGridIte
     return computedOverflow == Overflow::Hidden || computedOverflow == Overflow::Scroll || computedOverflow == Overflow::Auto;
 }
 
+static LayoutUnit automaticInlineSizeForGridItem(const PlacedGridItem& placedGridItem, LayoutUnit borderAndPadding,
+    const TrackSizingFunctionsList& trackSizingFunctions, LayoutUnit columnsSize, const IntegrationUtils& integrationUtils)
+{
+    auto& inlineAxisSizes = placedGridItem.inlineAxisSizes();
+    ASSERT(inlineAxisSizes.preferredSize.isAuto());
+
+    // https://drafts.csswg.org/css-grid-1/#grid-item-sizing
+    //
+    // "Grid item calculations for automatic sizes in a given dimensions vary by their
+    //  self-alignment values:"
+    auto alignmentPosition = placedGridItem.inlineAxisAlignment().position();
+
+    // ----- normal & stretch -----
+    // Normal: "If the grid item has no preferred aspect ratio, and no natural size
+    //  in the relevant axis (if it is a replaced element), the grid item is sized
+    //  as for align-self: stretch.
+    //
+    //  Otherwise, the grid item is sized consistent with the size calculation rules
+    //  for block-level elements for the corresponding axis. (See CSS 2 § 10.)"
+    //
+    // Stretch: "Use the inline size calculation rules for non-replaced boxes
+    //  (defined in CSS 2 § 10.3.3 Block-level, non-replaced elements in normal
+    //  flow), i.e. the stretch-fit size.
+    //
+    //  NOTE: This can distort the aspect ratio of an item with a preferred
+    //  aspect ratio, if its size is also constrained in the other axis."
+    auto sizedAsStretch = alignmentPosition == ItemPosition::Stretch
+        || (alignmentPosition == ItemPosition::Normal && !placedGridItem.preferredAspectRatio() && !placedGridItem.isReplacedElement());
+
+    if (sizedAsStretch) {
+        // https://www.w3.org/TR/css-align-3/#valdef-align-self-stretch
+        // CSS Align 3 caveat: stretch only stretches when neither margin is
+        // auto; "Otherwise, this value is identical to start" — which CSS
+        // Grid §6.6 maps to the fit-content "all other values" case.
+        auto& marginStart = inlineAxisSizes.marginStart;
+        auto& marginEnd = inlineAxisSizes.marginEnd;
+        if (marginStart.isAuto() || marginEnd.isAuto()) {
+            ASSERT_NOT_IMPLEMENTED_YET();
+            return { };
+        }
+
+        auto& usedZoom = placedGridItem.usedZoom();
+        auto minimumSize = GridLayoutUtils::usedInlineMinimumSize(placedGridItem, trackSizingFunctions, borderAndPadding, columnsSize, integrationUtils);
+        auto maximumSize = [&inlineAxisSizes, &usedZoom] {
+            auto& computedMaximumSize = inlineAxisSizes.maximumSize;
+            if (computedMaximumSize.isNone())
+                return LayoutUnit::max();
+            return LayoutUnit { computedMaximumSize.tryFixed()->resolveZoom(usedZoom) };
+        };
+
+        auto stretchedWidth = columnsSize - LayoutUnit { marginStart.tryFixed()->resolveZoom(usedZoom) } - LayoutUnit { marginEnd.tryFixed()->resolveZoom(usedZoom) } - borderAndPadding;
+        return std::max(minimumSize, std::min(maximumSize(), stretchedWidth));
+    }
+
+    // "Otherwise" (Normal) — CSS 2 §10. For grid items this means:
+    //  - Aspect-ratio item.
+    //  - Replaced element.
+    if (alignmentPosition == ItemPosition::Normal) {
+        ASSERT_NOT_IMPLEMENTED_YET();
+        return { };
+    }
+
+    // ----- all other values -----
+    // "Size the item as fit-content."
+    ASSERT_NOT_IMPLEMENTED_YET();
+    return { };
+}
+
 LayoutUnit usedInlineSizeForGridItem(const PlacedGridItem& placedGridItem, LayoutUnit borderAndPadding,
     const TrackSizingFunctionsList& trackSizingFunctions, LayoutUnit columnsSize, const IntegrationUtils& integrationUtils)
 {
@@ -143,42 +211,8 @@ LayoutUnit usedInlineSizeForGridItem(const PlacedGridItem& placedGridItem, Layou
     ASSERT(inlineAxisSizes.maximumSize.isFixed() || inlineAxisSizes.maximumSize.isNone());
 
     auto& preferredSize = inlineAxisSizes.preferredSize;
-    if (preferredSize.isAuto()) {
-        // Grid item calculations for automatic sizes in a given dimensions vary by their
-        // self-alignment values:
-        auto alignmentPosition = placedGridItem.inlineAxisAlignment().position();
-
-        // normal:
-        // If the grid item has no preferred aspect ratio, and no natural size in the relevant
-        // axis (if it is a replaced element), the grid item is sized as for align-self: stretch.
-        //
-        // https://www.w3.org/TR/css-align-3/#propdef-align-self
-        //
-        // When the box’s computed width/height (as appropriate to the axis) is auto and neither of
-        // its margins (in the appropriate axis) are auto, sets the box’s used size to the length
-        // necessary to make its outer size as close to filling the alignment container as possible
-        // while still respecting the constraints imposed by min-height/min-width/max-height/max-width.
-        auto& marginStart = inlineAxisSizes.marginStart;
-        auto& marginEnd = inlineAxisSizes.marginEnd;
-        if ((alignmentPosition == ItemPosition::Normal) && !placedGridItem.preferredAspectRatio() && !placedGridItem.isReplacedElement()
-            && !marginStart.isAuto() && !marginEnd.isAuto()) {
-            auto& usedZoom = placedGridItem.usedZoom();
-
-            auto minimumSize = GridLayoutUtils::usedInlineMinimumSize(placedGridItem, trackSizingFunctions, borderAndPadding, columnsSize, integrationUtils);
-            auto maximumSize = [&inlineAxisSizes, &usedZoom] {
-                auto& computedMaximumSize = inlineAxisSizes.maximumSize;
-                if (computedMaximumSize.isNone())
-                    return LayoutUnit::max();
-                return LayoutUnit { computedMaximumSize.tryFixed()->resolveZoom(usedZoom) };
-            };
-
-            auto stretchedWidth = columnsSize - LayoutUnit { marginStart.tryFixed()->resolveZoom(usedZoom) } - LayoutUnit { marginEnd.tryFixed()->resolveZoom(usedZoom) } - borderAndPadding;
-            return std::max(minimumSize, std::min(maximumSize(), stretchedWidth));
-        }
-
-        ASSERT_NOT_IMPLEMENTED_YET();
-        return { };
-    }
+    if (preferredSize.isAuto())
+        return automaticInlineSizeForGridItem(placedGridItem, borderAndPadding, trackSizingFunctions, columnsSize, integrationUtils);
 
     if (preferredSize.isFixed() || preferredSize.isPercent() || preferredSize.isCalculated())
         return Style::evaluate<LayoutUnit>(preferredSize, columnsSize, placedGridItem.usedZoom()) + borderAndPadding;
@@ -287,6 +321,74 @@ static LayoutUnit automaticMinimumBlockSize(const PlacedGridItem& gridItem, Layo
     return contentBasedMinimumSize();
 }
 
+static LayoutUnit automaticBlockSizeForGridItem(const PlacedGridItem& placedGridItem, LayoutUnit borderAndPadding,
+    const TrackSizingFunctionsList& trackSizingFunctions, LayoutUnit rowsSize, const GridFormattingContext& formattingContext, LayoutUnit inlineAxisConstraint)
+{
+    auto& blockAxisSizes = placedGridItem.blockAxisSizes();
+    ASSERT(blockAxisSizes.preferredSize.isAuto());
+
+    // https://drafts.csswg.org/css-grid-1/#grid-item-sizing
+    //
+    // "Grid item calculations for automatic sizes in a given dimensions vary by their
+    //  self-alignment values:"
+    auto alignmentPosition = placedGridItem.blockAxisAlignment().position();
+
+    // ----- normal & stretch -----
+    // Normal: "If the grid item has no preferred aspect ratio, and no natural size
+    //  in the relevant axis (if it is a replaced element), the grid item is sized
+    //  as for align-self: stretch.
+    //
+    //  Otherwise, the grid item is sized consistent with the size calculation rules
+    //  for block-level elements for the corresponding axis. (See CSS 2 § 10.)"
+    //
+    // Stretch: "Use the inline size calculation rules for non-replaced boxes
+    //  (defined in CSS 2 § 10.3.3 Block-level, non-replaced elements in normal
+    //  flow), i.e. the stretch-fit size.
+    //
+    //  NOTE: This can distort the aspect ratio of an item with a preferred
+    //  aspect ratio, if its size is also constrained in the other axis."
+    auto sizedAsStretch = alignmentPosition == ItemPosition::Stretch
+        || (alignmentPosition == ItemPosition::Normal && !placedGridItem.preferredAspectRatio() && !placedGridItem.isReplacedElement());
+
+    if (sizedAsStretch) {
+        // https://www.w3.org/TR/css-align-3/#valdef-align-self-stretch
+        // CSS Align 3 caveat: stretch only stretches when neither margin is
+        // auto; "Otherwise, this value is identical to start" — which CSS
+        // Grid §6.6 maps to the fit-content "all other values" case.
+        auto& marginStart = blockAxisSizes.marginStart;
+        auto& marginEnd = blockAxisSizes.marginEnd;
+        if (marginStart.isAuto() || marginEnd.isAuto()) {
+            ASSERT_NOT_IMPLEMENTED_YET();
+            return { };
+        }
+
+        auto& usedZoom = placedGridItem.usedZoom();
+        auto minimumSize = GridLayoutUtils::usedBlockMinimumSize(placedGridItem, trackSizingFunctions, borderAndPadding, rowsSize, formattingContext, inlineAxisConstraint);
+        auto maximumSize = [&blockAxisSizes, &usedZoom] {
+            auto& computedMaximumSize = blockAxisSizes.maximumSize;
+            if (computedMaximumSize.isNone())
+                return LayoutUnit::max();
+            return LayoutUnit { computedMaximumSize.tryFixed()->resolveZoom(usedZoom) };
+        };
+
+        auto stretchedBlockSize = rowsSize - LayoutUnit { marginStart.tryFixed()->resolveZoom(usedZoom) } - LayoutUnit { marginEnd.tryFixed()->resolveZoom(usedZoom) } - borderAndPadding;
+        return std::max(minimumSize, std::min(maximumSize(), stretchedBlockSize));
+    }
+
+    // "Otherwise" (Normal) — CSS 2 §10. For grid items this means:
+    //  - Aspect-ratio item.
+    //  - Replaced element.
+    if (alignmentPosition == ItemPosition::Normal) {
+        ASSERT_NOT_IMPLEMENTED_YET();
+        return { };
+    }
+
+    // ----- all other values -----
+    // "Size the item as fit-content."
+    ASSERT_NOT_IMPLEMENTED_YET();
+    return { };
+}
+
 LayoutUnit usedBlockSizeForGridItem(const PlacedGridItem& placedGridItem, LayoutUnit borderAndPadding,
     const TrackSizingFunctionsList& trackSizingFunctions, LayoutUnit rowsSize, const GridFormattingContext& formattingContext, LayoutUnit inlineAxisConstraint)
 {
@@ -294,38 +396,8 @@ LayoutUnit usedBlockSizeForGridItem(const PlacedGridItem& placedGridItem, Layout
     ASSERT(blockAxisSizes.maximumSize.isFixed() || blockAxisSizes.maximumSize.isNone());
 
     auto& preferredSize = blockAxisSizes.preferredSize;
-    if (preferredSize.isAuto()) {
-        // Grid item calculations for automatic sizes in a given dimensions vary by their
-        // self-alignment values:
-        auto alignmentPosition = placedGridItem.blockAxisAlignment().position();
-
-        // normal:
-        // If the grid item has no preferred aspect ratio, and no natural size in the relevant
-        // axis (if it is a replaced element), the grid item is sized as for align-self: stretch.
-        //
-        // https://www.w3.org/TR/css-align-3/#propdef-align-self
-        //
-        // When the box’s computed width/height (as appropriate to the axis) is auto and neither of
-        // its margins (in the appropriate axis) are auto, sets the box’s used size to the length
-        // necessary to make its outer size as close to filling the alignment container as possible
-        // while still respecting the constraints imposed by min-height/min-width/max-height/max-width.
-        auto& marginStart = blockAxisSizes.marginStart;
-        auto& marginEnd = blockAxisSizes.marginEnd;
-        if ((alignmentPosition == ItemPosition::Normal) && !placedGridItem.preferredAspectRatio() && !placedGridItem.isReplacedElement()
-            && !marginStart.isAuto() && !marginEnd.isAuto()) {
-            auto& usedZoom = placedGridItem.usedZoom();
-
-            auto minimumSize = GridLayoutUtils::usedBlockMinimumSize(placedGridItem, trackSizingFunctions, borderAndPadding, rowsSize, formattingContext, inlineAxisConstraint);
-            auto maximumSize = [&blockAxisSizes, &usedZoom] {
-                auto& computedMaximumSize = blockAxisSizes.maximumSize;
-                if (computedMaximumSize.isNone())
-                    return LayoutUnit::max();
-                return LayoutUnit { computedMaximumSize.tryFixed()->resolveZoom(usedZoom) };
-            };
-            auto stretchedBlockSize = rowsSize - LayoutUnit { marginStart.tryFixed()->resolveZoom(usedZoom) } - LayoutUnit { marginEnd.tryFixed()->resolveZoom(usedZoom) } - borderAndPadding;
-            return std::max(minimumSize, std::min(maximumSize(), stretchedBlockSize));
-        }
-    }
+    if (preferredSize.isAuto())
+        return automaticBlockSizeForGridItem(placedGridItem, borderAndPadding, trackSizingFunctions, rowsSize, formattingContext, inlineAxisConstraint);
 
     if (preferredSize.isFixed() || preferredSize.isPercent() || preferredSize.isCalculated())
         return Style::evaluate<LayoutUnit>(preferredSize, rowsSize, placedGridItem.usedZoom()) + borderAndPadding;


### PR DESCRIPTION
#### ff13bb799d60d0c49eb530e168e30f321566e255
<pre>
[GFC] Build up remaining skeleton code for grid item sizing.
<a href="https://bugs.webkit.org/show_bug.cgi?id=314875">https://bugs.webkit.org/show_bug.cgi?id=314875</a>
<a href="https://rdar.apple.com/problem/177135436">rdar://problem/177135436</a>

Reviewed by NOBODY (OOPS!).

We currently have some code that is used to determine the inline and
block size of a grid item. There are a few different ways this can be
done since it depends on the alignment of the item, but we only really
implement one particular case. In this patch we basically build up the
remainder of the skeleton code with some ASSERT_NOT_IMPLEMENTED_YET()s
to make it clear what the remaining work to be done is.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff13bb799d60d0c49eb530e168e30f321566e255

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163360 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36843 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30058 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172299 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119807 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165229 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37170 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36843 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126858 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89430 "layout-tests (failure)") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166319 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29130 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146851 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107425 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28176 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26808 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20001 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138071 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24575 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174803 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27404 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26231 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135169 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36512 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30907 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135158 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37298 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146370 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99252 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30456 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23215 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36008 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108849 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35506 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1240 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35754 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35654 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->