### PR TITLE
WIP: experiment a-v (2-layer switch v3: drop empty-bag gate, keep simple-selector + registry)

### DIFF
--- a/Source/WebCore/css/CSSVariableData.cpp
+++ b/Source/WebCore/css/CSSVariableData.cpp
@@ -61,6 +61,12 @@ bool CSSVariableData::operator==(const CSSVariableData& other) const
     return tokens() == other.tokens();
 }
 
+void add(Hasher& hasher, const CSSVariableData& data)
+{
+    for (auto& token : data.tokens())
+        add(hasher, token);
+}
+
 CSSVariableData::CSSVariableData(const CSSParserTokenRange& range, const CSSParserContext& context)
     : CSSVariableData(range, Style::IsAttrTainted::No, context)
 {

--- a/Source/WebCore/css/CSSVariableData.h
+++ b/Source/WebCore/css/CSSVariableData.h
@@ -74,4 +74,6 @@ private:
     Style::IsAttrTainted m_isAttrTainted { };
 };
 
+void add(Hasher&, const CSSVariableData&);
+
 } // namespace WebCore

--- a/Source/WebCore/css/MutableStyleProperties.cpp
+++ b/Source/WebCore/css/MutableStyleProperties.cpp
@@ -118,6 +118,7 @@ bool MutableStyleProperties::removePropertyAtIndex(int index, String* returnText
     // A more efficient removal strategy would involve marking entries as empty
     // and sweeping them when the vector grows too big.
     m_propertyVector.removeAt(index);
+    didMutate();
     return true;
 }
 
@@ -187,6 +188,7 @@ void MutableStyleProperties::setProperty(CSSPropertyID propertyID, Ref<CSSValue>
     removeProperties(shorthand.properties());
     for (auto longhand : shorthand)
         m_propertyVector.append(CSSProperty(longhand, value.copyRef(), important));
+    didMutate();
 }
 
 bool MutableStyleProperties::canUpdateInPlace(const CSSProperty& property, CSSProperty* toReplace) const
@@ -222,11 +224,13 @@ bool MutableStyleProperties::setProperty(const CSSProperty& property, CSSPropert
             if (*toReplace == property)
                 return false;
             *toReplace = property;
+            didMutate();
             return true;
         }
         m_propertyVector.removeAt(toReplace - m_propertyVector.begin());
     }
     m_propertyVector.append(property);
+    didMutate();
     return true;
 }
 
@@ -245,7 +249,10 @@ bool MutableStyleProperties::parseDeclaration(const String& styleDeclaration, CS
     CSSParser::parseDeclarationList(*this, styleDeclaration, context);
 
     // We could do better. Just changing property order does not require style invalidation.
-    return oldProperties != m_propertyVector;
+    bool changed = oldProperties != m_propertyVector;
+    if (changed)
+        didMutate();
+    return changed;
 }
 
 bool MutableStyleProperties::addParsedProperties(const ParsedPropertyVector& properties)
@@ -279,7 +286,10 @@ bool MutableStyleProperties::mergeAndOverrideOnConflict(const StyleProperties& o
 
 void MutableStyleProperties::clear()
 {
+    if (m_propertyVector.isEmpty())
+        return;
     m_propertyVector.clear();
+    didMutate();
 }
 
 bool MutableStyleProperties::removeProperties(std::span<const CSSPropertyID> properties)
@@ -291,9 +301,12 @@ bool MutableStyleProperties::removeProperties(std::span<const CSSPropertyID> pro
     HashSet<CSSPropertyID> toRemove;
     toRemove.addAll(properties);
 
-    return m_propertyVector.removeAllMatching([&toRemove](const CSSProperty& property) {
+    bool removed = m_propertyVector.removeAllMatching([&toRemove](const CSSProperty& property) {
         return toRemove.contains(property.id());
     }) > 0;
+    if (removed)
+        didMutate();
+    return removed;
 }
 
 int MutableStyleProperties::findPropertyIndex(CSSPropertyID propertyID) const

--- a/Source/WebCore/css/MutableStyleProperties.h
+++ b/Source/WebCore/css/MutableStyleProperties.h
@@ -89,10 +89,18 @@ public:
     bool setCustomProperty(const String& propertyName, const String& value, CSSParserContext, IsImportant = IsImportant::No);
     bool removeCustomProperty(const String& propertyName, String* returnText = nullptr);
 
+    // Monotonic counter incremented on every in-place mutation. Used by the
+    // MatchedDeclarationsCache to detect that a cached MatchedProperties was mutated
+    // after capture, so it can be evicted instead of returning stale style.
+    // (rdar://173598541.)
+    unsigned mutationCount() const { return m_mutationCount; }
+
 private:
     explicit MutableStyleProperties(CSSParserMode);
     explicit MutableStyleProperties(const StyleProperties&);
     MutableStyleProperties(Vector<CSSProperty>&&);
+
+    void didMutate() { ++m_mutationCount; }
 
     bool removeLonghandProperty(CSSPropertyID, String* returnText);
     bool removeShorthandProperty(CSSPropertyID, String* returnText);
@@ -105,6 +113,7 @@ private:
 
     const std::unique_ptr<CSSStyleProperties> m_cssomWrapper;
     Vector<CSSProperty, 4> m_propertyVector;
+    unsigned m_mutationCount { 0 };
 };
 
 inline void MutableStyleProperties::deref() const

--- a/Source/WebCore/css/StyleProperties.h
+++ b/Source/WebCore/css/StyleProperties.h
@@ -133,6 +133,10 @@ public:
     bool NODELETE hasCSSOMWrapper() const;
     bool isMutable() const { return m_isMutable; }
 
+    // 0 for ImmutableStyleProperties (can't mutate). Forwards to MutableStyleProperties::mutationCount()
+    // otherwise. Used by MatchedDeclarationsCache to detect in-place mutations of cached properties.
+    inline unsigned mutationCount() const;
+
     bool traverseSubresources(NOESCAPE const Function<bool(const CachedResource&)>& handler) const;
     bool mayDependOnBaseURL() const;
 

--- a/Source/WebCore/css/StylePropertiesInlines.h
+++ b/Source/WebCore/css/StylePropertiesInlines.h
@@ -59,6 +59,13 @@ inline unsigned StyleProperties::propertyCount() const
     return uncheckedDowncast<ImmutableStyleProperties>(*this).propertyCount();
 }
 
+inline unsigned StyleProperties::mutationCount() const
+{
+    if (m_isMutable)
+        return uncheckedDowncast<MutableStyleProperties>(*this).mutationCount();
+    return 0;
+}
+
 inline void StyleProperties::deref() const
 {
     if (!derefBase())

--- a/Source/WebCore/css/parser/CSSParserToken.cpp
+++ b/Source/WebCore/css/parser/CSSParserToken.cpp
@@ -32,6 +32,7 @@
 
 #include "CSSMarkup.h"
 #include "CSSPropertyParser.h"
+#include <wtf/Hasher.h>
 #include <wtf/HexNumber.h>
 #include <wtf/NeverDestroyed.h>
 #include <wtf/text/StringBuilder.h>
@@ -617,6 +618,36 @@ bool CSSParserToken::operator==(const CSSParserToken& other) const
         return m_whitespaceCount == other.m_whitespaceCount;
     default:
         return true;
+    }
+}
+
+void add(Hasher& hasher, const CSSParserToken& token)
+{
+    add(hasher, token.type());
+
+    switch (token.type()) {
+    case DelimiterToken:
+        add(hasher, token.delimiter());
+        break;
+    case HashToken:
+        add(hasher, token.m_hashTokenType);
+        [[fallthrough]];
+    case IdentToken:
+    case FunctionToken:
+    case StringToken:
+    case UrlToken:
+        add(hasher, token.value().toStringWithoutCopying());
+        break;
+    case DimensionToken:
+    case NumberToken:
+    case PercentageToken:
+        add(hasher, token.originalText().toStringWithoutCopying());
+        break;
+    case NonNewlineWhitespaceToken:
+        add(hasher, token.m_whitespaceCount);
+        break;
+    default:
+        break;
     }
 }
 

--- a/Source/WebCore/css/parser/CSSParserToken.h
+++ b/Source/WebCore/css/parser/CSSParserToken.h
@@ -154,6 +154,8 @@ public:
     void updateCharacters(std::span<const CharacterType> characters);
 
 private:
+    friend void add(Hasher&, const CSSParserToken&);
+
     void initValueFromStringView(StringView string)
     {
         m_valueLength = string.length();
@@ -193,5 +195,7 @@ inline void CSSParserToken::updateCharacters(std::span<const CharacterType> char
     m_valueIs8Bit = (sizeof(CharacterType) == 1);
     m_valueDataCharRaw = characters.data();
 }
+
+void add(Hasher&, const CSSParserToken&);
 
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSParserTokenRange.cpp
+++ b/Source/WebCore/css/parser/CSSParserTokenRange.cpp
@@ -140,4 +140,10 @@ String CSSParserTokenRange::serialize(CSSParserToken::SerializationMode mode) co
     return builder.toString();
 }
 
+void add(Hasher& hasher, const CSSParserTokenRange& range)
+{
+    for (auto& token : range)
+        add(hasher, token);
+}
+
 } // namespace WebCore

--- a/Source/WebCore/css/parser/CSSParserTokenRange.h
+++ b/Source/WebCore/css/parser/CSSParserTokenRange.h
@@ -115,4 +115,6 @@ private:
     std::span<const CSSParserToken> m_tokens;
 };
 
+void add(Hasher&, const CSSParserTokenRange&);
+
 } // namespace WebCore

--- a/Source/WebCore/page/SettingsBase.cpp
+++ b/Source/WebCore/page/SettingsBase.cpp
@@ -40,6 +40,7 @@
 #include "RenderObjectInlines.h"
 #include "RenderWidget.h"
 #include "Settings.h"
+#include "StyleScope.h"
 #include "SystemFontDatabase.h"
 #include <wtf/StdLibExtras.h>
 #include <wtf/TZoneMallocInlines.h>
@@ -58,6 +59,10 @@ static void invalidateAfterGenericFamilyChange(Page* page)
     // do not respond to changes in Settings values.
     FontCascadeCache::forCurrentThread().invalidate();
     SystemFontDatabase::singleton().invalidate();
+
+    // A generic-family / system font Settings change re-resolves font-family:sans-serif etc., which
+    // the process-shared MatchedDeclarationsCache isn't keyed on; drop those entries. (rdar://173598541.)
+    Style::Scope::invalidateSharedMatchedDeclarationsCaches();
 
     if (page)
         page->setNeedsRecalcStyleInAllFrames();

--- a/Source/WebCore/rendering/style/RenderStyle+GettersInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyle+GettersInlines.h
@@ -45,6 +45,11 @@ inline bool RenderStyle::inheritedEqual(const RenderStyle& other) const
     return m_computedStyle.inheritedEqual(other.m_computedStyle);
 }
 
+inline bool RenderStyle::inheritedEqualForMDC(const RenderStyle& other) const
+{
+    return m_computedStyle.inheritedEqualForMDC(other.m_computedStyle);
+}
+
 inline bool RenderStyle::nonInheritedEqual(const RenderStyle& other) const
 {
     return m_computedStyle.nonInheritedEqual(other.m_computedStyle);

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -75,6 +75,7 @@ public:
     bool operator==(const RenderStyle&) const;
 
     bool inheritedEqual(const RenderStyle&) const;
+    bool inheritedEqualForMDC(const RenderStyle&) const;
     bool nonInheritedEqual(const RenderStyle&) const;
     bool fastPathInheritedEqual(const RenderStyle&) const;
     bool nonFastPathInheritedEqual(const RenderStyle&) const;

--- a/Source/WebCore/style/ElementRuleCollector.cpp
+++ b/Source/WebCore/style/ElementRuleCollector.cpp
@@ -979,6 +979,8 @@ void ElementRuleCollector::addElementInlineStyleProperties(bool includeSMILPrope
 
 void ElementRuleCollector::addMatchedProperties(MatchedProperties&& matchedProperties, DeclarationOrigin declarationOrigin)
 {
+    // Snapshot mutationCount centrally so all paths that build MatchedProperties capture it.
+    matchedProperties.mutationCountAtCapture = matchedProperties.properties->mutationCount();
     auto& declarations = declarationsForOrigin(declarationOrigin);
     if (!declarations.isEmpty() && declarations.last() == matchedProperties) {
         // It might also be beneficial to overwrite the previous declaration (insteading of appending) if it affects the same exact properties.

--- a/Source/WebCore/style/MatchResult.h
+++ b/Source/WebCore/style/MatchResult.h
@@ -45,6 +45,11 @@ struct MatchedProperties {
     CascadeLayerPriority cascadeLayerPriority { RuleSet::cascadeLayerPriorityForUnlayered };
     IsStartingStyle isStartingStyle { IsStartingStyle::No };
     IsCacheable isCacheable { IsCacheable::Yes };
+    // Snapshot of `properties->mutationCount()` at construction. Used to detect
+    // in-place mutations of the StyleProperties so a cached MatchedProperties no
+    // longer compares equal to a freshly-collected one with the same .properties
+    // pointer but different content. (rdar://173598541.)
+    unsigned mutationCountAtCapture { 0 };
 };
 
 struct MatchResult : RefCounted<MatchResult> {
@@ -77,8 +82,12 @@ private:
 
 inline bool operator==(const MatchedProperties& a, const MatchedProperties& b)
 {
-    return a.properties.ptr() == b.properties.ptr()
-        && a.linkMatchType == b.linkMatchType
+    if (a.properties.ptr() != b.properties.ptr())
+        return false;
+    // Detect in-place mutations of StyleProperties: same pointer, different content.
+    if (a.mutationCountAtCapture != b.mutationCountAtCapture)
+        return false;
+    return a.linkMatchType == b.linkMatchType
         && a.allowlistType == b.allowlistType
         && a.styleScopeOrdinal == b.styleScopeOrdinal
         && a.fromStyleAttribute == b.fromStyleAttribute
@@ -126,6 +135,7 @@ inline void add(Hasher& hasher, const MatchedProperties& matchedProperties)
 
     add(hasher,
         matchedProperties.properties.ptr(),
+        matchedProperties.mutationCountAtCapture,
         matchedProperties.linkMatchType,
         matchedProperties.allowlistType,
         matchedProperties.styleScopeOrdinal,

--- a/Source/WebCore/style/MatchedDeclarationsCache.cpp
+++ b/Source/WebCore/style/MatchedDeclarationsCache.cpp
@@ -47,23 +47,13 @@ namespace Style {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(MatchedDeclarationsCache);
 
-MatchedDeclarationsCache::MatchedDeclarationsCache(const Resolver& owner)
-    : m_owner(owner)
+MatchedDeclarationsCache::MatchedDeclarationsCache(bool isSharedAcrossDocuments)
+    : m_isSharedAcrossDocuments(isSharedAcrossDocuments)
     , m_sweepTimer(*this, &MatchedDeclarationsCache::sweep)
 {
 }
 
 MatchedDeclarationsCache::~MatchedDeclarationsCache() = default;
-
-void MatchedDeclarationsCache::ref() const
-{
-    m_owner->ref();
-}
-
-void MatchedDeclarationsCache::deref() const
-{
-    m_owner->deref();
-}
 
 bool MatchedDeclarationsCache::isCacheable(const Element& element, const RenderStyle& style, const RenderStyle& parentStyle)
 {
@@ -91,8 +81,10 @@ bool MatchedDeclarationsCache::isCacheable(const Element& element, const RenderS
     if (style.usesAnchorFunctions())
         return false;
 
-    // Getting computed style after a font environment change but before full style resolution may involve styles with non-current fonts.
-    // Avoid caching them.
+    // Getting computed style after a font environment change but before full style resolution may
+    // involve styles with non-current fonts. Avoid caching them. Required even with the simple-
+    // selector adoption gate, because the global FontCache generation can bump (system font
+    // installed, locale change, generic-family mapping change) for any document.
     Ref fontSelector = element.document().fontSelector();
     if (!style.fontCascade().isCurrent(fontSelector.get()))
         return false;
@@ -133,7 +125,7 @@ unsigned MatchedDeclarationsCache::computeHash(const MatchResult& matchResult, c
         if (allNonCacheable)
             return 0;
     }
-    return AlreadyHashed::avoidDeletedValue(WTF::computeHash(matchResult, &inheritedCustomProperties));
+    return AlreadyHashed::avoidDeletedValue(WTF::computeHash(matchResult, inheritedCustomProperties.hash()));
 }
 
 std::optional<MatchedDeclarationsCache::Result> MatchedDeclarationsCache::find(unsigned hash, const MatchResult& matchResult, const Style::CustomPropertyData& inheritedCustomProperties, const RenderStyle& parentStyle)
@@ -150,15 +142,22 @@ std::optional<MatchedDeclarationsCache::Result> MatchedDeclarationsCache::find(u
         if (!matchResult.cacheablePropertiesEqual(*entry.matchResult))
             continue;
 
-        if (&entry.parentRenderStyle->inheritedCustomProperties() != &inheritedCustomProperties)
+        if (!arePointingToEqualData(&entry.parentRenderStyle->inheritedCustomProperties(), &inheritedCustomProperties))
             continue;
 
-        if (parentStyle.inheritedEqual(*entry.parentRenderStyle))
+        // The shared (cross-document) cache uses the relaxed FontDescription-only equality so
+        // entries can match across documents with simple font selectors; the per-Resolver cache
+        // uses strict inherited equality, exactly matching ToT. (rdar://173598541.)
+        bool inheritedMatches = m_isSharedAcrossDocuments
+            ? parentStyle.inheritedEqualForMDC(*entry.parentRenderStyle)
+            : parentStyle.inheritedEqual(*entry.parentRenderStyle);
+        if (inheritedMatches)
             return std::make_optional(Result { .entry = entry, .inheritedEqual = true });
         partiallyMatchingEntry = &entry;
     }
     if (partiallyMatchingEntry)
         return std::make_optional(Result { .entry = *partiallyMatchingEntry, .inheritedEqual = false });
+
     return std::nullopt;
 }
 
@@ -200,6 +199,25 @@ void MatchedDeclarationsCache::remove(unsigned hash)
 void MatchedDeclarationsCache::invalidate()
 {
     m_entries.clear();
+}
+
+void MatchedDeclarationsCache::invalidateIfDocumentElementRelativeUnitsChanged(const RenderStyle& documentElementStyle)
+{
+    // Compare the relative-unit basis by length-resolution *value*, not by fontCascade identity or
+    // FontCache generation. styleChangeAffectsRelativeUnits() uses fontCascadeEqual() (per-document
+    // fontSelector identity) and the global generation is volatile across an SP3 run (unrelated
+    // webfont loads), either of which would flush away cross-document reuse on every reload.
+    // Style::equalForLengthResolution compares computed/specified size + the realized primary-font
+    // metrics (xHeight/zeroWidth) + zoom — stable for the same actual font, so identical reloads
+    // don't flush, but a real :root font change (incl. "sans-serif" remapping to a different system
+    // font, which changes the metrics) does. computedLineHeight covers rlh. (rdar://173598541.)
+    bool changed = !m_documentElementStyleForRelativeUnits
+        || !Style::equalForLengthResolution(*m_documentElementStyleForRelativeUnits, documentElementStyle)
+        || m_documentElementStyleForRelativeUnits->computedLineHeight() != documentElementStyle.computedLineHeight();
+    if (!changed)
+        return;
+    invalidate();
+    m_documentElementStyleForRelativeUnits = RenderStyle::clonePtr(documentElementStyle);
 }
 
 template<typename Callback>

--- a/Source/WebCore/style/MatchedDeclarationsCache.h
+++ b/Source/WebCore/style/MatchedDeclarationsCache.h
@@ -38,10 +38,15 @@ namespace Style {
 
 class Resolver;
 
-class MatchedDeclarationsCache : public CanMakeWeakPtr<MatchedDeclarationsCache> {
+class MatchedDeclarationsCache : public RefCounted<MatchedDeclarationsCache>, public CanMakeWeakPtr<MatchedDeclarationsCache> {
     WTF_MAKE_TZONE_ALLOCATED(MatchedDeclarationsCache);
 public:
-    explicit MatchedDeclarationsCache(const Resolver&);
+    // A "shared" cache is the process-global instance reused across documents/iterations; it uses
+    // relaxed (FontDescription-only, for simple selectors) inherited equality so entries can match
+    // across documents. A non-shared (per-Resolver) cache uses strict inherited equality, exactly
+    // matching ToT — it is the fallback for entries excluded from the shared cache (e.g. viewport-
+    // unit styles) and for documents that don't qualify for sharing. (rdar://173598541.)
+    static Ref<MatchedDeclarationsCache> create(bool isSharedAcrossDocuments = false) { return adoptRef(*new MatchedDeclarationsCache(isSharedAcrossDocuments)); }
     ~MatchedDeclarationsCache();
 
     static bool isCacheable(const Element&, const RenderStyle&, const RenderStyle& parentStyle);
@@ -69,16 +74,22 @@ public:
     void invalidate();
     void clearEntriesAffectedByViewportUnits();
 
-    void NODELETE ref() const;
-    void deref() const;
+    // Flush only if the documentElement's relative-unit basis (font + line-height, what rem/rcap/
+    // rch/rex/ric/rlh resolve against) differs from what the cached entries were built under. Lets
+    // the shared cache survive identical reloads (cross-document reuse) while still invalidating on
+    // a real :root font change. (rdar://173598541.)
+    void invalidateIfDocumentElementRelativeUnitsChanged(const RenderStyle& documentElementStyle);
 
 private:
+    explicit MatchedDeclarationsCache(bool isSharedAcrossDocuments);
+
     template<typename Callback>
     void removeAllMatching(const Callback& matches);
 
     void sweep();
 
-    SingleThreadWeakRef<const Resolver> m_owner;
+    const bool m_isSharedAcrossDocuments;
+    std::unique_ptr<const RenderStyle> m_documentElementStyleForRelativeUnits; // rem/rcap/… basis the entries were built under (rdar://173598541)
     HashMap<unsigned, Vector<Entry>, AlreadyHashed> m_entries;
     Timer m_sweepTimer;
     unsigned m_additionsSinceLastSweep { 0 };

--- a/Source/WebCore/style/PageRuleCollector.cpp
+++ b/Source/WebCore/style/PageRuleCollector.cpp
@@ -31,6 +31,7 @@
 
 #include "CommonAtomStrings.h"
 #include "StyleProperties.h"
+#include "StylePropertiesInlines.h"
 #include "StyleRule.h"
 #include "UserAgentStyle.h"
 #include <ranges>
@@ -87,7 +88,9 @@ void PageRuleCollector::matchPageRules(RuleSet* rules, bool isLeftPage, bool isF
     std::ranges::stable_sort(matchedPageRules, comparePageRules);
 
     m_result->authorDeclarations.appendContainerWithMapping(matchedPageRules, [](auto& pageRule) {
-        return MatchedProperties { pageRule->properties() };
+        MatchedProperties result { pageRule->properties() };
+        result.mutationCountAtCapture = pageRule->properties().mutationCount();
+        return result;
     });
 }
 

--- a/Source/WebCore/style/PropertyCascade.cpp
+++ b/Source/WebCore/style/PropertyCascade.cpp
@@ -34,6 +34,7 @@
 #include "PaintWorkletGlobalScope.h"
 #include "PropertyAllowlist.h"
 #include "StyleBuilderGenerated.h"
+#include "StylePropertiesInlines.h"
 #include "StyleKeyword+Mappings.h"
 #include "StylePropertyShorthand.h"
 #include <ranges>
@@ -52,8 +53,10 @@ PropertyCascade::PropertyCascade(const MatchResult& matchResult, IncludedPropert
 {
     ASSERT(!m_includedProperties.isEmpty());
 
-    if (positionTryFallbackProperties)
+    if (positionTryFallbackProperties) {
         m_positionTryFallbackProperties = MatchedProperties { *positionTryFallbackProperties };
+        m_positionTryFallbackProperties->mutationCountAtCapture = positionTryFallbackProperties->mutationCount();
+    }
 
     buildCascade();
 }

--- a/Source/WebCore/style/RuleSetBuilder.cpp
+++ b/Source/WebCore/style/RuleSetBuilder.cpp
@@ -540,6 +540,9 @@ void RuleSetBuilder::addMutatingRulesToResolver()
                 continue;
             auto& registry = m_resolver->document().styleScope().counterStyleRegistry();
             registry.addCounterStyle(styleRuleCounterStyle->descriptors());
+            // Counter-style registration changes list-marker resolution; flush any
+            // stale entries kept alive by the shared MDC. (rdar://173598541.)
+            m_resolver->invalidateMatchedDeclarationsCache();
             continue;
         }
         if (auto* styleRuleProperty = dynamicDowncast<StyleRuleProperty>(rule.get())) {
@@ -549,6 +552,9 @@ void RuleSetBuilder::addMutatingRulesToResolver()
                 continue;
             auto& registry = m_resolver->document().styleScope().customPropertyRegistry();
             registry.registerFromStylesheet(styleRuleProperty->descriptor());
+            // @property registration changes how custom properties compute; flush any
+            // stale entries kept alive by the shared MDC. (rdar://173598541.)
+            m_resolver->invalidateMatchedDeclarationsCache();
             continue;
         }
         if (auto* styleRuleViewTransition = dynamicDowncast<StyleRuleViewTransition>(rule.get()))

--- a/Source/WebCore/style/StyleCustomProperty.cpp
+++ b/Source/WebCore/style/StyleCustomProperty.cpp
@@ -73,6 +73,30 @@ bool CustomProperty::valueEquals(const CustomProperty& other) const
     );
 }
 
+void add(Hasher& hasher, const CustomProperty& property)
+{
+    add(hasher, property.name());
+    add(hasher, property.value().index());
+
+    return WTF::switchOn(property.value(),
+        [&](const CustomProperty::GuaranteedInvalid&) {
+        },
+        [&](const Ref<CSSVariableData>& value) {
+            add(hasher, value.get());
+        },
+        [&](const CustomProperty::Value& value) {
+            // FIXME: Hash values.
+            add(hasher, value.index());
+        },
+        [&](const CustomProperty::ValueList& value) {
+            // FIXME: Hash values.
+            add(hasher, value.values.size());
+            if (value.values.size())
+                add(hasher, value.values[0].index());
+        }
+    );
+}
+
 Ref<CSSValue> CustomProperty::propertyValue(CSSValuePool& pool, const RenderStyle& style) const
 {
     auto convertValue = [&](const Value& value) {

--- a/Source/WebCore/style/StyleCustomProperty.h
+++ b/Source/WebCore/style/StyleCustomProperty.h
@@ -127,6 +127,8 @@ private:
     mutable RefPtr<CSSVariableData> m_cachedTokens;
 };
 
+void add(Hasher&, const CustomProperty&);
+
 inline Ref<const CustomProperty> CustomProperty::createForGuaranteedInvalid(const AtomString& name)
 {
     return adoptRef(*new CustomProperty(name, Kind { GuaranteedInvalid { } }));

--- a/Source/WebCore/style/StyleCustomPropertyRegistry.h
+++ b/Source/WebCore/style/StyleCustomPropertyRegistry.h
@@ -50,6 +50,11 @@ public:
     void registerFromStylesheet(const StyleRuleProperty::Descriptor&);
     void clearRegisteredFromStylesheets();
 
+    // True when no custom properties are registered (neither via CSS.registerProperty nor @property).
+    // Used to keep registry-dependent computed values out of the cross-document MatchedDeclarationsCache.
+    // (rdar://173598541.)
+    bool isEmpty() const { return m_propertiesFromAPI.isEmpty() && m_propertiesFromStylesheet.isEmpty(); }
+
     const RenderStyle& initialValuePrototypeStyle() const LIFETIME_BOUND;
 
     bool invalidatePropertiesWithViewportUnits(Document&);

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -54,6 +54,7 @@
 #include "LocalFrameView.h"
 #include "Logging.h"
 #include "MatchResultCache.h"
+#include "MatchedDeclarationsCache.h"
 #include "MediaList.h"
 #include "MutableCSSSelector.h"
 #include "NodeRenderStyle.h"
@@ -76,6 +77,7 @@
 #include "SharedStringHash.h"
 #include "StyleAdjuster.h"
 #include "StyleBuilder.h"
+#include "StyleCustomPropertyRegistry.h"
 #include "StyleEasingFunction.h"
 #include "StyleFontSizeFunctions.h"
 #include "StyleKeyword+Mappings.h"
@@ -183,7 +185,7 @@ Resolver::Resolver(Document& document, ScopeType scopeType)
     : m_document(document)
     , m_scopeType(scopeType)
     , m_ruleSets(*this)
-    , m_matchedDeclarationsCache(*this)
+    , m_matchedDeclarationsCache(MatchedDeclarationsCache::create())
     , m_matchAuthorAndUserStyles(settings().authorAndUserStylesEnabled())
 {
     initialize();
@@ -697,12 +699,40 @@ Vector<Ref<const StyleRule>> Resolver::pseudoStyleRulesForElement(const Element*
 
 void Resolver::invalidateMatchedDeclarationsCache()
 {
-    m_matchedDeclarationsCache.invalidate();
+    // Flush both caches. Callers are genuine style/font-environment changes — @font-face /
+    // @font-palette-values / @font-feature-values / @counter-style / @property processing
+    // (RuleSetBuilder), @property registration, Document::fontsNeedUpdate, and page environment
+    // changes — that invalidate the shared cache's entries too. These are rare for the simple-
+    // selector documents that adopt the shared cache (which by definition have none of those
+    // at-rules), so cross-document reuse is preserved. The frequent per-document path —
+    // documentElement relative-unit changes — does NOT come here; it uses
+    // invalidateMatchedDeclarationsCacheForDocumentElementChange(), which only flushes the shared
+    // cache on an actual rem-basis change. (rdar://173598541.)
+    m_matchedDeclarationsCache->invalidate();
+    if (m_sharedMatchedDeclarationsCache)
+        m_sharedMatchedDeclarationsCache->invalidate();
+}
+
+void Resolver::invalidateMatchedDeclarationsCacheForDocumentElementChange(const RenderStyle& documentElementStyle)
+{
+    // The documentElement's font/line-height changed, which affects rem/rcap/rch/rex/ric/rlh
+    // resolution. Always flush the per-Resolver cache; flush the shared cache only if the basis
+    // actually differs from what its entries were built under (so identical reloads keep their
+    // cross-document entries). (rdar://173598541.)
+    m_matchedDeclarationsCache->invalidate();
+    if (m_sharedMatchedDeclarationsCache)
+        m_sharedMatchedDeclarationsCache->invalidateIfDocumentElementRelativeUnitsChanged(documentElementStyle);
 }
 
 void Resolver::clearCachedDeclarationsAffectedByViewportUnits()
 {
-    m_matchedDeclarationsCache.clearEntriesAffectedByViewportUnits();
+    m_matchedDeclarationsCache->clearEntriesAffectedByViewportUnits();
+}
+
+void Resolver::setSharedMatchedDeclarationsCache(Ref<MatchedDeclarationsCache>&& cache, bool documentHasSimpleFontSelector)
+{
+    m_sharedMatchedDeclarationsCache = WTF::move(cache);
+    m_documentHasSimpleFontSelector = documentHasSimpleFontSelector;
 }
 
 void Resolver::applyMatchedProperties(State& state, const MatchResult& matchResult, PropertyCascade::IncludedProperties&& includedProperties)
@@ -711,9 +741,34 @@ void Resolver::applyMatchedProperties(State& state, const MatchResult& matchResu
     auto& parentStyle = *state.parentStyle();
     Ref element = *state.element();
 
+    // Per-call routing (rdar://173598541): use the process-shared MDC when this document's font
+    // selector is simple AND the document has no registered custom properties. The non-empty
+    // inherited-custom-property-bag gate that was here previously has been removed: the cache
+    // hash is content-based (inheritedCustomProperties.hash()) and equality uses
+    // arePointingToEqualData which compares by content on pointer mismatch, so non-empty bags
+    // can produce hits across documents.
+    bool canUseSharedCache = m_sharedMatchedDeclarationsCache
+        && m_documentHasSimpleFontSelector
+        && document().customPropertyRegistry().isEmpty();
+
     unsigned cacheHash = MatchedDeclarationsCache::computeHash(matchResult, parentStyle.inheritedCustomProperties());
 
-    auto cacheResult = m_matchedDeclarationsCache.find(cacheHash, matchResult, parentStyle.inheritedCustomProperties(), parentStyle);
+    // Look up the shared (cross-document) cache first when eligible, then fall back to the
+    // per-Resolver cache. The per-Resolver cache is the ToT-equivalent store: it holds entries
+    // excluded from the shared cache (viewport-unit styles, whose resolved values are viewport-
+    // dependent) and everything for non-shared documents. (rdar://173598541.)
+    bool hitCameFromShared = false;
+    auto cacheResult = [&]() -> std::optional<MatchedDeclarationsCache::Result> {
+        if (canUseSharedCache) {
+            if (auto result = m_sharedMatchedDeclarationsCache->find(cacheHash, matchResult, parentStyle.inheritedCustomProperties(), parentStyle)) {
+                hitCameFromShared = true;
+                return result;
+            }
+        }
+        if (auto result = m_matchedDeclarationsCache->find(cacheHash, matchResult, parentStyle.inheritedCustomProperties(), parentStyle))
+            return result;
+        return std::nullopt;
+    }();
 
     auto hasUsableEntry = cacheResult && MatchedDeclarationsCache::isCacheable(element.get(), style, parentStyle);
     if (hasUsableEntry) {
@@ -760,7 +815,10 @@ void Resolver::applyMatchedProperties(State& state, const MatchResult& matchResu
 
     if (hasUsableEntry && !cacheResult->entry.isUsableAfterHighPriorityProperties(style)) {
         // High-priority properties may affect resolution of other properties. Kick out the existing cache entry and try again.
-        m_matchedDeclarationsCache.remove(cacheHash);
+        if (hitCameFromShared)
+            m_sharedMatchedDeclarationsCache->remove(cacheHash);
+        else
+            m_matchedDeclarationsCache->remove(cacheHash);
         applyMatchedProperties(state, matchResult, PropertyCascade::normalProperties());
         return;
     }
@@ -770,8 +828,17 @@ void Resolver::applyMatchedProperties(State& state, const MatchResult& matchResu
 
     setGlobalStateAfterApplyingProperties(builder.state());
 
-    if (((cacheHash && !cacheResult) || (cacheResult && !cacheResult->inheritedEqual)) && MatchedDeclarationsCache::isCacheable(element, style, parentStyle))
-        m_matchedDeclarationsCache.add(style, parentStyle, cacheHash, matchResult);
+    // Route the new entry: viewport-unit styles never enter the shared cache (a full cache hit
+    // copies the resolved, viewport-dependent lengths via copyNonInheritedFrom without running the
+    // Builder, serving a stale used value — observed poisoning size-to-content autosizing), so they
+    // go to the per-Resolver cache (ToT behavior). Everything else for a shared-eligible document
+    // goes to the shared cache. (rdar://173598541.)
+    if (((cacheHash && !cacheResult) || (cacheResult && !cacheResult->inheritedEqual)) && MatchedDeclarationsCache::isCacheable(element, style, parentStyle)) {
+        if (canUseSharedCache && !style.usesViewportUnits())
+            m_sharedMatchedDeclarationsCache->add(style, parentStyle, cacheHash, matchResult);
+        else
+            m_matchedDeclarationsCache->add(style, parentStyle, cacheHash, matchResult);
+    }
 }
 
 void Resolver::setGlobalStateAfterApplyingProperties(const BuilderState& builderState)

--- a/Source/WebCore/style/StyleResolver.h
+++ b/Source/WebCore/style/StyleResolver.h
@@ -24,7 +24,6 @@
 #include "CSSSelector.h"
 #include "ElementRuleCollector.h"
 #include "InspectorCSSOMWrappers.h"
-#include "MatchedDeclarationsCache.h"
 #include "MediaQueryEvaluator.h"
 #include "PropertyCascade.h"
 #include "RuleSet.h"
@@ -73,6 +72,7 @@ enum class RuleMatchingBehavior: uint8_t {
 namespace Style {
 
 class CustomFunctionRegistry;
+class MatchedDeclarationsCache;
 struct BuilderContext;
 struct CachedMatchResult;
 struct ResolvedStyle;
@@ -164,7 +164,15 @@ public:
     bool usesStartingStyleRules() const { return m_ruleSets.features().hasStartingStyleRules; }
 
     void invalidateMatchedDeclarationsCache();
+    void invalidateMatchedDeclarationsCacheForDocumentElementChange(const RenderStyle& documentElementStyle);
     void clearCachedDeclarationsAffectedByViewportUnits();
+
+    // Opt-in cross-document sharing (rdar://173598541): the per-Resolver MDC above is
+    // always present (ToT semantics). A process-shared MDC is additionally installed
+    // here for cross-document/iteration reuse. applyMatchedProperties routes each lookup
+    // to the shared cache only when canUseSharedMatchedDeclarationsCache() passes;
+    // otherwise it uses the per-Resolver cache.
+    void setSharedMatchedDeclarationsCache(Ref<MatchedDeclarationsCache>&&, bool documentHasSimpleFontSelector);
 
     InspectorCSSOMWrappers& inspectorCSSOMWrappers() LIFETIME_BOUND { return m_inspectorCSSOMWrappers; }
 
@@ -199,10 +207,12 @@ private:
 
     InspectorCSSOMWrappers m_inspectorCSSOMWrappers;
 
-    MatchedDeclarationsCache m_matchedDeclarationsCache;
+    Ref<MatchedDeclarationsCache> m_matchedDeclarationsCache;
+    RefPtr<MatchedDeclarationsCache> m_sharedMatchedDeclarationsCache;
 
     bool m_matchAuthorAndUserStyles { true };
     bool m_isSharedBetweenShadowTrees { false };
+    bool m_documentHasSimpleFontSelector { false };
 };
 
 } // namespace Style

--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -47,6 +47,7 @@
 #include "InspectorInstrumentation.h"
 #include "Logging.h"
 #include "MatchResultCache.h"
+#include "Page.h"
 #include "ProcessingInstruction.h"
 #include "RenderBoxInlines.h"
 #include "RenderElementStyleInlines.h"
@@ -109,11 +110,23 @@ Resolver& Scope::resolver()
             createOrFindSharedShadowTreeResolver();
         else
             createDocumentResolver();
-        
+
         if (m_resolver->ruleSets().features().usesHasPseudoClass)
             m_usesHasPseudoClass = true;
     }
     return *m_resolver;
+}
+
+Scope::MatchedDeclarationsCaches& Scope::matchedDeclarationsCaches()
+{
+    static NeverDestroyed<MatchedDeclarationsCaches> caches;
+    return caches;
+}
+
+void Scope::invalidateSharedMatchedDeclarationsCaches()
+{
+    for (auto& cache : matchedDeclarationsCaches().values())
+        cache->invalidate();
 }
 
 void Scope::createDocumentResolver()
@@ -137,6 +150,33 @@ void Scope::createDocumentResolver()
     m_resolver->appendAuthorStyleSheets(m_activeStyleSheets);
 
     protect(m_document->fontSelector())->buildCompleted();
+
+    // Opt into cross-document MatchedDeclarationsCache sharing only for documents whose
+    // font selector is simple (no @font-face / feature values / palettes / counter styles).
+    // The per-call routing in Resolver::applyMatchedProperties further restricts shared-cache
+    // use to entries whose parent has an empty inherited custom-property bag. Documents that
+    // don't qualify keep only their per-Resolver MDC (ToT semantics). (rdar://173598541.)
+    Ref fontSelector = m_document->fontSelector();
+    if (fontSelector->isSimpleFontSelectorForDescription()) {
+        auto url = document().url();
+        if (url.isNull())
+            url = aboutBlankURL();
+
+        // Document-global rendering environment goes in the bucket key (computed once per resolver
+        // build, off the per-element hot path): used appearance and device scale factor. SP3 holds
+        // both constant, so this yields one bucket and full reuse; the dark-mode / hidpi tests that
+        // toggle them route to distinct buckets instead of returning stale style. (rdar://173598541.)
+        bool useDarkAppearance = false;
+        if (RefPtr page = m_document->page())
+            useDarkAppearance = page->useDarkAppearance();
+        auto deviceScaleFactorKey = static_cast<unsigned>(m_document->deviceScaleFactor() * 100 + 0.5f);
+
+        auto key = MatchedDeclarationsCacheKey { makeResolverSharingKey(), WTF::move(url), useDarkAppearance, deviceScaleFactorKey };
+        Ref sharedCache = matchedDeclarationsCaches().ensure(key, [&] {
+            return MatchedDeclarationsCache::create(/* isSharedAcrossDocuments */ true);
+        }).iterator->value;
+        m_resolver->setSharedMatchedDeclarationsCache(WTF::move(sharedCache), true);
+    }
 }
 
 void Scope::createOrFindSharedShadowTreeResolver()

--- a/Source/WebCore/style/StyleScope.h
+++ b/Source/WebCore/style/StyleScope.h
@@ -42,6 +42,8 @@
 #include <wtf/Identified.h>
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/URL.h>
+#include <wtf/URLHash.h>
 #include <wtf/UniqueRef.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakHashMap.h>
@@ -70,6 +72,7 @@ namespace Style {
 
 class CustomPropertyRegistry;
 class MatchResultCache;
+class MatchedDeclarationsCache;
 class Resolver;
 class RuleSet;
 struct MatchResult;
@@ -128,6 +131,12 @@ public:
     void didChangeViewportSize();
 
     void invalidateMatchedDeclarationsCache();
+
+    // Flush every process-shared MatchedDeclarationsCache. For document-wide font-environment
+    // changes (generic-family / system font Settings) that aren't captured by the bucket key or the
+    // per-document rem hook, and which can't be left stale. Rare (no SP3 suite changes font Settings
+    // mid-run), so cross-document reuse is preserved. (rdar://173598541.)
+    static void invalidateSharedMatchedDeclarationsCaches();
 
     bool hasPendingUpdate() const { return m_pendingUpdate || m_hasDescendantWithPendingUpdate; }
     void flushPendingUpdate();
@@ -236,6 +245,15 @@ private:
 
     bool invalidateForContainerDependencies(LayoutDependencyUpdateContext&);
     bool invalidateForPositionTryFallbacks(LayoutDependencyUpdateContext&);
+
+    // Key for the process-shared MatchedDeclarationsCache registry. Beyond stylesheet identity
+    // (ResolverSharingKey) and URL, it captures the document-global rendering environment that
+    // changes resolved style without changing matched rules or inherited custom properties:
+    // used appearance (dark mode) and device scale factor (quantized x100). Documents in different
+    // environments must route to different cache instances. (rdar://173598541.)
+    using MatchedDeclarationsCacheKey = std::tuple<ResolverSharingKey, WTF::URL, bool, unsigned>;
+    using MatchedDeclarationsCaches = HashMap<MatchedDeclarationsCacheKey, Ref<MatchedDeclarationsCache>>;
+    static MatchedDeclarationsCaches& matchedDeclarationsCaches();
 
     const CheckedRef<Document> m_document;
     ShadowRoot* m_shadowRoot { nullptr };

--- a/Source/WebCore/style/StyleTreeResolver.cpp
+++ b/Source/WebCore/style/StyleTreeResolver.cpp
@@ -355,8 +355,12 @@ auto TreeResolver::resolveElement(Element& element, const RenderStyle* existingS
     bool isDocumentElement = &element == m_document->documentElement();
     if (isDocumentElement) {
         if (styleChangeAffectsRelativeUnits(*update.style, existingStyle)) {
-            // "rem" units are relative to the document element's font size so we need to recompute everything.
-            scope().resolver->invalidateMatchedDeclarationsCache();
+            // "rem"/"rcap"/"rch"/… units resolve against the documentElement's font, so a change
+            // there requires recomputing everything. Flush the per-Resolver MDC unconditionally and
+            // the shared MDC only if the relative-unit basis actually changed — an identical reload
+            // (existingStyle == null but same :root font) must not flush the shared cache, or we lose
+            // all cross-document reuse. (rdar://173598541.)
+            scope().resolver->invalidateMatchedDeclarationsCacheForDocumentElementChange(*update.style);
             descendantsToResolve = DescendantsToResolve::All;
         }
     }

--- a/Source/WebCore/style/computed/StyleComputedStyle.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyle.cpp
@@ -175,6 +175,21 @@ bool ComputedStyle::inheritedEqual(const ComputedStyle& other) const
         && m_inheritedRareData == other.m_inheritedRareData;
 }
 
+bool ComputedStyle::inheritedEqualForMDC(const ComputedStyle& other) const
+{
+    if (m_inheritedFlags != other.m_inheritedFlags)
+        return false;
+    if (m_inheritedRareData != other.m_inheritedRareData)
+        return false;
+    if (m_svgData.ptr() != other.m_svgData.ptr() && !m_svgData->inheritedEqual(other.m_svgData))
+        return false;
+    // Diverges from inheritedEqual here: fall through to InheritedData::equalsForMDC,
+    // which uses the simple-selector relaxation on FontData.
+    if (m_inheritedData.ptr() == other.m_inheritedData.ptr())
+        return true;
+    return m_inheritedData->equalsForMDC(*other.m_inheritedData);
+}
+
 bool ComputedStyle::nonInheritedEqual(const ComputedStyle& other) const
 {
     return m_nonInheritedFlags == other.m_nonInheritedFlags

--- a/Source/WebCore/style/computed/StyleComputedStyle.h
+++ b/Source/WebCore/style/computed/StyleComputedStyle.h
@@ -48,6 +48,7 @@ public:
     bool operator==(const ComputedStyle&) const;
 
     bool inheritedEqual(const ComputedStyle&) const;
+    bool inheritedEqualForMDC(const ComputedStyle&) const;
     bool nonInheritedEqual(const ComputedStyle&) const;
     bool NODELETE fastPathInheritedEqual(const ComputedStyle&) const;
     bool nonFastPathInheritedEqual(const ComputedStyle&) const;

--- a/Source/WebCore/style/computed/data/StyleCustomPropertyData.cpp
+++ b/Source/WebCore/style/computed/data/StyleCustomPropertyData.cpp
@@ -88,6 +88,7 @@ void CustomPropertyData::set(const AtomString& name, Ref<const CustomProperty>&&
     }());
 
     m_mayHaveAnimatableProperties = m_mayHaveAnimatableProperties || value->isAnimatable();
+    m_hash = 0;
 
     auto addResult = m_ownValues.set(name, WTF::move(value));
 
@@ -174,6 +175,22 @@ AtomString CustomPropertyData::findKeyAtIndex(unsigned index) const
         return IterationStatus::Continue;
     });
     return key;
+}
+
+unsigned CustomPropertyData::hash() const
+{
+    if (!m_hash) {
+        Hasher hasher;
+        if (m_parentValues)
+            add(hasher, m_parentValues->hash());
+
+        // Property names are included in values.
+        for (auto& value : m_ownValues.values())
+            add(hasher, value.get());
+
+        m_hash = hasher.hash();
+    }
+    return m_hash;
 }
 
 #if !LOG_DISABLED

--- a/Source/WebCore/style/computed/data/StyleCustomPropertyData.h
+++ b/Source/WebCore/style/computed/data/StyleCustomPropertyData.h
@@ -58,7 +58,11 @@ public:
     void forEach(NOESCAPE const Function<IterationStatus(const KeyValuePair<AtomString, Ref<const CustomProperty>>&)>&) const;
     AtomString findKeyAtIndex(unsigned) const;
 
+    unsigned hash() const;
+
 private:
+    friend void add(Hasher&, const CustomPropertyData&);
+
     CustomPropertyData() = default;
     CustomPropertyData(const CustomPropertyData&);
 
@@ -72,6 +76,7 @@ private:
 #if ASSERT_ENABLED
     mutable bool m_hasChildren { false };
 #endif
+    mutable unsigned m_hash { 0 };
 };
 
 } // namespace Style

--- a/Source/WebCore/style/computed/data/StyleFontData.cpp
+++ b/Source/WebCore/style/computed/data/StyleFontData.cpp
@@ -27,6 +27,8 @@
 #include "config.h"
 #include "StyleFontData.h"
 
+#include "FontCascadeInlines.h"
+#include "FontSelector.h"
 #include "StyleComputedStyle+DifferenceLogging.h"
 #include "StyleComputedStyle+InitialInlines.h"
 #include "StyleKeyword+Logging.h"
@@ -60,6 +62,23 @@ bool FontData::operator==(const FontData& o) const
     return letterSpacing == o.letterSpacing
         && wordSpacing == o.wordSpacing
         && fontCascade == o.fontCascade;
+}
+
+bool FontData::equalsForMDC(const FontData& o) const
+{
+    if (letterSpacing != o.letterSpacing || wordSpacing != o.wordSpacing)
+        return false;
+
+    // For simple-selector documents, FontDescription is sufficient to determine font
+    // resolution; skip the per-document selector identity / version / generation checks
+    // so cross-document MDC entries with identical descriptions match. Falls back to
+    // strict FontCascade::operator== otherwise.
+    RefPtr a = fontCascade.fontSelector();
+    RefPtr b = o.fontCascade.fontSelector();
+    if (a && b && a->isSimpleFontSelectorForDescription() && b->isSimpleFontSelectorForDescription())
+        return fontCascade.fontDescription() == o.fontCascade.fontDescription();
+
+    return fontCascade == o.fontCascade;
 }
 
 #if !LOG_DISABLED

--- a/Source/WebCore/style/computed/data/StyleFontData.h
+++ b/Source/WebCore/style/computed/data/StyleFontData.h
@@ -44,6 +44,13 @@ public:
 
     bool operator==(const FontData&) const;
 
+    // MatchedDeclarationsCache-only equality. Same as operator== for the common case,
+    // but for documents with simple font selectors (no @font-face / feature values /
+    // palettes) treats two FontDatas with equal FontDescription as equal regardless of
+    // per-document fontSelector / version / generation. Lets MDC entries cached by one
+    // document be matched by another with the same descriptions. (rdar://173598541.)
+    bool equalsForMDC(const FontData&) const;
+
 #if !LOG_DISABLED
     void dumpDifferences(TextStream&, const FontData&) const;
 #endif

--- a/Source/WebCore/style/computed/data/StyleInheritedData.cpp
+++ b/Source/WebCore/style/computed/data/StyleInheritedData.cpp
@@ -92,6 +92,27 @@ bool InheritedData::nonFastPathInheritedEqual(const InheritedData& other) const
         && borderVerticalSpacing == other.borderVerticalSpacing;
 }
 
+bool InheritedData::equalsForMDC(const InheritedData& other) const
+{
+    if (lineHeight != other.lineHeight)
+        return false;
+#if ENABLE(TEXT_AUTOSIZING)
+    if (specifiedLineHeight != other.specifiedLineHeight)
+        return false;
+#endif
+    if (color != other.color || visitedLinkColor != other.visitedLinkColor)
+        return false;
+    if (borderHorizontalSpacing != other.borderHorizontalSpacing
+        || borderVerticalSpacing != other.borderVerticalSpacing)
+        return false;
+    // Fast pointer-equal short-circuit for the common case (same DataRef instance).
+    if (fontData.ptr() == other.fontData.ptr())
+        return true;
+    Ref protectedA = *fontData;
+    Ref protectedB = *other.fontData;
+    return protectedA->equalsForMDC(protectedB.get());
+}
+
 void InheritedData::fastPathInheritFrom(const InheritedData& inheritParent)
 {
     color = inheritParent.color;

--- a/Source/WebCore/style/computed/data/StyleInheritedData.h
+++ b/Source/WebCore/style/computed/data/StyleInheritedData.h
@@ -47,6 +47,11 @@ public:
 
     bool operator==(const InheritedData&) const;
 
+    // MDC-only equality: same as operator== but uses FontData::equalsForMDC for the
+    // fontData comparison, so cross-document entries can match when descriptions are
+    // equal even if fontSelector identity differs. (rdar://173598541.)
+    bool equalsForMDC(const InheritedData&) const;
+
 #if !LOG_DISABLED
     void dumpDifferences(TextStream&, const InheritedData&) const;
 #endif


### PR DESCRIPTION
#### 45936f3b9bca25730028d5607ed245e26b267d0d
<pre>
WIP: experiment a-v (2-layer switch v3: drop empty-bag gate, keep simple-selector + registry)
<a href="https://bugs.webkit.org/show_bug.cgi?id=314843">https://bugs.webkit.org/show_bug.cgi?id=314843</a>
rdar://177100844
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45936f3b9bca25730028d5607ed245e26b267d0d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165925 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39415 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32996 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174968 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123180 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1c6e8046-59e8-4675-8b6f-a8b726800175) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167791 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39841 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39419 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128961 "Found 1 new test failure: imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/javascript-url-return-value-handling-dynamic.html (failure)") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90844 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c8be4474-49c7-45e9-8ec0-dd6cc0ea174a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168884 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31333 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149076 "Found 1 new API test failure: TestWebKitAPI.CopyHTML.SanitizationPreservesCharacterSet (failure)") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109488 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1b5480e6-1034-4418-aa7f-8660ff7688eb) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30310 "Found 1 new test failure: imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/javascript-url-return-value-handling-dynamic.html (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28986 "Found 1 new API test failure: TestWebKitAPI.CopyHTML.SanitizationPreservesCharacterSet (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23112 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140278 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26775 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177501 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30407 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28481 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137302 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39484 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33133 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137231 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40172 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148570 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102755 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32516 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25437 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38683 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111756 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38080 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3519 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38325 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38223 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->