### PR TITLE
[JSC] Compare 8-bit strings a word at a time in `Array#indexOf` / `Array#includes`

### DIFF
--- a/JSTests/microbenchmarks/array-includes-string-8bit-long.js
+++ b/JSTests/microbenchmarks/array-includes-string-8bit-long.js
@@ -1,0 +1,23 @@
+function makeString(len, ch) {
+    let s = "";
+    for (let i = 0; i < len; ++i)
+        s += ch;
+    return s;
+}
+
+function test(arr, key) {
+    return arr.includes(key);
+}
+noInline(test);
+
+let arr = [];
+for (let i = 0; i < 64; ++i)
+    arr.push(String.fromCharCode(65 + (i % 26)) + makeString(63, "x"));
+
+let key = "@" + makeString(63, "x");
+let result = 0;
+for (let i = 0; i < 5e4; ++i)
+    result += test(arr, key) ? 1 : 0;
+
+if (result !== 0)
+    throw new Error("bad result: " + result);

--- a/JSTests/microbenchmarks/array-indexof-string-8bit-long.js
+++ b/JSTests/microbenchmarks/array-indexof-string-8bit-long.js
@@ -1,0 +1,23 @@
+function makeString(len, ch) {
+    let s = "";
+    for (let i = 0; i < len; ++i)
+        s += ch;
+    return s;
+}
+
+function test(arr, key) {
+    return arr.indexOf(key);
+}
+noInline(test);
+
+let arr = [];
+for (let i = 0; i < 64; ++i)
+    arr.push(String.fromCharCode(65 + (i % 26)) + makeString(63, "x"));
+
+let key = "@" + makeString(63, "x");
+let result = 0;
+for (let i = 0; i < 5e4; ++i)
+    result += test(arr, key);
+
+if (result !== -5e4)
+    throw new Error("bad result: " + result);

--- a/JSTests/microbenchmarks/array-indexof-string-8bit-short.js
+++ b/JSTests/microbenchmarks/array-indexof-string-8bit-short.js
@@ -1,0 +1,23 @@
+function makeString(len, ch) {
+    let s = "";
+    for (let i = 0; i < len; ++i)
+        s += ch;
+    return s;
+}
+
+function test(arr, key) {
+    return arr.indexOf(key);
+}
+noInline(test);
+
+let arr = [];
+for (let i = 0; i < 64; ++i)
+    arr.push(String.fromCharCode(65 + (i % 26)) + makeString(3, "x"));
+
+let key = "@" + makeString(3, "x");
+let result = 0;
+for (let i = 0; i < 5e4; ++i)
+    result += test(arr, key);
+
+if (result !== -5e4)
+    throw new Error("bad result: " + result);

--- a/JSTests/stress/array-indexof-includes-string-word-compare.js
+++ b/JSTests/stress/array-indexof-includes-string-word-compare.js
@@ -1,0 +1,138 @@
+function shouldBe(actual, expected)
+{
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected ' + expected);
+}
+
+function freshCopy(s) {
+    return (s + "!").slice(0, s.length);
+}
+
+// Long 8-bit strings (length >= 8) so the word-at-a-time path runs.
+(function () {
+    function indexOf(array, value)
+    {
+        return array.indexOf(value);
+    }
+    noInline(indexOf);
+
+    function includes(array, value)
+    {
+        return array.includes(value);
+    }
+    noInline(includes);
+
+    const N = 50;
+    const array = [];
+    for (let i = 0; i < N; ++i)
+        array.push(freshCopy(String.fromCharCode(65 + i) + "x".repeat(31)));
+
+    for (let i = 0; i < testLoopCount; ++i) {
+        const targetIdx = i % N;
+        const target = freshCopy(String.fromCharCode(65 + targetIdx) + "x".repeat(31));
+        shouldBe(indexOf(array, target), targetIdx);
+        shouldBe(includes(array, target), true);
+        const missing = freshCopy("@" + "x".repeat(31));
+        shouldBe(indexOf(array, missing), -1);
+        shouldBe(includes(array, missing), false);
+        const tailMismatch = freshCopy(String.fromCharCode(65 + targetIdx) + "x".repeat(30) + "y");
+        shouldBe(indexOf(array, tailMismatch), -1);
+        shouldBe(includes(array, tailMismatch), false);
+    }
+}());
+
+// Length not a multiple of 8: exercises the overlapping word tail.
+(function () {
+    function indexOf(array, value)
+    {
+        return array.indexOf(value);
+    }
+    noInline(indexOf);
+
+    const N = 32;
+    const array = [];
+    for (let i = 0; i < N; ++i)
+        array.push(freshCopy(String.fromCharCode(65 + i) + "y".repeat(12)));
+
+    for (let i = 0; i < testLoopCount; ++i) {
+        const targetIdx = i % N;
+        const target = freshCopy(String.fromCharCode(65 + targetIdx) + "y".repeat(12));
+        shouldBe(indexOf(array, target), targetIdx);
+        const headMismatch = freshCopy("@" + "y".repeat(12));
+        shouldBe(indexOf(array, headMismatch), -1);
+    }
+}());
+
+// Short strings (length < 8) still go through the byte loop.
+(function () {
+    function indexOf(array, value)
+    {
+        return array.indexOf(value);
+    }
+    noInline(indexOf);
+
+    const N = 50;
+    const array = [];
+    for (let i = 0; i < N; ++i)
+        array.push(freshCopy("ab" + String.fromCharCode(65 + i)));
+
+    for (let i = 0; i < testLoopCount; ++i) {
+        const targetIdx = i % N;
+        const target = freshCopy("ab" + String.fromCharCode(65 + targetIdx));
+        shouldBe(indexOf(array, target), targetIdx);
+        shouldBe(indexOf(array, freshCopy("ab@")), -1);
+    }
+}());
+
+// 16-bit search element bails to the slow path; verify it still produces the right result.
+(function () {
+    function indexOf(array, value)
+    {
+        return array.indexOf(value);
+    }
+    noInline(indexOf);
+
+    function includes(array, value)
+    {
+        return array.includes(value);
+    }
+    noInline(includes);
+
+    const N = 32;
+    const array = [];
+    for (let i = 0; i < N; ++i)
+        array.push(freshCopy(String.fromCharCode(0x3041 + i) + "あ".repeat(11)));
+
+    for (let i = 0; i < testLoopCount; ++i) {
+        const targetIdx = i % N;
+        const target = freshCopy(String.fromCharCode(0x3041 + targetIdx) + "あ".repeat(11));
+        shouldBe(indexOf(array, target), targetIdx);
+        shouldBe(includes(array, target), true);
+        const missing = freshCopy("ヿ" + "あ".repeat(11));
+        shouldBe(indexOf(array, missing), -1);
+        shouldBe(includes(array, missing), false);
+    }
+}());
+
+// Mixed-width: 8-bit search vs 16-bit array elements that compare equal goes to the slow path.
+(function () {
+    function indexOf(array, value)
+    {
+        return array.indexOf(value);
+    }
+    noInline(indexOf);
+
+    const N = 32;
+    const array = [];
+    for (let i = 0; i < N; ++i) {
+        // Force 16-bit storage even though the contents are Latin-1.
+        const s = ("あ" + String.fromCharCode(65 + i) + "z".repeat(10)).slice(1);
+        array.push(s);
+    }
+
+    for (let i = 0; i < testLoopCount; ++i) {
+        const targetIdx = i % N;
+        const target = freshCopy(String.fromCharCode(65 + targetIdx) + "z".repeat(10));
+        shouldBe(indexOf(array, target), targetIdx);
+    }
+}());

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -10341,17 +10341,30 @@ void SpeculativeJIT::compileArrayIndexOfOrArrayIncludes(Node* node)
             loadPtr(Address(leftStringGPR, StringImpl::dataOffset()), leftStringGPR);
             loadPtr(Address(rightStringGPR, StringImpl::dataOffset()), rightStringGPR);
 
+            constexpr unsigned pointerSize = sizeof(void*);
+
+            Jump longString = branch32(AboveOrEqual, compareLengthGPR, TrustedImm32(pointerSize));
+
+            Label byteLoop = label();
             sub32(TrustedImm32(1), compareLengthGPR);
-
-            Label compareLoop = label();
-
             load8(BaseIndex(leftStringGPR, compareLengthGPR, TimesOne), leftCharGPR);
             load8(BaseIndex(rightStringGPR, compareLengthGPR, TimesOne), rightCharGPR);
             falseCase.append(branch32(NotEqual, leftCharGPR, rightCharGPR));
+            branchTest32(NonZero, compareLengthGPR).linkTo(byteLoop, this);
+            trueCase.append(jump());
 
-            sub32(TrustedImm32(1), compareLengthGPR);
-            trueCase.append(branch32(LessThan, compareLengthGPR, TrustedImm32(0)));
-            jump(compareLoop);
+            longString.link(this);
+            Label wordLoop = label();
+            sub32(TrustedImm32(pointerSize), compareLengthGPR);
+            loadPtr(BaseIndex(leftStringGPR, compareLengthGPR, TimesOne), leftCharGPR);
+            loadPtr(BaseIndex(rightStringGPR, compareLengthGPR, TimesOne), rightCharGPR);
+            falseCase.append(branchPtr(NotEqual, leftCharGPR, rightCharGPR));
+            branch32(AboveOrEqual, compareLengthGPR, TrustedImm32(pointerSize)).linkTo(wordLoop, this);
+
+            trueCase.append(branchTest32(Zero, compareLengthGPR));
+            loadPtr(Address(leftStringGPR), leftCharGPR);
+            loadPtr(Address(rightStringGPR), rightCharGPR);
+            trueCase.append(branchPtr(Equal, leftCharGPR, rightCharGPR));
 
             falseCase.link(this);
 

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -8663,6 +8663,11 @@ IGNORE_CLANG_WARNINGS_END
             LBasicBlock loadBytes = m_out.newBlock();
             LBasicBlock compareBytesLoop = m_out.newBlock();
             LBasicBlock checkCompareBytesLoopEnd = m_out.newBlock();
+            LBasicBlock compareWordsPreheader = m_out.newBlock();
+            LBasicBlock compareWordsLoop = m_out.newBlock();
+            LBasicBlock checkCompareWordsLoopEnd = m_out.newBlock();
+            LBasicBlock compareWordsTail = m_out.newBlock();
+            LBasicBlock compareWordsTailLoad = m_out.newBlock();
             LBasicBlock loopNext = m_out.newBlock();
             LBasicBlock notFound = m_out.newBlock();
             LBasicBlock continuation = m_out.newBlock();
@@ -8741,9 +8746,9 @@ IGNORE_CLANG_WARNINGS_END
             LValue elementData = m_out.loadPtr(elementImpl, m_heaps.StringImpl_data);
             LValue searchElementData = m_out.loadPtr(searchElementImpl, m_heaps.StringImpl_data);
 
+            constexpr unsigned pointerSize = sizeof(void*);
             ValueFromBlock compareBytesLoopIndexAtStart = m_out.anchor(elementLength);
-
-            m_out.jump(compareBytesLoop);
+            m_out.branch(m_out.below(elementLength, m_out.constInt32(pointerSize)), usually(compareBytesLoop), rarely(compareWordsPreheader));
 
             m_out.appendTo(compareBytesLoop, checkCompareBytesLoopEnd);
 
@@ -8757,9 +8762,32 @@ IGNORE_CLANG_WARNINGS_END
 
             m_out.branch(m_out.notEqual(elementByte, searchElementByte), unsure(loopNext), unsure(checkCompareBytesLoopEnd));
 
-            m_out.appendTo(checkCompareBytesLoopEnd, loopNext);
+            m_out.appendTo(checkCompareBytesLoopEnd, compareWordsPreheader);
             m_out.addIncomingToPhi(compareBytesLoopIndexAtLoopTop, m_out.anchor(compareBytesLoopIndexInLoop));
             m_out.branch(m_out.notZero32(compareBytesLoopIndexInLoop), unsure(compareBytesLoop), unsure(continuation));
+
+            m_out.appendTo(compareWordsPreheader, compareWordsLoop);
+            ValueFromBlock compareWordsLoopIndexAtStart = m_out.anchor(m_out.zeroExtPtr(elementLength));
+            m_out.jump(compareWordsLoop);
+
+            m_out.appendTo(compareWordsLoop, checkCompareWordsLoopEnd);
+            LValue compareWordsLoopIndexAtLoopTop = m_out.phi(pointerType(), compareWordsLoopIndexAtStart);
+            LValue compareWordsLoopIndexInLoop = m_out.sub(compareWordsLoopIndexAtLoopTop, m_out.constIntPtr(pointerSize));
+            LValue elementWord = m_out.load64(TypedPointer(m_heaps.characters8.atAnyIndex(), m_out.add(elementData, compareWordsLoopIndexInLoop)));
+            LValue searchElementWord = m_out.load64(TypedPointer(m_heaps.characters8.atAnyIndex(), m_out.add(searchElementData, compareWordsLoopIndexInLoop)));
+            m_out.branch(m_out.notEqual(elementWord, searchElementWord), unsure(loopNext), unsure(checkCompareWordsLoopEnd));
+
+            m_out.appendTo(checkCompareWordsLoopEnd, compareWordsTail);
+            m_out.addIncomingToPhi(compareWordsLoopIndexAtLoopTop, m_out.anchor(compareWordsLoopIndexInLoop));
+            m_out.branch(m_out.aboveOrEqual(compareWordsLoopIndexInLoop, m_out.constIntPtr(pointerSize)), unsure(compareWordsLoop), unsure(compareWordsTail));
+
+            m_out.appendTo(compareWordsTail, compareWordsTailLoad);
+            m_out.branch(m_out.isNull(compareWordsLoopIndexInLoop), unsure(continuation), unsure(compareWordsTailLoad));
+
+            m_out.appendTo(compareWordsTailLoad, loopNext);
+            LValue elementTailWord = m_out.load64(TypedPointer(m_heaps.characters8.atAnyIndex(), elementData));
+            LValue searchElementTailWord = m_out.load64(TypedPointer(m_heaps.characters8.atAnyIndex(), searchElementData));
+            m_out.branch(m_out.notEqual(elementTailWord, searchElementTailWord), unsure(loopNext), unsure(continuation));
 
             m_out.appendTo(loopNext,  notFound);
             LValue nextIndex = m_out.add(index, m_out.intPtrOne);


### PR DESCRIPTION
#### f9477aedc258729b85cfb1756d7132ff3006c437
<pre>
[JSC] Compare 8-bit strings a word at a time in `Array#indexOf` / `Array#includes`
<a href="https://bugs.webkit.org/show_bug.cgi?id=314877">https://bugs.webkit.org/show_bug.cgi?id=314877</a>

Reviewed by Yusuke Suzuki.

The inlined string comparison fast path in compileArrayIndexOfOrArrayIncludes()
compared 8-bit characters one byte at a time. Apply the same byte/word-adaptive
compare loop that 312326@main introduced for === string equality: compare a
pointer-sized word per iteration walking backwards, and handle the 1..7 byte head
remainder with a single overlapping word load at offset 0, which is safe because
we only enter the word loop when the length is at least one word.

                                                   baseline                  patched

  array-indexof-string-8bit-short                 6.1780+-0.2478            6.0840+-0.3123          might be 1.0154x faster
  array-indexof-string-16bit-different-length   334.7192+-28.7340         322.0814+-19.0505         might be 1.0392x faster
  array-indexof-string-8bit-different-length    333.9152+-18.3467         325.5161+-25.0645         might be 1.0258x faster
  array-includes-string-8bit-long                52.8048+-1.7717     ^      9.8028+-0.6724        ^ definitely 5.3867x faster
  array-indexof-string-8bit-long                 52.1911+-0.6792     ^      9.9372+-0.6180        ^ definitely 5.2521x faster

Tests: JSTests/microbenchmarks/array-includes-string-8bit-long.js
       JSTests/microbenchmarks/array-indexof-string-8bit-long.js
       JSTests/microbenchmarks/array-indexof-string-8bit-short.js
       JSTests/stress/array-indexof-includes-string-word-compare.js

* JSTests/microbenchmarks/array-includes-string-8bit-long.js: Added.
(makeString):
(test):
* JSTests/microbenchmarks/array-indexof-string-8bit-long.js: Added.
(makeString):
(test):
* JSTests/microbenchmarks/array-indexof-string-8bit-short.js: Added.
(makeString):
(test):
* JSTests/stress/array-indexof-includes-string-word-compare.js: Added.
(shouldBe):
(freshCopy):
(indexOf):
(includes):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileArrayIndexOfOrArrayIncludes):

Canonical link: <a href="https://commits.webkit.org/313389@main">https://commits.webkit.org/313389@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/325dab7bceaf5181c28a76da8bce3d8c253f18ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162934 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36413 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29601 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171872 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119380 "Built successfully") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/36912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36415 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126481 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89085 "1 flakes 17 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165893 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/36912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146435 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107057 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/36912 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26413 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19572 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/155073 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137595 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24164 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174376 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23820 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/23651 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25811 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134792 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36084 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30516 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134787 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36360 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/36750 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145960 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98549 "Built successfully") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/29994 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22797 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195335 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35580 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/105342 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50740 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35079 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/819 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35326 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35227 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->