### PR TITLE
[JSC] Simplify bytecode writer

### DIFF
--- a/Source/JavaScriptCore/bytecode/InstructionStream.h
+++ b/Source/JavaScriptCore/bytecode/InstructionStream.h
@@ -28,6 +28,7 @@
 
 #include <JavaScriptCore/BytecodeIndex.h>
 #include <JavaScriptCore/Instruction.h>
+#include <wtf/UnalignedAccess.h>
 #include <wtf/Vector.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -241,43 +242,24 @@ public:
         return m_position;
     }
 
-    void write(uint8_t byte)
+    template<typename... Args>
+        requires (sizeof...(Args) > 0 && (... && std::integral<Args>))
+    void write(Args... args)
     {
-        ASSERT(!m_finalized);
-        if (m_position < m_instructions.size())
-            m_instructions[m_position++] = byte;
-        else {
-            m_instructions.append(byte);
-            m_position++;
-        }
+        constexpr size_t totalSize = (sizeof(Args) + ...);
+        auto* p = static_cast<uint8_t*>(reserve<totalSize>());
+        ((WTF::unalignedStore(p, args), p += sizeof(args)), ...);
     }
 
-    void write(uint16_t h)
+    template<size_t size>
+    uint8_t* reserve()
     {
         ASSERT(!m_finalized);
-        uint8_t bytes[2];
-        std::memcpy(bytes, &h, sizeof(h));
-
-        // Though not always obvious, we don't have to invert the order of the
-        // bytes written here for CPU(BIG_ENDIAN). This is because the incoming
-        // i value is already ordered in big endian on CPU(BIG_EDNDIAN) platforms.
-        write(bytes[0]);
-        write(bytes[1]);
-    }
-
-    void write(uint32_t i)
-    {
-        ASSERT(!m_finalized);
-        uint8_t bytes[4];
-        std::memcpy(bytes, &i, sizeof(i));
-
-        // Though not always obvious, we don't have to invert the order of the
-        // bytes written here for CPU(BIG_ENDIAN). This is because the incoming
-        // i value is already ordered in big endian on CPU(BIG_EDNDIAN) platforms.
-        write(bytes[0]);
-        write(bytes[1]);
-        write(bytes[2]);
-        write(bytes[3]);
+        if ((m_position + size) > m_instructions.size())
+            m_instructions.grow(m_position + size);
+        auto* result = m_instructions.mutableSpan().data() + m_position;
+        m_position += size;
+        return result;
     }
 
     void rewind(MutableRef& ref)

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGeneratorBase.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGeneratorBase.h
@@ -72,12 +72,15 @@ public:
     void alignWideOpcode16();
     void alignWideOpcode32();
 
-    void write(uint8_t);
-    void write(uint16_t);
-    void write(uint32_t);
-    void write(int8_t);
-    void write(int16_t);
-    void write(int32_t);
+    template<typename... Args>
+        requires (sizeof...(Args) > 0 && (... && std::integral<Args>))
+    void write(Args... args)
+    {
+        m_writer.write(args...);
+    }
+
+    template<OpcodeSize size, typename... Ops>
+    void writeOpcode(typename Traits::OpcodeTraits::OpcodeID, Ops...);
 
 protected:
     void reclaimFreeRegisters();

--- a/Source/JavaScriptCore/bytecompiler/BytecodeGeneratorBaseInlines.h
+++ b/Source/JavaScriptCore/bytecompiler/BytecodeGeneratorBaseInlines.h
@@ -27,6 +27,7 @@
 
 #include "BytecodeGeneratorBase.h"
 
+#include "Fits.h"
 #include "RegisterID.h"
 #include "StackAlignment.h"
 
@@ -123,40 +124,27 @@ void BytecodeGeneratorBase<Traits>::alignWideOpcode32()
 }
 
 template<typename Traits>
-void BytecodeGeneratorBase<Traits>::write(uint8_t b)
+template<OpcodeSize size, typename... Ops>
+void BytecodeGeneratorBase<Traits>::writeOpcode(typename Traits::OpcodeTraits::OpcodeID opcodeID, Ops... ops)
 {
-    m_writer.write(b);
-}
-
-
-template<typename Traits>
-void BytecodeGeneratorBase<Traits>::write(uint16_t h)
-{
-    m_writer.write(h);
-}
-
-template<typename Traits>
-void BytecodeGeneratorBase<Traits>::write(uint32_t i)
-{
-    m_writer.write(i);
-}
-
-template<typename Traits>
-void BytecodeGeneratorBase<Traits>::write(int8_t b)
-{
-    m_writer.write(static_cast<uint8_t>(b));
-}
-
-template<typename Traits>
-void BytecodeGeneratorBase<Traits>::write(int16_t h)
-{
-    m_writer.write(static_cast<uint16_t>(h));
-}
-
-template<typename Traits>
-void BytecodeGeneratorBase<Traits>::write(int32_t i)
-{
-    m_writer.write(static_cast<uint32_t>(i));
+    using OpcodeTraits = typename Traits::OpcodeTraits;
+    using OpcodeIDType = typename OpcodeTraits::OpcodeID;
+    constexpr auto opcodeIDSize = OpcodeIDWidthBySize<OpcodeTraits, size>::opcodeIDSize;
+    if constexpr (size == OpcodeSize::Wide16) {
+        m_writer.write(
+            Fits<OpcodeIDType, OpcodeSize::Narrow>::convert(OpcodeTraits::wide16),
+            Fits<OpcodeIDType, opcodeIDSize>::convert(opcodeID),
+            Fits<Ops, size>::convert(ops)...);
+    } else if constexpr (size == OpcodeSize::Wide32) {
+        m_writer.write(
+            Fits<OpcodeIDType, OpcodeSize::Narrow>::convert(OpcodeTraits::wide32),
+            Fits<OpcodeIDType, opcodeIDSize>::convert(opcodeID),
+            Fits<Ops, size>::convert(ops)...);
+    } else {
+        m_writer.write(
+            Fits<OpcodeIDType, opcodeIDSize>::convert(opcodeID),
+            Fits<Ops, size>::convert(ops)...);
+    }
 }
 
 template<typename Traits>

--- a/Source/JavaScriptCore/generator/Argument.rb
+++ b/Source/JavaScriptCore/generator/Argument.rb
@@ -54,10 +54,6 @@ class Argument
         Fits::check size, @name, @type
     end
 
-    def fits_write(size)
-        Fits::write size, @name, @type
-    end
-
     def assert_fits(size)
         "ASSERT((#{fits_check size}));"
     end

--- a/Source/JavaScriptCore/generator/Fits.rb
+++ b/Source/JavaScriptCore/generator/Fits.rb
@@ -29,8 +29,4 @@ module Fits
     def self.check(size, name, type)
         "Fits<#{type.to_s}, #{size}>::check(#{name})"
     end
-
-    def self.write(size, name, type)
-        "gen->write(#{convert(size, name, type)});"
-    end
 end

--- a/Source/JavaScriptCore/generator/Opcode.rb
+++ b/Source/JavaScriptCore/generator/Opcode.rb
@@ -182,6 +182,13 @@ EOF
         ["enum Tmps : uint8_t {"].concat(@tmps.map {|(tmp, type)| "        #{tmp},"}).push("    };").join("\n")
     end
 
+    def emitImpl
+        operand_args = (@args || []).map(&:name)
+        operand_args << @metadata.emitter_local.name unless @metadata.empty?
+        all_args = ["opcodeID"] + operand_args
+        "            gen->template writeOpcode<__size>(#{all_args.join(", ")});"
+    end
+
     def emitter
         op_wide16 = Argument.new(wide16, opcodeIDType, 0)
         op_wide32 = Argument.new(wide32, opcodeIDType, 0)
@@ -253,12 +260,7 @@ private:
         if (checkImpl<__size>(gen#{untyped_args}#{metadata_arg})) {
             if (recordOpcode)
                 gen->recordOpcode(opcodeID);
-            if (__size == OpcodeSize::Wide16)
-                #{op_wide16.fits_write Size::Narrow}
-            else if (__size == OpcodeSize::Wide32)
-                #{op_wide32.fits_write Size::Narrow}
-            #{Argument.new("opcodeID", opcodeIDType, 0).fits_write "OpcodeIDWidthBySize<#{type_prefix}OpcodeTraits, __size>::opcodeIDSize"}
-#{map_operands_with_size("            ", "__size", &:fits_write).join "\n"}
+#{emitImpl}
             return true;
         }
         return false;


### PR DESCRIPTION
#### 83e85f875a707c58a94138d4e6cca9aae8b41e97
<pre>
[JSC] Simplify bytecode writer
<a href="https://bugs.webkit.org/show_bug.cgi?id=314878">https://bugs.webkit.org/show_bug.cgi?id=314878</a>
<a href="https://rdar.apple.com/177142767">rdar://177142767</a>

Reviewed by Keith Miller.

Currently bytecode writer generated by a script is emitting things like,

```
gen-&gt;write(Fits&lt;OpcodeID, OpcodeIDWidthBySize&lt;JSOpcodeTraits, __size&gt;::opcodeIDSize&gt;::convert(opcodeID));
gen-&gt;write(Fits&lt;VirtualRegister, __size&gt;::convert(dst));
gen-&gt;write(Fits&lt;VirtualRegister, __size&gt;::convert(scope));
gen-&gt;write(Fits&lt;unsigned, __size&gt;::convert(var));
gen-&gt;write(Fits&lt;GetPutInfo, __size&gt;::convert(getPutInfo));
gen-&gt;write(Fits&lt;unsigned, __size&gt;::convert(localScopeDepth));
gen-&gt;write(Fits&lt;unsigned, __size&gt;::convert(offset));
gen-&gt;write(Fits&lt;unsigned, __size&gt;::convert(valueProfile));
gen-&gt;write(Fits&lt;unsigned, __size&gt;::convert(__metadataID));
```

and each write function is checking capacity and writing byte. And we
are checking for each byte. So this is slow. Instead, we generate things
like,

```
gen-&gt;template writeOpcode&lt;__size&gt;(opcodeID, message, errorType);
```

and this function will use variadic-templatized `write` function which
accumulate necessary size, reserve region and emit them via
WTF::unalignedStore.

```
    m_writer.write(
        Fits&lt;OpcodeIDType, opcodeIDSize&gt;::convert(opcodeID),
        Fits&lt;Ops, size&gt;::convert(ops)...);
```

This is significantly faster for JS code which generates huge amount of bytecode.

* Source/JavaScriptCore/bytecode/InstructionStream.h:
(JSC::InstructionStreamWriter::write):
(JSC::InstructionStreamWriter::reserve):
* Source/JavaScriptCore/bytecompiler/BytecodeGeneratorBase.h:
(JSC::BytecodeGeneratorBase::write):
* Source/JavaScriptCore/bytecompiler/BytecodeGeneratorBaseInlines.h:
(JSC::BytecodeGeneratorBase&lt;Traits&gt;::writeOpcode):
(JSC::BytecodeGeneratorBase&lt;Traits&gt;::write): Deleted.
* Source/JavaScriptCore/generator/Argument.rb:
* Source/JavaScriptCore/generator/Fits.rb:
* Source/JavaScriptCore/generator/Opcode.rb:

Canonical link: <a href="https://commits.webkit.org/313312@main">https://commits.webkit.org/313312@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8c3da6043a751adde199fbe65154a468c044adf9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162726 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36202 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29349 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171664 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119172 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36306 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36206 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126302 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/88946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165685 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28653 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146213 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106879 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/491dcc90-dab7-4aae-9942-5844092ffa64) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27699 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26231 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19364 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137407 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23942 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174168 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23565 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21481 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25587 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134612 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35876 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30331 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134607 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35860 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145738 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98247 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24735 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/29148 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22574 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195127 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35370 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/103121 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50500 "Found 1 new JSC stress test failure: stress/regexp-dot-star-enclosure-contains-capturing-terms-out-of-stack.js.bytecode-cache (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34871 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35116 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35019 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->