### PR TITLE
[JSC] Use `truncateDoubleToInt32`/`64()` in more round-trip double-to-int checks

### DIFF
--- a/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
+++ b/Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp
@@ -55,6 +55,7 @@
 #include "UnlinkedMetadataTableInlines.h"
 #include "YarrFlags.h"
 #include <wtf/Assertions.h>
+#include <wtf/MathExtras.h>
 #include <wtf/text/StringBuilder.h>
 
 namespace JSC {
@@ -5060,7 +5061,7 @@ static void processClauseList(ClauseListNode* list, Vector<ExpressionNode*, 8>& 
         literalVector.append(clauseExpression);
         if (clauseExpression->isNumber()) {
             double value = static_cast<NumberNode*>(clauseExpression)->value();
-            int32_t intVal = static_cast<int32_t>(value);
+            int32_t intVal = truncateDoubleToInt32(value);
             if ((typeForTable & ~SwitchNumber) || (intVal != value)) {
                 typeForTable = SwitchNeither;
                 break;

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -1534,7 +1534,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
                 break;
             }
             if (producesInteger(node->arithRoundingMode())) {
-                int32_t roundedValueAsInt32 = static_cast<int32_t>(roundedValue);
+                int32_t roundedValueAsInt32 = truncateDoubleToInt32(roundedValue);
                 if (roundedValueAsInt32 == roundedValue) {
                     if (shouldCheckNegativeZero(node->arithRoundingMode())) {
                         if (roundedValueAsInt32 || !std::signbit(roundedValue)) {

--- a/Source/JavaScriptCore/parser/ASTBuilder.h
+++ b/Source/JavaScriptCore/parser/ASTBuilder.h
@@ -33,6 +33,7 @@
 #include "SyntaxChecker.h"
 #include "VariableEnvironment.h"
 #include <utility>
+#include <wtf/MathExtras.h>
 
 namespace JSC {
 
@@ -1331,7 +1332,7 @@ ExpressionNode* ASTBuilder::makeDivNode(const JSTokenLocation& location, Express
         const NumberNode& numberExpr1 = static_cast<NumberNode&>(*expr1);
         const NumberNode& numberExpr2 = static_cast<NumberNode&>(*expr2);
         double result = numberExpr1.value() / numberExpr2.value();
-        if (static_cast<int64_t>(result) == result)
+        if (truncateDoubleToInt64(result) == result)
             return createNumberFromBinaryOperation(location, result, numberExpr1, numberExpr2);
         return createDoubleLikeNumber(location, result);
     }

--- a/Source/JavaScriptCore/parser/Lexer.cpp
+++ b/Source/JavaScriptCore/parser/Lexer.cpp
@@ -34,6 +34,7 @@
 #include <string.h>
 #include <wtf/Assertions.h>
 #include <wtf/HexNumber.h>
+#include <wtf/MathExtras.h>
 #include <wtf/dtoa.h>
 #include <wtf/text/MakeString.h>
 
@@ -511,7 +512,7 @@ Lexer<T>::Lexer(VM& vm, JSParserBuiltinMode builtinMode, JSParserScriptMode scri
 
 static inline JSTokenType NODELETE tokenTypeForIntegerLikeToken(double doubleValue)
 {
-    if ((doubleValue || !std::signbit(doubleValue)) && static_cast<int64_t>(doubleValue) == doubleValue)
+    if ((doubleValue || !std::signbit(doubleValue)) && truncateDoubleToInt64(doubleValue) == doubleValue)
         return INTEGER;
     return DOUBLE;
 }

--- a/Source/JavaScriptCore/runtime/HashMapHelper.h
+++ b/Source/JavaScriptCore/runtime/HashMapHelper.h
@@ -33,6 +33,7 @@
 #include <JavaScriptCore/JSString.h>
 #include <JavaScriptCore/VMTrapsInlines.h>
 #include <wtf/Int128.h>
+#include <wtf/MathExtras.h>
 
 namespace JSC {
 
@@ -62,7 +63,7 @@ ALWAYS_INLINE JSValue normalizeMapKey(JSValue key)
     if (std::isnan(d))
         return jsNaN();
 
-    int i = static_cast<int>(d);
+    int32_t i = truncateDoubleToInt32(d);
     if (i == d) {
         // When a key is -0, we convert it to positive zero.
         // When a key is the double representation for an integer, we convert it to an integer.

--- a/Source/JavaScriptCore/runtime/MathCommon.cpp
+++ b/Source/JavaScriptCore/runtime/MathCommon.cpp
@@ -462,7 +462,7 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationToInt32SensibleSlow, UCPUStrictInt32,
 #if HAVE(ARM_IDIV_INSTRUCTIONS)
 static inline bool isStrictInt32(double value)
 {
-    int32_t valueAsInt32 = static_cast<int32_t>(value);
+    int32_t valueAsInt32 = truncateDoubleToInt32(value);
     if (value != valueAsInt32)
         return false;
 

--- a/Source/JavaScriptCore/runtime/TypedArrayAdaptors.h
+++ b/Source/JavaScriptCore/runtime/TypedArrayAdaptors.h
@@ -30,6 +30,7 @@
 #include <JavaScriptCore/MathCommon.h>
 #include <JavaScriptCore/TypedArrayAdaptersForwardDeclarations.h>
 #include <JavaScriptCore/TypedArrayType.h>
+#include <wtf/MathExtras.h>
 
 namespace JSC {
 
@@ -70,7 +71,7 @@ struct IntegralTypedArrayAdaptor {
 #if HAVE(FJCVTZS_INSTRUCTION)
         return static_cast<Type>(toInt32(value));
 #else
-        int32_t result = static_cast<int32_t>(value);
+        int32_t result = truncateDoubleToInt32(value);
         if (static_cast<double>(result) != value)
             result = toInt32(value);
         return static_cast<Type>(result);


### PR DESCRIPTION
#### a3aa7524f30f91d081faf7779ee32243241e8a37
<pre>
[JSC] Use `truncateDoubleToInt32`/`64()` in more round-trip double-to-int checks
<a href="https://bugs.webkit.org/show_bug.cgi?id=314884">https://bugs.webkit.org/show_bug.cgi?id=314884</a>

Reviewed by Yusuke Suzuki.

This patch changes to use `truncateDoubleToInt32` and `truncateDoubleToInt64` in
more round-trip double-to-int checks.

* Source/JavaScriptCore/bytecompiler/NodesCodegen.cpp:
(JSC::processClauseList):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/parser/ASTBuilder.h:
(JSC::ASTBuilder::makeDivNode):
* Source/JavaScriptCore/parser/Lexer.cpp:
(JSC::tokenTypeForIntegerLikeToken):
* Source/JavaScriptCore/runtime/HashMapHelper.h:
(JSC::normalizeMapKey):
* Source/JavaScriptCore/runtime/MathCommon.cpp:
(JSC::isStrictInt32):
* Source/JavaScriptCore/runtime/TypedArrayAdaptors.h:
(JSC::IntegralTypedArrayAdaptor::toNativeFromDouble):

Canonical link: <a href="https://commits.webkit.org/313375@main">https://commits.webkit.org/313375@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/992d6afc839a764a732861d73ebe5457e53dbeec

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162932 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36411 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29586 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171870 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119378 "Built successfully") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/36915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36413 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126482 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89084 "2 flakes 19 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165891 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/36915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146423 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107058 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/36915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26411 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19570 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/155071 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137594 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24152 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174374 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23818 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/23639 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25799 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134790 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36082 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30514 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134785 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36354 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/36494 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145948 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98544 "Built successfully") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/29740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22785 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195333 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35578 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/105332 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50737 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35077 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/807 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35324 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35225 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->