### PR TITLE
REGRESSION (309405@main): CSS stretch and anonymous wrappers

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/stretch/stretch-anonymous-block-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/stretch/stretch-anonymous-block-001-expected.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference Case</title>
+<style>
+  .container {
+    height: 200px;
+  }
+  iframe {
+    box-sizing: border-box;
+    height: 200px;
+    width: 40px;
+    border: 5px solid blue;
+    margin: 0;
+    background: cyan;
+  }
+</style>
+<body>
+  <div class="container">
+    <div style="height: 0"></div>
+    <iframe></iframe>
+  </div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/stretch/stretch-anonymous-block-001-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/stretch/stretch-anonymous-block-001-ref.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Reference Case</title>
+<style>
+  .container {
+    height: 200px;
+  }
+  iframe {
+    box-sizing: border-box;
+    height: 200px;
+    width: 40px;
+    border: 5px solid blue;
+    margin: 0;
+    background: cyan;
+  }
+</style>
+<body>
+  <div class="container">
+    <div style="height: 0"></div>
+    <iframe></iframe>
+  </div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/stretch/stretch-anonymous-block-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/stretch/stretch-anonymous-block-001.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Test: 'stretch' heights resolve through an anonymous block wrapper</title>
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#sizing-values">
+<link rel="match" href="stretch-anonymous-block-001-ref.html">
+<meta name="assert"
+      content="When a block container has mixed block-level and inline-level children, the inline children are wrapped in an anonymous block box. height:stretch on those inline children should still resolve against the (non-anonymous) containing block, not be treated as indefinite due to the anonymous block wrapper sitting between.">
+<style>
+  .container {
+    height: 200px;
+  }
+  iframe {
+    box-sizing: border-box;
+    height: stretch;
+    width: 40px;
+    border: 5px solid blue;
+    margin: 0;
+    background: cyan;
+  }
+</style>
+<body>
+  <div class="container">
+    <!-- The block-level <div> forces .container's children to be non-inline,
+         wrapping the following inline iframe in an anonymous block box. -->
+    <div style="height: 0"></div>
+    <iframe></iframe>
+  </div>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/stretch/stretch-quirk-002-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/stretch/stretch-quirk-002-expected.html
@@ -1,0 +1,20 @@
+<!-- no doctype, to trigger quirks mode -->
+<meta charset="utf-8">
+<title>CSS Reference Case</title>
+<style>
+  body {
+    margin: 0;
+  }
+  iframe {
+    box-sizing: border-box;
+    height: 100vh;
+    width: 40px;
+    border: 5px solid blue;
+    margin: 0;
+    background: cyan;
+  }
+</style>
+<body>
+  <div style="height: 0"></div>
+  <iframe></iframe>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/stretch/stretch-quirk-002-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/stretch/stretch-quirk-002-ref.html
@@ -1,0 +1,20 @@
+<!-- no doctype, to trigger quirks mode -->
+<meta charset="utf-8">
+<title>CSS Reference Case</title>
+<style>
+  body {
+    margin: 0;
+  }
+  iframe {
+    box-sizing: border-box;
+    height: 100vh;
+    width: 40px;
+    border: 5px solid blue;
+    margin: 0;
+    background: cyan;
+  }
+</style>
+<body>
+  <div style="height: 0"></div>
+  <iframe></iframe>
+</body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/stretch/stretch-quirk-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/stretch/stretch-quirk-002.html
@@ -1,0 +1,27 @@
+<!-- no doctype, to trigger quirks mode -->
+<meta charset="utf-8">
+<title>CSS Test: 'stretch' heights resolve through an anonymous block wrapper</title>
+<link rel="help" href="https://drafts.csswg.org/css-sizing-4/#sizing-values">
+<link rel="help" href="https://quirks.spec.whatwg.org/#the-body-element-fills-the-html-element-quirk">
+<link rel="match" href="stretch-quirk-002-ref.html">
+<meta name="assert"
+      content="When body has mixed block-level and inline-level children, the inline children are wrapped in an anonymous block box. height:stretch on those inline children should still resolve against the body, not be treated as indefinite due to the anonymous block wrapper sitting between.">
+<style>
+  body {
+    margin: 0;
+  }
+  iframe {
+    box-sizing: border-box;
+    height: stretch;
+    width: 40px;
+    border: 5px solid blue;
+    margin: 0;
+    background: cyan;
+  }
+</style>
+<body>
+  <!-- The block-level <div> forces body's children to be non-inline,
+       wrapping the following inline iframe in an anonymous block box. -->
+  <div style="height: 0"></div>
+  <iframe></iframe>
+</body>

--- a/Source/WebCore/rendering/RenderBlock.cpp
+++ b/Source/WebCore/rendering/RenderBlock.cpp
@@ -2961,7 +2961,7 @@ std::optional<LayoutUnit> RenderBlock::availableLogicalHeightForPercentageComput
 {
     // For anonymous blocks that are skipped during percentage height calculation,
     // we consider them to have an indefinite height.
-    if (skipContainingBlockForPercentHeightCalculation(*this, false))
+    if (skipContainingBlockForPercentageOrStretchHeightCalculation(*this, false))
         return { };
 
     auto availableHeight = [&]() -> std::optional<LayoutUnit> {

--- a/Source/WebCore/rendering/RenderBox.cpp
+++ b/Source/WebCore/rendering/RenderBox.cpp
@@ -3822,7 +3822,7 @@ template<typename SizeType> std::optional<LayoutUnit> RenderBox::computeContentA
     );
 }
 
-bool RenderBox::skipContainingBlockForPercentHeightCalculation(const RenderBox& containingBlock, bool isPerpendicularWritingMode) const
+bool RenderBox::skipContainingBlockForPercentageOrStretchHeightCalculation(const RenderBox& containingBlock, bool isPerpendicularWritingMode) const
 {
     // Flow threads for multicol or paged overflow should be skipped. They are invisible to the DOM,
     // and percent heights of children should be resolved against the multicol or paged container.
@@ -3892,7 +3892,7 @@ template<typename SizeType> std::optional<LayoutUnit> RenderBox::computePercenta
     const RenderBox* containingBlockChild = this;
     LayoutUnit rootMarginBorderPaddingHeight;
     bool isHorizontal = isHorizontalWritingMode();
-    while (containingBlock && !is<RenderView>(*containingBlock) && skipContainingBlockForPercentHeightCalculation(*containingBlock, isHorizontal != containingBlock->isHorizontalWritingMode())) {
+    while (containingBlock && !is<RenderView>(*containingBlock) && skipContainingBlockForPercentageOrStretchHeightCalculation(*containingBlock, isHorizontal != containingBlock->isHorizontalWritingMode())) {
         if (containingBlock->isBody() || containingBlock->isDocumentElementRenderer())
             rootMarginBorderPaddingHeight += containingBlock->marginBefore() + containingBlock->marginAfter() + containingBlock->borderAndPaddingLogicalHeight();
         skippedAutoHeightContainingBlock = true;
@@ -5195,7 +5195,24 @@ bool RenderBox::containingBlockHasDefiniteBlockSize() const
     if (isOrthogonal(*this, *containingBlock))
         return true;
 
-    // The containing block has a directly resolvable height (fixed, percentage, etc.)
+    // Walk past containing blocks that percentage and stretch height resolution skip.
+    bool isHorizontal = isHorizontalWritingMode();
+    while (containingBlock && !is<RenderView>(*containingBlock)
+        && skipContainingBlockForPercentageOrStretchHeightCalculation(*containingBlock, isHorizontal != containingBlock->isHorizontalWritingMode()))
+        containingBlock = containingBlock->containingBlock();
+    if (!containingBlock)
+        return false;
+
+    // The walk may have landed on a perpendicular ancestor; orthogonal containing
+    // blocks always have a definite block size (their inline axis is definite).
+    if (isOrthogonal(*this, *containingBlock))
+        return true;
+
+    // RenderView always has a definite block size (the viewport).
+    if (is<RenderView>(*containingBlock))
+        return true;
+
+    // The (resolved) containing block has a directly resolvable height (fixed, percentage, etc.).
     if (containingBlock->hasDefiniteLogicalHeight() || containingBlock->stretchesToViewport())
         return true;
 

--- a/Source/WebCore/rendering/RenderBox.h
+++ b/Source/WebCore/rendering/RenderBox.h
@@ -686,7 +686,7 @@ protected:
     const RenderElement* pushMappingToContainer(const RenderLayerModelObject*, RenderGeometryMap&) const override;
     void mapAbsoluteToLocalPoint(OptionSet<MapCoordinatesMode>, TransformState&) const override;
 
-    bool skipContainingBlockForPercentHeightCalculation(const RenderBox& containingBlock, bool isPerpendicularWritingMode) const;
+    bool skipContainingBlockForPercentageOrStretchHeightCalculation(const RenderBox& containingBlock, bool isPerpendicularWritingMode) const;
 
     void incrementVisuallyNonEmptyPixelCountIfNeeded(const IntSize&);
     bool NODELETE shouldIgnoreAspectRatio() const;

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -2541,8 +2541,7 @@ Overflow RenderFlexibleBox::crossAxisOverflowForFlexItem(const RenderBox& flexIt
 
 bool RenderFlexibleBox::flexItemHasPercentHeightDescendants(const RenderBox& renderer) const
 {
-    // FIXME: This function can be removed soon after webkit.org/b/204318 is fixed. Evaluate whether the
-    // skipContainingBlockForPercentHeightCalculation() check below should be moved to the caller in that case.
+    // FIXME: This function can be removed soon after webkit.org/b/204318 is fixed.
     CheckedPtr renderBlock = dynamicDowncast<RenderBlock>(renderer);
     if (!renderBlock)
         return false;


### PR DESCRIPTION
#### 0b3ed4d01fe569e0f51f40791ed0a922e52f3ff6
<pre>
REGRESSION (<a href="https://commits.webkit.org/309405@main">309405@main</a>): CSS stretch and anonymous wrappers
<a href="https://bugs.webkit.org/show_bug.cgi?id=314885">https://bugs.webkit.org/show_bug.cgi?id=314885</a>
<a href="https://rdar.apple.com/176398251">rdar://176398251</a>

Reviewed by NOBODY (OOPS!).

Stretch height calculation should work in the same way as percentage
height calculation, by skipping anonymous wrappers. Not doing this
properly caused at least one website to not render its iframe at
viewport height.

Fix is verified with new tests and behavior matches Chromium and Gecko
(though the latter only when stretch keyword support is enabled).

Tests: imported/w3c/web-platform-tests/css/css-sizing/stretch/stretch-anonymous-block-001.html
       imported/w3c/web-platform-tests/css/css-sizing/stretch/stretch-quirk-002.html

Upstream: <a href="https://github.com/web-platform-tests/wpt/pull/59896">https://github.com/web-platform-tests/wpt/pull/59896</a>
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b3ed4d01fe569e0f51f40791ed0a922e52f3ff6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162736 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36212 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29361 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171674 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119182 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9d9542ed-e203-4372-be99-6cfbaabfcaa7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164605 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36316 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36216 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126309 "Found 1 new test failure: fast/block/fill-available-with-no-specified-containing-block-height.html (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88953 "1 flakes 19 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e00acca1-ef67-439c-b749-1d981d9159db) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165695 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28661 "Found 2 new test failures: fast/block/fill-available-with-no-specified-containing-block-height.html fast/forms/datalist/datalist-textinput-dynamically-add-options-on-keydown.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146223 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106886 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27707 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26239 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19374 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137415 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23952 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174178 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21491 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25597 "Found 1 new test failure: fast/block/fill-available-with-no-specified-containing-block-height.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134619 "Found 1 new test failure: fast/block/fill-available-with-no-specified-containing-block-height.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35886 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30339 "Found 1 new test failure: fast/block/fill-available-with-no-specified-containing-block-height.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134614 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35870 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145748 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98262 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/29156 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22584 "Found 1 new test failure: fast/block/fill-available-with-no-specified-containing-block-height.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35380 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/103131 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34881 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35126 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35029 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->