### PR TITLE
Support :host:has()

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -7510,12 +7510,6 @@ imported/w3c/web-platform-tests/css/css-scoping/has-slotted-functional-flattened
 imported/w3c/web-platform-tests/css/css-scoping/has-slotted-functional-flattened-004.tentative.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-scoping/has-slotted-functional-flattened-006.tentative.html [ ImageOnlyFailure ]
 
-# :host:has - https://bugs.webkit.org/show_bug.cgi?id=282687
-imported/w3c/web-platform-tests/css/css-scoping/host-has-internal-001.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-scoping/host-has-internal-002.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-scoping/host-has-internal-003.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-scoping/host-has-internal-004.html [ ImageOnlyFailure ]
-
 imported/w3c/web-platform-tests/webrtc-encoded-transform/script-transform-generateKeyFrame-simulcast.https.html [ Pass Failure ]
 imported/w3c/web-platform-tests/webrtc-encoded-transform/RTCRtpScriptTransform-encoded-transform.https.html [ Pass Failure ]
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/host-has-shadow-tree-element-at-nonsubject-position-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/host-has-shadow-tree-element-at-nonsubject-position-expected.txt
@@ -1,28 +1,28 @@
 
-FAIL Initial color assert_equals: expected "rgb(255, 0, 0)" but got "rgb(255, 192, 203)"
-FAIL Add .descendant to #shadow_child assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 192, 203)"
-FAIL Remove .descendant from #shadow_child assert_equals: expected "rgb(255, 0, 0)" but got "rgb(255, 192, 203)"
-FAIL Add .descendant to #shadow_descendant assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 192, 203)"
-FAIL Add .ancestor to #shadow_child:has(.descendant) assert_equals: expected "rgb(128, 0, 128)" but got "rgb(255, 192, 203)"
-FAIL Remove .ancestor from #shadow_child:has(.descendant) assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 192, 203)"
+PASS Initial color
+PASS Add .descendant to #shadow_child
+PASS Remove .descendant from #shadow_child
+PASS Add .descendant to #shadow_descendant
+PASS Add .ancestor to #shadow_child:has(.descendant)
+PASS Remove .ancestor from #shadow_child:has(.descendant)
 PASS Add .child to #shadow_child:has(.descendant)
-FAIL Remove .child from #shadow_child:has(.descendant) assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 192, 203)"
-FAIL Remove .descendant from #shadow_descendant assert_equals: expected "rgb(255, 0, 0)" but got "rgb(255, 192, 203)"
-FAIL Add .child to #shadow_child assert_equals: expected "rgb(0, 0, 255)" but got "rgb(255, 192, 203)"
-FAIL Add .grand_child to #shadow_descendant assert_equals: expected "rgb(255, 255, 240)" but got "rgb(255, 192, 203)"
-FAIL Add .host_context to #host assert_equals: expected "rgb(135, 206, 235)" but got "rgb(255, 192, 203)"
-FAIL Add .descendant to #shadow_descendant.grand_child assert_equals: expected "rgb(144, 238, 144)" but got "rgb(255, 192, 203)"
-FAIL Remove .descendant from #shadow_descendant.grand_child assert_equals: expected "rgb(135, 206, 235)" but got "rgb(255, 192, 203)"
-FAIL Remove .grand_child from #shadow_descendant assert_equals: expected "rgb(0, 0, 255)" but got "rgb(255, 192, 203)"
-FAIL Remove .child from #shadow_child assert_equals: expected "rgb(255, 0, 0)" but got "rgb(255, 192, 203)"
-FAIL Add .child to #shadow_descendant assert_equals: expected "rgb(255, 0, 0)" but got "rgb(255, 192, 203)"
-FAIL Remove .child from #shadow_descendant assert_equals: expected "rgb(255, 0, 0)" but got "rgb(255, 192, 203)"
-FAIL Insert #first_child.descendant to shadow root assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 192, 203)"
-FAIL Remove #first_child.descendant from shadow root assert_equals: expected "rgb(255, 0, 0)" but got "rgb(255, 192, 203)"
-FAIL Insert #last_child.descendant to shadow root assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 192, 203)"
-FAIL Remove #last_child.descendant from shadow root assert_equals: expected "rgb(255, 0, 0)" but got "rgb(255, 192, 203)"
-FAIL Insert #child_in_middle.descendant before #shadow_child assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 192, 203)"
-FAIL Remove #child_in_middle.descendant from shadow root assert_equals: expected "rgb(255, 0, 0)" but got "rgb(255, 192, 203)"
-FAIL Insert #grand_child.descendant before #shadow_descendant assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 192, 203)"
-FAIL Remove #grand_child.descendant from shadow tree assert_equals: expected "rgb(255, 0, 0)" but got "rgb(255, 192, 203)"
+PASS Remove .child from #shadow_child:has(.descendant)
+PASS Remove .descendant from #shadow_descendant
+PASS Add .child to #shadow_child
+FAIL Add .grand_child to #shadow_descendant assert_equals: expected "rgb(255, 255, 240)" but got "rgb(0, 0, 255)"
+PASS Add .host_context to #host
+PASS Add .descendant to #shadow_descendant.grand_child
+PASS Remove .descendant from #shadow_descendant.grand_child
+PASS Remove .grand_child from #shadow_descendant
+PASS Remove .child from #shadow_child
+PASS Add .child to #shadow_descendant
+PASS Remove .child from #shadow_descendant
+PASS Insert #first_child.descendant to shadow root
+PASS Remove #first_child.descendant from shadow root
+PASS Insert #last_child.descendant to shadow root
+PASS Remove #last_child.descendant from shadow root
+PASS Insert #child_in_middle.descendant before #shadow_child
+PASS Remove #child_in_middle.descendant from shadow root
+PASS Insert #grand_child.descendant before #shadow_descendant
+PASS Remove #grand_child.descendant from shadow tree
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/host-has-shadow-tree-element-at-subject-position-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/host-has-shadow-tree-element-at-subject-position-expected.txt
@@ -1,28 +1,28 @@
 
-FAIL Initial color assert_equals: expected "rgb(0, 0, 0)" but got "rgb(255, 192, 203)"
-FAIL Add .descendant to #shadow_child assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 192, 203)"
-FAIL Remove .descendant from #shadow_child assert_equals: expected "rgb(0, 0, 0)" but got "rgb(255, 192, 203)"
-FAIL Add .descendant to #shadow_descendant assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 192, 203)"
-FAIL Add .ancestor to #shadow_child:has(.descendant) assert_equals: expected "rgb(128, 0, 128)" but got "rgb(255, 192, 203)"
-FAIL Remove .ancestor from #shadow_child:has(.descendant) assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 192, 203)"
+PASS Initial color
+PASS Add .descendant to #shadow_child
+PASS Remove .descendant from #shadow_child
+PASS Add .descendant to #shadow_descendant
+PASS Add .ancestor to #shadow_child:has(.descendant)
+PASS Remove .ancestor from #shadow_child:has(.descendant)
 PASS Add .child to #shadow_child:has(.descendant)
-FAIL Remove .child from #shadow_child:has(.descendant) assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 192, 203)"
-FAIL Remove .descendant from #shadow_descendant assert_equals: expected "rgb(0, 0, 0)" but got "rgb(255, 192, 203)"
-FAIL Add .child to #shadow_child assert_equals: expected "rgb(0, 0, 255)" but got "rgb(255, 192, 203)"
-FAIL Add .grand_child to #shadow_descendant assert_equals: expected "rgb(255, 255, 240)" but got "rgb(255, 192, 203)"
-FAIL Add .host_context to #host assert_equals: expected "rgb(135, 206, 235)" but got "rgb(255, 192, 203)"
-FAIL Add .descendant to #shadow_descendant.grand_child assert_equals: expected "rgb(144, 238, 144)" but got "rgb(255, 192, 203)"
-FAIL Remove .descendant from #shadow_descendant.grand_child assert_equals: expected "rgb(135, 206, 235)" but got "rgb(255, 192, 203)"
-FAIL Remove .grand_child from #shadow_descendant assert_equals: expected "rgb(0, 0, 255)" but got "rgb(255, 192, 203)"
-FAIL Remove .child from #shadow_child assert_equals: expected "rgb(0, 0, 0)" but got "rgb(255, 192, 203)"
-FAIL Add .child to #shadow_descendant assert_equals: expected "rgb(0, 0, 0)" but got "rgb(255, 192, 203)"
-FAIL Remove .child from #shadow_descendant assert_equals: expected "rgb(0, 0, 0)" but got "rgb(255, 192, 203)"
-FAIL Insert #first_child.descendant to shadow root assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 192, 203)"
-FAIL Remove #first_child.descendant from shadow root assert_equals: expected "rgb(0, 0, 0)" but got "rgb(255, 192, 203)"
-FAIL Insert #last_child.descendant to shadow root assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 192, 203)"
-FAIL Remove #last_child.descendant from shadow root assert_equals: expected "rgb(0, 0, 0)" but got "rgb(255, 192, 203)"
-FAIL Insert #child_in_middle.descendant before #shadow_child assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 192, 203)"
-FAIL Remove #child_in_middle.descendant from shadow root assert_equals: expected "rgb(0, 0, 0)" but got "rgb(255, 192, 203)"
-FAIL Insert #grand_child.descendant before #shadow_descendant assert_equals: expected "rgb(0, 128, 0)" but got "rgb(255, 192, 203)"
-FAIL Remove #grand_child.descendant from shadow tree assert_equals: expected "rgb(0, 0, 0)" but got "rgb(255, 192, 203)"
+PASS Remove .child from #shadow_child:has(.descendant)
+PASS Remove .descendant from #shadow_descendant
+PASS Add .child to #shadow_child
+FAIL Add .grand_child to #shadow_descendant assert_equals: expected "rgb(255, 255, 240)" but got "rgb(0, 0, 255)"
+PASS Add .host_context to #host
+PASS Add .descendant to #shadow_descendant.grand_child
+PASS Remove .descendant from #shadow_descendant.grand_child
+PASS Remove .grand_child from #shadow_descendant
+PASS Remove .child from #shadow_child
+PASS Add .child to #shadow_descendant
+PASS Remove .child from #shadow_descendant
+PASS Insert #first_child.descendant to shadow root
+PASS Remove #first_child.descendant from shadow root
+PASS Insert #last_child.descendant to shadow root
+PASS Remove #last_child.descendant from shadow root
+PASS Insert #child_in_middle.descendant before #shadow_child
+PASS Remove #child_in_middle.descendant from shadow root
+PASS Insert #grand_child.descendant before #shadow_descendant
+PASS Remove #grand_child.descendant from shadow tree
 

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -796,8 +796,8 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, LocalContext& c
         // https://bugs.webkit.org/show_bug.cgi?id=283062
         bool isNotPseudoClass = selector.match() == CSSSelector::Match::PseudoClass && selector.pseudoClass() == CSSSelector::PseudoClass::Not;
 
-        // We can early return when we know it's neither :host, :scope (which can match when the scoping root is the shadow host), a compound :is(:host) , a pseudo-element.
-        if (!selector.isHostPseudoClass() && !isPseudoElement && !selector.isScopePseudoClass() && (!selector.selectorList() || isNotPseudoClass))
+        // We can early return when we know it's neither :host, :scope (which can match when the scoping root is the shadow host), a compound :is(:host) , a pseudo-element, nor the implicit :has() scope sentinel anchored at the host.
+        if (!selector.isHostPseudoClass() && !isPseudoElement && !selector.isScopePseudoClass() && selector.match() != CSSSelector::Match::HasScope && (!selector.selectorList() || isNotPseudoClass))
             return false;
     }
 
@@ -842,7 +842,12 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, LocalContext& c
 
     if (selector.match() == CSSSelector::Match::HasScope) {
         checkingContext.matchedInsideScope = true;
-        return element.ptr() == checkingContext.hasScope || checkingContext.matchesAllHasScopes;
+        bool matched = element.ptr() == checkingContext.hasScope || checkingContext.matchesAllHasScopes;
+        // For :host:has() the implicit scope sentinel anchors at the host; treat hitting it
+        // on the host as satisfying the mustMatchHostPseudoClass requirement.
+        if (matched && context.mustMatchHostPseudoClass && element->shadowRoot())
+            context.matchedHostPseudoClass = true;
+        return matched;
     }
 
     if (selector.match() == CSSSelector::Match::PseudoClass) {
@@ -1006,7 +1011,7 @@ bool SelectorChecker::checkOne(CheckingContext& checkingContext, LocalContext& c
                 return hasMatchedAnything;
             }
         case CSSSelector::PseudoClass::Has:
-            return matchHasPseudoClass(checkingContext, element, *selector.selectorList());
+            return matchHasPseudoClass(checkingContext, element, *selector.selectorList(), context.mustMatchHostPseudoClass);
         case CSSSelector::PseudoClass::PlaceholderShown:
             if (auto* formControl = dynamicDowncast<HTMLTextFormControlElement>(element.get()))
                 return formControl->isPlaceholderVisible();
@@ -1496,7 +1501,7 @@ static bool canJITCompileHasArgument(const CSSSelector& selector)
 }
 #endif
 
-bool SelectorChecker::matchHasPseudoClass(CheckingContext& checkingContext, const Element& element, const CSSSelectorList& selectorList) const
+bool SelectorChecker::matchHasPseudoClass(CheckingContext& checkingContext, const Element& element, const CSSSelectorList& selectorList, bool matchingHost) const
 {
     // :has() should never be nested with another :has()
     // This is generally discarded at parsing time, but
@@ -1515,7 +1520,7 @@ bool SelectorChecker::matchHasPseudoClass(CheckingContext& checkingContext, cons
 
         unsigned argIndex = 0;
         for (auto& hasSelector : selectorList) {
-            if (matchHasArgumentSelector(checkingContext, element, hasSelector, &compiledSelectors[argIndex++]))
+            if (matchHasArgumentSelector(checkingContext, element, hasSelector, &compiledSelectors[argIndex++], matchingHost))
                 return true;
         }
         return false;
@@ -1523,13 +1528,13 @@ bool SelectorChecker::matchHasPseudoClass(CheckingContext& checkingContext, cons
 #endif
 
     for (auto& hasSelector : selectorList) {
-        if (matchHasArgumentSelector(checkingContext, element, hasSelector, nullptr))
+        if (matchHasArgumentSelector(checkingContext, element, hasSelector, nullptr, matchingHost))
             return true;
     }
     return false;
 }
 
-bool SelectorChecker::matchHasArgumentSelector(CheckingContext& checkingContext, const Element& element, const CSSSelector& hasSelector, CompiledSelector* compiledSelector) const
+bool SelectorChecker::matchHasArgumentSelector(CheckingContext& checkingContext, const Element& element, const CSSSelector& hasSelector, CompiledSelector* compiledSelector, bool matchingHost) const
 {
     UNUSED_PARAM(compiledSelector);
     auto matchElement = Style::computeHasArgumentRelation(hasSelector);
@@ -1553,13 +1558,22 @@ bool SelectorChecker::matchHasArgumentSelector(CheckingContext& checkingContext,
         }
     }();
 
+    // When :has() is part of a :host compound (either the subject is the shadow host, or
+    // the ancestor walk has crossed the shadow root upward), :has() must traverse the host's
+    // shadow tree, not its light-tree descendants.
+    bool traversesShadowTree = matchingHost && element.shadowRoot();
+    CheckedRef<const ContainerNode> traversalRoot = traversesShadowTree ? static_cast<const ContainerNode&>(*element.shadowRoot()) : element;
+
     auto canMatch = [&] {
         switch (traversalType) {
         case HasTraversalType::Children:
         case HasTraversalType::Descendants:
-            return !!element.firstElementChild();
+            return !!traversalRoot->firstElementChild();
         case HasTraversalType::Siblings:
         case HasTraversalType::SiblingDescendants:
+            // A shadow root has no element siblings, so :host:has(~ x) never matches.
+            if (traversesShadowTree)
+                return false;
             return !!element.nextElementSibling();
         }
         ASSERT_NOT_REACHED();
@@ -1592,6 +1606,9 @@ bool SelectorChecker::matchHasArgumentSelector(CheckingContext& checkingContext,
         return *match;
 
     auto filterForElement = [&]() -> Style::HasSelectorFilter* {
+        // Filters are keyed by light-tree context; skip for shadow-tree traversal.
+        if (traversesShadowTree)
+            return nullptr;
         if (!checkingContext.selectorMatchingState)
             return nullptr;
         auto type = [&]() -> std::optional<Style::HasSelectorFilter::Type> {
@@ -1632,7 +1649,8 @@ bool SelectorChecker::matchHasArgumentSelector(CheckingContext& checkingContext,
 
     auto checkRelative = [&](auto& elementToCheck) {
 #if ENABLE(CSS_SELECTOR_JIT)
-        if (compiledSelector) {
+        // Shadow-tree traversal needs the interpreter; gate per-call so the static-only canJITCompileHasArgument cache (shared across rules) isn't poisoned.
+        if (compiledSelector && !traversesShadowTree) {
             if (compiledSelector->status == SelectorCompilationStatus::NotCompiled) {
                 if (canJITCompileHasArgument(hasSelector))
                     SelectorCompiler::compileSelector(*compiledSelector, hasSelector, SelectorCompiler::SelectorContext::RuleCollector, SelectorCompiler::SelectorPurpose::HasArgument);
@@ -1663,7 +1681,7 @@ bool SelectorChecker::matchHasArgumentSelector(CheckingContext& checkingContext,
         return result;
     };
 
-    auto checkDescendants = [&](const Element& descendantRoot) {
+    auto checkDescendants = [&](const ContainerNode& descendantRoot) {
         for (auto it = descendantsOfType<Element>(descendantRoot).begin(); it;) {
             CheckedRef descendant = *it;
             if (checkRelative(descendant))
@@ -1687,28 +1705,30 @@ bool SelectorChecker::matchHasArgumentSelector(CheckingContext& checkingContext,
         switch (traversalType) {
         case HasTraversalType::Children:
             // :has(> .child)
-            for (CheckedRef child : childrenOfType<Element>(element)) {
+            for (CheckedRef child : childrenOfType<Element>(traversalRoot)) {
                 if (checkRelative(child))
                     return true;
             }
             break;
         case HasTraversalType::Descendants: {
             // :has(.descendant)
-            if (cache) {
+            if (cache && !traversesShadowTree) {
                 // See if we already know this descendant selector doesn't match in this subtree.
+                // Only valid for light-tree traversal; shadow-tree walks don't share a failure subtree with light ancestors.
                 for (CheckedPtr ancestor = element.parentElement(); ancestor; ancestor = ancestor->parentElement()) {
                     auto key = Style::makeHasPseudoClassCacheKey(*ancestor, hasSelector);
                     if (cache->get(key) == Style::HasPseudoClassMatch::FailsSubtree)
                         return false;
                 }
             }
-            if (checkDescendants(element))
+            if (checkDescendants(traversalRoot))
                 return true;
 
             break;
         }
         case HasTraversalType::Siblings:
             // :has(~ .sibling)
+            ASSERT(!traversesShadowTree);
             for (CheckedPtr sibling = element.nextElementSibling(); sibling; sibling = sibling->nextElementSibling()) {
                 if (checkRelative(*sibling))
                     return true;
@@ -1716,6 +1736,7 @@ bool SelectorChecker::matchHasArgumentSelector(CheckingContext& checkingContext,
             break;
         case HasTraversalType::SiblingDescendants:
             // :has(~ .sibling .descendant)
+            ASSERT(!traversesShadowTree);
             for (CheckedPtr sibling = element.nextElementSibling(); sibling; sibling = sibling->nextElementSibling()) {
                 if (checkDescendants(*sibling))
                     return true;

--- a/Source/WebCore/css/SelectorChecker.h
+++ b/Source/WebCore/css/SelectorChecker.h
@@ -140,8 +140,8 @@ private:
     MatchResult matchRecursively(CheckingContext&, LocalContext&, EnumSet<PseudoElementType>&) const;
     bool checkOne(CheckingContext&, LocalContext&, MatchType&) const;
     bool matchSelectorList(CheckingContext&, const LocalContext&, const Element&, const CSSSelectorList&) const;
-    bool matchHasPseudoClass(CheckingContext&, const Element&, const CSSSelectorList&) const;
-    bool matchHasArgumentSelector(CheckingContext&, const Element&, const CSSSelector&, CompiledSelector*) const;
+    bool matchHasPseudoClass(CheckingContext&, const Element&, const CSSSelectorList&, bool matchingHost) const;
+    bool matchHasArgumentSelector(CheckingContext&, const Element&, const CSSSelector&, CompiledSelector*, bool matchingHost) const;
 
     bool NODELETE checkScrollbarPseudoClass(const CheckingContext&, const Element&, const CSSSelector&) const;
     bool NODELETE checkViewTransitionPseudoClass(const CheckingContext&, const Element&, const CSSSelector&) const;

--- a/Source/WebCore/style/ChildChangeInvalidation.cpp
+++ b/Source/WebCore/style/ChildChangeInvalidation.cpp
@@ -66,6 +66,7 @@ static bool isSiblingHasRelation(const MatchElement& matchElement)
         return true;
     case MatchElement::HasRelation::Child:
     case MatchElement::HasRelation::Descendant:
+    case MatchElement::HasRelation::HostDescendant:
         return false;
     }
     ASSERT_NOT_REACHED();
@@ -91,6 +92,7 @@ void ChildChangeInvalidation::invalidateForChangedElement(Element& changedElemen
         case MatchElement::HasRelation::Descendant:
         case MatchElement::HasRelation::SiblingChild:
         case MatchElement::HasRelation::SiblingDescendant:
+        case MatchElement::HasRelation::HostDescendant:
             return true;
         default:
             return true;

--- a/Source/WebCore/style/RuleFeature.cpp
+++ b/Source/WebCore/style/RuleFeature.cpp
@@ -185,6 +185,24 @@ static bool isSiblingCombinator(CSSSelector::Relation relation)
     return relation == CSSSelector::Relation::DirectAdjacent || relation == CSSSelector::Relation::IndirectAdjacent;
 }
 
+static bool compoundContainsHostPseudoClass(const CSSSelector& anySimpleInCompound)
+{
+    // Iterate every simple selector in this compound. WebKit stores compound members
+    // contiguously in selector storage; firstInCompound returns the subject (rightmost
+    // in source) and lastInCompound returns the leftmost. Walk from leftmost to subject.
+    auto* leftmost = anySimpleInCompound.lastInCompound();
+    auto* subject = anySimpleInCompound.firstInCompound();
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+    for (auto* simple = leftmost; ; ++simple) {
+        if (simple->match() == CSSSelector::Match::PseudoClass && simple->isHostPseudoClass())
+            return true;
+        if (simple == subject)
+            break;
+    }
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
+    return false;
+}
+
 static MatchElement computeSubSelectorMatchElement(MatchElement matchElement, const CSSSelector& selector, const CSSSelector& childSelector)
 {
     if (selector.match() == CSSSelector::Match::PseudoClass) {
@@ -204,6 +222,14 @@ static MatchElement computeSubSelectorMatchElement(MatchElement matchElement, co
 
         if (type == CSSSelector::PseudoClass::Has) {
             auto hasArgumentRelation = computeHasArgumentRelation(childSelector);
+            // :host:has(...) — has-bearer is the shadow host. Collapse Child/Descendant to
+            // HostDescendant so the invalidator can cross the shadow boundary upward.
+            // Sibling relations are kept as-is (the host has no shadow-tree siblings, so
+            // these will simply not match at runtime).
+            if (compoundContainsHostPseudoClass(selector)) {
+                if (hasArgumentRelation == MatchElement::HasRelation::Child || hasArgumentRelation == MatchElement::HasRelation::Descendant)
+                    hasArgumentRelation = MatchElement::HasRelation::HostDescendant;
+            }
             return { matchElement.relation, hasArgumentRelation };
         }
     }
@@ -234,6 +260,7 @@ static bool isHasScopeBreakingCombinator(CSSSelector::Relation relation, MatchEl
         case MatchElement::HasRelation::Descendant:
         case MatchElement::HasRelation::SiblingChild:
         case MatchElement::HasRelation::SiblingDescendant:
+        case MatchElement::HasRelation::HostDescendant:
             return false;
         }
     }

--- a/Source/WebCore/style/RuleFeature.h
+++ b/Source/WebCore/style/RuleFeature.h
@@ -69,6 +69,7 @@ struct MatchElement {
         IndirectSibling, // :has(~ .changed)
         SiblingChild, // :has(~ .a > .changed)
         SiblingDescendant, // :has(~ .a .changed)
+        HostDescendant, // :host:has(...) — has-bearer is a shadow host, .changed is anywhere in its shadow tree (covers the Child case too).
     };
 
     Relation relation;

--- a/Source/WebCore/style/StyleInvalidator.cpp
+++ b/Source/WebCore/style/StyleInvalidator.cpp
@@ -399,6 +399,20 @@ void Invalidator::invalidateStyleWithMatchElement(Element& element, MatchElement
             }
             return;
         }
+        if (hasRelation == HasRelation::HostDescendant) {
+            // :host:has(...) .subject — has-bearer is the host; subjects live in the shadow tree.
+            RefPtr shadowRoot = element.containingShadowRoot();
+            if (!shadowRoot)
+                return;
+            for (Ref shadowChild : childrenOfType<Element>(*shadowRoot)) {
+                SelectorMatchingState shadowMatchingState;
+                invalidateIfNeeded(shadowChild.get(), &shadowMatchingState);
+                invalidateStyleForDescendants(shadowChild.get(), &shadowMatchingState);
+            }
+            if (RefPtr host = shadowRoot->host())
+                invalidateIfNeeded(*host, nullptr);
+            return;
+        }
         if (matchElement.relation == Relation::Ancestor && hasRelation == HasRelation::Descendant) {
             // .foo:has(.changed) .subject — find outermost ancestor matching any scope selector (.foo) to bound traversal.
             // If no ancestor matches any ruleset's scope and no ruleset is scope-breaking, no bearer exists and we can skip.
@@ -506,6 +520,14 @@ void Invalidator::invalidateStyleWithMatchElement(Element& element, MatchElement
         for (RefPtr ancestor : ancestors | std::views::reverse) {
             invalidateIfNeeded(*ancestor, &selectorMatchingState);
             selectorMatchingState.selectorFilter.pushParent(ancestor.get());
+        }
+        break;
+    }
+    case HasRelation::HostDescendant: {
+        // :host:has(...) — has-bearer is the changed element's shadow host.
+        if (RefPtr shadowRoot = element.containingShadowRoot()) {
+            if (RefPtr host = shadowRoot->host())
+                invalidateIfNeeded(*host, nullptr);
         }
         break;
     }


### PR DESCRIPTION
#### c376374b3d92bdcd4fff4a80d60b13672e318e17
<pre>
Support :host:has()
<a href="https://bugs.webkit.org/show_bug.cgi?id=282687">https://bugs.webkit.org/show_bug.cgi?id=282687</a>
<a href="https://rdar.apple.com/139799278">rdar://139799278</a>

Reviewed by Alan Baradlay.

Per-spec :host:has(.descendant) should match against shadow tree descendants.
<a href="https://drafts.csswg.org/css-shadow/#host-selector">https://drafts.csswg.org/css-shadow/#host-selector</a>

Match-time, root the :has() argument traversal at the host&apos;s shadow root
when the :has() is matching the host as a :host pseudo. The signal is
LocalContext::mustMatchHostPseudoClass, which matchRecursively already
sets when the subject is the host (styleScopeOrdinal == Shadow) and when
the ancestor walk has crossed the shadow root upward. The implicit
HasScope sentinel inside the argument is allowed through the
mustMatchHostPseudoClass early-out and treated as satisfying :host when
it lands on the host.

Invalidation, classify the features statically. When :has() is in a
compound that also contains :host, the inner Child/Descendant
has-relation is collapsed to a new HasRelation::HostDescendant. The
invalidator has dedicated arms for it in subject and non-subject
positions: subject reaches the host via containingShadowRoot();
non-subject invalidates the host&apos;s shadow tree where the subjects live.

Improves 50 of the 52 subtests in the host-has-shadow-tree-element-at-
{subject,nonsubject}-position WPTs from 1 PASS to 25 PASS each.
Remaining FAIL is a :host-context() chained-:has() case.

* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/host-has-shadow-tree-element-at-nonsubject-position-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/selectors/invalidation/host-has-shadow-tree-element-at-subject-position-expected.txt:

Rebaseline: 50 previously-failing subtests now pass.

* Source/WebCore/css/SelectorChecker.h:

Plumb a matchingHost bool through matchHasPseudoClass and
matchHasArgumentSelector.

* Source/WebCore/css/SelectorChecker.cpp:
(WebCore::SelectorChecker::checkOne const):

Pass context.mustMatchHostPseudoClass through. Allow Match::HasScope
through the mustMatchHostPseudoClass early-out and treat HasScope on
the host as having matched :host.

(WebCore::SelectorChecker::matchHasPseudoClass const):
(WebCore::SelectorChecker::matchHasArgumentSelector const):

Root :has() traversal at the host&apos;s shadow root when matchingHost is
set. Sibling traversals bail (the host has no shadow-tree siblings);
JIT and light-tree-only caches are skipped on the shadow path.

* Source/WebCore/style/RuleFeature.h:

Add HasRelation::HostDescendant.

* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::compoundContainsHostPseudoClass):

Walk compound members from lastInCompound() to firstInCompound() with
storage increment. WebKit&apos;s &quot;first in complex selector&quot; flag is on the
subject (rightmost in source, storage[0]).

(WebCore::Style::computeSubSelectorMatchElement):

When :has() sits in a :host compound, collapse Child/Descendant to
HostDescendant.

(WebCore::Style::isHasScopeBreakingCombinator):

* Source/WebCore/style/ChildChangeInvalidation.cpp:
(WebCore::Style::isSiblingHasRelation):
(WebCore::Style::ChildChangeInvalidation::invalidateForChangedElement):

Cover HostDescendant in the existing switches.

* Source/WebCore/style/StyleInvalidator.cpp:
(WebCore::Style::Invalidator::invalidateStyleWithMatchElement):

Subject-position HostDescendant invalidates the host;
non-subject-position invalidates the host&apos;s shadow tree and the host.

Canonical link: <a href="https://commits.webkit.org/313350@main">https://commits.webkit.org/313350@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/157669ab3a833d2bd91afc94c572236ae2337927

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162755 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36231 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29383 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171693 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119201 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/60f9fad1-a713-49f7-b91b-b983152132c4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164624 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36335 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36235 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126326 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/88969 "18 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1c5dfb9c-06e6-404d-a08d-d93ae41e0491) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165714 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28675 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146244 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106903 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cff3fb5c-e971-43ba-a914-1f964baa0ae2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27721 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26253 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19393 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137429 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/23973 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174197 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21670 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25618 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134636 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35905 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30354 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134631 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36344 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35889 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145769 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98301 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/29169 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22605 "Too many flaky failures: http/tests/misc/policy-delegate-called-twice.html, http/tests/navigation/process-swap-on-client-side-redirect-private.html, http/tests/resourceLoadStatistics/only-partitioned-cookies-after-redirect.html, http/tests/security/canvas-cors-with-two-hosts.html, http/tests/security/contentSecurityPolicy/1.1/stylehash-multiple-policies.html, http/tests/security/contentSecurityPolicy/report-blocked-data-uri.py, http/tests/security/mixedContent/redirect-https-to-http-iframe-in-main-frame.html, http/tests/site-isolation/frame-index.html, http/tests/storageAccess/deny-storage-access-under-opener-if-auto-dismiss-ephemeral.html, http/tests/websocket/tests/hybi/contentextensions/upgrade.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35399 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/103299 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34900 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35145 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35048 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->