### PR TITLE
[CMake][Mac] Build WebBackForwardList.swift and pass TestWebKitAPI back/forward tests

### DIFF
--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -967,6 +967,10 @@ macro(GENERATE_MESSAGE_SOURCES _output_source _inputs)
         # DEPENDS needs the actual path. Check source tree first, then derived.
         if (EXISTS ${WEBKIT_DIR}/${_file}.messages.in)
             list(APPEND _input_files ${WEBKIT_DIR}/${_file}.messages.in)
+            file(STRINGS ${WEBKIT_DIR}/${_file}.messages.in _swift_attr REGEX "SwiftReceiver")
+            if (_swift_attr)
+                list(APPEND _outputs ${WebKit_DERIVED_SOURCES_DIR}/${_name}MessageReceiver.swift)
+            endif ()
         else ()
             list(APPEND _input_files ${WebKit_DERIVED_SOURCES_DIR}/${_name}.messages.in)
         endif ()
@@ -1262,6 +1266,11 @@ if (ENABLE_BACK_FORWARD_LIST_SWIFT)
 endif ()
 
 list(APPEND WebKit_SOURCES ${WebKit_DERIVED_SOURCES})
+
+if (TARGET WebKit_SwiftCxxHeader)
+    add_custom_target(WebKit_DerivedHeadersForSwift DEPENDS ${WebKit_HEADERS} ${WebKit_DERIVED_SOURCES})
+    add_dependencies(WebKit_SwiftCxxHeader WebKit_DerivedHeadersForSwift)
+endif ()
 
 WEBKIT_COMPUTE_SOURCES(WebKit)
 

--- a/Source/WebKit/PlatformCocoa.cmake
+++ b/Source/WebKit/PlatformCocoa.cmake
@@ -95,6 +95,7 @@ list(APPEND WebKit_PRIVATE_INCLUDE_DIRECTORIES
     "${WEBKIT_DIR}/UIProcess/API/Cocoa"
     "${WEBKIT_DIR}/UIProcess/Authentication/cocoa"
     "${WEBKIT_DIR}/UIProcess/Cocoa"
+    "${WEBKIT_DIR}/UIProcess/Cocoa/Separated"
     "${WEBKIT_DIR}/UIProcess/Cocoa/SOAuthorization"
     "${WEBKIT_DIR}/UIProcess/Cocoa/TextExtraction"
     "${WEBKIT_DIR}/UIProcess/Extensions/Cocoa"

--- a/Source/WebKit/PlatformMac.cmake
+++ b/Source/WebKit/PlatformMac.cmake
@@ -40,8 +40,9 @@ list(APPEND WebKit_SOURCES
     NetworkProcess/mac/NetworkConnectionToWebProcessMac.mm
 
     UIProcess/PDF/WKPDFHUDView.mm
-    ${WEBKIT_DIR}/UIProcess/PDF/WKPDFHUDView.swift
     ${WEBKIT_DIR}/Platform/cocoa/WKMaterialHostingSupport.swift
+    ${WEBKIT_DIR}/UIProcess/Cocoa/Foundation+Extras.swift
+    ${WEBKIT_DIR}/UIProcess/PDF/WKPDFHUDView.swift
 
     WebProcess/InjectedBundle/API/c/mac/WKBundlePageMac.mm
 )
@@ -69,62 +70,109 @@ set(GPUProcess_SOURCES Shared/EntryPointUtilities/Cocoa/AuxiliaryProcessMain.cpp
 set(WebProcess_INCLUDE_DIRECTORIES ${CMAKE_BINARY_DIR})
 set(NetworkProcess_INCLUDE_DIRECTORIES ${CMAKE_BINARY_DIR})
 
-# Stripped-down module map for Swift — full map's C++ submodules fail in CMake's explicit module context.
+# WebBackForwardList.swift and friends need the full C++ WebKit_Internal module
+# (WebPageProxy, SessionState, WebBackForwardListSwiftUtilities, ...) so use the
+# source-tree map directly. The earlier ObjC-only stripped map is insufficient
+# once ENABLE_BACK_FORWARD_LIST_SWIFT pulls in C++ interop.
+set(WebKit_SWIFT_INTEROP_MODULE_PATH "${WEBKIT_DIR}/Modules/Internal")
+
+# WebCore_Private.modulemap in-tree is a `framework module` that umbrellas the
+# Xcode framework's PrivateHeaders/. CMake stages those headers as a flat
+# directory instead, and umbrellaing it pulls in headers (ANGLEHeaders.h etc.)
+# whose own dependencies aren't on the Swift Clang importer's search path.
+# Expose only what WebBackForwardList.swift names directly; the rest of the
+# WebCore:: types it uses are reachable transitively via WebKit_Internal headers.
 set(WebKit_CMAKE_MODULEMAP_DIR "${CMAKE_BINARY_DIR}/WebKit/SwiftModules")
 file(MAKE_DIRECTORY "${WebKit_CMAKE_MODULEMAP_DIR}")
 file(WRITE "${WebKit_CMAKE_MODULEMAP_DIR}/module.modulemap"
-"module WebKit_Internal [system] {
-    module WKPDFHUDView {
-        requires objc
-        header \"${WEBKIT_DIR}/UIProcess/PDF/WKPDFHUDView.h\"
-        export *
-    }
-
-    module WKWebView {
-        requires objc
-        header \"${WebKit_FRAMEWORK_HEADERS_DIR}/WebKit/WKWebView.h\"
-        export *
-    }
-
-    module WKMaterialHostingSupport {
-        requires objc
-        header \"${WEBKIT_DIR}/Platform/cocoa/WKMaterialHostingSupport.h\"
-        export *
-    }
-
-    module _WKTextExtractionInternal {
-        requires objc
-        header \"${WEBKIT_DIR}/UIProcess/API/Cocoa/_WKTextExtractionInternal.h\"
-        export *
-    }
+"module WebCore_Private [system] {
+    requires cplusplus
+    header \"${WebCore_PRIVATE_FRAMEWORK_HEADERS_DIR}/WebCore/DiagnosticLoggingKeys.h\"
+    header \"${WebCore_PRIVATE_FRAMEWORK_HEADERS_DIR}/WebCore/DiagnosticLoggingClient.h\"
+    export *
 }
 ")
-set(WebKit_SWIFT_INTEROP_MODULE_PATH "${WebKit_CMAKE_MODULEMAP_DIR}")
 
-# Mirror flags to target_compile_options so native Swift compilation matches typecheck.
 # Xcode does not set SWIFT_TREAT_WARNINGS_AS_ERRORS; override CMake's -warnings-as-errors.
 # Must go in WebKit_COMPILE_OPTIONS (applied after -warnings-as-errors in _WEBKIT_TARGET_SETUP).
 list(APPEND WebKit_COMPILE_OPTIONS "$<$<COMPILE_LANGUAGE:Swift>:-no-warnings-as-errors>")
-target_compile_options(WebKit PRIVATE
-    "$<$<COMPILE_LANGUAGE:Swift>:-DHAVE_MATERIAL_HOSTING>"
-    "$<$<COMPILE_LANGUAGE:Swift>:-I${WEBKIT_DIR}/Platform/spi/Cocoa>"
-    "$<$<COMPILE_LANGUAGE:Swift>:-I${WEBKIT_DIR}/Platform/spi/Cocoa/Modules>"
-    "$<$<COMPILE_LANGUAGE:Swift>:-I${WEBKIT_DIR}/Platform/spi/ios>"
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -I${WebKit_FRAMEWORK_HEADERS_DIR}>"
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -I${WTF_FRAMEWORK_HEADERS_DIR}>"
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -I${bmalloc_FRAMEWORK_HEADERS_DIR}>"
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -I${PAL_FRAMEWORK_HEADERS_DIR}>"
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -I${ICU_INCLUDE_DIRS}>"
+
+# The full WebKit_Internal C++ module pulls in WebPageProxy.h and friends, which
+# quote-include across the entire WebKit/WebCore/JSC private header set. Mirror
+# the C++ target's include directories to swiftc's Clang importer so those
+# resolve. cmakeconfig.h is force-included because the headers assume the
+# project's prefix header has already defined ENABLE()/HAVE() values.
+set(WebKit_SWIFT_CLANG_INCLUDE_DIRS
+    ${CMAKE_BINARY_DIR}
+    ${WebKit_FRAMEWORK_HEADERS_DIR}
+    ${WebKit_DERIVED_SOURCES_DIR}
+    ${WebCore_PRIVATE_FRAMEWORK_HEADERS_DIR}
+    ${JavaScriptCore_FRAMEWORK_HEADERS_DIR}
+    ${JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS_DIR}
+    ${WTF_FRAMEWORK_HEADERS_DIR}
+    ${bmalloc_FRAMEWORK_HEADERS_DIR}
+    ${PAL_FRAMEWORK_HEADERS_DIR}
+    ${ICU_INCLUDE_DIRS}
+    ${WebKit_CMAKE_MODULEMAP_DIR}
+    ${WebKit_PRIVATE_INCLUDE_DIRECTORIES}
 )
 
-set(WebKit_SWIFT_EXTRA_OPTIONS
-    -DHAVE_MATERIAL_HOSTING
-    -Xcc -I${WebKit_FRAMEWORK_HEADERS_DIR}
-    -Xcc -I${WTF_FRAMEWORK_HEADERS_DIR}
-    -Xcc -I${bmalloc_FRAMEWORK_HEADERS_DIR}
-    -Xcc -I${PAL_FRAMEWORK_HEADERS_DIR}
-    -Xcc -I${ICU_INCLUDE_DIRS}
+# Module PCMs compile with a clean preprocessor (no -include), so feed
+# cmakeconfig.h's content and the export-macro stubs as -Xcc -D instead. The
+# Clang importer applies -D to every module build. Each pair is kept as a single
+# list element so target_compile_options can wrap it in SHELL: -- otherwise CMake
+# deduplicates the repeated -Xcc and only the first flag reaches the importer.
+set(WebKit_SWIFT_CLANG_FLAG_PAIRS
+    "-Xcc -DBUILDING_WEBKIT"
+    "-Xcc -DJS_EXPORT_PRIVATE="
+    "-Xcc -DPAL_EXPORT="
+    "-Xcc -DWEBCORE_EXPORT="
+    "-Xcc -DWEBCORE_TESTSUPPORT_EXPORT="
+    "-Xcc -DWK_SUPPORTS_SWIFT_OBJCXX_INTEROP=1"
+    "-Xcc -fmodule-map-file=${WTF_FRAMEWORK_HEADERS_DIR}/wtf/module.modulemap"
+    "-Xcc -fmodule-map-file=${PAL_FRAMEWORK_HEADERS_DIR}/pal/module.modulemap"
 )
+# ASSERT_ENABLED (and therefore the layout of RefCountedBase, IPC::MessageReceiver,
+# and many others) is keyed off NDEBUG. CMake adds -DNDEBUG to CXX flags in Release
+# but not to swiftc, so the Clang importer would otherwise see a Debug layout and
+# inline ref()/adoptRef() against the wrong member offsets.
+string(TOUPPER "${CMAKE_BUILD_TYPE}" _build_type_upper)
+if (CMAKE_CXX_FLAGS_${_build_type_upper} MATCHES "NDEBUG" OR CMAKE_CXX_FLAGS MATCHES "NDEBUG")
+    list(APPEND WebKit_SWIFT_CLANG_FLAG_PAIRS "-Xcc -DNDEBUG" "-Xcc -DRELEASE_WITHOUT_OPTIMIZATIONS")
+endif ()
+unset(_build_type_upper)
+# GET_WEBKIT_CONFIG_VARIABLES filters out falsy entries, so the importer would
+# miss every =0 and fall back to PlatformEnableCocoa.h defaults — which diverges
+# from cmakeconfig.h and shifts member offsets in headers Swift inlines.
+set(_swift_clang_config_vars ${_WEBKIT_CONFIG_FILE_VARIABLES})
+list(REMOVE_DUPLICATES _swift_clang_config_vars)
+foreach (_var IN LISTS _swift_clang_config_vars)
+    if (${${_var}})
+        list(APPEND WebKit_SWIFT_CLANG_FLAG_PAIRS "-Xcc -D${_var}=1")
+    else ()
+        list(APPEND WebKit_SWIFT_CLANG_FLAG_PAIRS "-Xcc -D${_var}=0")
+    endif ()
+endforeach ()
+unset(_swift_clang_config_vars)
+foreach (_dir IN LISTS WebKit_SWIFT_CLANG_INCLUDE_DIRS)
+    list(APPEND WebKit_SWIFT_CLANG_FLAG_PAIRS "-Xcc -I${_dir}")
+endforeach ()
+
+# HAVE_MATERIAL_HOSTING is a PlatformHave.h preprocessor flag (macOS 16+),
+# not a CMake define. SWIFT_EXTRA_OPTIONS and SWIFT_INCLUDE_DIRECTORIES only
+# affect the typecheck custom command. Mirror everything to target_compile_options
+# so the actual Swift compilation sees the same flags.
+set(WebKit_SWIFT_EXTRA_OPTIONS -DHAVE_MATERIAL_HOSTING)
+target_compile_options(WebKit PRIVATE "$<$<COMPILE_LANGUAGE:Swift>:-DHAVE_MATERIAL_HOSTING>")
+foreach (_pair IN LISTS WebKit_SWIFT_CLANG_FLAG_PAIRS)
+    target_compile_options(WebKit PRIVATE "$<$<COMPILE_LANGUAGE:Swift>:SHELL:${_pair}>")
+    string(REPLACE " " ";" _split "${_pair}")
+    list(APPEND WebKit_SWIFT_EXTRA_OPTIONS ${_split})
+endforeach ()
+list(APPEND WebKit_SWIFT_EXTRA_OPTIONS -Xfrontend -emit-clang-header-min-access -Xfrontend internal)
+foreach (_dir IN LISTS WebKit_SWIFT_INCLUDE_DIRECTORIES)
+    target_compile_options(WebKit PRIVATE "$<$<COMPILE_LANGUAGE:Swift>:-I${_dir}>")
+endforeach ()
 
 add_custom_command(
     OUTPUT ${_log_messages_generated}

--- a/Source/cmake/OptionsMac.cmake
+++ b/Source/cmake/OptionsMac.cmake
@@ -130,6 +130,9 @@ WEBKIT_OPTION_DEFAULT_PORT_VALUE(ENABLE_WRITING_TOOLS PRIVATE ON)
 
 WEBKIT_OPTION_END()
 
+# rdar://177360289
+SET_AND_EXPOSE_TO_BUILD(ENABLE_BACK_FORWARD_LIST_SWIFT ON)
+
 # -----------------------------------------------------------------------------
 # Toolchain / SDK resolution
 # -----------------------------------------------------------------------------

--- a/Source/cmake/WebKitMacros.cmake
+++ b/Source/cmake/WebKitMacros.cmake
@@ -811,6 +811,21 @@ macro(WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER _target _module_n
                 endif ()
             endforeach ()
         endif ()
+        # The clang importer must agree with C++ TUs on every layout-affecting
+        # feature check; sanitizers gate ASAN_ENABLED → ENABLE_SECURITY_ASSERTIONS
+        # → RefCountDebuggerImpl members. Without this, Swift's inline `new` of a
+        # RefCounted C++ type undersizes the allocation and the C++ ctor overflows
+        # it. -sanitize= instruments Swift codegen; the importer ignores -Xcc
+        # -fsanitize= for __has_feature(), so define __SANITIZE_*__ directly so
+        # Compiler.h's #ifdef path sets ASAN_ENABLED/TSAN_ENABLED.
+        foreach (_sanitizer IN LISTS ENABLE_SANITIZERS)
+            list(APPEND _swift_options "-sanitize=${_sanitizer}")
+            if (_sanitizer STREQUAL "address")
+                list(APPEND _swift_options "-Xcc" "-D__SANITIZE_ADDRESS__")
+            elseif (_sanitizer STREQUAL "thread")
+                list(APPEND _swift_options "-Xcc" "-D__SANITIZE_THREAD__")
+            endif ()
+        endforeach ()
         # swiftc spawns swift-plugin-server under sandbox-exec to expand macros
         # (e.g. SwiftUI @State). When the cmake build itself runs inside an
         # outer sandbox that disallows nested sandbox_apply, macro expansion
@@ -819,15 +834,9 @@ macro(WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER _target _module_n
         # WebKit's own, so the isolation it provides isn't load-bearing here.
         list(APPEND _swift_options "-disable-sandbox")
         if (NOT (PORT STREQUAL GTK OR PORT STREQUAL WPE))
-            # This does not yet work on non-Apple platforms for reasons yet to be determined.
-            list(APPEND _swift_options "-explicit-module-build")
-            # -explicit-module-build makes swiftc scan and compile every transitive
-            # SDK Clang module to .pcm before typechecking. Without a fixed cache
-            # path each invocation does that into a private temp dir and discards
-            # it, so the -typecheck/-emit-clang-header pass below and cmake's own
-            # Swift compile each pay the full SDK-module cold cost, every build.
-            # Pin the cache so the second invocation -- and every later rebuild --
-            # reuses the first one's .pcm set.
+            # Implicit module builds share work via -module-cache-path; explicit
+            # builds were tried but strip project -Xcc -include/-I from per-module
+            # PCM compiles, which breaks the C++ interop modules' prefix header.
             list(APPEND _swift_options "-module-cache-path" "${CMAKE_BINARY_DIR}/SwiftModuleCache")
             set_property(DIRECTORY "${CMAKE_BINARY_DIR}" APPEND PROPERTY ADDITIONAL_CLEAN_FILES "${CMAKE_BINARY_DIR}/SwiftModuleCache")
         endif ()

--- a/Tools/Scripts/swift/swiftc-wrapper.sh
+++ b/Tools/Scripts/swift/swiftc-wrapper.sh
@@ -34,7 +34,16 @@ for arg in "$@"; do
 done
 
 for arg in "$@"; do
+    if [[ -n "$pass_next_verbatim" ]]; then
+        args+=("$arg")
+        pass_next_verbatim=
+        continue
+    fi
     case "$arg" in
+        "-Xcc"|"-Xlinker"|"-Xfrontend")
+            args+=("$arg")
+            pass_next_verbatim=1
+            ;;
         "-mfpmath=sse") ;;
         "-msse") ;;
         "-msse2") ;;

--- a/Tools/TestWebKitAPI/PlatformMac.cmake
+++ b/Tools/TestWebKitAPI/PlatformMac.cmake
@@ -98,6 +98,8 @@ list(APPEND TestWebKit_SOURCES
     Helpers/mac/WebKitAgnosticTest.mm
 
     Tests/WebCore/ASN1Utilities.cpp
+
+    Tests/WebKit/WKWebView/WKBackForwardListTests.mm
 )
 
 list(APPEND TestWebKit_PRIVATE_INCLUDE_DIRECTORIES


### PR DESCRIPTION
#### 04c87ca350d12baa5cccf76688771d1c19d520ea
<pre>
[CMake][Mac] Build WebBackForwardList.swift and pass TestWebKitAPI back/forward tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=313969">https://bugs.webkit.org/show_bug.cgi?id=313969</a>

Reviewed by Adrian Taylor.

Enable ENABLE_BACK_FORWARD_LIST_SWIFT in the CMake Mac port and wire up
the Swift sources (APIArray.swift, StdlibExtras.swift,
WebBackForwardList.swift, generated WebBackForwardListMessageReceiver.swift)
plus the full source-tree WebKit_Internal modulemap so the C++ interop
types (WebPageProxy, SessionState) are visible to Swift.

Drop -explicit-module-build: per-module PCM compiles strip project
-Xcc -include/-I, breaking the C++ interop modules&apos; prefix header.
Implicit builds with a pinned -module-cache-path retain the warm-cache
win without that breakage.

Forward ENABLE_SANITIZERS to swiftc as -sanitize= and to its clang
importer as -Xcc -D__SANITIZE_ADDRESS__/__SANITIZE_THREAD__. The importer
is parse-only and ignores -Xcc -fsanitize= for __has_feature(), so without
the explicit define it sees ASAN_ENABLED=0 -&gt; ENABLE_SECURITY_ASSERTIONS=0
-&gt; RefCountDebuggerImpl members compiled out -&gt; Swift-emitted inline
`new WebBackForwardListMessageForwarder` allocates 32 bytes while the
C++-compiled ctor writes the debug members past that, and ASan reports a
heap-buffer-overflow on every WKWebView creation. Make swiftc-wrapper.sh
pass -Xcc/-Xlinker/-Xfrontend argument pairs through verbatim so the
follow-on arg isn&apos;t independently rewritten.

Mark the generated WebBackForwardListMessageReceiver.swift as GENERATED so
configure succeeds on a cold DerivedSources dir; build ordering is already
covered via the sibling .cpp OUTPUT.

Add WebKit_DerivedHeadersForSwift dependency on WebKit_SwiftCxxHeader so
derived headers exist before swiftc -emit-clang-header runs.

Mirror cmakeconfig.h to the importer by iterating
_WEBKIT_CONFIG_FILE_VARIABLES directly. GET_WEBKIT_CONFIG_VARIABLES
filters out every falsy entry, so the importer would otherwise miss every
=0 define and fall back to PlatformEnableCocoa.h defaults -- and any
header member gated on a feature whose default differs from cmakeconfig.h
shifts the offsets Swift inlines against (e.g. WebPageProxy&apos;s
m_browsingContextGroup, observed once 276e17367772 started exposing OFF
features). Add UIProcess/Cocoa/Foundation+Extras.swift to the Mac Swift
source list so its `typealias String/URL` is visible -- the Xcode build
and PlatformIOS.cmake already compile it, which is why those builds never
needed any explicit String/URL disambiguation.

* Source/WebKit/CMakeLists.txt:
* Source/WebKit/PlatformCocoa.cmake:
* Source/WebKit/PlatformMac.cmake:
* Source/cmake/OptionsMac.cmake:
* Source/cmake/WebKitMacros.cmake:
* Tools/Scripts/swift/swiftc-wrapper.sh:
* Tools/TestWebKitAPI/PlatformMac.cmake:

Canonical link: <a href="https://commits.webkit.org/313434@main">https://commits.webkit.org/313434@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38a8e5a5b5050dd6a7d1f1651109dffe618e76a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163124 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36605 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29822 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172063 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119571 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e46008cc-f7f9-442b-b3a8-8e6d60eff40c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164993 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36743 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36605 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126645 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/89248 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8fc3bc35-a8ba-40bd-b634-7713e1b3a547) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166083 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/28853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146641 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107215 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bffe341d-1396-4bf4-bf39-f8c4be9922fb) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26590 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19763 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/155269 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137791 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24365 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174566 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/24011 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/26662 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26019 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134955 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36275 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30694 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134947 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36383 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37054 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146160 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98899 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/30241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23004 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195525 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35771 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108132 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50959 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35270 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1030 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35517 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35417 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->