### PR TITLE
Resync `css/cssom` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -10347,6 +10347,7 @@
         "web-platform-tests/css/cssom/CSSStyleSheet-constructable-concat-ref.html",
         "web-platform-tests/css/cssom/CSSStyleSheet-constructable-insertRule-base-uri-ref.html",
         "web-platform-tests/css/cssom/HTMLLinkElement-disabled-alternate-ref.html",
+        "web-platform-tests/css/cssom/all-initial-csstext-ref.html",
         "web-platform-tests/css/cssom/insertRule-from-script-ref.html",
         "web-platform-tests/css/cssom/medialist-dynamic-001-ref.html",
         "web-platform-tests/css/cssom/selectorText-modification-restyle-001-ref.html",

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleDeclaration-iterator-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleDeclaration-iterator-expected.txt
@@ -1,0 +1,3 @@
+
+PASS CSSStyleDeclaration should expose Symbol.iterator
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleDeclaration-iterator.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleDeclaration-iterator.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>CSSStyleDeclaration should expose Symbol.iterator</title>
+<link rel="help" href="https://drafts.csswg.org/cssom-1/">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=2025453">
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script>
+  test(function() {
+    assert_true(Symbol.iterator in CSSStyleDeclaration.prototype);
+  });
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleSheet-constructable-replace-thenable-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleSheet-constructable-replace-thenable-expected.txt
@@ -1,0 +1,3 @@
+
+PASS CSSStyleSheet.replace/replaceSync() when stylesheet is a thenable
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleSheet-constructable-replace-thenable.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleSheet-constructable-replace-thenable.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSSStyleSheet.replace/replaceSync() when stylesheet is a thenable</title>
+<link rel="author" href="mailto:emilio@crisal.io" title="Emilio Cobos Álvarez">
+<link rel="author" href="https://mozilla.org" title="Mozilla">
+<link rel="help" href="https://drafts.csswg.org/cssom/#extensions-to-the-document-or-shadow-root-interface">
+<link rel="help" href="https://bugzilla.mozilla.org/show_bug.cgi?id=2016237">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+promise_test(async function() {
+  const sheet = new CSSStyleSheet();
+  document.adoptedStyleSheets = [sheet];
+
+  let p2 = null;
+  let once = false;
+
+  Object.defineProperty(CSSStyleSheet.prototype, "then", {
+    configurable: true,
+    get() {
+      if (!once) {
+        once = true;
+        p2 = sheet.replace("b { color: blue; }");
+      }
+      return undefined;
+    },
+  });
+
+  await sheet.replace("a { color: red; }");
+  delete CSSStyleSheet.prototype.then;
+
+  assert_true(once, "Then getter was called");
+
+  await p2;
+
+  assert_true(true, "replace() from then() should settle");
+
+  // Check if sheet is still modifiable
+  sheet.replaceSync("c {}");
+
+  assert_equals(sheet.cssRules[0].selectorText, "c", "Sheet should still be modifiable");
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleSheet-template-adoption.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleSheet-template-adoption.html
@@ -19,6 +19,7 @@ test(function() {
   let root = host.attachShadow({ mode: "open" });
   root.innerHTML = `<div></div>`;
   root.adoptedStyleSheets = [sheet];
+  let adoptedStyleSheets = root.adoptedStyleSheets;
 
   function assertAdoptedStyleSheet() {
     assert_equals(host.ownerDocument, root.firstChild.ownerDocument, "Shadow root was not adopted?");
@@ -27,6 +28,7 @@ test(function() {
     if (root.ownerDocument == document) {
       assert_equals(getComputedStyle(root.firstChild).color, "rgb(0, 0, 255)", "Sheet should apply");
     }
+    assert_equals(adoptedStyleSheets, root.adoptedStyleSheets, "adoptedStyleSheets should be the same array");
   }
 
   assertAdoptedStyleSheet();
@@ -54,5 +56,6 @@ test(function() {
   document.body.appendChild(iframe);
   iframe.contentDocument.body.appendChild(host);
   assert_equals(root.adoptedStyleSheets.length, 0);
+  assert_equals(adoptedStyleSheets, root.adoptedStyleSheets, "adoptedStyleSheets should be the same array");
 }, "adoptedStyleSheets won'te be cleared when adopting into/from <template>s");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/WEB_FEATURES.yml
@@ -21,3 +21,88 @@ features:
   - HTMLLinkElement-disabled-006.html
   - HTMLLinkElement-disabled-007.html
   - HTMLLinkElement-disabled-alternate.html
+- name: get-computed-style
+  files:
+  - computed-style-001.html
+  - computed-style-set-property.html
+  - getComputedStyle-animations-replaced-into-ib-split.html
+  - getComputedStyle-detached-subtree.html
+  - getComputedStyle-display-none-001.html
+  - getComputedStyle-display-none-002.html
+  - getComputedStyle-display-none-003.html
+  - getComputedStyle-dynamic-subdoc.html
+  - getComputedStyle-getter-v-properties.tentative.html
+  - getComputedStyle-insets-absolute-crash.html
+  - getComputedStyle-insets-absolute-logical-crash.html
+  - getComputedStyle-insets-multicol-absolute-crash.html
+  - getComputedStyle-layout-dependent-removed-ib-sibling.html
+  - getComputedStyle-layout-dependent-replaced-into-ib-split.html
+  - getComputedStyle-logical-enumeration.html
+  - getComputedStyle-property-order.html
+  - getComputedStyle-pseudo.html
+  - getComputedStyle-pseudo-checkmark.html
+  - getComputedStyle-pseudo-picker-icon.html
+  - getComputedStyle-pseudo-with-argument.html
+  - getComputedStyle-special-chars-crash.html
+- name: font-face
+  files:
+  - CSSFontFaceRule.html
+  - cssom-fontfacerule*
+- name: font-variant
+  files:
+  - font-variant-shorthand-serialization.html
+- name: css-escape
+  files:
+  - escape.html
+- name: css-object-model
+  files:
+  # CSSGroupingRule:
+  - CSSGroupingRule-*
+  # CSSPageDescriptors:
+  - page-descriptors.html
+  - cssom-pagerule.html
+  # CSSRuleList:
+  - CSSRuleList.html
+  # CSSStyleDeclaration:
+  - css-style-declaration-modifications.html
+  - cssom-cssstyledeclaration-set.html
+  - cssstyledeclaration-*
+  # CSSStyleRule:
+  - CSSStyleRule.html
+  # Document.styleSheets / StyleSheetList / StyleSheet
+  - StyleSheetList*
+  # HTMLElement.style:
+  - style-attr-update-across-documents.html
+  # HTMLLinkElement.sheet / HTMLStyleElement.sheet:
+  - style-sheet-interfaces-*
+  # MediaList:
+  - MediaList*
+  - medialist-*
+  # CSSConditionRule:
+  - CSSConditionRule-conditionText.html
+  # CSSMediaRule:
+  - serialize-media-rule.html
+- name: matchmedia
+  files:
+  - mediaquery-sort-dedup.html
+- name: mutationobserver
+  files:
+  - MutationObserver-style.html
+- name: page-setup
+  files:
+  - cssom-pagerule.html
+  - page-descriptors.html
+- name: import
+  files:
+  - cssimportrule*
+- name: where
+  files:
+  - insert-invalid-where-rule-crash.html
+- name: namespace
+  files:
+  - CSSNamespaceRule.html
+  - CSSStyleRule-set-selectorText-namespace.html
+  - at-namespace.html
+  - delete-namespace-rule-when-child-rule-exists.html
+  - insertRule-namespace-no-index.html
+  - serialize-namespaced-type-selectors.html

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/adoptedstylesheets-observablearray-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/adoptedstylesheets-observablearray-expected.txt
@@ -3,4 +3,5 @@ Test Span
 PASS document.adoptedStyleSheets should allow mutation in-place
 PASS shadowRoot.adoptedStyleSheets should allow mutation in-place
 PASS adoptedStyleSheets should return true for isArray()
+PASS adoptedStyleSheets should not expose its backing object via prototype
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/adoptedstylesheets-observablearray.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/adoptedstylesheets-observablearray.html
@@ -89,4 +89,15 @@ test(function() {
   const shadow = host.attachShadow({mode: 'open'});
   assert_true(Array.isArray(shadow.adoptedStyleSheets));
 }, "adoptedStyleSheets should return true for isArray()");
+
+test(function() {
+  let backing = null;
+  Object.defineProperty(Array.prototype, "1", {
+    configurable: true,
+    set(v) { backing = this; }
+  });
+  document.adoptedStyleSheets = [new CSSStyleSheet(), new CSSStyleSheet()];
+  delete Array.prototype["1"];
+  assert_equals(backing, null);
+}, "adoptedStyleSheets should not expose its backing object via prototype");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/all-initial-csstext-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/all-initial-csstext-expected.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSSOM: cssText round-trip with `all: initial`</title>
+  <style>
+    .test {
+      all: initial;
+      display: block;
+      border: 1px solid #ccc;
+      padding: 10px;
+    }
+  </style>
+</head>
+<body>
+  <div class="test">First Element</div>
+  <br/>
+  <div class="test">Clone element</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/all-initial-csstext-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/all-initial-csstext-ref.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSSOM: cssText round-trip with `all: initial`</title>
+  <style>
+    .test {
+      all: initial;
+      display: block;
+      border: 1px solid #ccc;
+      padding: 10px;
+    }
+  </style>
+</head>
+<body>
+  <div class="test">First Element</div>
+  <br/>
+  <div class="test">Clone element</div>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/all-initial-csstext.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/all-initial-csstext.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>CSSOM: cssText round-trip with `all: initial`</title>
+  <link rel="author" title="Peng Zhou" href="mailto:zhoupeng.1996@bytedance.com">
+  <link rel="help" href="https://drafts.csswg.org/cssom/#dom-cssstyledeclaration-csstext">
+  <link rel="help" href="https://drafts.csswg.org/cssom/#css-declaration-blocks">
+  <link rel="match" href="all-initial-csstext-ref.html">
+  <style>
+    .test {
+      all: initial;
+      display: block;
+      border: 1px solid #ccc;
+      padding: 10px;
+    }
+  </style>
+</head>
+<body>
+  <div class="test">First Element</div>
+  <br/>
+  <div class="test-clone">Clone element</div>
+  <script>
+    const styleSheet = document.styleSheets[0];
+    const cssText = styleSheet.cssRules[0].style.cssText;
+    styleSheet.insertRule('.test-clone { ' + cssText + ' }', 1);
+  </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretRangeFromPoint-replace-document.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretRangeFromPoint-replace-document.tentative.html
@@ -10,8 +10,8 @@
     document.replaceChild(textarea, document.documentElement);
     let range = document.caretRangeFromPoint(0, 0);
     assert_true(range instanceof Range);
-    assert_equals(range.startOffset, 1);
-    assert_equals(range.endOffset, 1);
+    assert_equals(range.startOffset, 0);
+    assert_equals(range.endOffset, 0);
     assert_equals(range.startContainer, textarea);
     assert_equals(range.endContainer, textarea);
   }, "document.caretRangeFromPoint(0, 0)");

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretRangeFromPoint-textarea-transform.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretRangeFromPoint-textarea-transform.tentative-expected.txt
@@ -1,5 +1,5 @@
 
 
-FAIL document.caretRangeFromPoint(0, 0) assert_equals: expected Element node <textarea id="textarea">AAAAAAAAAAAAAAAAAAAAA</textarea> but got Element node <body><textarea id="textarea">AAAAAAAAAAAAAAAAAAAAA</text...
+PASS document.caretRangeFromPoint(0, 0)
 PASS document.caretRangeFromPoint(10, 10)
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretRangeFromPoint-textarea-transform.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretRangeFromPoint-textarea-transform.tentative.html
@@ -7,7 +7,7 @@
 <style>
   textarea {
     display: block;
-    translate: -50%;
+    translate: -50% -50%;
   }
 </style>
 <textarea id="textarea">

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretRangeFromPoint.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretRangeFromPoint.tentative-expected.txt
@@ -6,13 +6,12 @@ PASS document.caretRangeFromPoint() should return null if given coordinates outs
 PASS document.caretRangeFromPoint() should return a Range at the specified location
 PASS document.caretRangeFromPoint() should return a client rect close to the given coords
 FAIL document.caretRangeFromPoint() on a shadow should return a Range pointing at the same node as caretPositionFromPoint assert_equals: expected Element node <body><div id="div">abc</div>
-<div id="shadow">
+<div id="shadow"></div>
 
-</div>... but got Element node <div id="shadow">
+<c... but got Element node <div id="shadow"></div>
+FAIL document.caretRangeFromPoint() on a canvas should return a Range pointing at canvas assert_equals: expected Element node <canvas id="canvas" width="500" height="500"></canvas> but got Element node <body><div id="div">abc</div>
+<div id="shadow"></div>
 
-</div>
-FAIL document.caretRangeFromPoint() on a textarea should return a Range pointing at canvas assert_equals: expected Element node <canvas id="canvas" width="500" height="500"></canvas> but got Element node <body><div id="div">abc</div>
-<div id="shadow">
-
-</div>...
+<c...
+PASS document.caretRangeFromPoint() on an input should return a Range pointing at input with offset 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretRangeFromPoint.tentative.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretRangeFromPoint.tentative.html
@@ -7,6 +7,7 @@
 <style>
   div {
     display: inline-block;
+    font-family: monospace;
   }
   canvas {
     display: block;
@@ -14,13 +15,10 @@
   };
 </style>
 <div id="div">abc</div>
-<div id="shadow">
-  <template shadowrootmode="open">
-    <div>def</div>
-  </template>
-</div>
+<div id="shadow"><template shadowrootmode="open"><div>def</div></template></div>
 
 <canvas id="canvas" width="500" height="500"></canvas>
+<input id="input" value="aaaaaaaaaaaaaaaaaaaaaaaaaaa">
 
 <script>
   test(() => {
@@ -85,7 +83,7 @@
     const range = document.caretRangeFromPoint(x, y);
     let rangeRect = range.getBoundingClientRect();
     assert_approx_equals(rangeRect.x, x, 1);
-    assert_approx_equals(rangeRect.y, rect.height / 2, 3);
+    assert_approx_equals(rangeRect.y, rect.top, 3);
     assert_approx_equals(rangeRect.height, rect.height, 1);
     assert_approx_equals(rangeRect.width, 0, 0.02, "Caret range should be collapsed");
   }, "document.caretRangeFromPoint() should return a client rect close to the given coords");
@@ -93,7 +91,7 @@
   test(() => {
     const shadowDiv = shadow.shadowRoot.querySelector("div");
     const rect = shadow.getBoundingClientRect();
-    const characterWidth = rect.width / shadow.textContent.length;
+    const characterWidth = rect.width / shadow.shadowRoot.textContent.length;
     const characterIndex = 2;
     const x = rect.left + characterWidth * characterIndex;
     const y = rect.top + rect.height / 2;
@@ -102,8 +100,8 @@
     assert_true(range instanceof Range);
     assert_equals(range.startContainer, point.offsetNode);
     assert_equals(range.endContainer, point.offsetNode);
-    assert_equals(range.startOffset, characterIndex);
-    assert_equals(range.endOffset, characterIndex);
+    assert_equals(range.startOffset, point.offset);
+    assert_equals(range.endOffset, point.offset);
     assert_true(range.collapsed);
   }, "document.caretRangeFromPoint() on a shadow should return a Range pointing at the same node as caretPositionFromPoint");
 
@@ -118,5 +116,18 @@
     assert_equals(range.startOffset, 0);
     assert_equals(range.endOffset, 0);
     assert_true(range.collapsed);
-  }, "document.caretRangeFromPoint() on a textarea should return a Range pointing at canvas");
+  }, "document.caretRangeFromPoint() on a canvas should return a Range pointing at canvas");
+
+  test(() => {
+    const rect = input.getBoundingClientRect();
+    const x = rect.left + rect.width / 2;
+    const y = rect.top + rect.height / 2;
+    const range = document.caretRangeFromPoint(x, y);
+    assert_true(range instanceof Range);
+    assert_equals(range.startContainer, input);
+    assert_equals(range.endContainer, input);
+    assert_equals(range.startOffset, 0);
+    assert_equals(range.endOffset, 0);
+    assert_true(range.collapsed);
+  }, "document.caretRangeFromPoint() on an input should return a Range pointing at input with offset 0");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-all-shorthand-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-all-shorthand-expected.txt
@@ -5,4 +5,25 @@ PASS getPropertyValue('all') returns empty string when single property overriden
 PASS setProperty('all') sets all property values
 PASS removeProperty('all') removes all declarations affected by 'all'
 PASS removeProperty('all') removes an 'all' declaration
+PASS getPropertyValue('all') returns css-wide keyword when 'all' overrides prior property
+PASS getPropertyValue('all') returns later 'all' value when it overrides earlier 'all' and properties
+PASS getPropertyValue('all') returns empty string when property overridden after 'all'
+PASS getPropertyValue('all') returns empty string when single property overridden after 'all' via insertRule
+PASS getPropertyValue('all') returns css-wide keyword when 'all' overrides prior property via insertRule
+PASS getPropertyValue('all') returns later 'all' value when it overrides earlier 'all' and properties via insertRule
+PASS getPropertyValue('all') returns empty string when property overridden after 'all' via insertRule
+PASS getPropertyValue('all') returns empty string when single property overriden via setProperty
+PASS setProperty('all') overrides existing properties and earlier 'all'
+PASS getPropertyValue('all') returns empty string when property overridden after 'all' via setProperty
+PASS getPropertyValue('all') returns empty string with shorthand 'margin'
+PASS getPropertyValue('all') returns css-wide keyword when 'all' overrides shorthand 'margin'
+PASS getPropertyValue('all') returns empty string with shorthand 'margin' via setProperty
+PASS getPropertyValue('all') returns css-wide keyword when 'all' overrides shorthand 'margin' via setProperty
+PASS getPropertyValue('all') returns empty string with shorthand 'margin' via insertRule
+PASS getPropertyValue('all') returns css-wide keyword when 'all' overrides shorthand 'margin' via insertRule
+PASS getPropertyValue('margin') returns all's value when 'all' after 'margin-top'
+PASS getPropertyValue('margin') returns empty string when some of 'margin's longhands are overridden by 'all'
+PASS getPropertyValue('margin') returns serialized string when longhands are after 'all'
+PASS getPropertyValue('margin') returns all's value when all of 'margin's longhands are overridden by 'all'
+PASS getPropertyValue('margin') returns all's value when 'all' is redeclared after margin longhands
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-all-shorthand.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-all-shorthand.html
@@ -51,4 +51,167 @@
     assert_equals(style.getPropertyValue("all"), "");
   }, "removeProperty('all') removes an 'all' declaration");
 
+  test((t) => {
+    t.add_cleanup(() => { style.cssText = ""; } );
+    style.cssText = "width: 50px; all: revert";
+    assert_equals(style.getPropertyValue("width"), "revert");
+    assert_equals(style.getPropertyValue("all"), "revert");
+  }, "getPropertyValue('all') returns css-wide keyword when 'all' overrides prior property");
+
+  test((t) => {
+    t.add_cleanup(() => { style.cssText = ""; } );
+    style.cssText = "all: revert; width: 50px; all: unset";
+    assert_equals(style.getPropertyValue("width"), "unset");
+    assert_equals(style.getPropertyValue("all"), "unset");
+  }, "getPropertyValue('all') returns later 'all' value when it overrides earlier 'all' and properties");
+
+  test((t) => {
+    t.add_cleanup(() => { style.cssText = ""; } );
+    style.cssText = "width: 50px; all: revert; width: 100px";
+    assert_equals(style.getPropertyValue("width"), "100px");
+    assert_equals(style.getPropertyValue("all"), "");
+  }, "getPropertyValue('all') returns empty string when property overridden after 'all'");
+
+  test((t) => {
+    const sheet = new CSSStyleSheet();
+    sheet.insertRule(".foo { all: revert; width: 50px; }");
+    const style = sheet.cssRules[0].style;
+    assert_equals(style.getPropertyValue("width"), "50px");
+    assert_equals(style.getPropertyValue("all"), "");
+  }, "getPropertyValue('all') returns empty string when single property overridden after 'all' via insertRule");
+
+  test((t) => {
+    const sheet = new CSSStyleSheet();
+    sheet.insertRule(".foo { width: 50px; all: revert; }");
+    const style = sheet.cssRules[0].style;
+    assert_equals(style.getPropertyValue("width"), "revert");
+    assert_equals(style.getPropertyValue("all"), "revert");
+  }, "getPropertyValue('all') returns css-wide keyword when 'all' overrides prior property via insertRule");
+
+  test((t) => {
+    const sheet = new CSSStyleSheet();
+    sheet.insertRule(".foo { all: revert; width: 50px; all: unset; }");
+    const style = sheet.cssRules[0].style;
+    assert_equals(style.getPropertyValue("width"), "unset");
+    assert_equals(style.getPropertyValue("all"), "unset");
+  }, "getPropertyValue('all') returns later 'all' value when it overrides earlier 'all' and properties via insertRule");
+
+  test((t) => {
+    const sheet = new CSSStyleSheet();
+    sheet.insertRule(".foo { width: 50px; all: revert; width: 100px; }");
+    const style = sheet.cssRules[0].style;
+    assert_equals(style.getPropertyValue("width"), "100px");
+    assert_equals(style.getPropertyValue("all"), "");
+  }, "getPropertyValue('all') returns empty string when property overridden after 'all' via insertRule");
+
+  test((t) => {
+    t.add_cleanup(() => { style.cssText = ""; } );
+    style.cssText = "all: revert";
+    style.setProperty("width", "50px");
+    assert_equals(style.getPropertyValue("width"), "50px");
+    assert_equals(style.getPropertyValue("all"), "");
+  }, "getPropertyValue('all') returns empty string when single property overriden via setProperty");
+
+  test((t) => {
+    t.add_cleanup(() => { style.cssText = ""; } );
+    style.cssText = "all: revert; width: 50px";
+    style.setProperty("all", "unset");
+    assert_equals(style.getPropertyValue("width"), "unset");
+    assert_equals(style.getPropertyValue("all"), "unset");
+  }, "setProperty('all') overrides existing properties and earlier 'all'");
+
+  test((t) => {
+    t.add_cleanup(() => { style.cssText = ""; } );
+    style.cssText = "width: 50px; all: revert";
+    style.setProperty("width", "100px");
+    assert_equals(style.getPropertyValue("width"), "100px");
+    assert_equals(style.getPropertyValue("all"), "");
+  }, "getPropertyValue('all') returns empty string when property overridden after 'all' via setProperty");
+
+  test((t) => {
+    t.add_cleanup(() => { style.cssText = ""; } );
+    style.cssText = "all: revert; margin: initial";
+    assert_equals(style.getPropertyValue("margin"), "initial");
+    assert_equals(style.getPropertyValue("all"), "");
+  }, "getPropertyValue('all') returns empty string with shorthand 'margin'");
+
+  test((t) => {
+    t.add_cleanup(() => { style.cssText = ""; } );
+    style.cssText = "margin: initial; all: revert";
+    assert_equals(style.getPropertyValue("margin"), "revert");
+    assert_equals(style.getPropertyValue("all"), "revert");
+  }, "getPropertyValue('all') returns css-wide keyword when 'all' overrides shorthand 'margin'");
+
+  test((t) => {
+    t.add_cleanup(() => { style.cssText = ""; } );
+    style.cssText = "all: revert";
+    style.setProperty("margin", "initial");
+    assert_equals(style.getPropertyValue("margin"), "initial");
+    assert_equals(style.getPropertyValue("all"), "");
+  }, "getPropertyValue('all') returns empty string with shorthand 'margin' via setProperty");
+
+  test((t) => {
+    t.add_cleanup(() => { style.cssText = ""; } );
+    style.cssText = "margin: initial";
+    style.setProperty("all", "revert");
+    assert_equals(style.getPropertyValue("margin"), "revert");
+    assert_equals(style.getPropertyValue("all"), "revert");
+  }, "getPropertyValue('all') returns css-wide keyword when 'all' overrides shorthand 'margin' via setProperty");
+
+  test((t) => {
+    const sheet = new CSSStyleSheet();
+    sheet.insertRule(".foo { all: revert; margin: initial; }");
+    const style = sheet.cssRules[0].style;
+    assert_equals(style.getPropertyValue("margin"), "initial");
+    assert_equals(style.getPropertyValue("all"), "");
+  }, "getPropertyValue('all') returns empty string with shorthand 'margin' via insertRule");
+
+  test((t) => {
+    const sheet = new CSSStyleSheet();
+    sheet.insertRule(".foo { margin: initial; all: revert; }");
+    const style = sheet.cssRules[0].style;
+    assert_equals(style.getPropertyValue("margin"), "revert");
+    assert_equals(style.getPropertyValue("all"), "revert");
+  }, "getPropertyValue('all') returns css-wide keyword when 'all' overrides shorthand 'margin' via insertRule");
+
+  test((t) => {
+    t.add_cleanup(() => { style.cssText = ""; } );
+    style.cssText = "margin-top: 10px; all: revert";
+    assert_equals(style.getPropertyValue("margin"), "revert");
+    assert_equals(style.getPropertyValue("all"), "revert");
+    assert_equals(style.getPropertyValue("font"), "revert");
+  }, "getPropertyValue('margin') returns all's value when 'all' after 'margin-top'");
+
+  test((t) => {
+    t.add_cleanup(() => { style.cssText = ""; } );
+    style.cssText = "margin-top:10px; margin-right:20px; all: revert; margin-bottom:30px; margin-left:40px";
+    assert_equals(style.getPropertyValue("margin"), "");
+    assert_equals(style.getPropertyValue("all"), "");
+    assert_equals(style.getPropertyValue("font"), "revert");
+  }, "getPropertyValue('margin') returns empty string when some of 'margin's longhands are overridden by 'all'");
+
+  test((t) => {
+    t.add_cleanup(() => { style.cssText = ""; } );
+    style.cssText = "all: revert; margin-top: 10px; margin-right: 20px; margin-bottom: 30px; margin-left: 40px";
+    assert_equals(style.getPropertyValue("margin"), "10px 20px 30px 40px");
+    assert_equals(style.getPropertyValue("all"), "");
+    assert_equals(style.getPropertyValue("font"), "revert");
+  }, "getPropertyValue('margin') returns serialized string when longhands are after 'all'");
+
+  test((t) => {
+    t.add_cleanup(() => { style.cssText = ""; } );
+    style.cssText = "margin-top: 10px; margin-right: 20px; margin-bottom: 30px; margin-left: 40px; all: revert";
+    assert_equals(style.getPropertyValue("margin"), "revert");
+    assert_equals(style.getPropertyValue("all"), "revert");
+    assert_equals(style.getPropertyValue("font"), "revert");
+  }, "getPropertyValue('margin') returns all's value when all of 'margin's longhands are overridden by 'all'");
+
+  test((t) => {
+    t.add_cleanup(() => { style.cssText = ""; } );
+    style.cssText = "all: revert; margin-top: 10px; margin-right: 20px; margin-bottom: 30px; margin-left: 40px; all: unset";
+    assert_equals(style.getPropertyValue("margin"), "unset");
+    assert_equals(style.getPropertyValue("all"), "unset");
+    assert_equals(style.getPropertyValue("font"), "unset");
+  }, "getPropertyValue('margin') returns all's value when 'all' is redeclared after margin longhands");
+
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-nested-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-nested-expected.txt
@@ -1,0 +1,4 @@
+C
+
+PASS CSSNestedDeclarationBlock cssom interactions
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-nested.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-nested.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<title>CSSNestedDeclarationBlock cssom interactions</title>
+<link rel="help" href="https://drafts.csswg.org/css-nesting/#the-cssnestrule">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style id="s1">
+.parent {
+  color: red;
+  .child { background: blue; }
+  font-size: 20px;
+}
+</style>
+<div class="parent"><div class="child">C</div></div>
+<script>
+test(function() {
+  const sheet = document.getElementById('s1').sheet;
+  const nested = sheet.cssRules[0].cssRules[1];
+  assert_true(nested instanceof CSSNestedDeclarations, "Should be a nested declarations rule");
+  nested.style.color = "green";
+  assert_equals(
+    getComputedStyle(document.querySelector(".parent")).color,
+    "rgb(0, 128, 0)",
+    "Parent should be green now"
+  );
+});
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-removeProperty-all-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-removeProperty-all-expected.txt
@@ -1,3 +1,4 @@
 
 PASS CSSStyleDeclaration.removeProperty("all")
+PASS CSSStyleDeclaration.removeProperty("all") 1
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-removeProperty-all.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-removeProperty-all.html
@@ -14,4 +14,11 @@
     style.removeProperty("all");
     assert_equals(style.length, 0, "all is a shorthand of all properties, so should remove the property");
   });
+
+  test(function() {
+    let style = document.createElement("div").style;
+    style.cssText = "width: 40px; all: revert";
+    style.removeProperty("all");
+    assert_equals(style.getPropertyValue("all"), "", "all is a shorthand of all properties, so should return empty string");
+  });
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/font-family-serialization-001-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/font-family-serialization-001-expected.txt
@@ -1,6 +1,26 @@
 
-PASS Serialization of <generic-family>
-FAIL Serialization of quoted "<generic-family>" assert_equals: expected "\"serif\"" but got "serif"
-FAIL Serialization of prefixed -webkit-<generic-family> assert_equals: expected "-webkit-serif" but got "serif"
-FAIL Serialization of NonGenericFontFamilyName,-webkit-body,-webkit-standard,-webkit-pictograph,BlinkMacSystemFont assert_equals: expected "-webkit-body" but got "Times"
+FAIL Serialization of <generic-family> assert_equals: expected "generic(fangsong)" but got "-webkit-standard"
+FAIL Serialization of quoted "<generic-family>" assert_equals: expected "\"system-ui\"" but got "system-ui"
+FAIL Serialization of prefixed -webkit-<generic-family> assert_equals: expected "-webkit-generic(fangsong)" but got "-webkit-standard"
+FAIL Serialization of NonGenericFontFamilyName,-webkit-body,-webkit-standard,-webkit-pictograph,emoji,fangsong,BlinkMacSystemFont assert_equals: expected "-webkit-body" but got "Times"
+PASS Specified: multi-word family name serializes unquoted
+PASS Specified: quoted multi-word name normalizes to unquoted
+PASS Specified: three-word family name serializes unquoted
+PASS Computed: multi-word family name serializes unquoted
+PASS Computed: quoted multi-word name normalizes to unquoted
+PASS Specified: single-word family name
+PASS Specified: quoted single-word name normalizes to unquoted
+PASS Specified: digit-starting family name stays quoted
+PASS Computed: digit-starting family name stays quoted
+PASS Specified: single-digit family name stays quoted
+PASS Specified: quoted 'serif' stays quoted
+PASS Specified: quoted 'sans-serif' stays quoted
+PASS Computed: quoted 'serif' stays quoted
+PASS Specified: quoted 'initial' stays quoted
+PASS Specified: quoted 'inherit' stays quoted
+PASS Specified: quoted 'unset' stays quoted
+PASS Specified: quoted 'default' stays quoted
+PASS Specified: double-space family name stays quoted
+PASS Specified: mixed font-family list serialization
+PASS Computed: mixed font-family list serialization
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/font-family-serialization-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/font-family-serialization-001.html
@@ -4,16 +4,26 @@
 <title>Serialization of font-family</title>
 <link rel="help" href="https://drafts.csswg.org/cssom/#serialize-a-css-declaration-block">
 <link rel="help" href="https://drafts.csswg.org/css-fonts-4/#font-family-prop">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/5846">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/css/css-fonts/support/font-family-keywords.js"></script>
 <div id="target"></div>
 <script>
+  var target = document.getElementById('target');
+
   function SetFontFamilyAndSerialize(fontFamilyValue) {
-    var target = document.getElementById('target');
     target.setAttribute("style", `font-family: ${fontFamilyValue}`);
     return window.getComputedStyle(target).getPropertyValue('font-family');
   }
+
+  function SetFontFamilyAndSerializeSpecified(fontFamilyValue) {
+    target.setAttribute("style", `font-family: ${fontFamilyValue}`);
+    return target.style.fontFamily;
+  }
+
+  // Generic family keywords.
+
   test(function() {
     kGenericFontFamilyKeywords.forEach(keyword => {
       assert_equals(SetFontFamilyAndSerialize(keyword), keyword);
@@ -39,6 +49,105 @@
       assert_equals(SetFontFamilyAndSerialize(keyword), keyword);
     });
   }, `Serialization of ${kNonGenericFontFamilyKeywords}`);
+
+  // Multi-word family names: valid ident sequences serialize unquoted.
+  // See https://github.com/w3c/csswg-drafts/issues/5846
+
+  test(function() {
+    assert_equals(SetFontFamilyAndSerializeSpecified("Twisty Tie"), "Twisty Tie");
+  }, "Specified: multi-word family name serializes unquoted");
+
+  test(function() {
+    assert_equals(SetFontFamilyAndSerializeSpecified("'Twisty Tie'"), "Twisty Tie");
+  }, "Specified: quoted multi-word name normalizes to unquoted");
+
+  test(function() {
+    assert_equals(SetFontFamilyAndSerializeSpecified("Times New Roman"), "Times New Roman");
+  }, "Specified: three-word family name serializes unquoted");
+
+  test(function() {
+    assert_equals(SetFontFamilyAndSerialize("Twisty Tie"), "Twisty Tie");
+  }, "Computed: multi-word family name serializes unquoted");
+
+  test(function() {
+    assert_equals(SetFontFamilyAndSerialize("'Times New Roman'"), "Times New Roman");
+  }, "Computed: quoted multi-word name normalizes to unquoted");
+
+  // Single-word valid ident: no quotes needed.
+
+  test(function() {
+    assert_equals(SetFontFamilyAndSerializeSpecified("Veronica"), "Veronica");
+  }, "Specified: single-word family name");
+
+  test(function() {
+    assert_equals(SetFontFamilyAndSerializeSpecified("'Veronica'"), "Veronica");
+  }, "Specified: quoted single-word name normalizes to unquoted");
+
+  // Names starting with a digit: must be quoted.
+
+  test(function() {
+    assert_equals(SetFontFamilyAndSerializeSpecified("'34J'"), '"34J"');
+  }, "Specified: digit-starting family name stays quoted");
+
+  test(function() {
+    assert_equals(SetFontFamilyAndSerialize("'34J'"), '"34J"');
+  }, "Computed: digit-starting family name stays quoted");
+
+  test(function() {
+    assert_equals(SetFontFamilyAndSerializeSpecified("'1'"), '"1"');
+  }, "Specified: single-digit family name stays quoted");
+
+  // Quoted generic family keywords as family-name: must stay quoted.
+
+  test(function() {
+    assert_equals(SetFontFamilyAndSerializeSpecified('"serif"'), '"serif"');
+  }, "Specified: quoted 'serif' stays quoted");
+
+  test(function() {
+    assert_equals(SetFontFamilyAndSerializeSpecified('"sans-serif"'), '"sans-serif"');
+  }, "Specified: quoted 'sans-serif' stays quoted");
+
+  test(function() {
+    assert_equals(SetFontFamilyAndSerialize('"serif"'), '"serif"');
+  }, "Computed: quoted 'serif' stays quoted");
+
+  // CSS-wide keywords as family-name: must stay quoted.
+
+  test(function() {
+    assert_equals(SetFontFamilyAndSerializeSpecified('"initial"'), '"initial"');
+  }, "Specified: quoted 'initial' stays quoted");
+
+  test(function() {
+    assert_equals(SetFontFamilyAndSerializeSpecified('"inherit"'), '"inherit"');
+  }, "Specified: quoted 'inherit' stays quoted");
+
+  test(function() {
+    assert_equals(SetFontFamilyAndSerializeSpecified('"unset"'), '"unset"');
+  }, "Specified: quoted 'unset' stays quoted");
+
+  test(function() {
+    assert_equals(SetFontFamilyAndSerializeSpecified('"default"'), '"default"');
+  }, "Specified: quoted 'default' stays quoted");
+
+  // Names with special characters: must stay quoted.
+
+  test(function() {
+    assert_equals(SetFontFamilyAndSerializeSpecified("'A  B'"), '"A  B"');
+  }, "Specified: double-space family name stays quoted");
+
+  // Multiple families in a list.
+
+  test(function() {
+    assert_equals(
+        SetFontFamilyAndSerializeSpecified("Twisty Tie, '34J', \"serif\", Veronica, sans-serif"),
+        "Twisty Tie, \"34J\", \"serif\", Veronica, sans-serif");
+  }, "Specified: mixed font-family list serialization");
+
+  test(function() {
+    assert_equals(
+        SetFontFamilyAndSerialize("Twisty Tie, '34J', \"serif\", Veronica, sans-serif"),
+        "Twisty Tie, \"34J\", \"serif\", Veronica, sans-serif");
+  }, "Computed: mixed font-family list serialization");
 
 </script>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/invalid-pseudo-elements.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/invalid-pseudo-elements.html
@@ -1,6 +1,7 @@
 <!doctype html>
 <meta charset="utf-8">
 <title>CSSOM: Test that rules with invalid pseudo elements are not found</title>
+<link rel="author" title="Tim Nguyen" href="https://github.com/nt1m">
 <link rel="help" href="https://drafts.csswg.org/cssom/">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/selectorText-modification-restyle-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/selectorText-modification-restyle-002.html
@@ -2,7 +2,7 @@
 <title>CSSOM: Modify selectorText in a shadow tree stylesheet</title>
 <link rel="author" title="Rune Lillesveen" href="mailto:futhark@chromium.org">
 <link rel="help" href="https://drafts.csswg.org/cssom/#dom-cssstylerule-selectortext">
-<link rel="help" href="https://drafts.csswg.org/css-scoping/#selectors">
+<link rel="help" href="https://drafts.csswg.org/css-shadow/#selectors">
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/serialize-values-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/serialize-values-expected.txt
@@ -1,4 +1,13 @@
 
+PASS alignment-baseline: baseline
+FAIL alignment-baseline: text-bottom assert_equals: alignment-baseline raw inline style declaration expected "text-bottom" but got ""
+PASS alignment-baseline: alphabetic
+PASS alignment-baseline: ideographic
+PASS alignment-baseline: middle
+PASS alignment-baseline: central
+PASS alignment-baseline: mathematical
+FAIL alignment-baseline: text-top assert_equals: alignment-baseline raw inline style declaration expected "text-top" but got ""
+PASS alignment-baseline: inherit
 PASS background-attachment: scroll
 PASS background-attachment: fixed
 PASS background-attachment: inherit
@@ -187,6 +196,21 @@ PASS background-repeat: repeat-x
 PASS background-repeat: repeat-y
 PASS background-repeat: no-repeat
 PASS background-repeat: inherit
+PASS baseline-shift: sub
+PASS baseline-shift: super
+FAIL baseline-shift: top assert_equals: baseline-shift raw inline style declaration expected "top" but got ""
+FAIL baseline-shift: center assert_equals: baseline-shift raw inline style declaration expected "center" but got ""
+FAIL baseline-shift: bottom assert_equals: baseline-shift raw inline style declaration expected "bottom" but got ""
+PASS baseline-shift: 5%
+PASS baseline-shift: .5%
+PASS baseline-shift: 0px
+PASS baseline-shift: 1px
+PASS baseline-shift: .1em
+PASS baseline-shift: inherit
+FAIL baseline-source: auto assert_equals: baseline-source raw inline style declaration expected (string) "auto" but got (undefined) undefined
+FAIL baseline-source: first assert_equals: baseline-source raw inline style declaration expected (string) "first" but got (undefined) undefined
+FAIL baseline-source: last assert_equals: baseline-source raw inline style declaration expected (string) "last" but got (undefined) undefined
+FAIL baseline-source: inherit assert_equals: baseline-source raw inline style declaration expected (string) "inherit" but got (undefined) undefined
 PASS border-collapse: collapse
 PASS border-collapse: separate
 PASS border-collapse: inherit
@@ -377,7 +401,7 @@ PASS float: right
 PASS float: none
 PASS float: inherit
 PASS font-family: Arial
-FAIL font-family: 'Lucida Grande' assert_equals: font-family raw inline style declaration expected "\"Lucida Grande\"" but got "Lucida Grande"
+PASS font-family: 'Lucida Grande'
 PASS font-family: serif
 PASS font-family: sans-serif
 PASS font-family: inherit
@@ -643,20 +667,6 @@ PASS unicode-bidi: normal
 PASS unicode-bidi: embed
 PASS unicode-bidi: bidi-override
 PASS unicode-bidi: inherit
-PASS vertical-align: baseline
-PASS vertical-align: sub
-PASS vertical-align: super
-PASS vertical-align: top
-PASS vertical-align: text-top
-PASS vertical-align: middle
-PASS vertical-align: bottom
-PASS vertical-align: text-bottom
-PASS vertical-align: 5%
-PASS vertical-align: .5%
-PASS vertical-align: 0px
-PASS vertical-align: 1px
-PASS vertical-align: .1em
-PASS vertical-align: inherit
 PASS visibility: visible
 PASS visibility: hidden
 PASS visibility: collapse

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/serialize-values.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/serialize-values.html
@@ -112,7 +112,7 @@
     }
 
     function family_name() {
-      var values = ['Arial', {actual: "'Lucida Grande'", serialized: '"Lucida Grande"'}];
+      var values = ['Arial', {actual: "'Lucida Grande'", serialized: 'Lucida Grande'}];
       return iterable(values);
     }
 
@@ -264,6 +264,11 @@
     }
 
     var properties = [
+      ['alignment-baseline', {
+        'values': ['baseline', 'text-bottom', 'alphabetic', 'ideographic', 'middle',
+                   'central', 'mathematical', 'text-top', 'inherit'],
+        'initial': 'baseline'
+      }],
       ['background-attachment', {
         'values': ['scroll', 'fixed', 'inherit'],
         'initial': 'scroll',
@@ -287,6 +292,14 @@
       ['background-repeat', {
         'values': ['repeat', 'repeat-x', 'repeat-y', 'no-repeat', 'inherit'],
         'initial': 'repeat',
+      }],
+      ['baseline-shift', {
+        'values': ['sub', 'super', 'top', 'center', 'bottom', percentage, length, 'inherit'],
+        'initial': '0',
+      }],
+      ['baseline-source', {
+        'values': ['auto', 'first', 'last', 'inherit'],
+        'initial': 'auto',
       }],
       //background
       ['border-collapse', {
@@ -575,11 +588,6 @@
       ['unicode-bidi', {
         'values': ['normal', 'embed', 'bidi-override', 'inherit'],
         'initial': 'normal',
-      }],
-      ['vertical-align', {
-        'values': ['baseline', 'sub', 'super', 'top', 'text-top', 'middle', 'bottom', 'text-bottom',
-                   percentage, length, 'inherit'],
-        'initial': 'baseline',
       }],
       ['visibility', {
         'values': ['visible', 'hidden', 'collapse', 'inherit'],

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/set-selector-text-detached-rule-delete-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/set-selector-text-detached-rule-delete-crash.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<title>Crash when mutating selector test on detached rule tree (delete)</title>
+<link rel="help" href="https://issues.chromium.org/issues/499784386">
+<script>
+  const sheet = new CSSStyleSheet();
+  sheet.replaceSync('.a { .b { .c {} } } }');
+  const a = sheet.cssRules[0];
+  const b = a.cssRules[0];
+  b.cssRules[0];
+  sheet.deleteRule(0);
+  b.selectorText = '.bb';
+  b.insertRule('.r {}');
+  a.selectorText = '.aa';
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/set-selector-text-detached-rule-replace-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/set-selector-text-detached-rule-replace-crash.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<title>Crash when mutating selector test on detached rule tree (replace)</title>
+<link rel="help" href="https://issues.chromium.org/issues/499784386">
+<script>
+  const sheet = new CSSStyleSheet();
+  sheet.replaceSync('.a { .b { .c {} } } }');
+  const a = sheet.cssRules[0];
+  const b = a.cssRules[0];
+  b.cssRules[0];
+  sheet.replaceSync('');
+  b.selectorText = '.bb';
+  b.insertRule('.r {}');
+  a.selectorText = '.aa';
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/shorthand-values-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/shorthand-values-expected.txt
@@ -13,7 +13,7 @@ PASS The serialization of border: solid; border-style: dotted should be canonica
 PASS The serialization of border-width: 1px; should be canonical.
 PASS The serialization of overflow-x: scroll; overflow-y: hidden; should be canonical.
 PASS The serialization of overflow-x: scroll; overflow-y: scroll; should be canonical.
-PASS The serialization of outline-width: 2px; outline-style: dotted; outline-color: blue; should be canonical.
+FAIL The serialization of outline-width: 2px; outline-style: dotted; outline-color: blue; should be canonical. assert_equals: expected "outline: blue dotted 2px;" but got "outline: 2px dotted blue;"
 PASS The serialization of margin-top: 1px; margin-right: 2px; margin-bottom: 3px; margin-left: 4px; should be canonical.
 PASS The serialization of list-style-type: circle; list-style-position: inside; list-style-image: none; should be canonical.
 PASS The serialization of list-style-type: lower-alpha; should be canonical.

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/shorthand-values.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/shorthand-values.html
@@ -35,7 +35,7 @@
         'border-width: 1px;': 'border-width: 1px;',
         'overflow-x: scroll; overflow-y: hidden;': 'overflow: scroll hidden;',
         'overflow-x: scroll; overflow-y: scroll;': 'overflow: scroll;',
-        'outline-width: 2px; outline-style: dotted; outline-color: blue;': 'outline: 2px dotted blue;',
+        'outline-width: 2px; outline-style: dotted; outline-color: blue;': 'outline: blue dotted 2px;',
         'margin-top: 1px; margin-right: 2px; margin-bottom: 3px; margin-left: 4px;': 'margin: 1px 2px 3px 4px;',
         'list-style-type: circle; list-style-position: inside; list-style-image: none;': 'list-style: inside circle;',
         'list-style-type: lower-alpha;': 'list-style-type: lower-alpha;',

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/stylesheet-cross-origin-redirect-quirks.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/stylesheet-cross-origin-redirect-quirks.sub-expected.txt
@@ -1,0 +1,6 @@
+
+PASS Cross-origin stylesheet with wrong MIME type
+FAIL Cross-origin redirect to same-origin with wrong MIME type assert_equals: cross-origin redirect to same-origin with wrong MIME type should fire error expected "error" but got "load"
+PASS Same-origin redirect to cross-origin with wrong MIME type
+FAIL Same-origin redirect to cross-origin redirect back to same-origin with wrong MIME type assert_equals: double redirect through cross-origin with wrong MIME type should fire error expected "error" but got "load"
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/stylesheet-cross-origin-redirect-quirks.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/stylesheet-cross-origin-redirect-quirks.sub.html
@@ -1,0 +1,78 @@
+<!--
+  No DOCTYPE: this test must run in quirks mode.
+
+  https://html.spec.whatwg.org/#link-type-stylesheet
+
+     Quirk: If the document has been set to quirks mode, has the same origin as
+     the URL of the external resource, and the Content-Type metadata of the
+     external resource is not a supported style sheet type, the user agent must
+     instead assume it to be text/css.
+
+  This tests direct cross-origin URLs but also cross-origin to same-origin
+  redirects, which are tainted and already get blocked from e.g. accessing
+  .cssRules across browsers.
+-->
+<meta charset="utf-8">
+<title>CSSOM - Cross-origin redirects and MIME type in quirks mode</title>
+<link rel="help" href="https://drafts.csswg.org/cssom/#the-cssstylesheet-interface">
+<link rel="help" href="https://html.spec.whatwg.org/#link-type-stylesheet">
+<link rel="author" href="mailto:emilio@crisal.io" title="Emilio Cobos Álvarez">
+<link rel="author" href="https://mozilla.com" title="Mozilla">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+assert_equals(document.compatMode, "BackCompat", "must be in quirks mode");
+
+const SAME_ORIGIN = "{{location[scheme]}}://{{location[host]}}";
+const CROSS_ORIGIN = "{{location[scheme]}}://{{hosts[alt][]}}:{{location[port]}}";
+const CSS_FILE = "/css/cssom/stylesheet-same-origin.css";
+const CSS_WRONG_MIME = CSS_FILE + "?pipe=header(Content-Type,text/plain)";
+
+function redirect(origin, target) {
+  return origin + "/common/redirect.py?location=" + encodeURIComponent(target);
+}
+
+function loadStylesheet(href) {
+  return new Promise(resolve => {
+    const link = document.createElement("link");
+    link.rel = "stylesheet";
+    link.href = href;
+    link.onload = () => resolve({ link, event: "load" });
+    link.onerror = () => resolve({ link, event: "error" });
+    document.head.appendChild(link);
+  });
+}
+
+// stylesheet-same-origin.css sets body { padding: 10px }.
+function sheetApplied() {
+  return getComputedStyle(document.body).paddingTop == "10px";
+}
+
+promise_test(async t => {
+  const { link, event } = await loadStylesheet(CROSS_ORIGIN + CSS_WRONG_MIME);
+  t.add_cleanup(() => link.remove());
+  assert_equals(event, "error", "cross-origin with wrong MIME type should fire error");
+  assert_false(sheetApplied(), "styles should not apply");
+}, "Cross-origin stylesheet with wrong MIME type");
+
+promise_test(async t => {
+  const { link, event } = await loadStylesheet(redirect(CROSS_ORIGIN, SAME_ORIGIN + CSS_WRONG_MIME));
+  t.add_cleanup(() => link.remove());
+  assert_equals(event, "error", "cross-origin redirect to same-origin with wrong MIME type should fire error");
+  assert_false(sheetApplied(), "styles should not apply");
+}, "Cross-origin redirect to same-origin with wrong MIME type");
+
+promise_test(async t => {
+  const { link, event } = await loadStylesheet(redirect(SAME_ORIGIN, CROSS_ORIGIN + CSS_WRONG_MIME));
+  t.add_cleanup(() => link.remove());
+  assert_equals(event, "error", "same-origin redirect to cross-origin with wrong MIME type should fire error");
+  assert_false(sheetApplied(), "styles should not apply");
+}, "Same-origin redirect to cross-origin with wrong MIME type");
+
+promise_test(async t => {
+  const { link, event } = await loadStylesheet(redirect(SAME_ORIGIN, redirect(CROSS_ORIGIN, SAME_ORIGIN + CSS_WRONG_MIME)));
+  t.add_cleanup(() => link.remove());
+  assert_equals(event, "error", "double redirect through cross-origin with wrong MIME type should fire error");
+  assert_false(sheetApplied(), "styles should not apply");
+}, "Same-origin redirect to cross-origin redirect back to same-origin with wrong MIME type");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/stylesheet-same-origin.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/stylesheet-same-origin.sub-expected.txt
@@ -5,4 +5,5 @@ PASS Origin-clean check in cross-origin CSSOM Stylesheets (redirect from cross-o
 PASS Origin-clean check in loading error CSSOM Stylesheets
 PASS Origin-clean check in same-origin CSSOM Stylesheets
 PASS Origin-clean check in data:css CSSOM Stylesheets
+PASS Origin-clean check in copied cross-origin CSSOM Stylesheets
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/stylesheet-same-origin.sub.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/stylesheet-same-origin.sub.html
@@ -8,6 +8,7 @@
     <script src="/resources/testharnessreport.js"></script>
 
     <link id="crossorigin" href="http://www1.{{host}}:{{ports[http][1]}}/css/cssom/stylesheet-same-origin.css" rel="stylesheet">
+    <link id="crossorigin-clone" href="http://www1.{{host}}:{{ports[http][1]}}/css/cssom/stylesheet-same-origin.css" rel="stylesheet">
     <link id="sameorigin" href="stylesheet-same-origin.css" rel="stylesheet">
     <link id="sameorigindata" href="data:text/css,.green-text{color:rgb(0, 255, 0)}" rel="stylesheet">
     <link id="redirect-sameorigin-to-crossorigin"
@@ -20,6 +21,7 @@
 
     <script>
         var crossorigin = document.getElementById("crossorigin").sheet;
+        var crossoriginClone = document.getElementById("crossorigin-clone").sheet;
         var redirectSameOriginToCrossOrigin = document.getElementById("redirect-sameorigin-to-crossorigin").sheet;
         var redirectCrossOriginToSameOrigin = document.getElementById("redirect-crossorigin-to-sameorigin").sheet;
         var loadError = document.getElementById("loaderror").sheet;
@@ -77,6 +79,11 @@
             doOriginCleanCheck(sameorigindata, "data:css");
         }, "Origin-clean check in data:css CSSOM Stylesheets");
 
+        test(function() {
+            doOriginDirtyCheck(crossoriginClone, "cross-origin clone");
+            crossoriginClone.media.appendMedium("screen");
+            doOriginDirtyCheck(crossoriginClone, "cross-origin clone after mutation");
+        }, "Origin-clean check in copied cross-origin CSSOM Stylesheets");
     </script>
 </head>
 <body>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/cssom/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/cssom/w3c-import.log
@@ -26,6 +26,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSKeyframesRule.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSNamespaceRule.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSRuleList.html
+/LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleDeclaration-iterator.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleRule-set-selectorText-namespace.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleRule-set-selectorText.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleRule.html
@@ -43,6 +44,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleSheet-constructable-invalidation.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleSheet-constructable-replace-cssRules.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleSheet-constructable-replace-on-regular-sheet.html
+/LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleSheet-constructable-replace-thenable.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleSheet-constructable.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleSheet-modify-after-removal.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleSheet-template-adoption.html
@@ -64,6 +66,8 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/MediaList.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/MediaList2.xhtml
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/MutationObserver-style.html
+/LayoutTests/imported/w3c/web-platform-tests/css/cssom/StyleSheetList-constructable-shadow-with-style-recalc.html
+/LayoutTests/imported/w3c/web-platform-tests/css/cssom/StyleSheetList-constructable-shadow.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/StyleSheetList-constructable-with-style-recalc.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/StyleSheetList-constructable.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/StyleSheetList.html
@@ -76,10 +80,14 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/adoptedstylesheets-adopt-style.tentative.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/adoptedstylesheets-modify-array-and-sheet.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/adoptedstylesheets-observablearray.html
+/LayoutTests/imported/w3c/web-platform-tests/css/cssom/all-initial-csstext-expected.html
+/LayoutTests/imported/w3c/web-platform-tests/css/cssom/all-initial-csstext-ref.html
+/LayoutTests/imported/w3c/web-platform-tests/css/cssom/all-initial-csstext.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/at-namespace.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/base-uri.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/border-shorthand-serialization.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint-audioVideo.html
+/LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint-in-flex-container.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint-with-transformation.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretRangeFromPoint-replace-document.tentative.html
@@ -121,6 +129,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-mutationrecord-003.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-mutationrecord-004.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-mutationrecord-005.html
+/LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-nested.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-properties.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-registered-custom-properties.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-removeProperty-all.html
@@ -163,6 +172,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-property-order.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-pseudo-checkmark.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-pseudo-picker-icon.html
+/LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-pseudo-picker.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-pseudo-with-argument.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-pseudo.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/getComputedStyle-resolved-colors.html
@@ -218,12 +228,15 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/serialize-values.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/serialize-variable-reference.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/set-selector-text-attachment.html
+/LayoutTests/imported/w3c/web-platform-tests/css/cssom/set-selector-text-detached-rule-delete-crash.html
+/LayoutTests/imported/w3c/web-platform-tests/css/cssom/set-selector-text-detached-rule-replace-crash.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/setproperty-null-undefined.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/shorthand-serialization.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/shorthand-values.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/style-attr-update-across-documents.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/style-sheet-interfaces-001.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/style-sheet-interfaces-002.html
+/LayoutTests/imported/w3c/web-platform-tests/css/cssom/stylesheet-cross-origin-redirect-quirks.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/stylesheet-replacedata-dynamic-expected.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/stylesheet-replacedata-dynamic-ref.html
 /LayoutTests/imported/w3c/web-platform-tests/css/cssom/stylesheet-replacedata-dynamic.html

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/cssom/stylesheet-same-origin.sub-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/cssom/stylesheet-same-origin.sub-expected.txt
@@ -1,8 +1,0 @@
-
-PASS Origin-clean check in cross-origin CSSOM Stylesheets
-PASS Origin-clean check in cross-origin CSSOM Stylesheets (redirect from same-origin to cross-origin)
-PASS Origin-clean check in cross-origin CSSOM Stylesheets (redirect from cross-origin to same-origin)
-PASS Origin-clean check in loading error CSSOM Stylesheets
-PASS Origin-clean check in same-origin CSSOM Stylesheets
-PASS Origin-clean check in data:css CSSOM Stylesheets
-


### PR DESCRIPTION
#### 433bc2667c27215659742c8d5ac7703f7f1a2707
<pre>
Resync `css/cssom` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=314901">https://bugs.webkit.org/show_bug.cgi?id=314901</a>
<a href="https://rdar.apple.com/177175427">rdar://177175427</a>

Reviewed by Brandon Stewart.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/8440c03c3d9da98b80534a837a918edb6c328e65">https://github.com/web-platform-tests/wpt/commit/8440c03c3d9da98b80534a837a918edb6c328e65</a>

* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleDeclaration-iterator-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleDeclaration-iterator.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleSheet-constructable-replace-thenable-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleSheet-constructable-replace-thenable.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/CSSStyleSheet-template-adoption.html:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/WEB_FEATURES.yml:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/adoptedstylesheets-observablearray-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/adoptedstylesheets-observablearray.html:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/all-initial-csstext-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/all-initial-csstext-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/all-initial-csstext.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretPositionFromPoint.html:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretRangeFromPoint-replace-document.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretRangeFromPoint-textarea-transform.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretRangeFromPoint-textarea-transform.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretRangeFromPoint.tentative-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/caretRangeFromPoint.tentative.html:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-all-shorthand-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-all-shorthand.html:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-nested-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-nested.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-removeProperty-all-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/cssstyledeclaration-removeProperty-all.html:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/font-family-serialization-001-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/font-family-serialization-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/invalid-pseudo-elements.html:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/selectorText-modification-restyle-002.html:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/serialize-values-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/serialize-values.html:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/set-selector-text-detached-rule-delete-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/set-selector-text-detached-rule-replace-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/shorthand-values-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/shorthand-values.html:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/stylesheet-cross-origin-redirect-quirks.sub-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/stylesheet-cross-origin-redirect-quirks.sub.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/stylesheet-same-origin.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/stylesheet-same-origin.sub.html:
* LayoutTests/imported/w3c/web-platform-tests/css/cssom/w3c-import.log:
* LayoutTests/platform/glib/imported/w3c/web-platform-tests/css/cssom/stylesheet-same-origin.sub-expected.txt: Removed.
* Source/WebCore/css/CSSProperties.json:

Canonical link: <a href="https://commits.webkit.org/313348@main">https://commits.webkit.org/313348@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c76225ea58e834cc9c8ecaa16d6fc8c5ba883c5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162835 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36312 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29469 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171773 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119281 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36416 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36315 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126398 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/89018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/52bbea9c-4662-49a2-a933-5cb3193e99f8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165794 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28743 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146314 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106975 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27789 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26323 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19473 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137498 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24043 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174277 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25688 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134709 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35985 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30426 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134704 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36343 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35970 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145839 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98390 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/29236 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22675 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35479 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34980 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35225 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35128 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->