### PR TITLE
[ews-app]: auto-generate queue trigger relationships from config.json

### DIFF
--- a/Tools/CISupport/ews-app/ews/common/buildbot.py
+++ b/Tools/CISupport/ews-app/ews/common/buildbot.py
@@ -39,27 +39,7 @@ class Buildbot():
     icons_for_queues_mapping = {}
     queue_name_by_shortname_mapping = {}
     builder_name_to_id_mapping = {}
-
-    # FIXME: Auto-generate the queue's trigger relationship
-    QUEUE_TRIGGERS = {
-        'api-ios': 'ios-sim',
-        'ios-wk2': 'ios-sim',
-        'ios-wk2-wpt': 'ios-sim',
-        'api-mac': 'mac',
-        'mac-wk1': 'mac',
-        'mac-wk2': 'mac',
-        'mac-intel-wk2': 'mac',
-        'mac-wk2-stress': 'mac',
-        'api-mac-debug': 'mac-AS-debug',
-        'mac-AS-debug-wk2': 'mac-AS-debug',
-        'api-gtk': 'gtk',
-        'gtk-wk2': 'gtk',
-        'api-wpe': 'wpe',
-        'wpe-wk2': 'wpe',
-        'win-tests': 'win',
-        'jsc-armv7-tests': 'jsc-armv7',
-        'vision-wk2': 'vision-sim',
-    }
+    QUEUE_TRIGGERS = {}
 
     @classmethod
     def send_patch_to_buildbot(cls, patch_path, send_to_commit_queue=False, properties=None):
@@ -107,9 +87,17 @@ class Buildbot():
 
     @classmethod
     def fetch_config(cls):
-        config_url = 'https://{}/config.json'.format(config.BUILDBOT_SERVER_HOST)
-        config_data = util.fetch_data_from_url(config_url)
+        config_url = f'https://{config.BUILDBOT_SERVER_HOST}/config.json'
+        max_attempts = 3
+        config_data = None
+        for attempt in range(max_attempts):
+            config_data = util.fetch_data_from_url(config_url)
+            if config_data:
+                break
+            if attempt < max_attempts - 1:
+                _log.warning(f'Retrying fetch of {config_url} (attempt {attempt + 2}/{max_attempts})')
         if not config_data:
+            _log.error(f'Failed to fetch {config_url} after {max_attempts} attempts.')
             return {}
         try:
             return config_data.json()
@@ -118,15 +106,47 @@ class Buildbot():
             return {}
 
     @classmethod
-    def update_icons_for_queues_mapping(cls):
+    def update_queue_mappings(cls):
         config = cls.fetch_config()
         if not config:
             _log.error('Unable to fetch buildbot config.json')
             return
+        cls._update_icons_for_queues_mapping(config)
+        cls._update_queue_triggers(config)
+
+    @classmethod
+    def _update_icons_for_queues_mapping(cls, config):
         for builder in config.get('builders', []):
             shortname = builder.get('shortname')
             Buildbot.icons_for_queues_mapping[shortname] = builder.get('icon')
             Buildbot.queue_name_by_shortname_mapping[shortname] = builder.get('name')
+
+    @classmethod
+    def _update_queue_triggers(cls, config):
+        name_to_shortname = {}
+        for builder in config.get('builders', []):
+            name = builder.get('name')
+            shortname = builder.get('shortname')
+            if name and shortname:
+                name_to_shortname[name] = shortname
+
+        scheduler_to_builders = {}
+        for scheduler in config.get('schedulers', []):
+            if scheduler.get('type') != 'Triggerable':
+                continue
+            scheduler_to_builders[scheduler['name']] = scheduler.get('builderNames', [])
+
+        triggers = {}
+        for builder in config.get('builders', []):
+            parent_shortname = builder.get('shortname')
+            if not parent_shortname:
+                continue
+            for scheduler_name in builder.get('triggers', []):
+                for child_name in scheduler_to_builders.get(scheduler_name, []):
+                    child_shortname = name_to_shortname.get(child_name)
+                    if child_shortname:
+                        triggers[child_shortname] = parent_shortname
+        Buildbot.QUEUE_TRIGGERS = triggers
 
     @classmethod
     def update_builder_name_to_id_mapping(cls):

--- a/Tools/CISupport/ews-app/ews/fetcher.py
+++ b/Tools/CISupport/ews-app/ews/fetcher.py
@@ -49,14 +49,14 @@ class FetchLoop():
     def run(self):
         if util.load_password('ENABLE_APPLE_INTERNAL_BUILDS') is not None:
             GitHubEWS.update_approved_user_list_for_apple_internal_builds()
-        Buildbot.update_icons_for_queues_mapping()
+        Buildbot.update_queue_mappings()
         Buildbot.update_builder_name_to_id_mapping()
         custom_suffix = util.get_custom_suffix()
         if custom_suffix != '':
             _log.info(f'Skipping automatic Bugzilla patch sending on testing environment. custom_suffix: {custom_suffix}')
             return
         while True:
-            Buildbot.update_icons_for_queues_mapping()
+            Buildbot.update_queue_mappings()
             try:
                 BugzillaPatchFetcher().fetch()
                 BugzillaPatchFetcher().fetch_commit_queue_patches()


### PR DESCRIPTION
#### 17707eae20708f573a0b46f0d0e82c6d7d59a33e
<pre>
[ews-app]: auto-generate queue trigger relationships from config.json
<a href="https://bugs.webkit.org/show_bug.cgi?id=314903">https://bugs.webkit.org/show_bug.cgi?id=314903</a>
<a href="https://rdar.apple.com/177178866">rdar://177178866</a>

Reviewed by Ryan Haddad.

Remove the hardcoded mapping of test queues to their parent build queues.
It had to be manually maintained whenever queues changed on EWS.

Auto-generate the mapping from the buildmaster&apos;s config.json instead.

* Tools/CISupport/ews-app/ews/common/buildbot.py:

Canonical link: <a href="https://commits.webkit.org/313505@main">https://commits.webkit.org/313505@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96482db4fcd0df2264d4743f38c69b46d1d66924

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162776 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/36252 "Build was cancelled. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/29405 "Build was cancelled. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171714 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/119222 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164645 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/36356 "Build was cancelled. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/36256 "Build was cancelled. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/126347 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/119222 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165735 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/36356 "Build was cancelled. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/29405 "Build was cancelled. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/106924 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/36356 "Build was cancelled. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/36256 "Build was cancelled. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/19414 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/36356 "Build was cancelled. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/29405 "Build was cancelled. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/174218 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/29405 "Build was cancelled. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/174218 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35926 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/36256 "Build was cancelled. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/174218 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35910 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/29405 "Build was cancelled. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/98325 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24851 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/29190 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/29405 "Build was cancelled. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/35420 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/34921 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | [⏳ 🧪 mac-site-isolation ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Site-Isolation-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/35166 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/35069 "EWS skipped this build as PR had skip-ews label when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->