### PR TITLE
[GTK][WPE][Tools] container-sdk-autoenter fails on bots with /dev/console mount error

### DIFF
--- a/Tools/Scripts/webkitpy/port/linux_container_sdk_utils.py
+++ b/Tools/Scripts/webkitpy/port/linux_container_sdk_utils.py
@@ -174,6 +174,25 @@ def _container_hostname():
     return hostname
 
 
+def _running_inside_container():
+    """True if this process is itself already inside a container. Selects the
+    device-passthrough strategy in `_build_podman_run_args`: a nested rootless
+    pod's /dev has no /dev/console, so crun cannot create one when we bind the
+    host's entire /dev over the container's. Inside a container we instead let
+    crun own /dev (so --tty works) and re-expose host devices explicitly."""
+    # Cheap marker-file check first; fall back to systemd-detect-virt for
+    # minimal pod images that omit it.
+    if os.path.exists('/run/.containerenv') or os.path.exists('/.dockerenv'):
+        return True
+    try:
+        virt = subprocess.run(['systemd-detect-virt', '--container'],
+                              stdout=subprocess.PIPE,
+                              stderr=subprocess.DEVNULL).stdout.decode().strip()
+    except FileNotFoundError:
+        return False
+    return bool(virt) and virt != 'none'
+
+
 def _build_podman_run_args(pinned_version):
     """Static `podman run` flags for an ephemeral wkdev-build container.
 
@@ -249,23 +268,19 @@ def _build_podman_run_args(pinned_version):
         if os.path.exists(src):
             args += _bind_mount(src, dst, options='ro')
 
-    # Give the container its own devpts so crun does not fail to chown the
-    # caller's host /dev/pts/N when setting up the controlling TTY in rootless
-    # mode. Skipped under LXC, which does not permit a nested devpts mount.
-    try:
-        virt = subprocess.run(['systemd-detect-virt'], stdout=subprocess.PIPE,
-                              stderr=subprocess.DEVNULL).stdout.decode().strip()
-    except FileNotFoundError:
-        virt = ''
-    if virt != 'lxc':
-        args += ['--mount', 'type=devpts,destination=/dev/pts']
-
-    # Devices: gamepads, GPU, NVIDIA via CDI when available
-    args += ['-v', '/dev:/dev:rslave']
+    # Devices: gamepads, GPU, NVIDIA via CDI when available. Binding the host's
+    # entire /dev shadows the container's, so under --tty crun cannot create
+    # /dev/console from the pty in a nested rootless pod (the pod's /dev has
+    # none). Inside a container, let crun own /dev; GPU is passed explicitly.
+    if not _running_inside_container():
+        args += ['-v', '/dev:/dev:rslave']
+    args += ['--mount', 'type=devpts,destination=/dev/pts']
     if os.path.isdir('/run/udev'):
         args += ['-v', '/run/udev:/run/udev']
     if os.path.isdir('/dev/dri'):
         args += ['--device', '/dev/dri']
+    if os.path.isdir('/dev/input'):
+        args += ['--device', '/dev/input']
     if os.path.exists('/etc/cdi/nvidia.yaml') or os.path.exists('/var/run/cdi/nvidia.yaml'):
         args += ['--device', 'nvidia.com/gpu=all']
 
@@ -451,7 +466,7 @@ def maybe_enter_webkit_container_sdk(argv=None):
         container_command,
     ] + argv[1:]
 
-    print('Running inside WebKit Container SDK wkdev-sdk {}.'.format(pinned_version), file=sys.stderr)
+    print('Launching WebKit Container SDK wkdev-build {}.'.format(pinned_version), file=sys.stderr)
     sys.stdout.flush()
     sys.stderr.flush()
     os.execvp('podman', run_cmd)


### PR DESCRIPTION
#### c57f26e01334966d2cb89858e1cf54ed729b1f38
<pre>
[GTK][WPE][Tools] container-sdk-autoenter fails on bots with /dev/console mount error
<a href="https://bugs.webkit.org/show_bug.cgi?id=314907">https://bugs.webkit.org/show_bug.cgi?id=314907</a>

Reviewed by Carlos Alberto Lopez Perez.

In nested rootless setups (LXC, k8s pods, Docker/podman) crun aborts
container startup with `mount /dev/pts/N to /dev/console: No such file
or directory`. Root cause: binding the host&apos;s entire /dev over the
container&apos;s (`-v /dev:/dev:rslave`) shadows the container&apos;s /dev, so
under --tty crun cannot create /dev/console from the allocated pty -- a
nested pod&apos;s /dev has none for it to bind onto.

Generalize the prior LXC-only check to a `_running_inside_container()`
helper and use it to skip only the wholesale host /dev bind in that
case, letting crun own /dev. --tty and the container&apos;s own devpts are
kept, so interactive shells still get a controlling terminal on bots.
GPU (/dev/dri) and e.g. gamepads (/dev/input) are passed through explicitly.

* Tools/Scripts/webkitpy/port/linux_container_sdk_utils.py:
(_running_inside_container):
(_build_podman_run_args):
(maybe_enter_webkit_container_sdk):

Canonical link: <a href="https://commits.webkit.org/313330@main">https://commits.webkit.org/313330@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d22ba45a6d137edbbce6482704475d78fd4b5a27

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162828 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36305 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29462 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/171766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/119274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164697 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/36409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36308 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/171766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/119274 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165787 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/36409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/146309 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/171766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/162150 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/36409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/19466 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/36409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/24038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174270 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25683 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/134700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/35978 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/134695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/35963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145834 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98383 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24747 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/35963 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/22670 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/35472 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/34973 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/35218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/35121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->