### PR TITLE
ASSERTION FAILED: !shadowRoot() || shadowRoot()->mode() == ShadowRootMode::UserAgent

### DIFF
--- a/LayoutTests/fast/shadow-dom/style-invalidation-slotted-element-with-author-shadow-root-crash-expected.txt
+++ b/LayoutTests/fast/shadow-dom/style-invalidation-slotted-element-with-author-shadow-root-crash-expected.txt
@@ -1,0 +1,4 @@
+This tests that style invalidation does not crash when a slotted element has its own author shadow root.
+WebKit should not hit any assertion or crash and you should see PASS below.
+
+PASS - WebKit did not crash

--- a/LayoutTests/fast/shadow-dom/style-invalidation-slotted-element-with-author-shadow-root-crash.html
+++ b/LayoutTests/fast/shadow-dom/style-invalidation-slotted-element-with-author-shadow-root-crash.html
@@ -1,0 +1,38 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>This tests that style invalidation does not crash when a slotted element has its own author shadow root.<br>
+WebKit should not hit any assertion or crash and you should see PASS below.</p>
+<div id="host">
+    <span id="slotted">slotted</span>
+</div>
+<script>
+
+if (window.testRunner)
+    testRunner.dumpAsText();
+
+const host = document.getElementById('host');
+const root = host.attachShadow({mode: 'closed'});
+root.innerHTML = `
+    <style>
+        ::slotted(*) { color: red; }
+        .active ::slotted(*) { color: green; }
+    </style>
+    <div id="wrapper"><slot></slot></div>
+`;
+
+const slotted = document.getElementById('slotted');
+slotted.attachShadow({mode: 'open'}).innerHTML = '<div>nested</div>';
+
+document.body.offsetHeight;
+
+const wrapper = root.getElementById('wrapper');
+wrapper.className = 'active';
+
+document.body.offsetHeight;
+
+document.body.appendChild(document.createTextNode('PASS - WebKit did not crash'));
+
+</script>
+</body>
+</html>

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -3570,8 +3570,8 @@ RefPtr<Element> Element::retargetReferenceTargetForBindings(RefPtr<Element> elem
 
 ShadowRoot* Element::userAgentShadowRoot() const
 {
-    ASSERT(!shadowRoot() || shadowRoot()->mode() == ShadowRootMode::UserAgent);
-    return shadowRoot();
+    auto* root = shadowRoot();
+    return root && root->mode() == ShadowRootMode::UserAgent ? root : nullptr;
 }
 
 ShadowRoot& Element::ensureUserAgentShadowRoot()


### PR DESCRIPTION
#### 6bd49ed6463b56a0ddf86b11d9f2ef5e4183acc7
<pre>
ASSERTION FAILED: !shadowRoot() || shadowRoot()-&gt;mode() == ShadowRootMode::UserAgent
<a href="https://bugs.webkit.org/show_bug.cgi?id=314791">https://bugs.webkit.org/show_bug.cgi?id=314791</a>

Reviewed by Alan Baradlay.

Some callers of userAgentShadowRoot were expecting the function to check shadow root&apos;s
type and return nullptr when it&apos;s not an user-agent shadow root. Do that instead of
merely asserting in debug builds.

Test: fast/shadow-dom/style-invalidation-slotted-element-with-author-shadow-root-crash.html

* LayoutTests/fast/shadow-dom/style-invalidation-slotted-element-with-author-shadow-root-crash-expected.txt: Added.
* LayoutTests/fast/shadow-dom/style-invalidation-slotted-element-with-author-shadow-root-crash.html: Added.
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::userAgentShadowRoot const):

Canonical link: <a href="https://commits.webkit.org/313334@main">https://commits.webkit.org/313334@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c37a9dd9f70b12a198eaee10c231e9df101e114

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162809 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36286 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29442 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171747 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119255 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cadf2716-5628-4fd1-82d5-c6c0511c002a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164678 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36389 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36289 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126377 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/89004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f2466a5a-0d7f-4be6-aac4-54908a452bd9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165768 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28723 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146291 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106954 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ee567c66-ca68-46b7-ba0e-00385f4957d9) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19447 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137477 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24020 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174251 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21743 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25665 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134683 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35959 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30406 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134678 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35944 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145816 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98358 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24752 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/29214 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/22652 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35453 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/103473 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34954 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35199 "Built successfully") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35102 "Failed to compile WebKit") | | | | 
<!--EWS-Status-Bubble-End-->