### PR TITLE
[Site Isolation] http/tests/security/cross-origin-local-storage.html is failing

### DIFF
--- a/LayoutTests/http/tests/security/cross-origin-local-storage.html
+++ b/LayoutTests/http/tests/security/cross-origin-local-storage.html
@@ -1,10 +1,10 @@
+<!-- webkit-test-runner [ StorageBlockingPolicy=1 ] -->
 <html>
 <head>
 <script>
 if (window.testRunner) {
 	testRunner.dumpAsText();
 	testRunner.waitUntilDone();
-	internals.settings.setStorageBlockingPolicy('BlockThirdParty');
 }
 
 function continueTest() {

--- a/LayoutTests/platform/ios-site-isolation/TestExpectations
+++ b/LayoutTests/platform/ios-site-isolation/TestExpectations
@@ -212,7 +212,6 @@ http/tests/security/contentSecurityPolicy/1.1/frame-ancestors/frame-ancestors-ne
 http/tests/security/contentSecurityPolicy/1.1/frame-ancestors/frame-ancestors-nested-cross-in-same-url-block.html [ Failure ]
 http/tests/security/contentSecurityPolicy/1.1/frame-ancestors/frame-ancestors-self-block.html [ Failure ]
 http/tests/security/contentSecurityPolicy/1.1/frame-ancestors/frame-ancestors-url-block.html [ Failure ]
-http/tests/security/cross-origin-local-storage.html [ Failure ]
 http/tests/security/video-poster-cross-origin-crash2.html [ Failure ]
 http/tests/security/window-events-clear-domain.html [ Failure ]
 http/tests/security/xss-DENIED-iframe-src-alias.html [ Failure ]

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -214,7 +214,6 @@ http/tests/resourceLoadStatistics/user-interaction-in-cross-origin-sub-frame.htm
 http/tests/security/XFrameOptions/x-frame-options-ancestors-same-origin-deny.html [ Failure ]
 http/tests/security/XFrameOptions/x-frame-options-multiple-headers-sameorigin-deny.html [ Failure ]
 http/tests/security/XFrameOptions/x-frame-options-parent-same-origin-deny.html [ Failure ]
-http/tests/security/cross-origin-local-storage.html [ Failure ]
 http/tests/site-isolation/inspector/debugger/pause-in-cross-origin-iframe.html [ Pass ]
 http/tests/site-isolation/inspector/debugger/scriptParsed-frame-target.html [ Pass ]
 http/tests/site-isolation/inspector/debugger/setBreakpoint-cross-origin-iframe.html [ Pass ]


### PR DESCRIPTION
#### 8cc222c1c235ca073af5707fc14a9221b76cd3f0
<pre>
[Site Isolation] http/tests/security/cross-origin-local-storage.html is failing
<a href="https://bugs.webkit.org/show_bug.cgi?id=314859">https://bugs.webkit.org/show_bug.cgi?id=314859</a>
<a href="https://rdar.apple.com/177116495">rdar://177116495</a>

Reviewed by Sihui Liu.

When site isolation is enabled http/tests/security/cross-origin-local-storage.html
fails with the following diff compared to with site isolation disabled:

```
    -No value
    +Got value: value
```

This bug is due to the fact that the test calls internals.settings.setStorageBlockingPolicy(&apos;BlockThirdParty&apos;);
which doesn&apos;t propagate across process boundaries. This setting controls if third party
storage accesses go through a blocked/partitioned storage or the real persistent storage.

This setting is defined in Source/WebCore/page/Settings.yaml and has its C++ setter generated by
Source/WebCore/Scripts/GenerateSettings.rb.  This setting is per-page and doesn&apos;t propagate to other processes.

So, in this test the setting was set in the main frame&apos;s web process which didn&apos;t
propogate to the cross-origin iframe&apos;s web process with site isolation enabled.

This patch modifies this test to set this setting via the following WKTR header:
```
&lt;!-- webkit-test-runner [ StorageBlockingPolicy=1 ] --&gt;
```
which is equivalent to internals.settings.setStorageBlockingPolicy(&apos;BlockThirdParty&apos;);
except that it directly modifies WebPreferences
which gets inherited by new processes that spawn up.

This patch fixes http/tests/security/cross-origin-local-storage.html
with site isolation enabled.

* LayoutTests/http/tests/security/cross-origin-local-storage.html:
* LayoutTests/platform/ios-site-isolation/TestExpectations:
* LayoutTests/platform/mac-site-isolation/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/313338@main">https://commits.webkit.org/313338@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4faf70d6d6f8f73e21c89cf8b6d914d375ee8577

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162812 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36289 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29445 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171750 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/119258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/14bc655c-f6c9-4754-b8eb-e004b28f8e0e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36393 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36292 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126380 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/119258 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e42acf2d-3496-42c6-99b8-13f6ee26e335) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165771 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28727 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146296 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106957 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4f72ba46-d4bf-46c9-bb6e-95aaac692857) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27773 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19450 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137482 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24025 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174254 "Built successfully") | | 
| | | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25670 "Found 1 new test failure: imported/w3c/web-platform-tests/dom/nodes/moveBefore/throws-exception.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134687 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35962 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30409 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134682 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/36334 "The change is no longer eligible for processing.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35947 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145821 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98361 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24755 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/29218 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22657 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35456 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34957 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35202 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35105 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->