### PR TITLE
Model attempts to download invalid USD files

### DIFF
--- a/LayoutTests/model-element/model-element-404-error-expected.txt
+++ b/LayoutTests/model-element/model-element-404-error-expected.txt
@@ -1,0 +1,4 @@
+
+PASS <model> dispatches an "error" event when the server returns HTTP 404.
+PASS <model> ready promise rejects with NetworkError when the server returns HTTP 404.
+

--- a/LayoutTests/model-element/model-element-404-error.html
+++ b/LayoutTests/model-element/model-element-404-error.html
@@ -1,0 +1,43 @@
+<!doctype html> <!-- webkit-test-runner [ ModelElementEnabled=true ] -->
+<meta charset="utf-8">
+<title>&lt;model> HTTP 404 error handling</title>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<body>
+<script>
+'use strict';
+
+promise_test(t => {
+    return new Promise((resolve, reject) => {
+        const model = document.createElement("model");
+        document.body.appendChild(model);
+        t.add_cleanup(() => model.remove());
+
+        assert_false(model.complete, "model.complete is false before load.");
+
+        model.addEventListener("error", () => {
+            assert_false(model.complete, "model.complete is false after receiving error event.");
+            resolve();
+        });
+        model.addEventListener("load", () => reject("received unexpected load event"));
+
+        const source = document.createElement("source");
+        source.src = "resources/does-not-exist.usdz";
+        model.appendChild(source);
+    });
+}, "<model> dispatches an \"error\" event when the server returns HTTP 404.");
+
+promise_test(async t => {
+    const model = document.createElement("model");
+    document.body.appendChild(model);
+    t.add_cleanup(() => model.remove());
+
+    const source = document.createElement("source");
+    source.src = "resources/does-not-exist.usdz";
+    model.appendChild(source);
+
+    await promise_rejects_dom(t, "NetworkError", model.ready);
+}, "<model> ready promise rejects with NetworkError when the server returns HTTP 404.");
+
+</script>
+</body>

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -1359,7 +1359,7 @@ void HTMLModelElement::environmentMapResetAndReject(Exception&& exception)
 void HTMLModelElement::environmentMapResourceFinished()
 {
     int status = m_environmentMapResource->response().httpStatusCode();
-    if (m_environmentMapResource->loadFailedOrCanceled() || !isHttpOkStatus(status)) {
+    if (m_environmentMapResource->loadFailedOrCanceled() || (status && !isHttpOkStatus(status))) {
         environmentMapResetAndReject(Exception { ExceptionCode::NetworkError });
 
         // sending a message with empty data to indicate resource removal
@@ -1401,7 +1401,8 @@ void HTMLModelElement::modelResourceFinished()
     };
 
     RefPtr resource = m_resource;
-    if (resource->loadFailedOrCanceled()) {
+    int status = resource->response().httpStatusCode();
+    if (resource->loadFailedOrCanceled() || (status && !isHttpOkStatus(status))) {
         m_data.reset();
 
         ActiveDOMObject::queueTaskToDispatchEvent(*this, TaskSource::DOMManipulation, Event::create(eventNames().errorEvent, Event::CanBubble::No, Event::IsCancelable::No));

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h
@@ -509,7 +509,7 @@ NS_SWIFT_SENDABLE
 - (void)setCurrentTime:(double)newTime;
 - (double)duration;
 - (void)loadModelFrom:(NSURL *)url;
-- (void)loadModel:(NSData *)data;
+- (BOOL)loadModel:(NSData *)data;
 - (nullable WKBridgeUpdateTexture *)loadEnvironmentMap:(NSData *)data;
 - (void)update:(double)deltaTime;
 - (void)setLoop:(BOOL)loop;

--- a/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
@@ -1860,19 +1860,20 @@ final class USDModelLoader {
         }
     }
 
-    func loadModel(data: Foundation.Data) {
+    func loadModel(data: Foundation.Data) -> Bool {
         do {
-            self.data = data
-            // swift-format-ignore: NeverForceUnwrap
-            self.stage = try UsdStage.open(buffer: self.data!)
+            self.stage = try UsdStage.open(buffer: data)
             guard let stage = self.stage else {
                 logError("model data is corrupted")
-                return
+                return false
             }
+            self.data = data
             self.setupTimes(from: stage)
             self.usdStageSession.loadStage(stage)
+            return true
         } catch {
-            fatalError(error.localizedDescription)
+            logError(error.localizedDescription)
+            return false
         }
     }
 
@@ -1906,7 +1907,8 @@ final class USDModelLoader {
         time = startTime + newTime
     }
 
-    func loadModel(from data: Data) {
+    func loadModel(from data: Data) -> Bool {
+        false
     }
 
     func update(deltaTime: TimeInterval) {
@@ -2038,8 +2040,8 @@ extension WKBridgeModelLoader {
         self.loader?.loadModel(from: url)
     }
 
-    func loadModel(_ data: Foundation.Data) {
-        self.loader?.loadModel(data: data)
+    func loadModel(_ data: Foundation.Data) -> Bool {
+        self.loader?.loadModel(data: data) ?? false
     }
 
     func loadEnvironmentMap(_ data: Foundation.Data) -> WKBridgeUpdateTexture? {
@@ -2259,7 +2261,8 @@ extension WKBridgeModelLoader {
     func loadModel(from url: Foundation.URL) {
     }
 
-    func loadModel(_ data: Foundation.Data) {
+    func loadModel(_ data: Foundation.Data) -> Bool {
+        false
     }
 
     func loadEnvironmentMap(_ data: Foundation.Data) -> WKBridgeUpdateTexture? {

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
@@ -267,7 +267,10 @@ void WebModelPlayer::load(WebCore::Model& modelSource, WebCore::LayoutSize size)
     }];
 
     m_retainedData = modelSource.data()->createNSData();
-    [m_modelLoader loadModel:m_retainedData.get()];
+    if (![m_modelLoader loadModel:m_retainedData.get()]) {
+        if (RefPtr client = m_client.get())
+            client->didFailLoading(protectedThis.get(), { });
+    }
 }
 
 void WebModelPlayer::notifyEntityTransformUpdated()


### PR DESCRIPTION
#### c478340a431f31696ed16610f0f1d9eee85037ad
<pre>
Model attempts to download invalid USD files
<a href="https://rdar.apple.com/177178825">rdar://177178825</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=314911">https://bugs.webkit.org/show_bug.cgi?id=314911</a>

Reviewed by Etienne Segonzac.

If we get a 404 or similar invalid response code, we shouldn&apos;t attempt
to proceeed to parse the USD.

Also report failure in parsing files which exist and call the delegate&apos;s
didFailLoading function.

Test: model-element/model-element-404-error.html

* LayoutTests/model-element/model-element-404-error-expected.txt: Added.
* LayoutTests/model-element/model-element-404-error.html: Added.
* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::modelResourceFinished):
* Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h:
* Source/WebKit/GPUProcess/graphics/Model/USDModel.swift:
(USDModelLoader.loadModel(_:)):
(USDModelLoader.loadModel(from:)):
(WKBridgeModelLoader.loadModel(_:)):
* Source/WebKit/WebProcess/Model/WebModelPlayer.mm:
(WebKit::WebModelPlayer::load):

Canonical link: <a href="https://commits.webkit.org/313542@main">https://commits.webkit.org/313542@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf5229448254ee4b586bc9dca0c34a0bb92b8513

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163349 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36832 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30047 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172288 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119796 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165218 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37159 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36832 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126850 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89423 "3 flakes 3 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166308 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29120 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146846 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107417 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28166 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26799 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19990 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138061 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24570 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174792 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27393 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26226 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135157 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36501 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30898 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135148 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36445 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37287 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146365 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99241 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30446 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23210 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35997 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108838 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35495 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1235 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35743 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35643 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->