### PR TITLE
[Wasm] Build JS Wrappers and JSToWasmCallees Lazily

### DIFF
--- a/Source/JavaScriptCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/MemoryUnsafeCastCheckerExpectations
@@ -130,7 +130,6 @@ tools/CellProfile.h
 tools/HeapVerifier.cpp
 tools/JSDollarVM.cpp
 tools/VMInspector.cpp
-wasm/WasmCalleeGroup.cpp
 wasm/WasmModule.cpp
 wasm/WasmOperations.cpp
 wasm/WasmStreamingCompiler.cpp

--- a/Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -169,6 +169,7 @@ wasm/js/JSWebAssemblyInstance.cpp
 wasm/js/JSWebAssemblyInstance.h
 wasm/js/JSWebAssemblyMemory.cpp
 wasm/js/JSWebAssemblyMemory.h
+wasm/js/WebAssemblyFunction.cpp
 wasm/js/WebAssemblyFunction.h
 wasm/js/WebAssemblyInstanceConstructor.cpp
 wasm/js/WebAssemblyModuleConstructor.cpp

--- a/Source/JavaScriptCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -102,6 +102,7 @@ runtime/TypeSet.cpp
 runtime/VMTraps.cpp
 runtime/WaiterListManager.h
 tools/JSDollarVM.cpp
+wasm/WasmCalleeGroup.cpp
 wasm/WasmBBQJIT.cpp
 wasm/WasmBBQJIT64.cpp
 wasm/WasmBBQPlan.cpp
@@ -125,4 +126,5 @@ wasm/js/JSWebAssembly.cpp
 wasm/js/JSWebAssemblyHelpers.h
 wasm/js/JSWebAssemblyInstance.cpp
 wasm/js/WasmToJS.cpp
+wasm/js/WebAssemblyFunction.cpp
 wasm/js/WebAssemblyModuleRecord.cpp

--- a/Source/JavaScriptCore/runtime/NativeCallee.h
+++ b/Source/JavaScriptCore/runtime/NativeCallee.h
@@ -65,13 +65,20 @@ public:
     using StorageType = CalleeBits;
     // Use an intermediate cast to uintptr_t to silence unsafe casting warning. It's locally "obvious" (other than the fact that RefPtr uses StorageType's constructor instead of a wrap) the
     // return value is of type T.
-    static T* unwrap(const CalleeBits& calleeBits) { return reinterpret_cast<T*>(reinterpret_cast<uintptr_t>(calleeBits.asNativeCallee())); }
+    static T* unwrap(const CalleeBits& calleeBits)
+    {
+        if (!calleeBits)
+            return nullptr;
+        return reinterpret_cast<T*>(reinterpret_cast<uintptr_t>(calleeBits.asNativeCallee()));
+    }
     static T* exchange(CalleeBits& calleeBits, T* newCallee)
     {
         T* result = unwrap(calleeBits);
         calleeBits = newCallee;
         return result;
     }
+
+    static void swap(CalleeBits& a, CalleeBits& b) { std::swap(a, b); }
 
     // FIXME: This isn't hashable since we don't have hashTableDeletedValue() or isHashTableDeletedValue()
     // but those probably shouldn't be hard to add if needed.

--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.cpp
@@ -33,6 +33,7 @@
 #include "WasmCallee.h"
 #include "WasmIPIntPlan.h"
 #include "WasmMachineThreads.h"
+#include "WasmModuleInformation.h"
 #include "WasmWorklist.h"
 
 namespace JSC { namespace Wasm {
@@ -51,12 +52,15 @@ CalleeGroup::CalleeGroup(MemoryMode mode, const CalleeGroup& other)
     : m_calleeCount(other.m_calleeCount)
     , m_mode(mode)
     , m_ipintCallees(other.m_ipintCallees)
-    , m_jsToWasmCallees(other.m_jsToWasmCallees)
     , m_callers(m_calleeCount)
     , m_wasmIndirectCallEntrypoints(other.m_wasmIndirectCallEntrypoints)
     , m_wasmIndirectCallWasmCallees(other.m_wasmIndirectCallWasmCallees)
     , m_wasmToWasmExitStubs(other.m_wasmToWasmExitStubs)
 {
+    {
+        Locker otherLocker { other.m_jsToWasmCalleesLock };
+        m_jsToWasmCallees = other.m_jsToWasmCallees;
+    }
     Locker locker { m_lock };
     setCompilationFinished();
 }
@@ -85,7 +89,6 @@ CalleeGroup::CalleeGroup(VM& vm, MemoryMode mode, ModuleInformation& moduleInfor
         }
 
         m_wasmToWasmExitStubs = m_plan->takeWasmToWasmExitStubs();
-        m_jsToWasmCallees = static_cast<IPIntPlan*>(m_plan.get())->takeJSToWasmCallees();
 
         setCompilationFinished();
     })));
@@ -102,6 +105,23 @@ CalleeGroup::CalleeGroup(VM& vm, MemoryMode mode, ModuleInformation& moduleInfor
 }
 
 CalleeGroup::~CalleeGroup() = default;
+
+JSToWasmCallee& CalleeGroup::ensureJSToWasmCallee(const ModuleInformation& moduleInformation, FunctionSpaceIndex functionIndexSpace)
+{
+    ASSERT(runnable());
+    ASSERT(functionIndexSpace >= functionImportCount());
+    unsigned calleeIndex = functionIndexSpace - functionImportCount();
+
+    Locker locker { m_jsToWasmCalleesLock };
+    auto addResult = m_jsToWasmCallees.ensure(calleeIndex, [&] {
+        auto& ipintCallee = m_ipintCallees->at(calleeIndex).get();
+        bool usesSIMD = moduleInformation.usesSIMD(FunctionCodeIndex(calleeIndex));
+        auto callee = JSToWasmCallee::create(Ref<const RTT> { ipintCallee.signatureRTT() }, usesSIMD);
+        callee->setWasmCallee(CalleeBits::encodeNativeCallee(&ipintCallee));
+        return callee;
+    });
+    return *addResult.iterator->value;
+}
 
 void CalleeGroup::waitUntilFinished()
 {

--- a/Source/JavaScriptCore/wasm/WasmCalleeGroup.h
+++ b/Source/JavaScriptCore/wasm/WasmCalleeGroup.h
@@ -101,18 +101,7 @@ public:
         return FunctionCodeIndex(spaceIndex - functionImportCount());
     }
 
-    // These two callee getters are only valid once the callees have been populated.
-
-    JSToWasmCallee& jsToWasmCalleeFromFunctionIndexSpace(FunctionSpaceIndex functionIndexSpace)
-    {
-        ASSERT(runnable());
-        ASSERT(functionIndexSpace >= functionImportCount());
-        unsigned calleeIndex = functionIndexSpace - functionImportCount();
-
-        auto callee = m_jsToWasmCallees.get(calleeIndex);
-        RELEASE_ASSERT(callee);
-        return *callee;
-    }
+    JSToWasmCallee& ensureJSToWasmCallee(const ModuleInformation&, FunctionSpaceIndex functionIndexSpace);
 
     RefPtr<JITCallee> replacement(const AbstractLocker& locker, FunctionSpaceIndex functionIndexSpace) WTF_REQUIRES_LOCK(m_lock)
     {
@@ -266,7 +255,8 @@ private:
     OptimizedCallees m_currentlyInstallingOptimizedCallees WTF_GUARDED_BY_LOCK(m_lock) { };
     FixedVector<OptimizedCallees> m_optimizedCallees WTF_GUARDED_BY_LOCK(m_lock);
     const Ref<IPIntCallees> m_ipintCallees;
-    UncheckedKeyHashMap<uint32_t, RefPtr<JSToWasmCallee>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_jsToWasmCallees;
+    UncheckedKeyHashMap<uint32_t, RefPtr<JSToWasmCallee>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_jsToWasmCallees WTF_GUARDED_BY_LOCK(m_jsToWasmCalleesLock);
+    mutable Lock m_jsToWasmCalleesLock;
 #if ENABLE(WEBASSEMBLY_BBQJIT) || ENABLE(WEBASSEMBLY_OMGJIT)
     // FIXME: We should probably find some way to prune dead entries periodically.
     UncheckedKeyHashMap<uint32_t, ThreadSafeWeakPtr<OMGOSREntryCallee>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>> m_osrEntryCallees WTF_GUARDED_BY_LOCK(m_lock);

--- a/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmConstExprGenerator.cpp
@@ -623,7 +623,7 @@ public:
     [[nodiscard]] PartialResult addRefFunc(FunctionSpaceIndex index, ExpressionType& result)
     {
         if (m_mode == Mode::Evaluate) {
-            JSValue wrapper = m_instance->getFunctionWrapper(index);
+            JSValue wrapper = m_instance->ensureFunctionWrapper(index);
             ASSERT(!wrapper.isNull());
             ASSERT(wrapper.isObject());
             m_keepAlive.appendWithCrashOnOverflow(asObject(wrapper));

--- a/Source/JavaScriptCore/wasm/WasmFunctionParser.h
+++ b/Source/JavaScriptCore/wasm/WasmFunctionParser.h
@@ -386,7 +386,6 @@ private:
 
     // FIXME add a macro as above for WASM_TRY_APPEND_TO_CONTROL_STACK https://bugs.webkit.org/show_bug.cgi?id=165862
 
-    void addReferencedFunctions(const Element&);
     [[nodiscard]] PartialResult parseArrayTypeDefinition(ASCIILiteral, bool, TypeSignatureIndex&, FieldType&, Type&);
     [[nodiscard]] PartialResult parseBlockSignatureAndNotifySIMDUseIfNeeded(BlockSignature&);
 
@@ -1908,20 +1907,6 @@ auto FunctionParser<Context>::checkExpressionStack(const ControlType& controlDat
 }
 
 template<typename Context>
-void FunctionParser<Context>::addReferencedFunctions(const Element& segment)
-{
-    if (!isSubtype(segment.elementType, funcrefType()))
-        return;
-
-    // Add each function index as a referenced function. This ensures that
-    // wrappers will be created for GC.
-    for (uint32_t i = 0; i < segment.length(); i++) {
-        if (segment.initTypes[i] == Element::InitializationType::FromRefFunc)
-            m_info.addReferencedFunction(FunctionSpaceIndex(segment.initialBitsOrIndices[i]));
-    }
-}
-
-template<typename Context>
 auto FunctionParser<Context>::parseArrayTypeDefinition(ASCIILiteral operation, bool isNullable, TypeSignatureIndex& typeIndex, FieldType& elementType, Type& arrayRefType) -> PartialResult
 {
     // Parse type index
@@ -2608,10 +2593,6 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_VALIDATOR_FAIL_IF(storageType.is<PackedType>(), "type mismatch in array.new_elem: expected `funcref` or `externref`");
 
             WASM_VALIDATOR_FAIL_IF(!isSubtype(elementsSegment.elementType, storageType.unpacked()), "type mismatch in array.new_elem: segment elements have type ", elementsSegment.elementType, " but array.new_elem operation expects elements of type ", storageType.unpacked());
-            // Create function wrappers for any functions in this element segment.
-            // We conservatively assume that the `array.new_canon_elem` instruction will be executed.
-            // An optimization would be to lazily create the wrappers when the array is initialized.
-            addReferencedFunctions(elementsSegment);
 
             // Get the array size
             TypedExpression size;
@@ -2770,7 +2751,6 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
             WASM_VALIDATOR_FAIL_IF(dstFieldType.mutability != Mutability::Mutable, "array.init_elem index ", dstTypeIndex, " does not reference a mutable array definition");
 
             WASM_VALIDATOR_FAIL_IF(!isSubtype(segmentElementType, unpackedElementType), "type mismatch in array.init_elem: segment elements have type ", segmentElementType, " but array.init_elem operation expects elements of type ", unpackedElementType);
-            addReferencedFunctions(elementsSegment);
 
             TypedExpression dst, dstOffset, srcOffset, size;
             WASM_TRY_POP_EXPRESSION_STACK_INTO(size, "array.init_elem"_s);
@@ -3117,7 +3097,6 @@ FOR_EACH_WASM_MEMORY_STORE_OP(CREATE_CASE)
         // Function references don't need to be declared in constant expression contexts.
         if constexpr (!std::is_same<Context, ConstExprGenerator>())
             WASM_VALIDATOR_FAIL_IF(!m_info.isDeclaredFunction(index), "ref.func index "_s, index, " isn't declared"_s);
-        m_info.addReferencedFunction(index);
 
         ExpressionType result;
         WASM_TRY_ADD_TO_CONTEXT(addRefFunc(index, result));

--- a/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
@@ -78,10 +78,6 @@ bool IPIntPlan::prepareImpl()
         return false;
     m_wasmInternalFunctions.resize(functions.size());
 
-    if (!tryReserveCapacity(m_entrypoints, functions.size(), " WebAssembly functions"_s))
-        return false;
-    m_entrypoints.resize(functions.size());
-
     if (!m_ipintCallees)
         m_ipintCallees = IPIntCallees::create(functions.size());
     return true;
@@ -112,7 +108,6 @@ void IPIntPlan::compileFunction(FunctionCodeIndex functionIndex)
 
     m_wasmInternalFunctions[functionIndex] = WTF::move(*parseAndCompileResult);
 
-    IPIntCallee* ipintCallee = nullptr;
     {
         auto callee = IPIntCallee::create(*m_wasmInternalFunctions[functionIndex], functionIndexSpace, signature, m_moduleInformation->nameSection->get(functionIndexSpace));
         ASSERT(!callee->entrypoint());
@@ -136,30 +131,8 @@ void IPIntPlan::compileFunction(FunctionCodeIndex functionIndex)
             entrypoint = LLInt::getCodeFunctionPtr<CFunctionPtrTag>(ipint_trampoline);
 
         callee->setEntrypointWithoutRegistration(entrypoint);
-        ipintCallee = callee.ptr();
         m_ipintCallees->at(functionIndex) = WTF::move(callee);
     }
-
-    // If the function is exported via module, then we ensure JSToWasm entrypoint.
-    if (m_compilerMode != CompilerMode::Validation) {
-        if (m_exportedFunctionIndices.contains(functionIndex)) {
-            if (!ensureEntrypoint(*ipintCallee, functionIndex)) {
-                Locker locker { m_lock };
-                Base::fail(makeString("JIT is disabled, but the entrypoint for "_s, functionIndex.rawIndex(), " requires JIT"_s));
-                return;
-            }
-        }
-    }
-
-}
-
-bool IPIntPlan::ensureEntrypoint(IPIntCallee&, FunctionCodeIndex functionIndex)
-{
-    if (m_entrypoints[functionIndex])
-        return true;
-
-    m_entrypoints[functionIndex] = JSToWasmCallee::create(Ref { m_moduleInformation->rtt(m_moduleInformation->internalFunctionTypeSignatureIndices[functionIndex]) }, m_moduleInformation->usesSIMD(functionIndex));
-    return true;
 }
 
 void IPIntPlan::didCompleteCompilation()
@@ -175,22 +148,6 @@ void IPIntPlan::didCompleteCompilation()
 
     if (m_compilerMode == CompilerMode::Validation)
         return;
-
-    for (uint32_t functionIndex = 0; functionIndex < m_moduleInformation->functions.size(); functionIndex++) {
-        if (!m_entrypoints[functionIndex]) {
-            const FunctionSpaceIndex functionIndexSpace = FunctionSpaceIndex(functionIndex + m_moduleInformation->importFunctionCount());
-            if (m_exportedFunctionIndices.contains(functionIndex) || m_moduleInformation->hasReferencedFunction(functionIndexSpace)) {
-                if (!ensureEntrypoint(m_ipintCallees->at(functionIndex).get(), FunctionCodeIndex(functionIndex))) {
-                    Base::fail(makeString("JIT is disabled, but the entrypoint for "_s, functionIndex, " requires JIT"_s));
-                    return;
-                }
-            }
-        }
-        if (auto& callee = m_entrypoints[functionIndex]) {
-            callee->setWasmCallee(CalleeBits::encodeNativeCallee(&m_ipintCallees->at(functionIndex).get()));
-            m_jsToWasmCallees.add(functionIndex, callee);
-        }
-    }
 
     for (auto& unlinked : m_unlinkedWasmToWasmCalls) {
         for (auto& call : unlinked) {

--- a/Source/JavaScriptCore/wasm/WasmIPIntPlan.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntPlan.h
@@ -37,9 +37,6 @@ namespace Wasm {
 
 class IPIntCallee;
 
-using JSToWasmCalleeMap = UncheckedKeyHashMap<uint32_t, RefPtr<JSToWasmCallee>, DefaultHash<uint32_t>, WTF::UnsignedWithZeroKeyHashTraits<uint32_t>>;
-
-
 class IPIntPlan final : public EntryPlan {
     using Base = EntryPlan;
 
@@ -52,12 +49,6 @@ public:
     {
         RELEASE_ASSERT(!failed() && !hasWork());
         return m_ipintCallees.releaseNonNull();
-    }
-
-    JSToWasmCalleeMap&& takeJSToWasmCallees()
-    {
-        RELEASE_ASSERT(!failed() && !hasWork());
-        return WTF::move(m_jsToWasmCallees);
     }
 
     bool hasWork() const final
@@ -81,13 +72,9 @@ private:
     bool prepareImpl() final;
     void didCompleteCompilation() WTF_REQUIRES_LOCK(m_lock) final;
 
-    bool ensureEntrypoint(IPIntCallee&, FunctionCodeIndex functionIndex);
-
     Vector<std::unique_ptr<FunctionIPIntMetadataGenerator>> m_wasmInternalFunctions;
     RefPtr<IPIntCallees> m_ipintCallees;
     bool m_calleesAlreadyRegistered { false };
-    Vector<RefPtr<JSToWasmCallee>> m_entrypoints;
-    JSToWasmCalleeMap m_jsToWasmCallees;
 };
 
 } } // namespace JSC::Wasm

--- a/Source/JavaScriptCore/wasm/WasmModuleInformation.h
+++ b/Source/JavaScriptCore/wasm/WasmModuleInformation.h
@@ -119,16 +119,6 @@ struct ModuleInformation final : public ThreadSafeRefCounted<ModuleInformation> 
     const TableInformation& table(unsigned index) const { return tables[index]; }
     const GlobalInformation& global(unsigned index) const { return globals[index]; }
 
-    void initializeFunctionTrackers() const
-    {
-        size_t totalNumberOfFunctions = functionIndexSpaceSize();
-        m_referencedFunctions = FixedBitVector(totalNumberOfFunctions);
-    }
-
-    const FixedBitVector& referencedFunctions() const LIFETIME_BOUND { return m_referencedFunctions; }
-    bool hasReferencedFunction(FunctionSpaceIndex functionIndexSpace) const { return m_referencedFunctions.test(functionIndexSpace); }
-    void addReferencedFunction(FunctionSpaceIndex functionIndexSpace) const { m_referencedFunctions.concurrentTestAndSet(functionIndexSpace); }
-
     bool isDeclaredFunction(FunctionSpaceIndex index) const { return m_declaredFunctions.contains(index); }
     void addDeclaredFunction(FunctionSpaceIndex index) { m_declaredFunctions.set(index); }
 
@@ -233,7 +223,6 @@ struct ModuleInformation final : public ThreadSafeRefCounted<ModuleInformation> 
 
     BitVector m_declaredFunctions;
     BitVector m_declaredExceptions;
-    mutable FixedBitVector m_referencedFunctions;
     size_t m_totalFunctionSize { 0 };
     uint32_t m_numSmallFunctions { 0 };
 

--- a/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
+++ b/Source/JavaScriptCore/wasm/WasmOperationsInlines.h
@@ -48,7 +48,7 @@ namespace Wasm {
 
 inline EncodedJSValue refFunc(JSWebAssemblyInstance* instance, uint32_t index)
 {
-    JSValue value = instance->getFunctionWrapper(index);
+    JSValue value = instance->ensureFunctionWrapper(Wasm::FunctionSpaceIndex(index));
     ASSERT(value.isCallable());
     return JSValue::encode(value);
 }

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
@@ -257,9 +257,6 @@ auto SectionParser::parseFunction() -> PartialResult
         m_info->functions.append({ start, end, Vector<uint8_t>() });
     }
 
-    // Note that `initializeFunctionTrackers` should only be used after both parseImport and parseFunction
-    // finish updating importFunctionTypeSignatureIndices and internalFunctionTypeSignatureIndices.
-    m_info->initializeFunctionTrackers();
     return { };
 }
 
@@ -830,7 +827,6 @@ auto SectionParser::parseInitExpr(uint8_t& opcode, bool& isExtendedConstantExpre
         WASM_PARSER_FAIL_IF(!parseVarUInt32(index), "can't get ref.func index"_s);
         WASM_PARSER_FAIL_IF(index >= m_info->functionIndexSpaceSize(), "ref.func index "_s, index, " exceeds the number of functions "_s, m_info->functionIndexSpaceSize());
         auto spaceIndex = FunctionSpaceIndex(index);
-        m_info->addReferencedFunction(spaceIndex);
         TypeIndex typeIndex = m_info->rtt(spaceIndex).asTypeIndex();
         resultType = { TypeKind::Ref, typeIndex };
         bitsOrImportNumber = index;

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
@@ -47,6 +47,7 @@
 #include "WasmTypeDefinitionInlines.h"
 #include "WebAssemblyFunctionBase.h"
 #include "WebAssemblyModuleRecord.h"
+#include "WebAssemblyWrapperFunction.h"
 #include <wtf/CheckedArithmetic.h>
 #include <wtf/StdLibExtras.h>
 #include <wtf/text/MakeString.h>
@@ -446,6 +447,38 @@ void JSWebAssemblyInstance::setFunctionWrapper(unsigned i, JSValue value)
     ASSERT(getFunctionWrapper(i) == value);
 }
 
+JSValue JSWebAssemblyInstance::ensureFunctionWrapper(FunctionSpaceIndex functionIndexSpace)
+{
+    JSValue wrapper = getFunctionWrapper(functionIndexSpace);
+    if (!wrapper.isNull())
+        return wrapper;
+
+    JSGlobalObject* globalObject = this->realm();
+    VM& vm = globalObject->vm();
+
+    if (isImportFunction(functionIndexSpace)) {
+        JSObject* functionImport = getImportFunctionObject(functionIndexSpace, globalObject);
+        if (isWebAssemblyHostFunction(functionImport))
+            wrapper = functionImport;
+        else {
+            Ref rtt = m_module->rttFromFunctionIndexSpace(functionIndexSpace);
+            wrapper = WebAssemblyWrapperFunction::create(vm, globalObject, globalObject->webAssemblyWrapperFunctionStructure(), functionImport, functionIndexSpace, this, WTF::move(rtt));
+        }
+    } else {
+        Wasm::CalleeGroup* calleeGroup = this->calleeGroup();
+        auto wasmCallee = calleeGroup->wasmCalleeFromFunctionIndexSpace(functionIndexSpace);
+        ASSERT(wasmCallee);
+        Wasm::WasmToWasmImportableFunction::LoadLocation entrypointLoadLocation = calleeGroup->entrypointLoadLocationFromFunctionIndexSpace(functionIndexSpace);
+        Ref rtt = m_module->rttFromFunctionIndexSpace(functionIndexSpace);
+        WebAssemblyFunction* function = WebAssemblyFunction::create(vm, globalObject, globalObject->webAssemblyFunctionStructure(), rtt->argumentCount(), makeString(functionIndexSpace.rawIndex()), this, *wasmCallee, entrypointLoadLocation, WTF::move(rtt));
+        wrapper = function;
+    }
+
+    ASSERT(wrapper.isCallable());
+    setFunctionWrapper(functionIndexSpace, wrapper);
+    return wrapper;
+}
+
 Table* JSWebAssemblyInstance::table(unsigned i)
 {
     return tables()[i].get();
@@ -524,8 +557,6 @@ void JSWebAssemblyInstance::initElementSegment(uint32_t tableIndex, const Elemen
     RELEASE_ASSERT(length <= segment.length());
 
     JSWebAssemblyTable* jsTable = this->jsTable(tableIndex);
-    JSGlobalObject* globalObject = this->realm();
-    VM& vm = globalObject->vm();
 
     for (uint32_t index = 0; index < length; ++index) {
         const auto srcIndex = srcOffset + index;
@@ -544,49 +575,9 @@ void JSWebAssemblyInstance::initElementSegment(uint32_t tableIndex, const Elemen
             // for the import.
             // https://bugs.webkit.org/show_bug.cgi?id=165510
             auto functionIndex = Wasm::FunctionSpaceIndex(initialBitsOrIndex);
-            Ref<const Wasm::RTT> rtt = m_module->rttFromFunctionIndexSpace(functionIndex);
-            if (isImportFunction(functionIndex)) {
-                JSObject* functionImport = getImportFunctionObject(functionIndex, globalObject);
-                if (isWebAssemblyHostFunction(functionImport)) {
-                    // If we ever import a WebAssemblyWrapperFunction, we set the import as the unwrapped value.
-                    // Because a WebAssemblyWrapperFunction can never wrap another WebAssemblyWrapperFunction,
-                    // the only type this could be is WebAssemblyFunction.
-                    WebAssemblyFunction* wasmFunction = downcast<WebAssemblyFunction>(functionImport);
-                    jsTable->set(dstIndex, wasmFunction);
-                    continue;
-                }
-                auto* wrapperFunction = WebAssemblyWrapperFunction::create(
-                    vm,
-                    globalObject,
-                    globalObject->webAssemblyWrapperFunctionStructure(),
-                    functionImport,
-                    functionIndex,
-                    this,
-                    WTF::move(rtt));
-                jsTable->set(dstIndex, wrapperFunction);
-                continue;
-            }
-
-            auto& jsToWasmCallee = calleeGroup()->jsToWasmCalleeFromFunctionIndexSpace(functionIndex);
-            auto wasmCallee = calleeGroup()->wasmCalleeFromFunctionIndexSpace(functionIndex);
-            ASSERT(wasmCallee);
-            WasmToWasmImportableFunction::LoadLocation entrypointLoadLocation = calleeGroup()->entrypointLoadLocationFromFunctionIndexSpace(functionIndex);
-            // FIXME: Say we export local function "foo" at function index 0.
-            // What if we also set it to the table an Element w/ index 0.
-            // Does (new Instance(...)).exports.foo === table.get(0)?
-            // https://bugs.webkit.org/show_bug.cgi?id=165825
-            WebAssemblyFunction* function = WebAssemblyFunction::create(
-                vm,
-                globalObject,
-                globalObject->webAssemblyFunctionStructure(),
-                rtt->argumentCount(),
-                WTF::makeString(functionIndex.rawIndex()),
-                this,
-                jsToWasmCallee,
-                *wasmCallee,
-                entrypointLoadLocation,
-                WTF::move(rtt));
-            jsTable->set(dstIndex, function);
+            JSValue wrapper = ensureFunctionWrapper(functionIndex);
+            ASSERT(wrapper.isCallable());
+            jsTable->set(dstIndex, wrapper);
             continue;
         }
 
@@ -673,10 +664,7 @@ void JSWebAssemblyInstance::copyElementSegment(JSWebAssemblyArray* array, const 
         if (initType == Element::InitializationType::FromRefFunc) {
             uint32_t functionIndex = static_cast<uint32_t>(initialBitsOrIndex);
 
-            // A wrapper for this function should have been created during parsing.
-            // A future optimization would be for the parser to not create the wrappers,
-            // and create them here dynamically instead.
-            JSValue value = getFunctionWrapper(functionIndex);
+            JSValue value = ensureFunctionWrapper(FunctionSpaceIndex(functionIndex));
             ASSERT(value.isCallable());
             set(i, static_cast<uint64_t>(JSValue::encode(value)));
             continue;

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.h
@@ -292,6 +292,7 @@ public:
     JSValue getFunctionWrapper(unsigned) const;
     typename FunctionWrapperMap::ValuesConstIteratorRange functionWrappers() const { return m_functionWrappers.values(); }
     void setFunctionWrapper(unsigned, JSValue);
+    JSValue ensureFunctionWrapper(Wasm::FunctionSpaceIndex);
     void setBuiltinCalleeBits(uint32_t builtinID, CalleeBits calleeBits) { m_builtinCalleeBits[builtinID] = calleeBits; }
 
     Wasm::Global* getGlobalBinding(unsigned i)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.cpp
@@ -79,13 +79,18 @@ JSC_DEFINE_HOST_FUNCTION(callWebAssemblyFunction, (JSGlobalObject* globalObject,
     return vmEntryToWasm(wasmFunction->jsToWasm(ArityCheckMode::MustCheckArity).taggedPtr(), &vm, &protoCallFrame);
 }
 
-WebAssemblyFunction* WebAssemblyFunction::create(VM& vm, JSGlobalObject* globalObject, Structure* structure, unsigned length, const String& name, JSWebAssemblyInstance* instance, Wasm::JSToWasmCallee& jsToWasm, Wasm::IPIntCallee& wasmCallee, Wasm::WasmToWasmImportableFunction::LoadLocation wasmToWasmEntrypointLoadLocation, Ref<const Wasm::RTT>&& rtt)
+WebAssemblyFunction* WebAssemblyFunction::create(VM& vm, JSGlobalObject* globalObject, Structure* structure, unsigned length, const String& name, JSWebAssemblyInstance* instance, Wasm::IPIntCallee& wasmCallee, Wasm::WasmToWasmImportableFunction::LoadLocation wasmToWasmEntrypointLoadLocation, Ref<const Wasm::RTT>&& rtt)
 {
     NativeExecutable* base = vm.getHostFunction(callWebAssemblyFunction, ImplementationVisibility::Public, WasmFunctionIntrinsic, callHostFunctionAsConstructor, nullptr, String());
     // Since ClosureCall uses this executable as an identity for Wasm CallIC thunk, we need to make it diversified.
     NativeExecutable* executable = NativeExecutable::create(vm, base->generatedJITCodeForCall(), callWebAssemblyFunction, base->generatedJITCodeForConstruct(), callHostFunctionAsConstructor, ImplementationVisibility::Public, name);
-    WebAssemblyFunction* function = new (NotNull, allocateCell<WebAssemblyFunction>(vm)) WebAssemblyFunction(vm, executable, globalObject, structure, instance, jsToWasm, wasmCallee, wasmToWasmEntrypointLoadLocation, WTF::move(rtt));
+    WebAssemblyFunction* function = new (NotNull, allocateCell<WebAssemblyFunction>(vm)) WebAssemblyFunction(vm, executable, globalObject, structure, instance, wasmCallee, wasmToWasmEntrypointLoadLocation, WTF::move(rtt));
     function->finishCreation(vm, executable, length, name);
+    // The LLInt and JIT JS->Wasm entry trampolines read m_boxedJSToWasmCallee and
+    // m_frameSize directly from this object, and are entered from many paths that
+    // bypass callWebAssemblyFunction. Ensure they are populated before any such entry.
+    // FIXME: Move this to those places so the JSToWasmCallee is materialized lazily.
+    function->ensureJSToWasmCallee();
     return function;
 }
 
@@ -95,12 +100,23 @@ Structure* WebAssemblyFunction::createStructure(VM& vm, JSGlobalObject* globalOb
     return Structure::create(vm, globalObject, prototype, TypeInfo(JSFunctionType, StructureFlags), info());
 }
 
-WebAssemblyFunction::WebAssemblyFunction(VM& vm, NativeExecutable* executable, JSGlobalObject* globalObject, Structure* structure, JSWebAssemblyInstance* instance, Wasm::JSToWasmCallee& jsToWasm, Wasm::IPIntCallee& wasmCallee, Wasm::WasmToWasmImportableFunction::LoadLocation wasmToWasmEntrypointLoadLocation, Ref<const Wasm::RTT>&& rtt)
+WebAssemblyFunction::WebAssemblyFunction(VM& vm, NativeExecutable* executable, JSGlobalObject* globalObject, Structure* structure, JSWebAssemblyInstance* instance, Wasm::IPIntCallee& wasmCallee, Wasm::WasmToWasmImportableFunction::LoadLocation wasmToWasmEntrypointLoadLocation, Ref<const Wasm::RTT>&& rtt)
     : Base { vm, executable, globalObject, structure, Wasm::WasmOrJSImportableFunction { { { CalleeBits(&wasmCallee), { instance, WriteBarrierEarlyInit }, wasmToWasmEntrypointLoadLocation }, rtt.ptr() }, { }, { } }, nullptr }
-    , m_boxedJSToWasmCallee(jsToWasm)
-    , m_frameSize(jsToWasm.frameSize())
     , m_taintedness(instance->taintedness())
 {
+}
+
+Wasm::JSToWasmCallee& WebAssemblyFunction::ensureJSToWasmCallee()
+{
+    // WebAssemblyFunction is tied to a single thread; CalleeGroup's cache has its own lock.
+    if (m_boxedJSToWasmCallee) [[likely]]
+        return *m_boxedJSToWasmCallee;
+
+    auto* wasmCallee = uncheckedDowncast<Wasm::Callee>(importableFunction().boxedCallee.asNativeCallee());
+    auto& callee = instance()->calleeGroup()->ensureJSToWasmCallee(instance()->moduleInformation(), wasmCallee->index());
+    m_frameSize = callee.frameSize();
+    m_boxedJSToWasmCallee = &callee;
+    return callee;
 }
 
 template<typename Visitor>

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.h
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyFunction.h
@@ -62,14 +62,15 @@ public:
 
     DECLARE_VISIT_CHILDREN;
 
-    JS_EXPORT_PRIVATE static WebAssemblyFunction* create(VM&, JSGlobalObject*, Structure*, unsigned, const String&, JSWebAssemblyInstance*, Wasm::JSToWasmCallee&, Wasm::IPIntCallee&, WasmToWasmImportableFunction::LoadLocation, Ref<const Wasm::RTT>&&);
+    JS_EXPORT_PRIVATE static WebAssemblyFunction* create(VM&, JSGlobalObject*, Structure*, unsigned, const String&, JSWebAssemblyInstance*, Wasm::IPIntCallee&, WasmToWasmImportableFunction::LoadLocation, Ref<const Wasm::RTT>&&);
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue);
 
-    Wasm::JSToWasmCallee* jsToWasmCallee() const { return m_boxedJSToWasmCallee.ptr(); }
+    Wasm::JSToWasmCallee* jsToWasmCallee() const { return m_boxedJSToWasmCallee.get(); }
+    JS_EXPORT_PRIVATE Wasm::JSToWasmCallee& ensureJSToWasmCallee();
     CodePtr<WasmEntryPtrTag> jsToWasm(ArityCheckMode arity)
     {
         ASSERT_UNUSED(arity, arity == ArityCheckMode::ArityCheckNotRequired || arity == ArityCheckMode::MustCheckArity);
-        return m_boxedJSToWasmCallee->entrypoint();
+        return ensureJSToWasmCallee().entrypoint();
     }
 
     CodePtr<JSEntryPtrTag> jsCallICEntrypoint()
@@ -94,13 +95,14 @@ public:
     static constexpr ptrdiff_t offsetOfFrameSize() { return OBJECT_OFFSETOF(WebAssemblyFunction, m_frameSize); }
 
 private:
-    WebAssemblyFunction(VM&, NativeExecutable*, JSGlobalObject*, Structure*, JSWebAssemblyInstance*, Wasm::JSToWasmCallee&, Wasm::IPIntCallee&, WasmToWasmImportableFunction::LoadLocation entrypointLoadLocation, Ref<const Wasm::RTT>&&);
+    WebAssemblyFunction(VM&, NativeExecutable*, JSGlobalObject*, Structure*, JSWebAssemblyInstance*, Wasm::IPIntCallee&, WasmToWasmImportableFunction::LoadLocation entrypointLoadLocation, Ref<const Wasm::RTT>&&);
 
     CodePtr<JSEntryPtrTag> jsCallEntrypointSlow();
 
-    // This let's the JS->Wasm interpreter find its metadata
-    Ref<Wasm::JSToWasmCallee, BoxedNativeCalleePtrTraits<Wasm::JSToWasmCallee>> m_boxedJSToWasmCallee;
-    uint32_t m_frameSize;
+    // The JS->Wasm interpreter trampoline reads this directly. Populated by
+    // ensureJSToWasmCallee, which create() invokes before the wrapper is exposed.
+    RefPtr<Wasm::JSToWasmCallee, BoxedNativeCalleePtrTraits<Wasm::JSToWasmCallee>> m_boxedJSToWasmCallee;
+    uint32_t m_frameSize { 0 };
     SourceTaintedOrigin m_taintedness;
 
 #if ENABLE(JIT)

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleRecord.cpp
@@ -548,47 +548,13 @@ void WebAssemblyModuleRecord::initializeExports(JSGlobalObject* globalObject)
         m_instance->setTag(moduleInformation.importExceptionCount() + index, Wasm::Tag::create(Ref { moduleInformation.rtt(typeSignatureIndex) }));
     }
 
-    unsigned functionImportCount = calleeGroup->functionImportCount();
-    auto makeFunctionWrapper = [&] (Wasm::FunctionSpaceIndex functionIndexSpace) -> JSValue {
-        // If we already made a wrapper, do not make a new one.
-        JSValue wrapper = m_instance->getFunctionWrapper(functionIndexSpace);
-
-        if (!wrapper.isNull())
-            return wrapper;
-
-        // 1. If e is a closure c:
-        //   i. If there is an Exported Function Exotic Object func in funcs whose func.[[Closure]] equals c, then return func.
-        //   ii. (Note: At most one wrapper is created for any closure, so func is unique, even if there are multiple occurrences in the list. Moreover, if the item was an import that is already an Exported Function Exotic Object, then the original function object will be found. For imports that are regular JS functions, a new wrapper will be created.)
-        if (functionIndexSpace < functionImportCount) {
-            JSObject* functionImport = m_instance->getImportFunctionObject(functionIndexSpace, globalObject);
-            if (isWebAssemblyHostFunction(functionImport))
-                wrapper = functionImport;
-            else {
-                Ref rtt = module->rttFromFunctionIndexSpace(functionIndexSpace);
-                wrapper = WebAssemblyWrapperFunction::create(vm, globalObject, globalObject->webAssemblyWrapperFunctionStructure(), functionImport, functionIndexSpace, m_instance.get(), WTF::move(rtt));
-            }
-        } else {
-            //   iii. Otherwise:
-            //     a. Let func be an Exported Function Exotic Object created from c.
-            //     b. Append func to funcs.
-            //     c. Return func.
-            auto& jsToWasmCallee = calleeGroup->jsToWasmCalleeFromFunctionIndexSpace(functionIndexSpace);
-            auto wasmCallee = calleeGroup->wasmCalleeFromFunctionIndexSpace(functionIndexSpace);
-            ASSERT(wasmCallee);
-            Wasm::WasmToWasmImportableFunction::LoadLocation entrypointLoadLocation = calleeGroup->entrypointLoadLocationFromFunctionIndexSpace(functionIndexSpace);
-            Ref rtt = module->rttFromFunctionIndexSpace(functionIndexSpace);
-            WebAssemblyFunction* function = WebAssemblyFunction::create(vm, globalObject, globalObject->webAssemblyFunctionStructure(), rtt->argumentCount(), makeString(functionIndexSpace.rawIndex()), m_instance.get(), jsToWasmCallee, *wasmCallee, entrypointLoadLocation, WTF::move(rtt));
-            wrapper = function;
-        }
-
-        ASSERT(wrapper.isCallable());
-        m_instance->setFunctionWrapper(functionIndexSpace, wrapper);
-
-        return wrapper;
-    };
-
-    for (auto functionIndexSpace : moduleInformation.referencedFunctions())
-        makeFunctionWrapper(Wasm::FunctionSpaceIndex(functionIndexSpace));
+    // Eagerly materialize wrappers only for exported functions. Wrappers for
+    // functions referenced only by ref.func or element segments are created
+    // lazily by ensureFunctionWrapper when needed.
+    for (const auto& exp : moduleInformation.exports) {
+        if (exp.kind == Wasm::ExternalKind::Function)
+            m_instance->ensureFunctionWrapper(Wasm::FunctionSpaceIndex(exp.kindIndex));
+    }
 
     // Tables
     for (unsigned i = 0; i < moduleInformation.tableCount(); ++i) {
@@ -617,8 +583,8 @@ void WebAssemblyModuleRecord::initializeExports(JSGlobalObject* globalObject)
             case Wasm::TableInformation::FromRefFunc: {
                 ASSERT(initialBitsOrImportNumber < moduleInformation.functionIndexSpaceSize());
                 auto functionSpaceIndex = Wasm::FunctionSpaceIndex(initialBitsOrImportNumber);
-                ASSERT(makeFunctionWrapper(functionSpaceIndex).isCallable());
-                initialBitsOrImportNumber = JSValue::encode(makeFunctionWrapper(functionSpaceIndex));
+                ASSERT(m_instance->ensureFunctionWrapper(functionSpaceIndex).isCallable());
+                initialBitsOrImportNumber = JSValue::encode(m_instance->ensureFunctionWrapper(functionSpaceIndex));
                 break;
             }
             case Wasm::TableInformation::FromExtendedExpression: {
@@ -681,8 +647,8 @@ void WebAssemblyModuleRecord::initializeExports(JSGlobalObject* globalObject)
             } else if (global.initializationType == Wasm::GlobalInformation::FromRefFunc) {
                 ASSERT(global.initialBits.initialBitsOrImportNumber < moduleInformation.functionIndexSpaceSize());
                 auto functionSpaceIndex = Wasm::FunctionSpaceIndex(global.initialBits.initialBitsOrImportNumber);
-                ASSERT(makeFunctionWrapper(functionSpaceIndex).isCallable());
-                initialBits = JSValue::encode(makeFunctionWrapper(functionSpaceIndex));
+                ASSERT(m_instance->ensureFunctionWrapper(functionSpaceIndex).isCallable());
+                initialBits = JSValue::encode(m_instance->ensureFunctionWrapper(functionSpaceIndex));
             } else if (global.initializationType == Wasm::GlobalInformation::FromExtendedExpression) {
                 ASSERT(global.initialBits.initialBitsOrImportNumber < moduleInformation.constantExpressions.size());
                 evaluateConstantExpression(globalObject, moduleInformation.constantExpressions[global.initialBits.initialBitsOrImportNumber], moduleInformation, global.type, initialBits);
@@ -722,9 +688,9 @@ void WebAssemblyModuleRecord::initializeExports(JSGlobalObject* globalObject)
         switch (exp.kind) {
         case Wasm::ExternalKind::Function: {
             auto functionSpaceIndex = Wasm::FunctionSpaceIndex(exp.kindIndex);
-            exportedValue = makeFunctionWrapper(functionSpaceIndex);
+            exportedValue = m_instance->ensureFunctionWrapper(functionSpaceIndex);
             ASSERT(exportedValue.isCallable());
-            ASSERT(makeFunctionWrapper(functionSpaceIndex) == exportedValue);
+            ASSERT(m_instance->ensureFunctionWrapper(functionSpaceIndex) == exportedValue);
             break;
         }
         case Wasm::ExternalKind::Table: {
@@ -818,11 +784,10 @@ void WebAssemblyModuleRecord::initializeExports(JSGlobalObject* globalObject)
             ASSERT(startFunction);
             m_startFunction.set(vm, this, startFunction);
         } else {
-            auto& jsToWasmCallee = calleeGroup->jsToWasmCalleeFromFunctionIndexSpace(startFunctionIndexSpace);
             auto wasmCallee = calleeGroup->wasmCalleeFromFunctionIndexSpace(startFunctionIndexSpace);
             ASSERT(wasmCallee);
             Wasm::WasmToWasmImportableFunction::LoadLocation entrypointLoadLocation = calleeGroup->entrypointLoadLocationFromFunctionIndexSpace(startFunctionIndexSpace);
-            WebAssemblyFunction* function = WebAssemblyFunction::create(vm, globalObject, globalObject->webAssemblyFunctionStructure(), rtt->argumentCount(), "start"_s, m_instance.get(), jsToWasmCallee, *wasmCallee, entrypointLoadLocation, WTF::move(rtt));
+            WebAssemblyFunction* function = WebAssemblyFunction::create(vm, globalObject, globalObject->webAssemblyFunctionStructure(), rtt->argumentCount(), "start"_s, m_instance.get(), *wasmCallee, entrypointLoadLocation, WTF::move(rtt));
             m_startFunction.set(vm, this, function);
         }
     }


### PR DESCRIPTION
#### 29ac32293df6aedf716001999056f180b7145eaa
<pre>
[Wasm] Build JS Wrappers and JSToWasmCallees Lazily
<a href="https://bugs.webkit.org/show_bug.cgi?id=314910">https://bugs.webkit.org/show_bug.cgi?id=314910</a>
<a href="https://rdar.apple.com/177187656">rdar://177187656</a>

Reviewed by Yusuke Suzuki.

Wasm instantiation eagerly built two things that are commonly unused:

1. A WebAssemblyFunction (or WebAssemblyWrapperFunction) wrapper for every
function listed in ModuleInformation::referencedFunctions() — the union of
exports, ref.func targets, and element-segment entries. Many modules never
expose most of those functions to JS.

2. A Wasm::JSToWasmCallee for every defined Wasm function, built inside
IPIntPlan and stored in CalleeGroup::m_jsToWasmCallees. Most internal
functions are never called from JS, so the thunk and frame-size
computation were wasted.

This patch makes both lazy. The resulting eagerness matrix is:

| Function kind                      | Wrapper                      | JS-&gt;Wasm callee |
|------------------------------------|------------------------------|-----------------|
| Exported                           | eager (instantiation)        | eager-on-create |
| In an active element segment       | eager (table-init at link)   | eager-on-create |
| Only via passive/dec element seg   | lazy (table.init/table.copy) | eager-on-create |
| Only via ref.func                  | lazy (ref.func execution)    | eager-on-create |
| Host import                        | lazy                         | n/a             |

Wrappers for non-exports are now materialized on demand by the new
JSWebAssemblyInstance::ensureFunctionWrapper(FunctionSpaceIndex), which
folds in the previous makeFunctionWrapper lambda from
WebAssemblyModuleRecord. The eager loop over referencedFunctions() is
replaced with a smaller exports-only loop in WebAssemblyModuleRecord.
Active element segments still create wrappers at instantiation, but only
for the functions they actually contain (via the table-init code path),
not the precomputed union of all referenced functions. ref.func, table
init/copy, const-expr evaluation, and the start-function path all now
route through ensureFunctionWrapper.

JSToWasmCallee construction is removed from IPIntPlan
(takeJSToWasmCallees, ensureEntrypoint, m_entrypoints, m_jsToWasmCallees
are gone). CalleeGroup::ensureJSToWasmCallee(const ModuleInformation&amp;,
FunctionSpaceIndex) creates and caches the JSToWasmCallee on first
demand, guarded by a dedicated m_jsToWasmCalleesLock so it does not
contend with the rest of CalleeGroup::m_lock. WebAssemblyFunction owns a
RefPtr to the boxed callee and exposes ensureJSToWasmCallee, which is
called from WebAssemblyFunction::create so the LLInt and JIT JS-&gt;Wasm
entry trampolines (which read m_boxedJSToWasmCallee and m_frameSize
directly via fixed offsets, bypassing callWebAssemblyFunction) always
observe a populated value. WebAssemblyFunction is single-threaded so no
extra locking is needed there.

Also, remove the ModuleInformation::referencedFunctions() function and
related BitVector. The referencedFunctions list was only used to
determine which functions to create wrappers for.

No new tests, no behavior change. Covered by existing tests.

Canonical link: <a href="https://commits.webkit.org/313362@main">https://commits.webkit.org/313362@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc6f29f179902343595a56101689fd95421240b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162910 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36388 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29558 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171848 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119356 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/428dbd61-abdd-4e47-ac3a-f1dd9e1a1382) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36493 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36391 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126459 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/89060 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/01580d08-bc74-420d-b3c7-2f9003a1a66a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165869 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/28807 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146397 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107036 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/61c41b62-2c0a-4c70-a951-2672fcedf53f) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/162231 "Build is in progress. Recent messages:") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27853 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26389 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19548 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137564 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24126 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174352 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23776 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/22568 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25772 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134769 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36060 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30492 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134764 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/36181 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145922 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98486 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24768 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/29429 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22759 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195311 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35555 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/104293 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50670 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35055 "Built successfully") | | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35301 "Hash fc6f29f1 for PR 65007 does not build (failure)") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35203 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->