### PR TITLE
Flex container's preferred widths become stale when its parent's height changes

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5002,8 +5002,6 @@ imported/w3c/web-platform-tests/css/css-writing-modes/test-plan/req-tcu-font.htm
 imported/w3c/web-platform-tests/css/cssom-view/smooth-scrollIntoView-with-smooth-fragment-scroll-iframe.html [ Skip ]
 imported/w3c/web-platform-tests/css/cssom-view/smooth-scroll-nonstop.html [ Skip ] # passes few subtests
 
-webkit.org/b/219343 imported/w3c/web-platform-tests/css/css-flexbox/aspect-ratio-intrinsic-size-005.html [ ImageOnlyFailure ]
-
 webkit.org/b/145176 imported/w3c/web-platform-tests/css/css-flexbox/flexbox_align-items-stretch-3.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-flexbox/select-element-multiple.html [ ImageOnlyFailure ]
 webkit.org/b/210093 imported/w3c/web-platform-tests/css/css-flexbox/select-element-zero-height-001.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/aspect-ratio-intrinsic-size-011-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/aspect-ratio-intrinsic-size-011-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/aspect-ratio-intrinsic-size-011.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/aspect-ratio-intrinsic-size-011.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#intrinsic-sizes">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="A fit-content sized block must recompute its width when its height changes, when its child is a flex container with a stretched aspect-ratio flex item.">
+<p>Test passes if there is a filled green square.</p>
+<div id="target" style="height: 50px; width: fit-content; background: green;">
+  <div style="display: flex; height: 100%; background: green;">
+    <div style="aspect-ratio: 1/1;"></div>
+  </div>
+</div>
+<script>
+document.body.offsetTop;
+document.getElementById('target').style.height = '100px';
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/aspect-ratio-intrinsic-size-012-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/aspect-ratio-intrinsic-size-012-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green 200x100 rectangle.</p>
+<div style="width:200px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/aspect-ratio-intrinsic-size-012-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/aspect-ratio-intrinsic-size-012-ref.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green 200x100 rectangle.</p>
+<div style="width:200px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/aspect-ratio-intrinsic-size-012.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/aspect-ratio-intrinsic-size-012.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#intrinsic-sizes">
+<link rel="match" href="aspect-ratio-intrinsic-size-012-ref.html">
+<meta name="assert" content="A min-content sized block must recompute its width when its height changes, applying a non-square aspect-ratio to the new height.">
+<p>Test passes if there is a filled green 200x100 rectangle.</p>
+<div id="target" style="height: 50px; width: min-content; background: green;">
+  <div style="display: flex; height: 100%; background: green;">
+    <div style="aspect-ratio: 2/1;"></div>
+  </div>
+</div>
+<script>
+document.body.offsetTop;
+document.getElementById('target').style.height = '100px';
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/aspect-ratio-intrinsic-size-013-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/aspect-ratio-intrinsic-size-013-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green 130x100 rectangle.</p>
+<div style="width:130px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/aspect-ratio-intrinsic-size-013-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/aspect-ratio-intrinsic-size-013-ref.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green 130x100 rectangle.</p>
+<div style="width:130px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/aspect-ratio-intrinsic-size-013.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/aspect-ratio-intrinsic-size-013.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#intrinsic-sizes">
+<link rel="match" href="aspect-ratio-intrinsic-size-013-ref.html">
+<meta name="assert" content="A flex container with multiple items, only one of which has aspect-ratio, must recompute its preferred widths when its parent's height changes.">
+<p>Test passes if there is a filled green 130x100 rectangle.</p>
+<div id="target" style="height: 50px; width: min-content; background: green;">
+  <div style="display: flex; height: 100%; background: green;">
+    <div style="width: 30px;"></div>
+    <div style="aspect-ratio: 1/1;"></div>
+  </div>
+</div>
+<script>
+document.body.offsetTop;
+document.getElementById('target').style.height = '100px';
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/aspect-ratio-intrinsic-size-014-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/aspect-ratio-intrinsic-size-014-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width:100px; height:100px; background:green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/aspect-ratio-intrinsic-size-014.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-flexbox/aspect-ratio-intrinsic-size-014.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-sizing-3/#intrinsic-sizes">
+<link rel="match" href="../reference/ref-filled-green-100px-square-only.html">
+<meta name="assert" content="A float (shrink-to-fit) containing a flex container with percent height and a stretched aspect-ratio flex item must recompute its width when its height changes.">
+<p>Test passes if there is a filled green square.</p>
+<div id="target" style="float: left; height: 50px; background: green;">
+  <div style="display: flex; height: 100%; background: green;">
+    <div style="aspect-ratio: 1/1;"></div>
+  </div>
+</div>
+<script>
+document.body.offsetTop;
+document.getElementById('target').style.height = '100px';
+</script>

--- a/Source/WebCore/rendering/RenderBlockFlow.cpp
+++ b/Source/WebCore/rendering/RenderBlockFlow.cpp
@@ -757,6 +757,28 @@ void RenderBlockFlow::layoutBlock(RelayoutChildren relayoutChildren, LayoutUnit 
     }
 }
 
+static bool formattingContextRootPreferredWidthsDependOnOwnHeight(const RenderBlock& formattingContextRoot)
+{
+    ASSERT(formattingContextRoot.createsNewFormattingContext());
+
+    if (auto* flexBox = dynamicDowncast<RenderFlexibleBox>(formattingContextRoot)) {
+        // The flex cross-size override that drives this dependency is only applied to a flex item
+        // when hasDefiniteCrossSizeForFlexItem(item) is true, which per
+        // https://drafts.csswg.org/css-flexbox/#definite-sizes section 9.8.1 requires a single-line
+        // flex container:
+        //   "If a single-line flex container has a definite cross size, the automatic preferred outer
+        //    cross size of any stretched flex items is the flex container's inner cross size (clamped
+        //    to the flex item's min and max cross size) and is considered definite."
+        // In multi-line containers each line's cross size is driven by its own items, so the
+        // container's preferred widths cannot depend on its own height through this mechanism.
+        if (flexBox->isMultiline())
+            return false;
+        if (flexBox->hasStretchedFlexItemWithAspectRatio())
+            return true;
+    }
+    return false;
+}
+
 void RenderBlockFlow::dirtyForLayoutFromPercentageHeightDescendant(RenderBox& descendant)
 {
     // Let's not dirty the height percentage descendant when it has an absolutely positioned containing block ancestor. We should be able to dirty such boxes through the regular invalidation logic.
@@ -764,6 +786,13 @@ void RenderBlockFlow::dirtyForLayoutFromPercentageHeightDescendant(RenderBox& de
         if (ancestor->isOutOfFlowPositioned())
             return;
     }
+
+    // When the descendant is itself a formatting context root whose preferred widths depend on its own
+    // height (e.g. a flex container with a stretched aspect-ratio item that takes a cross-size override
+    // from the container), our height change can leave its cached preferred widths stale.
+    if (CheckedPtr formattingContextRoot = dynamicDowncast<RenderBlock>(descendant); formattingContextRoot && formattingContextRoot->createsNewFormattingContext()
+        && formattingContextRootPreferredWidthsDependOnOwnHeight(*formattingContextRoot))
+        descendant.setNeedsPreferredWidthsUpdate();
 
     for (CheckedPtr<RenderElement> renderer = &descendant; renderer && renderer != this && !renderer->normalChildNeedsLayout(); renderer = renderer->container()) {
         renderer->setChildNeedsLayout(MarkingBehavior::MarkOnlyThis);

--- a/Source/WebCore/rendering/RenderFlexibleBox.cpp
+++ b/Source/WebCore/rendering/RenderFlexibleBox.cpp
@@ -889,6 +889,21 @@ static bool flexItemHasAspectRatio(const RenderBox& flexItem)
         || isSVGRootWithIntrinsicAspectRatio(flexItem);
 }
 
+bool RenderFlexibleBox::hasStretchedFlexItemWithAspectRatio() const
+{
+    for (auto& flexItem : childrenOfType<RenderBox>(*this)) {
+        if (flexItem.isOutOfFlowPositioned() || flexItem.isExcludedFromNormalLayout())
+            continue;
+        if (!flexItemHasAspectRatio(flexItem))
+            continue;
+        if (alignmentForFlexItem(flexItem) == ItemPosition::Stretch
+            && !hasAutoMarginsInCrossAxis(flexItem)
+            && preferredCrossSizeLengthForFlexItem(flexItem).isAuto())
+            return true;
+    }
+    return false;
+}
+
 template<typename SizeType> std::optional<LayoutUnit> RenderFlexibleBox::computeMainAxisExtentForFlexItem(RenderBox& flexItem, const SizeType& size)
 {
     // If we have a horizontal flow, that means the main size is the width.

--- a/Source/WebCore/rendering/RenderFlexibleBox.h
+++ b/Source/WebCore/rendering/RenderFlexibleBox.h
@@ -109,11 +109,13 @@ public:
 
     bool NODELETE isColumnOrRowReverse() const;
     bool NODELETE isWrapReverse() const;
+    bool NODELETE isMultiline() const;
     bool NODELETE mainAxisIsFlexItemInlineAxis(const RenderBox&) const;
     ItemPosition alignmentForFlexItem(const RenderBox&) const;
     Style::FlexBasis flexBasisForFlexItem(const RenderBox&) const;
     bool hasDefiniteCrossSizeForFlexItem(const RenderBox& flexItem) const;
     bool canResolveCrossSizeFromAspectRatioDuringLayout() const;
+    bool hasStretchedFlexItemWithAspectRatio() const;
 
 protected:
     void computeIntrinsicLogicalWidths(LayoutUnit& minLogicalWidth, LayoutUnit& maxLogicalWidth) const override;
@@ -159,7 +161,6 @@ private:
 
     bool NODELETE isColumnFlow() const;
     bool NODELETE isLeftToRightFlow() const;
-    bool NODELETE isMultiline() const;
     const Style::PreferredSize& NODELETE preferredMainSizeLengthForFlexItem(const RenderBox&) const LIFETIME_BOUND;
     const Style::MinimumSize& NODELETE minMainSizeLengthForFlexItem(const RenderBox&) const LIFETIME_BOUND;
     const Style::MaximumSize& NODELETE maxMainSizeLengthForFlexItem(const RenderBox&) const LIFETIME_BOUND;


### PR DESCRIPTION
#### 7009b52f456d3f48ffb28bab32adbcfe386b2730
<pre>
Flex container&apos;s preferred widths become stale when its parent&apos;s height changes
<a href="https://bugs.webkit.org/show_bug.cgi?id=230151">https://bugs.webkit.org/show_bug.cgi?id=230151</a>
<a href="https://rdar.apple.com/83240099">rdar://83240099</a>

Reviewed by Alan Baradlay.

A block (e.g. shrink-to-fit / min-content) with a flex container child
whose height is a percentage of the block can render at the wrong width
when the block&apos;s height changes. If the flex container has a stretched
aspect-ratio item, the container&apos;s intrinsic width depends on its own
cross size: during preferred-widths computation the container propagates
its cross size to the item as an overriding size, and the item&apos;s
aspect-ratio derives its inline size from that override.

The cached preferred widths on the flex container were never invalidated
when the parent&apos;s height changed, so callers (e.g. the parent&apos;s min-content
width resolution) read a stale value.

Add some additional logic in RenderBlockFlow::dirtyForLayoutFromPercentageHeightDescendant
that basically attempts to detect this case by asking the formatting
context root if its preferred widths depends on its own height.

For now we only handle flex containers in this patch along with some
testcases that demonstrate the problem. If we find any other formatting
contexts that share this issue when its content has aspect-ratio, or
even if we find some other type of content in any FC that can trigger
this dependency, we can extend this function to cover those cases.

Canonical link: <a href="https://commits.webkit.org/313536@main">https://commits.webkit.org/313536@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6f729ea4ff2735cef33f33a8a1ba416a5d28dc53

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163348 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36831 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30046 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172287 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119795 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a99ea8b6-9e58-4069-b213-b07ca0b14b5c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165217 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37158 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36831 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126849 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/89422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7eb66b9b-08dc-4d25-a19c-bea08dd64204) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166307 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29119 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146843 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107416 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fe06402b-c74e-46ea-99eb-8107ef46b790) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28165 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26797 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19989 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138060 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24567 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174791 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27392 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26223 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135155 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36500 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30896 "Found 3 new test failures: http/tests/site-isolation/page-lifecycle/pagehide.html http/tests/site-isolation/page-lifecycle/pageswap.html http/tests/site-isolation/page-lifecycle/unload.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135146 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36438 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37286 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146362 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99240 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30447 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23207 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35995 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108837 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35494 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1232 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35742 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35642 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->