### PR TITLE
AX: VoiceOver generally does not automatically move into dialogs, despite presence of the autofocus attribute and / or explicit focus() calls

### DIFF
--- a/LayoutTests/accessibility/dialog-focus-on-open-expected.txt
+++ b/LayoutTests/accessibility/dialog-focus-on-open-expected.txt
@@ -1,0 +1,12 @@
+This test verifies that when a dialog opens and a heading inside it is programmatically focused, the focused element reported to assistive technologies is the heading.
+
+PASS: window.focusedAtNotificationTime === 'heading'
+PASS: accessibilityController.focusedElement.domIdentifier === 'heading'
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Show dialog
+Create
+
+Cancel  Create

--- a/LayoutTests/accessibility/dialog-focus-on-open.html
+++ b/LayoutTests/accessibility/dialog-focus-on-open.html
@@ -1,0 +1,49 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<html>
+<head>
+<script src="../resources/accessibility-helper.js"></script>
+<script src="../resources/js-test.js"></script>
+</head>
+<body>
+
+<button id="showButton" onclick="
+    document.getElementById('dialog').showModal();
+    document.getElementById('heading').focus();
+">Show dialog</button>
+
+<dialog id="dialog">
+    <h2 id="heading" tabindex="-1">Create</h2>
+    <button id="cancel">Cancel</button>
+    <button id="create">Create</button>
+</dialog>
+
+<script>
+var output = "This test verifies that when a dialog opens and a heading inside it is programmatically focused, the focused element reported to assistive technologies is the heading.\n\n";
+
+if (window.accessibilityController) {
+    window.jsTestIsAsync = true;
+
+    var showButton = accessibilityController.accessibleElementById("showButton");
+
+    window.focusedAtNotificationTime = null;
+    accessibilityController.addNotificationListener(function(element, notification) {
+        if (notification === "AXFocusChanged") {
+            var focused = accessibilityController.focusedElement;
+            window.focusedAtNotificationTime = focused ? focused.domIdentifier : "null";
+        }
+    });
+
+    setTimeout(async function() {
+        showButton.press();
+
+        output += await expectAsync("window.focusedAtNotificationTime", "'heading'");
+        output += expect("accessibilityController.focusedElement.domIdentifier", "'heading'");
+
+        accessibilityController.removeNotificationListener();
+        debug(output);
+        finishJSTest();
+    }, 0);
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -967,6 +967,8 @@ accessibility/aria-table-selection-support.html [ Skip ]
 # AccessibilityUIElement::isAttributeSupported doesn't handle AXExpanded.
 accessibility/aria-expanded-links.html [ Skip ]
 
+accessibility/dialog-focus-on-open.html [ Failure ]
+
 # AccessibilityUIElement::customContent is not implemented.
 accessibility/dynamic-aria-describedby-subtree.html [ Failure ]
 accessibility/dynamic-aria-describedby-text.html [ Failure ]

--- a/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
+++ b/Source/WebCore/accessibility/mac/AXObjectCacheMac.mm
@@ -697,6 +697,18 @@ void AXObjectCache::frameLoadingEventPlatformNotification(RenderView* renderView
 
 void AXObjectCache::platformHandleFocusedUIElementChanged(AccessibilityObject*, AccessibilityObject*)
 {
+#if ENABLE(ACCESSIBILITY_ISOLATED_TREE)
+    // Process any pending isolated-tree node updates (e.g. queued children-changed walks for
+    // newly-revealed subtrees like the contents of a just-opened <dialog>) before calling
+    // NSAccessibilityHandleFocusChanged. AppKit synchronously calls [NSApp accessibilityFocusedUIElement]
+    // from inside NSAccessibilityHandleFocusChanged on the same call stack. That query lands on
+    // our wrapper's accessibilityFocusedUIElement, which goes through the AX thread to
+    // AXIsolatedTree::focusedNode. If we serve that query before the focused object's subtree
+    // has been resolved into the isolated tree's pending appends, focusedNode returns null,
+    // meaning VoiceOver won't move to it.
+    processQueuedIsolatedNodeUpdates();
+#endif
+
     NSAccessibilityHandleFocusChanged();
     // AXFocusChanged is a test specific notification name and not something a real AT will be listening for
     if (!gShouldRepostNotificationsForTests) [[unlikely]]
@@ -706,12 +718,15 @@ void AXObjectCache::platformHandleFocusedUIElementChanged(AccessibilityObject*, 
     if (!rootWebArea)
         return;
 
-    callOnMainThread([webArea = rootWebArea] {
-        // Do not post focus-changed notifications to layout tests synchronously. Otherwise JS event
-        // handlers could dirty style / layout in the middle of contexts where we expect clean style
-        // and layout, e.g. AXObjectCache::performDeferredCacheUpdate.
-        [webArea->wrapper() accessibilityPostedNotification:NSAccessibilityFocusChangedNotification userInfo:nil];
-    });
+    // Post the test-only notification synchronously so layout tests observe the same timing
+    // as AppKit's synchronous [NSApp accessibilityFocusedUIElement] query inside
+    // NSAccessibilityHandleFocusChanged, i.e. while the focus change is still on the call stack
+    // and before performDeferredCacheUpdate has finished its remaining work. (Delivery to a real
+    // AT like VoiceOver crosses a process boundary and is async; what we're mirroring is the
+    // local same-stack moment when AppKit asks for the focused element.) Tests that need to dirty
+    // style/layout in response should defer that work via setTimeout, since real ATs can't trigger
+    // JS synchronously in response to notifications but our test infrastructure can.
+    [rootWebArea->wrapper() accessibilityPostedNotification:NSAccessibilityFocusChangedNotification userInfo:nil];
 }
 
 void AXObjectCache::handleScrolledToAnchor(const Node&)


### PR DESCRIPTION
#### f3b6d2ac3f94074de46b2e61b19f48bf46a191db
<pre>
AX: VoiceOver generally does not automatically move into dialogs, despite presence of the autofocus attribute and / or explicit focus() calls
<a href="https://bugs.webkit.org/show_bug.cgi?id=314893">https://bugs.webkit.org/show_bug.cgi?id=314893</a>
<a href="https://rdar.apple.com/177167634">rdar://177167634</a>

Reviewed by Dominic Mazzoni.

When a &lt;dialog&gt; opens and the page focuses an element inside it (e.g. a heading
with tabindex=&quot;-1&quot;), VoiceOver fails to move its cursor onto the focused element.

When dialog.show() runs, the dialog&apos;s content gets renderers and a children-changed
update is queued on the dialog&apos;s parent, but the actual subtree walk that adds new
descendants to the isolated tree&apos;s pending appends doesn&apos;t happen until
processQueuedNodeUpdates runs (via the snapshot timer, fired after
performDeferredCacheUpdate). When the deferred focus change runs first,
setIsolatedTreeFocusedObject writes the heading&apos;s AXID into focusedNodeID, but the
heading&apos;s AXIsolatedObject isn&apos;t in the reader-thread node map yet. Inside
NSAccessibilityHandleFocusChanged, AppKit synchronously calls
[NSApp accessibilityFocusedUIElement] on the same call stack. That lands on our
wrapper, goes through the AX thread to focusedNode(), and returns nil because the
focused AXID has no corresponding AXIsolatedObject. AppKit&apos;s currentElement is nil,
so it skips NSAccessibilityPostNotification entirely and VoiceOver is never told.

Fix this by calling processQueuedIsolatedNodeUpdates in platformHandleFocusedUIElementChanged
before NSAccessibilityHandleFocusChanged, so the focused object&apos;s subtree is in the
isolated tree before AppKit&apos;s synchronous focused-element query.

Also drop the callOnMainThread around the test-only accessibilityPostedNotification
call so the test path matches the timing of AppKit&apos;s synchronous
[NSApp accessibilityFocusedUIElement] query. With the previous async dispatch,
performDeferredCacheUpdate finished before the test JS listener fired, masking the
bug. Tests that need to dirty style/layout in the listener should defer it via
setTimeout (see focus-in-remote-frame.html), since real ATs cannot
synchronously dirty style/layout, and doing so in the middle of
performDeferredCacheUpdate breaks the invariant of layout needing to be
clean for the duration of the function.

* LayoutTests/accessibility/dialog-focus-on-open-expected.txt: Added.
* LayoutTests/accessibility/dialog-focus-on-open.html: Added.
* Source/WebCore/accessibility/mac/AXObjectCacheMac.mm:
(WebCore::AXObjectCache::platformHandleFocusedUIElementChanged):

Canonical link: <a href="https://commits.webkit.org/313425@main">https://commits.webkit.org/313425@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/012d715ff0712418c4933356e9a17663ea634759

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162847 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36324 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29523 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171785 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119293 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164716 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36428 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36327 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126409 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89021 "17 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165806 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28753 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146364 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106986 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27799 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26334 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19485 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137508 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24093 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174289 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21815 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25738 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134718 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35997 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30437 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134713 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36380 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/36980 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145889 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98408 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/30180 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22725 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35556 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/103533 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34992 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/748 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35302 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35140 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->