### PR TITLE
Allow redirects with `declarativeNetRequest` permission if the user granted the extension access to the page

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm
@@ -725,7 +725,7 @@ void WebExtensionController::updateWebsitePoliciesForNavigation(API::WebsitePoli
     auto actionPatterns = websitePolicies.activeContentRuleListActionPatterns();
 
     for (Ref context : m_extensionContexts) {
-        if (!context->hasPermission(WKWebExtensionPermissionDeclarativeNetRequestWithHostAccess))
+        if (!context->hasPermission(WKWebExtensionPermissionDeclarativeNetRequestWithHostAccess) && !context->hasPermission(WKWebExtensionPermissionDeclarativeNetRequest))
             continue;
 
         Vector<String> patterns;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIDeclarativeNetRequest.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIDeclarativeNetRequest.mm
@@ -37,6 +37,9 @@
 
 namespace TestWebKitAPI {
 
+static NSString *declarativeNetRequestPermisisonKey = @"declarativeNetRequest";
+static NSString *declarativeNetRequestWithHostAccessPermisisonKey = @"declarativeNetRequestWithHostAccess";
+
 TEST(WKWebExtensionAPIDeclarativeNetRequest, BlockedLoadTest)
 {
     TestWebKitAPI::HTTPServer server({
@@ -778,7 +781,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RemoveDynamicRules)
     Util::loadAndRunExtension(declarativeNetRequestManifest, @{ @"background.js": backgroundScript  });
 }
 
-static void runRedirectRule(bool useEnhancedSecurity)
+static void runRedirectRule(bool useEnhancedSecurity, NSString *permission)
 {
     auto *pageScript = Util::constructScript(@[
         @"<script>",
@@ -821,7 +824,7 @@ static void runRedirectRule(bool useEnhancedSecurity)
 
         @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO },
 
-        @"permissions": @[ @"declarativeNetRequestWithHostAccess" ],
+        @"permissions": @[ permission ],
         @"host_permissions": @[ @"*://localhost/*" ],
 
         @"declarative_net_request": @{
@@ -873,17 +876,22 @@ static void runRedirectRule(bool useEnhancedSecurity)
     [manager run];
 }
 
-TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRule)
+TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRuleWithHostAccessPermission)
 {
-    runRedirectRule(false);
+    runRedirectRule(false, declarativeNetRequestWithHostAccessPermisisonKey);
 }
 
 TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRuleWithEnhancedSecurity)
 {
-    runRedirectRule(true);
+    runRedirectRule(true, declarativeNetRequestWithHostAccessPermisisonKey);
 }
 
-TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRuleWithoutHostAccessPermission)
+TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRuleWithDeclarativeNetRequestPermission)
+{
+    runRedirectRule(false, declarativeNetRequestPermisisonKey);
+}
+
+static void runRedirectRuleWithoutPermission(NSString *permission)
 {
     auto *pageScript = Util::constructScript(@[
         @"<script>",
@@ -926,7 +934,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRuleWithoutHostAccessPermis
 
         @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO },
 
-        @"permissions": @[ @"declarativeNetRequestWithHostAccess" ],
+        @"permissions": @[ permission ],
         @"host_permissions": @[ @"*://localhost/*" ],
 
         @"declarative_net_request": @{
@@ -949,7 +957,11 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRuleWithoutHostAccessPermis
 
     auto manager = Util::loadExtension(manifest, resources);
 
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusDeniedExplicitly forPermission:WKWebExtensionPermissionDeclarativeNetRequestWithHostAccess];
+    if ([permission isEqualToString:declarativeNetRequestPermisisonKey])
+        [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusDeniedExplicitly forPermission:WKWebExtensionPermissionDeclarativeNetRequest];
+    else
+        [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusDeniedExplicitly forPermission:WKWebExtensionPermissionDeclarativeNetRequestWithHostAccess];
+
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
 
     [manager runUntilTestMessage:@"Load Tab"];
@@ -959,7 +971,17 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRuleWithoutHostAccessPermis
     [manager run];
 }
 
-TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRuleWithoutHostPermission)
+TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRuleWithoutHostAccessPermission)
+{
+    runRedirectRuleWithoutPermission(declarativeNetRequestWithHostAccessPermisisonKey);
+}
+
+TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRuleWithoutDeclarativeNetRequestPermission)
+{
+    runRedirectRuleWithoutPermission(declarativeNetRequestPermisisonKey);
+}
+
+static void runRedirectRuleWithoutHostPermission(NSString *permission)
 {
     auto *pageScript = Util::constructScript(@[
         @"<script>",
@@ -1002,7 +1024,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRuleWithoutHostPermission)
 
         @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO },
 
-        @"permissions": @[ @"declarativeNetRequestWithHostAccess" ],
+        @"permissions": @[ permission ],
         @"host_permissions": @[ @"*://localhost/*" ],
 
         @"declarative_net_request": @{
@@ -1032,7 +1054,17 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRuleWithoutHostPermission)
     [manager run];
 }
 
-TEST(WKWebExtensionAPIDeclarativeNetRequest, ModifyHeadersRule)
+TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRuleWithHostAccessPermissionWithoutHostPermission)
+{
+    runRedirectRuleWithoutHostPermission(declarativeNetRequestWithHostAccessPermisisonKey);
+}
+
+TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRuleWithDeclarativeNetRequestPermissionWithoutHostPermission)
+{
+    runRedirectRuleWithoutHostPermission(declarativeNetRequestPermisisonKey);
+}
+
+static void runModifyHeadersRule(NSString *permission)
 {
     auto *pageScript = Util::constructScript(@[
         @"<script>",
@@ -1076,7 +1108,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, ModifyHeadersRule)
 
         @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO },
 
-        @"permissions": @[ @"declarativeNetRequestWithHostAccess" ],
+        @"permissions": @[ permission ],
         @"host_permissions": @[ @"*://localhost/*" ],
 
         @"declarative_net_request": @{
@@ -1098,6 +1130,97 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, ModifyHeadersRule)
     };
 
     auto manager = Util::loadExtension(manifest, resources);
+
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
+
+    [manager runUntilTestMessage:@"Load Tab"];
+
+    [manager.get().defaultTab.webView loadRequest:urlRequest];
+
+    [manager run];
+}
+
+TEST(WKWebExtensionAPIDeclarativeNetRequest, ModifyHeadersRuleWithHostAccessPermission)
+{
+    runModifyHeadersRule(declarativeNetRequestWithHostAccessPermisisonKey);
+}
+
+TEST(WKWebExtensionAPIDeclarativeNetRequest, ModifyHeadersRuleWithDeclarativeNetRequestPermission)
+{
+    runModifyHeadersRule(declarativeNetRequestPermisisonKey);
+}
+
+static void runModifyHeadersRuleWithoutPermission(NSString *permission)
+{
+    auto *pageScript = Util::constructScript(@[
+        @"<script>",
+        @"  browser.test.assertEq(document.referrer, '')",
+
+        @"  browser.test.notifyPass()",
+        @"</script>"
+    ]);
+
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, pageScript } },
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *urlRequest = server.requestWithLocalhost();
+
+    auto *rules = @[@{
+        @"id": @1,
+        @"priority": @1,
+
+        @"action": @{
+            @"type": @"modifyHeaders",
+            @"requestHeaders": @[ @{
+                @"header": @"Referer",
+                @"operation": @"set",
+                @"value": @"https://example.com/"
+            } ]
+        },
+
+        @"condition": @{
+            @"urlFilter": @"localhost",
+            @"resourceTypes": @[ @"main_frame" ]
+        }
+    }];
+
+    auto *manifest = @{
+        @"manifest_version": @3,
+
+        @"name": @"Test",
+        @"description": @"Test",
+        @"version": @"1",
+
+        @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO },
+
+        @"permissions": @[ permission ],
+        @"host_permissions": @[ @"*://localhost/*" ],
+
+        @"declarative_net_request": @{
+            @"rule_resources": @[ @{
+                @"id": @"modifyHeadersRule",
+                @"enabled": @YES,
+                @"path": @"rules.json"
+            } ]
+        }
+    };
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.sendMessage('Load Tab')"
+    ]);
+
+    auto *resources = @{
+        @"background.js": backgroundScript,
+        @"rules.json": rules
+    };
+
+    auto manager = Util::loadExtension(manifest, resources);
+
+    if ([permission isEqualToString:declarativeNetRequestPermisisonKey])
+        [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusDeniedExplicitly forPermission:WKWebExtensionPermissionDeclarativeNetRequest];
+    else
+        [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusDeniedExplicitly forPermission:WKWebExtensionPermissionDeclarativeNetRequestWithHostAccess];
 
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
 
@@ -1110,82 +1233,15 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, ModifyHeadersRule)
 
 TEST(WKWebExtensionAPIDeclarativeNetRequest, ModifyHeadersRuleWithoutHostAccessPermission)
 {
-    auto *pageScript = Util::constructScript(@[
-        @"<script>",
-        @"  browser.test.assertEq(document.referrer, '')",
-
-        @"  browser.test.notifyPass()",
-        @"</script>"
-    ]);
-
-    TestWebKitAPI::HTTPServer server({
-        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, pageScript } },
-    }, TestWebKitAPI::HTTPServer::Protocol::Http);
-
-    auto *urlRequest = server.requestWithLocalhost();
-
-    auto *rules = @[@{
-        @"id": @1,
-        @"priority": @1,
-
-        @"action": @{
-            @"type": @"modifyHeaders",
-            @"requestHeaders": @[ @{
-                @"header": @"Referer",
-                @"operation": @"set",
-                @"value": @"https://example.com/"
-            } ]
-        },
-
-        @"condition": @{
-            @"urlFilter": @"localhost",
-            @"resourceTypes": @[ @"main_frame" ]
-        }
-    }];
-
-    auto *manifest = @{
-        @"manifest_version": @3,
-
-        @"name": @"Test",
-        @"description": @"Test",
-        @"version": @"1",
-
-        @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO },
-
-        @"permissions": @[ @"declarativeNetRequestWithHostAccess" ],
-        @"host_permissions": @[ @"*://localhost/*" ],
-
-        @"declarative_net_request": @{
-            @"rule_resources": @[ @{
-                @"id": @"modifyHeadersRule",
-                @"enabled": @YES,
-                @"path": @"rules.json"
-            } ]
-        }
-    };
-
-    auto *backgroundScript = Util::constructScript(@[
-        @"browser.test.sendMessage('Load Tab')"
-    ]);
-
-    auto *resources = @{
-        @"background.js": backgroundScript,
-        @"rules.json": rules
-    };
-
-    auto manager = Util::loadExtension(manifest, resources);
-
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusDeniedExplicitly forPermission:WKWebExtensionPermissionDeclarativeNetRequestWithHostAccess];
-    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forURL:urlRequest.URL];
-
-    [manager runUntilTestMessage:@"Load Tab"];
-
-    [manager.get().defaultTab.webView loadRequest:urlRequest];
-
-    [manager run];
+    runModifyHeadersRuleWithoutPermission(declarativeNetRequestWithHostAccessPermisisonKey);
 }
 
-TEST(WKWebExtensionAPIDeclarativeNetRequest, ModifyHeadersRuleWithoutHostPermission)
+TEST(WKWebExtensionAPIDeclarativeNetRequest, ModifyHeadersRuleWithoutDeclarativeNetRequestPermission)
+{
+    runModifyHeadersRuleWithoutPermission(declarativeNetRequestPermisisonKey);
+}
+
+static void runModifyHeadersRuleWithoutHostPermission(NSString *permission)
 {
     auto *pageScript = Util::constructScript(@[
         @"<script>",
@@ -1229,7 +1285,7 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, ModifyHeadersRuleWithoutHostPermiss
 
         @"background": @{ @"scripts": @[ @"background.js" ], @"type": @"module", @"persistent": @NO },
 
-        @"permissions": @[ @"declarativeNetRequestWithHostAccess" ],
+        @"permissions": @[ permission ],
         @"host_permissions": @[ @"*://localhost/*" ],
 
         @"declarative_net_request": @{
@@ -1257,6 +1313,16 @@ TEST(WKWebExtensionAPIDeclarativeNetRequest, ModifyHeadersRuleWithoutHostPermiss
     [manager.get().defaultTab.webView loadRequest:urlRequest];
 
     [manager run];
+}
+
+TEST(WKWebExtensionAPIDeclarativeNetRequest, ModifyHeadersRuleWithHostAccessPermissionWithoutHostPermission)
+{
+    runModifyHeadersRuleWithoutHostPermission(declarativeNetRequestWithHostAccessPermisisonKey);
+}
+
+TEST(WKWebExtensionAPIDeclarativeNetRequest, ModifyHeadersRuleWithDeclarativeNetRequestPermissionWithoutHostPermission)
+{
+    runModifyHeadersRuleWithoutHostPermission(declarativeNetRequestPermisisonKey);
 }
 
 TEST(WKWebExtensionAPIDeclarativeNetRequest, MainFrameAllowAllRequests)


### PR DESCRIPTION
#### 455fcf1ca6a1ab6e5b8062b7a40b605592b0b033
<pre>
Allow redirects with `declarativeNetRequest` permission if the user granted the extension access to the page
<a href="https://bugs.webkit.org/show_bug.cgi?id=314912">https://bugs.webkit.org/show_bug.cgi?id=314912</a>
<a href="https://rdar.apple.com/173970555">rdar://173970555</a>

Reviewed by NOBODY (OOPS!).

Per the MDN docs, an extension should still be able to perform this redirect if they have access to
the site without specifying `declarativeNetRequestWithHostAccess` in the manifest.

<a href="https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest">https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/declarativeNetRequest</a>

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIDeclarativeNetRequest.mm

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionControllerCocoa.mm:
(WebKit::WebExtensionController::updateWebsitePoliciesForNavigation):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIDeclarativeNetRequest.mm:
(TestWebKitAPI::runRedirectRule):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRuleWithHostAccessPermission)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRuleWithEnhancedSecurity)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRuleWithDeclarativeNetRequestPermission)):
(TestWebKitAPI::runRedirectRuleWithoutPermission):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRuleWithoutHostAccessPermission)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRuleWithoutDeclarativeNetRequestPermission)):
(TestWebKitAPI::runRedirectRuleWithoutHostPermission):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRuleWithHostAccessPermissionWithoutHostPermission)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRuleWithDeclarativeNetRequestPermissionWithoutHostPermission)):
(TestWebKitAPI::runModifyHeadersRule):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, ModifyHeadersRuleWithHostAccessPermission)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, ModifyHeadersRuleWithDeclarativeNetRequestPermission)):
(TestWebKitAPI::runModifyHeadersRuleWithoutPermission):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, ModifyHeadersRuleWithoutHostAccessPermission)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, ModifyHeadersRuleWithoutDeclarativeNetRequestPermission)):
(TestWebKitAPI::runModifyHeadersRuleWithoutHostPermission):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, ModifyHeadersRuleWithHostAccessPermissionWithoutHostPermission)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, ModifyHeadersRuleWithDeclarativeNetRequestPermissionWithoutHostPermission)):
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRule)): Deleted.
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, RedirectRuleWithoutHostPermission)): Deleted.
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, ModifyHeadersRule)): Deleted.
(TestWebKitAPI::TEST(WKWebExtensionAPIDeclarativeNetRequest, ModifyHeadersRuleWithoutHostPermission)): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/455fcf1ca6a1ab6e5b8062b7a40b605592b0b033

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162842 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36319 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29476 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171780 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119288 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164711 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36423 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36322 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126404 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89019 "1 flakes 18 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165801 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28752 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146323 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106981 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27798 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26332 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19480 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137507 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24052 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174284 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/21807 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25697 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134713 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35992 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30435 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134708 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35977 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145848 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98397 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/29241 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22684 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35486 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/103526 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34987 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35232 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35135 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->