### PR TITLE
Add support for GPC

### DIFF
--- a/LayoutTests/fast/dom/navigator-detached-no-crash-expected.txt
+++ b/LayoutTests/fast/dom/navigator-detached-no-crash-expected.txt
@@ -10,6 +10,7 @@ navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
 navigator.credentials is OK
+navigator.globalPrivacyControl is OK
 navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK
@@ -40,6 +41,7 @@ navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
 navigator.credentials is OK
+navigator.globalPrivacyControl is OK
 navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK

--- a/LayoutTests/imported/w3c/resources/import-expectations.json
+++ b/LayoutTests/imported/w3c/resources/import-expectations.json
@@ -192,6 +192,7 @@
     "web-platform-tests/generic-sensor": "skip",
     "web-platform-tests/geolocation": "import",
     "web-platform-tests/geolocation-sensor": "skip",
+    "web-platform-tests/gpc": "import",
     "web-platform-tests/graphics-aam": "skip",
     "web-platform-tests/graphics-aria": "import",
     "web-platform-tests/gyroscope": "skip",

--- a/LayoutTests/imported/w3c/web-platform-tests/gpc/META.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/gpc/META.yml
@@ -1,0 +1,7 @@
+spec: https://www.w3.org/TR/gpc/
+suggested_reviewers:
+  - AramZS
+  - bvandersloot-mozilla
+  - j-br0
+  - pes10k
+  - SebastianZimmeck

--- a/LayoutTests/imported/w3c/web-platform-tests/gpc/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/gpc/WEB_FEATURES.yml
@@ -1,0 +1,3 @@
+features:
+- name: gpc
+  files: "**"

--- a/LayoutTests/imported/w3c/web-platform-tests/gpc/global_privacy_control.testdriver-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/gpc/global_privacy_control.testdriver-expected.txt
@@ -1,0 +1,3 @@
+
+PASS GPC Testdriver Validation
+

--- a/LayoutTests/imported/w3c/web-platform-tests/gpc/global_privacy_control.testdriver.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/gpc/global_privacy_control.testdriver.html
@@ -1,0 +1,24 @@
+<!doctype html>
+<meta charset=utf-8>
+<title>GPC Testdriver Validation</title>
+<script src=/resources/testharness.js></script>
+<script src=/resources/testharnessreport.js></script>
+<script src="/resources/testdriver.js"></script>
+<script src='/resources/testdriver-vendor.js'></script>
+<script>
+
+promise_test(async t => {
+    // We do not test the initial value deliberately
+    const getInitial = await test_driver.get_global_privacy_control();
+    assert_true(getInitial.gpc === true || getInitial.gpc === false, "Initial value of GPC must be a boolean true or false.")
+    const setTrue = await test_driver.set_global_privacy_control(true);
+    assert_true(setTrue.gpc, "Setting a true global privacy control value results in a true value returned after awaiting.");
+    const getTrue = await test_driver.get_global_privacy_control();
+    assert_true(getTrue.gpc, "Reading the global privacy control value after set to true results in a true value after awaiting.");
+    const setFalse = await test_driver.set_global_privacy_control(false);
+    assert_false(setFalse.gpc, "Setting a false global privacy control value results in a false value returned after awaiting.");
+    const getFalse = await test_driver.get_global_privacy_control();
+    assert_false(getFalse.gpc, "Reading the global privacy control value after set to false results in a false value after awaiting.");
+});
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/gpc/idlharness.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/gpc/idlharness.any-expected.txt
@@ -1,0 +1,21 @@
+
+PASS idl_test setup
+PASS idl_test validation
+PASS Partial interface Navigator: member names are unique
+PASS Partial interface mixin NavigatorID: member names are unique
+PASS Navigator includes GlobalPrivacyControl: member names are unique
+PASS WorkerNavigator includes GlobalPrivacyControl: member names are unique
+PASS Navigator includes NavigatorID: member names are unique
+PASS Navigator includes NavigatorLanguage: member names are unique
+PASS Navigator includes NavigatorOnLine: member names are unique
+PASS Navigator includes NavigatorContentUtils: member names are unique
+PASS Navigator includes NavigatorCookies: member names are unique
+PASS Navigator includes NavigatorPlugins: member names are unique
+PASS Navigator includes NavigatorConcurrentHardware: member names are unique
+PASS WorkerNavigator includes NavigatorID: member names are unique
+PASS WorkerNavigator includes NavigatorLanguage: member names are unique
+PASS WorkerNavigator includes NavigatorOnLine: member names are unique
+PASS WorkerNavigator includes NavigatorConcurrentHardware: member names are unique
+PASS Navigator interface: attribute globalPrivacyControl
+PASS Navigator interface: navigator must inherit property "globalPrivacyControl" with the proper type
+

--- a/LayoutTests/imported/w3c/web-platform-tests/gpc/idlharness.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/gpc/idlharness.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/gpc/idlharness.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/gpc/idlharness.any.js
@@ -1,0 +1,15 @@
+// META: global=window,worker
+// META: script=/resources/WebIDLParser.js
+// META: script=/resources/idlharness.js
+
+idl_test(
+  ['gpc'],
+  ['html'],
+  idl_array => {
+    if (self.Window) {
+      idl_array.add_objects({ Navigator: ['navigator'] });
+    } else {
+      idl_array.add_objects({ WorkerNavigator: ['navigator'] });
+    }
+  }
+);

--- a/LayoutTests/imported/w3c/web-platform-tests/gpc/idlharness.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/gpc/idlharness.any.serviceworker-expected.txt
@@ -1,0 +1,21 @@
+
+PASS idl_test setup
+PASS idl_test validation
+PASS Partial interface Navigator: member names are unique
+PASS Partial interface mixin NavigatorID: member names are unique
+PASS Navigator includes GlobalPrivacyControl: member names are unique
+PASS WorkerNavigator includes GlobalPrivacyControl: member names are unique
+PASS Navigator includes NavigatorID: member names are unique
+PASS Navigator includes NavigatorLanguage: member names are unique
+PASS Navigator includes NavigatorOnLine: member names are unique
+PASS Navigator includes NavigatorContentUtils: member names are unique
+PASS Navigator includes NavigatorCookies: member names are unique
+PASS Navigator includes NavigatorPlugins: member names are unique
+PASS Navigator includes NavigatorConcurrentHardware: member names are unique
+PASS WorkerNavigator includes NavigatorID: member names are unique
+PASS WorkerNavigator includes NavigatorLanguage: member names are unique
+PASS WorkerNavigator includes NavigatorOnLine: member names are unique
+PASS WorkerNavigator includes NavigatorConcurrentHardware: member names are unique
+PASS WorkerNavigator interface: attribute globalPrivacyControl
+PASS WorkerNavigator interface: navigator must inherit property "globalPrivacyControl" with the proper type
+

--- a/LayoutTests/imported/w3c/web-platform-tests/gpc/idlharness.any.serviceworker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/gpc/idlharness.any.serviceworker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/gpc/idlharness.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/gpc/idlharness.any.sharedworker-expected.txt
@@ -1,0 +1,21 @@
+
+PASS idl_test setup
+PASS idl_test validation
+PASS Partial interface Navigator: member names are unique
+PASS Partial interface mixin NavigatorID: member names are unique
+PASS Navigator includes GlobalPrivacyControl: member names are unique
+PASS WorkerNavigator includes GlobalPrivacyControl: member names are unique
+PASS Navigator includes NavigatorID: member names are unique
+PASS Navigator includes NavigatorLanguage: member names are unique
+PASS Navigator includes NavigatorOnLine: member names are unique
+PASS Navigator includes NavigatorContentUtils: member names are unique
+PASS Navigator includes NavigatorCookies: member names are unique
+PASS Navigator includes NavigatorPlugins: member names are unique
+PASS Navigator includes NavigatorConcurrentHardware: member names are unique
+PASS WorkerNavigator includes NavigatorID: member names are unique
+PASS WorkerNavigator includes NavigatorLanguage: member names are unique
+PASS WorkerNavigator includes NavigatorOnLine: member names are unique
+PASS WorkerNavigator includes NavigatorConcurrentHardware: member names are unique
+PASS WorkerNavigator interface: attribute globalPrivacyControl
+PASS WorkerNavigator interface: navigator must inherit property "globalPrivacyControl" with the proper type
+

--- a/LayoutTests/imported/w3c/web-platform-tests/gpc/idlharness.any.sharedworker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/gpc/idlharness.any.sharedworker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/gpc/idlharness.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/gpc/idlharness.any.worker-expected.txt
@@ -1,0 +1,21 @@
+
+PASS idl_test setup
+PASS idl_test validation
+PASS Partial interface Navigator: member names are unique
+PASS Partial interface mixin NavigatorID: member names are unique
+PASS Navigator includes GlobalPrivacyControl: member names are unique
+PASS WorkerNavigator includes GlobalPrivacyControl: member names are unique
+PASS Navigator includes NavigatorID: member names are unique
+PASS Navigator includes NavigatorLanguage: member names are unique
+PASS Navigator includes NavigatorOnLine: member names are unique
+PASS Navigator includes NavigatorContentUtils: member names are unique
+PASS Navigator includes NavigatorCookies: member names are unique
+PASS Navigator includes NavigatorPlugins: member names are unique
+PASS Navigator includes NavigatorConcurrentHardware: member names are unique
+PASS WorkerNavigator includes NavigatorID: member names are unique
+PASS WorkerNavigator includes NavigatorLanguage: member names are unique
+PASS WorkerNavigator includes NavigatorOnLine: member names are unique
+PASS WorkerNavigator includes NavigatorConcurrentHardware: member names are unique
+PASS WorkerNavigator interface: attribute globalPrivacyControl
+PASS WorkerNavigator interface: navigator must inherit property "globalPrivacyControl" with the proper type
+

--- a/LayoutTests/imported/w3c/web-platform-tests/gpc/idlharness.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/gpc/idlharness.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/gpc/navigator-globalPrivacyControl.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/gpc/navigator-globalPrivacyControl.https-expected.txt
@@ -1,0 +1,10 @@
+
+PASS Expected navigator.globalPrivacyControl value (true) is read from the window
+PASS Expected navigator.globalPrivacyControl value (true) is read from the dedicated worker
+PASS Expected navigator.globalPrivacyControl value (true) is read from the shared worker
+PASS Expected navigator.globalPrivacyControl value (true) is read from the service worker
+PASS Expected navigator.globalPrivacyControl value (false) is read from the window
+PASS Expected navigator.globalPrivacyControl value (false) is read from the dedicated worker
+PASS Expected navigator.globalPrivacyControl value (false) is read from the shared worker
+PASS Expected navigator.globalPrivacyControl value (false) is read from the service worker
+

--- a/LayoutTests/imported/w3c/web-platform-tests/gpc/navigator-globalPrivacyControl.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/gpc/navigator-globalPrivacyControl.https.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<title>Primary navigator.globalPrivacyControl test window</title>
+<head>
+  <script src="/resources/testdriver.js"></script>
+  <script src='/resources/testdriver-vendor.js'></script>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+  <div id="log"></div>
+  <script>
+    setup({explicit_done: true});
+    async function run() {
+      const windows_to_close = [];
+      for (const gpcValue of [true, false]) {
+        await test_driver.set_global_privacy_control(gpcValue);
+
+        let child_window = window.open(`support/navigator-globalPrivacyControl.html?gpc=${gpcValue}`);
+        windows_to_close.push(child_window);
+        await fetch_tests_from_window(child_window);
+      }
+
+      for (const w of windows_to_close) {
+        w.close();
+      }
+      done();
+    }
+    run();
+
+  </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/gpc/sec-gpc.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/gpc/sec-gpc.https-expected.txt
@@ -1,0 +1,14 @@
+
+PASS Expected Sec-GPC value (true) is on the document fetch
+PASS Expected Sec-GPC value (true) is on the image fetch
+PASS Expected Sec-GPC value (true) is on the script fetch
+PASS Expected Sec-GPC value (true) is on the iframe fetch
+PASS Expected Sec-GPC value (true) is on the framed image fetch
+PASS Expected Sec-GPC value (true) is on the framed script fetch
+PASS Expected Sec-GPC value (false) is on the document fetch
+PASS Expected Sec-GPC value (false) is on the image fetch
+PASS Expected Sec-GPC value (false) is on the script fetch
+PASS Expected Sec-GPC value (false) is on the iframe fetch
+PASS Expected Sec-GPC value (false) is on the framed image fetch
+PASS Expected Sec-GPC value (false) is on the framed script fetch
+

--- a/LayoutTests/imported/w3c/web-platform-tests/gpc/sec-gpc.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/gpc/sec-gpc.https.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html>
+<title>Primary Sec-GPC test window</title>
+<head>
+  <script src="/resources/testdriver.js"></script>
+  <script src='/resources/testdriver-vendor.js'></script>
+  <script src="/resources/testharness.js"></script>
+  <script src="/resources/testharnessreport.js"></script>
+</head>
+<body>
+  <div id="log"></div>
+  <script>
+    setup({explicit_done: true});
+    async function run() {
+      const windows_to_close = [];
+      for (const gpcValue of [true, false]) {
+        await test_driver.set_global_privacy_control(gpcValue);
+
+        let child_window = window.open(`support/getGPC.py?gpc=${gpcValue}`);
+        windows_to_close.push(child_window);
+        await fetch_tests_from_window(child_window);
+      }
+
+      for (const w of windows_to_close) {
+        w.close();
+      }
+      done();
+    }
+    run();
+
+  </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/gpc/support/getGPC.py
+++ b/LayoutTests/imported/w3c/web-platform-tests/gpc/support/getGPC.py
@@ -1,0 +1,95 @@
+import base64
+
+def maybeBoolToJavascriptLiteral(value):
+  if value == None:
+    return "undefined"
+  if value == True:
+    return "true"
+  if value == False:
+    return "false"
+  raise ValueError("Expected bool or None")
+
+def main(request, response):
+  destination = request.headers.get("sec-fetch-dest").decode("utf-8")
+  gpcValue = request.headers.get("sec-gpc") == b'1'
+  expectedGPCValue = request.GET.get(b"gpc") == b"true"
+  inFrame = request.GET.get(b"framed") != None
+  destinationDescription = "framed " + destination if inFrame else destination
+  if destination == "document" or destination == "iframe":
+    response.headers.set('Content-Type', 'text/html');
+    return f"""
+<!DOCTYPE html>
+<html>
+<title>Sec-GPC {destination}</title>
+<head>
+  <script src="/resources/testharness.js"></script>
+</head>
+<body>
+  <div id="log"></div>
+  <img id="imageTest">
+  <script>
+    test(function(t) {{
+      assert_equals({maybeBoolToJavascriptLiteral(gpcValue)}, {maybeBoolToJavascriptLiteral(expectedGPCValue)}, "Expected Sec-GPC value ({maybeBoolToJavascriptLiteral(expectedGPCValue)}) is on the {destinationDescription} fetch");
+    }}, `Expected Sec-GPC value ({maybeBoolToJavascriptLiteral(expectedGPCValue)}) is on the {destinationDescription} fetch`);
+    promise_test(function(t) {{
+      const image = document.getElementById("imageTest");
+      const testResult = new Promise((resolve, reject) => {{
+        image.addEventListener('load', resolve);
+        image.addEventListener('error', reject);
+      }});
+      image.src = "getGPC.py?gpc={maybeBoolToJavascriptLiteral(expectedGPCValue)}";
+      return testResult;
+    }}, `Expected Sec-GPC value ({maybeBoolToJavascriptLiteral(expectedGPCValue)}) is on the {"framed " if destination == "iframe" or inFrame else ""}image fetch`);
+  </script>
+""" + (f"""
+  <script>
+    const iframe = document.createElement("iframe");
+    iframe.src = "getGPC.py?gpc={maybeBoolToJavascriptLiteral(expectedGPCValue)}";
+    document.body.appendChild(iframe);
+    async function run() {{
+      await fetch_tests_from_window(iframe.contentWindow);
+      await fetch_tests_from_worker(new Worker("getGPC.py?gpc={maybeBoolToJavascriptLiteral(expectedGPCValue)}"));
+      await fetch_tests_from_worker(new SharedWorker("getGPC.py?gpc={maybeBoolToJavascriptLiteral(expectedGPCValue)}"));
+      await new Promise((resolve, reject) => {{
+        const script = document.createElement("script");
+        script.src = "getGPC.py?gpc={maybeBoolToJavascriptLiteral(expectedGPCValue)}";
+        script.onload = resolve;
+        script.onerror = reject;
+        document.head.appendChild(script);
+      }});
+      let r = await navigator.serviceWorker.register(
+        "getGPC.py?gpc={maybeBoolToJavascriptLiteral(expectedGPCValue)}",
+        {{scope: "./blank.html"}});
+      let sw = r.active || r.installing || r.waiting;
+      await fetch_tests_from_worker(sw);
+      await r.unregister();
+    }}
+    run();
+  </script>
+  """ if destination == "document" else "") + f"""
+  <script src="getGPC.py?gpc={maybeBoolToJavascriptLiteral(expectedGPCValue)}{"&framed" if destination == "iframe" or inFrame else ""}"></script>
+</body>
+</html>
+"""
+  elif destination == "image":
+    if gpcValue == expectedGPCValue:
+      return (200, [(b"Content-Type", b"image/png")], base64.b64decode("iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAEUlEQVR42mP8nzaTAQQYYQwALssD/5ca+r8AAAAASUVORK5CYII="))
+    return (400, [], "")
+  elif destination == "script":
+    response.headers.set('Content-Type', 'application/javascript');
+    return f"""
+debugger;
+test(function(t) {{
+  assert_equals({maybeBoolToJavascriptLiteral(gpcValue)}, {maybeBoolToJavascriptLiteral(expectedGPCValue)}, "Expected Sec-GPC value ({maybeBoolToJavascriptLiteral(expectedGPCValue)}) is on the {destinationDescription} fetch");
+}}, `Expected Sec-GPC value ({maybeBoolToJavascriptLiteral(expectedGPCValue)}) is on the {destinationDescription} fetch`);
+"""
+  elif destination == "worker" or destination == "sharedworker" or destination == "serviceworker":
+    response.headers.set('Content-Type', 'application/javascript');
+    return f"""
+importScripts("/resources/testharness.js");
+test(function(t) {{
+  assert_equals({maybeBoolToJavascriptLiteral(gpcValue)}, {maybeBoolToJavascriptLiteral(expectedGPCValue)}, "Expected Sec-GPC value ({maybeBoolToJavascriptLiteral(expectedGPCValue)}) is on the {destinationDescription} fetch");
+}}, `Expected Sec-GPC value ({maybeBoolToJavascriptLiteral(expectedGPCValue)}) is on the {destinationDescription} fetch`);
+done();
+"""
+  raise ValueError("Unexpected destination")

--- a/LayoutTests/imported/w3c/web-platform-tests/gpc/support/navigator-globalPrivacyControl.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/gpc/support/navigator-globalPrivacyControl.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<title>navigator.globalPrivacyControl Window</title>
+<head>
+  <script src="/resources/testharness.js"></script>
+</head>
+<body>
+  <div id="log"></div>
+  <script>
+    setup({explicit_done: true});
+    const queryString = window.location.search;
+    const urlParams = new URLSearchParams(queryString);
+    const expectedValue = urlParams.has("gpc", "true");
+    test(function(t) {
+      assert_equals(navigator.globalPrivacyControl, expectedValue, "Expected navigator.globalPrivacyControl value is read from the window");
+    }, `Expected navigator.globalPrivacyControl value (${expectedValue}) is read from the window`);
+
+    async function run() {
+      await Promise.all([
+        fetch_tests_from_worker(new Worker(`navigator-globalPrivacyControl.js?gpc=${expectedValue}&workerType=dedicated`)),
+        fetch_tests_from_worker(new SharedWorker(`navigator-globalPrivacyControl.js?gpc=${expectedValue}&workerType=shared`)),
+      ]);
+
+      let r = await navigator.serviceWorker.register(
+        `navigator-globalPrivacyControl.js?gpc=${expectedValue}&workerType=service`,
+        {scope: `blank.html`});
+      let sw = r.active || r.installing || r.waiting;
+      await fetch_tests_from_worker(sw),
+      await r.unregister();
+      done();
+    }
+    run();
+  </script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/gpc/support/navigator-globalPrivacyControl.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/gpc/support/navigator-globalPrivacyControl.js
@@ -1,0 +1,11 @@
+importScripts("/resources/testharness.js");
+
+const queryString = self.location.search;
+const urlParams = new URLSearchParams(queryString);
+const expectedValue = urlParams.has("gpc", "true");
+const workerType = urlParams.get("workerType");
+test(function(t) {
+  assert_equals(navigator.globalPrivacyControl, expectedValue, "Expected navigator.globalPrivacyControl value is read from the worker");
+}, `Expected navigator.globalPrivacyControl value (${expectedValue}) is read from the ${workerType} worker`);
+
+done();

--- a/LayoutTests/imported/w3c/web-platform-tests/gpc/support/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/gpc/support/w3c-import.log
@@ -1,0 +1,19 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/gpc/support/getGPC.py
+/LayoutTests/imported/w3c/web-platform-tests/gpc/support/navigator-globalPrivacyControl.html
+/LayoutTests/imported/w3c/web-platform-tests/gpc/support/navigator-globalPrivacyControl.js

--- a/LayoutTests/imported/w3c/web-platform-tests/gpc/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/gpc/w3c-import.log
@@ -1,0 +1,22 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/gpc/META.yml
+/LayoutTests/imported/w3c/web-platform-tests/gpc/WEB_FEATURES.yml
+/LayoutTests/imported/w3c/web-platform-tests/gpc/global_privacy_control.testdriver.html
+/LayoutTests/imported/w3c/web-platform-tests/gpc/idlharness.any.js
+/LayoutTests/imported/w3c/web-platform-tests/gpc/navigator-globalPrivacyControl.https.html
+/LayoutTests/imported/w3c/web-platform-tests/gpc/sec-gpc.https.html

--- a/LayoutTests/imported/w3c/web-platform-tests/resources/testdriver.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/resources/testdriver.js
@@ -2169,6 +2169,25 @@
          */
         clear_display_features: function(context=null) {
             return window.test_driver_internal.clear_display_features(context);
+        },
+
+        /**
+         * Gets the current Global Privacy Control (GPC) setting.
+         *
+         * @returns {Promise<{gpc: boolean}>} Fulfilled with the current GPC state.
+         */
+        get_global_privacy_control: function(context=null) {
+            return window.test_driver_internal.get_global_privacy_control(context);
+        },
+
+        /**
+         * Sets the Global Privacy Control (GPC) setting.
+         *
+         * @param {boolean} value - The GPC value to set.
+         * @returns {Promise<{gpc: boolean}>} Fulfilled with the new GPC state.
+         */
+        set_global_privacy_control: function(value, context=null) {
+            return window.test_driver_internal.set_global_privacy_control(value, context);
         }
     };
 

--- a/LayoutTests/platform/gtk/fast/dom/navigator-detached-no-crash-expected.txt
+++ b/LayoutTests/platform/gtk/fast/dom/navigator-detached-no-crash-expected.txt
@@ -7,6 +7,7 @@ navigator.clearAppBadge() is OK
 navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
+navigator.globalPrivacyControl is OK
 navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK
@@ -43,6 +44,7 @@ navigator.clearAppBadge() is OK
 navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
+navigator.globalPrivacyControl is OK
 navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK

--- a/LayoutTests/platform/mac-wk2/fast/dom/navigator-detached-no-crash-expected.txt
+++ b/LayoutTests/platform/mac-wk2/fast/dom/navigator-detached-no-crash-expected.txt
@@ -10,6 +10,7 @@ navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
 navigator.credentials is OK
+navigator.globalPrivacyControl is OK
 navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.isLoggedIn() is OK
@@ -52,6 +53,7 @@ navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
 navigator.credentials is OK
+navigator.globalPrivacyControl is OK
 navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.isLoggedIn() is OK

--- a/LayoutTests/platform/win/fast/dom/navigator-detached-no-crash-expected.txt
+++ b/LayoutTests/platform/win/fast/dom/navigator-detached-no-crash-expected.txt
@@ -7,6 +7,7 @@ navigator.clearAppBadge() is OK
 navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
+navigator.globalPrivacyControl is OK
 navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK
@@ -40,6 +41,7 @@ navigator.clearAppBadge() is OK
 navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
+navigator.globalPrivacyControl is OK
 navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK

--- a/LayoutTests/platform/wpe/fast/dom/navigator-detached-no-crash-expected.txt
+++ b/LayoutTests/platform/wpe/fast/dom/navigator-detached-no-crash-expected.txt
@@ -7,6 +7,7 @@ navigator.clearAppBadge() is OK
 navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
+navigator.globalPrivacyControl is OK
 navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK
@@ -43,6 +44,7 @@ navigator.clearAppBadge() is OK
 navigator.clipboard is OK
 navigator.contacts is OK
 navigator.cookieEnabled is OK
+navigator.globalPrivacyControl is OK
 navigator.gpu is OK
 navigator.hardwareConcurrency is OK
 navigator.javaEnabled() is OK

--- a/LayoutTests/resources/testdriver-vendor.js
+++ b/LayoutTests/resources/testdriver-vendor.js
@@ -725,3 +725,21 @@ window.test_driver_internal.set_storage_access = async function (origin, embeddi
     context = context ?? window;
     await context.testRunner.setStorageAccess(blocked);
 }
+
+/**
+ *
+ * @returns {Promise<boolean>}
+ */
+window.test_driver_internal.get_global_privacy_control = function() {
+    return Promise.resolve({ gpc: testRunner.getGlobalPrivacyControl() });
+}
+
+/**
+ *
+ * @param {value} bool
+ * @returns {Promise<void>}
+ */
+window.test_driver_internal.set_global_privacy_control = function(value) {
+    testRunner.setGlobalPrivacyControl(value);
+    return Promise.resolve({ gpc: value });
+}

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -3413,6 +3413,20 @@ GetUserMediaRequiresFocus:
     WebCore:
       default: true
 
+GlobalPrivacyControlEnabled:
+  type: bool
+  status: testable
+  category: privacy
+  humanReadableName: "Global Privacy Control"
+  humanReadableDescription: "Enable Global Privacy Control (GPC) signal"
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 GoogleAntiFlickerOptimizationQuirkEnabled:
   type: bool
   status: mature

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -2113,6 +2113,7 @@ set(WebCore_SUPPLEMENTAL_IDL_FILES
     page/DOMWindow+VisualViewport.idl
     page/Navigator+UserActivation.idl
     page/NavigatorCookies.idl
+    page/NavigatorGlobalPrivacyControl.idl
     page/NavigatorID.idl
     page/NavigatorLanguage.idl
     page/NavigatorOnLine.idl

--- a/Source/WebCore/DerivedSources-input.xcfilelist
+++ b/Source/WebCore/DerivedSources-input.xcfilelist
@@ -1928,6 +1928,7 @@ $(PROJECT_DIR)/page/NavigationNavigationType.idl
 $(PROJECT_DIR)/page/NavigationTransition.idl
 $(PROJECT_DIR)/page/Navigator+LoginStatus.idl
 $(PROJECT_DIR)/page/Navigator+UserActivation.idl
+$(PROJECT_DIR)/page/NavigatorGlobalPrivacyControl.idl
 $(PROJECT_DIR)/page/Navigator.idl
 $(PROJECT_DIR)/page/NavigatorCookies.idl
 $(PROJECT_DIR)/page/NavigatorID.idl

--- a/Source/WebCore/DerivedSources-output.xcfilelist
+++ b/Source/WebCore/DerivedSources-output.xcfilelist
@@ -2099,6 +2099,8 @@ $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+Geolocation.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+Geolocation.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+LoginStatus.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+LoginStatus.h
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigatorGlobalPrivacyControl.cpp
+$(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigatorGlobalPrivacyControl.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+MediaCapabilities.cpp
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+MediaCapabilities.h
 $(BUILT_PRODUCTS_DIR)/DerivedSources/WebCore/JSNavigator+MediaDevices.cpp

--- a/Source/WebCore/DerivedSources.make
+++ b/Source/WebCore/DerivedSources.make
@@ -1584,6 +1584,7 @@ JS_BINDING_IDLS := \
     $(WebCore)/page/NavigatorUABrandVersion.idl \
     $(WebCore)/page/NavigatorUAData.idl \
     $(WebCore)/page/Navigator+LoginStatus.idl \
+    $(WebCore)/page/NavigatorGlobalPrivacyControl.idl \
     $(WebCore)/page/Navigator+UserActivation.idl \
     $(WebCore)/page/NavigatorCookies.idl \
     $(WebCore)/page/NavigatorID.idl \

--- a/Source/WebCore/Sources.txt
+++ b/Source/WebCore/Sources.txt
@@ -2218,6 +2218,7 @@ page/NavigationTransition.cpp
 page/Navigator.cpp
 page/NavigatorBase.cpp
 page/NavigatorLoginStatus.cpp
+page/NavigatorGlobalPrivacyControl.cpp
 page/NavigatorUAData.cpp
 page/OpportunisticTaskScheduler.cpp
 page/OriginAccessEntry.cpp

--- a/Source/WebCore/WebCore.xcodeproj/project.pbxproj
+++ b/Source/WebCore/WebCore.xcodeproj/project.pbxproj
@@ -2503,6 +2503,7 @@
 		55F1F4A427BC993300132A6B /* WebAssemblyCachedScriptSourceProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 55F1F4A227BC993200132A6B /* WebAssemblyCachedScriptSourceProvider.h */; };
 		55FA7FFB2110ECD7005AEFE7 /* SVGZoomAndPanType.h in Headers */ = {isa = PBXBuildFile; fileRef = 55FA7FFA2110ECD7005AEFE7 /* SVGZoomAndPanType.h */; };
 		55FD9FC127B20D520045DA1F /* WebAssemblyScriptSourceCode.h in Headers */ = {isa = PBXBuildFile; fileRef = 55FD9FBF27B20D520045DA1F /* WebAssemblyScriptSourceCode.h */; };
+		564EF2812FA167E3008E9EC3 /* NavigatorGlobalPrivacyControl.h in Headers */ = {isa = PBXBuildFile; fileRef = 564EF27D2FA05074008E9EC3 /* NavigatorGlobalPrivacyControl.h */; };
 		5704405A1E53936200356601 /* JSAesCbcCfbParams.h in Headers */ = {isa = PBXBuildFile; fileRef = 570440591E53936200356601 /* JSAesCbcCfbParams.h */; };
 		5706A6981DDE5E4600A03B14 /* JSRsaOaepParams.h in Headers */ = {isa = PBXBuildFile; fileRef = 5706A6971DDE5E4600A03B14 /* JSRsaOaepParams.h */; };
 		57093D1324C97C8F0086C52D /* FetchResponse.h in Headers */ = {isa = PBXBuildFile; fileRef = 413015D61C7B570400091C6E /* FetchResponse.h */; };
@@ -13237,6 +13238,9 @@
 		55FA7FFA2110ECD7005AEFE7 /* SVGZoomAndPanType.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SVGZoomAndPanType.h; sourceTree = "<group>"; };
 		55FD9FBF27B20D520045DA1F /* WebAssemblyScriptSourceCode.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebAssemblyScriptSourceCode.h; sourceTree = "<group>"; };
 		560A7F202DB83BDE00B69AF8 /* SVGFilterEffectGraph.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SVGFilterEffectGraph.h; sourceTree = "<group>"; };
+		564EF27C2FA04E9E008E9EC3 /* NavigatorGlobalPrivacyControl.idl */ = {isa = PBXFileReference; lastKnownFileType = text; path = "NavigatorGlobalPrivacyControl.idl"; sourceTree = "<group>"; };
+		564EF27D2FA05074008E9EC3 /* NavigatorGlobalPrivacyControl.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = NavigatorGlobalPrivacyControl.h; sourceTree = "<group>"; };
+		564EF27E2FA05074008E9EC3 /* NavigatorGlobalPrivacyControl.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = NavigatorGlobalPrivacyControl.cpp; sourceTree = "<group>"; };
 		565E7E6449095E4933B5F978 /* Volume2.svg */ = {isa = PBXFileReference; lastKnownFileType = text; path = Volume2.svg; sourceTree = "<group>"; };
 		56FFE14C3114000000000000 /* StyleLocalPropertyRegistry.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = StyleLocalPropertyRegistry.cpp; sourceTree = "<group>"; };
 		570440571E53851600356601 /* CryptoAlgorithmAESCFBCocoa.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CryptoAlgorithmAESCFBCocoa.cpp; sourceTree = "<group>"; };
@@ -31054,6 +31058,9 @@
 				E12719C90EEEC21300F61213 /* NavigatorBase.cpp */,
 				E12719C60EEEC16800F61213 /* NavigatorBase.h */,
 				7C2E0BD92511800E005F3C87 /* NavigatorCookies.idl */,
+				564EF27E2FA05074008E9EC3 /* NavigatorGlobalPrivacyControl.cpp */,
+				564EF27D2FA05074008E9EC3 /* NavigatorGlobalPrivacyControl.h */,
+				564EF27C2FA04E9E008E9EC3 /* NavigatorGlobalPrivacyControl.idl */,
 				7C5BEA3A1E9EE77100CC517B /* NavigatorID.idl */,
 				7C5BEA3B1E9EE77100CC517B /* NavigatorLanguage.idl */,
 				6D61E3762C2E016F00F1C6AA /* NavigatorLoginStatus.cpp */,
@@ -47242,6 +47249,7 @@
 				0753E09A2E595C9F00A52914 /* NavigatorEME.h in Headers */,
 				513EB5F22BF2D9B800BC98B1 /* NavigatorGamepad.h in Headers */,
 				9711460414EF009A00674FD9 /* NavigatorGeolocation.h in Headers */,
+				564EF2812FA167E3008E9EC3 /* NavigatorGlobalPrivacyControl.h in Headers */,
 				5EA725D61ACABD5700EAD17B /* NavigatorMediaDevices.h in Headers */,
 				077BA572260FA0140072F19F /* NavigatorMediaSession.h in Headers */,
 				93B0A65326CDD14100AA21E4 /* NavigatorPermissions.h in Headers */,

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -3527,6 +3527,9 @@ void FrameLoader::updateRequestAndAddExtraFields(Frame& targetFrame, ResourceReq
 
     applyUserAgentIfNeeded(request);
 
+    if (page && page->settings().globalPrivacyControlEnabled())
+        request.addHTTPHeaderFieldIfNotPresent(HTTPHeaderName::SecGPC, "1"_s);
+
     if (isMainResource)
         request.setHTTPHeaderField(HTTPHeaderName::Accept, CachedResourceRequest::acceptHeaderValueFromType(CachedResource::Type::MainResource, request.url().protocolIsSecure()));
 

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -1026,6 +1026,8 @@ void CachedResourceLoader::updateHTTPRequestHeaders(FrameLoader& frameLoader, Ca
         request.updateCacheModeIfNeeded(cachePolicy(type, request.resourceRequest().url()));
     request.updateAccordingCacheMode();
     request.updateAcceptEncodingHeader();
+    if (frame->settings().globalPrivacyControlEnabled())
+        request.updateGlobalPrivacyControlHeader();
 }
 
 static FetchOptions::Destination NODELETE destinationForType(CachedResource::Type type, LocalFrame& frame)

--- a/Source/WebCore/loader/cache/CachedResourceRequest.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceRequest.cpp
@@ -273,6 +273,11 @@ void CachedResourceRequest::updateAcceptEncodingHeader()
     m_resourceRequest.addHTTPHeaderFieldIfNotPresent(HTTPHeaderName::AcceptEncoding, "identity"_s);
 }
 
+void CachedResourceRequest::updateGlobalPrivacyControlHeader()
+{
+    m_resourceRequest.addHTTPHeaderFieldIfNotPresent(HTTPHeaderName::SecGPC, "1"_s);
+}
+
 void CachedResourceRequest::removeFragmentIdentifierIfNeeded()
 {
     URL url = MemoryCache::removeFragmentIdentifierIfNeeded(m_resourceRequest.url());

--- a/Source/WebCore/loader/cache/CachedResourceRequest.h
+++ b/Source/WebCore/loader/cache/CachedResourceRequest.h
@@ -89,6 +89,7 @@ public:
     void setAcceptHeaderIfNone(CachedResource::Type);
     void updateAccordingCacheMode();
     void updateAcceptEncodingHeader();
+    void updateGlobalPrivacyControlHeader();
     void NODELETE updateCacheModeIfNeeded(CachePolicy);
 
     void NODELETE disableCachingIfNeeded();

--- a/Source/WebCore/page/Navigator.idl
+++ b/Source/WebCore/page/Navigator.idl
@@ -40,4 +40,5 @@ Navigator includes NavigatorServiceWorker;
 Navigator includes NavigatorShare;
 Navigator includes NavigatorStorage;
 Navigator includes NavigatorGPU;
+Navigator includes NavigatorGlobalPrivacyControl;
 [EnabledByQuirk=needsNavigatorUserAgentData] Navigator includes NavigatorUA;

--- a/Source/WebCore/page/NavigatorGlobalPrivacyControl.cpp
+++ b/Source/WebCore/page/NavigatorGlobalPrivacyControl.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2019-2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "NavigatorGlobalPrivacyControl.h"
+
+#include "Navigator.h"
+#include "WorkerNavigator.h"
+
+namespace WebCore {
+
+bool NavigatorGlobalPrivacyControl::globalPrivacyControl(Navigator& navigator)
+{
+    auto* frame = navigator.frame();
+    if (!frame)
+        return false;
+    return frame->settings().globalPrivacyControlEnabled();
+}
+
+bool NavigatorGlobalPrivacyControl::globalPrivacyControl(WorkerNavigator& navigator)
+{
+    auto* scope = navigator.scriptExecutionContext();
+    if (!scope)
+        return false;
+    return scope->settingsValues().globalPrivacyControlEnabled;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/page/NavigatorGlobalPrivacyControl.h
+++ b/Source/WebCore/page/NavigatorGlobalPrivacyControl.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2019-2025 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+namespace WebCore {
+class Navigator;
+class WorkerNavigator;
+
+class NavigatorGlobalPrivacyControl {
+
+    public:
+        static bool globalPrivacyControl(Navigator&);
+        static bool globalPrivacyControl(WorkerNavigator&);
+
+};
+}

--- a/Source/WebCore/page/NavigatorGlobalPrivacyControl.idl
+++ b/Source/WebCore/page/NavigatorGlobalPrivacyControl.idl
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2020 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// https://www.w3.org/TR/gpc/
+[                                                                                                                           
+    ImplementedBy=NavigatorGlobalPrivacyControl                                                                          
+] interface mixin NavigatorGlobalPrivacyControl {         
+    readonly attribute boolean globalPrivacyControl;
+};

--- a/Source/WebCore/page/WorkerNavigator.idl
+++ b/Source/WebCore/page/WorkerNavigator.idl
@@ -43,3 +43,4 @@ WorkerNavigator includes NavigatorServiceWorker;
 WorkerNavigator includes NavigatorStorage;
 WorkerNavigator includes NavigatorGPU;
 WorkerNavigator includes NavigatorUA;
+WorkerNavigator includes NavigatorGlobalPrivacyControl;

--- a/Source/WebCore/platform/network/HTTPHeaderNames.in
+++ b/Source/WebCore/platform/network/HTTPHeaderNames.in
@@ -90,6 +90,7 @@ Reporting-Endpoints
 Sec-Fetch-Dest
 Sec-Fetch-Mode
 Sec-Fetch-Site
+Sec-GPC
 Sec-Purpose
 Sec-Speculation-Tags
 Speculation-Rules

--- a/Source/WebKit/UIProcess/API/C/WKPreferences.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKPreferences.cpp
@@ -1620,6 +1620,11 @@ bool WKPreferencesGetPunchOutWhiteBackgroundsInDarkMode(WKPreferencesRef prefere
     return protect(toImpl(preferencesRef))->punchOutWhiteBackgroundsInDarkMode();
 }
 
+bool WKPreferencesGetBoolValueForKeyForTesting(WKPreferencesRef preferencesRef, WKStringRef key)
+{
+    return toImpl(preferencesRef)->store().getBoolValueForKey(toWTFString(key));
+}
+
 void WKPreferencesSetCaptureAudioInUIProcessEnabled(WKPreferencesRef, bool)
 {
 }

--- a/Source/WebKit/UIProcess/API/C/WKPreferencesRefPrivate.h
+++ b/Source/WebKit/UIProcess/API/C/WKPreferencesRefPrivate.h
@@ -457,6 +457,7 @@ WK_EXPORT bool WKPreferencesGetColorFilterEnabled(WKPreferencesRef);
 WK_EXPORT void WKPreferencesSetPunchOutWhiteBackgroundsInDarkMode(WKPreferencesRef, bool flag);
 WK_EXPORT bool WKPreferencesGetPunchOutWhiteBackgroundsInDarkMode(WKPreferencesRef);
 
+WK_EXPORT bool WKPreferencesGetBoolValueForKeyForTesting(WKPreferencesRef, WKStringRef key);
 
 // The following are all deprecated and do nothing. They should be removed when possible.
 

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm
@@ -875,6 +875,16 @@ static WebCore::EditableLinkBehavior NODELETE toEditableLinkBehavior(_WKEditable
     return protect(*_preferences)->textExtractionEnabled();
 }
 
+- (BOOL)_globalPrivacyControlEnabled
+{
+    return _preferences->globalPrivacyControlEnabled();
+}
+
+- (void)_setGlobalPrivacyControlEnabled:(BOOL)enabled
+{
+    _preferences->setGlobalPrivacyControlEnabled(enabled);
+}
+
 - (void)_setColorFilterEnabled:(BOOL)enabled
 {
     protect(*_preferences)->setColorFilterEnabled(enabled);

--- a/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h
@@ -140,6 +140,8 @@ typedef NS_ENUM(NSInteger, _WKPitchCorrectionAlgorithm) {
 
 @property (nonatomic, setter=_setTextExtractionEnabled:) BOOL _textExtractionEnabled WK_API_AVAILABLE(macos(15.0), ios(18.0), visionos(2.0));
 
+@property (nonatomic, setter=_setGlobalPrivacyControlEnabled:) BOOL _globalPrivacyControlEnabled WK_API_AVAILABLE(macos(WK_MAC_TBA), ios(WK_IOS_TBA));
+
 + (NSArray<_WKFeature *> *)_features WK_API_AVAILABLE(macos(13.3), ios(16.4));
 - (BOOL)_isEnabledForFeature:(_WKFeature *)feature WK_API_AVAILABLE(macos(10.12), ios(10.0));
 - (void)_setEnabled:(BOOL)value forFeature:(_WKFeature *)feature WK_API_AVAILABLE(macos(10.12), ios(10.0));

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -7239,6 +7239,8 @@ void WebPageProxy::preferencesDidChange()
             webProcess.send(Messages::WebPage::PreferencesDidChange(preferencesStore(), sharedPreferencesVersion), pageID);
     });
 
+    // Shared and service worker processes maintain their own preferences snapshot; propagate changes so newly launched workers pick up the updated values.
+    protect(m_configuration->processPool())->updatePreferencesForRemoteWorkers(preferencesStore());
     websiteDataStore().propagateSettingUpdates();
 }
 

--- a/Source/WebKit/UIProcess/WebProcessPool.cpp
+++ b/Source/WebKit/UIProcess/WebProcessPool.cpp
@@ -1409,6 +1409,13 @@ void WebProcessPool::updateRemoteWorkerUserAgent(const String& userAgent)
         workerProcess->setRemoteWorkerUserAgent(m_remoteWorkerUserAgent);
 }
 
+void WebProcessPool::updatePreferencesForRemoteWorkers(const WebPreferencesStore& store)
+{
+    m_remoteWorkerPreferences = store;
+    for (Ref workerProcess : remoteWorkerProcesses())
+        workerProcess->updateRemoteWorkerPreferencesStore(store);
+}
+
 void WebProcessPool::pageBeginUsingWebsiteDataStore(WebPageProxy& page, WebsiteDataStore& dataStore)
 {
     RELEASE_ASSERT(RunLoop::isMain());

--- a/Source/WebKit/UIProcess/WebProcessPool.h
+++ b/Source/WebKit/UIProcess/WebProcessPool.h
@@ -417,6 +417,7 @@ public:
     void serviceWorkerProcessCrashed(WebProcessProxy&, ProcessTerminationReason);
 
     void updateRemoteWorkerUserAgent(const String& userAgent);
+    void updatePreferencesForRemoteWorkers(const WebPreferencesStore&);
     Ref<WebUserContentControllerProxy> userContentControllerForRemoteWorkers();
     static void establishRemoteWorkerContextConnectionToNetworkProcess(RemoteWorkerType, WebCore::Site&&, std::optional<WebCore::ProcessIdentifier> requestingProcessIdentifier, std::optional<WebCore::ScriptExecutionContextIdentifier> serviceWorkerPageIdentifier, PAL::SessionID, WebCore::CrossOriginEmbedderPolicyValue, CompletionHandler<void(WebCore::ProcessIdentifier)>&&);
 

--- a/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
+++ b/Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl
@@ -206,6 +206,10 @@ interface TestRunner {
     // Screen Wake Lock
     undefined setScreenWakeLockPermission(boolean value);
 
+    // Global Privacy Control
+    undefined setGlobalPrivacyControl(boolean value);
+    boolean getGlobalPrivacyControl();
+
     // MediaStream
     undefined setCameraPermission(boolean value);
     undefined setMicrophonePermission(boolean value);

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp
@@ -1117,6 +1117,16 @@ bool TestRunner::hasStatisticsIsolatedSession(JSStringRef hostName)
     return postSynchronousPageMessageReturningBoolean("HasStatisticsIsolatedSession", hostName);
 }
 
+void TestRunner::setGlobalPrivacyControl(bool value)
+{
+    postSynchronousMessageWithReturnValue("SetGlobalPrivacyControl", adoptWK(WKBooleanCreate(value)));
+}
+
+bool TestRunner::getGlobalPrivacyControl()
+{
+    return postSynchronousMessageReturningBoolean("GetGlobalPrivacyControl");
+}
+
 void TestRunner::installTextDidChangeInTextFieldCallback(JSContextRef context, JSValueRef callback)
 {
     cacheTestRunnerCallback(context, TextDidChangeInTextFieldCallbackID, callback);

--- a/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
+++ b/Tools/WebKitTestRunner/InjectedBundle/TestRunner.h
@@ -403,6 +403,9 @@ public:
     void setStatisticsCacheMaxAgeCap(double seconds);
     bool hasStatisticsIsolatedSession(JSStringRef hostName);
 
+    void setGlobalPrivacyControl(bool);
+    bool getGlobalPrivacyControl();
+
     // Injected bundle form client.
     void installTextDidChangeInTextFieldCallback(JSContextRef, JSValueRef callback);
     void textDidChangeInTextFieldCallback();

--- a/Tools/WebKitTestRunner/TestInvocation.cpp
+++ b/Tools/WebKitTestRunner/TestInvocation.cpp
@@ -39,6 +39,7 @@
 #include <WebKit/WKHTTPCookieStoreRef.h>
 #include <WebKit/WKInspector.h>
 #include <WebKit/WKPagePrivate.h>
+#include <WebKit/WKPreferencesRefPrivate.h>
 #include <WebKit/WKRetainPtr.h>
 #include <WebKit/WKWebsiteDataStoreRef.h>
 #include <climits>
@@ -1320,6 +1321,16 @@ WKRetainPtr<WKTypeRef> TestInvocation::didReceiveSynchronousMessageFromInjectedB
 
     if (WKStringIsEqualToUTF8CString(messageName, "SetHasMouseDeviceForTesting")) {
         TestController::singleton().setHasMouseDeviceForTesting((booleanValue(messageBody)));
+        return nullptr;
+    }
+
+    if (WKStringIsEqualToUTF8CString(messageName, "GetGlobalPrivacyControl")) {
+        bool value = WKPreferencesGetBoolValueForKeyForTesting(TestController::singleton().platformPreferences(), toWK("GlobalPrivacyControlEnabled").get());
+        return adoptWK(WKBooleanCreate(value)).leakRef();
+    }
+
+    if (WKStringIsEqualToUTF8CString(messageName, "SetGlobalPrivacyControl")) {
+        WKPreferencesSetBoolValueForKeyForTesting(TestController::singleton().platformPreferences(), booleanValue(messageBody), toWK("GlobalPrivacyControlEnabled").get());
         return nullptr;
     }
 


### PR DESCRIPTION
#### a85517357bbc7d8753045c7c73503291999169ff
<pre>
Add support for GPC
<a href="https://rdar.apple.com/175706854">rdar://175706854</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=313856">https://bugs.webkit.org/show_bug.cgi?id=313856</a>

Reviewed by NOBODY (OOPS!).

Implementing Global Privacy Control (GPC), which communicates a person’s request to
websites and services not to sell or share their personal information with third parties.
<a href="https://www.w3.org/TR/gpc.">https://www.w3.org/TR/gpc.</a>

Tests: imported/w3c/web-platform-tests/gpc/global_privacy_control.testdriver.html
       imported/w3c/web-platform-tests/gpc/idlharness.any.html
       imported/w3c/web-platform-tests/gpc/idlharness.any.serviceworker.html
       imported/w3c/web-platform-tests/gpc/idlharness.any.sharedworker.html
       imported/w3c/web-platform-tests/gpc/idlharness.any.worker.html
       imported/w3c/web-platform-tests/gpc/navigator-globalPrivacyControl.https.html
       imported/w3c/web-platform-tests/gpc/sec-gpc.https.html
       imported/w3c/web-platform-tests/gpc/support/navigator-globalPrivacyControl.html

* LayoutTests/fast/dom/navigator-detached-no-crash-expected.txt:
* LayoutTests/imported/w3c/resources/import-expectations.json:
* LayoutTests/imported/w3c/web-platform-tests/gpc/META.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/gpc/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/gpc/global_privacy_control.testdriver-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/gpc/global_privacy_control.testdriver.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/gpc/idlharness.any-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/gpc/idlharness.any.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/gpc/idlharness.any.js: Added.
* LayoutTests/imported/w3c/web-platform-tests/gpc/idlharness.any.serviceworker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/gpc/idlharness.any.serviceworker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/gpc/idlharness.any.sharedworker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/gpc/idlharness.any.sharedworker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/gpc/idlharness.any.worker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/gpc/idlharness.any.worker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/gpc/navigator-globalPrivacyControl.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/gpc/navigator-globalPrivacyControl.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/gpc/sec-gpc.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/gpc/sec-gpc.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/gpc/support/getGPC.py: Added.
(maybeBoolToJavascriptLiteral):
(main):
* LayoutTests/imported/w3c/web-platform-tests/gpc/support/navigator-globalPrivacyControl.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/gpc/support/navigator-globalPrivacyControl.js: Added.
(test):
* LayoutTests/imported/w3c/web-platform-tests/gpc/support/w3c-import.log: Added.
* LayoutTests/imported/w3c/web-platform-tests/gpc/w3c-import.log: Added.
* LayoutTests/imported/w3c/web-platform-tests/resources/testdriver.js:
(window.test_driver):
* LayoutTests/platform/gtk/fast/dom/navigator-detached-no-crash-expected.txt:
* LayoutTests/platform/mac-wk2/fast/dom/navigator-detached-no-crash-expected.txt:
* LayoutTests/platform/win/fast/dom/navigator-detached-no-crash-expected.txt:
* LayoutTests/platform/wpe/fast/dom/navigator-detached-no-crash-expected.txt:
* LayoutTests/resources/testdriver-vendor.js:
(window.test_driver_internal.get_global_privacy_control):
(window.test_driver_internal.set_global_privacy_control):
* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/DerivedSources-input.xcfilelist:
* Source/WebCore/DerivedSources-output.xcfilelist:
* Source/WebCore/DerivedSources.make:
* Source/WebCore/Sources.txt:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::updateRequestAndAddExtraFields):
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::updateHTTPRequestHeaders):
* Source/WebCore/loader/cache/CachedResourceRequest.cpp:
(WebCore::CachedResourceRequest::updateGlobalPrivacyControlHeader):
* Source/WebCore/loader/cache/CachedResourceRequest.h:
* Source/WebCore/page/Navigator.idl:
* Source/WebCore/page/NavigatorGlobalPrivacyControl.cpp: Added.
(WebCore::NavigatorGlobalPrivacyControl::globalPrivacyControl):
* Source/WebCore/page/NavigatorGlobalPrivacyControl.h: Added.
* Source/WebCore/page/NavigatorGlobalPrivacyControl.idl: Added.
* Source/WebCore/page/WorkerNavigator.idl:
* Source/WebCore/platform/network/HTTPHeaderNames.in:
* Source/WebKit/UIProcess/API/C/WKPreferences.cpp:
(WKPreferencesGetBoolValueForKeyForTesting):
* Source/WebKit/UIProcess/API/C/WKPreferencesRefPrivate.h:
* Source/WebKit/UIProcess/API/Cocoa/WKPreferences.mm:
(-[WKPreferences _globalPrivacyControlEnabled]):
(-[WKPreferences _setGlobalPrivacyControlEnabled:]):
* Source/WebKit/UIProcess/API/Cocoa/WKPreferencesPrivate.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::preferencesDidChange):
* Source/WebKit/UIProcess/WebProcessPool.cpp:
(WebKit::WebProcessPool::updatePreferencesForRemoteWorkers):
* Source/WebKit/UIProcess/WebProcessPool.h:
* Tools/WebKitTestRunner/InjectedBundle/Bindings/TestRunner.idl:
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.cpp:
(WTR::TestRunner::setGlobalPrivacyControl):
(WTR::TestRunner::getGlobalPrivacyControl):
* Tools/WebKitTestRunner/InjectedBundle/TestRunner.h:
* Tools/WebKitTestRunner/TestInvocation.cpp:
(WTR::TestInvocation::didReceiveSynchronousMessageFromInjectedBundle):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a85517357bbc7d8753045c7c73503291999169ff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162840 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36317 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29474 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171778 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/119286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164709 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36421 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36320 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/126406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/119286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165799 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/28750 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/146321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/106983 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26330 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19478 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/24050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174282 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/23679 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/21805 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/25695 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/134715 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35990 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30433 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/134710 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/35975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/145846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/98395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/35975 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/22682 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195241 "Built successfully") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/35484 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/103524 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/50591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/34985 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/35230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/35133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->