### PR TITLE
Cherry-pick 305413.428@safari-7624-branch (b29ab81cd8b0). https://bugs.webkit.org/show_bug.cgi?id=309184

### DIFF
--- a/LayoutTests/fast/forms/label/label-click-event-dispatch-untrusted-expected.txt
+++ b/LayoutTests/fast/forms/label/label-click-event-dispatch-untrusted-expected.txt
@@ -1,0 +1,10 @@
+Tests that clicking a label dispatches an untrusted click event on the associated form control.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS event.isTrusted is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/label/label-click-event-dispatch-untrusted.html
+++ b/LayoutTests/fast/forms/label/label-click-event-dispatch-untrusted.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<input id="input" type="checkbox">
+<label id="label" for="input"></label>
+
+<script>
+
+description("Tests that clicking a label dispatches an untrusted click event on the associated form control.");
+
+input.addEventListener("click", (event) => {
+    shouldBeFalse("event.isTrusted");
+});
+
+label.click();
+
+</script>
+
+</body>
+</html>

--- a/LayoutTests/http/tests/resourceLoadStatistics/third-party-cookie-blocking-about-blank-popup-expected.txt
+++ b/LayoutTests/http/tests/resourceLoadStatistics/third-party-cookie-blocking-about-blank-popup-expected.txt
@@ -1,0 +1,10 @@
+Tests that third-party cookies are blocked for requests made from an about:blank popup.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS about:blank popup: third-party cookie was correctly blocked.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/resourceLoadStatistics/third-party-cookie-blocking-about-blank-popup.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/third-party-cookie-blocking-about-blank-popup.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <script src="/js-test-resources/js-test.js"></script>
+    <script src="resources/util.js"></script>
+</head>
+<body>
+<script>
+    description("Tests that third-party cookies are blocked for requests made from an about:blank popup.");
+    jsTestIsAsync = true;
+
+    const firstPartyOrigin = "http://127.0.0.1:8000";
+    const thirdPartyOrigin = "https://localhost:8443";
+    const resourcePath = "/resourceLoadStatistics/resources";
+    const thirdPartyBaseUrl = thirdPartyOrigin + resourcePath;
+    const cookieName = "aboutBlankTestCookie";
+    const subPathToSetCookie = "/set-cookie.py?name=" + cookieName + "&value=value";
+    const returnUrl = firstPartyOrigin + "/resourceLoadStatistics/third-party-cookie-blocking-about-blank-popup.html";
+    const subPathToGetCookies = "/get-cookies.py?name1=" + cookieName;
+
+    function runTest() {
+        switch (document.location.hash) {
+            case "#step1":
+                document.location.href = thirdPartyBaseUrl + subPathToSetCookie + "#" + returnUrl + "#step2";
+                break;
+            case "#step2":
+                var popup = window.open("about:blank");
+                if (!popup) {
+                    testFailed("Could not open about:blank popup.");
+                    finishTest();
+                    return;
+                }
+
+                popup.eval(
+                    "fetch('" + thirdPartyOrigin + "/cookies/resources/echo-cookies.py', { credentials: 'include' })" +
+                    ".then(function(r) { return r.text(); })" +
+                    ".then(function(text) {" +
+                    "    window.opener.postMessage({ type: 'fetch-done', result: text }, '*');" +
+                    "})" +
+                    ".catch(function(err) {" +
+                    "    window.opener.postMessage({ type: 'fetch-done', result: 'ERROR: ' + err.message }, '*');" +
+                    "});"
+                );
+
+                window.addEventListener("message", function handler(event) {
+                    if (event.data && event.data.type === "fetch-done") {
+                        window.removeEventListener("message", handler);
+                        var result = event.data.result;
+                        if (result.indexOf(cookieName) === -1) {
+                            testPassed("about:blank popup: third-party cookie was correctly blocked.");
+                        } else {
+                            testFailed("about:blank popup: third-party cookie was sent. Result: " + result);
+                        }
+                        popup.close();
+                        finishTest();
+                    }
+                });
+                break;
+        }
+    }
+
+    function finishTest() {
+        testRunner.setStatisticsShouldBlockThirdPartyCookies(false, function() {
+            setEnableFeature(false, finishJSTest);
+        });
+    }
+
+    if (document.location.hash === "") {
+        setEnableFeature(true, function () {
+            document.location.hash = "step1";
+            testRunner.setStatisticsShouldBlockThirdPartyCookies(true, runTest);
+        });
+    } else {
+        runTest();
+    }
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/blob-url-inherits-multiple-csp-policies-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/blob-url-inherits-multiple-csp-policies-expected.txt
@@ -1,0 +1,14 @@
+CONSOLE MESSAGE: Refused to execute a script because its hash, its nonce, or 'unsafe-inline' does not appear in the script-src directive of the Content Security Policy.
+Tests that a blob: URL iframe inherits ALL CSP policies from its creator document, not just the last one. When the creator has two enforced CSP headers where one blocks inline scripts, inline scripts inside the blob document should be blocked.
+
+
+
+--------
+Frame: '<!--frame1-->'
+--------
+
+
+--------
+Frame: '<!--frame2-->'
+--------
+PASS: Inline script was blocked by CSP.

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/blob-url-inherits-multiple-csp-policies.html
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/blob-url-inherits-multiple-csp-policies.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.dumpChildFramesAsText();
+    testRunner.waitUntilDone();
+}
+setTimeout(function() {
+    if (window.testRunner)
+        testRunner.notifyDone();
+}, 1000);
+</script>
+</head>
+<body>
+<p>Tests that a blob: URL iframe inherits ALL CSP policies from its creator document,
+not just the last one. When the creator has two enforced CSP headers where one blocks
+inline scripts, inline scripts inside the blob document should be blocked.</p>
+<iframe src="http://127.0.0.1:8000/security/contentSecurityPolicy/resources/echo-multiple-csp-blob-iframe.py"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/path-traversal-bypass-with-percent-encoding-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/path-traversal-bypass-with-percent-encoding-expected.txt
@@ -1,0 +1,44 @@
+CONSOLE MESSAGE: Refused to load http://127.0.0.1:8000/security/contentSecurityPolicy/resources%2F..%2F..%2Fresources/script.js because it does not appear in the script-src directive of the Content Security Policy.
+CONSOLE MESSAGE: Refused to load http://127.0.0.1:8000/security/contentSecurityPolicy%2F..%2Fresources/script.js because it does not appear in the script-src directive of the Content Security Policy.
+CONSOLE MESSAGE: Refused to load http://127.0.0.1:8000/security/contentSecurityPolicy%2f..%2fresources/script.js because it does not appear in the script-src directive of the Content Security Policy.
+CONSOLE MESSAGE: Refused to load http://127.0.0.1:8000/security/contentSecurityPolicy/resources%2f..%2F..%2Fresources/script.js because it does not appear in the script-src directive of the Content Security Policy.
+CONSOLE MESSAGE: Refused to load http://127.0.0.1:8000/security/contentSecurityPolicy/resources%2F..%2F..%2F..%2F..%2Fresources/script.js because it does not appear in the script-src directive of the Content Security Policy.
+CONSOLE MESSAGE: Refused to load http://127.0.0.1:8000/security%2F..%2F..%2F..%2F..%2Fetc/script.js because it does not appear in the script-src directive of the Content Security Policy.
+Percent-encoded path traversal sequences (%2F..%2F) should not bypass CSP path restrictions.
+
+
+
+--------
+Frame: '<!--frame1-->'
+--------
+PASS
+
+--------
+Frame: '<!--frame2-->'
+--------
+PASS
+
+--------
+Frame: '<!--frame3-->'
+--------
+PASS
+
+--------
+Frame: '<!--frame4-->'
+--------
+PASS
+
+--------
+Frame: '<!--frame5-->'
+--------
+PASS
+
+--------
+Frame: '<!--frame6-->'
+--------
+PASS
+
+--------
+Frame: '<!--frame7-->'
+--------
+PASS

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/path-traversal-bypass-with-percent-encoding.html
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/path-traversal-bypass-with-percent-encoding.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src='resources/multiple-iframe-test.js'></script>
+<script>
+var tests = [
+    // Normal path within allowed dir.
+    ['yes', 'script-src 127.0.0.1:8000/security/', 'resources/script.js'],
+
+    // Multi-level %2F..%2F traversal outside allowed dir. Normalizes to /resources/script.js.
+    ['no', 'script-src 127.0.0.1:8000/security/contentSecurityPolicy/resources/', 'http://127.0.0.1:8000/security/contentSecurityPolicy/resources%2F..%2F..%2Fresources/script.js'],
+
+    // Single-level %2F..%2F traversal. Normalizes to /security/resources/script.js.
+    ['no', 'script-src 127.0.0.1:8000/security/contentSecurityPolicy/', 'http://127.0.0.1:8000/security/contentSecurityPolicy%2F..%2Fresources/script.js'],
+
+    // Lowercase %2f should also be blocked.
+    ['no', 'script-src 127.0.0.1:8000/security/contentSecurityPolicy/', 'http://127.0.0.1:8000/security/contentSecurityPolicy%2f..%2fresources/script.js'],
+
+    // Mixed case %2f and %2F in the same URL.
+    ['no', 'script-src 127.0.0.1:8000/security/contentSecurityPolicy/resources/', 'http://127.0.0.1:8000/security/contentSecurityPolicy/resources%2f..%2F..%2Fresources/script.js'],
+
+    // Four consecutive dot segments. Normalizes to /resources/script.js.
+    ['no', 'script-src 127.0.0.1:8000/security/contentSecurityPolicy/resources/', 'http://127.0.0.1:8000/security/contentSecurityPolicy/resources%2F..%2F..%2F..%2F..%2Fresources/script.js'],
+
+    // Traversal past root clamps to /. Normalizes to /etc/script.js.
+    ['no', 'script-src 127.0.0.1:8000/security/', 'http://127.0.0.1:8000/security%2F..%2F..%2F..%2F..%2Fetc/script.js'],
+];
+</script>
+</head>
+<body onload="test()">
+  <p>
+    Percent-encoded path traversal sequences (%2F..%2F) should not bypass CSP path restrictions.
+  </p>
+</body>
+</html>

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/resources/create-blob-iframe.js
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/resources/create-blob-iframe.js
@@ -1,0 +1,12 @@
+var iframe = document.getElementById("blob-frame");
+var html = [
+    "<!DOCTYPE html>",
+    "<html><body>",
+    "<p id='result'>PASS: Inline script was blocked by CSP.</p>",
+    "<script>",
+    "document.getElementById('result').textContent = 'FAIL: Inline script executed (CSP policy was dropped).';",
+    "</" + "script>",
+    "</body></html>"
+].join("\n");
+var blob = new Blob([html], { type: "text/html" });
+iframe.src = URL.createObjectURL(blob);

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/resources/echo-multiple-csp-blob-iframe.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/resources/echo-multiple-csp-blob-iframe.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+
+import sys
+
+sys.stdout.write(
+    'Content-Type: text/html; charset=UTF-8\r\n'
+    "Content-Security-Policy: script-src 'self'; frame-src blob:; default-src 'self'\r\n"
+    "Content-Security-Policy: script-src 'self' 'unsafe-inline'; frame-src blob:; default-src 'self'\r\n"
+    '\r\n'
+    '<!DOCTYPE html>\n'
+    '<html>\n'
+    '<body>\n'
+    '<iframe id="blob-frame"></iframe>\n'
+    '<script src="/security/contentSecurityPolicy/resources/create-blob-iframe.js"></script>\n'
+    '</body>\n'
+    '</html>\n'
+)

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/inheriting-csp-for-local-schemes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/inheriting-csp-for-local-schemes-expected.txt
@@ -4,7 +4,7 @@ PASS trusted-types directive should be inherited in local srcdoc frames
 PASS require-trusted-types-for directive should be inherited in local data frames
 PASS trusted-types directive should be inherited in local data frames
 PASS require-trusted-types-for directive should be inherited in local blob frames
-FAIL trusted-types directive should be inherited in local blob frames assert_not_equals: got disallowed value null
+PASS trusted-types directive should be inherited in local blob frames
 PASS require-trusted-types-for directive should be inherited in local about:blank frames
 PASS trusted-types directive should be inherited in local about:blank frames
 PASS require-trusted-types-for directive should not be inherited in local blank.html frames

--- a/Source/JavaScriptCore/yarr/RegularExpression.cpp
+++ b/Source/JavaScriptCore/yarr/RegularExpression.cpp
@@ -103,7 +103,7 @@ int RegularExpression::match(StringView str, unsigned startFrom, int* matchLengt
     if (str.isNull())
         return -1;
 
-    int offsetVectorSize = (d->m_numSubpatterns + 1) * 2;
+    int offsetVectorSize = d->m_regExpByteCode->m_offsetsSize;
     unsigned* offsetVector;
     Vector<unsigned, 32> nonReturnedOvector;
 

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/test/acm_random.h
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/test/acm_random.h
@@ -52,6 +52,13 @@ class ACMRandom {
     return (value >> 19) & 0xfff;
   }
 
+  uint16_t Rand10() {
+    const uint32_t value =
+        random_.Generate(testing::internal::Random::kMaxRange);
+    // There's a bit more entropy in the upper bits of this implementation.
+    return (value >> 21) & 0x3ff;
+  }
+
   uint8_t Rand8() {
     const uint32_t value =
         random_.Generate(testing::internal::Random::kMaxRange);

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/test/encode_api_test.cc
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/test/encode_api_test.cc
@@ -54,7 +54,8 @@ void *Memset16(void *dest, int val, size_t length) {
 }
 
 vpx_image_t *CreateImage(vpx_bit_depth_t bit_depth, vpx_img_fmt_t fmt,
-                         unsigned int width, unsigned int height) {
+                         unsigned int width, unsigned int height,
+                         libvpx_test::ACMRandom *rng = nullptr) {
   assert(fmt != VPX_IMG_FMT_NV12);
   if (bit_depth > VPX_BITS_8) {
     fmt = static_cast<vpx_img_fmt_t>(fmt | VPX_IMG_FMT_HIGHBITDEPTH);
@@ -62,26 +63,38 @@ vpx_image_t *CreateImage(vpx_bit_depth_t bit_depth, vpx_img_fmt_t fmt,
   vpx_image_t *image = vpx_img_alloc(nullptr, fmt, width, height, 1);
   if (!image) return image;
 
-  const int val = 1 << (bit_depth - 1);
+  auto get_val = [bit_depth, &rng]() {
+    if (rng != nullptr) {
+      switch (bit_depth) {
+        case VPX_BITS_8: return static_cast<int>(rng->Rand8());
+        case VPX_BITS_10: return static_cast<int>(rng->Rand10());
+        case VPX_BITS_12: return static_cast<int>(rng->Rand12());
+      }
+    }
+    return 1 << (bit_depth - 1);
+  };
+  const int val_y = get_val();
+  const int val_u = get_val();
+  const int val_v = get_val();
   const unsigned int uv_h =
       (image->d_h + image->y_chroma_shift) >> image->y_chroma_shift;
   const unsigned int uv_w =
       (image->d_w + image->x_chroma_shift) >> image->x_chroma_shift;
   if (bit_depth > VPX_BITS_8) {
     for (unsigned int i = 0; i < image->d_h; ++i) {
-      Memset16(image->planes[0] + i * image->stride[0], val, image->d_w);
+      Memset16(image->planes[0] + i * image->stride[0], val_y, image->d_w);
     }
     for (unsigned int i = 0; i < uv_h; ++i) {
-      Memset16(image->planes[1] + i * image->stride[1], val, uv_w);
-      Memset16(image->planes[2] + i * image->stride[2], val, uv_w);
+      Memset16(image->planes[1] + i * image->stride[1], val_u, uv_w);
+      Memset16(image->planes[2] + i * image->stride[2], val_v, uv_w);
     }
   } else {
     for (unsigned int i = 0; i < image->d_h; ++i) {
-      memset(image->planes[0] + i * image->stride[0], val, image->d_w);
+      memset(image->planes[0] + i * image->stride[0], val_y, image->d_w);
     }
     for (unsigned int i = 0; i < uv_h; ++i) {
-      memset(image->planes[1] + i * image->stride[1], val, uv_w);
-      memset(image->planes[2] + i * image->stride[2], val, uv_w);
+      memset(image->planes[1] + i * image->stride[1], val_u, uv_w);
+      memset(image->planes[2] + i * image->stride[2], val_v, uv_w);
     }
   }
 
@@ -1197,7 +1210,9 @@ class VP9Encoder {
 
   void Configure(unsigned int threads, unsigned int width, unsigned int height,
                  vpx_rc_mode end_usage, vpx_enc_deadline_t deadline);
-  void Encode(bool key_frame);
+  // If `rng` is non-null, use it to generate the image values for encoding.
+  // Otherwise the midpoint of the configured bitdepth is used.
+  void Encode(bool key_frame, libvpx_test::ACMRandom *rng = nullptr);
 
  private:
   const int speed_;
@@ -1264,10 +1279,10 @@ void VP9Encoder::Configure(unsigned int threads, unsigned int width,
       << vpx_codec_error_detail(&enc_);
 }
 
-void VP9Encoder::Encode(bool key_frame) {
+void VP9Encoder::Encode(bool key_frame, libvpx_test::ACMRandom *rng) {
   assert(initialized_);
   const vpx_codec_cx_pkt_t *pkt;
-  vpx_image_t *image = CreateImage(bit_depth_, fmt_, cfg_.g_w, cfg_.g_h);
+  vpx_image_t *image = CreateImage(bit_depth_, fmt_, cfg_.g_w, cfg_.g_h, rng);
   ASSERT_NE(image, nullptr);
   const vpx_enc_frame_flags_t frame_flags = key_frame ? VPX_EFLAG_FORCE_KF : 0;
   ASSERT_EQ(
@@ -2260,6 +2275,25 @@ TEST(EncodeAPI, PerFramePsnrNotSupportedWithLagInFrames) {
   vpx_img_free(image);
   ASSERT_EQ(vpx_codec_destroy(&enc), VPX_CODEC_OK);
 }
+
+TEST(EncodeAPI, Buganizer487259772ScaledRefs) {
+  libvpx_test::ACMRandom rng;
+  VP9Encoder encoder(/*speed=*/7, /*row_mt=*/0, VPX_BITS_8, VPX_IMG_FMT_I420);
+  encoder.Configure(/*threads=*/1, /*width=*/478, /*height=*/755, VPX_VBR,
+                    VPX_DL_REALTIME);
+  encoder.Configure(/*threads=*/1, /*width=*/387, /*height=*/438, VPX_VBR,
+                    VPX_DL_REALTIME);
+  encoder.Encode(/*key_frame=*/false, &rng);
+  encoder.Encode(/*key_frame=*/true, &rng);
+  encoder.Encode(/*key_frame=*/false, &rng);
+  encoder.Encode(/*key_frame=*/false, &rng);
+
+  encoder.Configure(/*threads=*/1, /*width=*/341, /*height=*/655, VPX_VBR,
+                    VPX_DL_REALTIME);
+  encoder.Encode(/*key_frame=*/false, &rng);
+  encoder.Encode(/*key_frame=*/false, &rng);
+}
+
 #endif  // CONFIG_VP9_ENCODER
 
 }  // namespace

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/encoder/vp9_pickmode.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/encoder/vp9_pickmode.c
@@ -2283,6 +2283,18 @@ void vp9_pick_inter_mode(VP9_COMP *cpi, MACROBLOCK *x, TileDataEnc *tile_data,
     // need to compute best_pred_sad which is only used to skip golden NEWMV.
     if (use_golden_nonzeromv && this_mode == NEWMV && ref_frame == LAST_FRAME &&
         frame_mv[NEWMV][LAST_FRAME].as_int != INVALID_MV) {
+      struct buf_2d backup_yv12[MAX_MB_PLANE] = { { 0, 0 } };
+      const YV12_BUFFER_CONFIG *scaled_ref_frame =
+          vp9_get_scaled_ref_frame(cpi, ref_frame);
+      if (scaled_ref_frame) {
+        assert(scaled_ref_frame->y_width == cpi->Source->y_width &&
+               scaled_ref_frame->y_height == cpi->Source->y_height);
+        // Swap out the reference frame for a version that's been scaled to
+        // match the resolution of the current frame, allowing the existing
+        // motion search code to be used without additional modifications.
+        for (i = 0; i < MAX_MB_PLANE; i++) backup_yv12[i] = xd->plane[i].pre[0];
+        vp9_setup_pre_planes(xd, 0, scaled_ref_frame, mi_row, mi_col, NULL);
+      }
       const int pre_stride = xd->plane[0].pre[0].stride;
       const uint8_t *const pre_buf =
           xd->plane[0].pre[0].buf +
@@ -2291,6 +2303,9 @@ void vp9_pick_inter_mode(VP9_COMP *cpi, MACROBLOCK *x, TileDataEnc *tile_data,
       best_pred_sad = cpi->fn_ptr[bsize].sdf(
           x->plane[0].src.buf, x->plane[0].src.stride, pre_buf, pre_stride);
       x->pred_mv_sad[LAST_FRAME] = best_pred_sad;
+      if (scaled_ref_frame) {
+        for (i = 0; i < MAX_MB_PLANE; i++) xd->plane[i].pre[0] = backup_yv12[i];
+      }
     }
 
     if (this_mode != NEARESTMV && !comp_pred &&

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -314,6 +314,16 @@ AllowTestOnlyIPC:
       default: false
   sharedPreferenceForWebProcess: true
 
+AllowTestOnlyOriginAccessAllowListIPC:
+  type: bool
+  status: embedder
+  exposed: [ WebKit ]
+  webcoreBinding: none
+  defaultValue:
+    WebKit:
+      default: false
+  sharedPreferenceForWebProcess: true
+
 AllowTopNavigationToDataURLs:
   type: bool
   humanReadableName: "Allow top navigation to data: URLs"

--- a/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
+++ b/Source/WebCore/animation/StyleOriginatedTimelinesController.cpp
@@ -253,13 +253,13 @@ void StyleOriginatedTimelinesController::documentDidResolveStyle()
     }
 
     // Purge any inactive named timeline no longer attached to an animation.
-    for (auto& [name, timelines] : m_nameToTimelineMap) {
+    m_nameToTimelineMap.removeIf([](auto& keyValuePair) {
+        auto& timelines = keyValuePair.value;
         timelines.removeAllMatching([](auto& timeline) {
             return timeline->isInactiveStyleOriginatedTimeline() && timeline->relevantAnimations().isEmpty();
         });
-        if (timelines.isEmpty())
-            m_nameToTimelineMap.remove(name);
-    }
+        return timelines.isEmpty();
+    });
 
     m_removedTimelines.clear();
 }

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -629,7 +629,14 @@ bool Element::dispatchKeyEvent(const PlatformKeyboardEvent& platformEvent)
 
 bool Element::dispatchSimulatedClick(Event* underlyingEvent, SimulatedClickMouseEventOptions eventOptions, SimulatedClickVisualOptions visualOptions)
 {
-    return simulateClick(*this, underlyingEvent, eventOptions, visualOptions, SimulatedClickSource::UserAgent);
+    auto simulatedClickSource = [&] {
+        if (!underlyingEvent)
+            return SimulatedClickSource::UserAgent;
+
+        return underlyingEvent->isTrusted() ? SimulatedClickSource::UserAgent : SimulatedClickSource::Bindings;
+    }();
+
+    return simulateClick(*this, underlyingEvent, eventOptions, visualOptions, simulatedClickSource);
 }
 
 Ref<Node> Element::cloneNodeInternal(Document& document, CloningOperation type, CustomElementRegistry* fallbackRegistry) const

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1206,8 +1206,19 @@ void FrameLoader::resetMultipleFormSubmissionProtection()
 
 void FrameLoader::updateFirstPartyForCookies()
 {
-    if (RefPtr page = m_frame->page())
-        setFirstPartyForCookies(page->mainFrameURL());
+    RefPtr page = m_frame->page();
+    if (!page)
+        return;
+
+    auto firstPartyForCookies = page->mainFrameURL();
+    if (SecurityPolicy::shouldInheritSecurityOriginFromOwner(firstPartyForCookies)) {
+        if (RefPtr opener = dynamicDowncast<LocalFrame>(page->mainFrame().opener())) {
+            if (RefPtr openerDocument = opener->document())
+                firstPartyForCookies = openerDocument->firstPartyForCookies();
+        }
+    }
+
+    setFirstPartyForCookies(firstPartyForCookies);
 }
 
 void FrameLoader::setFirstPartyForCookies(const URL& url)

--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -390,4 +390,12 @@ void Frame::setPrinting(bool printing, FloatSize pageSize, FloatSize originalPag
         loaderClient().setPrinting(printing, pageSize, originalPageSize, maximumShrinkRatio, shouldAdjustViewSize);
 }
 
+SecurityOrigin& Frame::topOrigin() const
+{
+    if (RefPtr page = this->page())
+        return page->mainFrameOrigin();
+
+    return SecurityOrigin::opaqueOrigin();
+}
+
 } // namespace WebCore

--- a/Source/WebCore/page/Frame.h
+++ b/Source/WebCore/page/Frame.h
@@ -83,6 +83,7 @@ public:
     WEBCORE_EXPORT std::optional<uint64_t> indexInFrameTreeSiblings() const;
     WEBCORE_EXPORT Vector<uint64_t> pathToFrame() const;
     FrameIdentifier frameID() const { return m_frameID; }
+    WEBCORE_EXPORT SecurityOrigin& topOrigin() const;
     inline Page* page() const; // Defined in DocumentPage.h.
     inline RefPtr<Page> protectedPage() const; // Defined in DocumentPage.h.
     inline std::optional<PageIdentifier> pageID() const; // Defined in DocumentPage.h.

--- a/Source/WebCore/page/csp/ContentSecurityPolicyResponseHeaders.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyResponseHeaders.cpp
@@ -66,10 +66,10 @@ void ContentSecurityPolicyResponseHeaders::addPolicyHeadersTo(ResourceResponse& 
     for (const auto& header : m_headers) {
         switch (header.second) {
         case ContentSecurityPolicyHeaderType::Enforce:
-            response.setHTTPHeaderField(HTTPHeaderName::ContentSecurityPolicy, header.first);
+            response.addHTTPHeaderField(HTTPHeaderName::ContentSecurityPolicy, header.first);
             break;
         case ContentSecurityPolicyHeaderType::Report:
-            response.setHTTPHeaderField(HTTPHeaderName::ContentSecurityPolicyReportOnly, header.first);
+            response.addHTTPHeaderField(HTTPHeaderName::ContentSecurityPolicyReportOnly, header.first);
             break;
         }
     }

--- a/Source/WebCore/page/csp/ContentSecurityPolicySource.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicySource.cpp
@@ -106,15 +106,48 @@ bool ContentSecurityPolicySource::hostMatches(const URL& url) const
 
 bool ContentSecurityPolicySource::pathMatches(const URL& url) const
 {
+    // https://www.w3.org/TR/CSP3/#match-paths
+    // Path A is the source expression's path (m_path, from the CSP directive).
+    // Path B is the URL's path being checked against the policy.
+
+    // Step 1: empty path automatically matches.
     if (m_path.isEmpty())
         return true;
 
-    auto path = PAL::decodeURLEscapeSequences(url.path());
+    auto urlPath = url.path();
 
-    if (m_path.endsWith('/'))
-        return path.startsWith(m_path);
+    // Step 2: "/" matches empty path.
+    if (m_path == "/"_s && urlPath.isEmpty())
+        return true;
 
-    return path == m_path;
+    // Step 3: directory match if path A ends with '/'.
+    bool exactMatch = !m_path.endsWith('/');
+
+    // Step 4: strictly split both on '/'.
+    auto pathListA = m_path.splitAllowingEmptyEntries('/');
+    auto pathListB = urlPath.toString().splitAllowingEmptyEntries('/');
+
+    // Step 5: path A must not have more segments than path B.
+    if (pathListA.size() > pathListB.size())
+        return false;
+
+    // Step 6: exact match requires same number of segments.
+    if (exactMatch && pathListA.size() != pathListB.size())
+        return false;
+
+    // Step 7: for directory match, remove trailing empty segment from A.
+    if (!exactMatch) {
+        ASSERT(pathListA.last().isEmpty());
+        pathListA.removeLast();
+    }
+
+    // Step 8: compare each segment after percent-decoding.
+    for (unsigned i = 0; i < pathListA.size(); ++i) {
+        if (PAL::decodeURLEscapeSequences(pathListA[i]) != PAL::decodeURLEscapeSequences(pathListB[i]))
+            return false;
+    }
+
+    return true;
 }
 
 bool ContentSecurityPolicySource::portMatches(const URL& url) const

--- a/Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp
@@ -543,7 +543,7 @@ template<typename CharacterType> String ContentSecurityPolicySourceList::parsePa
     ASSERT(buffer.position() <= buffer.end());
     ASSERT(buffer.atEnd() || (*buffer == '#' || *buffer == '?'));
 
-    return PAL::decodeURLEscapeSequences(begin.first(buffer.position() - begin.data()));
+    return String(begin.first(buffer.position() - begin.data()));
 }
 
 // port              = ":" ( 1*DIGIT / "*" )

--- a/Source/WebCore/platform/graphics/PixelBufferConversion.cpp
+++ b/Source/WebCore/platform/graphics/PixelBufferConversion.cpp
@@ -467,7 +467,15 @@ void convertImagePixels(const ConstPixelBufferConversionView& source, const Pixe
 {
 #if ENABLE(PIXEL_FORMAT_RGBA16F)
     auto isSourceFloat = source.format.pixelFormat == PixelFormat::RGBA16F;
+    if (isSourceFloat && destinationSize.height() > 0 && destinationSize.width() > 0) {
+        RELEASE_ASSERT((source.rows.size_bytes() - destinationSize.width() * (4 * sizeof(Float16))) / source.bytesPerRow >= size_t(destinationSize.height() - 1), "Expected source size_bytes >= (height-1) * bytesPerRow + width*4*sizeof(Float16)");
+        RELEASE_ASSERT(source.rows.size_bytes() / (4 * sizeof(Float16)) / destinationSize.width() >= size_t(destinationSize.height()), "Expected source size_bytes >= width * height * 4*sizeof(Float16)");
+    }
     auto isDestinationFloat = destination.format.pixelFormat == PixelFormat::RGBA16F;
+    if (isDestinationFloat && destinationSize.height() > 0 && destinationSize.width() > 0) {
+        RELEASE_ASSERT((destination.rows.size_bytes() - destinationSize.width() * (4 * sizeof(Float16))) / destination.bytesPerRow >= size_t(destinationSize.height() - 1), "Expected destination size_bytes >= (height-1) * bytesPerRow + width*4*sizeof(Float16)");
+        RELEASE_ASSERT(destination.rows.size_bytes() / (4 * sizeof(Float16)) / destinationSize.width() >= size_t(destinationSize.height()), "Expected destination size_bytes >= width * height * 4*sizeof(Float16)");
+    }
     if (isSourceFloat && isDestinationFloat)
         return convertImagePixelsFromFloat16ToFloat16(source, destination, destinationSize);
     if (isSourceFloat)

--- a/Source/WebCore/workers/service/server/SWServer.cpp
+++ b/Source/WebCore/workers/service/server/SWServer.cpp
@@ -129,7 +129,10 @@ std::optional<ServiceWorkerClientData> SWServer::serviceWorkerClientWithOriginBy
         return std::nullopt;
 
     auto clientIterator = m_clientsById.find(clientIdentifier);
-    ASSERT(clientIterator != m_clientsById.end());
+    if (clientIterator == m_clientsById.end()) [[unlikely]] {
+        ASSERT_NOT_REACHED();
+        return std::nullopt;
+    }
     return clientIterator->value;
 }
 
@@ -141,6 +144,10 @@ std::optional<ServiceWorkerClientData> SWServer::topLevelServiceWorkerClientFrom
 
     for (auto clientIdentifier : iterator->value.identifiers) {
         auto clientIterator = m_clientsById.find(clientIdentifier);
+        if (clientIterator == m_clientsById.end()) {
+            ASSERT_NOT_REACHED();
+            continue;
+        }
         if (clientIterator->value->frameType == ServiceWorkerClientFrameType::TopLevel && clientIterator->value->pageIdentifier == pageIdentifier)
             return clientIterator->value;
     }

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
@@ -92,9 +92,9 @@ messages -> NetworkConnectionToWebProcess WantsDispatchMessage {
     [EnabledBy=StorageAccessAPIEnabled] StorageAccessQuirkForTopFrameDomain(URL topFrameURL) -> (Vector<WebCore::RegistrableDomain> domains)
     [EnabledBy=StorageAccessAPIEnabled] RequestStorageAccessUnderOpener(WebCore::RegistrableDomain domainInNeedOfStorageAccess, WebCore::PageIdentifier openerPageID, WebCore::RegistrableDomain openerDomain)
 
-    AddOriginAccessAllowListEntry(String sourceOrigin, String destinationProtocol, String destinationHost, bool allowDestinationSubdomains);
-    RemoveOriginAccessAllowListEntry(String sourceOrigin, String destinationProtocol, String destinationHost, bool allowDestinationSubdomains);
-    ResetOriginAccessAllowLists();
+    [EnabledBy=AllowTestOnlyOriginAccessAllowListIPC] AddOriginAccessAllowListEntry(String sourceOrigin, String destinationProtocol, String destinationHost, bool allowDestinationSubdomains);
+    [EnabledBy=AllowTestOnlyOriginAccessAllowListIPC] RemoveOriginAccessAllowListEntry(String sourceOrigin, String destinationProtocol, String destinationHost, bool allowDestinationSubdomains);
+    [EnabledBy=AllowTestOnlyOriginAccessAllowListIPC] ResetOriginAccessAllowLists();
 
     GetNetworkLoadInformationResponse(WebCore::ResourceLoaderIdentifier resourceLoadIdentifier) -> (WebCore::ResourceResponse response) Synchronous
     GetNetworkLoadIntermediateInformation(WebCore::ResourceLoaderIdentifier resourceLoadIdentifier) -> (Vector<WebCore::NetworkTransactionInformation> transactions) Synchronous

--- a/Source/WebKit/Shared/FrameInfoData.cpp
+++ b/Source/WebKit/Shared/FrameInfoData.cpp
@@ -34,11 +34,13 @@ FrameInfoData legacyEmptyFrameInfo(WebCore::ResourceRequest&& request)
     constexpr bool isFocused { false };
     constexpr bool errorOccurred { false };
 
+    auto opaqueOrigin = WebCore::SecurityOriginData::createOpaque();
     return FrameInfoData {
         isMainFrame,
         FrameType::Local,
         WTF::move(request),
-        WebCore::SecurityOriginData::createOpaque(),
+        opaqueOrigin,
+        opaqueOrigin,
         String { },
         WebCore::generateFrameIdentifier(),
         std::nullopt,

--- a/Source/WebKit/Shared/FrameInfoData.h
+++ b/Source/WebKit/Shared/FrameInfoData.h
@@ -47,6 +47,7 @@ struct FrameInfoData {
     FrameType frameType { FrameType::Local };
     WebCore::ResourceRequest request;
     WebCore::SecurityOriginData securityOrigin;
+    WebCore::SecurityOriginData topOrigin;
     String frameName;
     WebCore::FrameIdentifier frameID;
     Markable<WebPageProxyIdentifier> webPageProxyID;

--- a/Source/WebKit/Shared/FrameInfoData.serialization.in
+++ b/Source/WebKit/Shared/FrameInfoData.serialization.in
@@ -29,6 +29,7 @@ struct WebKit::FrameInfoData {
     WebKit::FrameType frameType;
     WebCore::ResourceRequest request;
     WebCore::SecurityOriginData securityOrigin;
+    WebCore::SecurityOriginData topOrigin;
     String frameName;
     WebCore::FrameIdentifier frameID;
     Markable<WebKit::WebPageProxyIdentifier> webPageProxyID;

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -1255,7 +1255,7 @@ void UIDelegate::UIClient::willCloseLocalInspector(WebPageProxy&, WebInspectorUI
 #if ENABLE(DEVICE_ORIENTATION)
 void UIDelegate::UIClient::shouldAllowDeviceOrientationAndMotionAccess(WebKit::WebPageProxy& page, WebFrameProxy& webFrameProxy, FrameInfoData&& frameInfo, CompletionHandler<void(bool)>&& completionHandler)
 {
-    Ref securityOrigin = WebCore::SecurityOrigin::createFromString(page.protectedPageLoadState()->activeURL());
+    Ref securityOrigin = frameInfo.topOrigin.securityOrigin();
     RefPtr uiDelegate = m_uiDelegate.get();
     if (!uiDelegate || !uiDelegate->m_delegate.get() || !uiDelegate->m_delegateMethods.webViewRequestDeviceOrientationAndMotionPermissionForOriginDecisionHandler) {
         alertForPermission(page, MediaPermissionReason::DeviceOrientation, securityOrigin->data(), WTF::move(completionHandler));

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp
@@ -1340,7 +1340,7 @@ void WebExtensionContext::addInjectedContent(const InjectedContentVector& inject
 
         HashSet<String> excludeMatchPatternsSet;
         excludeMatchPatternsSet.addAll(injectedContentData.expandedExcludeMatchPatternStrings());
-        excludeMatchPatternsSet.unionWith(baseExcludeMatchPatternsSet);
+        excludeMatchPatternsSet.addAll(baseExcludeMatchPatternsSet);
 
         auto excludeMatchPatterns = copyToVector(excludeMatchPatternsSet);
 

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -238,11 +238,13 @@ void ProvisionalPageProxy::cancel()
     ASSERT(mainFrame);
     auto error = WebKit::cancelledError(m_request);
     error.setType(WebCore::ResourceError::Type::Cancellation);
+    auto securityOriginData = SecurityOriginData::fromURLWithoutStrictOpaqueness(m_request.url());
     FrameInfoData frameInfo {
         true, // isMainFrame
         FrameType::Local,
         m_request,
-        SecurityOriginData::fromURLWithoutStrictOpaqueness(m_request.url()),
+        securityOriginData,
+        securityOriginData,
         { },
         mainFrame->frameID(),
         m_page ? std::optional { m_page->identifier() } : std::nullopt,

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -2469,8 +2469,11 @@ RefPtr<API::Navigation> WebPageProxy::loadSimulatedRequest(WebCore::ResourceRequ
 
     process->markProcessAsRecentlyUsed();
     process->assumeReadAccessToBaseURL(*this, baseURL, [weakProcess = WeakPtr { process }, loadParameters = WTF::move(loadParameters), simulatedResponse = WTF::move(simulatedResponse), webPageID = m_webPageID] () mutable {
-        weakProcess->send(Messages::WebPage::LoadSimulatedRequestAndResponse(WTF::move(loadParameters), simulatedResponse), webPageID);
-        weakProcess->startResponsivenessTimer();
+        RefPtr protectedProcess = weakProcess.get();
+        if (!protectedProcess)
+            return;
+        protectedProcess->send(Messages::WebPage::LoadSimulatedRequestAndResponse(WTF::move(loadParameters), simulatedResponse), webPageID);
+        protectedProcess->startResponsivenessTimer();
     });
 
     return navigation;
@@ -2527,14 +2530,18 @@ void WebPageProxy::loadAlternateHTML(Ref<WebCore::DataSegment>&& htmlData, const
     ] () mutable {
         process->markProcessAsRecentlyUsed();
         process->assumeReadAccessToBaseURLs(*this, { baseURL.string(), unreachableURL.string() }, [weakThis = WeakPtr { *this }, weakProcess = WeakPtr { process }, baseURL, unreachableURL, loadParameters = WTF::move(loadParameters)] () mutable {
-            if (!weakThis || !weakProcess)
+            RefPtr protectedThis = weakThis.get();
+            if (!protectedThis)
+                return;
+            RefPtr protectedProcess = weakProcess.get();
+            if (!protectedProcess)
                 return;
             if (baseURL.protocolIsFile())
-                weakProcess->addPreviouslyApprovedFileURL(baseURL);
+                protectedProcess->addPreviouslyApprovedFileURL(baseURL);
             if (unreachableURL.protocolIsFile())
-                weakProcess->addPreviouslyApprovedFileURL(unreachableURL);
-            weakThis->send(Messages::WebPage::LoadAlternateHTML(WTF::move(loadParameters)));
-            weakProcess->startResponsivenessTimer();
+                protectedProcess->addPreviouslyApprovedFileURL(unreachableURL);
+            protectedThis->send(Messages::WebPage::LoadAlternateHTML(WTF::move(loadParameters)));
+            protectedProcess->startResponsivenessTimer();
         });
     };
 
@@ -2594,18 +2601,19 @@ RefPtr<API::Navigation> WebPageProxy::reload(OptionSet<WebCore::ReloadOption> op
     if (!url.isEmpty()) {
         // We may not have an extension yet if back/forward list was reinstated after a WebProcess crash or a browser relaunch
         maybeInitializeSandboxExtensionHandle(protectedLegacyMainFrameProcess(), URL { url }, currentResourceDirectoryURL(), true, [weakThis = WeakPtr { *this }, process = WTF::move(process), options = WTF::move(options), sandboxExtensionHandle = WTF::move(sandboxExtensionHandle), navigation](std::optional<SandboxExtension::Handle>&& sandboxExtension) mutable {
-            if (!weakThis)
+            RefPtr protectedThis = weakThis.get();
+            if (!protectedThis)
                 return;
             if (sandboxExtension)
                 sandboxExtensionHandle = WTF::move(*sandboxExtension);
-            weakThis->send(Messages::WebPage::Reload(navigation->navigationID(), options, WTF::move(sandboxExtensionHandle)));
+            protectedThis->send(Messages::WebPage::Reload(navigation->navigationID(), options, WTF::move(sandboxExtensionHandle)));
             process->startResponsivenessTimer();
 
-            if (weakThis->shouldForceForegroundPriorityForClientNavigation())
+            if (protectedThis->shouldForceForegroundPriorityForClientNavigation())
                 navigation->setClientNavigationActivity(process->protectedThrottler()->foregroundActivity("Client reload"_s));
 
 #if ENABLE(SPEECH_SYNTHESIS)
-            weakThis->resetSpeechSynthesizer();
+            protectedThis->resetSpeechSynthesizer();
 #endif
         });
     }
@@ -3647,13 +3655,14 @@ void WebPageProxy::executeEditCommand(const String& commandName, const String& a
 
     auto completionHandler = [weakThis = WeakPtr { *this }, commandName, argument, frameID] () mutable {
         static NeverDestroyed<String> ignoreSpellingCommandName(MAKE_STATIC_STRING_IMPL("ignoreSpelling"));
-        if (!weakThis)
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
             return;
 
         if (commandName == ignoreSpellingCommandName)
-            ++weakThis->m_pendingLearnOrIgnoreWordMessageCount;
+            ++protectedThis->m_pendingLearnOrIgnoreWordMessageCount;
 
-        weakThis->sendToProcessContainingFrame(frameID, Messages::WebPage::ExecuteEditCommand(commandName, argument));
+        protectedThis->sendToProcessContainingFrame(frameID, Messages::WebPage::ExecuteEditCommand(commandName, argument));
     };
 
     if (auto pasteAccessCategory = pasteAccessCategoryForCommand(commandName)) {
@@ -11057,9 +11066,8 @@ void WebPageProxy::contextMenuItemSelected(const WebContextMenuItemData& item, c
     }
     auto targetFrameID = focusedOrMainFrame() ? std::optional(focusedOrMainFrame()->frameID()) : std::nullopt;
     platformDidSelectItemFromActiveContextMenu(item, [weakThis = WeakPtr { *this }, item, targetFrameID] () mutable {
-        if (!weakThis)
-            return;
-        weakThis->sendToProcessContainingFrame(targetFrameID, Messages::WebPage::DidSelectItemFromActiveContextMenu(item));
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->sendToProcessContainingFrame(targetFrameID, Messages::WebPage::DidSelectItemFromActiveContextMenu(item));
     });
 }
 

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -11378,11 +11378,18 @@ void WebPageProxy::focusFromServiceWorker(CompletionHandler<void()>&& callback)
 
 // Other
 
-void WebPageProxy::setFocus(bool focused)
+void WebPageProxy::setFocus(bool focused, std::optional<WebCore::UserGestureTokenIdentifier> userGestureTokenIdentifier)
 {
-    if (focused)
+    if (focused) {
+        if (userGestureTokenIdentifier) {
+            if (RefPtr userInitiatedAction = legacyMainFrameProcess().userInitiatedActivity(userGestureTokenIdentifier)) {
+                if (userInitiatedAction->consumed())
+                    return;
+                userInitiatedAction->setConsumed();
+            }
+        }
         m_uiClient->focus(this);
-    else
+    } else
         m_uiClient->unfocus(this);
 }
 
@@ -17135,13 +17142,21 @@ INSTANTIATE_SEND_SYNC_TO_PROCESS_CONTAINING_FRAME(WebPage::ComputePagesForPrinti
 #endif
 #undef INSTANTIATE_SEND_SYNC_TO_PROCESS_CONTAINING_FRAME
 
-void WebPageProxy::focusRemoteFrame(IPC::Connection& connection, WebCore::FrameIdentifier frameID)
+void WebPageProxy::focusRemoteFrame(IPC::Connection& connection, WebCore::FrameIdentifier frameID, std::optional<WebCore::UserGestureTokenIdentifier> userGestureTokenIdentifier)
 {
     RefPtr destinationFrame = WebFrameProxy::webFrame(frameID);
     if (!destinationFrame || !destinationFrame->isMainFrame())
         return;
 
     ASSERT(destinationFrame->page() == this);
+
+    if (userGestureTokenIdentifier) {
+        if (RefPtr userInitiatedAction = WebProcessProxy::fromConnection(connection)->userInitiatedActivity(userGestureTokenIdentifier)) {
+            if (userInitiatedAction->consumed())
+                return;
+            userInitiatedAction->setConsumed();
+        }
+    }
 
     broadcastFocusedFrameToOtherProcesses(connection, std::make_optional(frameID));
     setFocus(true);

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -30,6 +30,7 @@
 #include "APIObject.h"
 #include "MessageReceiver.h"
 #include <WebCore/LayerHostingContextIdentifier.h>
+#include <WebCore/UserGestureTokenIdentifier.h>
 #include <wtf/ApproximateTime.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/CompletionHandler.h>
@@ -2155,7 +2156,7 @@ public:
     void getLoadDecisionForIcon(const WebCore::LinkIcon&, CallbackID);
 
     void focusFromServiceWorker(CompletionHandler<void()>&&);
-    void setFocus(bool focused);
+    void setFocus(bool focused, std::optional<WebCore::UserGestureTokenIdentifier> = std::nullopt);
     void setWindowFrame(const WebCore::FloatRect&);
     void getWindowFrame(CompletionHandler<void(const WebCore::FloatRect&)>&&);
     void getWindowFrameWithCallback(Function<void(WebCore::FloatRect)>&&);
@@ -3495,7 +3496,7 @@ private:
 
     void broadcastFocusedFrameToOtherProcesses(IPC::Connection&, std::optional<WebCore::FrameIdentifier>&&);
 
-    void focusRemoteFrame(IPC::Connection&, WebCore::FrameIdentifier);
+    void focusRemoteFrame(IPC::Connection&, WebCore::FrameIdentifier, std::optional<WebCore::UserGestureTokenIdentifier>);
     void postMessageToRemote(WebCore::FrameIdentifier source, const WebCore::SecurityOriginData& sourceOrigin, WebCore::FrameIdentifier target, std::optional<WebCore::SecurityOriginData> targetOrigin, const WebCore::MessageWithMessagePorts&);
     void renderTreeAsTextForTesting(WebCore::FrameIdentifier, uint64_t baseIndent, OptionSet<WebCore::RenderAsTextFlag>, CompletionHandler<void(String&&)>&&);
     void layerTreeAsTextForTesting(WebCore::FrameIdentifier, uint64_t baseIndent, OptionSet<WebCore::LayerTreeAsTextOptions>, CompletionHandler<void(String&&)>&&);

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -39,7 +39,7 @@ messages -> WebPageProxy {
     DidReceiveEventIPC(enum:uint32_t WebKit::WebEventType eventType, bool handled, struct std::optional<WebCore::RemoteUserInputEventData> remoteUserInputEventData)
     SetCursor(WebCore::Cursor cursor)
     SetCursorHiddenUntilMouseMoves(bool hiddenUntilMouseMoves)
-    SetFocus(bool focused)
+    SetFocus(bool focused, std::optional<WebCore::UserGestureTokenIdentifier> userGestureTokenIdentifier)
     TakeFocus(enum:uint8_t WebCore::FocusDirection direction)
     FocusFromServiceWorker() -> ()
     FocusedElementChanged(std::optional<WebCore::FrameIdentifier> frameID, struct WebCore::FocusOptions options)
@@ -655,7 +655,7 @@ messages -> WebPageProxy {
 
     [EnabledBy=SiteIsolationEnabled] DispatchLoadEventToFrameOwnerElement(WebCore::FrameIdentifier frameID)
 
-    [EnabledBy=SiteIsolationEnabled] FocusRemoteFrame(WebCore::FrameIdentifier frameID)
+    [EnabledBy=SiteIsolationEnabled] FocusRemoteFrame(WebCore::FrameIdentifier frameID, std::optional<WebCore::UserGestureTokenIdentifier> userGestureTokenIdentifier)
     [EnabledBy=SiteIsolationEnabled] PostMessageToRemote(WebCore::FrameIdentifier source, WebCore::SecurityOriginData sourceOrigin, WebCore::FrameIdentifier target, std::optional<WebCore::SecurityOriginData> targetOrigin, struct WebCore::MessageWithMessagePorts message)
     [EnabledBy=SiteIsolationEnabled] RenderTreeAsTextForTesting(WebCore::FrameIdentifier identifier, uint64_t baseIndent, OptionSet<WebCore::RenderAsTextFlag> behavior) -> (String renderTreeDump) Synchronous
     [EnabledBy=SiteIsolationEnabled] FrameTextForTesting(WebCore::FrameIdentifier frameID) -> (String text) Synchronous

--- a/Source/WebKit/UIProcess/WebsiteData/WebDeviceOrientationAndMotionAccessController.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebDeviceOrientationAndMotionAccessController.cpp
@@ -45,24 +45,24 @@ WebDeviceOrientationAndMotionAccessController::WebDeviceOrientationAndMotionAcce
 
 void WebDeviceOrientationAndMotionAccessController::shouldAllowAccess(WebPageProxy& page, WebFrameProxy& frame, FrameInfoData&& frameInfo, bool mayPrompt, CompletionHandler<void(DeviceOrientationOrMotionPermissionState)>&& completionHandler)
 {
-    auto originData = SecurityOrigin::createFromString(page.protectedPageLoadState()->activeURL())->data();
-    auto currentPermission = cachedDeviceOrientationPermission(originData);
+    auto requestOriginData = frameInfo.topOrigin;
+    auto currentPermission = cachedDeviceOrientationPermission(requestOriginData);
     if (currentPermission != DeviceOrientationOrMotionPermissionState::Prompt || !mayPrompt)
         return completionHandler(currentPermission);
 
-    auto& pendingRequests = m_pendingRequests.ensure(originData, [] {
+    auto& pendingRequests = m_pendingRequests.ensure(requestOriginData, [] {
         return Vector<CompletionHandler<void(WebCore::DeviceOrientationOrMotionPermissionState)>> { };
     }).iterator->value;
     pendingRequests.append(WTF::move(completionHandler));
     if (pendingRequests.size() > 1)
         return;
 
-    page.uiClient().shouldAllowDeviceOrientationAndMotionAccess(page, frame, WTF::move(frameInfo), [weakThis = WeakPtr { *this }, originData](bool granted) mutable {
+    page.uiClient().shouldAllowDeviceOrientationAndMotionAccess(page, frame, WTF::move(frameInfo), [weakThis = WeakPtr { *this }, requestOriginData](bool granted) mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
-        protectedThis->m_deviceOrientationPermissionDecisions.set(originData, granted);
-        auto requests = protectedThis->m_pendingRequests.take(originData);
+        protectedThis->m_deviceOrientationPermissionDecisions.set(requestOriginData, granted);
+        auto requests = protectedThis->m_pendingRequests.take(requestOriginData);
         for (auto& completionHandler : requests)
             completionHandler(granted ? DeviceOrientationOrMotionPermissionState::Granted : DeviceOrientationOrMotionPermissionState::Denied);
     });

--- a/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
+++ b/Source/WebKit/UIProcess/mac/WebPageProxyMac.mm
@@ -338,9 +338,8 @@ void WebPageProxy::didPerformDictionaryLookup(const DictionaryPopupInfo& diction
         DictionaryLookup::showPopup(dictionaryPopupInfo, pageClient->protectedViewForPresentingRevealPopover().get(), [this](TextIndicator& textIndicator) {
             setTextIndicator(textIndicator, WebCore::TextIndicatorLifetime::Permanent);
         }, nullptr, [weakThis = WeakPtr { *this }] {
-            if (!weakThis)
-                return;
-            weakThis->clearTextIndicatorWithAnimation(WebCore::TextIndicatorDismissalAnimation::None);
+            if (RefPtr protectedThis = weakThis.get())
+                protectedThis->clearTextIndicatorWithAnimation(WebCore::TextIndicatorDismissalAnimation::None);
         });
     }
 }
@@ -489,9 +488,8 @@ void WebPageProxy::scheduleSetObscuredContentInsetsDispatch()
     m_didScheduleSetObscuredContentInsetsDispatch = true;
 
     callOnMainRunLoop([weakThis = WeakPtr { *this }] {
-        if (!weakThis)
-            return;
-        weakThis->dispatchSetObscuredContentInsets();
+        if (RefPtr protectedThis = weakThis.get())
+            protectedThis->dispatchSetObscuredContentInsets();
     });
 }
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp
@@ -121,6 +121,7 @@
 #include <WebCore/TextDetectorInterface.h>
 #include <WebCore/TextIndicator.h>
 #include <WebCore/TextRecognitionOptions.h>
+#include <WebCore/UserGestureIndicator.h>
 #include <WebCore/ViewportConfiguration.h>
 #include <WebCore/WindowFeatures.h>
 #include <wtf/JSONValues.h>
@@ -270,14 +271,16 @@ FloatRect WebChromeClient::pageRect() const
 
 void WebChromeClient::focus()
 {
-    if (RefPtr page = m_page.get())
-        page->send(Messages::WebPageProxy::SetFocus(true));
+    if (RefPtr page = m_page.get()) {
+        auto tokenIdentifier = WebProcess::singleton().userGestureTokenIdentifier(page->identifier(), UserGestureIndicator::currentUserGesture());
+        page->send(Messages::WebPageProxy::SetFocus(true, tokenIdentifier));
+    }
 }
 
 void WebChromeClient::unfocus()
 {
     if (RefPtr page = m_page.get())
-        page->send(Messages::WebPageProxy::SetFocus(false));
+        page->send(Messages::WebPageProxy::SetFocus(false, std::nullopt));
 }
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -116,6 +116,7 @@ std::optional<NavigationActionData> WebFrameLoaderClient::navigationActionData(c
         FrameType::Local,
         ResourceRequest { URL { requester.url } },
         requester.securityOrigin->data(),
+        requester.topOrigin->data(),
         { },
         WTF::move(originatingFrameID),
         originatingPageID,

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp
@@ -31,6 +31,7 @@
 #include "WebFrameProxyMessages.h"
 #include "WebPage.h"
 #include "WebPageProxyMessages.h"
+#include "WebProcess.h"
 #include <WebCore/AXObjectCache.h>
 #include <WebCore/FocusControllerTypes.h>
 #include <WebCore/FrameInlines.h>
@@ -42,6 +43,7 @@
 #include <WebCore/NodeDocument.h>
 #include <WebCore/PolicyChecker.h>
 #include <WebCore/RemoteFrame.h>
+#include <WebCore/UserGestureIndicator.h>
 
 namespace WebKit {
 using namespace WebCore;
@@ -176,14 +178,16 @@ void WebRemoteFrameClient::closePage()
 
 void WebRemoteFrameClient::focus()
 {
-    if (RefPtr page = m_frame->page())
-        page->send(Messages::WebPageProxy::FocusRemoteFrame(m_frame->frameID()));
+    if (RefPtr page = m_frame->page()) {
+        auto tokenIdentifier = WebProcess::singleton().userGestureTokenIdentifier(page->identifier(), UserGestureIndicator::currentUserGesture());
+        page->send(Messages::WebPageProxy::FocusRemoteFrame(m_frame->frameID(), tokenIdentifier));
+    }
 }
 
 void WebRemoteFrameClient::unfocus()
 {
     if (RefPtr page = m_frame->page())
-        page->send(Messages::WebPageProxy::SetFocus(false));
+        page->send(Messages::WebPageProxy::SetFocus(false, std::nullopt));
 }
 
 void WebRemoteFrameClient::documentURLForConsoleLog(CompletionHandler<void(const URL&)>&& completionHandler)

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -326,6 +326,7 @@ FrameInfoData WebFrame::info(WithCertificateInfo withCertificateInfo) const
         // FIXME: This should use the full request.
         ResourceRequest(url()),
         SecurityOriginData::fromFrame(coreLocalFrame.get()),
+        coreFrame ? coreFrame->topOrigin().data() : SecurityOriginData { },
         coreFrame ? coreFrame->tree().specifiedName().string() : String(),
         frameID(),
         page ? std::optional { page->webPageProxyIdentifier() } : std::nullopt,

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -166,6 +166,7 @@ if (ENABLE_JAVASCRIPTCORE)
         Tests/JavaScriptCore/DisallowVMEntry.cpp
         Tests/JavaScriptCore/InspectorConsoleMessage.cpp
         Tests/JavaScriptCore/PropertySlot.cpp
+        Tests/JavaScriptCore/RegularExpression.cpp
     )
 
     set(TestJavaScriptCore_LIBRARIES

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -1519,6 +1519,7 @@
 		FE9CD7E42D10CE7500266FDD /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 574F55D0204D471C002948C6 /* Security.framework */; };
 		FEC2A85424CE975F00ADBC35 /* DisallowVMEntry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FEC2A85324CE974E00ADBC35 /* DisallowVMEntry.cpp */; };
 		FEC2A85624CEB65F00ADBC35 /* PropertySlot.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FEC2A85524CEB65F00ADBC35 /* PropertySlot.cpp */; };
+		FEC2A85826CF000000ADBC35 /* RegularExpression.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FEC2A85726CF000000ADBC35 /* RegularExpression.cpp */; };
 		FF10AAF92831B1E600B9875B /* CompactPtr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FF10AAF82831B1E600B9875B /* CompactPtr.cpp */; };
 		FF41AC702A79CAA000AC0FA5 /* WYHash.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FF41AC682A79CAA000AC0FA5 /* WYHash.cpp */; };
 		FF5D0CB4283221AD00F3278A /* CompactRefPtr.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FF5D0CB3283221AD00F3278A /* CompactRefPtr.cpp */; };
@@ -4483,6 +4484,7 @@
 		FEB6F74E1B2BA44E009E4922 /* NakedPtr.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = NakedPtr.cpp; sourceTree = "<group>"; };
 		FEC2A85324CE974E00ADBC35 /* DisallowVMEntry.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DisallowVMEntry.cpp; sourceTree = "<group>"; };
 		FEC2A85524CEB65F00ADBC35 /* PropertySlot.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PropertySlot.cpp; sourceTree = "<group>"; };
+		FEC2A85726CF000000ADBC35 /* RegularExpression.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RegularExpression.cpp; sourceTree = "<group>"; };
 		FF10AAF82831B1E600B9875B /* CompactPtr.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CompactPtr.cpp; sourceTree = "<group>"; };
 		FF25942A2834B7A7006892D6 /* AlignedRefLogger.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AlignedRefLogger.h; sourceTree = "<group>"; };
 		FF41AC682A79CAA000AC0FA5 /* WYHash.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WYHash.cpp; sourceTree = "<group>"; };
@@ -4803,6 +4805,7 @@
 				FEC2A85324CE974E00ADBC35 /* DisallowVMEntry.cpp */,
 				14CC42E524B8D8FA00E64F48 /* JSRunLoopTimer.mm */,
 				FEC2A85524CEB65F00ADBC35 /* PropertySlot.cpp */,
+				FEC2A85726CF000000ADBC35 /* RegularExpression.cpp */,
 			);
 			path = JavaScriptCore;
 			sourceTree = "<group>";
@@ -8093,6 +8096,7 @@
 				EBA75C49275ED7C700D6D31C /* PushMessageCrypto.cpp in Sources */,
 				7B0594792CB44CF600B571AC /* RegionTests.cpp in Sources */,
 				6B4E861C2220A5520022F389 /* RegistrableDomain.cpp in Sources */,
+				FEC2A85826CF000000ADBC35 /* RegularExpression.cpp in Sources */,
 				7CCE7F0D1A411AE600447C4C /* ReloadPageAfterCrash.cpp in Sources */,
 				7CCE7EC91A411A7E00447C4C /* RenderedImageFromDOMNode.mm in Sources */,
 				7CCE7ECA1A411A7E00447C4C /* RenderedImageFromDOMRange.mm in Sources */,

--- a/Tools/TestWebKitAPI/Tests/JavaScriptCore/RegularExpression.cpp
+++ b/Tools/TestWebKitAPI/Tests/JavaScriptCore/RegularExpression.cpp
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include <JavaScriptCore/InitializeThreading.h>
+#include <JavaScriptCore/RegularExpression.h>
+#include <JavaScriptCore/YarrFlags.h>
+
+namespace TestWebKitAPI {
+
+using JSC::Yarr::RegularExpression;
+
+TEST(JavaScriptCore_RegularExpression, DuplicateNamedCaptureGroupSimple)
+{
+    JSC::initialize();
+
+    RegularExpression re("(?<a>x)|(?<a>y)"_s, { JSC::Yarr::Flags::UnicodeSets });
+    EXPECT_TRUE(re.isValid());
+
+    int matchLength = 0;
+    EXPECT_EQ(0, re.match("x"_s, 0, &matchLength));
+    EXPECT_EQ(1, matchLength);
+
+    EXPECT_EQ(0, re.match("y"_s, 0, &matchLength));
+    EXPECT_EQ(1, matchLength);
+}
+
+TEST(JavaScriptCore_RegularExpression, DuplicateNamedCaptureGroupMultiple)
+{
+    JSC::initialize();
+
+    RegularExpression re("(?<a>x)|(?<a>y)|(?<b>x)|(?<b>y)|(?<c>x)|(?<c>y)"_s, { JSC::Yarr::Flags::UnicodeSets });
+    EXPECT_TRUE(re.isValid());
+
+    int matchLength = 0;
+    EXPECT_EQ(0, re.match("x"_s, 0, &matchLength));
+    EXPECT_EQ(1, matchLength);
+
+    EXPECT_EQ(0, re.match("y"_s, 0, &matchLength));
+    EXPECT_EQ(1, matchLength);
+}
+
+TEST(JavaScriptCore_RegularExpression, DuplicateNamedCaptureGroupNoMatch)
+{
+    JSC::initialize();
+
+    RegularExpression re("(?<a>x)|(?<a>y)"_s, { JSC::Yarr::Flags::UnicodeSets });
+    EXPECT_TRUE(re.isValid());
+
+    int matchLength = 0;
+    EXPECT_EQ(-1, re.match("z"_s, 0, &matchLength));
+}
+
+TEST(JavaScriptCore_RegularExpression, DuplicateNamedCaptureGroupSearchRev)
+{
+    JSC::initialize();
+
+    RegularExpression re("(?<a>x)|(?<a>y)"_s, { JSC::Yarr::Flags::UnicodeSets });
+    EXPECT_TRUE(re.isValid());
+
+    EXPECT_EQ(3, re.searchRev("abxyz"_s));
+    EXPECT_EQ(1, re.matchedLength());
+}
+
+} // namespace TestWebKitAPI

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/DeviceOrientation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/DeviceOrientation.mm
@@ -36,6 +36,7 @@
 #import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKUIDelegatePrivate.h>
 #import <WebKit/WKWebViewPrivateForTesting.h>
+#import <WebKit/_WKWebsiteDataStoreConfiguration.h>
 #import <wtf/Function.h>
 #import <wtf/HashMap.h>
 #import <wtf/RetainPtr.h>
@@ -457,6 +458,63 @@ TEST(WebKit, DeviceOrientationPermissionInIFrame)
 
     TestWebKitAPI::Util::run(&askedClientForPermission);
 
+}
+
+static constexpr auto requestPermissionPageBytes = R"TESTRESOURCE(
+<script>
+function requestPermission() {
+    DeviceOrientationEvent.requestPermission().then((result) => {
+        webkit.messageHandlers.testHandler.postMessage(result);
+    }).catch(() => {
+        webkit.messageHandlers.testHandler.postMessage('error');
+    });
+}
+</script>
+)TESTRESOURCE"_s;
+
+TEST(DeviceOrientation, PermissionOriginDuringPendingNavigation)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/source"_s, { requestPermissionPageBytes } },
+        { "/target"_s, { "hi"_s } }
+    }, TestWebKitAPI::HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    RetainPtr messageHandler = adoptNS([[DeviceOrientationMessageHandler alloc] init]);
+    [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
+
+    static RetainPtr<TestWKWebView> webView;
+    webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+
+    RetainPtr permissionDelegate = adoptNS([[DeviceOrientationPermissionValidationDelegate alloc] init]);
+    [webView setUIDelegate:permissionDelegate.get()];
+
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate allowAnyTLSCertificate];
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example1.com/source"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // Start permission request on example1.com after navigation to example2.com starts
+    // and active URL is changed to example2.com.
+    navigationDelegate.get().didStartProvisionalNavigation = ^(WKWebView *, WKNavigation *) {
+        [webView evaluateJavaScript:@"requestPermission();" completionHandler:nil];
+    };
+    static bool receivedPermissionRequest = false;
+    didReceiveMessage = false;
+    [permissionDelegate setValidationHandler:[&](WKSecurityOrigin *origin, WKFrameInfo *frame) {
+        EXPECT_WK_STREQ(origin.protocol, @"https");
+        EXPECT_WK_STREQ(origin.host, @"example1.com");
+        EXPECT_WK_STREQ(frame.securityOrigin.protocol, @"https");
+        EXPECT_WK_STREQ(frame.securityOrigin.host, @"example1.com");
+        receivedPermissionRequest = true;
+    }];
+    [webView evaluateJavaScript:@"location.href = 'https://example2.com/target'" completionHandler:nil];
+    TestWebKitAPI::Util::run(&receivedPermissionRequest);
+
+    TestWebKitAPI::Util::run(&didReceiveMessage);
+    EXPECT_WK_STREQ(@"granted", receivedMessages.get()[0]);
 }
 
 #endif // ENABLE(DEVICE_ORIENTATION) && PLATFORM(IOS_FAMILY)

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
@@ -26,8 +26,11 @@
 #import "config.h"
 
 #import "DeprecatedGlobalValues.h"
+#import "HTTPServer.h"
 #import "PlatformUtilities.h"
 #import "RemoteObjectRegistry.h"
+#import "TestNavigationDelegate.h"
+#import "TestUIDelegate.h"
 #import "TestWKWebView.h"
 #import "Utilities.h"
 #import <WebKit/WKNavigationDelegatePrivate.h>
@@ -876,6 +879,75 @@ TEST(IPCTestingAPI, SpeechSynthesisWithLockdownMode)
         && [alertMessage containsString:@"Receiver cancelled the reply due to invalid destination or deserialization error"]);
 
     [WKProcessPool _setCaptivePortalModeEnabledGloballyForTesting:NO];
+}
+
+static RetainPtr<NSString> sendOriginAccessAllowListEntryAndFetchCrossOrigin(bool allowOriginAccessAllowListIPC)
+{
+    using namespace TestWebKitAPI;
+
+    HTTPServer server({
+        { "/pageA"_s, { "<!DOCTYPE html>"_s } },
+        { "/pageB"_s, { "<!DOCTYPE html>"_s } },
+        { "/target"_s, { {{ "Content-Type"_s, "text/plain"_s }}, "cross-origin-data"_s } },
+    });
+    auto serverPort = server.port();
+
+    auto configA = adoptNS([[WKWebViewConfiguration alloc] init]);
+    for (_WKFeature *feature in [WKPreferences _features]) {
+        if ([feature.key isEqualToString:@"IPCTestingAPIEnabled"])
+            [[configA preferences] _setEnabled:YES forFeature:feature];
+        if ([feature.key isEqualToString:@"AllowTestOnlyOriginAccessAllowListIPC"])
+            [[configA preferences] _setEnabled:allowOriginAccessAllowListIPC forFeature:feature];
+    }
+
+    auto configB = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configB setProcessPool:[configA processPool]];
+
+    auto webViewA = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configA.get()]);
+    auto webViewB = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configB.get()]);
+
+    [webViewA loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%u/pageA", serverPort]]]];
+    [webViewA _test_waitForDidFinishNavigation];
+
+    [webViewB loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"http://localhost:%u/pageB", serverPort]]]];
+    [webViewB _test_waitForDidFinishNavigation];
+
+    [webViewA stringByEvaluatingJavaScript:[NSString stringWithFormat:
+        @"IPC.sendMessage('Networking', 0,"
+        "  IPC.messages.NetworkConnectionToWebProcess_AddOriginAccessAllowListEntry.name,"
+        "  ["
+        "    { type: 'String', value: 'http://localhost:%u' },"
+        "    { type: 'String', value: 'http' },"
+        "    { type: 'String', value: '127.0.0.1' },"
+        "    { type: 'bool', value: 1 }"
+        "  ]"
+        ")", serverPort]];
+
+    Util::runFor(0.5_s);
+
+    [webViewB evaluateJavaScript:[NSString stringWithFormat:
+        @"try {"
+        "  var xhr = new XMLHttpRequest();"
+        "  xhr.open('GET', 'http://127.0.0.1:%u/target', false);"
+        "  xhr.send();"
+        "  alert('FETCHED:' + xhr.responseText);"
+        "} catch(e) {"
+        "  alert('BLOCKED:' + e);"
+        "}", serverPort] completionHandler:nil];
+
+    return [webViewB _test_waitForAlert];
+}
+
+TEST(IPCTestingAPI, AddOriginAccessAllowListEntryRequiresTestOnlyIPC)
+{
+    auto result = sendOriginAccessAllowListEntryAndFetchCrossOrigin(false);
+    EXPECT_TRUE([result hasPrefix:@"BLOCKED:"]);
+}
+
+TEST(IPCTestingAPI, AddOriginAccessAllowListEntryAllowedWithTestOnlyIPC)
+{
+    auto result = sendOriginAccessAllowListEntryAndFetchCrossOrigin(true);
+    EXPECT_WK_STREQ(result, "FETCHED:cross-origin-data");
 }
 
 #endif

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm
@@ -62,6 +62,7 @@
 #import <WebKit/_WKTextManipulationDelegate.h>
 #import <WebKit/_WKTextManipulationItem.h>
 #import <WebKit/_WKTextManipulationToken.h>
+#import <WebKit/_WKUserInitiatedAction.h>
 #import <WebKit/_WKWebsiteDataStoreConfiguration.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/text/MakeString.h>
@@ -2480,6 +2481,78 @@ TEST(SiteIsolation, OpenedWindowFocusDelegates)
 
     [opener.webView.get() evaluateJavaScript:@"w.blur()" completionHandler:nil];
     Util::run(&calledUnfocusWebView);
+}
+
+TEST(SiteIsolation, PopunderPreventedByConsumedAction)
+{
+    auto openerHTML = "<script>"
+        "window.name = 'opener';"
+        "addEventListener('mouseup', () => {"
+        "    window.open('https://domain3.com/popup');"
+        "    w.focus();"
+        "});"
+        "let w = window.open('https://domain2.com/opened');"
+        "</script>"_s;
+    HTTPServer server({
+        { "/example"_s, { openerHTML } },
+        { "/opened"_s, { ""_s } },
+        { "/popup"_s, { ""_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    __block WebViewAndDelegates opener;
+    __block WebViewAndDelegates opened;
+    __block RetainPtr<TestWKWebView> popupWebView;
+    __block RetainPtr<TestNavigationDelegate> popupNavigationDelegate;
+    __block int windowOpenCount = 0;
+    opener.navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [opener.navigationDelegate allowAnyTLSCertificate];
+    auto configuration = server.httpsProxyConfiguration();
+    enableSiteIsolation(configuration);
+    opener.webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    opener.webView.get().navigationDelegate = opener.navigationDelegate.get();
+    opener.uiDelegate = adoptNS([TestUIDelegate new]);
+    opener.uiDelegate.get().createWebViewWithConfiguration = ^(WKWebViewConfiguration *configuration, WKNavigationAction *navigationAction, WKWindowFeatures *) {
+        enableSiteIsolation(configuration);
+        if (!windowOpenCount++) {
+            // First window.open: the pre-opened cross-origin window.
+            opened.webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration]);
+            opened.navigationDelegate = adoptNS([TestNavigationDelegate new]);
+            [opened.navigationDelegate allowAnyTLSCertificate];
+            opened.uiDelegate = adoptNS([TestUIDelegate new]);
+            opened.webView.get().navigationDelegate = opened.navigationDelegate.get();
+            opened.webView.get().UIDelegate = opened.uiDelegate.get();
+            return opened.webView.get();
+        }
+        // Second window.open (the popup): consume the gesture.
+        [navigationAction._userInitiatedAction consume];
+        popupNavigationDelegate = adoptNS([TestNavigationDelegate new]);
+        [popupNavigationDelegate allowAnyTLSCertificate];
+        popupWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+        [popupWebView setNavigationDelegate:popupNavigationDelegate.get()];
+        return popupWebView.get();
+    };
+    [opener.webView setUIDelegate:opener.uiDelegate.get()];
+    opener.webView.get().configuration.preferences.javaScriptCanOpenWindowsAutomatically = YES;
+    [opener.webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/example"]]];
+    while (!opened.webView)
+        Util::spinRunLoop();
+    [opened.navigationDelegate waitForDidFinishNavigation];
+
+    __block bool focusCalled = false;
+    [opened.uiDelegate setFocusWebView:^(WKWebView *) {
+        focusCalled = true;
+    }];
+
+    [opener.webView mouseDownAtPoint:CGPointMake(50, 50) simulatePressure:NO];
+    [opener.webView mouseUpAtPoint:CGPointMake(50, 50)];
+    [opener.webView waitForPendingMouseEvents];
+    while (!popupWebView)
+        Util::spinRunLoop();
+
+    // The popup was created, but w.focus() on the cross-origin window should NOT
+    // have called the focus delegate because the user gesture was already consumed
+    // during popup creation. This exercises the FocusRemoteFrame IPC path.
+    EXPECT_FALSE(focusCalled);
 }
 #endif
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/SwitchInputTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/SwitchInputTests.mm
@@ -27,6 +27,7 @@
 
 #if PLATFORM(COCOA)
 
+#import "IOSMouseEventTestHarness.h"
 #import "InstanceMethodSwizzler.h"
 #import "PlatformUtilities.h"
 #import "Test.h"
@@ -63,9 +64,38 @@ TEST(SwitchInputTests, HapticFeedbackOnDrag)
 
 #endif // PLATFORM(MAC)
 
+#if HAVE(UI_IMPACT_FEEDBACK_GENERATOR)
+
+TEST(SwitchInputTests, HapticFeedbackOnClick)
+{
+    __block bool done = false;
+
+    InstanceMethodSwizzler swizzler {
+        UIImpactFeedbackGenerator.class,
+        @selector(impactOccurred),
+        imp_implementationWithBlock(^{
+            done = true;
+        })
+    };
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 300)]);
+    [webView synchronouslyLoadHTMLString:@"<meta name='viewport' content='width=device-width,initial-scale=1'><label><input type='checkbox' switch></label>"];
+
+    TestWebKitAPI::MouseEventTestHarness testHarness { webView.get() };
+    testHarness.mouseMove(15, 10);
+    testHarness.mouseDown();
+    testHarness.mouseUp();
+    [webView waitForPendingMouseEvents];
+    [webView waitForNextPresentationUpdate];
+
+    TestWebKitAPI::Util::run(&done);
+}
+
+#endif // HAVE(UI_IMPACT_FEEDBACK_GENERATOR)
+
 #if HAVE(UI_IMPACT_FEEDBACK_GENERATOR) || PLATFORM(MAC)
 
-TEST(SwitchInputTests, HapticFeedbackRequiresUserGesture)
+TEST(SwitchInputTests, HapticFeedbackRequiresUserGestureAndTrustedEvent)
 {
     InstanceMethodSwizzler swizzler {
 #if PLATFORM(MAC)
@@ -81,9 +111,18 @@ TEST(SwitchInputTests, HapticFeedbackRequiresUserGesture)
     };
 
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 300)]);
-    [webView synchronouslyLoadHTMLString:@"<label><input type='checkbox' switch></label>"];
+    [webView synchronouslyLoadHTMLString:@"<meta name='viewport' content='width=device-width,initial-scale=1'><div style='width: 100px; height: 100px; background: red;' onclick=\"document.querySelector('label').click()\"></div><label><input type='checkbox' switch></label>"];
 
-    [webView stringByEvaluatingJavaScript:@"document.querySelector('label').click()"];
+#if PLATFORM(MAC)
+    [webView sendClickAtPoint:NSMakePoint(15, 290)];
+#else
+    TestWebKitAPI::MouseEventTestHarness testHarness { webView.get() };
+    testHarness.mouseMove(15, 10);
+    testHarness.mouseDown();
+    testHarness.mouseUp();
+#endif
+
+    [webView waitForPendingMouseEvents];
     [webView waitForNextPresentationUpdate];
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/VerifyUserGestureFromUIProcess.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/VerifyUserGestureFromUIProcess.mm
@@ -219,6 +219,56 @@ TEST(VerifyUserGesture, InvalidateAuthorizationTokensByPage)
         Util::spinRunLoop();
     EXPECT_FALSE(openedConsumed);
 }
+
+TEST(VerifyUserGesture, PopunderPreventedByConsumedAction)
+{
+    auto openerHTML = "<script>"
+        "window.name = 'opener';"
+        "addEventListener('mouseup', () => {"
+        "    window.open('https://domain2.com/popup');"
+        "    window.open('', 'opener');"
+        "});"
+        "</script>"_s;
+    HTTPServer server({
+        { "/opener"_s, { openerHTML } },
+        { "/popup"_s, { ""_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto configuration = server.httpsProxyConfiguration();
+    auto navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate allowAnyTLSCertificate];
+    auto uiDelegate = adoptNS([TestUIDelegate new]);
+    auto openerWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+    [openerWebView setNavigationDelegate:navigationDelegate.get()];
+    [openerWebView setUIDelegate:uiDelegate.get()];
+
+    __block RetainPtr<TestWKWebView> popupWebView;
+    uiDelegate.get().createWebViewWithConfiguration = ^(WKWebViewConfiguration *configuration, WKNavigationAction *navigationAction, WKWindowFeatures *) {
+        // Consume the user action, as Safari's _shouldSuppressCreateWebView does.
+        [navigationAction._userInitiatedAction consume];
+        popupWebView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration]);
+        return popupWebView.get();
+    };
+
+    __block bool focusCalled = false;
+    uiDelegate.get().focusWebView = ^(WKWebView *) {
+        focusCalled = true;
+    };
+
+    [openerWebView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://domain1.com/opener"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [openerWebView mouseDownAtPoint:CGPointMake(50, 50) simulatePressure:NO];
+    [openerWebView mouseUpAtPoint:CGPointMake(50, 50)];
+    [openerWebView waitForPendingMouseEvents];
+    while (!popupWebView)
+        Util::spinRunLoop();
+
+    // The popup was created, but the second window.open("", "opener") should NOT
+    // have focused the opener because the _userInitiatedAction was already consumed
+    // during popup creation.
+    EXPECT_FALSE(focusCalled);
+}
 #endif
 
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm
@@ -28,6 +28,7 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #import "HTTPServer.h"
+#import "TestNavigationDelegate.h"
 #import "WebExtensionUtilities.h"
 #import <WebKit/WKUserContentControllerPrivate.h>
 
@@ -1885,6 +1886,80 @@ TEST(WKWebExtensionAPIScripting, MigrateScriptDataToNewFormat)
     }
 
     [manager run];
+}
+
+TEST(WKWebExtensionAPIScripting, ContentScriptsRespectDeniedMatchPatterns)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, ""_s } }
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *manifest = @{
+        @"manifest_version": @3,
+
+        @"name": @"Content Scripts Test",
+        @"description": @"Content Scripts Test",
+        @"version": @"1.0",
+
+        @"content_scripts": @[ @{
+            @"matches": @[ @"*://*/*" ],
+            @"js": @[ @"content.js" ],
+            @"css": @[ @"content.css" ],
+            @"run_at": @"document_end"
+        } ]
+    };
+
+    auto *contentScript = Util::constructScript(@[
+        @"document.body.dataset.scriptInjected = 'true'"
+    ]);
+
+    auto *contentStyle = @"body { background-color: rgb(255, 0, 0) !important; }";
+
+    auto *resources = @{
+        @"content.js": contentScript,
+        @"content.css": contentStyle
+    };
+
+    auto manager = Util::loadExtension(manifest, resources);
+
+    // Grant all hosts and schemes, but deny localhost specifically
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:WKWebExtensionMatchPattern.allHostsAndSchemesMatchPattern];
+
+    auto *localhostRequest = server.requestWithLocalhost();
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusDeniedExplicitly forURL:localhostRequest.URL];
+
+    // Test 1: Load localhost, verify script and style are NOT injected due to denied pattern
+    [manager.get().defaultTab.webView loadRequest:localhostRequest];
+    [manager.get().defaultTab.webView _test_waitForDidFinishNavigation];
+
+    // Verify the script and style were NOT injected by checking the page
+    __block bool doneCheckingLocalhost = false;
+    [manager.get().defaultTab.webView evaluateJavaScript:@"({ scriptInjected: document.body.dataset.scriptInjected === 'true', backgroundColor: getComputedStyle(document.body).backgroundColor })" completionHandler:^(id result, NSError *error) {
+        EXPECT_NULL(error);
+        EXPECT_NS_EQUAL([result objectForKey:@"scriptInjected"], @NO);
+        EXPECT_FALSE([[result objectForKey:@"backgroundColor"] isEqualToString:@"rgb(255, 0, 0)"]);
+        doneCheckingLocalhost = true;
+    }];
+
+    TestWebKitAPI::Util::run(&doneCheckingLocalhost);
+
+    // Test 2: Load 127.0.0.1 (loopback), verify script and style ARE injected
+    // This should work because allHostsAndSchemesMatchPattern is granted and loopback is not denied
+    auto *loopbackRequest = server.request();
+
+    [manager.get().defaultTab.webView loadRequest:loopbackRequest];
+    [manager.get().defaultTab.webView _test_waitForDidFinishNavigation];
+
+    // Verify the script and style WERE injected
+    __block bool doneCheckingLoopback = false;
+    [manager.get().defaultTab.webView evaluateJavaScript:@"({ scriptInjected: document.body.dataset.scriptInjected === 'true', backgroundColor: getComputedStyle(document.body).backgroundColor })" completionHandler:^(id result, NSError *error) {
+        EXPECT_NULL(error);
+        EXPECT_NS_EQUAL([result objectForKey:@"scriptInjected"], @YES);
+        EXPECT_NS_EQUAL([result objectForKey:@"backgroundColor"], @"rgb(255, 0, 0)");
+        doneCheckingLoopback = true;
+    }];
+
+    TestWebKitAPI::Util::run(&doneCheckingLoopback);
 }
 
 } // namespace TestWebKitAPI

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1386,6 +1386,7 @@ void TestController::resetPreferencesToConsistentValues(const TestOptions& optio
         WKPreferencesSetMinimumFontSize(preferences, 0);
 
         WKPreferencesSetBoolValueForKeyForTesting(preferences, options.allowTestOnlyIPC(), toWK("AllowTestOnlyIPC").get());
+        WKPreferencesSetBoolValueForKeyForTesting(preferences, options.allowTestOnlyOriginAccessAllowListIPC(), toWK("AllowTestOnlyOriginAccessAllowListIPC").get());
 
         for (const auto& [key, value] : options.boolWebPreferenceFeatures())
             WKPreferencesSetBoolValueForKeyForTesting(preferences, value, toWK(key).get());

--- a/Tools/WebKitTestRunner/TestOptions.cpp
+++ b/Tools/WebKitTestRunner/TestOptions.cpp
@@ -177,6 +177,7 @@ const TestFeatures& TestOptions::defaults()
         features.boolTestRunnerFeatures = {
             { "allowsLinkPreview", true },
             { "allowTestOnlyIPC", false },
+            { "allowTestOnlyOriginAccessAllowListIPC", true },
             { "appHighlightsEnabled", false },
             { "dumpJSConsoleLogInStdErr", false },
             { "editable", false },
@@ -259,6 +260,7 @@ const std::unordered_map<std::string, TestHeaderKeyType>& TestOptions::keyTypeMa
         { "allowsLinkPreview", TestHeaderKeyType::BoolTestRunner },
         { "appHighlightsEnabled", TestHeaderKeyType::BoolTestRunner },
         { "allowTestOnlyIPC", TestHeaderKeyType::BoolTestRunner },
+        { "allowTestOnlyOriginAccessAllowListIPC", TestHeaderKeyType::BoolTestRunner },
         { "dumpJSConsoleLogInStdErr", TestHeaderKeyType::BoolTestRunner },
         { "editable", TestHeaderKeyType::BoolTestRunner },
         { "enableInAppBrowserPrivacy", TestHeaderKeyType::BoolTestRunner },

--- a/Tools/WebKitTestRunner/TestOptions.h
+++ b/Tools/WebKitTestRunner/TestOptions.h
@@ -56,6 +56,7 @@ public:
     bool allowsLinkPreview() const { return boolTestRunnerFeatureValue("allowsLinkPreview"); }
     bool appHighlightsEnabled() const { return boolTestRunnerFeatureValue("appHighlightsEnabled"); }
     bool allowTestOnlyIPC() const { return boolTestRunnerFeatureValue("allowTestOnlyIPC"); }
+    bool allowTestOnlyOriginAccessAllowListIPC() const { return boolTestRunnerFeatureValue("allowTestOnlyOriginAccessAllowListIPC"); }
     bool dumpJSConsoleLogInStdErr() const { return boolTestRunnerFeatureValue("dumpJSConsoleLogInStdErr"); }
     bool editable() const { return boolTestRunnerFeatureValue("editable"); }
     bool enableInAppBrowserPrivacy() const { return boolTestRunnerFeatureValue("enableInAppBrowserPrivacy"); }


### PR DESCRIPTION
#### 2935a3518a2f62765b368d82ed77e4bcefb55ba6
<pre>
Cherry-pick 305413.428@safari-7624-branch (b29ab81cd8b0). <a href="https://bugs.webkit.org/show_bug.cgi?id=309184">https://bugs.webkit.org/show_bug.cgi?id=309184</a>

    Potential &apos;overflow&apos; issue committed to upstream libwebrtc
    <a href="https://rdar.apple.com/171591550">rdar://171591550</a>

    Reviewed by Jean-Yves Avenard.

    Cherry-picking of <a href="https://github.com/webmproject/libvpx/commit/ab5ec7a1852f634b81d29ade3c5fa74056498973">https://github.com/webmproject/libvpx/commit/ab5ec7a1852f634b81d29ade3c5fa74056498973</a>, given WebKit uses that code path.

    Identifier: 305413.428@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.512@webkitglib/2.52">https://commits.webkit.org/305877.512@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 4e802b153d9bbd8e2b9c6578b22f0501a7690406
<pre>
Cherry-pick 305413.427@safari-7624-branch (e7c824391cd2). <a href="https://bugs.webkit.org/show_bug.cgi?id=309184">https://bugs.webkit.org/show_bug.cgi?id=309184</a>

    Same user gesture can be used for both opening a window and focussing previous one
    <a href="https://rdar.apple.com/168506684">rdar://168506684</a>
    <a href="https://bugs.webkit.org/show_bug.cgi?id=309184">https://bugs.webkit.org/show_bug.cgi?id=309184</a>

    Reviewed by Ryosuke Niwa.

    chrome().focus() sends SetFocus(true) to the UIProcess with no user gesture
    context. A common client consuming the _WKUserInitiatedAction during popup
    creation (in createWebViewWithConfiguration) has no way to prevent a subsequent
    focus of an existing window from the same gesture — the focus path bypasses the
    consumed check entirely.

    To fix this, we plumb UserGestureTokenIdentifier through SetFocus and
    FocusRemoteFrame IPC so setFocus() can look up the API::UserInitiatedAction and
    skip the focus if already consumed.

    Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/VerifyUserGestureFromUIProcess.mm

    * Source/WebKit/UIProcess/WebPageProxy.cpp:
    (WebKit::WebPageProxy::setFocus):
    (WebKit::WebPageProxy::focusRemoteFrame):
    * Source/WebKit/UIProcess/WebPageProxy.h:
    * Source/WebKit/UIProcess/WebPageProxy.messages.in:
    * Source/WebKit/WebProcess/WebCoreSupport/WebChromeClient.cpp:
    (WebKit::WebChromeClient::focus):
    (WebKit::WebChromeClient::unfocus):
    * Source/WebKit/WebProcess/WebCoreSupport/WebRemoteFrameClient.cpp:
    (WebKit::WebRemoteFrameClient::focus):
    (WebKit::WebRemoteFrameClient::unfocus):
    * Tools/TestWebKitAPI/Tests/WebKitCocoa/SiteIsolation.mm:
    (TestWebKitAPI::TEST(SiteIsolation, PopunderPreventedByConsumedAction)):
    * Tools/TestWebKitAPI/Tests/WebKitCocoa/VerifyUserGestureFromUIProcess.mm:
    (TestWebKitAPI::TEST(VerifyUserGesture, PopunderPreventedByConsumedAction)):

    Identifier: 305413.427@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.511@webkitglib/2.52">https://commits.webkit.org/305877.511@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### d68285a796d6f6dbafc0ba1f97539f3c6c174792
<pre>
Cherry-pick 305413.421@safari-7624-branch (44da09d437d9). <a href="https://bugs.webkit.org/show_bug.cgi?id=309516">https://bugs.webkit.org/show_bug.cgi?id=309516</a>

    Gate AddOriginAccessAllowListEntry IPC behind AllowTestOnlyIPC
    <a href="https://rdar.apple.com/171243270">rdar://171243270</a>

    Reviewed by Charlie Wolfe and Ryosuke Niwa.

    Origin access allowlist IPC messages on NetworkConnectionToWebProcess
    modify a process-global allowlist with no validation, allowing a
    compromised WebContent process to bypass CORS for all connections.

    These messages are only used by TestRunner SPI. Gate them behind
    EnabledBy=AllowTestOnlyIPC so they are rejected unless the test-only
    flag is set.

    Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm

    * Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
    * Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in:
    * Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm:
    (AddOriginAccessAllowListEntryRequiresTestOnlyIPC)):
    (AddOriginAccessAllowListEntryAllowedWithTestOnlyIPC)):
    * Tools/WebKitTestRunner/TestController.cpp:
    (WTR::TestController::resetPreferencesToConsistentValues):
    * Tools/WebKitTestRunner/TestOptions.cpp:
    (WTR::TestOptions::defaults):
    (WTR::TestOptions::keyTypeMapping):
    * Tools/WebKitTestRunner/TestOptions.h:
    (WTR::TestOptions::allowTestOnlyOriginAccessAllowListIPC const):

    Identifier: 305413.421@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.510@webkitglib/2.52">https://commits.webkit.org/305877.510@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### b156190d9ea698c104e7df5cba288f05fb2017b4
<pre>
Cherry-pick 305413.426@safari-7624-branch (7f6a77dee81b). <a href="https://bugs.webkit.org/show_bug.cgi?id=309516">https://bugs.webkit.org/show_bug.cgi?id=309516</a>

    Extension scripts/style sheets are injected into denied domains if Other Websites are set to allow.
    <a href="https://webkit.org/b/309516">https://webkit.org/b/309516</a>
    <a href="https://rdar.apple.com/171724038">rdar://171724038</a>

    Reviewed by Brian Weinstein.

    During Objective-C++ to C++ conversion, NSMutableSet&apos;s unionSet: (modifies in place) was incorrectly
    translated to HashSet::unionWith() (returns new set). Changed to addAll() to match original semantics.

    Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm
    * Source/WebKit/UIProcess/Extensions/WebExtensionContext.cpp:
    (WebKit::WebExtensionContext::addInjectedContent): Use addAll() instead of unionWith().
    * Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPIScripting.mm:
    (TestWebKitAPI::TEST(WKWebExtensionAPIScripting, ContentScriptsRespectDeniedMatchPatterns)): Added.

    Identifier: 305413.426@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.509@webkitglib/2.52">https://commits.webkit.org/305877.509@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 5f2edbc0d76694e21300425e9b52bff23655ad84
<pre>
Cherry-pick 305413.404@safari-7624-branch (790d8fc2d3b4). <a href="https://bugs.webkit.org/show_bug.cgi?id=308707">https://bugs.webkit.org/show_bug.cgi?id=308707</a>

    Check Float16 buffer sizes before conversion
    <a href="https://rdar.apple.com/169442684">rdar://169442684</a>

    Reviewed by Mike Wyrzykowski.

    Check that Float16 buffers are large enough to fit the expected amount
    of data to be read/written by convertImagePixels() and subroutines.

    * Source/WebCore/platform/graphics/PixelBufferConversion.cpp:
    (WebCore::convertImagePixels):

    Identifier: 305413.404@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.508@webkitglib/2.52">https://commits.webkit.org/305877.508@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 824d13f1f428de98f19fefb65880b0a3e3c1b47b
<pre>
Cherry-pick 305413.400@safari-7624-branch (a8304e8264d0). <a href="https://bugs.webkit.org/show_bug.cgi?id=308707">https://bugs.webkit.org/show_bug.cgi?id=308707</a>

    StyleOriginatedTimelinesController::documentDidResolveStyle: Use removeIf
    <a href="https://rdar.apple.com/171096572">rdar://171096572</a>

    Reviewed by Tim Horton.

    To avoid invalidating the loop iterator by removing the current element,
    use HashMap::removeIf to correctly remove elements whose timeline have
    become empty.

    * Source/WebCore/animation/StyleOriginatedTimelinesController.cpp:
    (WebCore::StyleOriginatedTimelinesController::documentDidResolveStyle):

    Identifier: 305413.400@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.507@webkitglib/2.52">https://commits.webkit.org/305877.507@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 38e0495846f0bfbe71f8a0cf21c56e70f2061a5e
<pre>
Cherry-pick 305413.398@safari-7624-branch (86cffcf010ab). <a href="https://bugs.webkit.org/show_bug.cgi?id=308707">https://bugs.webkit.org/show_bug.cgi?id=308707</a>

    [JSC] YARR RegularExpression heap overflow - duplicate named capture groups
    <a href="https://bugs.webkit.org/show_bug.cgi?id=308707">https://bugs.webkit.org/show_bug.cgi?id=308707</a>
    <a href="https://rdar.apple.com/171240602">rdar://171240602</a>

    Reviewed by Keith Miller.

    RegularExpression&apos;s offsets vector allocation size is incorrect: that
    formula was updated when named captures are added, but
    RegularExpression&apos;s computation was not updated correctly. This patch
    fixes it.

    Tests: Tools/TestWebKitAPI/CMakeLists.txt
           Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
           Tools/TestWebKitAPI/Tests/JavaScriptCore/RegularExpression.cpp

    * Source/JavaScriptCore/yarr/RegularExpression.cpp:
    (JSC::Yarr::RegularExpression::match const):
    * Tools/TestWebKitAPI/CMakeLists.txt:
    * Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
    * Tools/TestWebKitAPI/Tests/JavaScriptCore/RegularExpression.cpp: Added.
    (TestWebKitAPI::TEST(JavaScriptCore_RegularExpression, DuplicateNamedCaptureGroupSimple)):
    (TestWebKitAPI::TEST(JavaScriptCore_RegularExpression, DuplicateNamedCaptureGroupMultiple)):
    (TestWebKitAPI::TEST(JavaScriptCore_RegularExpression, DuplicateNamedCaptureGroupNoMatch)):
    (TestWebKitAPI::TEST(JavaScriptCore_RegularExpression, DuplicateNamedCaptureGroupSearchRev)):

    Identifier: 305413.398@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.506@webkitglib/2.52">https://commits.webkit.org/305877.506@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 4cc26452c9a257db6d3539b144a2d6277398cb1d
<pre>
Cherry-pick 305413.397@safari-7624-branch (79f65b10f8d8). <a href="https://bugs.webkit.org/show_bug.cgi?id=309108">https://bugs.webkit.org/show_bug.cgi?id=309108</a>

    WebPageProxy crash in dispatchSetObscuredContentInsets() and clearTextIndicatorWithAnimation()
    &lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=309108">https://bugs.webkit.org/show_bug.cgi?id=309108</a>&gt;
    &lt;<a href="https://rdar.apple.com/167427221">rdar://167427221</a>&gt;

    Reviewed by Anne van Kesteren.

    Crashes occur when a `WebPageProxy` object is destroyed when a `WeakPtr`
    is used to make a method call since it doesn&apos;t keep the object alive.

    Promote unsafe `WeakPtr&lt;WebPageProxy&gt;` usage to `RefPtr&lt;WebPageProxy` to
    ensure the object stays alive for the duration of the method call.  Also
    promote `WeakPtr&lt;WebProcessProxy&gt;` in completion callbacks where the
    process object could be destroyed during sandbox extension processing.

    * Source/WebKit/UIProcess/WebPageProxy.cpp:
    (WebKit::WebPageProxy::loadSimulatedRequest):
    (WebKit::WebPageProxy::loadAlternateHTML):
    (WebKit::WebPageProxy::reload):
    (WebKit::WebPageProxy::executeEditCommand):
    (WebKit::WebPageProxy::contextMenuItemSelected):
    * Source/WebKit/UIProcess/mac/WebPageProxyMac.mm:
    (WebKit::WebPageProxy::didPerformDictionaryLookup):
    (WebKit::WebPageProxy::scheduleSetObscuredContentInsetsDispatch):

    Identifier: 305413.397@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.505@webkitglib/2.52">https://commits.webkit.org/305877.505@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 4a8a90644cfc7a9a4b3cab13c4c0b49c53862787
<pre>
Cherry-pick 305413.395@safari-7624-branch (2c99c891b64c). <a href="https://bugs.webkit.org/show_bug.cgi?id=309082">https://bugs.webkit.org/show_bug.cgi?id=309082</a>

    Haptic feedback for &lt;input type=checkbox switch&gt; can be triggered with a programmatic click on an associated label
    <a href="https://bugs.webkit.org/show_bug.cgi?id=309082">https://bugs.webkit.org/show_bug.cgi?id=309082</a>
    <a href="https://rdar.apple.com/171635705">rdar://171635705</a>

    Reviewed by Lily Spiniolas, Wenson Hsieh, and Abrar Rahman Protyasha.

    288403@main ensured that haptic feedback for &lt;input type=checkbox switch&gt; required
    user activation. However, it is also desired that haptics are only triggered for
    trusted events. This goal can currently be bypassed by calling `click()` on a label
    associated with the input. The result is that calling `click()` on the label,
    immediately following a user gesture, can allow for haptics to be programmatically
    triggered.

    The underlying issue is that untrusted click events on label elements become
    trusted click events on the associated control. This is because
    `Element::dispatchSimulatedClick` unconditionally sets `SimulatedClickSource::UserAgent`.
    While this is desirable for accessibility use cases, it is incorrect when the
    underlying event is untrusted.

    Fix by specifying `SimulatedClickSource::Bindings` if there is an underlying
    event and it is untrusted.

    Tests: fast/forms/label/label-click-event-dispatch-untrusted.html
           Tools/TestWebKitAPI/Tests/WebKitCocoa/SwitchInputTests.mm

    * LayoutTests/fast/forms/label/label-click-event-dispatch-untrusted-expected.txt: Added.
    * LayoutTests/fast/forms/label/label-click-event-dispatch-untrusted.html: Added.
    * Source/WebCore/dom/Element.cpp:
    (WebCore::Element::dispatchSimulatedClick):

    If there is an underlying event, the simulated click should be marked as from
    &quot;bindings&quot;, making it untrusted. This change is not made to `simulateClick` itself
    since that is used by `Element::click()`, which has no underlying event and is
    always untrusted.

    * Tools/TestWebKitAPI/Tests/WebKitCocoa/SwitchInputTests.mm:
    (TEST(SwitchInputTests, HapticFeedbackOnClick)):

    Add a test to verify that haptics are still triggered for a trusted click.

    (TEST(SwitchInputTests, HapticFeedbackRequiresUserGestureAndTrustedEvent)):

    Update the `HapticFeedbackRequiresUserGesture` test to also perform a user
    gesture, and ensure haptics cannot be triggered programmatically.

    (TEST(SwitchInputTests, HapticFeedbackRequiresUserGesture)): Deleted.

    Identifier: 305413.395@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.504@webkitglib/2.52">https://commits.webkit.org/305877.504@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 3807b6715c0e4edc800b91dcc4d4cee519531069
<pre>
Cherry-pick 305413.385@safari-7624-branch (a90148642299). <a href="https://bugs.webkit.org/show_bug.cgi?id=308906">https://bugs.webkit.org/show_bug.cgi?id=308906</a>

    Fix CSP policy loss in blob: URL inheritance when page sends multiple CSP headers
    <a href="https://bugs.webkit.org/show_bug.cgi?id=308906">https://bugs.webkit.org/show_bug.cgi?id=308906</a>
    <a href="https://rdar.apple.com/168927377">rdar://168927377</a>

    Reviewed by Anne van Kesteren.

    A page with two or more CSP headers correctly enforces those policies on
    itself, but blob: URLs it creates only see the last one. The policies
    are correctly captured in the policy container, but
    ContentSecurityPolicyResponseHeaders::addPolicyHeadersTo() writes them
    to the blob response using ResourceResponse::setHTTPHeaderField(), which
    overwrites policies rather than appending them together.

    Change to use ResourceResponse::addHTTPHeaderField() which
    comma-concatenates the values and preserves all CSP policies.

    Test: http/tests/security/contentSecurityPolicy/blob-url-inherits-multiple-csp-policies.html

    * LayoutTests/http/tests/security/contentSecurityPolicy/blob-url-inherits-multiple-csp-policies-expected.txt: Added.
    * LayoutTests/http/tests/security/contentSecurityPolicy/blob-url-inherits-multiple-csp-policies.html: Added.
    * LayoutTests/http/tests/security/contentSecurityPolicy/resources/create-blob-iframe.js: Added.
    * LayoutTests/http/tests/security/contentSecurityPolicy/resources/echo-multiple-csp-blob-iframe.py: Added.
    * LayoutTests/imported/w3c/web-platform-tests/trusted-types/inheriting-csp-for-local-schemes-expected.txt:
    * Source/WebCore/page/csp/ContentSecurityPolicyResponseHeaders.cpp:
    (WebCore::ContentSecurityPolicyResponseHeaders::addPolicyHeadersTo const):

    Identifier: 305413.385@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.503@webkitglib/2.52">https://commits.webkit.org/305877.503@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 6e172821747e972e3bd722b520d0bce3de56aac0
<pre>
Cherry-pick 305413.383@safari-7624-branch (91ab7f0ce691). <a href="https://bugs.webkit.org/show_bug.cgi?id=308844">https://bugs.webkit.org/show_bug.cgi?id=308844</a>

    SWServer::topLevelServiceWorkerClientFromPageIdentifier() crashes when maps are out-of-sync
    &lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=308844">https://bugs.webkit.org/show_bug.cgi?id=308844</a>&gt;
    &lt;<a href="https://rdar.apple.com/157943937">rdar://157943937</a>&gt;

    Reviewed by Brent Fulgham.

    A crash occurs in `topLevelServiceWorkerClientFromPageIdentifier()` when
    the Service Worker maps `m_clientIdentifiersPerOrigin` and `m_clientsById`
    become out-of-sync.  The function iterates over client identifiers from
    `m_clientIdentifiersPerOrigin` and calls `m_clientsById.find()` for each
    one, but never checks whether the result equals `m_clientsById.end()`
    before dereferencing it.

    Add an end-iterator check in `topLevelServiceWorkerClientFromPageIdentifier()`
    and use `continue` to skip missing clients (matching the pattern in
    `clientIsAppInitiatedForRegistrableDomain()`).

    Also replace the ASSERT-only guard in `serviceWorkerClientWithOriginByID()`
    with a proper end-iterator check that returns `std::nullopt` in release
    builds.

    No test since this is a race condition with no known steps to reproduce.

    * Source/WebCore/workers/service/server/SWServer.cpp:
    (WebCore::SWServer::serviceWorkerClientWithOriginByID):
    - Replace ASSERT-only check with end-iterator check returning
      std::nullopt.
    (WebCore::SWServer::topLevelServiceWorkerClientFromPageIdentifier):
    - Add end-iterator check with ASSERT_NOT_REACHED() to continue in order
      to skip missing clients.

    Identifier: 305413.383@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.502@webkitglib/2.52">https://commits.webkit.org/305877.502@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 60e6301e22c8516b50856d0d5b0619e0c741e6b4
<pre>
Cherry-pick 305413.379@safari-7624-branch (e979e8c9cdc1). <a href="https://bugs.webkit.org/show_bug.cgi?id=308675">https://bugs.webkit.org/show_bug.cgi?id=308675</a>

    Align ContentSecurityPolicySource::pathMatches() with CSP3 spec path matching algorithm
    <a href="https://bugs.webkit.org/show_bug.cgi?id=308675">https://bugs.webkit.org/show_bug.cgi?id=308675</a>
    <a href="https://rdar.apple.com/168933742">rdar://168933742</a>

    Reviewed by Anne van Kesteren.

    WebKit&apos;s pathMatches() diverged from the CSP3 spec by percent-decoding
    the entire URL path as a flat string, then doing prefix/equality checks.
    This made it vulnerable to %2F..%2F path traversal bypasses.

    This change adopts the spec&apos;s algorithm (§ 6.7.2.12): split both paths
    on literal &apos;/&apos;, percent-decode each segment, and compare corresponding
    pairs. This eliminates the vulnerability — %2F never produces a segment
    boundary, so sequences like %2F..%2F stay trapped in a single segment
    and won&apos;t match the expected path component.

    Test: http/tests/security/contentSecurityPolicy/path-traversal-bypass-with-percent-encoding.html

    * LayoutTests/http/tests/security/contentSecurityPolicy/path-traversal-bypass-with-percent-encoding-expected.txt: Added.
    * LayoutTests/http/tests/security/contentSecurityPolicy/path-traversal-bypass-with-percent-encoding.html: Added.
    * Source/WebCore/page/csp/ContentSecurityPolicySource.cpp:
    (WebCore::ContentSecurityPolicySource::pathMatches const):
    * Source/WebCore/page/csp/ContentSecurityPolicySourceList.cpp:
    (WebCore::ContentSecurityPolicySourceList::parsePath):

    Identifier: 305413.379@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.501@webkitglib/2.52">https://commits.webkit.org/305877.501@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 49e38d5404ca6e014d68dfaa6545ab33ad261d17
<pre>
Cherry-pick 305413.367@safari-7624-branch (322ddc58184f). <a href="https://bugs.webkit.org/show_bug.cgi?id=308445">https://bugs.webkit.org/show_bug.cgi?id=308445</a>

    Use requesting origin instead of active origin for DeviceOrientation permission request
    <a href="https://rdar.apple.com/168597925">rdar://168597925</a>

    Reviewed by Chris Dumez.

    The current implementation uses active origin (origin being navigating to) instead of requesting origin in permission
    prompt, and this might lead to permission being granted to a wrong origin.

    API test: DeviceOrientation.PermissionOriginDuringPendingNavigation

    * Source/WebCore/page/Frame.cpp:
    (WebCore::Frame::topOrigin const):
    * Source/WebCore/page/Frame.h:
    * Source/WebKit/Shared/FrameInfoData.cpp:
    (WebKit::legacyEmptyFrameInfo):
    * Source/WebKit/Shared/FrameInfoData.h:
    * Source/WebKit/Shared/FrameInfoData.serialization.in:
    * Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
    (WebKit::UIDelegate::UIClient::shouldAllowDeviceOrientationAndMotionAccess):
    * Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
    (WebKit::ProvisionalPageProxy::cancel):
    * Source/WebKit/UIProcess/WebsiteData/WebDeviceOrientationAndMotionAccessController.cpp:
    (WebKit::WebDeviceOrientationAndMotionAccessController::shouldAllowAccess):
    * Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
    (WebKit::WebFrameLoaderClient::navigationActionData const):
    * Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
    (WebKit::WebFrame::info const):
    * Tools/TestWebKitAPI/Tests/WebKitCocoa/DeviceOrientation.mm:
    ((DeviceOrientation, PermissionOriginDuringPendingNavigation)):

    Identifier: 305413.367@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.500@webkitglib/2.52">https://commits.webkit.org/305877.500@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 7f9aac406e5b278abf7734e70e3eaa7a19dd2471
<pre>
Cherry-pick 305413.366@safari-7624-branch (8acf8433e6be). <a href="https://bugs.webkit.org/show_bug.cgi?id=308445">https://bugs.webkit.org/show_bug.cgi?id=308445</a>

    Block third-party cookies for requests from about:blank popups
    <a href="https://bugs.webkit.org/show_bug.cgi?id=308445">https://bugs.webkit.org/show_bug.cgi?id=308445</a>
    <a href="https://rdar.apple.com/168927271">rdar://168927271</a>

    Reviewed by Matthew Finkel.

    When an about:blank popup made cross-origin requests, its firstPartyForCookies was set to about:blank,
    which has an empty registrable domain. thirdPartyCookieBlockingDecisionForRequest() returns
    ThirdPartyCookieBlockingDecision::None for empty domains, bypassing third-party cookie blocking.

    FrameLoader::updateFirstPartyForCookies() should inherit the opener&apos;s firstPartyForCookies when the main
    frame URL is an about:blank or other owner-inherited document.

    * LayoutTests/http/tests/resourceLoadStatistics/third-party-cookie-blocking-about-blank-popup-expected.txt: Added.
    * LayoutTests/http/tests/resourceLoadStatistics/third-party-cookie-blocking-about-blank-popup.html: Added.
    * Source/WebCore/loader/FrameLoader.cpp:
    (WebCore::FrameLoader::updateFirstPartyForCookies):

    Identifier: 305413.366@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.499@webkitglib/2.52">https://commits.webkit.org/305877.499@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/88391c24b8818956ab5b6b0fd99d0254f8692c1d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162843 "1 style error") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36320 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29477 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171781 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/119289 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164712 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36424 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36323 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126407 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/119289 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165802 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/36424 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/29477 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/106984 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/36424 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/36323 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19481 "Unable to build WebKit without PR, please check manually (failure)") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/36424 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/29477 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174285 "Built successfully") | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23682 "Found 1 new JSC stress test failure: wasm.yaml/wasm/stress/simd-exception-throwing-v128-clobbers-fp.js.wasm-slow-memory (failure)") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/22270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/29477 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134716 "Passed tests") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/35993 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/36323 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134711 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/35978 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/29477 "Unable to build WebKit without PR, please check manually (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/98398 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24764 "Built successfully and passed tests") | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/35978 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/29477 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195244 "Built successfully") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35487 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/104000 "Failed to checkout and rebase branch from PR 65016") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50595 "Passed tests") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/34988 "Unable to build WebKit without PR, please check manually (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35233 "Unable to build WebKit without PR, please check manually (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35136 "Unable to build WebKit without PR, please check manually (failure)") | | | 
<!--EWS-Status-Bubble-End-->