### PR TITLE
Rewrite http/tests/security/cross-origin-indexeddb.html to actually verify storage blocking policy

### DIFF
--- a/LayoutTests/http/tests/security/cross-origin-indexeddb-expected.txt
+++ b/LayoutTests/http/tests/security/cross-origin-indexeddb-expected.txt
@@ -1,17 +1,5 @@
-Both frames can successfully open the database.
+Tests that when the storage blocking policy is BlockThirdParty, IndexedDB opened by a third-party iframe is transient.
 
-
-
---------
-Frame: '<!--frame1-->'
---------
-Successfully called window.indexedDB.deleteDatabase().
-Successfully called window.indexedDB.open().
-
-
---------
-Frame: '<!--frame2-->'
---------
-Successfully called window.indexedDB.deleteDatabase().
-Successfully called window.indexedDB.open().
+Third-party iframe stored data in IndexedDB; terminating network process.
+PASS: Third-party IndexedDB did not persist across network process restart.
 

--- a/LayoutTests/http/tests/security/cross-origin-indexeddb.html
+++ b/LayoutTests/http/tests/security/cross-origin-indexeddb.html
@@ -2,16 +2,38 @@
 <!DOCTYPE html>
 <html>
 <head>
-    <script>
-        if (window.testRunner) {
-            testRunner.dumpAsText();
-            testRunner.dumpChildFramesAsText();
-        }
-    </script>
+<title>Cross-origin IndexedDB is transient under BlockThirdParty</title>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+function log(message) {
+    document.getElementById("output").textContent += message + "\n";
+}
+
+window.addEventListener("message", event => {
+    if (event.data === "stored") {
+        log("Third-party iframe stored data in IndexedDB; terminating network process.");
+        if (window.testRunner)
+            testRunner.terminateNetworkProcess();
+        return;
+    }
+    if (event.data === "TRANSIENT")
+        log("PASS: Third-party IndexedDB did not persist across network process restart.");
+    else if (event.data === "PERSISTENT")
+        log("FAIL: Third-party IndexedDB persisted across network process restart; BlockThirdParty was not enforced.");
+    else
+        log(event.data);
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+</script>
 </head>
 <body>
-    <p>Both frames can successfully open the database.</p>
-    <iframe src="http://localhost:8000/security/resources/cross-origin-iframe-for-indexeddb.html"></iframe>
-    <iframe src="http://127.0.0.1:8000/security/resources/cross-origin-iframe-for-indexeddb.html"></iframe>
+<p>Tests that when the storage blocking policy is BlockThirdParty, IndexedDB opened by a third-party iframe is transient.</p>
+<pre id="output"></pre>
+<iframe src="http://localhost:8000/security/resources/cross-origin-iframe-for-indexeddb-transience.html"></iframe>
 </body>
 </html>

--- a/LayoutTests/http/tests/security/resources/cross-origin-iframe-for-indexeddb-transience.html
+++ b/LayoutTests/http/tests/security/resources/cross-origin-iframe-for-indexeddb-transience.html
@@ -1,0 +1,37 @@
+<!DOCTYPE html>
+<script>
+const dbname = "cross-origin-indexeddb-transience-test";
+
+function report(message) {
+    parent.postMessage(message, "*");
+}
+
+const deleteRequest = indexedDB.deleteDatabase(dbname);
+deleteRequest.onerror = () => report("FAIL: initial deleteDatabase failed");
+deleteRequest.onsuccess = () => {
+    const openRequest = indexedDB.open(dbname, 1);
+    openRequest.onerror = () => report("FAIL: open failed: " + openRequest.error);
+    openRequest.onupgradeneeded = event => {
+        event.target.result.createObjectStore("s");
+    };
+    openRequest.onsuccess = event => {
+        const db = event.target.result;
+        db.onclose = () => {
+            let upgradeFired = false;
+            const reopenRequest = indexedDB.open(dbname, 1);
+            reopenRequest.onerror = () => report("FAIL: reopen failed: " + reopenRequest.error);
+            reopenRequest.onupgradeneeded = () => { upgradeFired = true; };
+            reopenRequest.onsuccess = () => {
+                report(upgradeFired ? "TRANSIENT" : "PERSISTENT");
+            };
+        };
+        // Force a strict-durability write so the SQLite WAL is checkpointed
+        // to the main database file before we ask the parent to terminate
+        // the network process.
+        const tx = db.transaction("s", "readwrite", { durability: "strict" });
+        tx.onerror = () => report("FAIL: durable write tx failed: " + tx.error);
+        tx.oncomplete = () => report("stored");
+        tx.objectStore("s").put("v", "k");
+    };
+};
+</script>


### PR DESCRIPTION
#### 9ed47b46a8bef399472fd82703c995ca5a817680
<pre>
Rewrite http/tests/security/cross-origin-indexeddb.html to actually verify storage blocking policy
<a href="https://bugs.webkit.org/show_bug.cgi?id=314922">https://bugs.webkit.org/show_bug.cgi?id=314922</a>
<a href="https://rdar.apple.com/177202636">rdar://177202636</a>

Reviewed by Per Arne Vollan.

While debugging cross-origin storage tests under Site Isolation, I noticed this test passes even when storage blocking
policy is not properly configured under SI. It turns out the test only exercises an IndexedDB behavior (open() succeeds)
that holds under both `StorageBlockingPolicy::AllowAll` and `StorageBlockingPolicy::BlockThirdParty`, so the result
tells us nothing about whether the policy is actually applied.

Rewrite the test to verify whether the third-party database is ephemeral instead: the storage should be ephemeral under
BlockThirdParty policy and persistent under AllowAll policy. With this change, if the wrong policy is in effect the test
produces a visibly different result instead of silently passing.

* LayoutTests/http/tests/security/cross-origin-indexeddb-expected.txt:
* LayoutTests/http/tests/security/cross-origin-indexeddb.html:
* LayoutTests/http/tests/security/resources/cross-origin-iframe-for-indexeddb-transience.html: Added.

Canonical link: <a href="https://commits.webkit.org/313633@main">https://commits.webkit.org/313633@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4663f85599de215755c22407bc4c41f02ee182f0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163612 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37096 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30315 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172552 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/120061 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37427 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37095 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127082 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89591 "layout-tests (failure)") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166571 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29356 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147092 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107636 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28405 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27038 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20255 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138304 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24809 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175057 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26472 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135386 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36766 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31140 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135368 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36497 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37551 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146604 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99612 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30675 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23456 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36261 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35759 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1482 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36009 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35906 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->