### PR TITLE
REGRESSION (309010@main): observablehq.com: Cannot scroll-to-zoom over most of the scatterplot

### DIFF
--- a/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/svg-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/svg-expected.txt
@@ -1,9 +1,9 @@
 (event region
         (rect (0,0) width=800 height=600)
       (touch event listener region: asynchronousDispatchRegion:
-        (rect (8,8) width=114 height=113)
+        (rect (8,8) width=120 height=120)
 eventSpecificSynchronousDispatchRegions: eventName: touchstart eventRect:
-        (rect (8,8) width=114 height=113)
+        (rect (8,8) width=120 height=120)
 
       )
     )

--- a/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/svg-with-layer-based-svg-engine-expected.txt
+++ b/LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/svg-with-layer-based-svg-engine-expected.txt
@@ -1,9 +1,9 @@
 (event region
         (rect (0,0) width=800 height=600)
       (touch event listener region: asynchronousDispatchRegion:
-        (rect (8,8) width=114 height=113)
+        (rect (8,8) width=120 height=120)
 eventSpecificSynchronousDispatchRegions: eventName: touchstart eventRect:
-        (rect (8,8) width=114 height=113)
+        (rect (8,8) width=120 height=120)
 
       )
     )

--- a/LayoutTests/fast/events/wheel/wheel-event-on-svg-with-stroked-lines-expected.txt
+++ b/LayoutTests/fast/events/wheel/wheel-event-on-svg-with-stroked-lines-expected.txt
@@ -1,0 +1,11 @@
+PASS: wheel event was dispatched to <svg> with mouse in empty interior.
+
+(event region
+        (rect (0,0) width=800 height=600)
+      (wheel event listener region
+        (rect (8,8) width=300 height=300)
+        (non-passive
+          (rect (8,8) width=300 height=300)
+        )
+      )
+      )

--- a/LayoutTests/fast/events/wheel/wheel-event-on-svg-with-stroked-lines-with-layer-based-svg-engine-expected.txt
+++ b/LayoutTests/fast/events/wheel/wheel-event-on-svg-with-stroked-lines-with-layer-based-svg-engine-expected.txt
@@ -1,0 +1,11 @@
+PASS: wheel event was dispatched to <svg> with mouse in empty interior.
+
+(event region
+        (rect (0,0) width=800 height=600)
+      (wheel event listener region
+        (rect (8,8) width=300 height=300)
+        (non-passive
+          (rect (8,8) width=300 height=300)
+        )
+      )
+      )

--- a/LayoutTests/fast/events/wheel/wheel-event-on-svg-with-stroked-lines-with-layer-based-svg-engine.html
+++ b/LayoutTests/fast/events/wheel/wheel-event-on-svg-with-stroked-lines-with-layer-based-svg-engine.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ LayerBasedSVGEngineEnabled=true ] -->
+<html>
+<head>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+            testRunner.dontForceRepaint();
+        }
+
+        function extractEventRegionFromLayerTree(output) {
+            const startMarker = '(event region';
+            const startIndex = output.indexOf(startMarker);
+            if (startIndex === -1)
+                return "no event region";
+            let depth = 0;
+            let endIndex = startIndex;
+            for (let i = startIndex; i < output.length; i++) {
+                if (output[i] === '(') depth++;
+                else if (output[i] === ')') {
+                    depth--;
+                    if (depth === 0) {
+                        endIndex = i + 1;
+                        break;
+                    }
+                }
+            }
+            return output.substring(startIndex, endIndex).trim();
+        }
+
+        async function runTest() {
+            if (!window.internals || !window.eventSender)
+                return;
+
+            const svg = document.getElementById('svg');
+            svg.addEventListener('wheel', () => {
+                const layerTree = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+                const eventRegion = extractEventRegionFromLayerTree(layerTree);
+                document.documentElement.innerHTML = '';
+                const output = document.createElement('pre');
+                output.textContent = "PASS: wheel event was dispatched to <svg> with mouse in empty interior." + "\n\n" + eventRegion;
+                document.body.appendChild(output);
+                testRunner.notifyDone();
+            });
+
+            await UIHelper.mouseWheelScrollAt(158, 158);
+        }
+
+        window.addEventListener('load', runTest);
+    </script>
+</head>
+<body>
+    <svg id="svg" viewBox="0 0 300 300" style="width:300px; height:300px;">
+        <g stroke="lightblue" stroke-opacity="1" stroke-width="10">
+            <line x1="5"   y1="5"   x2="295" y2="5"   />
+            <line x1="295" y1="5"   x2="295" y2="295" />
+            <line x1="295" y1="295" x2="5"   y2="295" />
+            <line x1="5"   y1="295" x2="5"   y2="5"   />
+        </g>
+    </svg>
+</body>
+</html>

--- a/LayoutTests/fast/events/wheel/wheel-event-on-svg-with-stroked-lines.html
+++ b/LayoutTests/fast/events/wheel/wheel-event-on-svg-with-stroked-lines.html
@@ -1,0 +1,63 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="../../../resources/ui-helper.js"></script>
+    <script>
+        if (window.testRunner) {
+            testRunner.dumpAsText();
+            testRunner.waitUntilDone();
+            testRunner.dontForceRepaint();
+        }
+
+        function extractEventRegionFromLayerTree(output) {
+            const startMarker = '(event region';
+            const startIndex = output.indexOf(startMarker);
+            if (startIndex === -1)
+                return "no event region";
+            let depth = 0;
+            let endIndex = startIndex;
+            for (let i = startIndex; i < output.length; i++) {
+                if (output[i] === '(') depth++;
+                else if (output[i] === ')') {
+                    depth--;
+                    if (depth === 0) {
+                        endIndex = i + 1;
+                        break;
+                    }
+                }
+            }
+            return output.substring(startIndex, endIndex).trim();
+        }
+
+        async function runTest() {
+            if (!window.internals || !window.eventSender)
+                return;
+
+            const svg = document.getElementById('svg');
+            svg.addEventListener('wheel', () => {
+                const layerTree = internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_EVENT_REGION | internals.LAYER_TREE_INCLUDES_ROOT_LAYER_PROPERTIES);
+                const eventRegion = extractEventRegionFromLayerTree(layerTree);
+                document.documentElement.innerHTML = '';
+                const output = document.createElement('pre');
+                output.textContent = "PASS: wheel event was dispatched to <svg> with mouse in empty interior." + "\n\n" + eventRegion;
+                document.body.appendChild(output);
+                testRunner.notifyDone();
+            });
+
+            await UIHelper.mouseWheelScrollAt(158, 158);
+        }
+
+        window.addEventListener('load', runTest);
+    </script>
+</head>
+<body>
+    <svg id="svg" viewBox="0 0 300 300" style="width:300px; height:300px;">
+        <g stroke="lightblue" stroke-opacity="1" stroke-width="10">
+            <line x1="5"   y1="5"   x2="295" y2="5"   />
+            <line x1="295" y1="5"   x2="295" y2="295" />
+            <line x1="295" y1="295" x2="5"   y2="295" />
+            <line x1="5"   y1="295" x2="5"   y2="5"   />
+        </g>
+    </svg>
+</body>
+</html>

--- a/LayoutTests/interaction-region/svg-expected.txt
+++ b/LayoutTests/interaction-region/svg-expected.txt
@@ -52,15 +52,7 @@
           (opacity 0.60)
           (drawsContent 1)
           (event region
-            (rect (245,40) width=70 height=14)
-            (rect (6,54) width=164 height=57)
-            (rect (245,54) width=70 height=57)
-            (rect (6,111) width=164 height=27)
-            (rect (235,155) width=90 height=4)
-            (rect (23,159) width=54 height=46)
-            (rect (235,159) width=90 height=46)
-            (rect (23,205) width=54 height=7)
-            (rect (8,216) width=160 height=80)
+            (rect (0,0) width=400 height=400)
 
           (interaction regions [
             (interaction (6,54) width=164 height=84)
@@ -81,7 +73,7 @@
           (opacity 0.60)
           (drawsContent 1)
           (event region
-            (rect (0,133) width=367 height=267)
+            (rect (0,0) width=400 height=400)
 
           (interaction regions [
             (interaction (0,133.33) width=366.67 height=266.67)
@@ -94,7 +86,7 @@
           (opacity 0.60)
           (drawsContent 1)
           (event region
-            (rect (66,0) width=334 height=267)
+            (rect (0,0) width=400 height=400)
 
           (interaction regions [
             (interaction (66.67,0) width=333.33 height=266.67)

--- a/LayoutTests/platform/glib/fast/events/wheel/wheel-event-on-svg-with-stroked-lines-expected.txt
+++ b/LayoutTests/platform/glib/fast/events/wheel/wheel-event-on-svg-with-stroked-lines-expected.txt
@@ -1,0 +1,3 @@
+PASS: wheel event was dispatched to <svg> with mouse in empty interior.
+
+no event region

--- a/LayoutTests/platform/glib/fast/events/wheel/wheel-event-on-svg-with-stroked-lines-with-layer-based-svg-engine-expected.txt
+++ b/LayoutTests/platform/glib/fast/events/wheel/wheel-event-on-svg-with-stroked-lines-with-layer-based-svg-engine-expected.txt
@@ -1,0 +1,3 @@
+PASS: wheel event was dispatched to <svg> with mouse in empty interior.
+
+no event region

--- a/LayoutTests/platform/win/fast/events/wheel/wheel-event-on-svg-with-stroked-lines-expected.txt
+++ b/LayoutTests/platform/win/fast/events/wheel/wheel-event-on-svg-with-stroked-lines-expected.txt
@@ -1,0 +1,3 @@
+PASS: wheel event was dispatched to <svg> with mouse in empty interior.
+
+no event region

--- a/LayoutTests/platform/win/fast/events/wheel/wheel-event-on-svg-with-stroked-lines-with-layer-based-svg-engine-expected.txt
+++ b/LayoutTests/platform/win/fast/events/wheel/wheel-event-on-svg-with-stroked-lines-with-layer-based-svg-engine-expected.txt
@@ -1,0 +1,3 @@
+PASS: wheel event was dispatched to <svg> with mouse in empty interior.
+
+no event region

--- a/Source/WebCore/rendering/EventRegion.cpp
+++ b/Source/WebCore/rendering/EventRegion.cpp
@@ -52,7 +52,7 @@ EventRegionContext::EventRegionContext(EventRegion& eventRegion)
 
 EventRegionContext::~EventRegionContext() = default;
 
-void EventRegionContext::unite(const FloatRoundedRect& roundedRect, const RenderObject& renderer, const RenderStyle& style, bool overrideUserModifyIsEditable)
+void EventRegionContext::unite(const FloatRoundedRect& roundedRect, const RenderObject& renderer, const RenderStyle& style, bool overrideUserModifyIsEditable, ContributeToInteractionRegions contributeToInteractionRegions)
 {
     auto transformAndClipIfNeeded = [&](auto input, auto transform) {
         if (m_transformStack.isEmpty() && m_clipStack.isEmpty())
@@ -71,6 +71,9 @@ void EventRegionContext::unite(const FloatRoundedRect& roundedRect, const Render
     m_eventRegion.unite(region, renderer, style, overrideUserModifyIsEditable);
 
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)
+    if (contributeToInteractionRegions == ContributeToInteractionRegions::No)
+        return;
+
     auto rect = roundedRect.rect();
     if (auto* modelObject = dynamicDowncast<RenderLayerModelObject>(renderer))
         rect = snapRectToDevicePixelsIfNeeded(rect, *modelObject);
@@ -93,6 +96,7 @@ void EventRegionContext::unite(const FloatRoundedRect& roundedRect, const Render
     uniteInteractionRegions(renderer, layerBounds, clipOffset, transform);
 #else
     UNUSED_PARAM(renderer);
+    UNUSED_PARAM(contributeToInteractionRegions);
 #endif
 }
 

--- a/Source/WebCore/rendering/EventRegion.h
+++ b/Source/WebCore/rendering/EventRegion.h
@@ -59,7 +59,8 @@ public:
 
     bool isEventRegionContext() const final { return true; }
 
-    WEBCORE_EXPORT void unite(const FloatRoundedRect&, const RenderObject&, const RenderStyle&, bool overrideUserModifyIsEditable = false);
+    enum class ContributeToInteractionRegions : bool { No, Yes };
+    WEBCORE_EXPORT void unite(const FloatRoundedRect&, const RenderObject&, const RenderStyle&, bool overrideUserModifyIsEditable = false, ContributeToInteractionRegions = ContributeToInteractionRegions::Yes);
     bool contains(const IntRect&) const;
 
 #if ENABLE(INTERACTION_REGIONS_IN_EVENT_REGION)

--- a/Source/WebCore/rendering/RenderReplaced.cpp
+++ b/Source/WebCore/rendering/RenderReplaced.cpp
@@ -271,13 +271,23 @@ void RenderReplaced::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
     if (paintInfo.phase == PaintPhase::EventRegion) {
         auto* resources = SVGResourcesCache::cachedResourcesForRenderer(*this);
         bool svgRootHasChildrenOrFilters = isRenderOrLegacyRenderSVGRoot() && (firstChild() || (resources && resources->filter()) || svgFilterResourceFromStyle());
-        if (svgRootHasChildrenOrFilters && !isSkippedContentRoot(*this))
-            paintReplaced(paintInfo, adjustedPaintOffset);
-        else if (visibleToHitTesting()) {
+
+        // Always add the element's own border rect so events targeting the element itself
+        // (e.g. a listener on an <svg>) dispatch even where descendants don't cover its area.
+        // For SVG roots whose children will be painted below, skip the interaction-region
+        // contribution so the SVG root's border rect doesn't change the interaction-region
+        // shape. The children still register their precise bounds via paintReplaced.
+        if (visibleToHitTesting()) {
             auto borderRect = LayoutRect(adjustedPaintOffset, size());
             auto borderShape = BorderShape::shapeForBorderRect(style(), borderRect);
-            paintInfo.eventRegionContext()->unite(borderShape.deprecatedPixelSnappedRoundedRect(document().deviceScaleFactor()), *this, style());
+            auto contributeToInteractionRegions = (svgRootHasChildrenOrFilters && !isSkippedContentRoot(*this))
+                ? EventRegionContext::ContributeToInteractionRegions::No
+                : EventRegionContext::ContributeToInteractionRegions::Yes;
+            paintInfo.eventRegionContext()->unite(borderShape.deprecatedPixelSnappedRoundedRect(document().deviceScaleFactor()), *this, style(), false, contributeToInteractionRegions);
         }
+
+        if (svgRootHasChildrenOrFilters && !isSkippedContentRoot(*this))
+            paintReplaced(paintInfo, adjustedPaintOffset);
         return;
     }
 

--- a/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRoot.cpp
@@ -25,6 +25,7 @@
 #include "config.h"
 #include "RenderSVGRoot.h"
 
+#include "BorderShape.h"
 #include "GraphicsContext.h"
 #include "HitTestResult.h"
 #include "LayoutRepainter.h"
@@ -311,8 +312,9 @@ bool RenderSVGRoot::shouldApplyViewportClip() const
 // on LFC/SVG integration once the LBSE is upstreamed.
 void RenderSVGRoot::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
 {
-    // Don't paint, if the context explicitly disabled it.
-    if (paintInfo.context().paintingDisabled() && !paintInfo.context().detectingContentfulPaint())
+    // Don't paint, if the context explicitly disabled it. The event region phase still needs to
+    // run so the SVG root contributes its bounds even when descendants don't cover the area.
+    if (paintInfo.phase != PaintPhase::EventRegion && paintInfo.context().paintingDisabled() && !paintInfo.context().detectingContentfulPaint())
         return;
 
     // An empty viewport disables rendering.
@@ -361,6 +363,17 @@ void RenderSVGRoot::paintObject(PaintInfo& paintInfo, const LayoutPoint& paintOf
     if (paintInfo.phase == PaintPhase::ClippingMask && style().usedVisibility() == Visibility::Visible) {
         paintSVGClippingMask(paintInfo, objectBoundingBox());
         return;
+    }
+
+    if (paintInfo.phase == PaintPhase::EventRegion && visibleToHitTesting() && !isSkippedContentRoot(*this)) {
+        // Add the SVG root's own border rect so events targeting the <svg> element dispatch
+        // even where descendants don't cover its area. Children still register their precise
+        // bounds via paintContents below. Skip the interaction-region contribution so the
+        // SVG root's border rect doesn't change the interaction-region shape — only the
+        // children should contribute to interaction regions.
+        auto borderRect = LayoutRect(adjustedPaintOffset, size());
+        auto borderShape = BorderShape::shapeForBorderRect(style(), borderRect);
+        paintInfo.eventRegionContext()->unite(borderShape.deprecatedPixelSnappedRoundedRect(document().deviceScaleFactor()), *this, style(), false, EventRegionContext::ContributeToInteractionRegions::No);
     }
 
     if (paintInfo.paintRootBackgroundOnly())


### PR DESCRIPTION
#### 8fb33b52b92ec2153e19339d431459cf5d05f17f
<pre>
REGRESSION (309010@main): observablehq.com: Cannot scroll-to-zoom over most of the scatterplot
<a href="https://bugs.webkit.org/show_bug.cgi?id=314923">https://bugs.webkit.org/show_bug.cgi?id=314923</a>
<a href="https://rdar.apple.com/176831922">rdar://176831922</a>

Reviewed by Abrar Rahman Protyasha.

309010@main fixed an issue where event regions failed to generate for the
children of an SVG element when event listeners were attached. These changes
inadvertently resulted in the bounding box of the SVG itself being excluded from
the event region, meaning event regions were only present where the children
were painted.

Fix this by ensuring the border rect of the SVG itself is included in the event
region and united with its children rather than only generating event regions
for children or for the parent.

Tests: fast/events/wheel/wheel-event-on-svg-with-stroked-lines-with-layer-based-svg-engine.html
       fast/events/wheel/wheel-event-on-svg-with-stroked-lines.html

* LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/svg-expected.txt:
* LayoutTests/fast/events/touch/ios/touch-event-regions-layer-tree/svg-with-layer-based-svg-engine-expected.txt:
* LayoutTests/fast/events/wheel/wheel-event-on-svg-with-stroked-lines-expected.txt: Added.
* LayoutTests/fast/events/wheel/wheel-event-on-svg-with-stroked-lines-with-layer-based-svg-engine-expected.txt: Added.
* LayoutTests/fast/events/wheel/wheel-event-on-svg-with-stroked-lines-with-layer-based-svg-engine.html: Added.
* LayoutTests/fast/events/wheel/wheel-event-on-svg-with-stroked-lines.html: Added.
* LayoutTests/interaction-region/svg-expected.txt:
* LayoutTests/platform/glib/fast/events/wheel/wheel-event-on-svg-with-stroked-lines-expected.txt: Added.
* LayoutTests/platform/glib/fast/events/wheel/wheel-event-on-svg-with-stroked-lines-with-layer-based-svg-engine-expected.txt: Added.
* LayoutTests/platform/win/fast/events/wheel/wheel-event-on-svg-with-stroked-lines-expected.txt: Added.
* LayoutTests/platform/win/fast/events/wheel/wheel-event-on-svg-with-stroked-lines-with-layer-based-svg-engine-expected.txt: Added.
* Source/WebCore/rendering/EventRegion.cpp:
(WebCore::EventRegionContext::unite):
* Source/WebCore/rendering/EventRegion.h:
* Source/WebCore/rendering/RenderReplaced.cpp:
(WebCore::RenderReplaced::paint):
* Source/WebCore/rendering/svg/RenderSVGRoot.cpp:
(WebCore::RenderSVGRoot::paint):
(WebCore::RenderSVGRoot::paintObject):

Canonical link: <a href="https://commits.webkit.org/314342@main">https://commits.webkit.org/314342@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67710c9808712a445e91565bad6fd51bcac3271d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165869 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39359 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32940 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174912 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123124 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/167735 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39785 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39363 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128910 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168828 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31278 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149028 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109434 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28933 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23056 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140223 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26727 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177437 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30351 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28433 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137247 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39428 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33080 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137172 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36953 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40116 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148522 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102671 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32465 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25389 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38627 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111700 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38023 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3471 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38269 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38167 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->