### PR TITLE
[iOS Text Autosizing] google.com search suggestion font size increases upon rotation from portrait to landscape, doesn't decrease after rotating back to portrait

### DIFF
--- a/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
+++ b/Source/WebCore/page/LocalFrameViewLayoutContext.cpp
@@ -271,7 +271,30 @@ void LocalFrameViewLayoutContext::performLayout(bool canDeferUpdateLayerPosition
 #endif
         layoutRoot->layout();
 #if ENABLE(TEXT_AUTOSIZING)
-        applyTextSizingIfNeeded(*layoutRoot.get());
+        {
+            CheckedPtr renderView = this->renderView();
+            auto state = renderView ? renderView->textAutosizingState() : RenderView::TextAutosizingState::Normal;
+            switch (state) {
+            case RenderView::TextAutosizingState::Normal:
+                applyTextSizingIfNeeded(*layoutRoot.get());
+                break;
+            case RenderView::TextAutosizingState::ResetScheduled: {
+                renderView->resetTextAutosizing();
+                // resetTextAutosizing() restores specified font sizes via setStyle. That
+                // dirties the render tree only if autosized nodes existed; a dirty tree
+                // forces a follow-up layout in this same resize transaction against the
+                // still-stale block widths, which must also skip autosize.
+                bool resetTriggeredFollowUpLayout = m_frameView->needsLayout();
+                renderView->setTextAutosizingState(resetTriggeredFollowUpLayout
+                    ? RenderView::TextAutosizingState::SkipAfterReset
+                    : RenderView::TextAutosizingState::Normal);
+                break;
+            }
+            case RenderView::TextAutosizingState::SkipAfterReset:
+                renderView->setTextAutosizingState(RenderView::TextAutosizingState::Normal);
+                break;
+            }
+        }
 #endif
         layoutRoot->absoluteQuads(layoutAreas);
 

--- a/Source/WebCore/rendering/RenderView.h
+++ b/Source/WebCore/rendering/RenderView.h
@@ -87,6 +87,16 @@ public:
     bool needsEventRegionUpdateForNonCompositedFrame() const { return m_needsEventRegionUpdateForNonCompositedFrame; }
     void setNeedsEventRegionUpdateForNonCompositedFrame(bool value = true) { m_needsEventRegionUpdateForNonCompositedFrame = value; }
 
+#if ENABLE(TEXT_AUTOSIZING)
+    enum class TextAutosizingState : uint8_t {
+        Normal,
+        ResetScheduled,
+        SkipAfterReset,
+    };
+    TextAutosizingState textAutosizingState() const { return m_textAutosizingState; }
+    void setTextAutosizingState(TextAutosizingState state) { m_textAutosizingState = state; }
+#endif
+
     std::optional<RepaintRects> computeVisibleRectsInContainer(const RepaintRects&, const RenderLayerModelObject* container, VisibleRectContext) const override;
     void repaintRootContents();
     void repaintViewRectangle(const LayoutRect&);
@@ -288,6 +298,9 @@ private:
     bool m_hasSoftwareFilters { false };
     bool m_needsRepaintHackAfterCompositingLayerUpdateForDebugOverlaysOnly { false };
     bool m_needsEventRegionUpdateForNonCompositedFrame { false };
+#if ENABLE(TEXT_AUTOSIZING)
+    TextAutosizingState m_textAutosizingState { TextAutosizingState::Normal };
+#endif
 
     SingleThreadWeakHashMap<RenderElement, Vector<WeakPtr<CachedImage>>> m_renderersWithPausedImageAnimation;
     WeakHashSet<SVGSVGElement, WeakPtrImplWithEventTargetData> m_SVGSVGElementsWithPausedImageAnimation;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2266,6 +2266,7 @@ private:
     void updateTextAutosizingEnablementFromInitialScale(double);
 #endif
     void resetTextAutosizing();
+    void scheduleTextAutosizingResetAfterLayout();
 
 #if ENABLE(VIEWPORT_RESIZING)
     void shrinkToFitContent(ZoomToInitialScale = ZoomToInitialScale::No);

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -3288,6 +3288,23 @@ void WebPage::resetTextAutosizing()
 #endif
 }
 
+#if ENABLE(TEXT_AUTOSIZING)
+void WebPage::scheduleTextAutosizingResetAfterLayout()
+{
+    for (RefPtr frame = &m_page->mainFrame(); frame; frame = frame->tree().traverseNext()) {
+        RefPtr localFrame = dynamicDowncast<LocalFrame>(frame.get());
+        if (!localFrame)
+            continue;
+        RefPtr document = localFrame->document();
+        if (!document || !document->renderView())
+            continue;
+        document->renderView()->setTextAutosizingState(RenderView::TextAutosizingState::ResetScheduled);
+    }
+}
+#else
+void WebPage::scheduleTextAutosizingResetAfterLayout() { }
+#endif
+
 #if ENABLE(VIEWPORT_RESIZING)
 
 void WebPage::shrinkToFitContent(ZoomToInitialScale zoomToInitialScale)
@@ -3425,8 +3442,17 @@ void WebPage::viewportConfigurationChanged(ZoomToInitialScale zoomToInitialScale
     resetIdempotentTextAutosizingIfNeeded(previousInitialScaleIgnoringContentSize);
     updateTextAutosizingEnablementFromInitialScale(initialScale);
 #endif
-    if (setFixedLayoutSize(m_viewportConfiguration.layoutSize()))
-        resetTextAutosizing();
+    if (setFixedLayoutSize(m_viewportConfiguration.layoutSize())) {
+        // During a dynamic viewport size update (rotation/resize), the upcoming
+        // layout may still see stale block widths from before the change, so
+        // running autosize against them would cache an inflated value at the
+        // wrong width. Other viewport changes (initial page load, etc.) precede
+        // the first layout, where there are no pre-existing widths to be stale.
+        if (m_inDynamicSizeUpdate)
+            scheduleTextAutosizingResetAfterLayout();
+        else
+            resetTextAutosizing();
+    }
 
     auto minimumScale = m_viewportConfiguration.minimumScale();
     auto previousMinimumScale = m_previousViewportConfigurationMinimumScale.value_or(minimumScale);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/TextAutosizingBoost.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/TextAutosizingBoost.mm
@@ -30,6 +30,7 @@
 #import "UIKitSPIForTesting.h"
 #import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKPreferencesRef.h>
+#import <WebKit/WKWebViewPrivate.h>
 
 #if PLATFORM(IOS_FAMILY)
 
@@ -64,6 +65,53 @@ TEST(TextAutosizingBoost, ChangeAutosizingBoostAtRuntime)
     EXPECT_EQ(30, regularSize.height);
     EXPECT_EQ(159, boostedSize.width);
     EXPECT_EQ(38, boostedSize.height);
+}
+
+// Regression test for rdar://113801810: autosized text must not stay inflated at
+// landscape size after rotation to portrait.
+TEST(TextAutosizingBoost, RotationDoesNotPersistAutosizedFontSize)
+{
+    // Inline body width set from script (cleared in the resize handler) reproduces
+    // the stale-width condition during rotation. Multi-line content is required
+    // because a single-line block does not inflate regardless of block width.
+    static NSString *testMarkup =
+        @"<meta name='viewport' content='width=device-width'>"
+        "<body style='margin: 0'>"
+        "<span id='top'>Hello world</span>"
+        "<br>"
+        "<span>Goodbye world</span>"
+        "<script>"
+        "document.body.style.width='960px';"
+        "window.addEventListener('resize',function(){document.body.style.removeProperty('width');});"
+        "</script>"
+        "</body>";
+
+    InstanceMethodSwizzler screenSizeSwizzler(UIScreen.class, @selector(_referenceBounds), reinterpret_cast<IMP>(mainScreenReferenceBoundsOverride));
+
+    CGSize wideSize { 960, 360 };
+    CGSize narrowSize { 320, 568 };
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, wideSize.width, wideSize.height)]);
+    WKPreferencesSetTextAutosizingEnabled((__bridge WKPreferencesRef)[webView configuration].preferences, true);
+    WKPreferencesSetTextAutosizingUsesIdempotentMode((__bridge WKPreferencesRef)[webView configuration].preferences, false);
+    [webView synchronouslyLoadHTMLString:testMarkup];
+    // _beginAnimatedResizeWithUpdates: only takes the animated path once the first
+    // frame has been committed.
+    [webView waitForNextPresentationUpdate];
+
+    float wideFontSize = [[webView objectByEvaluatingJavaScript:@"parseFloat(getComputedStyle(document.getElementById('top')).fontSize)"] floatValue];
+
+    // Animated resize is the only path that exercises the fix.
+    [webView _beginAnimatedResizeWithUpdates:^{
+        [webView setFrame:CGRectMake(0, 0, narrowSize.width, narrowSize.height)];
+    }];
+    [webView _endAnimatedResize];
+    [webView waitForNextPresentationUpdate];
+
+    float narrowFontSize = [[webView objectByEvaluatingJavaScript:@"parseFloat(getComputedStyle(document.getElementById('top')).fontSize)"] floatValue];
+
+    EXPECT_GT(wideFontSize, 16.0);
+    EXPECT_EQ(16.0, narrowFontSize);
 }
 
 #endif // PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 892f04447eea322ed3964a3a6f0cec0be2315cae
<pre>
[iOS Text Autosizing] google.com search suggestion font size increases upon rotation from portrait to landscape, doesn&apos;t decrease after rotating back to portrait
<a href="https://bugs.webkit.org/show_bug.cgi?id=314924">https://bugs.webkit.org/show_bug.cgi?id=314924</a>
<a href="https://rdar.apple.com/113801810">rdar://113801810</a>

Reviewed by Antti Koivisto.

iOS autosizes small text on wide pages so it stays readable, and caches that
result per block. On rotation the cache must be cleared, but today the clear
runs before the first post-rotation layout, which can still see stale block
widths. Autosize runs against those stale widths, inflates the font, and
caches the inflated value. Autosize only inflates, never deflates, so the
inflated font persists.

Defer the clear to after a layout, and skip autosize on any layout that may
still see stale widths. The clear restores the specified font size via
setStyle, which dirties the tree and triggers a second synchronous layout
still inside the resize transaction, so autosize must be skipped on that one
too.

The second skip is conditional on the clear having actually dirtied
something; otherwise a rotation where nothing was autosized would leave the
flag set and silently disable autosize on a future layout.

* Source/WebCore/page/LocalFrameViewLayoutContext.cpp:
(WebCore::LocalFrameViewLayoutContext::performLayout):
* Source/WebCore/rendering/RenderView.h:
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::scheduleTextAutosizingResetAfterLayout):
(WebKit::WebPage::viewportConfigurationChanged):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/TextAutosizingBoost.mm:

Canonical link: <a href="https://commits.webkit.org/313547@main">https://commits.webkit.org/313547@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/84649d532fe3ffbc8b35714fb10a104a108743ce

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163359 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36842 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30057 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172298 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119806 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165228 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37169 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36842 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126874 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89428 "layout-tests (failure)") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166318 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29129 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146854 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107428 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28175 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26807 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20000 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138070 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24578 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174802 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27403 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26234 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135166 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36511 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30906 "Found 2 new test failures: http/tests/site-isolation/page-lifecycle/pagehide.html http/tests/site-isolation/page-lifecycle/unload.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135157 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36447 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37297 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146373 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99251 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30458 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23218 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36007 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108848 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35505 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1243 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35753 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35653 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->