### PR TITLE
StabilityTracer: Crash in IPC::MessageReceiverMap::invalidate()

### DIFF
--- a/Source/WebKit/Platform/IPC/MessageReceiverMap.cpp
+++ b/Source/WebKit/Platform/IPC/MessageReceiverMap.cpp
@@ -27,7 +27,9 @@
 #include "MessageReceiverMap.h"
 
 #include "Decoder.h"
+#include "Logging.h"
 #include "MessageReceiver.h"
+#include <wtf/EnumTraits.h>
 
 namespace IPC {
 
@@ -102,13 +104,24 @@ void MessageReceiverMap::removeMessageReceiver(MessageReceiver& messageReceiver)
 
 void MessageReceiverMap::invalidate()
 {
-    for (auto& messageReceiver : m_globalMessageReceivers.values())
-        messageReceiver->willBeRemovedFromMessageReceiverMap();
+    for (auto& [name, messageReceiver] : m_globalMessageReceivers) {
+        if (messageReceiver)
+            messageReceiver->willBeRemovedFromMessageReceiverMap();
+        else {
+            RELEASE_LOG_FAULT(IPC, "MessageReceiverMap::invalidate(): %s failed to remove itself from the map before its destruction", WTF::String(WTF::enumName(name)).utf8().data());
+            ASSERT_NOT_REACHED();
+        }
+    }
     m_globalMessageReceivers.clear();
 
-
-    for (auto& messageReceiver : m_messageReceivers.values())
-        messageReceiver->willBeRemovedFromMessageReceiverMap();
+    for (auto& [nameAndDestinationID, messageReceiver] : m_messageReceivers) {
+        if (messageReceiver)
+            messageReceiver->willBeRemovedFromMessageReceiverMap();
+        else {
+            RELEASE_LOG_FAULT(IPC, "MessageReceiverMap::invalidate(): %s (destinationID=%" PRIu64 ") failed to remove itself from the map before its destruction", WTF::String(WTF::enumName(nameAndDestinationID.first)).utf8().data(), nameAndDestinationID.second);
+            ASSERT_NOT_REACHED();
+        }
+    }
     m_messageReceivers.clear();
 }
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
@@ -28,9 +28,11 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
+#include "WebExtensionControllerMessages.h"
 #include "WebExtensionControllerParameters.h"
 #include "WebExtensionControllerProxyMessages.h"
 #include "WebPageProxy.h"
+#include "WebProcessPool.h"
 #include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
 
@@ -81,6 +83,10 @@ WebExtensionController::WebExtensionController(Ref<WebExtensionControllerConfigu
 WebExtensionController::~WebExtensionController()
 {
     webExtensionControllers().remove(identifier());
+
+    for (Ref pool : m_processPools)
+        pool->removeMessageReceiver(Messages::WebExtensionController::messageReceiverName(), identifier());
+
     unloadAll();
 }
 


### PR DESCRIPTION
#### 825d9df3072fa0235e57fb6408d0d9725a858da7
<pre>
StabilityTracer: Crash in IPC::MessageReceiverMap::invalidate()
<a href="https://bugs.webkit.org/show_bug.cgi?id=314930">https://bugs.webkit.org/show_bug.cgi?id=314930</a>
<a href="https://rdar.apple.com/177091898">rdar://177091898</a>

Reviewed by Chris Dumez.

The crash in IPC::MessageReceiverMap::invalidate() is most likely because either
m_globalMessageReceivers or m_messageReceivers contain a WeakPtr&lt;MessageReceiver&gt;
that is null and attempting to dereference it to call willBeRemovedFromMessageReceiverMap()
hits the RELEASE_ASSERT in WeakPtr::operator-&gt;().

The MessageReceiver destructor asserts that the MessageReceiver is not in any
MessageReceiverMap. So these two maps should never contain a null WeakPtr. But
given that we see this crash and it&apos;s not obvious which MessageReceiver is not
removing itself from a map before destruction, we fix this crash by adding null
checks in invalidate(). We also add an ASSERT and RELEASE_LOG_FAULT so that we
can later catch which MessageReceiver is not removing itself from a map.

Even though it&apos;s not clear from the crash log alone which MessageReceiver is not
removing itself from a map, there is a case that we can speculatively fix:

WebExtensionController is added to the map in WebExtensionController::addProcessPool()
and removed in WebExtensionController::removeProcessPool(). But it seems possible
that it can be destroyed without removeProcessPool() being called, and its destructor
does not remove it from the map. This could possibly be the reason for the crash. So
we ensure that the destructor will remove it.

This is a speculative fix.

* Source/WebKit/Platform/IPC/MessageReceiverMap.cpp:
(IPC::MessageReceiverMap::invalidate):
* Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp:
(WebKit::WebExtensionController::~WebExtensionController):

Canonical link: <a href="https://commits.webkit.org/313494@main">https://commits.webkit.org/313494@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1ca8f0c724e0065f9d40fefdaebefd170948f12c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163171 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36652 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29869 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172110 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119618 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36980 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36653 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126691 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89293 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166130 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28967 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146692 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107260 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28013 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26639 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19810 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137906 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174613 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/26770 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26071 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134998 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36322 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30741 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134990 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36413 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37108 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146211 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98982 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30294 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23055 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35818 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108179 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35317 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1078 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35564 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35464 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->