### PR TITLE
Recover IndexedDB connections in dedicated workers after network process crash

### DIFF
--- a/LayoutTests/storage/indexeddb/modern/resources/worker-idb-after-network-crash.js
+++ b/LayoutTests/storage/indexeddb/modern/resources/worker-idb-after-network-crash.js
@@ -4,8 +4,6 @@ var dbname = "worker-idb-crash-test-" + Date.now();
 self.onmessage = function(event) {
     if (event.data === "open-db")
         openInitialDatabase();
-    else if (event.data === "idb-after-crash")
-        attemptRecoveryOpen();
 };
 
 function openInitialDatabase()
@@ -16,10 +14,14 @@ function openInitialDatabase()
     };
     request.onsuccess = function(e) {
         var db = e.target.result;
+        // Use db.onclose as the crash signal directly in the worker; the worker
+        // recovers on its own without needing the main page to do IDB.
+        db.onclose = function() {
+            attemptRecoveryOpen();
+        };
         var tx = db.transaction("store", "readwrite");
         tx.objectStore("store").put({ id: "key1", value: "hello" });
         tx.oncomplete = function() {
-            // Keep DB open — main page will use its own onclose as the crash signal.
             self.postMessage("db-ready");
         };
         tx.onerror = function(e) {

--- a/LayoutTests/storage/indexeddb/modern/worker-idb-after-network-crash-expected.txt
+++ b/LayoutTests/storage/indexeddb/modern/worker-idb-after-network-crash-expected.txt
@@ -1,12 +1,9 @@
 Starting worker and asking it to open an IDB database.
 [Worker] db-ready
-Worker has an open IDB connection. Opening main page DB before crash.
 Terminating network process.
-Main page DB closed by crash. Verifying main page recovery...
-Main page IDB recovered. Now testing worker...
 [Worker] recovery-ok
-PASS Worker opened a new IndexedDB database after network process crash
+PASS Worker opened a new IndexedDB database after network process crash without main page IDB activity
 PASS successfullyParsed is true
 
 TEST COMPLETE
-This test verifies that IndexedDB operations in a dedicated worker recover after the network process is terminated, without needing to recreate the worker.
+This test verifies that IndexedDB operations in a dedicated worker recover after the network process is terminated, without any IndexedDB activity on the main page to trigger the recovery.

--- a/LayoutTests/storage/indexeddb/modern/worker-idb-after-network-crash.html
+++ b/LayoutTests/storage/indexeddb/modern/worker-idb-after-network-crash.html
@@ -3,7 +3,8 @@
 <body>
 <div id="description">
 This test verifies that IndexedDB operations in a dedicated worker recover after
-the network process is terminated, without needing to recreate the worker.
+the network process is terminated, without any IndexedDB activity on the main
+page to trigger the recovery.
 </div>
 </body>
 <script>
@@ -14,7 +15,6 @@ if (window.testRunner) {
 }
 
 var worker = new Worker("resources/worker-idb-after-network-crash.js");
-var mainDb;
 
 worker.onmessage = function(event)
 {
@@ -22,34 +22,13 @@ worker.onmessage = function(event)
     debug("[Worker] " + data);
 
     if (data === "db-ready") {
-        debug("Worker has an open IDB connection. Opening main page DB before crash.");
-
-        // Open a main-page database so we can use its onclose as crash signal.
-        var request = indexedDB.open("main-page-crash-signal-" + Date.now(), 1);
-        request.onupgradeneeded = function(e) {
-            e.target.result.createObjectStore("test", { keyPath: "id" });
-        };
-        request.onsuccess = function(e) {
-            mainDb = e.target.result;
-            mainDb.onclose = function() {
-                debug("Main page DB closed by crash. Verifying main page recovery...");
-                verifyMainPageRecovery();
-            };
-
-            debug("Terminating network process.");
-            if (window.testRunner)
-                testRunner.terminateNetworkProcess();
-        };
-        request.onerror = function(e) {
-            testFailed("Failed to open main page signal DB: " + e.target.error);
-            finishJSTest();
-        };
-
+        debug("Terminating network process.");
+        if (window.testRunner)
+            testRunner.terminateNetworkProcess();
     } else if (data === "recovery-ok") {
-        testPassed("Worker opened a new IndexedDB database after network process crash");
+        testPassed("Worker opened a new IndexedDB database after network process crash without main page IDB activity");
         worker.terminate();
         finishJSTest();
-
     } else if (data.indexOf("recovery-fail:") === 0) {
         testFailed("Worker IndexedDB recovery failed: " + data.substring("recovery-fail:".length));
         worker.terminate();
@@ -62,24 +41,6 @@ worker.onerror = function(event)
     testFailed("Worker error: " + event.message);
     finishJSTest();
 };
-
-function verifyMainPageRecovery()
-{
-    var request = indexedDB.open("main-page-recovery-test-" + Date.now(), 1);
-    request.onupgradeneeded = function(e) {
-        e.target.result.createObjectStore("test", { keyPath: "id" });
-    };
-    request.onsuccess = function(e) {
-        var db = e.target.result;
-        db.close();
-        debug("Main page IDB recovered. Now testing worker...");
-        worker.postMessage("idb-after-crash");
-    };
-    request.onerror = function(e) {
-        testFailed("Main page IDB recovery failed: " + e.target.error);
-        finishJSTest();
-    };
-}
 
 debug("Starting worker and asking it to open an IDB database.");
 worker.postMessage("open-db");

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.cpp
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.cpp
@@ -62,6 +62,11 @@ void IDBConnectionProxy::ref()
     m_connectionToServer->ref();
 }
 
+bool IDBConnectionProxy::isValid() const
+{
+    return m_connectionToServer->isValid();
+}
+
 void IDBConnectionProxy::deref()
 {
     m_connectionToServer->deref();

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.h
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.h
@@ -120,6 +120,8 @@ public:
 
     IDBConnectionIdentifier serverConnectionIdentifier() const { return m_serverConnectionIdentifier; }
 
+    bool isValid() const;
+
     void NODELETE ref();
     void deref();
 

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.cpp
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.cpp
@@ -460,7 +460,7 @@ void IDBConnectionToServer::connectionToServerLost(const IDBError& error)
     LOG(IndexedDB, "IDBConnectionToServer::connectionToServerLost");
     ASSERT(isMainThread());
     ASSERT(m_serverConnectionIsValid);
-    
+
     m_serverConnectionIsValid = false;
     m_proxy->connectionToServerLost(error);
 }

--- a/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.h
+++ b/Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.h
@@ -161,6 +161,9 @@ private:
 
     WeakRef<IDBConnectionToServerDelegate> m_delegate;
     bool m_serverConnectionIsValid { true };
+public:
+    bool isValid() const { return m_serverConnectionIsValid; }
+private:
 
     const UniqueRef<IDBConnectionProxy> m_proxy;
 };

--- a/Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.cpp
@@ -38,6 +38,7 @@
 #include "DocumentPage.h"
 #include "DocumentSettingsValues.h"
 #include "FileSystemStorageConnection.h"
+#include "IDBConnectionProxy.h"
 #include "LocalFrame.h"
 #include "WebRTCProvider.h"
 #include "WorkletParameters.h"
@@ -89,6 +90,12 @@ bool AudioWorkletMessagingProxy::postTaskForModeToWorkletGlobalScope(ScriptExecu
 }
 
 RefPtr<CacheStorageConnection> AudioWorkletMessagingProxy::createCacheStorageConnection()
+{
+    ASSERT_NOT_REACHED();
+    return nullptr;
+}
+
+RefPtr<IDBClient::IDBConnectionProxy> AudioWorkletMessagingProxy::createIDBConnectionProxy()
 {
     ASSERT_NOT_REACHED();
     return nullptr;

--- a/Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.h
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.h
@@ -70,6 +70,7 @@ private:
     RefPtr<CacheStorageConnection> createCacheStorageConnection() final;
     RefPtr<FileSystemStorageConnection> createFileSystemStorageConnection() final;
     RefPtr<RTCDataChannelRemoteHandlerConnection> createRTCDataChannelRemoteHandlerConnection() final;
+    RefPtr<IDBClient::IDBConnectionProxy> createIDBConnectionProxy() final;
     void postTaskToLoader(ScriptExecutionContext::Task&&) final;
 
     bool isAudioWorkletMessagingProxy() const final { return true; }

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -4953,6 +4953,8 @@ void Document::setTrustedTypesEnforcement(JSC::TrustedTypesEnforcement enforceme
 
 IDBClient::IDBConnectionProxy* Document::idbConnectionProxy()
 {
+    if (RefPtr connectionProxy = m_idbConnectionProxy; connectionProxy && !connectionProxy->isValid())
+        m_idbConnectionProxy = nullptr;
     if (!m_idbConnectionProxy) {
         RefPtr currentPage = page();
         if (!currentPage)
@@ -4960,11 +4962,6 @@ IDBClient::IDBConnectionProxy* Document::idbConnectionProxy()
         m_idbConnectionProxy = currentPage->idbConnection().proxy();
     }
     return m_idbConnectionProxy.get();
-}
-
-void Document::clearIDBConnectionProxy()
-{
-    m_idbConnectionProxy = nullptr;
 }
 
 StorageConnection* Document::storageConnection()

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -920,7 +920,6 @@ public:
     bool requiresTrustedTypes() const { return m_requiresTrustedTypes && !shouldBypassMainWorldContentSecurityPolicy(); }
 
     IDBClient::IDBConnectionProxy* idbConnectionProxy() final;
-    void clearIDBConnectionProxy();
     StorageConnection* storageConnection();
     SocketProvider* NODELETE socketProvider() final;
     RefPtr<RTCDataChannelRemoteHandlerConnection> createRTCDataChannelRemoteHandlerConnection() final;

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -4213,33 +4213,18 @@ void Page::setAllowsMediaDocumentInlinePlayback(bool flag)
 
 IDBClient::IDBConnectionToServer& Page::idbConnection()
 {
+    if (RefPtr cached = m_idbConnectionToServer; cached && !cached->isValid())
+        m_idbConnectionToServer = nullptr;
+
     if (!m_idbConnectionToServer)
         m_idbConnectionToServer = m_databaseProvider->idbConnectionToServerForSession(m_sessionID);
-    
+
     return *m_idbConnectionToServer;
 }
 
 IDBClient::IDBConnectionToServer* Page::optionalIDBConnection()
 {
     return m_idbConnectionToServer.get();
-}
-
-void Page::clearIDBConnection()
-{
-    m_idbConnectionToServer = nullptr;
-}
-
-void Page::clearIDBConnectionOnAllDocuments()
-{
-    clearIDBConnection();
-    forEachDocument([](Document& document) {
-        document.clearIDBConnectionProxy();
-    });
-}
-
-void Page::refreshIDBConnectionForWorkers()
-{
-    WorkerGlobalScope::replaceIDBConnectionProxyOnAllWorkers(idbConnection().proxy());
 }
 
 #if ENABLE(RESOURCE_USAGE)

--- a/Source/WebCore/page/Page.h
+++ b/Source/WebCore/page/Page.h
@@ -1077,9 +1077,6 @@ public:
 
     IDBClient::IDBConnectionToServer& idbConnection();
     WEBCORE_EXPORT IDBClient::IDBConnectionToServer* NODELETE optionalIDBConnection();
-    WEBCORE_EXPORT void clearIDBConnection();
-    WEBCORE_EXPORT void clearIDBConnectionOnAllDocuments();
-    WEBCORE_EXPORT void refreshIDBConnectionForWorkers();
 
     void setShowAllPlugins(bool showAll) { m_showAllPlugins = showAll; }
     bool showAllPlugins() const;

--- a/Source/WebCore/workers/WorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerGlobalScope.cpp
@@ -245,22 +245,22 @@ RefPtr<RTCDataChannelRemoteHandlerConnection> WorkerGlobalScope::createRTCDataCh
 
 IDBClient::IDBConnectionProxy* WorkerGlobalScope::idbConnectionProxy()
 {
+    if (RefPtr connectionProxy = m_connectionProxy; connectionProxy && connectionProxy->isValid())
+        return m_connectionProxy.get();
+
+    // Request a fresh connection from the loader context on the main thread.
+    // Fetching it goes through Page::idbConnection() which lazily relaunches the network process.
+    RefPtr<IDBClient::IDBConnectionProxy> newConnectionProxy;
+    callOnMainThreadAndWait([workerThread = Ref { thread() }, &newConnectionProxy]() mutable {
+        if (workerThread->runLoop().terminated())
+            return;
+        if (CheckedPtr loader = workerThread->workerLoaderProxy())
+            newConnectionProxy = loader->createIDBConnectionProxy();
+    });
+    if (newConnectionProxy)
+        m_connectionProxy = WTF::move(newConnectionProxy);
+
     return m_connectionProxy.get();
-}
-
-void WorkerGlobalScope::replaceIDBConnectionProxy(RefPtr<IDBClient::IDBConnectionProxy>&& proxy)
-{
-    m_connectionProxy = WTF::move(proxy);
-}
-
-void WorkerGlobalScope::replaceIDBConnectionProxyOnAllWorkers(RefPtr<IDBClient::IDBConnectionProxy>&& proxy)
-{
-    Locker locker { allWorkerGlobalScopeIdentifiersLock };
-    for (auto& globalScopeIdentifier : allWorkerGlobalScopeIdentifiers()) {
-        postTaskTo(globalScopeIdentifier, [proxy](auto& context) {
-            downcast<WorkerGlobalScope>(context).replaceIDBConnectionProxy(RefPtr { proxy });
-        });
-    }
 }
 
 GraphicsClient* WorkerGlobalScope::graphicsClient()

--- a/Source/WebCore/workers/WorkerGlobalScope.h
+++ b/Source/WebCore/workers/WorkerGlobalScope.h
@@ -96,9 +96,7 @@ public:
     String origin() const;
     const String& inspectorIdentifier() const LIFETIME_BOUND { return m_inspectorIdentifier; }
 
-    IDBClient::IDBConnectionProxy* NODELETE idbConnectionProxy() final;
-    void replaceIDBConnectionProxy(RefPtr<IDBClient::IDBConnectionProxy>&&);
-    WEBCORE_EXPORT static void replaceIDBConnectionProxyOnAllWorkers(RefPtr<IDBClient::IDBConnectionProxy>&&);
+    IDBClient::IDBConnectionProxy* idbConnectionProxy() final;
     void suspend() final;
     void resume() final;
     GraphicsClient* graphicsClient() final;

--- a/Source/WebCore/workers/WorkerLoaderProxy.h
+++ b/Source/WebCore/workers/WorkerLoaderProxy.h
@@ -35,6 +35,10 @@
 
 namespace WebCore {
 
+namespace IDBClient {
+class IDBConnectionProxy;
+}
+
 class CacheStorageConnection;
 class FileSystemStorageConnection;
 class StorageConnection;
@@ -55,6 +59,8 @@ public:
     virtual RefPtr<RTCDataChannelRemoteHandlerConnection> createRTCDataChannelRemoteHandlerConnection() = 0;
 
     virtual RefPtr<FileSystemStorageConnection> createFileSystemStorageConnection() = 0;
+
+    virtual RefPtr<IDBClient::IDBConnectionProxy> createIDBConnectionProxy() = 0;
 
     virtual ScriptExecutionContextIdentifier loaderContextIdentifier() const = 0;
 

--- a/Source/WebCore/workers/WorkerMessagingProxy.cpp
+++ b/Source/WebCore/workers/WorkerMessagingProxy.cpp
@@ -342,6 +342,23 @@ RefPtr<RTCDataChannelRemoteHandlerConnection> WorkerMessagingProxy::createRTCDat
     return document->page()->webRTCProvider().createRTCDataChannelRemoteHandlerConnection();
 }
 
+RefPtr<IDBClient::IDBConnectionProxy> WorkerMessagingProxy::createIDBConnectionProxy()
+{
+    ASSERT(isMainThread());
+    RefPtr document = dynamicDowncast<Document>(*m_scriptExecutionContext);
+    if (!document)
+        document = Document::allDocumentsMap().get(m_loaderContextIdentifier);
+
+    if (!document)
+        return nullptr;
+
+    RefPtr page = document->page();
+    if (!page)
+        return nullptr;
+
+    return &page->idbConnection().proxy();
+}
+
 void WorkerMessagingProxy::postExceptionToWorkerObject(const String& errorMessage, int lineNumber, int columnNumber, const String& sourceURL)
 {
     if (!m_scriptExecutionContextIdentifier)

--- a/Source/WebCore/workers/WorkerMessagingProxy.h
+++ b/Source/WebCore/workers/WorkerMessagingProxy.h
@@ -91,6 +91,7 @@ private:
     RefPtr<CacheStorageConnection> createCacheStorageConnection() final;
     RefPtr<FileSystemStorageConnection> createFileSystemStorageConnection() final;
     RefPtr<RTCDataChannelRemoteHandlerConnection> createRTCDataChannelRemoteHandlerConnection() final;
+    RefPtr<IDBClient::IDBConnectionProxy> createIDBConnectionProxy() final;
 
     void workerThreadCreated(DedicatedWorkerThread&);
 

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp
@@ -161,6 +161,14 @@ RefPtr<CacheStorageConnection> ServiceWorkerThreadProxy::createCacheStorageConne
     return m_cacheStorageConnection;
 }
 
+RefPtr<IDBClient::IDBConnectionProxy> ServiceWorkerThreadProxy::createIDBConnectionProxy()
+{
+    // Service workers are terminated by WebProcess::networkProcessConnectionClosed()
+    // when the network process crashes, so there is no surviving worker to
+    // refresh an IDB proxy for.
+    return nullptr;
+}
+
 RefPtr<RTCDataChannelRemoteHandlerConnection> ServiceWorkerThreadProxy::createRTCDataChannelRemoteHandlerConnection()
 {
     ASSERT(isMainThread());

--- a/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h
+++ b/Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h
@@ -123,6 +123,7 @@ private:
     RefPtr<CacheStorageConnection> createCacheStorageConnection() final;
     RefPtr<FileSystemStorageConnection> createFileSystemStorageConnection() final;
     RefPtr<RTCDataChannelRemoteHandlerConnection> createRTCDataChannelRemoteHandlerConnection() final;
+    RefPtr<IDBClient::IDBConnectionProxy> createIDBConnectionProxy() final;
 
     // WorkerDebuggerProxy
     void postMessageToDebugger(const String&) final;

--- a/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp
+++ b/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp
@@ -187,6 +187,14 @@ RefPtr<CacheStorageConnection> SharedWorkerThreadProxy::createCacheStorageConnec
     return m_cacheStorageConnection;
 }
 
+RefPtr<IDBClient::IDBConnectionProxy> SharedWorkerThreadProxy::createIDBConnectionProxy()
+{
+    // Unlike dedicated workers, whether shared workers remain usable after a
+    // network process crash is not yet well-defined; skip IDB recovery here
+    // until that is settled.
+    return nullptr;
+}
+
 RefPtr<RTCDataChannelRemoteHandlerConnection> SharedWorkerThreadProxy::createRTCDataChannelRemoteHandlerConnection()
 {
     ASSERT(isMainThread());

--- a/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.h
+++ b/Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.h
@@ -83,6 +83,7 @@ private:
     RefPtr<CacheStorageConnection> createCacheStorageConnection() final;
     RefPtr<FileSystemStorageConnection> createFileSystemStorageConnection() final;
     RefPtr<RTCDataChannelRemoteHandlerConnection> createRTCDataChannelRemoteHandlerConnection() final;
+    RefPtr<IDBClient::IDBConnectionProxy> createIDBConnectionProxy() final;
     void postTaskToLoader(ScriptExecutionContext::Task&&) final;
     ScriptExecutionContextIdentifier loaderContextIdentifier() const final;
 

--- a/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
+++ b/Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp
@@ -224,15 +224,8 @@ void NetworkProcessConnection::didClose(IPC::Connection&)
     Ref<NetworkProcessConnection> protector(*this);
     WebProcess::singleton().networkProcessConnectionClosed(this);
 
-    if (auto idbConnection = std::exchange(m_webIDBConnection, nullptr)) {
+    if (auto idbConnection = std::exchange(m_webIDBConnection, nullptr))
         idbConnection->connectionToServerLost();
-
-        // Mark that workers need their IDB proxies refreshed. The actual refresh
-        // is deferred until the network process is relaunched for another reason
-        // (e.g. a document calling indexedDB.open()), to avoid unnecessarily
-        // relaunching the network process just for workers.
-        WebProcess::singleton().setNeedsIDBConnectionRefreshForWorkers();
-    }
 
     if (auto swConnection = std::exchange(m_swConnection, nullptr))
         swConnection->connectionToServerLost();

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -1403,12 +1403,9 @@ NetworkProcessConnection& WebProcess::ensureNetworkProcessConnection()
         RunLoop::mainSingleton().dispatch([this, protectedThis = Ref { *this }] {
             for (auto& webPage : m_pageMap.values())
                 webPage->synchronizeCORSDisablingPatternsWithNetworkProcess();
-
-            if (std::exchange(m_needsIDBConnectionRefreshForWorkers, false))
-                refreshIDBConnectionForWorkers();
         });
     }
-    
+
     return *m_networkProcessConnection;
 }
 
@@ -1446,18 +1443,6 @@ void WebProcess::networkProcessConnectionClosed(NetworkProcessConnection* connec
     for (auto key : copyToVector(m_storageAreaMaps.keys())) {
         if (RefPtr map = m_storageAreaMaps.get(key))
             map->disconnect();
-    }
-
-    for (auto& page : m_pageMap.values()) {
-        RefPtr corePage = page->corePage();
-        RefPtr idbConnection = corePage->optionalIDBConnection();
-        if (!idbConnection)
-            continue;
-        
-        if (RefPtr existingIDBConnectionToServer = connection->existingIDBConnectionToServer()) {
-            ASSERT_UNUSED(existingIDBConnectionToServer, idbConnection.get() == &existingIDBConnectionToServer->coreConnectionToServer());
-            corePage->clearIDBConnectionOnAllDocuments();
-        }
     }
 
     if (SWContextManager::singleton().connection())
@@ -1500,14 +1485,6 @@ void WebProcess::networkProcessConnectionClosed(NetworkProcessConnection* connec
     for (auto& weakSession : sessions) {
         if (RefPtr webtransportSession = weakSession.get())
             webtransportSession->didFail(std::nullopt, String(emptyString()));
-    }
-}
-
-void WebProcess::refreshIDBConnectionForWorkers()
-{
-    for (auto& page : m_pageMap.values()) {
-        if (RefPtr corePage = page->corePage())
-            corePage->refreshIDBConnectionForWorkers();
     }
 }
 

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -289,8 +289,6 @@ public:
     NetworkProcessConnection& ensureNetworkProcessConnection();
 
     void networkProcessConnectionClosed(NetworkProcessConnection*);
-    void refreshIDBConnectionForWorkers();
-    void setNeedsIDBConnectionRefreshForWorkers() { m_needsIDBConnectionRefreshForWorkers = true; }
     NetworkProcessConnection* existingNetworkProcessConnection() { return m_networkProcessConnection.get(); }
     WebLoaderStrategy& NODELETE webLoaderStrategy() LIFETIME_BOUND;
     WebFileSystemStorageConnection& fileSystemStorageConnection();
@@ -822,7 +820,6 @@ private:
 
     String m_uiProcessBundleIdentifier;
     RefPtr<NetworkProcessConnection> m_networkProcessConnection;
-    bool m_needsIDBConnectionRefreshForWorkers { false };
     const UniqueRef<WebLoaderStrategy> m_webLoaderStrategy;
     RefPtr<WebFileSystemStorageConnection> m_fileSystemStorageConnection;
 


### PR DESCRIPTION
#### cef0f2109f9f946482b2128fb08d9ff96670ad9b
<pre>
Recover IndexedDB connections in dedicated workers after network process crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=314932">https://bugs.webkit.org/show_bug.cgi?id=314932</a>
<a href="https://rdar.apple.com/177219395">rdar://177219395</a>

Reviewed by Brady Eidson.

If a page only uses IndexedDB from a dedicated worker, the worker&apos;s connection never recovers from a network process
crash -- the existing recovery in 309032@main only handles documents.

This patch replaces the existing push-based recovery with a lazy self-heal driven by new IDBConnectionProxy::isValid().
On the next IDB operation, Page::idbConnection(), Document::idbConnectionProxy() and
WorkerGlobalScope::idbConnectionProxy() each detect the invalid cached value and refetch. Workers reach the main thread
through a new WorkerLoaderProxy::createIDBConnectionProxy() virtual. The on-demand pattern is already used by other
worker storage APIs (e.g. WebCacheStorageConnection::ensureConnection),

Only dedicated workers are wired up. ServiceWorkerThreadProxy returns nullptr because service workers are deliberately
killed on network process close (SWContextManager::stopAllServiceWorkers) and start fresh on relaunch.
SharedWorkerThreadProxy also returns nullptr now: the broader behavior of shared workers after a network process crash
is not yet well-defined and needs to be settled separately.

worker-idb-after-network-crash.html is updated to cover the new behavior -- it no longer needs IDB operation in page to
relaunch network process.

* LayoutTests/storage/indexeddb/modern/resources/worker-idb-after-network-crash.js:
(self.onmessage):
(openInitialDatabase.db.onclose):
(openInitialDatabase.tx.oncomplete):
* LayoutTests/storage/indexeddb/modern/worker-idb-after-network-crash-expected.txt:
* LayoutTests/storage/indexeddb/modern/worker-idb-after-network-crash.html:
* Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.cpp:
(WebCore::IDBClient::IDBConnectionProxy::isValid const):
* Source/WebCore/Modules/indexeddb/client/IDBConnectionProxy.h:
* Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.cpp:
(WebCore::IDBClient::IDBConnectionToServer::connectionToServerLost):
* Source/WebCore/Modules/indexeddb/client/IDBConnectionToServer.h:
* Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.cpp:
(WebCore::AudioWorkletMessagingProxy::createIDBConnectionProxy):
* Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.h:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::idbConnectionProxy):
(WebCore::Document::clearIDBConnectionProxy): Deleted.
* Source/WebCore/dom/Document.h:
* Source/WebCore/page/Page.cpp:
(WebCore::Page::idbConnection):
(WebCore::Page::clearIDBConnection): Deleted.
(WebCore::Page::clearIDBConnectionOnAllDocuments): Deleted.
(WebCore::Page::refreshIDBConnectionForWorkers): Deleted.
* Source/WebCore/page/Page.h:
* Source/WebCore/workers/WorkerGlobalScope.cpp:
(WebCore::WorkerGlobalScope::idbConnectionProxy):
(WebCore::WorkerGlobalScope::replaceIDBConnectionProxy): Deleted.
(WebCore::WorkerGlobalScope::replaceIDBConnectionProxyOnAllWorkers): Deleted.
* Source/WebCore/workers/WorkerGlobalScope.h:
* Source/WebCore/workers/WorkerLoaderProxy.h:
* Source/WebCore/workers/WorkerMessagingProxy.cpp:
(WebCore::WorkerMessagingProxy::createIDBConnectionProxy):
* Source/WebCore/workers/WorkerMessagingProxy.h:
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.cpp:
(WebCore::ServiceWorkerThreadProxy::createIDBConnectionProxy):
* Source/WebCore/workers/service/context/ServiceWorkerThreadProxy.h:
* Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.cpp:
(WebCore::SharedWorkerThreadProxy::createIDBConnectionProxy):
(WebCore::SharedWorkerThreadProxy::createRTCDataChannelRemoteHandlerConnection):
* Source/WebCore/workers/shared/context/SharedWorkerThreadProxy.h:
* Source/WebKit/WebProcess/Network/NetworkProcessConnection.cpp:
(WebKit::NetworkProcessConnection::didClose):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::ensureNetworkProcessConnection):
(WebKit::WebProcess::networkProcessConnectionClosed):
(WebKit::WebProcess::refreshIDBConnectionForWorkers): Deleted.
* Source/WebKit/WebProcess/WebProcess.h:

Canonical link: <a href="https://commits.webkit.org/313509@main">https://commits.webkit.org/313509@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c0780214608907d3e90e2ad41ce217e148a506a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162922 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36401 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29573 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171860 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119368 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/352d2782-bfff-433b-99ab-f60d18fda47a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164791 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36927 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36403 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126472 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89072 "1 flakes 17 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/19c0614e-0f73-48e0-b174-00680ab460ed) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165881 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28935 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146409 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107048 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/978dc0ba-17f1-4bab-a160-c5de5345f402) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27981 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26402 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19560 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137874 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24138 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174364 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/23305 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25785 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134781 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36072 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30505 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134776 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36418 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/36952 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145934 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98524 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30155 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22771 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35568 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/105011 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35067 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/793 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35314 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35215 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->