### PR TITLE
[CMake] Teach run-api-tests to find CMake built binaries with --cmake

### DIFF
--- a/Tools/Scripts/webkitpy/port/base.py
+++ b/Tools/Scripts/webkitpy/port/base.py
@@ -172,7 +172,12 @@ class Port(object):
         self._executive = host.executive
         self._filesystem = host.filesystem
         self._webkit_finder = WebKitFinder(host.filesystem)
-        self._config = port_config.Config(self._executive, self._filesystem, self.port_name)
+        self._config = port_config.Config(
+            self._executive,
+            self._filesystem,
+            self.port_name,
+            use_cmake=bool(getattr(self._options, 'use_cmake', False)),
+        )
         self.pretty_patch = PrettyPatch(self._executive, self.path_from_webkit_base(), self._filesystem)
 
         self._http_server = None

--- a/Tools/Scripts/webkitpy/port/config.py
+++ b/Tools/Scripts/webkitpy/port/config.py
@@ -54,13 +54,14 @@ class Config(object):
         "Release": "--release",
     }
 
-    def __init__(self, executive, filesystem, port_implementation=None):
+    def __init__(self, executive, filesystem, port_implementation=None, use_cmake=False):
         self._executive = executive
         self._filesystem = filesystem
         self._webkit_finder = webkit_finder.WebKitFinder(self._filesystem)
         self._default_configuration = None
         self._build_directories = {}
         self._port_implementation = port_implementation
+        self._use_cmake = use_cmake
 
     def build_directory(self, configuration, for_host=False):
         """Returns the path to the build directory for the configuration."""
@@ -73,19 +74,23 @@ class Config(object):
         if self._port_implementation and not for_host:
             flags.append('--' + self._port_implementation)
 
-        if not self._build_directories.get(configuration):
+        if self._use_cmake:
+            flags.append('--cmake')
+
+        cache_key = (configuration, self._use_cmake)
+        if not self._build_directories.get(cache_key):
             args = ["perl", self._webkit_finder.path_to_script("webkit-build-directory")] + flags
             output = self._executive.run_command(args, cwd=self._webkit_finder.webkit_base(), return_stderr=False).rstrip()
             parts = output.split("\n")
-            self._build_directories[configuration] = parts[0]
+            self._build_directories[cache_key] = parts[0]
 
             if len(parts) == 2:
                 default_configuration = parts[1][len(parts[0]):]
                 if default_configuration.startswith("/"):
                     default_configuration = default_configuration[1:]
-                self._build_directories[default_configuration] = parts[1]
+                self._build_directories[(default_configuration, self._use_cmake)] = parts[1]
 
-        return self._build_directories[configuration]
+        return self._build_directories[cache_key]
 
     def flag_for_configuration(self, configuration):
         if not configuration:

--- a/Tools/Scripts/webkitpy/port/config_unittest.py
+++ b/Tools/Scripts/webkitpy/port/config_unittest.py
@@ -42,10 +42,10 @@ import webkitpy.port.config as config
 
 
 class ConfigTest(unittest.TestCase):
-    def make_config(self, output='', files=None, exit_code=0, exception=None, run_command_fn=None, stderr='', port_implementation=None):
+    def make_config(self, output='', files=None, exit_code=0, exception=None, run_command_fn=None, stderr='', port_implementation=None, use_cmake=False):
         e = MockExecutive2(output=output, exit_code=exit_code, exception=exception, run_command_fn=run_command_fn, stderr=stderr)
         fs = MockFileSystem(files)
-        return config.Config(e, fs, port_implementation=port_implementation)
+        return config.Config(e, fs, port_implementation=port_implementation, use_cmake=use_cmake)
 
     def assert_configuration(self, contents, expected):
         # This tests that a configuration file containing
@@ -93,6 +93,26 @@ class ConfigTest(unittest.TestCase):
             return '/tmp'
 
         c = self.make_config(run_command_fn=mock_run_command, port_implementation='gtk')
+
+    def test_build_directory_passes_cmake_flag(self):
+        seen = []
+
+        def mock_run_command(arg_list):
+            seen.append(list(arg_list))
+            if '--cmake' in arg_list:
+                return '/WebKitBuild/cmake-mac/Debug'
+            return '/WebKitBuild/Debug'
+
+        c_xcode = self.make_config(run_command_fn=mock_run_command, port_implementation='mac', use_cmake=False)
+        self.assertEqual(c_xcode.build_directory('Debug'), '/WebKitBuild/Debug')
+        self.assertNotIn('--cmake', seen[-1])
+
+        c_cmake = self.make_config(run_command_fn=mock_run_command, port_implementation='mac', use_cmake=True)
+        self.assertEqual(c_cmake.build_directory('Debug'), '/WebKitBuild/cmake-mac/Debug')
+        self.assertIn('--cmake', seen[-1])
+
+        c_cmake.build_directory('Release')
+        self.assertIn('--cmake', seen[-1])
 
     def test_default_configuration__release(self):
         self.assert_configuration('Release', 'Release')

--- a/Tools/Scripts/webkitpy/port/factory.py
+++ b/Tools/Scripts/webkitpy/port/factory.py
@@ -83,6 +83,8 @@ def configuration_options():
             help='Set the configuration to Debug'),
         optparse.make_option('--release', action='store_const', const='Release', dest="configuration",
             help='Set the configuration to Release'),
+        optparse.make_option('--cmake', action='store_true', default=False, dest='use_cmake',
+                             help='Use the CMake build tree (e.g. WebKitBuild/cmake-mac/<configuration>) instead of the default Xcode/Make tree'),
         optparse.make_option('--64-bit', action='store_const', const='x86_64', default=None, dest="architecture",
             help='use 64-bit binaries by default (x86_64 instead of x86)'),
         optparse.make_option('--32-bit', action='store_const', const='x86', default=None, dest="architecture",


### PR DESCRIPTION
#### 5c9c77898e538f04f03c5579bf8f36cfb227cb6a
<pre>
[CMake] Teach run-api-tests to find CMake built binaries with --cmake
<a href="https://bugs.webkit.org/show_bug.cgi?id=314938">https://bugs.webkit.org/show_bug.cgi?id=314938</a>
<a href="https://rdar.apple.com/177224796">rdar://177224796</a>

Reviewed by Pascoe.

Tools/Scripts/run-api-tests had no way to target a CMake build tree.
Passing --cmake exited with &quot;no such option&quot;, and Config.build_directory()
never forwarded --cmake to webkit-build-directory anyway, so paths always
resolved to the Xcode build products.

Add --cmake to configuration_options(), and thread it through Port
into Config, and append it to the webkit-build-directory invocation.

For example, now `run-api-tests --cmake --debug` will resolve binaries
out of WebKitBuild/cmake-mac/Debug/ (the mac-debug / mac-dev-debug
preset output) instead of WebKitBuild/Debug/.

* Tools/Scripts/webkitpy/port/base.py:
(Port.__init__):
* Tools/Scripts/webkitpy/port/config.py:
(Config.__init__):
(Config.build_directory):
* Tools/Scripts/webkitpy/port/config_unittest.py:
(ConfigTest.make_config):
(ConfigTest.test_build_directory_passes_cmake_flag):
(ConfigTest.test_build_directory_passes_cmake_flag.mock_run_command):
* Tools/Scripts/webkitpy/port/factory.py:
(configuration_options):

Canonical link: <a href="https://commits.webkit.org/313522@main">https://commits.webkit.org/313522@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c4b81659e6c044cc2471d333a94f9cf272146fff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163351 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36834 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30049 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172290 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/119798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d9101062-5c3a-44a1-a9ca-8589659f9fd1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165220 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37161 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36834 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/126851 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/119798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7f424b46-3e1d-45ef-be69-ec1ec7f7546f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166310 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29121 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/146847 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107418 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/db2d3579-a05f-4e22-9a3c-3a0a3906aee0) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/162672 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19992 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/138062 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24571 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174794 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26227 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/135168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36503 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30900 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135149 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36429 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37289 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146366 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99243 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30449 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/23211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35999 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35497 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1236 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35745 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35645 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->