### PR TITLE
[AppKit Gestures] Disambiguate drag-and-drop from text selection during press-and-drag

### DIFF
--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -46,6 +46,7 @@
 #import "ViewGestureController.h"
 #import "ViewSnapshotStore.h"
 #import "WKAPICast.h"
+#import "WKAppKitGestureController.h"
 #import "WKFullScreenWindowController.h"
 #import "WKStringCF.h"
 #import "WKViewInternal.h"
@@ -315,6 +316,9 @@ void PageClientImpl::didCommitLoadForMainFrame(const String&, bool)
     impl->dismissContentRelativeChildWindowsWithAnimation(true);
     impl->clearPromisedImageDragData();
     impl->pageDidScroll({ 0, 0 });
+#if HAVE(APPKIT_GESTURES_SUPPORT)
+    impl->invalidateCachedPositionInformation();
+#endif
 #if ENABLE(WRITING_TOOLS)
     impl->hideTextAnimationView();
 #endif
@@ -1224,8 +1228,15 @@ void PageClientImpl::showCaptionDisplaySettings(WebCore::HTMLMediaElementIdentif
     protect(m_impl)->showCaptionDisplaySettings(identifier, options, WTF::move(completionHandler));
 }
 
-void PageClientImpl::positionInformationDidChange(const InteractionInformationAtPosition&)
+void PageClientImpl::positionInformationDidChange(const InteractionInformationAtPosition& info)
 {
+    CheckedPtr impl = m_impl.get();
+    if (!impl)
+        return;
+
+#if HAVE(APPKIT_GESTURES_SUPPORT)
+    impl->positionInformationDidChange(info);
+#endif
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.h
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.h
@@ -44,6 +44,7 @@ class IntSize;
 namespace WebKit {
 class WebPageProxy;
 class WebViewImpl;
+struct InteractionInformationAtPosition;
 }
 
 OBJC_CLASS NSPanGestureRecognizer;
@@ -61,6 +62,9 @@ OBJC_CLASS NSPanGestureRecognizer;
 - (NSGestureRecognizer *)activeDragGestureRecognizer;
 - (void)setGestureDraggingSession:(NSDraggingSession *)session;
 - (void)clearGestureDragState;
+- (void)setTextSelectionDragGesture:(NSGestureRecognizer *)gesture completionHandler:(void (^)(NSDraggingSession *))completionHandler;
+- (void)positionInformationDidChange:(const WebKit::InteractionInformationAtPosition&)info;
+- (void)didCommitLoadForMainFrame;
 - (void)reset;
 
 #if ENABLE(TWO_PHASE_CLICKS)

--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
@@ -30,10 +30,13 @@
 
 #import "AppKitSPI.h"
 #import "IdentifierTypes.h"
+#import "InteractionInformationAtPosition.h"
+#import "InteractionInformationRequest.h"
 #import "NativeWebWheelEvent.h"
 #import "RemoteLayerTreeDrawingAreaProxy.h"
 #import "ScrollingAccelerationCurve.h"
 #import "ViewGestureController.h"
+#import "WKDeferringGestureRecognizer.h"
 #import "WKWebView.h"
 #import "WebEventModifier.h"
 #import "WebEventType.h"
@@ -53,6 +56,7 @@
 #import <WebCore/PointerID.h>
 #import <WebCore/Scrollbar.h>
 #import <source_location>
+#import <wtf/BlockPtr.h>
 #import <wtf/CheckedPtr.h>
 #import <wtf/Markable.h>
 #import <wtf/MonotonicTime.h>
@@ -150,7 +154,19 @@ static WebCore::FloatSize toRawPlatformDelta(WebCore::FloatSize delta)
     return -delta;
 }
 
-@interface WKAppKitGestureController () <NSGestureRecognizerDelegatePrivate>
+using InteractionInformationCallback = Function<void(const WebKit::InteractionInformationAtPosition&)>;
+
+struct InteractionInformationRequestAndCallback {
+    WebKit::InteractionInformationRequest request;
+    InteractionInformationCallback callback;
+};
+
+static bool representsDraggableElement(const WebKit::InteractionInformationAtPosition& info)
+{
+    return info.isLink || info.isImage || info.isAttachment || info.isDHTMLDraggable || info.isColorInput || info.prefersDraggingOverTextSelection;
+}
+
+@interface WKAppKitGestureController () <NSGestureRecognizerDelegatePrivate, WKDeferringGestureRecognizerDelegate>
 @end
 
 @implementation WKAppKitGestureController {
@@ -162,6 +178,10 @@ static WebCore::FloatSize toRawPlatformDelta(WebCore::FloatSize delta)
     RetainPtr<NSPressGestureRecognizer> _singleClickGestureRecognizer;
     RetainPtr<NSClickGestureRecognizer> _doubleClickGestureRecognizer;
     RetainPtr<NSPressGestureRecognizer> _secondaryClickGestureRecognizer;
+
+    // Auxiliary gesture recognizers to support drag-and-drop.
+    RetainPtr<NSGestureRecognizer> _textSelectionDragGesture;
+    RetainPtr<WKDeferringGestureRecognizer> _dragDeferringGestureRecognizer;
 
     bool _isMomentumActive;
 
@@ -181,7 +201,14 @@ static WebCore::FloatSize toRawPlatformDelta(WebCore::FloatSize delta)
 
     RetainPtr<NSPressGestureRecognizer> _dragPressGestureRecognizer;
     RetainPtr<NSDraggingSession> _gestureDraggingSession;
+    BlockPtr<void(NSDraggingSession *)> _textSelectionDragCompletionHandler;
     bool _dragGestureHasSentMouseDown;
+
+    WebKit::InteractionInformationAtPosition _positionInformation;
+    std::optional<WebKit::InteractionInformationRequest> _lastOutstandingPositionInformationRequest;
+    Vector<std::optional<InteractionInformationRequestAndCallback>> _pendingPositionInformationHandlers;
+    uint64_t _positionInformationCallbackDepth;
+    bool _hasValidPositionInformation;
 }
 
 #if __has_include(<WebKitAdditions/WKAppKitGestureControllerAdditionsImpl.mm>)
@@ -213,6 +240,7 @@ static WebCore::FloatSize toRawPlatformDelta(WebCore::FloatSize delta)
     [self setUpDoubleClickGestureRecognizer];
     [self setUpSecondaryClickGestureRecognizer];
     [self setUpDragPressGestureRecognizer];
+    [self setUpDragDeferringGestureRecognizer];
 }
 
 - (void)setUpPanGestureRecognizer
@@ -259,6 +287,22 @@ static WebCore::FloatSize toRawPlatformDelta(WebCore::FloatSize delta)
     [_secondaryClickGestureRecognizer setName:@"WKSecondaryClickGesture"];
 }
 
+- (void)setUpDragPressGestureRecognizer
+{
+    _dragPressGestureRecognizer = adoptNS([[NSPressGestureRecognizer alloc] initWithTarget:self action:@selector(dragPressGestureRecognized:)]);
+    [self configureForDragPress:_dragPressGestureRecognizer];
+    [_dragPressGestureRecognizer setDelegate:self];
+    [_dragPressGestureRecognizer setName:@"WKDragPressGesture"];
+}
+
+- (void)setUpDragDeferringGestureRecognizer
+{
+    _dragDeferringGestureRecognizer = adoptNS([[WKDeferringGestureRecognizer alloc] initWithDeferringGestureDelegate:self]);
+    [self configureForDragDeferral:_dragDeferringGestureRecognizer];
+    [_dragDeferringGestureRecognizer setDelegate:self];
+    [_dragDeferringGestureRecognizer setName:@"WKDragDeferringGesture"];
+}
+
 - (void)addGesturesToWebView
 {
     CheckedPtr viewImpl = _viewImpl.get();
@@ -274,8 +318,8 @@ static WebCore::FloatSize toRawPlatformDelta(WebCore::FloatSize delta)
     [webView addGestureRecognizer:_singleClickGestureRecognizer.get()];
     [webView addGestureRecognizer:_doubleClickGestureRecognizer.get()];
     [webView addGestureRecognizer:_secondaryClickGestureRecognizer.get()];
-
-    // FIXME: Add drag press gesture after rdar://problem/176383341 is resolved.
+    [webView addGestureRecognizer:_dragPressGestureRecognizer.get()];
+    [webView addGestureRecognizer:_dragDeferringGestureRecognizer.get()];
 }
 
 - (void)enableGesturesIfNeeded
@@ -285,8 +329,7 @@ static WebCore::FloatSize toRawPlatformDelta(WebCore::FloatSize delta)
     [self enableGestureIfNeeded:_singleClickGestureRecognizer.get()];
     [self enableGestureIfNeeded:_doubleClickGestureRecognizer.get()];
     [self enableGestureIfNeeded:_secondaryClickGestureRecognizer.get()];
-
-    // FIXME: Enable drag press gesture after rdar://problem/176383341 is resolved.
+    [self enableGestureIfNeeded:_dragPressGestureRecognizer.get()];
 }
 
 - (void)enableGestureIfNeeded:(NSGestureRecognizer *)gesture
@@ -573,15 +616,211 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     }
 }
 
-#pragma mark - Drag Press Gesture
+#pragma mark - WKDeferringGestureRecognizerDelegate
 
-- (void)setUpDragPressGestureRecognizer
+- (BOOL)deferringGestureRecognizer:(WKDeferringGestureRecognizer *)deferringGestureRecognizer shouldDeferOtherGestureRecognizer:(NSGestureRecognizer *)gestureRecognizer
 {
-    _dragPressGestureRecognizer = adoptNS([[NSPressGestureRecognizer alloc] initWithTarget:self action:@selector(dragPressGestureRecognized:)]);
-    [self configureForDragPress:_dragPressGestureRecognizer.get()];
-    [_dragPressGestureRecognizer setDelegate:self];
-    [_dragPressGestureRecognizer setName:@"WKDragPressGesture"];
+    CheckedPtr viewImpl = _viewImpl.get();
+    if (!viewImpl)
+        return NO;
+
+    RetainPtr webView = viewImpl->view();
+    if (!webView)
+        return NO;
+
+    for (NSGestureRecognizer *textSelectionGesture in [[webView textSelectionManager] gesturesForFailureRequirements]) {
+        if (gestureRecognizer == textSelectionGesture)
+            return deferringGestureRecognizer == _dragDeferringGestureRecognizer;
+    }
+
+    return NO;
 }
+
+- (BOOL)deferringGestureRecognizer:(WKDeferringGestureRecognizer *)deferringGestureRecognizer shouldDeferGesturesForEventThatWillBeginAction:(NSEvent *)event
+{
+    CheckedPtr viewImpl = _viewImpl.get();
+    if (!viewImpl)
+        return NO;
+
+    RetainPtr webView = viewImpl->view();
+    if (!webView)
+        return NO;
+
+    if (deferringGestureRecognizer == _dragDeferringGestureRecognizer) {
+        NSPoint locationInView = [webView convertPoint:[event locationInWindow] fromView:nil];
+        if (viewImpl->isTextSelectedAtPoint(locationInView)) {
+            WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(RefPtr { _page.get() }->logIdentifier(), "Drag deferral: not deferring; text already selected at %@", NSStringFromPoint(locationInView));
+            return NO;
+        }
+
+        WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(RefPtr { _page.get() }->logIdentifier(), "Drag deferral: deferring; awaiting position info at %@", NSStringFromPoint(locationInView));
+
+        WebKit::InteractionInformationRequest request { WebCore::IntPoint { locationInView } };
+        [self doAfterPositionInformationUpdate:[weakSelf = WeakObjCPtr<WKAppKitGestureController>(self), weakDeferring = WeakObjCPtr<WKDeferringGestureRecognizer>(deferringGestureRecognizer)](const auto& info) {
+            RetainPtr strongSelf = weakSelf.get();
+            RetainPtr strongDeferring = weakDeferring.get();
+            if (!strongSelf || !strongDeferring)
+                return;
+
+            auto deferralState = [strongDeferring state];
+            if (deferralState != NSGestureRecognizerStatePossible) {
+                WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(RefPtr { strongSelf->_page.get() }->logIdentifier(),
+                    "Drag deferral: position info arrived after deferring gesture exited Possible (state=%ld); skipping resolution", static_cast<long>(deferralState));
+                return;
+            }
+            bool isDraggable = representsDraggableElement(info);
+            WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(RefPtr { strongSelf->_page.get() }->logIdentifier(),
+                "Drag deferral resolved: isDraggable=%d (link=%d image=%d attachment=%d dhtml=%d color=%d prefersDrag=%d)",
+                isDraggable, info.isLink, info.isImage, info.isAttachment, info.isDHTMLDraggable, info.isColorInput, info.prefersDraggingOverTextSelection);
+            [strongDeferring endDeferralShouldPreventGestures:isDraggable];
+        } forRequest:request];
+
+        return YES;
+    }
+
+    return NO;
+}
+
+- (void)deferringGestureRecognizer:(WKDeferringGestureRecognizer *)deferringGestureRecognizer didEndActionWithEvent:(NSEvent *)event
+{
+    if (deferringGestureRecognizer.state != NSGestureRecognizerStatePossible)
+        return;
+
+    if (deferringGestureRecognizer == _dragDeferringGestureRecognizer) {
+        WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(RefPtr { _page.get() }->logIdentifier(), "Drag deferral: press ended before position info arrived; unblocking text selection");
+        if (auto abandonedRequest = std::exchange(_lastOutstandingPositionInformationRequest, std::nullopt)) {
+            for (auto& slot : _pendingPositionInformationHandlers) {
+                if (slot && slot->request.isValidForRequest(*abandonedRequest))
+                    slot.reset();
+            }
+        }
+    }
+
+    [deferringGestureRecognizer endDeferralShouldPreventGestures:NO];
+}
+
+- (void)deferringGestureRecognizer:(WKDeferringGestureRecognizer *)deferringGestureRecognizer didTransitionToState:(NSGestureRecognizerState)state
+{
+}
+
+#pragma mark - Position Information
+
+- (void)_invalidateCurrentPositionInformation
+{
+    _hasValidPositionInformation = false;
+    _positionInformation = { };
+}
+
+- (void)didCommitLoadForMainFrame
+{
+    [self _invalidateCurrentPositionInformation];
+}
+
+- (void)requestAsynchronousPositionInformationUpdate:(WebKit::InteractionInformationRequest)request
+{
+    if ([self _currentPositionInformationIsValidForRequest:request])
+        return;
+
+    RefPtr page = _page.get();
+    if (!page || !page->hasRunningProcess())
+        return;
+
+    _lastOutstandingPositionInformationRequest = request;
+    page->requestPositionInformation(request);
+}
+
+- (void)doAfterPositionInformationUpdate:(Function<void(const WebKit::InteractionInformationAtPosition&)>&&)handler forRequest:(WebKit::InteractionInformationRequest)request
+{
+    if ([self _currentPositionInformationIsValidForRequest:request]) {
+        handler(_positionInformation);
+        return;
+    }
+
+    _pendingPositionInformationHandlers.constructAndAppend(std::in_place, request, WTF::move(handler));
+
+    if (![self _hasValidOutstandingPositionInformationRequest:request])
+        [self requestAsynchronousPositionInformationUpdate:request];
+}
+
+- (BOOL)_currentPositionInformationIsValidForRequest:(const WebKit::InteractionInformationRequest&)request
+{
+    return _hasValidPositionInformation && _positionInformation.request.isValidForRequest(request);
+}
+
+- (BOOL)_hasValidOutstandingPositionInformationRequest:(const WebKit::InteractionInformationRequest&)request
+{
+    return _lastOutstandingPositionInformationRequest.and_then([&request](const auto& outstandingRequest) -> std::optional<bool> {
+        return outstandingRequest.isValidForRequest(request);
+    }).value_or(false);
+}
+
+- (void)_invokeAndRemovePendingHandlersValidForCurrentPositionInformation
+{
+    ASSERT(_hasValidPositionInformation);
+
+    ++_positionInformationCallbackDepth;
+    auto updatedPositionInformation = _positionInformation;
+
+    for (size_t index = 0; index < _pendingPositionInformationHandlers.size(); ++index) {
+        auto& slot = _pendingPositionInformationHandlers[index];
+        if (!slot)
+            continue;
+        if (![self _currentPositionInformationIsValidForRequest:slot->request])
+            continue;
+
+        auto requestAndHandler = std::exchange(slot, std::nullopt);
+        if (requestAndHandler->callback)
+            requestAndHandler->callback(updatedPositionInformation);
+    }
+
+    if (--_positionInformationCallbackDepth)
+        return;
+
+    for (int index = _pendingPositionInformationHandlers.size() - 1; index >= 0; --index) {
+        if (!_pendingPositionInformationHandlers[index])
+            _pendingPositionInformationHandlers.removeAt(index);
+    }
+}
+
+- (void)positionInformationDidChange:(const WebKit::InteractionInformationAtPosition&)info
+{
+    // Handlers run in `_invokeAndRemovePendingHandlersValidForCurrentPositionInformation`
+    // can re-enter into client code (e.g. UI delegate callbacks), which may release
+    // the WKWebView and tear `self` down before this method returns.
+    RetainPtr protectedSelf = self;
+
+    if (_lastOutstandingPositionInformationRequest && info.request.isValidForRequest(*_lastOutstandingPositionInformationRequest))
+        _lastOutstandingPositionInformationRequest = std::nullopt;
+
+    auto newInfo = info;
+    newInfo.mergeCompatibleOptionalInformation(_positionInformation);
+
+    _positionInformation = newInfo;
+    _hasValidPositionInformation = _positionInformation.canBeValid;
+
+    [self _invokeAndRemovePendingHandlersValidForCurrentPositionInformation];
+}
+
+- (BOOL)_dragPressShouldBeginAtLocation:(NSPoint)locationInViewCoordinates
+{
+    WebKit::InteractionInformationRequest request { WebCore::IntPoint { locationInViewCoordinates } };
+    int radius = static_cast<int>(std::ceil([_dragPressGestureRecognizer allowableMovement]));
+    // FIXME: Migrate to requestDragStart: IPC for an authoritative decision.
+    // The heuristic below approximates DragController::draggableElement() by consulting the same element-type and style signals.
+    bool isDraggable = representsDraggableElement(_positionInformation);
+    bool requestIsValid = _hasValidPositionInformation && _positionInformation.request.isApproximatelyValidForRequest(request, radius);
+    bool shouldDrag = requestIsValid && isDraggable;
+    WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(RefPtr { _page.get() }->logIdentifier(),
+        "Drag-press shouldBegin → %d (hasInfo=%d link=%d image=%d attachment=%d dhtml=%d color=%d prefersDrag=%d radius=%d)",
+        shouldDrag, _hasValidPositionInformation,
+        _positionInformation.isLink, _positionInformation.isImage, _positionInformation.isAttachment,
+        _positionInformation.isDHTMLDraggable, _positionInformation.isColorInput, _positionInformation.prefersDraggingOverTextSelection, radius);
+    if (!requestIsValid)
+        [self _invalidateCurrentPositionInformation];
+    return shouldDrag;
+}
+
+#pragma mark - Drag Handling
 
 - (void)dragPressGestureRecognized:(NSGestureRecognizer *)gesture
 {
@@ -955,19 +1194,42 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 
 - (NSGestureRecognizer *)activeDragGestureRecognizer
 {
+    if (_textSelectionDragGesture)
+        return _textSelectionDragGesture.get();
     if (_dragGestureHasSentMouseDown)
         return _dragPressGestureRecognizer.get();
     return nil;
 }
 
+- (void)setTextSelectionDragGesture:(NSGestureRecognizer *)gesture completionHandler:(void (^)(NSDraggingSession *))completionHandler
+{
+    if (_textSelectionDragGesture) {
+        WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(RefPtr { _page.get() }->logIdentifier(),
+            "Replacing prior text-selection drag gesture %@ (completion handler set: %d); prior drag never reached setGestureDraggingSession:",
+            _textSelectionDragGesture.get(), !!_textSelectionDragCompletionHandler);
+        ASSERT_NOT_REACHED();
+    }
+
+    _textSelectionDragGesture = gesture;
+    _textSelectionDragCompletionHandler = makeBlockPtr(completionHandler);
+}
+
 - (void)setGestureDraggingSession:(NSDraggingSession *)session
 {
     _gestureDraggingSession = session;
+    if (!_gestureDraggingSession)
+        return;
+
+    WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(RefPtr { _page.get() }->logIdentifier(), "Drag session began");
+    if (auto handler = std::exchange(_textSelectionDragCompletionHandler, nullptr))
+        handler(_gestureDraggingSession);
 }
 
 - (void)clearGestureDragState
 {
     _gestureDraggingSession = nil;
+    _textSelectionDragGesture = nil;
+    _textSelectionDragCompletionHandler = nullptr;
     _dragGestureHasSentMouseDown = false;
 }
 
@@ -980,6 +1242,9 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     _isSuppressingSingleClickGestureForTextSelection = false;
     _latestClickID.reset();
     _layerTreeTransactionIdAtLastInteractionStart.reset();
+    [self _invalidateCurrentPositionInformation];
+    _lastOutstandingPositionInformationRequest.reset();
+    _pendingPositionInformationHandlers.clear();
 }
 
 #pragma mark - NSGestureRecognizerDelegate
@@ -1000,6 +1265,9 @@ static inline bool isSamePair(NSGestureRecognizer *a, NSGestureRecognizer *b, NS
     WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(RefPtr { _page.get() }->logIdentifier(), "Gesture: %@, Other gesture: %@", gestureRecognizer, otherGestureRecognizer);
 
     if (isSamePair(gestureRecognizer, otherGestureRecognizer, _singleClickGestureRecognizer.get(), _panGestureRecognizer.get()))
+        return YES;
+
+    if ([gestureRecognizer isKindOfClass:WKDeferringGestureRecognizer.class] || [otherGestureRecognizer isKindOfClass:WKDeferringGestureRecognizer.class])
         return YES;
 
     if (isSamePair(gestureRecognizer, otherGestureRecognizer, _mouseTrackingGestureRecognizer.get(), _singleClickGestureRecognizer.get()))
@@ -1051,8 +1319,10 @@ static inline bool isSamePair(NSGestureRecognizer *a, NSGestureRecognizer *b, NS
     if (!webView)
         return NO;
 
-    // Fail any gestures from the text selection manager if the secondary click GR handles them.
+    if (gestureRecognizer == _dragDeferringGestureRecognizer)
+        return [_dragDeferringGestureRecognizer shouldDeferGestureRecognizer:otherGestureRecognizer];
 
+    // Fail any gestures from the text selection manager if the secondary click GR handles them.
     for (NSGestureRecognizer *gestureForFailureRequirements in [[webView textSelectionManager] gesturesForFailureRequirements]) {
         if (gestureRecognizer == _secondaryClickGestureRecognizer && otherGestureRecognizer == gestureForFailureRequirements)
             return YES;
@@ -1093,9 +1363,12 @@ static inline bool isSamePair(NSGestureRecognizer *a, NSGestureRecognizer *b, NS
         return NO;
     }
 
-    if (gestureRecognizer == _singleClickGestureRecognizer || gestureRecognizer == _mouseTrackingGestureRecognizer) {
-        // The platform text selection interaction should handle any gestures on a selection.
+    if (gestureRecognizer == _singleClickGestureRecognizer || gestureRecognizer == _mouseTrackingGestureRecognizer || gestureRecognizer == _dragPressGestureRecognizer) {
         NSPoint locationInViewCoordinates = [gestureRecognizer locationInView:webView];
+
+        if (gestureRecognizer == _dragPressGestureRecognizer)
+            return [self _dragPressShouldBeginAtLocation:locationInViewCoordinates];
+
         return !viewImpl->isTextSelectedAtPoint(locationInViewCoordinates);
     }
 
@@ -1121,7 +1394,8 @@ static inline bool isSamePair(NSGestureRecognizer *a, NSGestureRecognizer *b, NS
 
     bool isOurClickGesture = preventingGestureRecognizer == _singleClickGestureRecognizer
         || preventingGestureRecognizer == _secondaryClickGestureRecognizer
-        || preventingGestureRecognizer == _mouseTrackingGestureRecognizer;
+        || preventingGestureRecognizer == _mouseTrackingGestureRecognizer
+        || preventingGestureRecognizer == _dragPressGestureRecognizer;
 
     if (!isOurClickGesture)
         return YES;

--- a/Source/WebKit/UIProcess/mac/WKTextSelectionController.swift
+++ b/Source/WebKit/UIProcess/mac/WKTextSelectionController.swift
@@ -184,31 +184,15 @@ extension WKTextSelectionController {
 
         Logger.viewGestures.log("[pageProxyID=\(page.logIdentifier())] \(#function) point: \(String(reflecting: point))")
 
-        let timestamp = GetCurrentEventTime()
         let windowNumber = impl.windowNumber()
 
-        let mouseDown = NSEvent.mouseEvent(
-            with: .rightMouseDown,
-            location: point,
-            modifierFlags: [],
-            timestamp: timestamp,
-            windowNumber: windowNumber,
-            context: nil,
-            eventNumber: 0,
-            clickCount: 1,
-            pressure: 1
-        )
-        let mouseUp = NSEvent.mouseEvent(
-            with: .rightMouseUp,
-            location: point,
-            modifierFlags: [],
-            timestamp: timestamp,
-            windowNumber: windowNumber,
-            context: nil,
-            eventNumber: 0,
-            clickCount: 1,
-            pressure: 0
-        )
+        guard
+            let mouseDown = NSEvent.syntheticMouseEvent(.rightMouseDown, location: point, windowNumber: windowNumber, pressure: 1),
+            let mouseUp = NSEvent.syntheticMouseEvent(.rightMouseUp, location: point, windowNumber: windowNumber, pressure: 0)
+        else {
+            assertionFailure("NSEvent.mouseEvent(with:...) returned nil for context-menu synthesis")
+            return
+        }
 
         impl.mouseDown(mouseDown, .Automation)
         impl.mouseUp(mouseUp, .Automation)
@@ -216,11 +200,95 @@ extension WKTextSelectionController {
 
     @objc(dragSelectionWithGesture:completionHandler:)
     func dragSelection(withGesture gesture: NSGestureRecognizer, completionHandler: @escaping @Sendable (NSDraggingSession) -> Void) {
-        guard let page = view._protectedPage().get() else {
+        guard let page = view._protectedPage().get(), let impl = view._impl() else {
             return
         }
 
         Logger.viewGestures.log("[pageProxyID=\(page.logIdentifier())] \(#function) gesture: \(String(reflecting: gesture))")
+
+        let locationInWindow = gesture.location(in: nil)
+        let windowNumber = impl.windowNumber()
+        let modifierFlags = gesture.modifierFlags
+
+        let mouseDown = NSEvent.syntheticMouseEvent(
+            .leftMouseDown,
+            location: locationInWindow,
+            modifierFlags: modifierFlags,
+            windowNumber: windowNumber,
+            pressure: 1
+        )
+        let mouseDragged = NSEvent.syntheticMouseEvent(
+            .leftMouseDragged,
+            location: locationInWindow,
+            modifierFlags: modifierFlags,
+            windowNumber: windowNumber,
+            pressure: 1
+        )
+
+        guard let mouseDown, let mouseDragged else {
+            assertionFailure("NSEvent.mouseEvent(with:...) returned nil for drag-selection synthesis")
+            return
+        }
+
+        impl.setTextSelectionDragGesture(gesture) { session in
+            guard let session else { return }
+            completionHandler(session)
+        }
+
+        impl.mouseDown(mouseDown, .Automation, .Yes)
+        impl.mouseDragged(mouseDragged, .Automation, .Yes)
+
+        gesture.addTarget(self, action: #selector(textSelectionDragGestureUpdated(_:)))
+    }
+
+    @objc
+    private func textSelectionDragGestureUpdated(_ gesture: NSGestureRecognizer) {
+        guard let impl = view._impl() else {
+            gesture.removeTarget(self, action: #selector(textSelectionDragGestureUpdated(_:)))
+            return
+        }
+
+        let locationInWindow = gesture.location(in: nil)
+        let windowNumber = impl.windowNumber()
+        let modifierFlags = gesture.modifierFlags
+
+        switch gesture.state {
+        case .changed:
+            guard
+                let mouseDragged = NSEvent.syntheticMouseEvent(
+                    .leftMouseDragged,
+                    location: locationInWindow,
+                    modifierFlags: modifierFlags,
+                    windowNumber: windowNumber,
+                    pressure: 1
+                )
+            else {
+                assertionFailure("NSEvent.mouseEvent(with:...) returned nil for drag-update synthesis")
+                return
+            }
+
+            impl.mouseDragged(mouseDragged, .Automation, .Yes)
+
+        case .ended, .cancelled, .failed:
+            guard
+                let mouseUp = NSEvent.syntheticMouseEvent(
+                    .leftMouseUp,
+                    location: locationInWindow,
+                    modifierFlags: modifierFlags,
+                    windowNumber: windowNumber,
+                    pressure: 0
+                )
+            else {
+                assertionFailure("NSEvent.mouseEvent(with:...) returned nil for drag-end synthesis")
+                break
+            }
+
+            impl.mouseUp(mouseUp, .Automation, .Yes)
+            gesture.removeTarget(self, action: #selector(textSelectionDragGestureUpdated(_:)))
+
+        default:
+            break
+        }
     }
 
     @objc(beginRangeSelectionAtPoint:withGranularity:)
@@ -299,6 +367,28 @@ extension WebCore.TextGranularity {
             case .paragraph: .ParagraphGranularity
             @unknown default: .CharacterGranularity
             }
+    }
+}
+
+extension NSEvent {
+    fileprivate static func syntheticMouseEvent(
+        _ type: NSEvent.EventType,
+        location: NSPoint,
+        modifierFlags: NSEvent.ModifierFlags = [],
+        windowNumber: Int,
+        pressure: Float
+    ) -> NSEvent? {
+        NSEvent.mouseEvent(
+            with: type,
+            location: location,
+            modifierFlags: modifierFlags,
+            timestamp: GetCurrentEventTime(),
+            windowNumber: windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: pressure
+        )
     }
 }
 

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.h
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.h
@@ -600,6 +600,7 @@ public:
 
     NSDragOperation dragSourceOperationMask(NSDraggingSession *, NSDraggingContext);
     void draggingSessionEnded(NSDraggingSession *, NSPoint, NSDragOperation);
+    void cancelDrag();
 
     NSString *fileNameForFilePromiseProvider(NSFilePromiseProvider *, NSString *fileType);
     void writeToURLForFilePromiseProvider(NSFilePromiseProvider *, NSURL *, void(^)(NSError *));
@@ -630,6 +631,9 @@ public:
     ViewGestureController& ensureGestureController();
 #if HAVE(APPKIT_GESTURES_SUPPORT)
     WKAppKitGestureController *appKitGestureController() const LIFETIME_BOUND { return m_appKitGestureController.get(); }
+    void setTextSelectionDragGesture(NSGestureRecognizer *, void (^completionHandler)(NSDraggingSession *));
+    void invalidateCachedPositionInformation();
+    void positionInformationDidChange(const InteractionInformationAtPosition&);
 #endif
     void NODELETE setAllowsBackForwardNavigationGestures(bool);
     bool allowsBackForwardNavigationGestures() const { return m_allowsBackForwardNavigationGestures; }

--- a/Source/WebKit/UIProcess/mac/WebViewImpl.mm
+++ b/Source/WebKit/UIProcess/mac/WebViewImpl.mm
@@ -4703,6 +4703,14 @@ void WebViewImpl::draggingSessionEnded(NSDraggingSession *, NSPoint endPoint, NS
 #endif
 }
 
+void WebViewImpl::cancelDrag()
+{
+    m_page->dragCancelled();
+#if HAVE(APPKIT_GESTURES_SUPPORT)
+    [appKitGestureController() clearGestureDragState];
+#endif
+}
+
 #endif // ENABLE(DRAG_SUPPORT)
 
 void WebViewImpl::startWindowDrag()
@@ -4714,7 +4722,7 @@ void WebViewImpl::startDrag(const WebCore::DragItem& item, ShareableBitmap::Hand
 {
     auto dragImageAsBitmap = ShareableBitmap::create(WTF::move(dragImageHandle));
     if (!dragImageAsBitmap) {
-        m_page->dragCancelled();
+        cancelDrag();
         return;
     }
 
@@ -4757,7 +4765,7 @@ void WebViewImpl::startDrag(const WebCore::DragItem& item, ShareableBitmap::Hand
             bool missingDragInitiator = !lastMouseDownEvent;
 #endif
             if (missingDragInitiator) {
-                page->dragCancelled();
+                protectedThis->cancelDrag();
                 return;
             }
 
@@ -4772,13 +4780,13 @@ void WebViewImpl::startDrag(const WebCore::DragItem& item, ShareableBitmap::Hand
             if (promisedAttachmentInfo) {
                 RefPtr attachment = page->attachmentForIdentifier(promisedAttachmentInfo.attachmentIdentifier);
                 if (!attachment) {
-                    page->dragCancelled();
+                    protectedThis->cancelDrag();
                     return;
                 }
 
                 RetainPtr utiType = attachment->utiType().createNSString();
                 if (![utiType length]) {
-                    page->dragCancelled();
+                    protectedThis->cancelDrag();
                     return;
                 }
 
@@ -4814,8 +4822,7 @@ void WebViewImpl::startDrag(const WebCore::DragItem& item, ShareableBitmap::Hand
                 RetainPtr session = [view beginDraggingSessionWithItems:@[ draggingItem ] gesture:gesture source:static_cast<id<NSDraggingSource>>(view.get())];
                 [gestureController setGestureDraggingSession:session.get()];
                 if (!session) {
-                    page->dragCancelled();
-                    [gestureController clearGestureDragState];
+                    protectedThis->cancelDrag();
                     return;
                 }
             } else
@@ -7720,6 +7727,21 @@ void WebViewImpl::addTextSelectionManager()
 bool WebViewImpl::isTextSelectedAtPoint(NSPoint point)
 {
     return [m_textSelectionController isTextSelectedAtPoint:point];
+}
+
+void WebViewImpl::setTextSelectionDragGesture(NSGestureRecognizer *gesture, void (^completionHandler)(NSDraggingSession *))
+{
+    [m_appKitGestureController setTextSelectionDragGesture:gesture completionHandler:completionHandler];
+}
+
+void WebViewImpl::invalidateCachedPositionInformation()
+{
+    [m_appKitGestureController didCommitLoadForMainFrame];
+}
+
+void WebViewImpl::positionInformationDidChange(const InteractionInformationAtPosition& info)
+{
+    [m_appKitGestureController positionInformationDidChange:info];
 }
 
 void WebViewImpl::beginSuppressingSingleClickGestureForTextSelection()

--- a/Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptMessages.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptMessages.swift
@@ -163,6 +163,9 @@ extension JavaScriptMessages {
         public static var expression: String {
             """
             const selection = getSelection();
+            if (selection.rangeCount === 0 || selection.anchorNode === null) {
+                return { "kind": "none" };
+            }
             if (selection.isCollapsed) {
                 return {
                     "kind": "collapsed",

--- a/Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptTypes.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptTypes.swift
@@ -51,6 +51,9 @@ public enum JavaScriptSelection: Sendable, Equatable {
         }
     }
 
+    /// No current selection.
+    case none
+
     /// A collapsed selection.
     case collapsed(Position)
 
@@ -91,6 +94,10 @@ extension JavaScriptSelection: WebPage.JavaScriptEncodable {
     // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
     public func encoded() -> [String: Any?] {
         switch self {
+        case .none:
+            [
+                "kind": "none"
+            ]
         case .collapsed(let position):
             [
                 "kind": "collapsed",
@@ -115,6 +122,9 @@ extension JavaScriptSelection: WebPage.JavaScriptDecodable {
         }
 
         switch kind {
+        case "none":
+            self = .none
+
         case "collapsed":
             guard
                 let position = decodedRepresentation["position"] as? [String: Any?],

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift
@@ -362,6 +362,165 @@ struct AppKitGesturesTests {
         let expected = "Here's to the cra".count
         #expect(selection == expected)
     }
+
+    // MARK: - Drag Press Disambiguation Tests
+
+    @Test(
+        .bug("rdar://176317069", "REGRESSION(312023@main): Text cannot be selected with press + drag gesture"),
+        arguments: [true, false]
+    )
+    func pressDragOverTextCreatesSelection(contentEditable: Bool) async throws {
+        try await loadHTML(contentEditable: contentEditable)
+
+        let toBounds = try await screenBoundsOfText("to")
+        let crazyBounds = try await screenBoundsOfText("crazy")
+
+        try await page.callJavaScript(JavaScriptMessages.SetSelection(in: "div", offset: 0))
+        await page.waitForNextPresentationUpdate()
+
+        guard NSApp.isActive else { return }
+
+        await recap.play { composer in
+            composer._wk_drag(
+                withStart: toBounds.center,
+                end: crazyBounds.center,
+                duration: .seconds(1.5),
+                pressAndWait: .seconds(1.0)
+            )
+        }
+
+        await page.waitForNextPresentationUpdate()
+
+        let selection = try await page.callJavaScript(JavaScriptMessages.GetSelection())
+
+        if contentEditable {
+            // In editable text the gesture moves the insertion point rather
+            // than creating a range selection. Verify the caret moved away
+            // from the offset 0 we set above.
+            guard case .collapsed(let position) = selection else {
+                Issue.record("expected press-drag to leave a collapsed selection (caret) in editable text, got \(selection)")
+                return
+            }
+            #expect(position.container == "div")
+            #expect(position.offset > 0)
+        } else {
+            guard case .range = selection else {
+                Issue.record("expected press-drag to create a range selection in non-editable text, got \(selection)")
+                return
+            }
+        }
+    }
+
+    @Test(
+        .bug("rdar://176317069", "REGRESSION(312023@main): Text cannot be selected with press + drag gesture")
+    )
+    func pressDragOnLinkInitiatesDragAndDrop() async throws {
+        let html = """
+            <a id="link" href="https://webkit.org" style="font-size: 30px; display: block;">WebKit Link</a>
+            """
+        try await page.load(html: html).wait()
+
+        let linkRange = try #require("WebKit Link".utf16Range(of: "WebKit Link"))
+        let linkBounds = try await {
+            let viewportCoordinates = try await page.callJavaScript(
+                JavaScriptMessages.BoundingClientRect(in: "link", range: linkRange)
+            )
+            return convertToCoreGraphicsScreenCoordinates(
+                rectInViewportCoordinates: viewportCoordinates,
+                window: window
+            )
+        }()
+
+        let dragEnd = CGPoint(x: linkBounds.maxX + 50, y: linkBounds.midY)
+
+        guard NSApp.isActive else { return }
+
+        let dragInitiated = Future()
+
+        let implementation: @convention(block) (NSView, NSArray, NSGestureRecognizer, AnyObject) -> NSDraggingSession? = { _, _, _, _ in
+            dragInitiated.signal()
+            return NSDraggingSession()
+        }
+
+        try await withSwizzledObjectiveCInstanceMethod(
+            replacing: NSView.self,
+            name: #selector(NSView.beginDraggingSession(items:gesture:source:)),
+            with: implementation
+        ) {
+            await recap.play { composer in
+                composer._wk_drag(
+                    withStart: linkBounds.center,
+                    end: dragEnd,
+                    duration: .seconds(1.5),
+                    pressAndWait: .seconds(1.0)
+                )
+            }
+
+            await dragInitiated.wait()
+        }
+
+        await page.waitForNextPresentationUpdate()
+
+        let selection = try await page.callJavaScript(JavaScriptMessages.GetSelection())
+        #expect(selection == JavaScriptSelection.none)
+    }
+
+    @Test(
+        .bug("rdar://176317069", "REGRESSION(312023@main): Text cannot be selected with press + drag gesture")
+    )
+    func pressDragOnExistingSelectionDoesNotExtendSelection() async throws {
+        try await loadHTML(contentEditable: false)
+
+        let crazyRange = try #require(Self.text.utf16Range(of: "crazy"))
+        let onesRange = try #require(Self.text.utf16Range(of: "ones"))
+        let crazySelection = JavaScriptSelection.range(
+            base: .init(in: "div", at: crazyRange.lowerBound),
+            extent: .init(in: "div", at: crazyRange.upperBound)
+        )
+        try await page.callJavaScript(JavaScriptMessages.SetSelection(crazySelection))
+        await page.waitForNextPresentationUpdate()
+
+        let crazyBounds = try await screenBoundsOfText("crazy")
+        let onesBounds = try await screenBoundsOfText("ones")
+
+        guard NSApp.isActive else { return }
+
+        let dragInitiated = Future()
+
+        let implementation: @convention(block) (NSView, NSArray, NSGestureRecognizer, AnyObject) -> NSDraggingSession? = { _, _, _, _ in
+            dragInitiated.signal()
+            return NSDraggingSession()
+        }
+
+        try await withSwizzledObjectiveCInstanceMethod(
+            replacing: NSView.self,
+            name: #selector(NSView.beginDraggingSession(items:gesture:source:)),
+            with: implementation
+        ) {
+            await recap.play { composer in
+                composer._wk_drag(
+                    withStart: crazyBounds.center,
+                    end: onesBounds.center,
+                    duration: .seconds(1.5),
+                    pressAndWait: .seconds(1.0)
+                )
+            }
+
+            await dragInitiated.wait()
+        }
+
+        await page.waitForNextPresentationUpdate()
+
+        let selection = try await page.callJavaScript(JavaScriptMessages.GetSelection())
+
+        #expect(
+            selection
+                != .range(
+                    base: .init(in: "div", at: crazyRange.lowerBound),
+                    extent: .init(in: "div", at: onesRange.upperBound)
+                )
+        )
+    }
 }
 
 // MARK: Helpers


### PR DESCRIPTION
#### 26475c7bd8ca76d414f8723243d61a7637907301
<pre>
[AppKit Gestures] Disambiguate drag-and-drop from text selection during press-and-drag
<a href="https://bugs.webkit.org/show_bug.cgi?id=314870">https://bugs.webkit.org/show_bug.cgi?id=314870</a>
<a href="https://rdar.apple.com/176383341">rdar://176383341</a>

Reviewed by Richard Robinson.

Currently, any draggable element (link, image, `draggable=&quot;true&quot;`, etc.)
is siltently ignored in favor of text selection extensions when starting
a press-and-drag interaction. This is because NSTextSelectionManager
gestures recognize before WebKit can disambiguate this interaction.

This patch builds on top of 312982@main, which ported over async gesture
gates for AppKit gesture recognizers. We use this gesture to defer the
text selection gestures until the web process has reported the hit-test
content. On response, the deferring gesture either fails and lets the
text selection gestures proceed or transitions to .Ended, excluding the
text selection gestures and letting our drag press gesture win. We allow
our drag press gesture to win when the hit test reports draggable
content the press point.

In service of this patch, we also refactor text selection drag-and-drops.
Concretely, we let WKTextSelectionController launder the gesture it is
provided by NSTextSelectionManager via setTextSelectionDragGesture:...,
whose state is then read to perform the same mouseDown/Dragged sequences
we do elsewhere (to invoke drag-and-drop).

Non-exhaustive list of important changes, all made to solve this gesture
disambiguation problem:

- WKAppKitGestureController gains a position-information cache modeled
after the one in WKContentViewInteraction. Pending handlers are paired
with the request they were enqueued for, and only fire when the arriving
info matches.

- WebViewImpl::cancelDrag() consolidates the drag-cancel cleanup
(canceling the WebProcess drag and clearing the gesture controller&apos;s
drag state) so each early-return path in WebViewImpl::startDrag clears
both consistently.

Test: AppKitGesturesTests.pressDragOverTextCreatesSelection
      AppKitGesturesTests.pressDragOnLinkInitiatesDragAndDrop
      AppKitGesturesTests.pressDragOnExistingSelectionDoesNotExtendSelection

* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::didCommitLoadForMainFrame):
(WebKit::PageClientImpl::positionInformationDidChange):
* Source/WebKit/UIProcess/mac/WKAppKitGestureController.h:
* Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm:
(representsDraggableElement):
(-[WKAppKitGestureController setUpGestureRecognizers]):
(-[WKAppKitGestureController setUpDragPressGestureRecognizer]):
(-[WKAppKitGestureController setUpDragDeferringGestureRecognizer]):
(-[WKAppKitGestureController addGesturesToWebView]):
(-[WKAppKitGestureController enableGesturesIfNeeded]):
(-[WKAppKitGestureController deferringGestureRecognizer:shouldDeferOtherGestureRecognizer:]):
(-[WKAppKitGestureController deferringGestureRecognizer:shouldDeferGesturesForEventThatWillBeginAction:]):
(-[WKAppKitGestureController deferringGestureRecognizer:didEndActionWithEvent:]):
(-[WKAppKitGestureController deferringGestureRecognizer:didTransitionToState:]):
(-[WKAppKitGestureController _invalidateCurrentPositionInformation]):
(-[WKAppKitGestureController didCommitLoadForMainFrame]):
(-[WKAppKitGestureController requestAsynchronousPositionInformationUpdate:]):
(-[WKAppKitGestureController doAfterPositionInformationUpdate:forRequest:]):
(-[WKAppKitGestureController _currentPositionInformationIsValidForRequest:]):
(-[WKAppKitGestureController _hasValidOutstandingPositionInformationRequest:]):
(-[WKAppKitGestureController _invokeAndRemovePendingHandlersValidForCurrentPositionInformation]):
(-[WKAppKitGestureController positionInformationDidChange:]):
(-[WKAppKitGestureController _dragPressShouldBeginAtLocation:]):
(-[WKAppKitGestureController activeDragGestureRecognizer]):
(-[WKAppKitGestureController setTextSelectionDragGesture:completionHandler:]):
(-[WKAppKitGestureController setGestureDraggingSession:]):
(-[WKAppKitGestureController clearGestureDragState]):
(-[WKAppKitGestureController reset]):
(-[WKAppKitGestureController gestureRecognizer:shouldRecognizeSimultaneouslyWithGestureRecognizer:]):
(-[WKAppKitGestureController gestureRecognizer:shouldBeRequiredToFailByGestureRecognizer:]):
(-[WKAppKitGestureController gestureRecognizerShouldBegin:]):
(-[WKAppKitGestureController _gestureRecognizer:canPreventGestureRecognizer:]):
* Source/WebKit/UIProcess/mac/WKTextSelectionController.swift:
(WKTextSelectionController.showContextMenu(at:)):
(WKTextSelectionController.dragSelection(withGesture:completionHandler:)):
(WKTextSelectionController.textSelectionDragGestureUpdated(_:)):
* Source/WebKit/UIProcess/mac/WebViewImpl.h:
* Source/WebKit/UIProcess/mac/WebViewImpl.mm:
(WebKit::WebViewImpl::cancelDrag):
(WebKit::WebViewImpl::startDrag):
(WebKit::WebViewImpl::setTextSelectionDragGesture):
(WebKit::WebViewImpl::invalidateCachedPositionInformation):
(WebKit::WebViewImpl::positionInformationDidChange):
* Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptMessages.swift:
(GetSelection.expression):
  Address a minor latest issue with the selection JS helper. It is
  possible for non-editable content to have _no_ selection at all (i.e.
  anchorNode === null and rangeCount === 0). In these cases, we were
  still unconditionally accessing selection.acnhorNode.parentElement,
  which threw a JS eval exception. Instead, we want to encode this as a
  `.none` case in JavaScriptSelection, which we can then incorporate in
  the pressDragOnLinkInitiatesDragAndDrop test.
* Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptTypes.swift:
(JavaScriptSelection.encoded):
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift:
(AppKitGesturesTests.pressDragOverTextCreatesSelection(_:)):
(AppKitGesturesTests.pressDragOnLinkInitiatesDragAndDrop):
(AppKitGesturesTests.pressDragOnExistingSelectionDoesNotExtendSelection):

Canonical link: <a href="https://commits.webkit.org/313504@main">https://commits.webkit.org/313504@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61281480175000c5963bc83dbc22b1208035c4de

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163240 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36721 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29938 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172179 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119687 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/03b833e3-14b4-4636-a001-a74a95ddc2c6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165109 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37049 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36722 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126756 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89352 "5 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b922fc25-ba89-4078-976c-e2801cb836f2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166199 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29028 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146753 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107323 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c8b56182-f219-49a5-8b1c-ca1c5bf13a5c) 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/162561 "Build is in progress. Recent messages:") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26702 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19880 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137967 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24477 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174682 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/26868 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26132 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135061 "Passed tests") | | 
| [⏳ 🧪 services ](https://ews-build.webkit.org/#/builders/Services-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36391 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30804 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135053 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37177 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146272 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99090 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24852 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30356 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23116 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35887 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108274 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35386 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1141 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35633 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35533 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->