### PR TITLE
[WPE] Add support for using skia compositor with the legacy API

### DIFF
--- a/Source/WebCore/platform/graphics/PlatformDisplay.h
+++ b/Source/WebCore/platform/graphics/PlatformDisplay.h
@@ -114,6 +114,7 @@ public:
 
 #if USE(SKIA)
     GLContext* skiaGLContext();
+    void setSkiaGLContextForCurrentThread(std::unique_ptr<GLContext>&&);
     GrDirectContext* skiaGrContext() const;
     unsigned msaaSampleCount() const;
 #endif

--- a/Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp
@@ -236,6 +236,11 @@ public:
         return adoptRef(*new SkiaGLContext(display));
     }
 
+    static Ref<SkiaGLContext> create(std::unique_ptr<GLContext>&& glContext)
+    {
+        return adoptRef(*new SkiaGLContext(WTF::move(glContext)));
+    }
+
     ~SkiaGLContext()
     {
         if (m_skiaGLContext) {
@@ -264,8 +269,12 @@ public:
 
 private:
     explicit SkiaGLContext(PlatformDisplay& display)
+        : SkiaGLContext(GLContext::createOffscreen(display))
     {
-        auto glContext = GLContext::createOffscreen(display);
+    }
+
+    explicit SkiaGLContext(std::unique_ptr<GLContext>&& glContext)
+    {
         if (!glContext || !glContext->makeContextCurrent())
             return;
 
@@ -301,6 +310,13 @@ GLContext* PlatformDisplay::skiaGLContext()
     // the current thread so Skia cannot use OpenGL with coordinated graphics.
     return nullptr;
 #endif
+}
+
+void PlatformDisplay::setSkiaGLContextForCurrentThread(std::unique_ptr<GLContext>&& glContext)
+{
+    ASSERT(!s_skiaGLContext);
+    s_skiaGLContext = SkiaGLContext::create(WTF::move(glContext));
+    m_skiaGLContexts.add(*s_skiaGLContext);
 }
 
 GrDirectContext* PlatformDisplay::skiaGrContext() const

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
@@ -46,6 +46,9 @@
 
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkCanvas.h>
+#include <skia/gpu/ganesh/GrBackendSurface.h>
+#include <skia/gpu/ganesh/SkSurfaceGanesh.h>
+#include <skia/gpu/ganesh/gl/GrGLBackendSurface.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 #if PLATFORM(GTK) || ENABLE(WPE_PLATFORM)
@@ -533,6 +536,7 @@ std::unique_ptr<AcceleratedSurface::RenderTarget> AcceleratedSurface::RenderTarg
 
 AcceleratedSurface::RenderTargetWPEBackend::RenderTargetWPEBackend(AcceleratedSurface& surface, const IntSize& initialSize, UnixFileDescriptor&& hostFD)
     : RenderTarget(surface)
+    , m_size(initialSize)
 {
     ASSERT(hostFD, "RenderTargetWPEBackend created with invalid host FD");
     m_backend = wpe_renderer_backend_egl_target_create(hostFD.release());
@@ -550,7 +554,7 @@ AcceleratedSurface::RenderTargetWPEBackend::RenderTargetWPEBackend(AcceleratedSu
     };
     wpe_renderer_backend_egl_target_set_client(m_backend, &s_client, const_cast<AcceleratedSurface*>(&surface));
     wpe_renderer_backend_egl_target_initialize(m_backend, downcast<PlatformDisplayLibWPE>(PlatformDisplay::sharedDisplay()).backend(),
-        std::max(1, initialSize.width()), std::max(1, initialSize.height()));
+        std::max(1, m_size.width()), std::max(1, m_size.height()));
 }
 
 AcceleratedSurface::RenderTargetWPEBackend::~RenderTargetWPEBackend()
@@ -577,11 +581,27 @@ uint64_t AcceleratedSurface::RenderTargetWPEBackend::window() const
 
 void AcceleratedSurface::RenderTargetWPEBackend::resize(const IntSize& size)
 {
-    wpe_renderer_backend_egl_target_resize(m_backend, std::max(1, size.width()), std::max(1, size.height()));
+    m_size = size;
+    wpe_renderer_backend_egl_target_resize(m_backend, std::max(1, m_size.width()), std::max(1, m_size.height()));
+    m_skiaSurface = nullptr;
 }
 
 void AcceleratedSurface::RenderTargetWPEBackend::willRenderFrame()
 {
+    if (m_surface->useSkia() && !m_skiaSurface) {
+        GLint stencilBits;
+        glGetIntegerv(GL_STENCIL_BITS, &stencilBits);
+        GLint fbo;
+        glGetIntegerv(GL_FRAMEBUFFER_BINDING, &fbo);
+
+        GrGLFramebufferInfo fbInfo;
+        fbInfo.fFBOID = fbo;
+        fbInfo.fFormat = GL_RGBA8;
+        GrBackendRenderTarget renderTargetSkia = GrBackendRenderTargets::MakeGL(m_size.width(), m_size.height(), 0, stencilBits, fbInfo);
+        auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
+        RELEASE_ASSERT(grContext);
+        m_skiaSurface = SkSurfaces::WrapBackendRenderTarget(grContext, renderTargetSkia, kBottomLeft_GrSurfaceOrigin, kRGBA_8888_SkColorType, nullptr, nullptr);
+    }
     wpe_renderer_backend_egl_target_frame_will_render(m_backend);
 }
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
@@ -332,6 +332,7 @@ private:
         void didRenderFrame() override;
 
         struct wpe_renderer_backend_egl_target* m_backend { nullptr };
+        WebCore::IntSize m_size;
     };
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphicsGLib.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphicsGLib.cpp
@@ -141,14 +141,6 @@ void DrawingAreaCoordinatedGraphics::updatePreferences(const WebPreferencesStore
         settings.setAsyncOverflowScrollingEnabled(false);
     }
 
-#if PLATFORM(WPE)
-    // Skia compositor is not yet supported by WPE legacy API.
-    if (PlatformDisplay::sharedDisplay().type() == PlatformDisplay::Type::WPE) {
-        settings.setUseSkiaForComposition(false);
-        return;
-    }
-#endif
-
     if (settings.useSkiaForComposition()) {
         static auto useSkiaForComposition = String::fromLatin1(getenv("WEBKIT_USE_SKIA_FOR_COMPOSITION"));
         if (!useSkiaForComposition.isEmpty() && useSkiaForComposition == "0"_s)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
@@ -97,25 +97,21 @@ ThreadedCompositor::ThreadedCompositor(WebPage& webPage, LayerTreeHost& layerTre
         // a plain C cast expression in this one instance works in all cases.
         static_assert(sizeof(GLNativeWindowType) <= sizeof(uint64_t), "GLNativeWindowType must not be longer than 64 bits.");
         auto nativeSurfaceHandle = (GLNativeWindowType)m_surface->window();
-        if (m_useSkia && !nativeSurfaceHandle) {
-            // When using Skia for composition, use the thread-local SkiaGLContext from sharedDisplay()
-            // instead of creating a separate GLContext. This avoids expensive context switching between
-            // the compositor's context and Skia's context during paintToSkiaCanvas().
-            if (auto* context = PlatformDisplay::sharedDisplay().skiaGLContext()) {
-                context->makeContextCurrent();
-                glGetIntegerv(GL_MAX_TEXTURE_SIZE, &m_maxTextureSize);
-            }
+        auto context = GLContext::create(PlatformDisplay::sharedDisplay(), nativeSurfaceHandle);
+        if (!context || !context->makeContextCurrent()) {
+            m_state.state = State::Invalidated;
             return;
         }
 
-        m_context = GLContext::create(PlatformDisplay::sharedDisplay(), nativeSurfaceHandle);
-        if (m_context && m_context->makeContextCurrent()) {
+        glGetIntegerv(GL_MAX_TEXTURE_SIZE, &m_maxTextureSize);
+
+        if (m_useSkia)
+            PlatformDisplay::sharedDisplay().setSkiaGLContextForCurrentThread(WTF::move(context));
+        else {
+            m_context = WTF::move(context);
+            m_textureMapper = TextureMapper::create();
             if (!nativeSurfaceHandle)
                 m_flipY = !m_flipY;
-            glGetIntegerv(GL_MAX_TEXTURE_SIZE, &m_maxTextureSize);
-
-            if (!m_useSkia)
-                m_textureMapper = TextureMapper::create();
         }
     });
 }
@@ -364,11 +360,6 @@ void ThreadedCompositor::paintToSkiaCanvas(const TransformationMatrix& matrix, c
     auto& rootLayer = m_sceneState->rootLayer().ensureSkiaTarget();
     rootLayer.setTransform(matrix);
 
-    // We only need context switching here for the old API (indicated by m_context != nullptr).
-    auto& display = PlatformDisplay::sharedDisplay();
-    if (m_context)
-        display.skiaGLContext()->makeContextCurrent();
-
     m_surface->clear(reasons);
 
     canvas->save();
@@ -393,10 +384,7 @@ void ThreadedCompositor::paintToSkiaCanvas(const TransformationMatrix& matrix, c
 #endif
 
     if (auto* surface = canvas->getSurface())
-        display.skiaGrContext()->flushAndSubmit(surface, GrSyncCpu::kNo);
-
-    if (m_context)
-        m_context->makeContextCurrent();
+        PlatformDisplay::sharedDisplay().skiaGrContext()->flushAndSubmit(surface, GrSyncCpu::kNo);
 
     if (sceneHasRunningAnimations)
         requestComposition(CompositionReason::Animation);
@@ -494,6 +482,8 @@ void ThreadedCompositor::renderLayerTree()
 
     if (m_context)
         m_context->swapBuffers();
+    else
+        PlatformDisplay::sharedDisplay().skiaGLContext()->swapBuffers();
 
     m_surface->didRenderFrame();
     m_surface->sendFrame();


### PR DESCRIPTION
#### 1f77cbefe28bcbafc1fa965743f37a7d5c9d7873
<pre>
[WPE] Add support for using skia compositor with the legacy API
<a href="https://bugs.webkit.org/show_bug.cgi?id=314941">https://bugs.webkit.org/show_bug.cgi?id=314941</a>

Reviewed by Nikolas Zimmermann.

For the legacy API we need to create the GrContext for the compositor GL
context that uses a native surface. So this patch adds
PlatformDisplay::setSkiaGLContextForCurrentThread() to able to set the
thread GrContext instead of being automatically created with an
offscreen context. Then we need to create a SkSurface wrapping the
default frame buffer of the gl context in
AcceleratedSurface::RenderTargetWPEBackend.

* Source/WebCore/platform/graphics/PlatformDisplay.h:
* Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp:
(WebCore::SkiaGLContext::create):
(WebCore::SkiaGLContext::SkiaGLContext):
(WebCore::PlatformDisplay::setSkiaGLContextForCurrentThread):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp:
(WebKit::AcceleratedSurface::RenderTargetWPEBackend::RenderTargetWPEBackend):
(WebKit::AcceleratedSurface::RenderTargetWPEBackend::resize):
(WebKit::AcceleratedSurface::RenderTargetWPEBackend::willRenderFrame):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/DrawingAreaCoordinatedGraphicsGLib.cpp:
(WebKit::DrawingAreaCoordinatedGraphics::updatePreferences):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp:
(WebKit::m_renderTimer):
(WebKit::ThreadedCompositor::paintToSkiaCanvas):
(WebKit::ThreadedCompositor::renderLayerTree):

Canonical link: <a href="https://commits.webkit.org/313355@main">https://commits.webkit.org/313355@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/541ec3e1d8b4aa995c2ac98f94c37b1f09f60b96

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162901 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36379 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29548 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171839 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119347 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164770 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36482 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36381 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126452 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/89053 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165860 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/28800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146388 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107029 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27846 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26382 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19539 "Built successfully") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137557 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24117 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174343 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/22198 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25763 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134762 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36051 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30485 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134757 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/36106 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145913 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98471 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24763 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/29358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/22750 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35545 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/103930 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35046 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35291 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35194 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->