### PR TITLE
Unreviewed, reverting 312175@main (c53a7f951fa0)

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/ProcessAssertionCocoa.mm
@@ -55,17 +55,6 @@
 using WebKit::ProcessAndUIAssertion;
 #endif
 
-@interface WKRBSAssertion : RBSAssertion
-@end
-
-@implementation WKRBSAssertion
-- (void)dealloc
-{
-    [self invalidate];
-    [super dealloc];
-}
-@end
-
 static WorkQueue& assertionsWorkQueue()
 {
     static NeverDestroyed<Ref<WorkQueue>> workQueue(WorkQueue::create("ProcessAssertion Queue"_s, WorkQueue::QOS::UserInitiated));
@@ -96,7 +85,7 @@ static bool processHasActiveRunTimeLimitation()
 
 @implementation WKProcessAssertionBackgroundTaskManager
 {
-    RetainPtr<WKRBSAssertion> _backgroundTask;
+    RetainPtr<RBSAssertion> _backgroundTask;
     std::atomic<bool> _backgroundTaskWasInvalidated;
     ThreadSafeWeakHashSet<ProcessAndUIAssertion> _assertionsNeedingBackgroundTask;
     dispatch_block_t _pendingTaskReleaseTask;
@@ -198,7 +187,7 @@ static bool processHasActiveRunTimeLimitation()
         RELEASE_LOG(ProcessSuspension, "%p - WKProcessAssertionBackgroundTaskManager: beginBackgroundTaskWithName", self);
         RBSTarget *target = [RBSTarget currentProcess];
         RBSDomainAttribute *domainAttribute = [RBSDomainAttribute attributeWithDomain:@"com.apple.common" name:@"FinishTaskInterruptable"];
-        _backgroundTask = adoptNS([[WKRBSAssertion alloc] initWithExplanation:@"WebKit UIProcess background task" target:target attributes:@[domainAttribute]]);
+        _backgroundTask = adoptNS([[RBSAssertion alloc] initWithExplanation:@"WebKit UIProcess background task" target:target attributes:@[domainAttribute]]);
         [_backgroundTask addObserver:self];
 
         _backgroundTaskWasInvalidated = false;
@@ -274,6 +263,7 @@ static bool processHasActiveRunTimeLimitation()
     }
 
     [_backgroundTask removeObserver:self];
+    [_backgroundTask invalidate];
     _backgroundTask = nullptr;
 }
 
@@ -444,7 +434,7 @@ void ProcessAssertion::init(const String& environmentIdentifier)
         target = [RBSTarget targetWithPid:m_pid environmentIdentifier:environmentIdentifier.createNSString().get()];
 
     RetainPtr domainAttribute = [RBSDomainAttribute attributeWithDomain:runningBoardDomainForAssertionType(m_assertionType).createNSString().get() name:runningBoardAssertionName.createNSString().get()];
-    m_rbsAssertion = adoptNS([[WKRBSAssertion alloc] initWithExplanation:m_reason.createNSString().get() target:target attributes:@[domainAttribute.get()]]);
+    m_rbsAssertion = adoptNS([[RBSAssertion alloc] initWithExplanation:m_reason.createNSString().get() target:target attributes:@[domainAttribute.get()]]);
 
     m_delegate = adoptNS([[WKRBSAssertionDelegate alloc] init]);
     [m_rbsAssertion addObserver:m_delegate.get()];
@@ -523,6 +513,7 @@ ProcessAssertion::~ProcessAssertion()
         m_delegate.get().prepareForInvalidationCallback = nil;
         [m_rbsAssertion removeObserver:m_delegate.get()];
         m_delegate = nil;
+        [m_rbsAssertion invalidate];
     }
 
 #if USE(EXTENSIONKIT)

--- a/Source/WebKit/UIProcess/ProcessAssertion.h
+++ b/Source/WebKit/UIProcess/ProcessAssertion.h
@@ -47,7 +47,7 @@
 #if USE(RUNNINGBOARD)
 #include <wtf/RetainPtr.h>
 
-OBJC_CLASS WKRBSAssertion;
+OBJC_CLASS RBSAssertion;
 OBJC_CLASS WKRBSAssertionDelegate;
 #endif // USE(RUNNINGBOARD)
 
@@ -121,7 +121,7 @@ private:
     const ProcessID m_pid;
     const String m_reason;
 #if USE(RUNNINGBOARD)
-    RetainPtr<WKRBSAssertion> m_rbsAssertion;
+    RetainPtr<RBSAssertion> m_rbsAssertion;
     RetainPtr<WKRBSAssertionDelegate> m_delegate;
     bool m_wasInvalidated { false };
 #endif

--- a/Tools/Scripts/webkitpy/style/checkers/cpp.py
+++ b/Tools/Scripts/webkitpy/style/checkers/cpp.py
@@ -3763,26 +3763,6 @@ def check_objc_protocol(clean_lines, line_number, file_extension, error):
     error(line_number, 'spacing/objc-protocol', 2, "Protocol names shouldn't have a space before them.")
 
 
-def check_rbs_assertion(clean_lines, line_number, error):
-    """Looks for uses of [RBSAssertion alloc]
-
-    Before an RBSAssertion is deallocated, we must call invalidate on it.
-    This is easy to forget, and will cause a crash if forgotten. So we
-    must instead use WKRBSAssertion which automatically calls invalidate
-    before deallocation.
-
-    Args:
-      clean_lines: A CleansedLines instance containing the file.
-      line_number: The number of the line to check.
-      error: The function to call with any errors found.
-    """
-
-    line = clean_lines.elided[line_number]  # Get rid of comments and strings.
-
-    if search(r'\bRBSAssertion\s+alloc\b', line):
-        error(line_number, 'runtime/rbs_assertion', 5, 'Do not directly allocate RBSAssertion. Use WKRBSAssertion instead.')
-
-
 def check_safer_cpp(clean_lines, line_number, error):
     """Looks for safer C++ errors.
 
@@ -5136,7 +5116,6 @@ def process_line(filename, file_extension,
     check_ismainthread(filename, clean_lines, line, file_state, error)
     check_mainthreadneverdestroyed(filename, clean_lines, line, file_state, error)
     check_mainthreadlazyneverdestroyed(filename, clean_lines, line, file_state, error)
-    check_rbs_assertion(clean_lines, line, error)
 
 
 class _InlineASMState(object):
@@ -5280,7 +5259,6 @@ class CppChecker(object):
         'runtime/once_flag',
         'runtime/printf',
         'runtime/printf_format',
-        'runtime/rbs_assertion',
         'runtime/references',
         'runtime/retainptr',
         'runtime/rtti',


### PR DESCRIPTION
#### 99c338623e067e47576430f7ba54db0fd5cd454c
<pre>
Unreviewed, reverting 312175@main (c53a7f951fa0)
<a href="https://bugs.webkit.org/show_bug.cgi?id=314945">https://bugs.webkit.org/show_bug.cgi?id=314945</a>
<a href="https://rdar.apple.com/176995929">rdar://176995929</a>

Unreviewed, revert 312175@main since it introduced crashes. The issue is
two-fold:
- The process assertion no longer gets invalidated at a well defined time
  (i.e. when we don&apos;t need it anymore). Since it is an Objective C object,
  the destructor runs when the pool gets drained, which may be quite a bit
  later.
- This also means that invalidation can now happen on any thread, including
  some runningboard threads, instead of the main thread like it used to.
  This is not safe and leads to crashes.

Reverted change:

    Create WKRBSAssertion subclass of RBSAssertion to prevent missing invalidate calls
    <a href="https://bugs.webkit.org/show_bug.cgi?id=313382">https://bugs.webkit.org/show_bug.cgi?id=313382</a>
    <a href="https://rdar.apple.com/175648970">rdar://175648970</a>
    312175@main (c53a7f951fa0)

Canonical link: <a href="https://commits.webkit.org/313357@main">https://commits.webkit.org/313357@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6d08df45cd54b67e78bdda0dbe70915658522bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162905 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36383 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29553 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171843 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119351 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e68cf8a0-4c07-47e8-8bc5-cd82d9289885) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164774 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36487 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36385 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/126456 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/89056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/73da8922-4cdf-40d2-995c-8dffbeae061c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165864 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/28803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146393 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107033 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/760e638d-067b-4596-9a86-d7acaf172310) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/162226 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26385 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19543 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137560 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24122 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174347 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/22310 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25768 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/134766 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36055 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30488 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134761 "Passed tests") | | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/36346 "The change is no longer eligible for processing.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/36142 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145918 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98479 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24766 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/29391 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/22755 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35551 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/104039 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35050 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35295 "Built successfully") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35198 "Hash f6d08df4 for PR 65039 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->