### PR TITLE
Cherry-pick 305413.519@safari-7624-branch (19c426cf207c). https://bugs.webkit.org/show_bug.cgi?id=310175

### DIFF
--- a/JSTests/stress/growable-sharedarraybuffer-parallel-grow-during-prototype-methods.js
+++ b/JSTests/stress/growable-sharedarraybuffer-parallel-grow-during-prototype-methods.js
@@ -28,6 +28,7 @@ for (let round = 0; round < ROUNDS; round++) {
             ta.with(0, 0x41414141);
             ta.toReversed();
             ta.toSorted();
+            ta.sort((a, b) => a - b);
         } catch (e) {}
     }
 

--- a/LayoutTests/fast/loader/reload-on-pageswap-crash-expected.txt
+++ b/LayoutTests/fast/loader/reload-on-pageswap-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/loader/reload-on-pageswap-crash.html
+++ b/LayoutTests/fast/loader/reload-on-pageswap-crash.html
@@ -1,0 +1,29 @@
+<!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
+<script>
+testRunner?.dumpAsText();
+testRunner?.waitUntilDone();
+(async () => {
+  if (sessionStorage.testCompleted) {
+    delete sessionStorage.testCompleted;
+    testRunner?.notifyDone();
+  } else {
+    sessionStorage.testCompleted = true;
+    await navigation.reload();
+  }
+
+  let audio = document.createElement('audio');
+  audio.src = '/resources/foo.mp4';
+  await navigator.locks.query();
+  onpageswap = async (e) => {
+    let { committed, finished } = navigation.reload();
+    let committedRejected = await committed.then(() => false, () => true);
+    let finishedRejected = await finished.then(() => false, () => true);
+    if (!committedRejected)
+      document.write("FAIL: committed promise should have been rejected.");
+    if (!finishedRejected)
+      document.write("FAIL: finished promise should have been rejected.");
+  };
+  await cookieStore.get("bar");
+})();
+</script>
+PASS if no crash.

--- a/LayoutTests/http/tests/broadcastchannel/.htaccess
+++ b/LayoutTests/http/tests/broadcastchannel/.htaccess
@@ -1,0 +1,4 @@
+<FilesMatch "postmessage-shared(arraybuffer|wasmmemory)\.html$">
+    Header set Cross-Origin-Opener-Policy "same-origin"
+    Header set Cross-Origin-Embedder-Policy "require-corp"
+</FilesMatch>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-array-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-array-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "Array:3"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-array.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-array.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() { return [1, 2, 3]; }, "Array:3");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-arraybuffer-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-arraybuffer-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "ArrayBuffer:8"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-arraybuffer.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-arraybuffer.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() { return new ArrayBuffer(8); }, "ArrayBuffer:8");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-audiodata-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-audiodata-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "AudioData:1:4"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-audiodata.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-audiodata.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() {
+    return new AudioData({
+        format: 'f32',
+        sampleRate: 44100,
+        numberOfFrames: 4,
+        numberOfChannels: 1,
+        timestamp: 0,
+        data: new Float32Array([0.5, 0.5, 0.5, 0.5])
+    });
+}, "AudioData:1:4");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-blob-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-blob-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "Blob:5:text/plain"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-blob.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-blob.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() { return new Blob(["hello"], {type: "text/plain"}); }, "Blob:5:text/plain");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-boolean-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-boolean-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "boolean:true"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-boolean.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-boolean.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() { return true; }, "boolean:true");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-date-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-date-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "Date:1000"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-date.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-date.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() { return new Date(1000); }, "Date:1000");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-domexception-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-domexception-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "DOMException:AbortError:aborted"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-domexception.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-domexception.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() { return new DOMException("aborted", "AbortError"); }, "DOMException:AbortError:aborted");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-encodedaudiochunk-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-encodedaudiochunk-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "EncodedAudioChunk:key:4"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-encodedaudiochunk.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-encodedaudiochunk.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() {
+    return new EncodedAudioChunk({type: "key", timestamp: 0, data: new Uint8Array([1, 2, 3, 4])});
+}, "EncodedAudioChunk:key:4");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-encodedvideochunk-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-encodedvideochunk-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "EncodedVideoChunk:key:4"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-encodedvideochunk.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-encodedvideochunk.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() {
+    return new EncodedVideoChunk({type: "key", timestamp: 0, data: new Uint8Array([1, 2, 3, 4])});
+}, "EncodedVideoChunk:key:4");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-error-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-error-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "TypeError:oops"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-error.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-error.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() { return new TypeError("oops"); }, "TypeError:oops");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-imagebitmap-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-imagebitmap-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "ImageBitmap:2x2"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-imagebitmap.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-imagebitmap.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() {
+    var canvas = new OffscreenCanvas(2, 2);
+    var ctx = canvas.getContext("2d");
+    ctx.fillStyle = "red";
+    ctx.fillRect(0, 0, 2, 2);
+    return createImageBitmap(canvas);
+}, "ImageBitmap:2x2");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-imagedata-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-imagedata-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "ImageData:2x2"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-imagedata.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-imagedata.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() { return new ImageData(2, 2); }, "ImageData:2x2");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-map-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-map-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "Map:2"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-map.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-map.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() { return new Map([["a", 1], ["b", 2]]); }, "Map:2");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-mediastreamtrack-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-mediastreamtrack-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "MediaStreamTrack:video"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-mediastreamtrack.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-mediastreamtrack.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() {
+    var canvas = document.createElement("canvas");
+    canvas.width = 2;
+    canvas.height = 2;
+    var stream = canvas.captureStream();
+    return stream.getVideoTracks()[0];
+}, "MediaStreamTrack:video");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-null-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-null-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "null"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-null.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-null.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() { return null; }, "null");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-number-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-number-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "number:42"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-number.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-number.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() { return 42; }, "number:42");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-object-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-object-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "Object"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-object.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-object.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() { return {a: 1}; }, "Object");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-regexp-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-regexp-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "RegExp:/abc/gi"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-regexp.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-regexp.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() { return /abc/gi; }, "RegExp:/abc/gi");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-set-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-set-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "Set:3"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-set.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-set.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() { return new Set([10, 20, 30]); }, "Set:3");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-sharedarraybuffer-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-sharedarraybuffer-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "SharedArrayBuffer:8"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-sharedarraybuffer.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-sharedarraybuffer.html
@@ -1,0 +1,10 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ jscOptions=--useSharedArrayBuffer=true ] -->
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() { return new SharedArrayBuffer(8); }, "SharedArrayBuffer:8");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-sharedwasmmemory-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-sharedwasmmemory-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "WebAssembly.Memory:65536"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-sharedwasmmemory.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-sharedwasmmemory.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() {
+    return new WebAssembly.Memory({initial: 1, maximum: 1, shared: true});
+}, "WebAssembly.Memory:65536");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-string-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-string-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "string:hello"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-string.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-string.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() { return "hello"; }, "string:hello");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-typedarray-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-typedarray-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "Uint8Array:4"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-typedarray.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-typedarray.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() { return new Uint8Array([1, 2, 3, 4]); }, "Uint8Array:4");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-videoframe-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-videoframe-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "VideoFrame:2x2"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-videoframe.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-videoframe.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() {
+    var data = new Uint8Array(2 * 2 * 4);
+    return new VideoFrame(data, {format: "RGBA", codedWidth: 2, codedHeight: 2, timestamp: 0});
+}, "VideoFrame:2x2");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-wasmmodule-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-wasmmodule-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "WebAssembly.Module"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-wasmmodule.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-wasmmodule.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() {
+    return new WebAssembly.Module(new Uint8Array([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]));
+}, "WebAssembly.Module");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/resources/broadcastchannel-test-harness.js
+++ b/LayoutTests/http/tests/broadcastchannel/resources/broadcastchannel-test-harness.js
@@ -1,0 +1,125 @@
+const WORKER_COUNT = 10;
+
+function broadcastChannelTest(createValueFn, expected) {
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+
+    var output = document.getElementById("output");
+    function log(msg) {
+        output.textContent += msg + "\n";
+    }
+
+    function done() {
+        clearTimeout(timer);
+        workers.forEach(function(w) { w.terminate(); });
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }
+
+    var workerCode = [
+        'function inspect(d) {',
+        '    if (d === null) return "null";',
+        '    if (d === undefined) return "undefined";',
+        '    if (typeof d === "string") return "string:" + d;',
+        '    if (typeof d === "number") return "number:" + d;',
+        '    if (typeof d === "boolean") return "boolean:" + d;',
+        '    if (d instanceof Date) return "Date:" + d.getTime();',
+        '    if (d instanceof RegExp) return "RegExp:" + d.toString();',
+        '    if (d instanceof DOMException) return "DOMException:" + d.name + ":" + d.message;',
+        '    if (d instanceof Error) return d.constructor.name + ":" + d.message;',
+        '    if (typeof SharedArrayBuffer !== "undefined" && d instanceof SharedArrayBuffer) return "SharedArrayBuffer:" + d.byteLength;',
+        '    if (d instanceof ArrayBuffer) return "ArrayBuffer:" + d.byteLength;',
+        '    if (d instanceof DataView) return "DataView:" + d.byteLength;',
+        '    if (ArrayBuffer.isView(d)) return d.constructor.name + ":" + d.length;',
+        '    if (d instanceof Blob) return "Blob:" + d.size + ":" + d.type;',
+        '    if (typeof ImageBitmap !== "undefined" && d instanceof ImageBitmap) return "ImageBitmap:" + d.width + "x" + d.height;',
+        '    if (d instanceof ImageData) return "ImageData:" + d.width + "x" + d.height;',
+        '    if (d instanceof Map) return "Map:" + d.size;',
+        '    if (d instanceof Set) return "Set:" + d.size;',
+        '    if (Array.isArray(d)) return "Array:" + d.length;',
+        '    if (typeof EncodedVideoChunk !== "undefined" && d instanceof EncodedVideoChunk) return "EncodedVideoChunk:" + d.type + ":" + d.byteLength;',
+        '    if (typeof VideoFrame !== "undefined" && d instanceof VideoFrame) {',
+		'        var result = "VideoFrame:" + d.codedWidth + "x" + d.codedHeight;',
+		'        d.close();',
+		'        return result;',
+		'    }',
+        '    if (typeof EncodedAudioChunk !== "undefined" && d instanceof EncodedAudioChunk) return "EncodedAudioChunk:" + d.type + ":" + d.byteLength;',
+        '    if (typeof AudioData !== "undefined" && d instanceof AudioData) return "AudioData:" + d.numberOfChannels + ":" + d.numberOfFrames;',
+        '    if (typeof MediaStreamTrack !== "undefined" && d instanceof MediaStreamTrack) return "MediaStreamTrack:" + d.kind;',
+        '    if (typeof MediaStreamTrackHandle !== "undefined" && d instanceof MediaStreamTrackHandle) return "MediaStreamTrackHandle";',
+        '    if (typeof WebAssembly !== "undefined" && d instanceof WebAssembly.Module) return "WebAssembly.Module";',
+        '    if (typeof WebAssembly !== "undefined" && d instanceof WebAssembly.Memory) return "WebAssembly.Memory:" + d.buffer.byteLength;',
+        '    if (typeof d === "object") return "Object";',
+        '    return "unknown:" + typeof d;',
+        '}',
+        'var bc = new BroadcastChannel("test");',
+        'bc.onmessage = function(event) {',
+        '    try {',
+        '        self.postMessage(inspect(event.data));',
+        '    } catch (e) {',
+        '        self.postMessage("ERROR:" + e.message);',
+        '    }',
+        '};',
+        'self.postMessage("READY");'
+    ].join("\n");
+
+    var blob = new Blob([workerCode], { type: "application/javascript" });
+    var url = URL.createObjectURL(blob);
+    var readyCount = 0;
+    var results = [];
+    var workers = [];
+
+    var timer = setTimeout(function() {
+        log("FAIL: Test timed out (" + readyCount + " of " + WORKER_COUNT + " workers ready, " + results.length + " of " + WORKER_COUNT + " results received)");
+        done();
+    }, 10000);
+
+    for (var i = 0; i < WORKER_COUNT; i++) {
+        var w = new Worker(url);
+        workers.push(w);
+        w.onmessage = function(e) {
+            if (e.data === "READY") {
+                if (++readyCount === WORKER_COUNT)
+                    postValue();
+            } else {
+                results.push(e.data);
+                if (results.length === WORKER_COUNT)
+                    checkResults();
+            }
+        };
+        w.onerror = function(e) {
+            log("FAIL: Worker error: " + e.message);
+            done();
+        };
+    }
+
+    function postValue() {
+        try {
+            Promise.resolve(createValueFn()).then(function(value) {
+                var bc = new BroadcastChannel("test");
+                bc.postMessage(value);
+                bc.close();
+            }, function(e) {
+                log("FAIL: Error creating value: " + e.message);
+                done();
+            });
+        } catch (e) {
+            log("FAIL: Error creating value: " + e.message);
+            done();
+        }
+    }
+
+    function checkResults() {
+        URL.revokeObjectURL(url);
+        var allSame = results.every(function(r) { return r === results[0]; });
+        if (allSame && results[0] === expected)
+            log("PASS: All " + WORKER_COUNT + " workers received \"" + expected + "\"");
+        else if (!allSame)
+            log("FAIL: Workers received mismatched results: " + JSON.stringify(results));
+        else
+            log("FAIL: Expected \"" + expected + "\" but got \"" + results[0] + "\"");
+        done();
+    }
+}

--- a/LayoutTests/http/tests/contentextensions/block-embed-element-expected.txt
+++ b/LayoutTests/http/tests/contentextensions/block-embed-element-expected.txt
@@ -1,0 +1,3 @@
+CONSOLE MESSAGE: Content blocker prevented frame displaying http://127.0.0.1:8000/contentextensions/block-embed-element.html from loading a resource from http://127.0.0.1:8000/contentextensions/resources/should-load.html?should-be-blocked
+CONSOLE MESSAGE: Content blocker prevented frame displaying http://127.0.0.1:8000/contentextensions/block-embed-element.html from loading a resource from http://127.0.0.1:8000/media/resources/test.pdf?should-be-blocked
+

--- a/LayoutTests/http/tests/contentextensions/block-embed-element.html
+++ b/LayoutTests/http/tests/contentextensions/block-embed-element.html
@@ -1,0 +1,5 @@
+<script>testRunner?.dumpAsText();</script>
+<body>
+<embed src="http://127.0.0.1:8000/contentextensions/resources/should-load.html?should-be-blocked" type="text/html" width="100" height="100"></embed>
+<embed src="http://127.0.0.1:8000/media/resources/test.pdf?should-be-blocked" type="application/pdf" width="100" height="100"></embed>
+</body>

--- a/LayoutTests/http/tests/contentextensions/block-embed-element.json
+++ b/LayoutTests/http/tests/contentextensions/block-embed-element.json
@@ -1,0 +1,10 @@
+[
+    {
+        "action": {
+            "type": "block"
+        },
+        "trigger": {
+            "url-filter": ".*should-be-blocked"
+        }
+    }
+]

--- a/LayoutTests/http/tests/contentextensions/block-object-element-expected.txt
+++ b/LayoutTests/http/tests/contentextensions/block-object-element-expected.txt
@@ -1,0 +1,3 @@
+CONSOLE MESSAGE: Content blocker prevented frame displaying http://127.0.0.1:8000/contentextensions/block-object-element.html from loading a resource from http://127.0.0.1:8000/contentextensions/resources/should-load.html?should-be-blocked
+CONSOLE MESSAGE: Content blocker prevented frame displaying http://127.0.0.1:8000/contentextensions/block-object-element.html from loading a resource from http://127.0.0.1:8000/media/resources/test.pdf?should-be-blocked
+

--- a/LayoutTests/http/tests/contentextensions/block-object-element.html
+++ b/LayoutTests/http/tests/contentextensions/block-object-element.html
@@ -1,0 +1,5 @@
+<script>testRunner?.dumpAsText();</script>
+<body>
+<object data="http://127.0.0.1:8000/contentextensions/resources/should-load.html?should-be-blocked" type="text/html" width="100" height="100"></object>
+<object data="http://127.0.0.1:8000/media/resources/test.pdf?should-be-blocked" type="application/pdf" width="100" height="100"></object>
+</body>

--- a/LayoutTests/http/tests/contentextensions/block-object-element.json
+++ b/LayoutTests/http/tests/contentextensions/block-object-element.json
@@ -1,0 +1,10 @@
+[
+    {
+        "action": {
+            "type": "block"
+        },
+        "trigger": {
+            "url-filter": ".*should-be-blocked"
+        }
+    }
+]

--- a/LayoutTests/http/tests/storageAccess/no-gesture-rejection-should-not-grant-storage-access-under-opener.https-expected.txt
+++ b/LayoutTests/http/tests/storageAccess/no-gesture-rejection-should-not-grant-storage-access-under-opener.https-expected.txt
@@ -1,0 +1,17 @@
+Tests that a no-gesture requestStorageAccess() rejection in a popup's cross-site iframe does not fabricate user interaction that silently grants storage access under the opener.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS requestStorageAccess() was rejected without a user gesture in the popup iframe.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+
+
+--------
+Frame: '<!--frame1-->'
+--------
+Should not receive first-party cookie.
+Did not receive cookie named 'firstPartyCookie'.
+Client-side document.cookie:

--- a/LayoutTests/http/tests/storageAccess/no-gesture-rejection-should-not-grant-storage-access-under-opener.https.html
+++ b/LayoutTests/http/tests/storageAccess/no-gesture-rejection-should-not-grant-storage-access-under-opener.https.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script src="/js-test-resources/js-test.js"></script>
+    <script src="/resourceLoadStatistics/resources/util.js"></script>
+</head>
+<body onload="run()">
+<script>
+    description("Tests that a no-gesture requestStorageAccess() rejection in a popup's cross-site iframe does not fabricate user interaction that silently grants storage access under the opener.");
+    jsTestIsAsync = true;
+
+    function finishTest() {
+        setEnableFeature(false, finishJSTest);
+    }
+
+    function openIframe(url, onLoadHandler) {
+        const element = document.createElement("iframe");
+        element.src = url;
+        if (onLoadHandler) {
+            element.onload = onLoadHandler;
+        }
+        document.body.appendChild(element);
+    }
+
+    const thirdPartyOrigin = "https://localhost:8443";
+    const resourcePath = "/storageAccess/resources";
+    const thirdPartyBaseUrl = thirdPartyOrigin + resourcePath;
+    const firstPartyCookieName = "firstPartyCookie";
+    const subPathToGetCookies = "/get-cookies.py?name1=" + firstPartyCookieName;
+    var newWin;
+
+    function receiveMessage(event) {
+        if (event.origin === thirdPartyOrigin && event.data && event.data.type === "popup-result") {
+            if (event.data.storageAccessResult === "rejected")
+                testPassed("requestStorageAccess() was rejected without a user gesture in the popup iframe.");
+            else
+                testFailed("requestStorageAccess() was not rejected. Result: " + event.data.storageAccessResult);
+
+            newWin.close();
+
+            openIframe(thirdPartyBaseUrl + subPathToGetCookies + "&message=Should not receive first-party cookie.", finishTest);
+        }
+    }
+
+    function run() {
+        setEnableFeature(true, function() {
+            window.addEventListener("message", receiveMessage, false);
+
+            testRunner.setStatisticsPrevalentResource(thirdPartyOrigin, true, function() {
+                if (!testRunner.isStatisticsPrevalentResource(thirdPartyOrigin))
+                    testFailed("Host did not get set as prevalent resource.");
+                testRunner.setStatisticsHasHadUserInteraction(thirdPartyOrigin, true, function() {
+                    if (!testRunner.isStatisticsHasHadUserInteraction(thirdPartyOrigin))
+                        testFailed("Host did not get logged for user interaction.");
+                    testRunner.dumpChildFramesAsText();
+
+                    testRunner.statisticsUpdateCookieBlocking(function() {
+                        newWin = window.open(thirdPartyOrigin + resourcePath + "/request-storage-access-without-gesture-and-report-back.html#https://127.0.0.1:8443", "testWindow");
+                    });
+                });
+            });
+        });
+    }
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/storageAccess/resources/request-storage-access-without-gesture-and-report-back.html
+++ b/LayoutTests/http/tests/storageAccess/resources/request-storage-access-without-gesture-and-report-back.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <script>
+        document.cookie = "firstPartyCookie=value; SameSite=None; Secure";
+
+        window.addEventListener("message", function(event) {
+            if (event.data && event.data.type === "storage-access-result") {
+                window.opener.postMessage({
+                    type: "popup-result",
+                    storageAccessResult: event.data.result,
+                    storageAccessError: event.data.error
+                }, "https://127.0.0.1:8443");
+            }
+        });
+    </script>
+</head>
+<body>
+    <iframe id="crossSiteFrame"></iframe>
+    <script>
+        var frameOrigin = document.location.hash.substring(1);
+        document.getElementById("crossSiteFrame").src = frameOrigin + "/storageAccess/resources/request-storage-access-without-gesture-in-iframe.html";
+    </script>
+</body>
+</html>

--- a/LayoutTests/http/tests/storageAccess/resources/request-storage-access-without-gesture-in-iframe.html
+++ b/LayoutTests/http/tests/storageAccess/resources/request-storage-access-without-gesture-in-iframe.html
@@ -1,0 +1,26 @@
+<html>
+<head>
+    <script>
+        function run() {
+            document.requestStorageAccess().then(
+                function() {
+                    window.parent.postMessage({
+                        type: "storage-access-result",
+                        result: "resolved",
+                        error: null
+                    }, "*");
+                },
+                function(e) {
+                    window.parent.postMessage({
+                        type: "storage-access-result",
+                        result: "rejected",
+                        error: e.toString()
+                    }, "*");
+                }
+            );
+        }
+    </script>
+</head>
+<body onload="run()">
+</body>
+</html>

--- a/Source/JavaScriptCore/dfg/DFGGraph.cpp
+++ b/Source/JavaScriptCore/dfg/DFGGraph.cpp
@@ -237,7 +237,7 @@ void Graph::dump(PrintStream& out, const char* prefixStr, Node* node, DumpContex
         });
     }
 
-    if (toCString(NodeFlagsDump(node->flags())) != "<empty>")
+    if (toCString(NodeFlagsDump(node->flags())) != "<empty>"_s)
         out.print(comma, NodeFlagsDump(node->flags()));
     if (node->prediction())
         out.print(comma, SpeculationDump(node->prediction()));
@@ -564,7 +564,7 @@ void Graph::dumpBlockHeader(PrintStream& out, const char* prefixStr, BasicBlock*
                 continue;
 
             out.print(" D@", phiNode->index(), "<", phiNode->operand(), ",", phiNode->refCount());
-            if (toCString(NodeFlagsDump(phiNode->flags())) != "<empty>")
+            if (toCString(NodeFlagsDump(phiNode->flags())) != "<empty>"_s)
                 out.print(", ", NodeFlagsDump(phiNode->flags()));
             out.print(">->(");
             if (phiNode->child1()) {

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h
@@ -1525,11 +1525,11 @@ static ALWAYS_INLINE EncodedJSValue genericTypedArrayViewProtoFuncSortImpl(VM& v
 
     auto callData = JSC::getCallDataInline(comparatorValue);
 
-    size_t length = thisObject->length();
+    auto originalSpan = thisObject->typedSpan();
+    size_t length = originalSpan.size();
+
     if (length < 2)
         return JSValue::encode(thisObject);
-
-    auto originalSpan = thisObject->typedSpan();
 
     Vector<typename ViewClass::ElementType, 256> vector;
     auto totalSize = CheckedSize { length } * 2U;

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/av1/encoder/extend.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/av1/encoder/extend.c
@@ -115,11 +115,11 @@ void av1_copy_and_extend_frame(const YV12_BUFFER_CONFIG *src,
   // Extend src frame in buffer
   const int et_y = dst->border;
   const int el_y = dst->border;
-  const int er_y =
-      AOMMAX(src->y_width + dst->border, ALIGN_POWER_OF_TWO(src->y_width, 6)) -
-      src->y_crop_width;
-  const int eb_y = AOMMAX(src->y_height + dst->border,
-                          ALIGN_POWER_OF_TWO(src->y_height, 6)) -
+  const int er_y = AOMMAX(src->y_crop_width + dst->border,
+                          ALIGN_POWER_OF_TWO(src->y_crop_width, 6)) -
+                   src->y_crop_width;
+  const int eb_y = AOMMAX(src->y_crop_height + dst->border,
+                          ALIGN_POWER_OF_TWO(src->y_crop_height, 6)) -
                    src->y_crop_height;
   const int uv_width_subsampling = src->subsampling_x;
   const int uv_height_subsampling = src->subsampling_y;

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/test/encode_api_test.cc
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/test/encode_api_test.cc
@@ -1729,4 +1729,37 @@ TEST(EncodeAPI, Issue449341177) {
   ASSERT_EQ(aom_codec_destroy(&enc), AOM_CODEC_OK);
 }
 
+TEST(EncodeAPI, SizeAlignOverflow) {
+  aom_codec_iface_t *iface = aom_codec_av1_cx();
+  aom_codec_enc_cfg_t cfg;
+  ASSERT_EQ(aom_codec_enc_config_default(iface, &cfg, AOM_USAGE_REALTIME),
+            AOM_CODEC_OK);
+
+  cfg.g_w = 16;
+  cfg.g_h = 16;
+  cfg.g_threads = 1;
+  cfg.g_lag_in_frames = 0;
+
+  aom_codec_ctx_t enc;
+  ASSERT_EQ(aom_codec_enc_init(&enc, iface, &cfg, 0), AOM_CODEC_OK);
+
+  // Bug aomdiea:480978101: size_align=32 causes w,h=32 while d_w,d_h=16
+  // This mismatch causes buffer overflow in av1_copy_and_extend_frame()
+  // if the fix is not present.
+  aom_image_t *img =
+      aom_img_alloc_with_border(NULL, AOM_IMG_FMT_NV12, /*d_w=*/16, /*d_h=*/16,
+                                /*align=*/32,
+                                /*size_align=*/32,
+                                /*border=*/15);
+  ASSERT_NE(img, nullptr);
+  memset(img->img_data, 128, img->sz);
+
+  // Should not crash with heap-buffer-overflow
+  EXPECT_EQ(aom_codec_encode(&enc, img, /*pts=*/0, /*duration=*/1, /*flags=*/0),
+            AOM_CODEC_OK);
+
+  aom_img_free(img);
+  ASSERT_EQ(aom_codec_destroy(&enc), AOM_CODEC_OK);
+}
+
 }  // namespace

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/encoder/vp9_encoder.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/encoder/vp9_encoder.c
@@ -3494,9 +3494,13 @@ void vp9_scale_references(VP9_COMP *cpi) {
         int new_fb = cpi->scaled_ref_idx[ref_frame - 1];
         if (new_fb == INVALID_IDX) {
           new_fb = get_free_fb(cm);
+          if (new_fb == INVALID_IDX) {
+            assert(cm->error.setjmp);
+            vpx_internal_error(&cm->error, VPX_CODEC_MEM_ERROR,
+                               "Unable to find free frame buffer");
+          }
           force_scaling = 1;
         }
-        if (new_fb == INVALID_IDX) return;
         new_fb_ptr = &pool->frame_bufs[new_fb];
         if (force_scaling || new_fb_ptr->buf.y_crop_width != cm->width ||
             new_fb_ptr->buf.y_crop_height != cm->height) {

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/encoder/vp9_mcomp.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/encoder/vp9_mcomp.c
@@ -2288,6 +2288,8 @@ unsigned int vp9_int_pro_motion_estimation(const VP9_COMP *cpi, MACROBLOCK *x,
   MvLimits subpel_mv_limits;
 
   if (scaled_ref_frame) {
+    assert(scaled_ref_frame->y_width == cpi->Source->y_width &&
+           scaled_ref_frame->y_height == cpi->Source->y_height);
     int i;
     // Swap out the reference frame for a version that's been scaled to
     // match the resolution of the current frame, allowing the existing

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/encoder/vp9_pickmode.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/encoder/vp9_pickmode.c
@@ -183,6 +183,8 @@ static int combined_motion_search(VP9_COMP *cpi, MACROBLOCK *x,
   const YV12_BUFFER_CONFIG *scaled_ref_frame =
       vp9_get_scaled_ref_frame(cpi, ref);
   if (scaled_ref_frame) {
+    assert(scaled_ref_frame->y_width == cpi->Source->y_width &&
+           scaled_ref_frame->y_height == cpi->Source->y_height);
     int i;
     // Swap out the reference frame for a version that's been scaled to
     // match the resolution of the current frame, allowing the existing

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -314,6 +314,16 @@ AllowTestOnlyIPC:
       default: false
   sharedPreferenceForWebProcess: true
 
+AllowTestOnlyMockContentFilterIPC:
+  type: bool
+  status: embedder
+  exposed: [ WebKit ]
+  webcoreBinding: none
+  defaultValue:
+    WebKit:
+      default: false
+  sharedPreferenceForWebProcess: true
+
 AllowTestOnlyOriginAccessAllowListIPC:
   type: bool
   status: embedder

--- a/Source/WTF/wtf/SuspendableWorkQueue.cpp
+++ b/Source/WTF/wtf/SuspendableWorkQueue.cpp
@@ -103,6 +103,15 @@ void SuspendableWorkQueue::dispatch(Function<void()>&& function)
     });
 }
 
+void SuspendableWorkQueue::dispatchWithQOS(Function<void()>&& function, QOS qos)
+{
+    RELEASE_ASSERT(function);
+    WorkQueue::dispatchWithQOS([protectedThis = Ref { *this }, function = WTF::move(function)] {
+        protectedThis->suspendIfNeeded();
+        function();
+    }, qos);
+}
+
 void SuspendableWorkQueue::dispatchAfter(Seconds seconds, Function<void()>&& function)
 {
     RELEASE_ASSERT(function);

--- a/Source/WTF/wtf/SuspendableWorkQueue.h
+++ b/Source/WTF/wtf/SuspendableWorkQueue.h
@@ -41,6 +41,7 @@ public:
     void suspend(Function<void()>&& suspendFunction, CompletionHandler<void()>&& suspensionCompletionHandler);
     void resume();
     void dispatch(Function<void()>&&) final;
+    void dispatchWithQOS(Function<void()>&&, QOS);
     void dispatchAfter(Seconds, Function<void()>&&) final;
     void dispatchSync(Function<void()>&&) final;
     bool isSuspended() const;

--- a/Source/WTF/wtf/text/CString.cpp
+++ b/Source/WTF/wtf/text/CString.cpp
@@ -141,6 +141,15 @@ bool operator==(const CString& a, const CString& b)
     return equal(byteCast<Latin1Character>(a.span()).data(), byteCast<Latin1Character>(b.span()));
 }
 
+bool operator==(const CString& a, ASCIILiteral b)
+{
+    if (a.isNull() != b.isNull())
+        return false;
+    if (a.length() != b.length())
+        return false;
+    return equal(byteCast<Latin1Character>(a.span()).data(), b.span8());
+}
+
 unsigned CString::hash() const
 {
     if (isNull())

--- a/Source/WTF/wtf/text/CString.h
+++ b/Source/WTF/wtf/text/CString.h
@@ -111,6 +111,7 @@ private:
 } SWIFT_ESCAPABLE;
 
 WTF_EXPORT_PRIVATE bool operator==(const CString&, const CString&);
+WTF_EXPORT_PRIVATE bool operator==(const CString&, ASCIILiteral);
 WTF_EXPORT_PRIVATE bool operator<(const CString&, const CString&);
 
 WTF_EXPORT_PRIVATE CString convertToASCIILowercase(std::span<const char8_t>);

--- a/Source/WTF/wtf/text/StringCommon.h
+++ b/Source/WTF/wtf/text/StringCommon.h
@@ -1517,6 +1517,12 @@ inline NewlinePosition findNextNewline(std::span<const CharacterType> span, size
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
+
+inline bool operator==(ASCIILiteral a, const char* b)
+{
+    return equalSpans(a.spanIncludingNullTerminator(), unsafeSpanIncludingNullTerminator(b));
+}
+
 }
 
 using WTF::charactersContain;

--- a/Source/WebCore/Modules/indexeddb/server/IDBConnectionToClient.h
+++ b/Source/WebCore/Modules/indexeddb/server/IDBConnectionToClient.h
@@ -48,7 +48,7 @@ class IDBConnectionToClient : public RefCounted<IDBConnectionToClient> {
 public:
     WEBCORE_EXPORT static Ref<IDBConnectionToClient> create(IDBConnectionToClientDelegate&);
 
-    IDBConnectionIdentifier identifier() const;
+    WEBCORE_EXPORT IDBConnectionIdentifier identifier() const;
 
     void didDeleteDatabase(const IDBResultData&);
     void didOpenDatabase(const IDBResultData&);

--- a/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.h
+++ b/Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.h
@@ -62,7 +62,7 @@ public:
 
     WEBCORE_EXPORT ~UniqueIDBDatabaseTransaction();
 
-    UniqueIDBDatabaseConnection* databaseConnection() const;
+    WEBCORE_EXPORT UniqueIDBDatabaseConnection* databaseConnection() const;
     UniqueIDBDatabase* database() const;
     CheckedPtr<UniqueIDBDatabase> checkedDatabase() const;
     const IDBTransactionInfo& info() const { return m_transactionInfo; }

--- a/Source/WebCore/Modules/streams/ReadableStreamBYOBReader.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStreamBYOBReader.cpp
@@ -60,7 +60,11 @@ ReadableStreamBYOBReader::ReadableStreamBYOBReader(Ref<DOMPromise>&& promise, Re
 
 ReadableStreamBYOBReader::~ReadableStreamBYOBReader()
 {
-    RefPtr stream = m_stream;
+    RefPtr<ReadableStream> stream;
+    {
+        Locker locker { m_streamLock };
+        stream = m_stream;
+    }
     if (stream && stream->byobReader() == this)
         stream->setByobReader(nullptr);
 }
@@ -95,18 +99,22 @@ void ReadableStreamBYOBReader::readForBindings(JSDOMGlobalObject& globalObject, 
             return promise->reject(Exception { ExceptionCode::RangeError, "view's buffer is not large enough"_s });
     }
 
-    if (!m_stream)
-        return promise->reject(Exception { ExceptionCode::TypeError, "reader has no stream"_s });
-
+    {
+        Locker locker { m_streamLock };
+        if (!m_stream)
+            return promise->reject(Exception { ExceptionCode::TypeError, "reader has no stream"_s });
+    }
     read(globalObject, view, options.min, ReadableStreamReadIntoRequest::create(WTF::move(promise)));
 }
 
 // https://streams.spec.whatwg.org/#byob-reader-release-lock
 void ReadableStreamBYOBReader::releaseLock(JSDOMGlobalObject& globalObject)
 {
-    if (!m_stream)
-        return;
-
+    {
+        Locker locker { m_streamLock };
+        if (!m_stream)
+            return;
+    }
     genericRelease(globalObject);
 
     errorReadIntoRequests(Exception { ExceptionCode::TypeError, "releasing stream"_s });
@@ -115,7 +123,12 @@ void ReadableStreamBYOBReader::releaseLock(JSDOMGlobalObject& globalObject)
 // https://streams.spec.whatwg.org/#generic-reader-cancel
 Ref<DOMPromise> ReadableStreamBYOBReader::cancel(JSDOMGlobalObject& globalObject, JSC::JSValue value)
 {
-    if (!m_stream) {
+    bool hasStream;
+    {
+        Locker locker { m_streamLock };
+        hasStream = m_stream;
+    }
+    if (!hasStream) {
         auto [promise, deferred] = createPromiseAndWrapper(globalObject);
         deferred->reject(Exception { ExceptionCode::TypeError, "no stream"_s });
         return promise;
@@ -140,7 +153,10 @@ ExceptionOr<void> ReadableStreamBYOBReader::setupBYOBReader(JSDOMGlobalObject& g
 // https://streams.spec.whatwg.org/#set-up-readable-stream-byob-reader
 void ReadableStreamBYOBReader::initialize(JSDOMGlobalObject& globalObject, ReadableStream& stream)
 {
-    m_stream = &stream;
+    {
+        Locker locker { m_streamLock };
+        m_stream = stream;
+    }
 
     stream.setByobReader(this);
 
@@ -159,8 +175,11 @@ void ReadableStreamBYOBReader::initialize(JSDOMGlobalObject& globalObject, Reada
 // https://streams.spec.whatwg.org/#readable-stream-byob-reader-read
 void ReadableStreamBYOBReader::read(JSDOMGlobalObject& globalObject, JSC::ArrayBufferView& view, size_t optionMin, Ref<ReadableStreamReadIntoRequest>&& readRequest)
 {
-    ASSERT(m_stream);
-    Ref stream = *m_stream;
+    RefPtr<ReadableStream> stream;
+    {
+        Locker locker { m_streamLock };
+        stream = m_stream;
+    }
 
     stream->markAsDisturbed();
     if (stream->state() == ReadableStream::State::Errored) {
@@ -175,8 +194,11 @@ void ReadableStreamBYOBReader::read(JSDOMGlobalObject& globalObject, JSC::ArrayB
 // https://streams.spec.whatwg.org/#readable-stream-reader-generic-release
 void ReadableStreamBYOBReader::genericRelease(JSDOMGlobalObject& globalObject)
 {
-    ASSERT(m_stream);
-    Ref stream = *m_stream;
+    RefPtr<ReadableStream> stream;
+    {
+        Locker locker { m_streamLock };
+        stream = m_stream;
+    }
 
     ASSERT(stream->byobReader() == this);
 
@@ -193,7 +215,11 @@ void ReadableStreamBYOBReader::genericRelease(JSDOMGlobalObject& globalObject)
         controller->runReleaseSteps();
 
     stream->setByobReader(nullptr);
-    m_stream = nullptr;
+
+    {
+        Locker locker { m_streamLock };
+        m_stream = nullptr;
+    }
 }
 
 // https://streams.spec.whatwg.org/#abstract-opdef-readablestreambyobreadererrorreadintorequests
@@ -224,7 +250,11 @@ void ReadableStreamBYOBReader::rejectClosedPromise(JSC::JSValue reason)
 // https://streams.spec.whatwg.org/#readable-stream-reader-generic-cancel
 Ref<DOMPromise> ReadableStreamBYOBReader::genericCancel(JSDOMGlobalObject& globalObject, JSC::JSValue value)
 {
-    RefPtr stream = m_stream;
+    RefPtr<ReadableStream> stream;
+    {
+        Locker locker { m_streamLock };
+        stream = m_stream;
+    }
 
     ASSERT(stream);
     ASSERT(stream->byobReader() == this);
@@ -268,6 +298,7 @@ void ReadableStreamBYOBReader::onClosedPromiseRejection(ClosedCallback&& callbac
 
 bool ReadableStreamBYOBReader::isReachableFromOpaqueRoots() const
 {
+    Locker locker { m_streamLock };
     return readIntoRequestsSize() && m_stream && m_stream->isReachableFromOpaqueRoots();
 }
 
@@ -292,6 +323,7 @@ bool JSReadableStreamBYOBReaderOwner::isReachableFromOpaqueRoots(JSC::Handle<JSC
 template<typename Visitor>
 void ReadableStreamBYOBReader::visitAdditionalChildren(Visitor& visitor)
 {
+    Locker locker { m_streamLock };
     if (m_stream)
         SUPPRESS_UNCOUNTED_ARG m_stream->visitAdditionalChildren(visitor);
 }

--- a/Source/WebCore/Modules/streams/ReadableStreamBYOBReader.h
+++ b/Source/WebCore/Modules/streams/ReadableStreamBYOBReader.h
@@ -31,6 +31,7 @@
 #include "ScriptWrappable.h"
 #include "WebCoreOpaqueRoot.h"
 #include <wtf/Deque.h>
+#include <wtf/Lock.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
@@ -89,7 +90,8 @@ private:
 
     Ref<DOMPromise> m_closedPromise;
     Ref<DeferredPromise> m_closedDeferred;
-    RefPtr<ReadableStream> m_stream;
+    mutable Lock m_streamLock;
+    RefPtr<ReadableStream> m_stream WTF_GUARDED_BY_LOCK(m_streamLock);
     Deque<Ref<ReadableStreamReadIntoRequest>> m_readIntoRequests;
 
     ClosedCallback m_closedCallback;

--- a/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.cpp
@@ -75,7 +75,11 @@ ReadableStreamDefaultReader::ReadableStreamDefaultReader(Ref<ReadableStream>&& s
 
 ReadableStreamDefaultReader::~ReadableStreamDefaultReader()
 {
-    RefPtr stream = m_stream;
+    RefPtr<ReadableStream> stream;
+    {
+        Locker locker { m_streamLock };
+        stream = m_stream;
+    }
     if (stream && stream->defaultReader() == this)
         stream->setDefaultReader(nullptr);
 }
@@ -128,7 +132,11 @@ void ReadableStreamDefaultReader::read(JSDOMGlobalObject& globalObject, Ref<Read
         return;
     }
 
-    RefPtr stream = m_stream;
+    RefPtr<ReadableStream> stream;
+    {
+        Locker locker { m_streamLock };
+        stream = m_stream;
+    }
     if (!stream) {
         readRequest->runErrorSteps(Exception { ExceptionCode::TypeError, "stream is undefined"_s });
         return;
@@ -154,17 +162,19 @@ void ReadableStreamDefaultReader::read(JSDOMGlobalObject& globalObject, Ref<Read
 // https://streams.spec.whatwg.org/#default-reader-release-lock
 ExceptionOr<void> ReadableStreamDefaultReader::releaseLock(JSDOMGlobalObject& globalObject)
 {
-    if (!m_stream)
-        return { };
+    {
+        Locker locker { m_streamLock };
+        if (!m_stream)
+            return { };
 
-    if (RefPtr internalReader = this->internalDefaultReader()) {
-        auto result = internalReader->releaseLock();
-        if (!result.hasException()) {
-            RefPtr stream = std::exchange(m_stream, { });
-            stream->setDefaultReader(nullptr);
-            stream = nullptr;
+        if (RefPtr internalReader = this->internalDefaultReader()) {
+            auto result = internalReader->releaseLock();
+            if (!result.hasException()) {
+                RefPtr stream = std::exchange(m_stream, nullptr);
+                stream->setDefaultReader(nullptr);
+            }
+            return result;
         }
-        return result;
     }
 
     genericRelease(globalObject);
@@ -175,7 +185,11 @@ ExceptionOr<void> ReadableStreamDefaultReader::releaseLock(JSDOMGlobalObject& gl
 // https://streams.spec.whatwg.org/#set-up-readable-stream-default-reader
 ExceptionOr<void> ReadableStreamDefaultReader::setup(JSDOMGlobalObject& globalObject)
 {
-    RefPtr stream = m_stream;
+    RefPtr<ReadableStream> stream;
+    {
+        Locker locker { m_streamLock };
+        stream = m_stream;
+    }
 
     if (!stream)
         return Exception { ExceptionCode::TypeError, "stream is undefined"_s };
@@ -202,7 +216,11 @@ ExceptionOr<void> ReadableStreamDefaultReader::setup(JSDOMGlobalObject& globalOb
 // https://streams.spec.whatwg.org/#readable-stream-reader-generic-release
 void ReadableStreamDefaultReader::genericRelease(JSDOMGlobalObject& globalObject)
 {
-    RefPtr stream = m_stream;
+    RefPtr<ReadableStream> stream;
+    {
+        Locker locker { m_streamLock };
+        stream = m_stream;
+    }
 
     ASSERT(stream);
     ASSERT(stream->defaultReader() == this);
@@ -222,6 +240,8 @@ void ReadableStreamDefaultReader::genericRelease(JSDOMGlobalObject& globalObject
         controller->runReleaseSteps();
 
     stream->setDefaultReader(nullptr);
+
+    Locker locker { m_streamLock };
     m_stream = nullptr;
 }
 
@@ -236,7 +256,12 @@ void ReadableStreamDefaultReader::errorReadRequests(const Exception& exception)
 // https://streams.spec.whatwg.org/#generic-reader-cancel
 Ref<DOMPromise> ReadableStreamDefaultReader::cancel(JSDOMGlobalObject& globalObject, JSC::JSValue value)
 {
-    if (!m_stream) {
+    bool hasStream;
+    {
+        Locker locker { m_streamLock };
+        hasStream = m_stream;
+    }
+    if (!hasStream) {
         auto [promise, deferred] = createPromiseAndWrapper(globalObject);
         deferred->reject(Exception { ExceptionCode::TypeError, "no stream"_s });
         return promise;
@@ -248,7 +273,11 @@ Ref<DOMPromise> ReadableStreamDefaultReader::cancel(JSDOMGlobalObject& globalObj
 // https://streams.spec.whatwg.org/#readable-stream-reader-generic-cancel
 Ref<DOMPromise> ReadableStreamDefaultReader::genericCancel(JSDOMGlobalObject& globalObject, JSC::JSValue value)
 {
-    RefPtr stream = m_stream;
+    RefPtr<ReadableStream> stream;
+    {
+        Locker locker { m_streamLock };
+        stream = m_stream;
+    }
 
     ASSERT(stream);
     ASSERT(stream->defaultReader() == this);
@@ -350,8 +379,15 @@ void ReadableStreamDefaultReader::onClosedPromiseResolution(Function<void()>&& c
     });
 }
 
+ReadableStream* ReadableStreamDefaultReader::stream()
+{
+    Locker locker { m_streamLock };
+    return m_stream.get();
+}
+
 bool ReadableStreamDefaultReader::isReachableFromOpaqueRoots() const
 {
+    Locker locker { m_streamLock };
     return getNumReadRequests() && m_stream && m_stream->isReachableFromOpaqueRoots();
 }
 
@@ -397,6 +433,7 @@ bool JSReadableStreamDefaultReaderOwner::isReachableFromOpaqueRoots(JSC::Handle<
 template<typename Visitor>
 void ReadableStreamDefaultReader::visitAdditionalChildren(Visitor& visitor)
 {
+    Locker locker { m_streamLock };
     if (m_stream)
         SUPPRESS_UNCOUNTED_ARG m_stream->visitAdditionalChildren(visitor);
 }

--- a/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.h
+++ b/Source/WebCore/Modules/streams/ReadableStreamDefaultReader.h
@@ -30,6 +30,7 @@
 #include "ScriptWrappable.h"
 #include "WebCoreOpaqueRoot.h"
 #include <JavaScriptCore/Strong.h>
+#include <wtf/Lock.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WeakPtr.h>
@@ -75,7 +76,7 @@ public:
     bool isReachableFromOpaqueRoots() const;
     template<typename Visitor> void visitAdditionalChildren(Visitor&);
 
-    ReadableStream* stream() { return m_stream.get(); }
+    ReadableStream* stream();
 
 private:
     ReadableStreamDefaultReader(Ref<ReadableStream>&&, RefPtr<InternalReadableStreamDefaultReader>&&, Ref<DOMPromise>&&, Ref<DeferredPromise>&&);
@@ -86,7 +87,8 @@ private:
 
     Ref<DOMPromise> m_closedPromise;
     Ref<DeferredPromise> m_closedDeferred;
-    RefPtr<ReadableStream> m_stream;
+    mutable Lock m_streamLock;
+    RefPtr<ReadableStream> m_stream WTF_GUARDED_BY_LOCK(m_streamLock);
     Deque<Ref<ReadableStreamReadRequest>> m_readRequests;
 
     const RefPtr<InternalReadableStreamDefaultReader> m_internalDefaultReader;

--- a/Source/WebCore/accessibility/atspi/AccessibilityAtspi.cpp
+++ b/Source/WebCore/accessibility/atspi/AccessibilityAtspi.cpp
@@ -964,7 +964,7 @@ void AccessibilityAtspi::notifyValueChanged(AccessibilityObjectAtspi& atspiObjec
 
 void AccessibilityAtspi::notifyLoadEvent(AccessibilityObjectAtspi& atspiObject, const CString& event) const
 {
-    if (event != "LoadComplete")
+    if (event != "LoadComplete"_s)
         return;
 
     notify(atspiObject, "AXLoadComplete", nullptr);

--- a/Source/WebCore/bindings/js/JSSubscriberCustom.cpp
+++ b/Source/WebCore/bindings/js/JSSubscriberCustom.cpp
@@ -33,10 +33,7 @@ namespace WebCore {
 template<typename Visitor>
 void JSSubscriber::visitAdditionalChildren(Visitor& visitor)
 {
-    for (auto* teardown : wrapped().teardownCallbacksConcurrently())
-        teardown->visitJSFunction(visitor);
-
-    wrapped().observerConcurrently()->visitAdditionalChildren(visitor);
+    wrapped().visitAdditionalChildren(visitor);
 }
 
 DEFINE_VISIT_ADDITIONAL_CHILDREN(JSSubscriber);

--- a/Source/WebCore/bindings/js/JSXMLHttpRequestCustom.cpp
+++ b/Source/WebCore/bindings/js/JSXMLHttpRequestCustom.cpp
@@ -45,11 +45,7 @@ using namespace JSC;
 template<typename Visitor>
 void JSXMLHttpRequest::visitAdditionalChildren(Visitor& visitor)
 {
-    if (auto* upload = wrapped().optionalUpload())
-        addWebCoreOpaqueRoot(visitor, *upload);
-
-    if (SUPPRESS_UNCHECKED_LOCAL auto* responseDocument = wrapped().optionalResponseXML())
-        addWebCoreOpaqueRoot(visitor, *responseDocument);
+    wrapped().visitAdditionalChildren(visitor);
 }
 
 DEFINE_VISIT_ADDITIONAL_CHILDREN(JSXMLHttpRequest);

--- a/Source/WebCore/bindings/js/JSXPathResultCustom.cpp
+++ b/Source/WebCore/bindings/js/JSXPathResultCustom.cpp
@@ -27,21 +27,12 @@
 #include "config.h"
 #include "JSXPathResult.h"
 
-#include "JSNodeCustom.h"
-#include "WebCoreOpaqueRootInlines.h"
-#include "XPathValue.h"
-
 namespace WebCore {
 
 template<typename Visitor>
 void JSXPathResult::visitAdditionalChildren(Visitor& visitor)
 {
-    auto& value = wrapped().value();
-    if (value.isNodeSet()) {
-        // FIXME: This looks like it might race, but I'm not sure.
-        for (auto& node : value.toNodeSet())
-            addWebCoreOpaqueRoot(visitor, node.get());
-    }
+    wrapped().visitAdditionalChildren(visitor);
 }
 
 DEFINE_VISIT_ADDITIONAL_CHILDREN(JSXPathResult);

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -36,6 +36,7 @@
 #include "CryptoKeyRSA.h"
 #include "CryptoKeyRSAComponents.h"
 #include "CryptoKeyRaw.h"
+#include "HTMLCanvasElement.h"
 #include "IDBValue.h"
 #include "ImageBuffer.h"
 #include "JSAudioWorkletGlobalScope.h"
@@ -130,6 +131,7 @@
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
 #include "JSOffscreenCanvas.h"
 #include "OffscreenCanvas.h"
+#include "PlaceholderRenderingContext.h"
 #endif
 
 #if CPU(BIG_ENDIAN) || CPU(MIDDLE_ENDIAN) || CPU(NEEDS_ALIGNED_ACCESS)
@@ -6051,6 +6053,70 @@ SerializedScriptValue::SerializedScriptValue(Vector<uint8_t>&& buffer, Vector<UR
     }
 {
     m_internals.memoryCost = computeMemoryCost();
+}
+
+static std::unique_ptr<ArrayBufferContentsArray> copyArrayBufferContentsArray(const std::unique_ptr<ArrayBufferContentsArray>& source)
+{
+    if (!source)
+        return nullptr;
+    auto result = makeUnique<ArrayBufferContentsArray>();
+    result->reserveInitialCapacity(source->size());
+    for (auto& content : *source) {
+        result->append(JSC::ArrayBufferContents());
+        content.shareWith(result->last());
+    }
+    return result;
+}
+
+Ref<SerializedScriptValue> SerializedScriptValue::clone() const
+{
+    return create(m_internals.clone());
+}
+
+SerializedScriptValue::Internals SerializedScriptValue::Internals::clone() const
+{
+    return Internals {
+        data,
+        copyArrayBufferContentsArray(arrayBufferContentsArray),
+#if ENABLE(WEB_RTC)
+        detachedRTCDataChannels.map([](const auto& channel) {
+            return makeUnique<DetachedRTCDataChannel>(channel->identifier, channel->label.isolatedCopy(), channel->options.isolatedCopy(), channel->state);
+        }),
+#endif
+#if ENABLE(WEB_CODECS)
+        serializedVideoChunks,
+        serializedAudioChunks,
+        serializedVideoFrames,
+        serializedAudioData,
+#endif
+#if ENABLE(WEB_RTC)
+        serializedRTCEncodedAudioFrames.map([](const auto& frame) { return frame->clone(); }),
+        serializedRTCEncodedVideoFrames.map([](const auto& frame) { return frame->clone(); }),
+#endif
+#if ENABLE(MEDIA_SOURCE_IN_WORKERS)
+        detachedMediaSourceHandles,
+#endif
+#if ENABLE(MEDIA_STREAM)
+        serializedMediaStreamTracks.map([](const auto& track) {
+            return track->copy();
+        }),
+#endif
+        copyArrayBufferContentsArray(sharedBufferContentsArray),
+        detachedImageBitmaps,
+#if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
+        detachedOffscreenCanvases.map([](const auto& canvas) {
+            return makeUnique<DetachedOffscreenCanvas>(canvas->size(), canvas->originClean(), RefPtr { canvas->placeholderSource() });
+        }),
+        inMemoryOffscreenCanvases,
+#endif
+        inMemoryMessagePorts,
+#if ENABLE(WEBASSEMBLY)
+        wasmModulesArray ? makeUnique<WasmModuleArray>(*wasmModulesArray) : nullptr,
+        wasmMemoryHandlesArray ? makeUnique<WasmMemoryHandleArray>(*wasmMemoryHandlesArray) : nullptr,
+#endif
+        blobHandles.map([](const auto& handle) { return handle.isolatedCopy(); }),
+        memoryCost
+    };
 }
 
 SerializedScriptValue::SerializedScriptValue(Internals&& internals)

--- a/Source/WebCore/bindings/js/SerializedScriptValue.h
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.h
@@ -149,6 +149,8 @@ public:
     enum class DeserializationBehavior : uint8_t { Fail, Succeed, LegacyMapToNull, LegacyMapToUndefined, LegacyMapToEmptyObject };
     WEBCORE_EXPORT static DeserializationBehavior deserializationBehavior(JSC::JSObject&);
 
+    WEBCORE_EXPORT Ref<SerializedScriptValue> clone() const;
+
 private:
     friend struct IPC::ArgumentCoder<SerializedScriptValue>;
 
@@ -239,6 +241,8 @@ private:
 #endif
         Vector<URLKeepingBlobAlive> blobHandles { };
         uint64_t memoryCost { 0 };
+
+        WEBCORE_EXPORT Internals clone() const;
     };
     friend struct IPC::ArgumentCoder<Internals>;
 

--- a/Source/WebCore/dom/DocumentStorageAccess.cpp
+++ b/Source/WebCore/dom/DocumentStorageAccess.cpp
@@ -389,7 +389,7 @@ void DocumentStorageAccess::requestStorageAccessQuirk(RegistrableDomain&& reques
 
 void DocumentStorageAccess::enableTemporaryTimeUserGesture()
 {
-    m_temporaryUserGesture = makeUnique<UserGestureIndicator>(IsProcessingUserGesture::Yes, protectedDocument().ptr());
+    m_temporaryUserGesture = makeUnique<UserGestureIndicator>(IsProcessingUserGesture::Yes, protectedDocument().ptr(), UserGestureType::ActivationTriggering, UserGestureIndicator::ProcessInteractionStyle::Never);
 }
 
 void DocumentStorageAccess::consumeTemporaryTimeUserGesture()

--- a/Source/WebCore/dom/Subscriber.cpp
+++ b/Source/WebCore/dom/Subscriber.cpp
@@ -154,28 +154,20 @@ void Subscriber::reportErrorObject(JSC::JSValue value)
     reportException(globalObject, JSC::Exception::create(vm, value));
 }
 
-Vector<VoidCallback*> Subscriber::teardownCallbacksConcurrently()
+template<typename Visitor>
+void Subscriber::visitAdditionalChildren(Visitor& visitor)
 {
-    Locker locker { m_teardownsLock };
-    return m_teardowns.map([](auto& callback) {
-        return callback.ptr();
-    });
+    // Do not ref anything in this function, which runs in a GC thread concurrently to the main thread.
+    {
+        Locker locker { m_teardownsLock };
+        SUPPRESS_UNCOUNTED_LOCAL for (auto& teardown : m_teardowns)
+            SUPPRESS_UNCOUNTED_ARG teardown->visitJSFunction(visitor);
+    }
+
+    SUPPRESS_UNRETAINED_ARG m_observer->visitAdditionalChildren(visitor);
 }
 
-InternalObserver* Subscriber::observerConcurrently()
-{
-    return &m_observer.get();
-}
-
-void Subscriber::visitAdditionalChildren(JSC::AbstractSlotVisitor& visitor)
-{
-    // We cannot ref `teardown` here as this may get called from the GC thread.
-    SUPPRESS_UNRETAINED_ARG for (auto* teardown : teardownCallbacksConcurrently())
-        teardown->visitJSFunction(visitor);
-
-    // We cannot ref the observer here as this may get called from the GC thread.
-    SUPPRESS_UNRETAINED_ARG observerConcurrently()->visitAdditionalChildren(visitor);
-}
+DEFINE_VISIT_ADDITIONAL_CHILDREN(Subscriber);
 
 Subscriber::~Subscriber() = default;
 

--- a/Source/WebCore/dom/Subscriber.h
+++ b/Source/WebCore/dom/Subscriber.h
@@ -58,10 +58,7 @@ public:
 
     void reportErrorObject(JSC::JSValue);
 
-    // JSCustomMarkFunction; for JSSubscriberCustom
-    Vector<VoidCallback*> teardownCallbacksConcurrently();
-    InternalObserver* observerConcurrently();
-    void visitAdditionalChildren(JSC::AbstractSlotVisitor&);
+    template<typename Visitor> void visitAdditionalChildren(Visitor&);
 
 private:
     explicit Subscriber(ScriptExecutionContext&, Ref<InternalObserver>&&, const SubscribeOptions&);

--- a/Source/WebCore/html/HTMLPlugInElement.cpp
+++ b/Source/WebCore/html/HTMLPlugInElement.cpp
@@ -89,6 +89,12 @@
 #include <JavaScriptCore/JSGlobalObjectInlines.h>
 #include <wtf/TZoneMallocInlines.h>
 
+#if ENABLE(CONTENT_EXTENSIONS)
+#include "ContentExtensionsBackend.h"
+#include "ResourceLoadInfo.h"
+#include "UserContentProvider.h"
+#endif
+
 #if PLATFORM(COCOA)
 #include "YouTubePluginReplacement.h"
 #endif
@@ -549,6 +555,20 @@ bool HTMLPlugInElement::canLoadURL(const URL& completeURL) const
         if (contentDocument && !protectedDocument()->protectedSecurityOrigin()->isSameOriginDomain(contentDocument->protectedSecurityOrigin().get()))
             return false;
     }
+
+#if ENABLE(CONTENT_EXTENSIONS)
+    if (completeURL.isValid()) {
+        RefPtr page = document().page();
+        RefPtr frame = document().frame();
+        RefPtr documentLoader = frame ? frame->loader().documentLoader() : nullptr;
+        RefPtr userContentProvider = frame ? frame->userContentProvider() : nullptr;
+        if (page && documentLoader && userContentProvider) {
+            auto results = userContentProvider->processContentRuleListsForLoad(*page, completeURL, ContentExtensions::ResourceType::Other, *documentLoader);
+            if (results.shouldBlock())
+                return false;
+        }
+    }
+#endif
 
     return !isProhibitedSelfReference(completeURL);
 }

--- a/Source/WebCore/html/ImageBitmap.cpp
+++ b/Source/WebCore/html/ImageBitmap.cpp
@@ -78,6 +78,14 @@ DetachedImageBitmap::DetachedImageBitmap(UniqueRef<SerializedImageBuffer> bitmap
 {
 }
 
+DetachedImageBitmap::DetachedImageBitmap(const DetachedImageBitmap& other)
+    : m_bitmap(makeUniqueRefFromNonNullUniquePtr(other.m_bitmap->clone()))
+    , m_originClean(other.m_originClean)
+    , m_premultiplyAlpha(other.m_premultiplyAlpha)
+    , m_forciblyPremultiplyAlpha(other.m_forciblyPremultiplyAlpha)
+{
+}
+
 DetachedImageBitmap::DetachedImageBitmap(DetachedImageBitmap&&) = default;
 
 DetachedImageBitmap::~DetachedImageBitmap() = default;

--- a/Source/WebCore/html/ImageBitmap.h
+++ b/Source/WebCore/html/ImageBitmap.h
@@ -73,6 +73,7 @@ template<typename> class ExceptionOr;
 
 class DetachedImageBitmap {
 public:
+    DetachedImageBitmap(const DetachedImageBitmap&);
     DetachedImageBitmap(DetachedImageBitmap&&);
     WEBCORE_EXPORT ~DetachedImageBitmap();
     DetachedImageBitmap& operator=(DetachedImageBitmap&&);

--- a/Source/WebCore/html/OffscreenCanvas.h
+++ b/Source/WebCore/html/OffscreenCanvas.h
@@ -89,6 +89,7 @@ public:
     WEBCORE_EXPORT ~DetachedOffscreenCanvas();
     const IntSize& size() const { return m_size; }
     bool originClean() const { return m_originClean; }
+    const RefPtr<PlaceholderRenderingContextSource>& placeholderSource() const { return m_placeholderSource; }
     RefPtr<PlaceholderRenderingContextSource> takePlaceholderSource();
 
 private:

--- a/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
+++ b/Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm
@@ -176,7 +176,8 @@ GPUCanvasContextCocoa::GPUCanvasContextCocoa(CanvasBase& canvas, Ref<GPUComposit
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
-        if (auto* screenData = WebCore::screenData(displayID))
+        Ref screen = PlatformScreen::singleton();
+        if (auto* screenData = screen->screenData(displayID))
             protectedThis->updateScreenHeadroom(screenData->currentEDRHeadroom, screenData->suppressEDR);
     }))
 #endif // HAVE(SUPPORT_HDR_DISPLAY)
@@ -246,7 +247,8 @@ void GPUCanvasContextCocoa::updateScreenHeadroomFromScreenProperties()
 {
     m_currentEDRHeadroom = 1.f;
     m_suppressEDR = false;
-    for (const auto& screenData : WebCore::getScreenProperties().screenDataMap.values()) {
+    Ref screen = PlatformScreen::singleton();
+    for (const auto& screenData : screen->screenDatas().values()) {
         m_currentEDRHeadroom = std::max(m_currentEDRHeadroom, screenData.currentEDRHeadroom);
         m_suppressEDR |= screenData.suppressEDR;
     }

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -386,7 +386,7 @@ Navigation::Result Navigation::reload(ReloadOptions&& options, Ref<DeferredPromi
         state = currentEntry()->associatedHistoryItem().navigationAPIStateObject();
 
     RefPtr window = this->window();
-    if (!window->protectedDocument()->isFullyActive() || window->document()->unloadCounter())
+    if (!window->protectedDocument()->isFullyActive() || frame()->loader().isDispatchingPageSwapEvent() || window->document()->unloadCounter())
         return createErrorResult(WTF::move(committed), WTF::move(finished), ExceptionCode::InvalidStateError, "Invalid state"_s);
 
     RefPtr apiMethodTracker = maybeSetUpcomingNonTraversalTracker(WTF::move(committed), WTF::move(finished), WTF::move(options.info), WTF::move(state));

--- a/Source/WebCore/platform/PlatformScreen.cpp
+++ b/Source/WebCore/platform/PlatformScreen.cpp
@@ -43,8 +43,7 @@ static Lock& platformScreenLock()
 Ref<PlatformScreen>& PlatformScreen::instance() WTF_REQUIRES_LOCK(platformScreenLock())
 {
     static NeverDestroyed<Ref<PlatformScreen>> platformScreen = PlatformScreen::create({ });
-    static NeverDestroyed<Ref<PlatformScreen>> ref { platformScreen.get() };
-    return ref.get();
+    return platformScreen.get();
 }
 
 PlatformScreen::PlatformScreen(ScreenProperties&& properties)

--- a/Source/WebCore/platform/PlatformScreen.cpp
+++ b/Source/WebCore/platform/PlatformScreen.cpp
@@ -29,56 +29,96 @@
 #if PLATFORM(COCOA) || PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))
 
 #include "ScreenProperties.h"
+#include <wtf/Lock.h>
 #include <wtf/NeverDestroyed.h>
 
 namespace WebCore {
 
-static ScreenProperties& screenProperties()
+static Lock& platformScreenLock()
 {
-    static NeverDestroyed<ScreenProperties> screenProperties;
-    return screenProperties;
+    static Lock lock;
+    return lock;
 }
 
-const ScreenProperties& getScreenProperties()
+Ref<PlatformScreen>& PlatformScreen::instance() WTF_REQUIRES_LOCK(platformScreenLock())
 {
-    return screenProperties();
+    static NeverDestroyed<Ref<PlatformScreen>> platformScreen = PlatformScreen::create({ });
+    static NeverDestroyed<Ref<PlatformScreen>> ref { platformScreen.get() };
+    return ref.get();
 }
 
-PlatformDisplayID primaryScreenDisplayID()
+PlatformScreen::PlatformScreen(ScreenProperties&& properties)
+    : m_properties(WTF::move(properties))
 {
-    return screenProperties().primaryDisplayID;
 }
 
-void setScreenProperties(const ScreenProperties& properties)
+Ref<PlatformScreen> PlatformScreen::create(ScreenProperties&& properties)
 {
-    screenProperties() = properties;
+    return adoptRef(*new PlatformScreen(WTF::move(properties)));
 }
 
-const ScreenData* screenData(PlatformDisplayID screenDisplayID)
+Ref<const PlatformScreen> PlatformScreen::singleton()
 {
-    if (screenProperties().screenDataMap.isEmpty())
+    Locker locker { platformScreenLock() };
+    return instance().get();
+}
+
+const ScreenData* PlatformScreen::screenData(PlatformDisplayID screenDisplayID) const
+{
+    if (m_properties.screenDataMap.isEmpty())
         return nullptr;
 
     // Return property of the first screen if the screen is not found in the map.
     if (auto displayID = screenDisplayID ? screenDisplayID : primaryScreenDisplayID()) {
-        auto properties = screenProperties().screenDataMap.find(displayID);
-        if (properties != screenProperties().screenDataMap.end())
+        auto properties = m_properties.screenDataMap.find(displayID);
+        if (properties != m_properties.screenDataMap.end())
             return &properties->value;
     }
 
     // Last resort: use the first item in the screen list.
-    return &screenProperties().screenDataMap.begin()->value;
+    return &m_properties.screenDataMap.begin()->value;
+}
+
+PlatformDisplayID PlatformScreen::primaryScreenDisplayID() const
+{
+    return m_properties.primaryDisplayID;
+}
+
+const ScreenProperties& PlatformScreen::screenProperties() const
+{
+    return m_properties;
+}
+
+const ScreenDataMap& PlatformScreen::screenDatas() const
+{
+    return screenProperties().screenDataMap;
 }
 
 #if HAVE(SUPPORT_HDR_DISPLAY)
-void setScreenContentsFormatsForTesting(OptionSet<ContentsFormat> contentsFormats)
+OptionSet<ContentsFormat> PlatformScreen::screenContentsFormatsForTesting() const
 {
-    screenProperties().screenContentsFormatsForTesting = contentsFormats;
+    return m_properties.screenContentsFormatsForTesting;
+}
+#endif
+
+void PlatformScreen::updateSingletonProperties(ScreenProperties&& properties)
+{
+    Locker locker { platformScreenLock() };
+    Ref<PlatformScreen>& platformScreenRef = PlatformScreen::instance();
+
+    // If we have the only reference, we can update in place
+    if (platformScreenRef->hasOneRef())
+        platformScreenRef->m_properties = WTF::move(properties);
+    else
+        platformScreenRef = PlatformScreen::create(WTF::move(properties));
 }
 
-OptionSet<ContentsFormat> screenContentsFormatsForTesting()
+#if HAVE(SUPPORT_HDR_DISPLAY)
+void PlatformScreen::updateSingletonContentsFormatsForTesting(OptionSet<ContentsFormat> contentsFormats)
 {
-    return screenProperties().screenContentsFormatsForTesting;
+    auto properties = singleton()->screenProperties();
+    properties.screenContentsFormatsForTesting = contentsFormats;
+    updateSingletonProperties(WTF::move(properties));
 }
 #endif
 

--- a/Source/WebCore/platform/PlatformScreen.h
+++ b/Source/WebCore/platform/PlatformScreen.h
@@ -26,8 +26,10 @@
 #pragma once
 
 #include <WebCore/ContentsFormat.h>
+#include <WebCore/ScreenProperties.h>
 #include <wtf/Forward.h>
 #include <wtf/Platform.h>
+#include <wtf/ThreadSafeRefCounted.h>
 
 #if PLATFORM(MAC)
 OBJC_CLASS NSScreen;
@@ -59,10 +61,6 @@ class FloatRect;
 class FloatSize;
 class Widget;
 
-using PlatformDisplayID = uint32_t;
-
-using PlatformGPUID = uint64_t; // On MAC, global IOKit registryID that can identify a GPU across process boundaries.
-
 int screenDepth(Widget*);
 int screenDepthPerComponent(Widget*);
 bool screenIsMonochrome(Widget*);
@@ -81,13 +79,6 @@ FloatRect screenAvailableRect(Widget*);
 WEBCORE_EXPORT OptionSet<ContentsFormat> screenContentsFormats(Widget* = nullptr);
 WEBCORE_EXPORT bool screenSupportsExtendedColor(Widget* = nullptr);
 
-enum class DynamicRangeMode : uint8_t {
-    None,
-    Standard,
-    HLG,
-    HDR10,
-    DolbyVisionPQ,
-};
 #if HAVE(AVPLAYER_VIDEORANGEOVERRIDE)
 WEBCORE_EXPORT DynamicRangeMode preferredDynamicRangeMode(Widget* = nullptr);
 #else
@@ -103,17 +94,34 @@ constexpr bool screenSupportsHighDynamicRange(Widget* = nullptr) { return false;
 
 struct ScreenProperties;
 struct ScreenData;
-    
-WEBCORE_EXPORT ScreenProperties collectScreenProperties();
-WEBCORE_EXPORT void setScreenProperties(const ScreenProperties&);
-WEBCORE_EXPORT const ScreenProperties& getScreenProperties();
-WEBCORE_EXPORT const ScreenData* screenData(PlatformDisplayID screendisplayID);
-WEBCORE_EXPORT PlatformDisplayID primaryScreenDisplayID();
+
+class PlatformScreen : public ThreadSafeRefCounted<PlatformScreen> {
+public:
+    WEBCORE_EXPORT static Ref<const PlatformScreen> singleton();
+    WEBCORE_EXPORT static void updateSingletonProperties(ScreenProperties&&);
+
+    WEBCORE_EXPORT const ScreenData* screenData(PlatformDisplayID) const LIFETIME_BOUND;
+    WEBCORE_EXPORT PlatformDisplayID primaryScreenDisplayID() const;
+    WEBCORE_EXPORT const ScreenProperties& screenProperties() const LIFETIME_BOUND;
+    WEBCORE_EXPORT const ScreenDataMap& screenDatas() const LIFETIME_BOUND;
 
 #if HAVE(SUPPORT_HDR_DISPLAY)
-WEBCORE_EXPORT void setScreenContentsFormatsForTesting(OptionSet<ContentsFormat>);
-OptionSet<ContentsFormat> screenContentsFormatsForTesting();
+    WEBCORE_EXPORT OptionSet<ContentsFormat> screenContentsFormatsForTesting() const;
+    WEBCORE_EXPORT static void updateSingletonContentsFormatsForTesting(OptionSet<ContentsFormat>);
+#endif
 
+private:
+    static Ref<PlatformScreen> create(ScreenProperties&&);
+    static Ref<PlatformScreen>& instance();
+
+    explicit PlatformScreen(ScreenProperties&&);
+
+    ScreenProperties m_properties;
+};
+
+WEBCORE_EXPORT ScreenProperties collectScreenProperties();
+
+#if HAVE(SUPPORT_HDR_DISPLAY)
 WEBCORE_EXPORT float currentEDRHeadroomForDisplay(PlatformDisplayID);
 WEBCORE_EXPORT float maxEDRHeadroomForDisplay(PlatformDisplayID);
 WEBCORE_EXPORT bool suppressEDRForDisplay(PlatformDisplayID);

--- a/Source/WebCore/platform/ScreenProperties.h
+++ b/Source/WebCore/platform/ScreenProperties.h
@@ -27,13 +27,24 @@
 
 #include <WebCore/DestinationColorSpace.h>
 #include <WebCore/FloatRect.h>
-#include <WebCore/PlatformScreen.h>
 #include <wtf/HashMap.h>
 #include <wtf/Platform.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
+
+using PlatformGPUID = uint64_t; // On MAC, global IOKit registryID that can identify a GPU across process boundaries.
+
+using PlatformDisplayID = uint32_t;
+
+enum class DynamicRangeMode : uint8_t {
+    None,
+    Standard,
+    HLG,
+    HDR10,
+    DolbyVisionPQ,
+};
 
 struct ScreenData {
     FloatRect screenAvailableRect;

--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -185,6 +185,11 @@ public:
         return m_buffer->memoryCost();
     }
 
+    std::unique_ptr<SerializedImageBuffer> clone() const final
+    {
+        return makeUnique<DefaultSerializedImageBuffer>(m_buffer.get());
+    }
+
 private:
     RefPtr<ImageBuffer> m_buffer;
 };

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -279,6 +279,7 @@ public:
     virtual ~SerializedImageBuffer() = default;
 
     virtual size_t memoryCost() const = 0;
+    virtual std::unique_ptr<SerializedImageBuffer> clone() const { return nullptr; }
 
     WEBCORE_EXPORT static RefPtr<ImageBuffer> sinkIntoImageBuffer(std::unique_ptr<SerializedImageBuffer>, GraphicsClient* = nullptr);
 

--- a/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm
@@ -271,7 +271,8 @@ static bool isVP9CodecConfigurationRecordSupported(const VPCodecConfigurationRec
         auto screenSize = FloatSize(overrideForTesting->width, overrideForTesting->height).scaled(overrideForTesting->scale);
         has4kScreen = resolutionCategory(screenSize) >= ResolutionCategory::R_4K;
     } else {
-        for (auto& screenData : getScreenProperties().screenDataMap.values()) {
+        Ref screen = PlatformScreen::singleton();
+        for (auto& screenData : screen->screenDatas().values()) {
             if (resolutionCategory(screenData.screenRect.size().scaled(screenData.scaleFactor)) >= ResolutionCategory::R_4K) {
                 has4kScreen = true;
                 break;
@@ -404,7 +405,8 @@ std::optional<MediaCapabilitiesInfo> computeVPParameters(const VideoConfiguratio
         auto screenSize = FloatSize(overrideForTesting->width, overrideForTesting->height).scaled(overrideForTesting->scale);
         has4kScreen = resolutionCategory(screenSize) >= ResolutionCategory::R_4K;
     } else {
-        for (auto& screenData : getScreenProperties().screenDataMap.values()) {
+        Ref screen = PlatformScreen::singleton();
+        for (auto& screenData : screen->screenDatas().values()) {
             if (resolutionCategory(screenData.screenRect.size().scaled(screenData.scaleFactor)) >= ResolutionCategory::R_4K) {
                 has4kScreen = true;
                 break;

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -1067,7 +1067,8 @@ GStreamerRegistryScanner::RegistryLookupResult GStreamerRegistryScanner::isConfi
 #endif
 
 #if ENABLE(WPE_PLATFORM)
-        auto* scrData = screenData(primaryScreenDisplayID());
+        Ref platformScreen = PlatformScreen::singleton();
+        auto* scrData = platformScreen->screenData(PlatformScreen::singleton()->primaryScreenDisplayID());
         if (!scrData || !scrData->screenSupportsHighDynamicRange) {
             // Check HDR metadata field
             if (videoConfiguration.hdrMetadataType.has_value())

--- a/Source/WebCore/platform/gtk/PlatformScreenGtk.cpp
+++ b/Source/WebCore/platform/gtk/PlatformScreenGtk.cpp
@@ -59,13 +59,15 @@ static PlatformDisplayID widgetDisplayID(Widget* widget)
 
 int screenDepth(Widget* widget)
 {
-    auto* data = screenData(widgetDisplayID(widget));
+    Ref platformScreen = PlatformScreen::singleton();
+    auto* data = platformScreen->screenData(widgetDisplayID(widget));
     return data ? data->screenDepth : 24;
 }
 
 int screenDepthPerComponent(Widget* widget)
 {
-    auto* data = screenData(widgetDisplayID(widget));
+    Ref platformScreen = PlatformScreen::singleton();
+    auto* data = platformScreen->screenData(widgetDisplayID(widget));
     return data ? data->screenDepthPerComponent : 8;
 }
 
@@ -90,27 +92,31 @@ double fontDPI()
     if (xftDPI)
         return xftDPI.value() / 1024.0;
 
-    auto* data = screenData(primaryScreenDisplayID());
+    Ref platformScreen = PlatformScreen::singleton();
+    auto* data = platformScreen->screenData(platformScreen->primaryScreenDisplayID());
     return data ? data->dpi : 96.;
 }
 
 double screenDPI(PlatformDisplayID screendisplayID)
 {
-    auto* data = screenData(screendisplayID);
+    Ref platformScreen = PlatformScreen::singleton();
+    auto* data = platformScreen->screenData(screendisplayID);
     return data ? data->dpi : 96.;
 }
 
 
 FloatRect screenRect(Widget* widget)
 {
-    if (auto* data = screenData(widgetDisplayID(widget)))
+    Ref platformScreen = PlatformScreen::singleton();
+    if (auto* data = platformScreen->screenData(widgetDisplayID(widget)))
         return data->screenRect;
     return { };
 }
 
 FloatRect screenAvailableRect(Widget* widget)
 {
-    if (auto* data = screenData(widgetDisplayID(widget)))
+    Ref platformScreen = PlatformScreen::singleton();
+    if (auto* data = platformScreen->screenData(widgetDisplayID(widget)))
         return data->screenAvailableRect;
     return { };
 }
@@ -123,7 +129,8 @@ bool screenSupportsExtendedColor(Widget*)
 #if ENABLE(TOUCH_EVENTS)
 bool screenHasTouchDevice()
 {
-    return getScreenProperties().screenHasTouchDevice;
+    Ref platformScreen = PlatformScreen::singleton();
+    return platformScreen->screenProperties().screenHasTouchDevice;
 }
 #endif // ENABLE(TOUCH_EVENTS)
 

--- a/Source/WebCore/platform/ios/PlatformScreenIOS.mm
+++ b/Source/WebCore/platform/ios/PlatformScreenIOS.mm
@@ -66,7 +66,8 @@ bool screenIsMonochrome(Widget*)
 
 bool screenHasInvertedColors()
 {
-    if (auto data = screenData(primaryScreenDisplayID()))
+    Ref screen = PlatformScreen::singleton();
+    if (auto data = screen->screenData(screen->primaryScreenDisplayID()))
         return data->screenHasInvertedColors;
 
     return PAL::softLinkUIKitUIAccessibilityIsInvertColorsEnabled();
@@ -92,12 +93,13 @@ OptionSet<ContentsFormat> screenContentsFormats(Widget* widget)
 
 bool screenSupportsExtendedColor(Widget*)
 {
+    Ref screen = PlatformScreen::singleton();
 #if HAVE(SUPPORT_HDR_DISPLAY) && ENABLE(PIXEL_FORMAT_RGB10)
-    if (screenContentsFormatsForTesting().contains(ContentsFormat::RGBA10))
+    if (screen->screenContentsFormatsForTesting().contains(ContentsFormat::RGBA10))
         return true;
 #endif
 
-    if (auto data = screenData(primaryScreenDisplayID()))
+    if (auto data = screen->screenData(screen->primaryScreenDisplayID()))
         return data->screenSupportsExtendedColor;
 
     return MGGetBoolAnswer(kMGQHasExtendedColorDisplay);
@@ -105,12 +107,13 @@ bool screenSupportsExtendedColor(Widget*)
 
 bool screenSupportsHighDynamicRange(Widget*)
 {
+    Ref screen = PlatformScreen::singleton();
 #if HAVE(SUPPORT_HDR_DISPLAY) && ENABLE(PIXEL_FORMAT_RGBA16F)
-    if (screenContentsFormatsForTesting().contains(ContentsFormat::RGBA16F))
+    if (screen->screenContentsFormatsForTesting().contains(ContentsFormat::RGBA16F))
         return true;
 #endif
 
-    if (auto data = screenData(primaryScreenDisplayID()))
+    if (auto data = screen->screenData(screen->primaryScreenDisplayID()))
         return data->screenSupportsHighDynamicRange;
 
 #if USE(MEDIATOOLBOX)
@@ -128,7 +131,8 @@ bool screenSupportsHighDynamicRange(PlatformDisplayID)
 #if HAVE(SUPPORT_HDR_DISPLAY)
 float currentEDRHeadroomForDisplay(PlatformDisplayID)
 {
-    if (auto data = screenData(primaryScreenDisplayID()))
+    Ref screen = PlatformScreen::singleton();
+    if (auto data = screen->screenData(screen->primaryScreenDisplayID()))
         return data->currentEDRHeadroom;
 
     return [[PAL::getUIScreenClassSingleton() mainScreen] currentEDRHeadroom];
@@ -136,7 +140,8 @@ float currentEDRHeadroomForDisplay(PlatformDisplayID)
 
 float maxEDRHeadroomForDisplay(PlatformDisplayID)
 {
-    if (auto data = screenData(primaryScreenDisplayID()))
+    Ref screen = PlatformScreen::singleton();
+    if (auto data = screen->screenData(screen->primaryScreenDisplayID()))
         return data->maxEDRHeadroom;
 
     return [[PAL::getUIScreenClassSingleton() mainScreen] potentialEDRHeadroom];
@@ -144,7 +149,8 @@ float maxEDRHeadroomForDisplay(PlatformDisplayID)
 
 bool suppressEDRForDisplay(PlatformDisplayID)
 {
-    if (auto data = screenData(primaryScreenDisplayID()))
+    Ref screen = PlatformScreen::singleton();
+    if (auto data = screen->screenData(screen->primaryScreenDisplayID()))
         return data->suppressEDR;
 
     return false;
@@ -199,7 +205,8 @@ FloatRect screenAvailableRect(Widget* widget)
 
 float screenPPIFactor()
 {
-    if (auto data = screenData(primaryScreenDisplayID()))
+    Ref screen = PlatformScreen::singleton();
+    if (auto data = screen->screenData(screen->primaryScreenDisplayID()))
         return data->scaleFactor;
 
     static float ppiFactor = [] {
@@ -219,7 +226,8 @@ FloatSize screenSize()
     if (PAL::deviceHasIPadCapability() && [[PAL::getUIApplicationClassSingleton() sharedApplication] _isClassic])
         return { 320, 480 };
 
-    if (auto data = screenData(primaryScreenDisplayID()))
+    Ref screen = PlatformScreen::singleton();
+    if (auto data = screen->screenData(screen->primaryScreenDisplayID()))
         return data->screenRect.size();
 
     return FloatSize([[PAL::getUIScreenClassSingleton() mainScreen] _referenceBounds].size);
@@ -230,7 +238,8 @@ FloatSize availableScreenSize()
     if (PAL::deviceHasIPadCapability() && [[PAL::getUIApplicationClassSingleton() sharedApplication] _isClassic])
         return { 320, 480 };
 
-    if (auto data = screenData(primaryScreenDisplayID()))
+    Ref screen = PlatformScreen::singleton();
+    if (auto data = screen->screenData(screen->primaryScreenDisplayID()))
         return data->screenAvailableRect.size();
 
     return FloatSize([PAL::getUIScreenClassSingleton() mainScreen].bounds.size);

--- a/Source/WebCore/platform/mac/PlatformScreenMac.mm
+++ b/Source/WebCore/platform/mac/PlatformScreenMac.mm
@@ -218,7 +218,8 @@ void setShouldOverrideScreenSupportsHighDynamicRange(bool shouldOverride, bool s
 
 uint32_t primaryOpenGLDisplayMask()
 {
-    if (auto data = screenData(primaryScreenDisplayID()))
+    Ref screen = PlatformScreen::singleton();
+    if (auto data = screen->screenData(screen->primaryScreenDisplayID()))
         return data->displayMask;
 
     return 0;
@@ -226,7 +227,8 @@ uint32_t primaryOpenGLDisplayMask()
 
 uint32_t displayMaskForDisplay(PlatformDisplayID displayID)
 {
-    if (auto data = screenData(displayID))
+    Ref screen = PlatformScreen::singleton();
+    if (auto data = screen->screenData(displayID))
         return data->displayMask;
 
     ASSERT_NOT_REACHED();
@@ -235,12 +237,13 @@ uint32_t displayMaskForDisplay(PlatformDisplayID displayID)
 
 PlatformGPUID primaryGPUID()
 {
-    return gpuIDForDisplay(primaryScreenDisplayID());
+    return gpuIDForDisplay(PlatformScreen::singleton()->primaryScreenDisplayID());
 }
 
 PlatformGPUID gpuIDForDisplay(PlatformDisplayID displayID)
 {
-    if (auto data = screenData(displayID))
+    Ref screen = PlatformScreen::singleton();
+    if (auto data = screen->screenData(displayID))
         return data->gpuID;
 
     return 0;
@@ -284,14 +287,10 @@ PlatformGPUID gpuIDForDisplayMask(GLuint displayMask)
     return static_cast<PlatformGPUID>(static_cast<uint32_t>(gpuIDHigh)) << 32 | static_cast<uint32_t>(gpuIDLow);
 }
 
-static const ScreenData* screenProperties(Widget* widget)
-{
-    return screenData(displayID(widget));
-}
-
 bool screenIsMonochrome(Widget* widget)
 {
-    if (auto data = screenProperties(widget))
+    Ref platformScreen = PlatformScreen::singleton();
+    if (auto data = platformScreen->screenData(displayID(widget)))
         return data->screenIsMonochrome;
 
     // This is a system-wide accessibility setting, same on all screens.
@@ -301,7 +300,8 @@ bool screenIsMonochrome(Widget* widget)
 
 bool screenHasInvertedColors()
 {
-    if (auto data = screenData(primaryScreenDisplayID()))
+    Ref screen = PlatformScreen::singleton();
+    if (auto data = screen->screenData(screen->primaryScreenDisplayID()))
         return data->screenHasInvertedColors;
 
     // This is a system-wide accessibility setting, same on all screens.
@@ -311,7 +311,8 @@ bool screenHasInvertedColors()
 
 int screenDepth(Widget* widget)
 {
-    if (auto data = screenProperties(widget)) {
+    Ref platformScreen = PlatformScreen::singleton();
+    if (auto data = platformScreen->screenData(displayID(widget))) {
         ASSERT(data->screenDepth);
         return data->screenDepth;
     }
@@ -322,7 +323,8 @@ int screenDepth(Widget* widget)
 
 int screenDepthPerComponent(Widget* widget)
 {
-    if (auto data = screenProperties(widget)) {
+    Ref platformScreen = PlatformScreen::singleton();
+    if (auto data = platformScreen->screenData(displayID(widget))) {
         ASSERT(data->screenDepthPerComponent);
         return data->screenDepthPerComponent;
     }
@@ -333,7 +335,8 @@ int screenDepthPerComponent(Widget* widget)
 
 FloatRect screenRectForDisplay(PlatformDisplayID displayID)
 {
-    if (auto data = screenData(displayID)) {
+    Ref platformScreen = PlatformScreen::singleton();
+    if (auto data = platformScreen->screenData(displayID)) {
         ASSERT(!data->screenRect.isEmpty());
         return data->screenRect;
     }
@@ -344,13 +347,14 @@ FloatRect screenRectForDisplay(PlatformDisplayID displayID)
 
 FloatRect screenRectForPrimaryScreen()
 {
-    return screenRectForDisplay(primaryScreenDisplayID());
+    return screenRectForDisplay(PlatformScreen::singleton()->primaryScreenDisplayID());
 }
 
 #if HAVE(SUPPORT_HDR_DISPLAY)
 float currentEDRHeadroomForDisplay(PlatformDisplayID displayID)
 {
-    if (auto data = screenData(displayID))
+    Ref platformScreen = PlatformScreen::singleton();
+    if (auto data = platformScreen->screenData(displayID))
         return data->currentEDRHeadroom;
 
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
@@ -359,7 +363,8 @@ float currentEDRHeadroomForDisplay(PlatformDisplayID displayID)
 
 float maxEDRHeadroomForDisplay(PlatformDisplayID displayID)
 {
-    if (auto data = screenData(displayID))
+    Ref platformScreen = PlatformScreen::singleton();
+    if (auto data = platformScreen->screenData(displayID))
         return data->maxEDRHeadroom;
 
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
@@ -368,7 +373,8 @@ float maxEDRHeadroomForDisplay(PlatformDisplayID displayID)
 
 bool suppressEDRForDisplay(PlatformDisplayID displayID)
 {
-    if (auto data = screenData(displayID))
+    Ref platformScreen = PlatformScreen::singleton();
+    if (auto data = platformScreen->screenData(displayID))
         return data->suppressEDR;
 
     return false;
@@ -377,7 +383,8 @@ bool suppressEDRForDisplay(PlatformDisplayID displayID)
 
 FloatRect screenRect(Widget* widget)
 {
-    if (auto data = screenProperties(widget))
+    Ref platformScreen = PlatformScreen::singleton();
+    if (auto data = platformScreen->screenData(displayID(widget)))
         return data->screenRect;
 
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
@@ -386,7 +393,8 @@ FloatRect screenRect(Widget* widget)
 
 FloatRect screenAvailableRect(Widget* widget)
 {
-    if (auto data = screenProperties(widget))
+    Ref platformScreen = PlatformScreen::singleton();
+    if (auto data = platformScreen->screenData(displayID(widget)))
         return data->screenAvailableRect;
 
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
@@ -411,7 +419,8 @@ NSScreen *screen(PlatformDisplayID displayID)
 
 DestinationColorSpace screenColorSpace(Widget* widget)
 {
-    if (auto data = screenProperties(widget))
+    Ref platformScreen = PlatformScreen::singleton();
+    if (auto data = platformScreen->screenData(displayID(widget)))
         return data->colorSpace;
 
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
@@ -438,12 +447,13 @@ OptionSet<ContentsFormat> screenContentsFormats(Widget* widget)
 
 bool screenSupportsExtendedColor(Widget* widget)
 {
+    Ref platformScreen = PlatformScreen::singleton();
 #if HAVE(SUPPORT_HDR_DISPLAY) && ENABLE(PIXEL_FORMAT_RGB10)
-    if (screenContentsFormatsForTesting().contains(ContentsFormat::RGBA10))
+    if (platformScreen->screenContentsFormatsForTesting().contains(ContentsFormat::RGBA10))
         return true;
 #endif
 
-    if (auto data = screenProperties(widget))
+    if (auto data = platformScreen->screenData(displayID(widget)))
         return data->screenSupportsExtendedColor;
 
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
@@ -457,12 +467,14 @@ bool screenSupportsHighDynamicRange(Widget* widget)
 
 bool screenSupportsHighDynamicRange(PlatformDisplayID displayID)
 {
+    Ref screen = PlatformScreen::singleton();
+
 #if HAVE(SUPPORT_HDR_DISPLAY) && ENABLE(PIXEL_FORMAT_RGBA16F)
-    if (screenContentsFormatsForTesting().contains(ContentsFormat::RGBA16F))
+    if (screen->screenContentsFormatsForTesting().contains(ContentsFormat::RGBA16F))
         return true;
 #endif
 
-    if (auto data = screenData(displayID))
+    if (auto data = screen->screenData(displayID))
         return data->screenSupportsHighDynamicRange;
 
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
@@ -476,7 +488,8 @@ bool screenSupportsHighDynamicRange(PlatformDisplayID displayID)
 #if HAVE(AVPLAYER_VIDEORANGEOVERRIDE)
 DynamicRangeMode preferredDynamicRangeMode(Widget* widget)
 {
-    if (auto data = screenProperties(widget))
+    Ref platformScreen = PlatformScreen::singleton();
+    if (auto data = platformScreen->screenData(displayID(widget)))
         return data->preferredDynamicRangeMode;
 
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanCommunicateWithWindowServer));
@@ -499,14 +512,14 @@ FloatRect toUserSpace(const NSRect& rect, NSWindow *destination)
 FloatRect toUserSpaceForPrimaryScreen(const NSRect& rect)
 {
     FloatRect userRect = rect;
-    userRect.setY(NSMaxY(screenRectForDisplay(primaryScreenDisplayID())) - (userRect.y() + userRect.height())); // flip
+    userRect.setY(NSMaxY(screenRectForDisplay(PlatformScreen::singleton()->primaryScreenDisplayID())) - (userRect.y() + userRect.height())); // flip
     return userRect;
 }
 
 FloatPoint toUserSpaceForPrimaryScreen(const NSPoint& point)
 {
     FloatPoint userPoint = point;
-    userPoint.setY(NSMaxY(screenRectForDisplay(primaryScreenDisplayID())) - userPoint.y()); // flip
+    userPoint.setY(NSMaxY(screenRectForDisplay(PlatformScreen::singleton()->primaryScreenDisplayID())) - userPoint.y()); // flip
     return userPoint;
 }
 

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackDataHolder.cpp
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackDataHolder.cpp
@@ -103,6 +103,13 @@ MediaStreamTrackDataHolder::~MediaStreamTrackDataHolder()
 {
 }
 
+std::unique_ptr<MediaStreamTrackDataHolder> MediaStreamTrackDataHolder::copy() const
+{
+    auto holder = makeUnique<MediaStreamTrackDataHolder>(trackId.isolatedCopy(), label.isolatedCopy(), type, deviceType, isEnabled, isEnded, contentHint, isProducingData, isMuted, isInterrupted, settings.isolatedCopy(), capabilities.isolatedCopy(), source.copyRef());
+    holder->preventSourceFromEndingObserverWrapper = preventSourceFromEndingObserverWrapper;
+    return holder;
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackDataHolder.h
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackDataHolder.h
@@ -43,6 +43,7 @@ struct MediaStreamTrackDataHolder {
 
     MediaStreamTrackDataHolder(const MediaStreamTrackDataHolder &) = delete;
     MediaStreamTrackDataHolder &operator=(const MediaStreamTrackDataHolder &) = delete;
+    WEBCORE_EXPORT std::unique_ptr<MediaStreamTrackDataHolder> copy() const;
 
     String trackId;
     String label;

--- a/Source/WebCore/platform/mediastream/RealtimeIncomingAudioSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeIncomingAudioSource.cpp
@@ -49,7 +49,10 @@ RealtimeIncomingAudioSource::RealtimeIncomingAudioSource(Ref<webrtc::AudioTrackI
 
 RealtimeIncomingAudioSource::~RealtimeIncomingAudioSource()
 {
-    stop();
+    // Subclasses must call stop() in their destructors to ensure the audio
+    // track sink is removed BEFORE derived members are destroyed. Otherwise,
+    // the OnData callback may access destroyed members on the audio thread.
+    ASSERT(!isProducingData());
     m_audioTrack->UnregisterObserver(this);
 }
 

--- a/Source/WebCore/platform/mediastream/RealtimeIncomingVideoSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeIncomingVideoSource.cpp
@@ -73,7 +73,10 @@ RealtimeIncomingVideoSource::RealtimeIncomingVideoSource(Ref<webrtc::VideoTrackI
 
 RealtimeIncomingVideoSource::~RealtimeIncomingVideoSource()
 {
-    stop();
+    // Subclasses must call stop() in their destructors to ensure the video
+    // track sink is removed BEFORE derived members are destroyed. Otherwise,
+    // the OnFrame callback may access destroyed members on the video thread.
+    ASSERT(!isProducingData());
     m_videoTrack->UnregisterObserver(this);
 }
 

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingAudioSourceLibWebRTC.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingAudioSourceLibWebRTC.cpp
@@ -61,6 +61,11 @@ RealtimeIncomingAudioSourceLibWebRTC::RealtimeIncomingAudioSourceLibWebRTC(Ref<w
     GST_DEBUG("Created incoming audio source with ID: %s", persistentID().utf8().data());
 }
 
+RealtimeIncomingAudioSourceLibWebRTC::~RealtimeIncomingAudioSourceLibWebRTC()
+{
+    stop();
+}
+
 void RealtimeIncomingAudioSourceLibWebRTC::OnData(const void* audioData, int, int sampleRate, size_t numberOfChannels, size_t numberOfFrames)
 {
 #if GST_CHECK_VERSION(1, 22, 0)

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingAudioSourceLibWebRTC.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingAudioSourceLibWebRTC.h
@@ -38,6 +38,7 @@ namespace WebCore {
 class RealtimeIncomingAudioSourceLibWebRTC final : public RealtimeIncomingAudioSource {
 public:
     static Ref<RealtimeIncomingAudioSourceLibWebRTC> create(Ref<webrtc::AudioTrackInterface>&&, String&&);
+    ~RealtimeIncomingAudioSourceLibWebRTC();
 
 private:
     RealtimeIncomingAudioSourceLibWebRTC(Ref<webrtc::AudioTrackInterface>&&, String&&);

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingVideoSourceLibWebRTC.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingVideoSourceLibWebRTC.cpp
@@ -62,6 +62,11 @@ RealtimeIncomingVideoSourceLibWebRTC::RealtimeIncomingVideoSourceLibWebRTC(Ref<w
     GST_DEBUG("Created incoming video source with ID: %s", persistentID().utf8().data());
 }
 
+RealtimeIncomingVideoSourceLibWebRTC::~RealtimeIncomingVideoSourceLibWebRTC()
+{
+    stop();
+}
+
 void RealtimeIncomingVideoSourceLibWebRTC::OnFrame(const webrtc::VideoFrame& frame)
 {
     if (!isProducingData())

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingVideoSourceLibWebRTC.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingVideoSourceLibWebRTC.h
@@ -41,7 +41,7 @@ public:
 
 private:
     RealtimeIncomingVideoSourceLibWebRTC(Ref<webrtc::VideoTrackInterface>&&, String&&);
-    ~RealtimeIncomingVideoSourceLibWebRTC() { }
+    ~RealtimeIncomingVideoSourceLibWebRTC();
 
     // rtc::VideoSinkInterface
     void OnFrame(const webrtc::VideoFrame&) final;

--- a/Source/WebCore/platform/mediastream/mac/RealtimeIncomingAudioSourceCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/mac/RealtimeIncomingAudioSourceCocoa.cpp
@@ -72,6 +72,11 @@ RealtimeIncomingAudioSourceCocoa::RealtimeIncomingAudioSourceCocoa(Ref<webrtc::A
 {
 }
 
+RealtimeIncomingAudioSourceCocoa::~RealtimeIncomingAudioSourceCocoa()
+{
+    stop();
+}
+
 void RealtimeIncomingAudioSourceCocoa::startProducingData()
 {
     RealtimeIncomingAudioSource::startProducingData();

--- a/Source/WebCore/platform/mediastream/mac/RealtimeIncomingAudioSourceCocoa.h
+++ b/Source/WebCore/platform/mediastream/mac/RealtimeIncomingAudioSourceCocoa.h
@@ -42,6 +42,7 @@ namespace WebCore {
 class RealtimeIncomingAudioSourceCocoa final : public RealtimeIncomingAudioSource {
 public:
     static Ref<RealtimeIncomingAudioSourceCocoa> create(Ref<webrtc::AudioTrackInterface>&&, String&&);
+    ~RealtimeIncomingAudioSourceCocoa();
 
 private:
     RealtimeIncomingAudioSourceCocoa(Ref<webrtc::AudioTrackInterface>&&, String&&);

--- a/Source/WebCore/platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.h
+++ b/Source/WebCore/platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.h
@@ -45,6 +45,7 @@ enum class VideoFrameRotation : uint16_t;
 class RealtimeIncomingVideoSourceCocoa final : public RealtimeIncomingVideoSource {
 public:
     static Ref<RealtimeIncomingVideoSourceCocoa> create(Ref<webrtc::VideoTrackInterface>&&, String&&);
+    ~RealtimeIncomingVideoSourceCocoa();
 
 private:
     RealtimeIncomingVideoSourceCocoa(Ref<webrtc::VideoTrackInterface>&&, String&&);

--- a/Source/WebCore/platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.mm
+++ b/Source/WebCore/platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.mm
@@ -63,6 +63,11 @@ RealtimeIncomingVideoSourceCocoa::RealtimeIncomingVideoSourceCocoa(Ref<webrtc::V
 {
 }
 
+RealtimeIncomingVideoSourceCocoa::~RealtimeIncomingVideoSourceCocoa()
+{
+    stop();
+}
+
 CVPixelBufferPoolRef RealtimeIncomingVideoSourceCocoa::pixelBufferPool(size_t width, size_t height, webrtc::BufferType bufferType) WTF_IGNORES_THREAD_SAFETY_ANALYSIS
 {
     if (!m_pixelBufferPool || m_pixelBufferPoolWidth != width || m_pixelBufferPoolHeight != height || m_pixelBufferPoolBufferType != bufferType) {

--- a/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm
@@ -81,11 +81,11 @@ void NetworkStorageSession::setCookies(const Vector<Cookie>& cookies, const URL&
 {
     ASSERT(hasProcessPrivilege(ProcessPrivilege::CanAccessRawCookies) || m_isInMemoryCookieStore);
 
+    BEGIN_BLOCK_OBJC_EXCEPTIONS
     auto nsCookies = createNSArray(cookies, [] (auto& cookie) -> NSHTTPCookie * {
         return cookie.createNSHTTPCookie().autorelease();
     });
 
-    BEGIN_BLOCK_OBJC_EXCEPTIONS
     [nsCookieStorage() setCookies:nsCookies.get() forURL:url.createNSURL().get() mainDocumentURL:mainDocumentURL.createNSURL().get()];
     END_BLOCK_OBJC_EXCEPTIONS
 }

--- a/Source/WebCore/platform/wpe/PlatformScreenWPE.cpp
+++ b/Source/WebCore/platform/wpe/PlatformScreenWPE.cpp
@@ -57,7 +57,8 @@ static PlatformDisplayID widgetDisplayID(Widget* widget)
 int screenDepth(Widget* widget)
 {
 #if ENABLE(WPE_PLATFORM)
-    auto* data = screenData(widgetDisplayID(widget));
+    Ref platformScreen = PlatformScreen::singleton();
+    auto* data = platformScreen->screenData(widgetDisplayID(widget));
     return data ? data->screenDepth : 24;
 #else
     UNUSED_PARAM(widget);
@@ -69,7 +70,8 @@ int screenDepth(Widget* widget)
 int screenDepthPerComponent(Widget* widget)
 {
 #if ENABLE(WPE_PLATFORM)
-    auto* data = screenData(widgetDisplayID(widget));
+    Ref platformScreen = PlatformScreen::singleton();
+    auto* data = platformScreen->screenData(widgetDisplayID(widget));
     return data ? data->screenDepthPerComponent : 8;
 #else
     UNUSED_PARAM(widget);
@@ -97,7 +99,8 @@ bool screenHasInvertedColors()
 double screenDPI(PlatformDisplayID screendisplayID)
 {
 #if ENABLE(WPE_PLATFORM)
-    auto* data = screenData(screendisplayID);
+    Ref platformScreen = PlatformScreen::singleton();
+    auto* data = platformScreen->screenData(screendisplayID);
     return data ? data->dpi : 96.;
 #else
     UNUSED_PARAM(screendisplayID);
@@ -110,7 +113,7 @@ double fontDPI()
 {
 #if ENABLE(WPE_PLATFORM)
     // In WPE, there is no notion of font scaling separate from device DPI.
-    return screenDPI(primaryScreenDisplayID());
+    return screenDPI(PlatformScreen::singleton()->primaryScreenDisplayID());
 #else
     notImplemented();
     return 96.;
@@ -120,7 +123,8 @@ double fontDPI()
 FloatRect screenRect(Widget* widget)
 {
 #if ENABLE(WPE_PLATFORM)
-    if (auto* data = screenData(widgetDisplayID(widget)))
+    Ref platformScreen = PlatformScreen::singleton();
+    if (auto* data = platformScreen->screenData(widgetDisplayID(widget)))
         return data->screenRect;
 #endif
     // WPE can't offer any more useful information about the screen size,
@@ -134,7 +138,8 @@ FloatRect screenRect(Widget* widget)
 FloatRect screenAvailableRect(Widget* widget)
 {
 #if ENABLE(WPE_PLATFORM)
-    if (auto* data = screenData(widgetDisplayID(widget)))
+    Ref platformScreen = PlatformScreen::singleton();
+    if (auto* data = platformScreen->screenData(widgetDisplayID(widget)))
         return data->screenAvailableRect;
 #endif
     return screenRect(widget);

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -4126,7 +4126,7 @@ void Internals::setScreenContentsFormatsForTesting(const Vector<Internals::Conte
     }
 
 #if HAVE(SUPPORT_HDR_DISPLAY)
-    WebCore::setScreenContentsFormatsForTesting(contentsFormats);
+    PlatformScreen::singleton()->updateSingletonContentsFormatsForTesting(contentsFormats);
 #else
     UNUSED_PARAM(contentsFormats);
 #endif
@@ -7096,7 +7096,7 @@ void Internals::notifyResourceLoadObserver()
 unsigned Internals::primaryScreenDisplayID()
 {
 #if PLATFORM(COCOA)
-    return WebCore::primaryScreenDisplayID();
+    return PlatformScreen::singleton()->primaryScreenDisplayID();
 #else
     return 0;
 #endif

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -59,6 +59,7 @@
 #include "XMLHttpRequestProgressEvent.h"
 #include "XMLHttpRequestProgressEventThrottle.h"
 #include "XMLHttpRequestUpload.h"
+#include "WebCoreOpaqueRootInlines.h"
 #include "markup.h"
 #include <JavaScriptCore/ArrayBuffer.h>
 #include <JavaScriptCore/ArrayBufferView.h>
@@ -179,6 +180,7 @@ ExceptionOr<Document*> XMLHttpRequest::responseXML()
         // If it is text/html, then the responseType of "document" must have been supplied explicitly.
         if ((m_response.isInHTTPFamily() && !isXML && !isHTML)
             || (isHTML && responseType() == ResponseType::EmptyString)) {
+            Locker locker { m_gcLock };
             m_responseDocument = nullptr;
         } else {
             RefPtr<Document> responseDocument;
@@ -194,6 +196,7 @@ ExceptionOr<Document*> XMLHttpRequest::responseXML()
             if (m_decoder)
                 responseDocument->setDecoder(m_decoder.copyRef());
 
+            Locker locker { m_gcLock };
             if (!isHTML && !responseDocument->wellFormed())
                 m_responseDocument = nullptr;
             else
@@ -202,6 +205,7 @@ ExceptionOr<Document*> XMLHttpRequest::responseXML()
         m_createdDocument = true;
     }
 
+    Locker locker { m_gcLock };
     return m_responseDocument.get();
 }
 
@@ -273,6 +277,7 @@ String XMLHttpRequest::responseURL() const
 
 XMLHttpRequestUpload& XMLHttpRequest::upload()
 {
+    Locker locker { m_gcLock };
     if (!m_upload)
         lazyInitialize(m_upload, makeUniqueWithoutRefCountedCheck<XMLHttpRequestUpload>(*this));
     return *m_upload;
@@ -486,6 +491,7 @@ ExceptionOr<void> XMLHttpRequest::send(Document& document)
         auto converted = replaceUnpairedSurrogatesWithReplacementCharacter(WTF::move(serialized));
         auto encoded = PAL::TextCodecUTF8::encodeUTF8(WTF::move(converted));
         m_requestEntityBody = FormData::create(WTF::move(encoded));
+        Locker locker { m_gcLock };
         if (m_upload)
             m_requestEntityBody->setAlwaysStream(true);
     }
@@ -508,6 +514,7 @@ ExceptionOr<void> XMLHttpRequest::send(const String& body)
         }
 
         m_requestEntityBody = FormData::create(PAL::TextCodecUTF8::encodeUTF8(body));
+        Locker locker { m_gcLock };
         if (m_upload)
             m_requestEntityBody->setAlwaysStream(true);
     }
@@ -584,6 +591,7 @@ ExceptionOr<void> XMLHttpRequest::sendBytesData(std::span<const uint8_t> data)
 
     if (m_method != "GET"_s && m_method != "HEAD"_s) {
         m_requestEntityBody = FormData::create(data);
+        Locker locker { m_gcLock };
         if (m_upload)
             m_requestEntityBody->setAlwaysStream(true);
     }
@@ -599,9 +607,11 @@ ExceptionOr<void> XMLHttpRequest::createRequest()
         return Exception { ExceptionCode::NetworkError };
     }
 
-    if (m_async && m_upload && m_upload->hasEventListeners())
-        m_uploadListenerFlag = true;
-
+    {
+        Locker locker { m_gcLock };
+        if (m_async && m_upload && m_upload->hasEventListeners())
+            m_uploadListenerFlag = true;
+    }
     ResourceRequest request(URL { m_url });
     request.setRequester(ResourceRequestRequester::XHR);
     Ref context = *scriptExecutionContext();
@@ -647,9 +657,13 @@ ExceptionOr<void> XMLHttpRequest::createRequest()
 
     if (m_async) {
         m_progressEventThrottle->dispatchProgressEvent(eventNames().loadstartEvent);
-        if (!m_uploadComplete && m_uploadListenerFlag)
-            m_upload->dispatchProgressEvent(eventNames().loadstartEvent, 0, request.httpBody()->lengthInBytes());
-
+        if (!m_uploadComplete && m_uploadListenerFlag) {
+            RefPtr upload = [&] {
+                Locker locker { m_gcLock };
+                return m_upload.get();
+            }();
+            upload->dispatchProgressEvent(eventNames().loadstartEvent, 0, request.httpBody()->lengthInBytes());
+        }
         if (readyState() != OPENED || !m_sendFlag || m_loadingActivity)
             return { };
 
@@ -741,7 +755,10 @@ void XMLHttpRequest::clearResponseBuffers()
     m_responseBuilder.clear();
     m_responseEncoding = String();
     m_createdDocument = false;
-    m_responseDocument = nullptr;
+    {
+        Locker locker { m_gcLock };
+        m_responseDocument = nullptr;
+    }
     m_binaryResponseBuilder.reset();
     m_responseCacheIsValid = false;
 }
@@ -967,18 +984,22 @@ void XMLHttpRequest::didFinishLoading(ScriptExecutionContextIdentifier, std::opt
 
 void XMLHttpRequest::didSendData(unsigned long long bytesSent, unsigned long long totalBytesToBeSent)
 {
-    if (!m_upload)
+    RefPtr upload = [&] {
+        Locker locker { m_gcLock };
+        return m_upload.get();
+    }();
+    if (!upload)
         return;
 
     if (m_uploadListenerFlag)
-        m_upload->dispatchProgressEvent(eventNames().progressEvent, bytesSent, totalBytesToBeSent);
+        upload->dispatchProgressEvent(eventNames().progressEvent, bytesSent, totalBytesToBeSent);
 
     if (bytesSent == totalBytesToBeSent && !m_uploadComplete) {
         m_wasDidSendDataCalledForTotalBytes = true;
         m_uploadComplete = true;
         if (m_uploadListenerFlag) {
-            m_upload->dispatchProgressEvent(eventNames().loadEvent, bytesSent, totalBytesToBeSent);
-            m_upload->dispatchProgressEvent(eventNames().loadendEvent, bytesSent, totalBytesToBeSent);
+            upload->dispatchProgressEvent(eventNames().loadEvent, bytesSent, totalBytesToBeSent);
+            upload->dispatchProgressEvent(eventNames().loadendEvent, bytesSent, totalBytesToBeSent);
         }
     }
 }
@@ -1119,9 +1140,13 @@ void XMLHttpRequest::dispatchErrorEvents(const AtomString& type)
 {
     if (!m_uploadComplete) {
         m_uploadComplete = true;
-        if (m_upload && m_uploadListenerFlag) {
-            m_upload->dispatchProgressEvent(type, 0, 0);
-            m_upload->dispatchProgressEvent(eventNames().loadendEvent, 0, 0);
+        RefPtr upload = [&] {
+            Locker locker { m_gcLock };
+            return m_upload.get();
+        }();
+        if (upload && m_uploadListenerFlag) {
+            upload->dispatchProgressEvent(type, 0, 0);
+            upload->dispatchProgressEvent(eventNames().loadendEvent, 0, 0);
         }
     }
     m_progressEventThrottle->dispatchErrorProgressEvent(type);
@@ -1189,6 +1214,10 @@ void XMLHttpRequest::contextDestroyed()
 
 void XMLHttpRequest::updateHasRelevantEventListener()
 {
+    bool uploadHasRelevantEventListener = [&] {
+        Locker locker { m_gcLock };
+        return m_upload && m_upload->hasRelevantEventListener();
+    }();
     m_hasRelevantEventListener = hasEventListeners(eventNames().abortEvent)
         || hasEventListeners(eventNames().errorEvent)
         || hasEventListeners(eventNames().loadEvent)
@@ -1196,7 +1225,7 @@ void XMLHttpRequest::updateHasRelevantEventListener()
         || hasEventListeners(eventNames().progressEvent)
         || hasEventListeners(eventNames().readystatechangeEvent)
         || hasEventListeners(eventNames().timeoutEvent)
-        || (m_upload && m_upload->hasRelevantEventListener());
+        || uploadHasRelevantEventListener;
 }
 
 void XMLHttpRequest::eventListenersDidChange()
@@ -1233,5 +1262,18 @@ Ref<ThreadableLoader> XMLHttpRequest::LoadingActivity::protectedLoader() const
 {
     return loader;
 }
+
+template<typename Visitor>
+void XMLHttpRequest::visitAdditionalChildren(Visitor& visitor)
+{
+    Locker locker { m_gcLock };
+    if (m_upload)
+        addWebCoreOpaqueRoot(visitor, *m_upload);
+
+    if (m_responseDocument)
+        addWebCoreOpaqueRoot(visitor, *m_responseDocument);
+}
+
+DEFINE_VISIT_ADDITIONAL_CHILDREN(XMLHttpRequest);
 
 } // namespace WebCore

--- a/Source/WebCore/xml/XMLHttpRequest.h
+++ b/Source/WebCore/xml/XMLHttpRequest.h
@@ -105,7 +105,6 @@ public:
     enum class FinalMIMEType : bool { No, Yes };
     String responseMIMEType(FinalMIMEType = FinalMIMEType::No) const;
 
-    Document* optionalResponseXML() const { return m_responseDocument.get(); }
     ExceptionOr<Document*> responseXML();
 
     Ref<Blob> createResponseBlob();
@@ -132,7 +131,6 @@ public:
     String responseURL() const;
 
     XMLHttpRequestUpload& upload();
-    XMLHttpRequestUpload* optionalUpload() const { return m_upload.get(); }
 
     const ResourceResponse& resourceResponse() const { return m_response; }
 
@@ -142,6 +140,8 @@ public:
     void dispatchEvent(Event&) override;
 
     void dispatchThrottledProgressEventIfNeeded();
+
+    template<typename Visitor> void visitAdditionalChildren(Visitor&);
 
 private:
     friend class XMLHttpRequestUpload;
@@ -222,7 +222,8 @@ private:
 
     unsigned m_timeoutMilliseconds { 0 };
 
-    const std::unique_ptr<XMLHttpRequestUpload> m_upload;
+    Lock m_gcLock;
+    const std::unique_ptr<XMLHttpRequestUpload> m_upload WTF_GUARDED_BY_LOCK(m_gcLock);
 
     URLKeepingBlobAlive m_url;
     String m_method;
@@ -243,7 +244,7 @@ private:
 
     RefPtr<TextResourceDecoder> m_decoder;
 
-    RefPtr<Document> m_responseDocument;
+    RefPtr<Document> m_responseDocument WTF_GUARDED_BY_LOCK(m_gcLock);
 
     SharedBufferBuilder m_binaryResponseBuilder;
 

--- a/Source/WebCore/xml/XPathResult.cpp
+++ b/Source/WebCore/xml/XPathResult.cpp
@@ -29,7 +29,10 @@
 
 #include "Document.h"
 #include "ExceptionOr.h"
+#include "WebCoreOpaqueRootInlines.h"
 #include "XPathEvaluator.h"
+#include <JavaScriptCore/SlotVisitorMacros.h>
+#include <wtf/Locker.h>
 
 namespace WebCore {
 
@@ -49,7 +52,10 @@ XPathResult::XPathResult(Document& document, const XPath::Value& value)
     case XPath::Value::Type::NodeSet:
         m_resultType = UNORDERED_NODE_ITERATOR_TYPE;
         m_nodeSetPosition = 0;
-        m_nodeSet = m_value.toNodeSet();
+        {
+            Locker locker { m_nodeSetLock };
+            m_nodeSet = m_value.toNodeSet();
+        }
         m_document = document;
         m_domTreeVersion = document.domTreeVersion();
         return;
@@ -57,7 +63,21 @@ XPathResult::XPathResult(Document& document, const XPath::Value& value)
     ASSERT_NOT_REACHED();
 }
 
-XPathResult::~XPathResult() = default;
+XPathResult::~XPathResult()
+{
+#if ASSERT_ENABLED
+    if (!m_value.isNodeSet())
+        return;
+
+    auto& valueNodeSet = m_value.toNodeSet();
+    ASSERT(valueNodeSet.size() == m_nodeSet.size());
+    HashSet<const Node*> set;
+    for (auto& node : m_nodeSet)
+        set.add(&node.get());
+    for (auto& node : valueNodeSet)
+        ASSERT(set.contains(&node.get()));
+#endif
+}
 
 ExceptionOr<void> XPathResult::convertTo(unsigned short type)
 {
@@ -87,7 +107,10 @@ ExceptionOr<void> XPathResult::convertTo(unsigned short type)
     case ORDERED_NODE_ITERATOR_TYPE:
         if (!m_value.isNodeSet())
             return Exception { ExceptionCode::TypeError };
-        m_nodeSet.sort();
+        {
+            Locker locker { m_nodeSetLock };
+            m_nodeSet.sort();
+        }
         m_resultType = type;
         break;
     case ORDERED_NODE_SNAPSHOT_TYPE:
@@ -163,6 +186,7 @@ ExceptionOr<Node*> XPathResult::iterateNext()
     if (invalidIteratorState())
         return Exception { ExceptionCode::InvalidStateError };
 
+    Locker locker { m_nodeSetLock };
     if (m_nodeSetPosition >= m_nodeSet.size())
         return nullptr;
 
@@ -180,5 +204,15 @@ ExceptionOr<Node*> XPathResult::snapshotItem(unsigned index)
 
     return nodes[index];
 }
+
+template<typename Visitor>
+void XPathResult::visitAdditionalChildren(Visitor& visitor)
+{
+    Locker locker { m_nodeSetLock };
+    for (auto& node : m_nodeSet)
+        addWebCoreOpaqueRoot(visitor, node.get());
+}
+
+DEFINE_VISIT_ADDITIONAL_CHILDREN(XPathResult);
 
 } // namespace WebCore

--- a/Source/WebCore/xml/XPathResult.h
+++ b/Source/WebCore/xml/XPathResult.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <WebCore/XPathValue.h>
+#include <wtf/Lock.h>
 
 namespace WebCore {
 
@@ -66,12 +67,16 @@ public:
 
     const XPath::Value& value() const { return m_value; }
 
+    template<typename Visitor>
+    void visitAdditionalChildren(Visitor&);
+
 private:
     XPathResult(Document&, const XPath::Value&);
 
     XPath::Value m_value;
     unsigned m_nodeSetPosition { 0 };
-    XPath::NodeSet m_nodeSet; // FIXME: why duplicate the node set stored in m_value?
+    Lock m_nodeSetLock;
+    XPath::NodeSet m_nodeSet WTF_GUARDED_BY_LOCK(m_nodeSetLock);
     unsigned short m_resultType;
     RefPtr<Document> m_document;
     uint64_t m_domTreeVersion { 0 };

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -933,6 +933,8 @@ void NetworkConnectionToWebProcess::setRawCookie(const URL& firstParty, const UR
 {
     auto allowCookieAccess = m_networkProcess->allowsFirstPartyForCookies(m_webProcessIdentifier, firstParty);
     MESSAGE_CHECK(allowCookieAccess != NetworkProcess::AllowCookieAccess::Terminate);
+    MESSAGE_CHECK(RegistrableDomain::uncheckedCreateFromHost(cookie.domain).matches(firstParty));
+    MESSAGE_CHECK(RegistrableDomain(url).matches(firstParty));
     if (allowCookieAccess != NetworkProcess::AllowCookieAccess::Allow)
         return;
 

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -601,7 +601,7 @@ void NetworkConnectionToWebProcess::scheduleResourceLoad(NetworkResourceLoadPara
     }
 
     auto identifier = loadParameters.identifier;
-    RELEASE_ASSERT(identifier);
+    MESSAGE_CHECK(identifier);
     RELEASE_ASSERT(RunLoop::isMain());
     ASSERT(!m_networkResourceLoaders.contains(*identifier));
 

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
@@ -132,7 +132,7 @@ messages -> NetworkConnectionToWebProcess WantsDispatchMessage {
     PrioritizeResourceLoads(Vector<WebCore::ResourceLoaderIdentifier> loadIdentifiers)
 
 #if ENABLE(CONTENT_FILTERING)
-    InstallMockContentFilter(WebCore::MockContentFilterSettings settings)
+    [EnabledBy=AllowTestOnlyMockContentFilterIPC] InstallMockContentFilter(WebCore::MockContentFilterSettings settings)
 #endif
 
     UseRedirectionForCurrentNavigation(WebCore::ResourceLoaderIdentifier resourceLoadIdentifier, WebCore::ResourceResponse response)

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.cpp
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.cpp
@@ -27,9 +27,12 @@
 #include "IDBStorageRegistry.h"
 
 #include "IDBStorageConnectionToClient.h"
+#include "Logging.h"
 #include <WebCore/UniqueIDBDatabaseConnection.h>
 #include <WebCore/UniqueIDBDatabaseTransaction.h>
 #include <wtf/TZoneMallocInlines.h>
+
+#define MESSAGE_CHECK_WITH_RETURN_VALUE(assertion, connection, returnValue) MESSAGE_CHECK_WITH_RETURN_VALUE_BASE(assertion, connection, returnValue)
 
 namespace WebKit {
 
@@ -39,14 +42,16 @@ IDBStorageRegistry::~IDBStorageRegistry() = default;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(IDBStorageRegistry);
 
-WebCore::IDBServer::IDBConnectionToClient& IDBStorageRegistry::ensureConnectionToClient(IPC::Connection::UniqueID connection, WebCore::IDBConnectionIdentifier identifier)
+WebCore::IDBServer::IDBConnectionToClient* IDBStorageRegistry::ensureConnectionToClient(IPC::Connection& ipcConnection, const WebCore::IDBResourceIdentifier& requestIdentifier)
 {
+    MESSAGE_CHECK_WITH_RETURN_VALUE(requestIdentifier.connectionIdentifier(), ipcConnection, nullptr);
+    auto identifier = *requestIdentifier.connectionIdentifier();
     auto addResult = m_connectionsToClient.add(identifier, nullptr);
     if (addResult.isNewEntry)
-        addResult.iterator->value = makeUnique<IDBStorageConnectionToClient>(connection, identifier);
+        addResult.iterator->value = makeUnique<IDBStorageConnectionToClient>(ipcConnection.uniqueID(), identifier);
 
-    ASSERT(addResult.iterator->value->ipcConnection() == connection);
-    return addResult.iterator->value->connectionToClient();
+    MESSAGE_CHECK_WITH_RETURN_VALUE(addResult.iterator->value->ipcConnection() == ipcConnection.uniqueID(), ipcConnection, nullptr);
+    return &addResult.iterator->value->connectionToClient();
 }
 
 void IDBStorageRegistry::removeConnectionToClient(IPC::Connection::UniqueID connection)
@@ -93,16 +98,41 @@ void IDBStorageRegistry::unregisterTransaction(WebCore::IDBServer::UniqueIDBData
     m_transactions.remove(identifier);
 }
 
-WebCore::IDBServer::UniqueIDBDatabaseConnection* IDBStorageRegistry::connection(WebCore::IDBDatabaseConnectionIdentifier identifier)
+bool IDBStorageRegistry::isValidConnectionForIPC(WebCore::IDBServer::UniqueIDBDatabaseConnection& databaseConnection, IPC::Connection& ipcConnection)
 {
-    return m_connections.get(identifier);
+    auto connectionIdentifier = databaseConnection.connectionToClient().identifier();
+    auto it = m_connectionsToClient.find(connectionIdentifier);
+    if (it == m_connectionsToClient.end())
+        return true;
+    return it->value->ipcConnection() == ipcConnection.uniqueID();
 }
 
-WebCore::IDBServer::UniqueIDBDatabaseTransaction* IDBStorageRegistry::transaction(WebCore::IDBResourceIdentifier identifier)
+RefPtr<WebCore::IDBServer::UniqueIDBDatabaseConnection> IDBStorageRegistry::connection(WebCore::IDBDatabaseConnectionIdentifier identifier, IPC::Connection& ipcConnection)
 {
+    RefPtr databaseConnection = m_connections.get(identifier);
+    if (!databaseConnection)
+        return nullptr;
+
+    MESSAGE_CHECK_WITH_RETURN_VALUE(isValidConnectionForIPC(*databaseConnection, ipcConnection), ipcConnection, nullptr);
+
+    return databaseConnection;
+}
+
+RefPtr<WebCore::IDBServer::UniqueIDBDatabaseTransaction> IDBStorageRegistry::transaction(WebCore::IDBResourceIdentifier identifier, IPC::Connection& ipcConnection)
+{
+    MESSAGE_CHECK_WITH_RETURN_VALUE(identifier.connectionIdentifier(), ipcConnection, nullptr);
     if (identifier.isEmpty())
         return nullptr;
-    return m_transactions.get(identifier);
+    RefPtr transaction = m_transactions.get(identifier);
+    if (!transaction)
+        return nullptr;
+
+    if (RefPtr databaseConnection = transaction->databaseConnection())
+        MESSAGE_CHECK_WITH_RETURN_VALUE(isValidConnectionForIPC(*databaseConnection, ipcConnection), ipcConnection, nullptr);
+
+    return transaction;
 }
 
 } // namespace WebKit
+
+#undef MESSAGE_CHECK_WITH_RETURN_VALUE

--- a/Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.h
+++ b/Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.h
@@ -49,16 +49,18 @@ class IDBStorageRegistry : public CanMakeThreadSafeCheckedPtr<IDBStorageRegistry
 public:
     IDBStorageRegistry();
     ~IDBStorageRegistry();
-    WebCore::IDBServer::IDBConnectionToClient& ensureConnectionToClient(IPC::Connection::UniqueID, WebCore::IDBConnectionIdentifier);
+    WebCore::IDBServer::IDBConnectionToClient* ensureConnectionToClient(IPC::Connection&, const WebCore::IDBResourceIdentifier&);
     void removeConnectionToClient(IPC::Connection::UniqueID);
     void registerConnection(WebCore::IDBServer::UniqueIDBDatabaseConnection&);
     void unregisterConnection(WebCore::IDBServer::UniqueIDBDatabaseConnection&);
-    WebCore::IDBServer::UniqueIDBDatabaseConnection* connection(WebCore::IDBDatabaseConnectionIdentifier);
+    RefPtr<WebCore::IDBServer::UniqueIDBDatabaseConnection> connection(WebCore::IDBDatabaseConnectionIdentifier, IPC::Connection&);
     void registerTransaction(WebCore::IDBServer::UniqueIDBDatabaseTransaction&);
     void unregisterTransaction(WebCore::IDBServer::UniqueIDBDatabaseTransaction&);
-    WebCore::IDBServer::UniqueIDBDatabaseTransaction* transaction(WebCore::IDBResourceIdentifier);
+    RefPtr<WebCore::IDBServer::UniqueIDBDatabaseTransaction> transaction(WebCore::IDBResourceIdentifier, IPC::Connection&);
 
 private:
+    bool isValidConnectionForIPC(WebCore::IDBServer::UniqueIDBDatabaseConnection&, IPC::Connection&);
+
     HashMap<WebCore::IDBConnectionIdentifier, std::unique_ptr<IDBStorageConnectionToClient>> m_connectionsToClient;
     HashMap<WebCore::IDBDatabaseConnectionIdentifier, WeakPtr<WebCore::IDBServer::UniqueIDBDatabaseConnection>> m_connections;
     HashMap<WebCore::IDBResourceIdentifier, WeakPtr<WebCore::IDBServer::UniqueIDBDatabaseTransaction>> m_transactions;

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -1728,9 +1728,10 @@ void NetworkStorageManager::clear(IPC::Connection& connection, StorageAreaIdenti
 
 void NetworkStorageManager::openDatabase(IPC::Connection& connection, const WebCore::IDBOpenRequestData& requestData)
 {
-    MESSAGE_CHECK(requestData.requestIdentifier().connectionIdentifier(), connection);
-    Ref connectionToClient = m_idbStorageRegistry->ensureConnectionToClient(connection.uniqueID(), *requestData.requestIdentifier().connectionIdentifier());
-    checkedOriginStorageManager(requestData.databaseIdentifier().origin())->checkedIDBStorageManager(*m_idbStorageRegistry)->openDatabase(connectionToClient, requestData);
+    RefPtr connectionToClient = m_idbStorageRegistry->ensureConnectionToClient(connection, requestData.requestIdentifier());
+    if (!connectionToClient)
+        return;
+    checkedOriginStorageManager(requestData.databaseIdentifier().origin())->checkedIDBStorageManager(*m_idbStorageRegistry)->openDatabase(*connectionToClient, requestData);
 }
 
 void NetworkStorageManager::openDBRequestCancelled(const WebCore::IDBOpenRequestData& requestData)
@@ -1740,26 +1741,27 @@ void NetworkStorageManager::openDBRequestCancelled(const WebCore::IDBOpenRequest
 
 void NetworkStorageManager::deleteDatabase(IPC::Connection& connection, const WebCore::IDBOpenRequestData& requestData)
 {
-    MESSAGE_CHECK(requestData.requestIdentifier().connectionIdentifier(), connection);
-    Ref connectionToClient = m_idbStorageRegistry->ensureConnectionToClient(connection.uniqueID(), *requestData.requestIdentifier().connectionIdentifier());
-    checkedOriginStorageManager(requestData.databaseIdentifier().origin())->checkedIDBStorageManager(*m_idbStorageRegistry)->deleteDatabase(connectionToClient, requestData);
+    RefPtr connectionToClient = m_idbStorageRegistry->ensureConnectionToClient(connection, requestData.requestIdentifier());
+    if (!connectionToClient)
+        return;
+    checkedOriginStorageManager(requestData.databaseIdentifier().origin())->checkedIDBStorageManager(*m_idbStorageRegistry)->deleteDatabase(*connectionToClient, requestData);
 }
 
-void NetworkStorageManager::establishTransaction(WebCore::IDBDatabaseConnectionIdentifier databaseConnectionIdentifier, const WebCore::IDBTransactionInfo& transactionInfo)
+void NetworkStorageManager::establishTransaction(IPC::Connection& ipcConnection, WebCore::IDBDatabaseConnectionIdentifier databaseConnectionIdentifier, const WebCore::IDBTransactionInfo& transactionInfo)
 {
-    if (RefPtr connection = m_idbStorageRegistry->connection(databaseConnectionIdentifier))
+    if (RefPtr connection = m_idbStorageRegistry->connection(databaseConnectionIdentifier, ipcConnection))
         connection->establishTransaction(transactionInfo);
 }
 
-void NetworkStorageManager::databaseConnectionPendingClose(WebCore::IDBDatabaseConnectionIdentifier databaseConnectionIdentifier)
+void NetworkStorageManager::databaseConnectionPendingClose(IPC::Connection& ipcConnection, WebCore::IDBDatabaseConnectionIdentifier databaseConnectionIdentifier)
 {
-    if (RefPtr connection = m_idbStorageRegistry->connection(databaseConnectionIdentifier))
+    if (RefPtr connection = m_idbStorageRegistry->connection(databaseConnectionIdentifier, ipcConnection))
         connection->connectionPendingCloseFromClient();
 }
 
-void NetworkStorageManager::databaseConnectionClosed(WebCore::IDBDatabaseConnectionIdentifier databaseConnectionIdentifier)
+void NetworkStorageManager::databaseConnectionClosed(IPC::Connection& ipcConnection, WebCore::IDBDatabaseConnectionIdentifier databaseConnectionIdentifier)
 {
-    RefPtr connection = m_idbStorageRegistry->connection(databaseConnectionIdentifier);
+    RefPtr connection = m_idbStorageRegistry->connection(databaseConnectionIdentifier, ipcConnection);
     if (!connection)
         return;
 
@@ -1773,57 +1775,55 @@ void NetworkStorageManager::databaseConnectionClosed(WebCore::IDBDatabaseConnect
         checkedOriginStorageManager(databaseIdentifier.origin())->checkedIDBStorageManager(*m_idbStorageRegistry)->tryCloseDatabase(databaseIdentifier);
 }
 
-void NetworkStorageManager::abortOpenAndUpgradeNeeded(WebCore::IDBDatabaseConnectionIdentifier databaseConnectionIdentifier, const std::optional<WebCore::IDBResourceIdentifier>& transactionIdentifier)
+void NetworkStorageManager::abortOpenAndUpgradeNeeded(IPC::Connection& ipcConnection, WebCore::IDBDatabaseConnectionIdentifier databaseConnectionIdentifier, const std::optional<WebCore::IDBResourceIdentifier>& transactionIdentifier)
 {
     if (transactionIdentifier) {
-        if (RefPtr transaction = m_idbStorageRegistry->transaction(*transactionIdentifier))
+        if (RefPtr transaction = m_idbStorageRegistry->transaction(*transactionIdentifier, ipcConnection))
             transaction->abortWithoutCallback();
     }
 
-    if (RefPtr connection = m_idbStorageRegistry->connection(databaseConnectionIdentifier))
+    if (RefPtr connection = m_idbStorageRegistry->connection(databaseConnectionIdentifier, ipcConnection))
         connection->connectionClosedFromClient();
 }
 
-void NetworkStorageManager::didFireVersionChangeEvent(WebCore::IDBDatabaseConnectionIdentifier databaseConnectionIdentifier, const WebCore::IDBResourceIdentifier& requestIdentifier, const WebCore::IndexedDB::ConnectionClosedOnBehalfOfServer connectionClosed)
+void NetworkStorageManager::didFireVersionChangeEvent(IPC::Connection& ipcConnection, WebCore::IDBDatabaseConnectionIdentifier databaseConnectionIdentifier, const WebCore::IDBResourceIdentifier& requestIdentifier, const WebCore::IndexedDB::ConnectionClosedOnBehalfOfServer connectionClosed)
 {
-    if (RefPtr connection = m_idbStorageRegistry->connection(databaseConnectionIdentifier))
+    if (RefPtr connection = m_idbStorageRegistry->connection(databaseConnectionIdentifier, ipcConnection))
         connection->didFireVersionChangeEvent(requestIdentifier, connectionClosed);
 }
 
-void NetworkStorageManager::didGenerateIndexKeyForRecord(const WebCore::IDBResourceIdentifier& transactionIdentifier, const WebCore::IDBResourceIdentifier& requestIdentifier, const WebCore::IDBIndexInfo& indexInfo, const WebCore::IDBKeyData& key, const WebCore::IndexKey& indexKey, std::optional<int64_t> recordID)
+void NetworkStorageManager::didGenerateIndexKeyForRecord(IPC::Connection& connection, const WebCore::IDBResourceIdentifier& transactionIdentifier, const WebCore::IDBResourceIdentifier& requestIdentifier, const WebCore::IDBIndexInfo& indexInfo, const WebCore::IDBKeyData& key, const WebCore::IndexKey& indexKey, std::optional<int64_t> recordID)
 {
-    if (RefPtr transaction = m_idbStorageRegistry->transaction(transactionIdentifier))
+    if (RefPtr transaction = m_idbStorageRegistry->transaction(transactionIdentifier, connection))
         transaction->didGenerateIndexKeyForRecord(requestIdentifier, indexInfo, key, indexKey, recordID);
 }
 
 void NetworkStorageManager::abortTransaction(IPC::Connection& connection, const WebCore::IDBResourceIdentifier& transactionIdentifier)
 {
-    MESSAGE_CHECK(transactionIdentifier.connectionIdentifier(), connection);
-    if (RefPtr transaction = m_idbStorageRegistry->transaction(transactionIdentifier))
+    if (RefPtr transaction = m_idbStorageRegistry->transaction(transactionIdentifier, connection))
         transaction->abort();
 }
 
 void NetworkStorageManager::commitTransaction(IPC::Connection& connection, const WebCore::IDBResourceIdentifier& transactionIdentifier, uint64_t handledRequestResultsCount)
 {
-    MESSAGE_CHECK(transactionIdentifier.connectionIdentifier(), connection);
-    if (RefPtr transaction = m_idbStorageRegistry->transaction(transactionIdentifier))
+    if (RefPtr transaction = m_idbStorageRegistry->transaction(transactionIdentifier, connection))
         transaction->commit(handledRequestResultsCount);
 }
 
-void NetworkStorageManager::didFinishHandlingVersionChangeTransaction(WebCore::IDBDatabaseConnectionIdentifier databaseConnectionIdentifier, const WebCore::IDBResourceIdentifier& transactionIdentifier)
+void NetworkStorageManager::didFinishHandlingVersionChangeTransaction(IPC::Connection& ipcConnection, WebCore::IDBDatabaseConnectionIdentifier databaseConnectionIdentifier, const WebCore::IDBResourceIdentifier& transactionIdentifier)
 {
-    if (RefPtr connection = m_idbStorageRegistry->connection(databaseConnectionIdentifier))
-        connection->didFinishHandlingVersionChange(transactionIdentifier);
+    if (RefPtr databaseConnection = m_idbStorageRegistry->connection(databaseConnectionIdentifier, ipcConnection))
+        databaseConnection->didFinishHandlingVersionChange(transactionIdentifier);
 }
 
-RefPtr<WebCore::IDBServer::UniqueIDBDatabaseTransaction> NetworkStorageManager::idbTransaction(const WebCore::IDBRequestData& requestData)
+RefPtr<WebCore::IDBServer::UniqueIDBDatabaseTransaction> NetworkStorageManager::idbTransaction(const WebCore::IDBRequestData& requestData, IPC::Connection& connection)
 {
-    return m_idbStorageRegistry->transaction(requestData.transactionIdentifier());
+    return m_idbStorageRegistry->transaction(requestData.transactionIdentifier(), connection);
 }
 
 void NetworkStorageManager::createObjectStore(IPC::Connection& connection, const WebCore::IDBRequestData& requestData, const WebCore::IDBObjectStoreInfo& objectStoreInfo)
 {
-    RefPtr transaction = idbTransaction(requestData);
+    RefPtr transaction = idbTransaction(requestData, connection);
     if (!transaction)
         return;
     MESSAGE_CHECK(transaction->isVersionChange(), connection);
@@ -1833,7 +1833,7 @@ void NetworkStorageManager::createObjectStore(IPC::Connection& connection, const
 
 void NetworkStorageManager::deleteObjectStore(IPC::Connection& connection, const WebCore::IDBRequestData& requestData, const String& objectStoreName)
 {
-    RefPtr transaction = idbTransaction(requestData);
+    RefPtr transaction = idbTransaction(requestData, connection);
     if (!transaction)
         return;
     MESSAGE_CHECK(transaction->isVersionChange(), connection);
@@ -1843,7 +1843,7 @@ void NetworkStorageManager::deleteObjectStore(IPC::Connection& connection, const
 
 void NetworkStorageManager::renameObjectStore(IPC::Connection& connection, const WebCore::IDBRequestData& requestData, WebCore::IDBObjectStoreIdentifier objectStoreIdentifier, const String& newName)
 {
-    RefPtr transaction = idbTransaction(requestData);
+    RefPtr transaction = idbTransaction(requestData, connection);
     if (!transaction)
         return;
     MESSAGE_CHECK(transaction->isVersionChange(), connection);
@@ -1851,16 +1851,16 @@ void NetworkStorageManager::renameObjectStore(IPC::Connection& connection, const
     transaction->renameObjectStore(requestData, objectStoreIdentifier, newName);
 }
 
-void NetworkStorageManager::clearObjectStore(const WebCore::IDBRequestData& requestData, WebCore::IDBObjectStoreIdentifier objectStoreIdentifier)
+void NetworkStorageManager::clearObjectStore(IPC::Connection& connection, const WebCore::IDBRequestData& requestData, WebCore::IDBObjectStoreIdentifier objectStoreIdentifier)
 {
-    if (RefPtr transaction = idbTransaction(requestData))
+    if (RefPtr transaction = idbTransaction(requestData, connection))
         transaction->clearObjectStore(requestData, objectStoreIdentifier);
 }
 
 void NetworkStorageManager::createIndex(IPC::Connection& connection, const WebCore::IDBRequestData& requestData, const WebCore::IDBIndexInfo& indexInfo)
 {
     MESSAGE_CHECK(!requestData.requestIdentifier().isEmpty(), connection);
-    RefPtr transaction = idbTransaction(requestData);
+    RefPtr transaction = idbTransaction(requestData, connection);
     if (!transaction)
         return;
     MESSAGE_CHECK(transaction->isVersionChange(), connection);
@@ -1870,7 +1870,7 @@ void NetworkStorageManager::createIndex(IPC::Connection& connection, const WebCo
 
 void NetworkStorageManager::deleteIndex(IPC::Connection& connection, const WebCore::IDBRequestData& requestData, WebCore::IDBObjectStoreIdentifier objectStoreIdentifier, const String& indexName)
 {
-    RefPtr transaction = idbTransaction(requestData);
+    RefPtr transaction = idbTransaction(requestData, connection);
     if (!transaction)
         return;
     MESSAGE_CHECK(transaction->isVersionChange(), connection);
@@ -1880,7 +1880,7 @@ void NetworkStorageManager::deleteIndex(IPC::Connection& connection, const WebCo
 
 void NetworkStorageManager::renameIndex(IPC::Connection& connection, const WebCore::IDBRequestData& requestData, WebCore::IDBObjectStoreIdentifier objectStoreIdentifier, WebCore::IDBIndexIdentifier indexIdentifier, const String& newName)
 {
-    RefPtr transaction = idbTransaction(requestData);
+    RefPtr transaction = idbTransaction(requestData, connection);
     if (!transaction)
         return;
     MESSAGE_CHECK(transaction->isVersionChange(), connection);
@@ -1891,7 +1891,7 @@ void NetworkStorageManager::renameIndex(IPC::Connection& connection, const WebCo
 void NetworkStorageManager::putOrAdd(IPC::Connection& connection, const WebCore::IDBRequestData& requestData, const WebCore::IDBKeyData& keyData, const WebCore::IDBValue& value, const WebCore::IndexIDToIndexKeyMap& indexKeys, WebCore::IndexedDB::ObjectStoreOverwriteMode overwriteMode)
 {
     assertIsCurrent(workQueue());
-    RefPtr transaction = idbTransaction(requestData);
+    RefPtr transaction = idbTransaction(requestData, connection);
     if (!transaction)
         return;
 
@@ -1923,46 +1923,47 @@ void NetworkStorageManager::putOrAdd(IPC::Connection& connection, const WebCore:
     transaction->putOrAdd(requestData, keyData, value, indexKeys, overwriteMode);
 }
 
-void NetworkStorageManager::getRecord(const WebCore::IDBRequestData& requestData, const WebCore::IDBGetRecordData& getRecordData)
+void NetworkStorageManager::getRecord(IPC::Connection& connection, const WebCore::IDBRequestData& requestData, const WebCore::IDBGetRecordData& getRecordData)
 {
-    if (RefPtr transaction = idbTransaction(requestData))
+    if (RefPtr transaction = idbTransaction(requestData, connection))
         transaction->getRecord(requestData, getRecordData);
 }
 
-void NetworkStorageManager::getAllRecords(const WebCore::IDBRequestData& requestData, const WebCore::IDBGetAllRecordsData& getAllRecordsData)
+void NetworkStorageManager::getAllRecords(IPC::Connection& connection, const WebCore::IDBRequestData& requestData, const WebCore::IDBGetAllRecordsData& getAllRecordsData)
 {
-    if (RefPtr transaction = idbTransaction(requestData))
+    if (RefPtr transaction = idbTransaction(requestData, connection))
         transaction->getAllRecords(requestData, getAllRecordsData);
 }
 
-void NetworkStorageManager::getCount(const WebCore::IDBRequestData& requestData, const WebCore::IDBKeyRangeData& keyRangeData)
+void NetworkStorageManager::getCount(IPC::Connection& connection, const WebCore::IDBRequestData& requestData, const WebCore::IDBKeyRangeData& keyRangeData)
 {
-    if (RefPtr transaction = idbTransaction(requestData))
+    if (RefPtr transaction = idbTransaction(requestData, connection))
         transaction->getCount(requestData, keyRangeData);
 }
 
-void NetworkStorageManager::deleteRecord(const WebCore::IDBRequestData& requestData, const WebCore::IDBKeyRangeData& keyRangeData)
+void NetworkStorageManager::deleteRecord(IPC::Connection& connection, const WebCore::IDBRequestData& requestData, const WebCore::IDBKeyRangeData& keyRangeData)
 {
-    if (RefPtr transaction = idbTransaction(requestData))
+    if (RefPtr transaction = idbTransaction(requestData, connection))
         transaction->deleteRecord(requestData, keyRangeData);
 }
 
-void NetworkStorageManager::openCursor(const WebCore::IDBRequestData& requestData, const WebCore::IDBCursorInfo& cursorInfo)
+void NetworkStorageManager::openCursor(IPC::Connection& connection, const WebCore::IDBRequestData& requestData, const WebCore::IDBCursorInfo& cursorInfo)
 {
-    if (RefPtr transaction = idbTransaction(requestData))
+    if (RefPtr transaction = idbTransaction(requestData, connection))
         transaction->openCursor(requestData, cursorInfo);
 }
 
-void NetworkStorageManager::iterateCursor(const WebCore::IDBRequestData& requestData, const WebCore::IDBIterateCursorData& cursorData)
+void NetworkStorageManager::iterateCursor(IPC::Connection& connection, const WebCore::IDBRequestData& requestData, const WebCore::IDBIterateCursorData& cursorData)
 {
-    if (RefPtr transaction = idbTransaction(requestData))
+    if (RefPtr transaction = idbTransaction(requestData, connection))
         transaction->iterateCursor(requestData, cursorData);
 }
 
 void NetworkStorageManager::getAllDatabaseNamesAndVersions(IPC::Connection& connection, const WebCore::IDBResourceIdentifier& requestIdentifier, const WebCore::ClientOrigin& origin)
 {
-    MESSAGE_CHECK(requestIdentifier.connectionIdentifier(), connection);
-    Ref connectionToClient = m_idbStorageRegistry->ensureConnectionToClient(connection.uniqueID(), *requestIdentifier.connectionIdentifier());
+    RefPtr connectionToClient = m_idbStorageRegistry->ensureConnectionToClient(connection, requestIdentifier);
+    if (!connectionToClient)
+        return;
     auto result = checkedOriginStorageManager(origin)->checkedIDBStorageManager(*m_idbStorageRegistry)->getAllDatabaseNamesAndVersions();
     connectionToClient->didGetAllDatabaseNamesAndVersions(requestIdentifier, WTF::move(result));
 }

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -2176,7 +2176,9 @@ void NetworkStorageManager::importServiceWorkerRegistrations(CompletionHandler<v
     if (m_closed)
         return completionHandler(std::nullopt);
 
-    workQueue().dispatch([this, protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler)]() mutable {
+    RELEASE_LOG(Storage, "%p - NetworkStorageManager::importServiceWorkerRegistrations: Starting import", this);
+    auto startTime = MonotonicTime::now();
+    workQueue().dispatchWithQOS([this, protectedThis = Ref { *this }, startTime, completionHandler = WTF::move(completionHandler)]() mutable {
         assertIsCurrent(workQueue());
 
         std::optional<Vector<WebCore::ServiceWorkerContextData>> result;
@@ -2196,10 +2198,15 @@ void NetworkStorageManager::importServiceWorkerRegistrations(CompletionHandler<v
                 result = WTF::move(registrations);
         }
 
-        RunLoop::mainSingleton().dispatch([protectedThis = WTF::move(protectedThis), result = crossThreadCopy(WTF::move(result)), completionHandler = WTF::move(completionHandler)]() mutable {
+        RunLoop::mainSingleton().dispatch([protectedThis = WTF::move(protectedThis), startTime, result = crossThreadCopy(WTF::move(result)), completionHandler = WTF::move(completionHandler)]() mutable {
+            auto elapsed = MonotonicTime::now() - startTime;
+            if (elapsed > 2_s)
+                RELEASE_LOG_ERROR(Storage, "%p - NetworkStorageManager::importServiceWorkerRegistrations: Imported %zu registrations in %.0f ms", protectedThis.ptr(), result ? result->size() : 0, elapsed.milliseconds());
+            else
+                RELEASE_LOG(Storage, "%p - NetworkStorageManager::importServiceWorkerRegistrations: Imported %zu registrations in %.0f ms", protectedThis.ptr(), result ? result->size() : 0, elapsed.milliseconds());
             completionHandler(WTF::move(result));
         });
-    });
+    }, WorkQueue::QOS::UserInitiated);
 }
 
 void NetworkStorageManager::updateServiceWorkerRegistrations(Vector<WebCore::ServiceWorkerContextData>&& registrationsToUpdate, Vector<WebCore::ServiceWorkerRegistrationKey>&& registrationsToDelete, CompletionHandler<void(std::optional<Vector<WebCore::ServiceWorkerScripts>>)>&& completionHandler)

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h
@@ -122,6 +122,14 @@ public:
     void restoreSessionStorageForWebPage(WebPageProxyIdentifier, HashMap<WebCore::ClientOrigin, HashMap<String, String>>&&, CompletionHandler<void(bool)>&&);
     void didIncreaseQuota(WebCore::ClientOrigin&&, QuotaIncreaseRequestIdentifier, std::optional<uint64_t> newQuota);
     enum class ShouldComputeSize : bool { No, Yes };
+    enum class ShouldWriteOriginFile : bool { No, Yes };
+    struct AccessRecord {
+        bool isActive { false };
+        std::optional<bool> isPersisted;
+        uint64_t usage { 0 };
+        WallTime lastAccessTime;
+        Vector<WebCore::SecurityOriginData> clientOrigins;
+    };
     void fetchData(OptionSet<WebsiteDataType>, ShouldComputeSize, CompletionHandler<void(Vector<WebsiteData::Entry>&&)>&&);
     void deleteData(OptionSet<WebsiteDataType>, const Vector<WebCore::SecurityOriginData>&, CompletionHandler<void()>&&);
     void deleteData(OptionSet<WebsiteDataType>, const WebCore::ClientOrigin&, CompletionHandler<void()>&&);
@@ -168,7 +176,6 @@ private:
     bool isStorageAreaTypeEnabled(IPC::Connection&, StorageAreaBase::StorageType) const;
 
     void writeOriginToFileIfNecessary(const WebCore::ClientOrigin&, StorageAreaBase* = nullptr);
-    enum class ShouldWriteOriginFile : bool { No, Yes };
     OriginStorageManager& originStorageManager(const WebCore::ClientOrigin&, ShouldWriteOriginFile = ShouldWriteOriginFile::Yes);
     CheckedRef<OriginStorageManager> checkedOriginStorageManager(const WebCore::ClientOrigin& origin, ShouldWriteOriginFile shouldWriteOriginFile = ShouldWriteOriginFile::Yes) { return originStorageManager(origin, shouldWriteOriginFile); }
     bool removeOriginStorageManagerIfPossible(const WebCore::ClientOrigin&);
@@ -220,29 +227,29 @@ private:
     void openDatabase(IPC::Connection&, const WebCore::IDBOpenRequestData&);
     void openDBRequestCancelled(const WebCore::IDBOpenRequestData&);
     void deleteDatabase(IPC::Connection&, const WebCore::IDBOpenRequestData&);
-    void establishTransaction(WebCore::IDBDatabaseConnectionIdentifier, const WebCore::IDBTransactionInfo&);
-    void databaseConnectionPendingClose(WebCore::IDBDatabaseConnectionIdentifier);
-    void databaseConnectionClosed(WebCore::IDBDatabaseConnectionIdentifier);
-    void abortOpenAndUpgradeNeeded(WebCore::IDBDatabaseConnectionIdentifier, const std::optional<WebCore::IDBResourceIdentifier>& transactionIdentifier);
-    void didFireVersionChangeEvent(WebCore::IDBDatabaseConnectionIdentifier, const WebCore::IDBResourceIdentifier& requestIdentifier, const WebCore::IndexedDB::ConnectionClosedOnBehalfOfServer);
-    void didGenerateIndexKeyForRecord(const WebCore::IDBResourceIdentifier& transactionIdentifier, const WebCore::IDBResourceIdentifier& requestIdentifier, const WebCore::IDBIndexInfo&, const WebCore::IDBKeyData&, const WebCore::IndexKey&, std::optional<int64_t> recordID);
+    void establishTransaction(IPC::Connection&, WebCore::IDBDatabaseConnectionIdentifier, const WebCore::IDBTransactionInfo&);
+    void databaseConnectionPendingClose(IPC::Connection&, WebCore::IDBDatabaseConnectionIdentifier);
+    void databaseConnectionClosed(IPC::Connection&, WebCore::IDBDatabaseConnectionIdentifier);
+    void abortOpenAndUpgradeNeeded(IPC::Connection&, WebCore::IDBDatabaseConnectionIdentifier, const std::optional<WebCore::IDBResourceIdentifier>& transactionIdentifier);
+    void didFireVersionChangeEvent(IPC::Connection&, WebCore::IDBDatabaseConnectionIdentifier, const WebCore::IDBResourceIdentifier& requestIdentifier, const WebCore::IndexedDB::ConnectionClosedOnBehalfOfServer);
+    void didGenerateIndexKeyForRecord(IPC::Connection&, const WebCore::IDBResourceIdentifier& transactionIdentifier, const WebCore::IDBResourceIdentifier& requestIdentifier, const WebCore::IDBIndexInfo&, const WebCore::IDBKeyData&, const WebCore::IndexKey&, std::optional<int64_t> recordID);
     void abortTransaction(IPC::Connection&, const WebCore::IDBResourceIdentifier&);
     void commitTransaction(IPC::Connection&, const WebCore::IDBResourceIdentifier&, uint64_t handledRequestResultsCount);
-    void didFinishHandlingVersionChangeTransaction(WebCore::IDBDatabaseConnectionIdentifier, const WebCore::IDBResourceIdentifier&);
+    void didFinishHandlingVersionChangeTransaction(IPC::Connection&, WebCore::IDBDatabaseConnectionIdentifier, const WebCore::IDBResourceIdentifier&);
     void createObjectStore(IPC::Connection&, const WebCore::IDBRequestData&, const WebCore::IDBObjectStoreInfo&);
     void deleteObjectStore(IPC::Connection&, const WebCore::IDBRequestData&, const String& objectStoreName);
     void renameObjectStore(IPC::Connection&, const WebCore::IDBRequestData&, WebCore::IDBObjectStoreIdentifier, const String& newName);
-    void clearObjectStore(const WebCore::IDBRequestData&, WebCore::IDBObjectStoreIdentifier);
+    void clearObjectStore(IPC::Connection&, const WebCore::IDBRequestData&, WebCore::IDBObjectStoreIdentifier);
     void createIndex(IPC::Connection&, const WebCore::IDBRequestData&, const WebCore::IDBIndexInfo&);
     void deleteIndex(IPC::Connection&, const WebCore::IDBRequestData&, WebCore::IDBObjectStoreIdentifier, const String& indexName);
     void renameIndex(IPC::Connection&, const WebCore::IDBRequestData&, WebCore::IDBObjectStoreIdentifier, WebCore::IDBIndexIdentifier, const String& newName);
     void putOrAdd(IPC::Connection&, const WebCore::IDBRequestData&, const WebCore::IDBKeyData&, const WebCore::IDBValue&, const WebCore::IndexIDToIndexKeyMap&, WebCore::IndexedDB::ObjectStoreOverwriteMode);
-    void getRecord(const WebCore::IDBRequestData&, const WebCore::IDBGetRecordData&);
-    void getAllRecords(const WebCore::IDBRequestData&, const WebCore::IDBGetAllRecordsData&);
-    void getCount(const WebCore::IDBRequestData&, const WebCore::IDBKeyRangeData&);
-    void deleteRecord(const WebCore::IDBRequestData&, const WebCore::IDBKeyRangeData&);
-    void openCursor(const WebCore::IDBRequestData&, const WebCore::IDBCursorInfo&);
-    void iterateCursor(const WebCore::IDBRequestData&, const WebCore::IDBIterateCursorData&);
+    void getRecord(IPC::Connection&, const WebCore::IDBRequestData&, const WebCore::IDBGetRecordData&);
+    void getAllRecords(IPC::Connection&, const WebCore::IDBRequestData&, const WebCore::IDBGetAllRecordsData&);
+    void getCount(IPC::Connection&, const WebCore::IDBRequestData&, const WebCore::IDBKeyRangeData&);
+    void deleteRecord(IPC::Connection&, const WebCore::IDBRequestData&, const WebCore::IDBKeyRangeData&);
+    void openCursor(IPC::Connection&, const WebCore::IDBRequestData&, const WebCore::IDBCursorInfo&);
+    void iterateCursor(IPC::Connection&, const WebCore::IDBRequestData&, const WebCore::IDBIterateCursorData&);
     void getAllDatabaseNamesAndVersions(IPC::Connection&, const WebCore::IDBResourceIdentifier&, const WebCore::ClientOrigin&);
 
     // Message handlers for CacheStorage.
@@ -275,18 +282,11 @@ private:
     void fetchRegistrableDomainsForPersist();
     void didFetchRegistrableDomainsForPersist(HashSet<WebCore::RegistrableDomain>&&);
     bool persistOrigin(const WebCore::ClientOrigin&);
-    struct AccessRecord {
-        bool isActive { false };
-        std::optional<bool> isPersisted;
-        uint64_t usage { 0 };
-        WallTime lastAccessTime;
-        Vector<WebCore::SecurityOriginData> clientOrigins;
-    };
     void performEviction(HashMap<WebCore::SecurityOriginData, AccessRecord>&&);
     const SuspendableWorkQueue& workQueue() const WTF_RETURNS_CAPABILITY(m_queue.get()) { return m_queue; }
     SuspendableWorkQueue& workQueue() WTF_RETURNS_CAPABILITY(m_queue.get()) { return m_queue; }
     OriginQuotaManager::Parameters originQuotaManagerParameters(const WebCore::ClientOrigin&);
-    RefPtr<WebCore::IDBServer::UniqueIDBDatabaseTransaction> idbTransaction(const WebCore::IDBRequestData&);
+    RefPtr<WebCore::IDBServer::UniqueIDBDatabaseTransaction> idbTransaction(const WebCore::IDBRequestData&, IPC::Connection&);
     void setStorageSiteValidationEnabledInternal(bool);
     void addAllowedSitesForConnectionInternal(IPC::Connection::UniqueID, const Vector<WebCore::RegistrableDomain>&);
     bool isSiteAllowedForConnection(IPC::Connection::UniqueID, const WebCore::RegistrableDomain&) const;

--- a/Source/WebKit/Shared/LogStream.cpp
+++ b/Source/WebKit/Shared/LogStream.cpp
@@ -66,43 +66,42 @@ void LogStream::stopListeningForIPC()
 #endif
 }
 
-void LogStream::logOnBehalfOfWebContent(std::span<const uint8_t> logSubsystem, std::span<const uint8_t> logCategory, std::span<const uint8_t> nullTerminatedLogString, uint8_t logType)
+void LogStream::logOnBehalfOfWebContent(std::span<const uint8_t> subsystemSpan, std::span<const uint8_t> categorySpan, std::span<const uint8_t> stringSpan, uint8_t logType)
 {
 #if ENABLE(STREAMING_IPC_IN_LOG_FORWARDING)
     ASSERT(!isMainRunLoop());
 #endif
-    auto isNullTerminated = [](std::span<const uint8_t> view) {
-        return view.data() && !view.empty() && view.back() == '\0';
-    };
-
-    bool isValidLogType = logType == OS_LOG_TYPE_DEFAULT || logType == OS_LOG_TYPE_INFO || logType == OS_LOG_TYPE_DEBUG || logType == OS_LOG_TYPE_ERROR || logType == OS_LOG_TYPE_FAULT;
 
     RefPtr connection = m_connection.get();
-    MESSAGE_CHECK(isNullTerminated(nullTerminatedLogString) && isValidLogType, connection);
-    MESSAGE_CHECK(logSubsystem.size() <= logSubsystemMaxSize, connection);
-    MESSAGE_CHECK(logCategory.size() <= logCategoryMaxSize, connection);
-    MESSAGE_CHECK(nullTerminatedLogString.size() <= logStringMaxSize, connection);
+
+    bool isValidLogType = logType == OS_LOG_TYPE_DEFAULT || logType == OS_LOG_TYPE_INFO || logType == OS_LOG_TYPE_DEBUG || logType == OS_LOG_TYPE_ERROR || logType == OS_LOG_TYPE_FAULT;
+    MESSAGE_CHECK(isValidLogType, connection);
+
+    CString subsystem = subsystemSpan;
+    CString category = categorySpan;
+    CString string = stringSpan;
+    MESSAGE_CHECK(subsystem.length() < logSubsystemMaxSize, connection);
+    MESSAGE_CHECK(category.length() < logCategoryMaxSize, connection);
+    MESSAGE_CHECK(string.length() < logStringMaxSize, connection);
 
     // os_log_hook on sender side sends a null category and subsystem when logging to OS_LOG_DEFAULT.
     auto osLog = OSObjectPtr<os_log_t>();
-    if (isNullTerminated(logSubsystem) && isNullTerminated(logCategory)) {
-        auto subsystem = byteCast<char>(logSubsystem.data());
-        auto category = byteCast<char>(logCategory.data());
-        if (equalSpans("Testing\0"_span, logCategory))
-            globalLogCountForTesting++;
-        osLog = adoptOSObject(os_log_create(subsystem, category));
+    if (!subsystem.isEmpty() && !category.isEmpty()) {
+        if (category == "Testing"_s)
+            ++globalLogCountForTesting;
+        osLog = adoptOSObject(os_log_create(subsystem.data(), category.data()));
     }
 
     auto osLogPointer = osLog.get() ? osLog.get() : OS_LOG_DEFAULT;
 
 #if HAVE(OS_SIGNPOST)
-    if (WTFSignpostHandleIndirectLog(osLogPointer, m_pid, byteCast<char>(nullTerminatedLogString)))
+    if (WTFSignpostHandleIndirectLog(osLogPointer, m_pid, string.spanIncludingNullTerminator()))
         return;
 #endif
 
     // Use '%{public}s' in the format string for the preprocessed string from the WebContent process.
     // This should not reveal any redacted information in the string, since it has already been composed in the WebContent process.
-    os_log_with_type(osLogPointer, static_cast<os_log_type_t>(logType), "WebContent[%d] %{public}s", m_pid, byteCast<char>(nullTerminatedLogString).data());
+    os_log_with_type(osLogPointer, static_cast<os_log_type_t>(logType), "WebContent[%d] %{public}s", m_pid, string.data());
 }
 
 #if ENABLE(STREAMING_IPC_IN_LOG_FORWARDING)

--- a/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitProtocolHandler.cpp
@@ -687,7 +687,7 @@ void WebKitProtocolHandler::handleGPU(WebKitURISchemeRequest* request, RenderPro
     addTableRow(displayObject, "Bits per color component"_s, String::number(screenDepthPerComponent(nullptr)));
     addTableRow(displayObject, "Font Scaling DPI"_s, String::number(WebCore::fontDPI()));
 #if PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))
-    addTableRow(displayObject, "Screen DPI"_s, String::number(screenDPI(displayID.value_or(primaryScreenDisplayID()))));
+    addTableRow(displayObject, "Screen DPI"_s, String::number(screenDPI(displayID.value_or(PlatformScreen::singleton()->primaryScreenDisplayID()))));
 #endif
 
     if (displayID) {

--- a/Source/WebKit/UIProcess/API/glib/WebKitSecurityOrigin.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitSecurityOrigin.cpp
@@ -271,5 +271,5 @@ gchar* webkit_security_origin_to_string(WebKitSecurityOrigin* origin)
     g_return_val_if_fail(origin, nullptr);
 
     CString cstring = origin->securityOriginData.toString().utf8();
-    return cstring == "null" || cstring == "" ? nullptr : g_strdup (cstring.data());
+    return cstring == "null"_s || cstring == ""_s ? nullptr : g_strdup (cstring.data());
 }

--- a/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebProcessPoolCocoa.mm
@@ -1391,7 +1391,8 @@ void WebProcessPool::registerHighDynamicRangeChangeCallback()
 void WebProcessPool::didRefreshDisplay()
 {
 #if HAVE(SUPPORT_HDR_DISPLAY)
-    float headroom = currentEDRHeadroomForDisplay(primaryScreenDisplayID());
+    Ref screen = PlatformScreen::singleton();
+    float headroom = currentEDRHeadroomForDisplay(screen->primaryScreenDisplayID());
     if (m_currentEDRHeadroom != headroom) {
         m_currentEDRHeadroom = headroom;
         screenPropertiesChanged();

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -716,7 +716,7 @@ void ProvisionalPageProxy::didReceiveMessage(IPC::Connection& connection, IPC::D
 
     if (decoder.messageName() == Messages::WebBackForwardList::BackForwardUpdateItem::name()) {
         if (RefPtr page = m_page.get())
-            page->backForwardList().didReceiveMessage(connection, decoder);
+            page->backForwardList().didReceiveProvisionalMessage(connection, decoder);
         return;
     }
 

--- a/Source/WebKit/UIProcess/SpeechRecognitionServer.cpp
+++ b/Source/WebKit/UIProcess/SpeechRecognitionServer.cpp
@@ -75,7 +75,7 @@ std::optional<SharedPreferencesForWebProcess> SpeechRecognitionServer::sharedPre
 
 void SpeechRecognitionServer::start(WebCore::SpeechRecognitionConnectionClientIdentifier clientIdentifier, String&& lang, bool continuous, bool interimResults, uint64_t maxAlternatives, WebCore::ClientOrigin&& origin, WebCore::FrameIdentifier mainFrameIdentifier, FrameInfoData&& frameInfo)
 {
-    ASSERT(!m_requests.contains(clientIdentifier));
+    MESSAGE_CHECK(!m_requests.contains(clientIdentifier));
     auto requestInfo = WebCore::SpeechRecognitionRequestInfo { clientIdentifier, WTF::move(lang), continuous, interimResults, maxAlternatives, WTF::move(origin), mainFrameIdentifier };
     auto& newRequest = m_requests.add(clientIdentifier, WebCore::SpeechRecognitionRequest::create(WTF::move(requestInfo))).iterator->value;
 

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -641,12 +641,10 @@ void WebBackForwardList::backForwardAddItem(IPC::Connection& connection, Ref<Fra
         backForwardAddItemShared(connection, WTF::move(navigatedFrameState), webPageProxy->didLoadWebArchive() ? LoadedWebArchive::Yes : LoadedWebArchive::No);
 }
 
-void WebBackForwardList::backForwardAddItemShared(IPC::Connection& connection, Ref<FrameState>&& navigatedFrameState, LoadedWebArchive loadedWebArchive)
+static void messageCheckItemURLs(Ref<FrameState>& frameState, Ref<WebProcessProxy>& process)
 {
-    Ref process = WebProcessProxy::fromConnection(connection);
-
-    URL itemURL { navigatedFrameState->urlString };
-    URL itemOriginalURL { navigatedFrameState->originalURLString };
+    URL itemURL { frameState->urlString };
+    URL itemOriginalURL { frameState->originalURLString };
 #if PLATFORM(COCOA)
     if (linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::PushStateFilePathRestriction)
 #if PLATFORM(MAC)
@@ -654,12 +652,17 @@ void WebBackForwardList::backForwardAddItemShared(IPC::Connection& connection, R
 #endif // PLATFORM(MAC)
     ) {
 #endif // PLATFORM(COCOA)
-        ASSERT(!itemURL.protocolIsFile() || process->wasPreviouslyApprovedFileURL(itemURL));
         MESSAGE_CHECK(process, !itemURL.protocolIsFile() || process->wasPreviouslyApprovedFileURL(itemURL));
         MESSAGE_CHECK(process, !itemOriginalURL.protocolIsFile() || process->wasPreviouslyApprovedFileURL(itemOriginalURL));
 #if PLATFORM(COCOA)
     }
 #endif
+}
+
+void WebBackForwardList::backForwardAddItemShared(IPC::Connection& connection, Ref<FrameState>&& navigatedFrameState, LoadedWebArchive loadedWebArchive)
+{
+    Ref process = WebProcessProxy::fromConnection(connection);
+    messageCheckItemURLs(navigatedFrameState, process);
 
     if (RefPtr targetFrame = WebFrameProxy::webFrame(navigatedFrameState->frameID)) {
         if (targetFrame->isPendingInitialHistoryItem()) {
@@ -687,8 +690,11 @@ void WebBackForwardList::backForwardAddItemShared(IPC::Connection& connection, R
     }
 }
 
-void WebBackForwardList::backForwardSetChildItem(BackForwardFrameItemIdentifier frameItemID, Ref<FrameState>&& frameState)
+void WebBackForwardList::backForwardSetChildItem(IPC::Connection& connection, BackForwardFrameItemIdentifier frameItemID, Ref<FrameState>&& frameState)
 {
+    Ref process = WebProcessProxy::fromConnection(connection);
+    messageCheckItemURLs(frameState, process);
+
     RefPtr item = currentItem();
     if (!item)
         return;
@@ -705,6 +711,14 @@ void WebBackForwardList::backForwardClearChildren(BackForwardItemIdentifier item
 
 void WebBackForwardList::backForwardUpdateItem(IPC::Connection& connection, Ref<FrameState>&& frameState)
 {
+    Ref process = WebProcessProxy::fromConnection(connection);
+
+    // In the case of a process swap, the `backForwardUpdateItem` message can be received from the old process,
+    // and therefore present an unexpected file: URL.
+    // We can safely skip the message check in these cases.
+    if (!m_handlingProvisionalMessage)
+        messageCheckItemURLs(frameState, process);
+
     RefPtr frameItem = frameState->itemID && frameState->frameItemID ? WebBackForwardListFrameItem::itemForID(*frameState->itemID, *frameState->frameItemID) : nullptr;
     if (!frameItem)
         return;
@@ -716,7 +730,6 @@ void WebBackForwardList::backForwardUpdateItem(IPC::Connection& connection, Ref<
     if (RefPtr webPageProxy = m_page.get()) {
         ASSERT(webPageProxy->identifier() == item->pageID() && frameState->itemID == item->identifier());
 
-        Ref process = *downcast<WebProcessProxy>(AuxiliaryProcessProxy::fromConnection(connection));
         if (!!item->backForwardCacheEntry() != frameState->hasCachedPage) {
             if (frameState->hasCachedPage)
             webPageProxy->protectedBackForwardCache()->addEntry(*item, process->coreProcessIdentifier());
@@ -807,6 +820,12 @@ String WebBackForwardList::loggingString()
     }
 
     return builder.toString();
+}
+
+void WebBackForwardList::didReceiveProvisionalMessage(IPC::Connection& connection, IPC::Decoder& decoder)
+{
+    SetForScope scope(m_handlingProvisionalMessage, true);
+    didReceiveMessage(connection, decoder);
 }
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebBackForwardList.h
+++ b/Source/WebKit/UIProcess/WebBackForwardList.h
@@ -93,6 +93,7 @@ public:
     void setItemsAsRestoredFromSessionIf(NOESCAPE Function<bool(WebBackForwardListItem&)>&&);
 
     void didReceiveMessage(IPC::Connection&, IPC::Decoder&);
+    void didReceiveProvisionalMessage(IPC::Connection&, IPC::Decoder&);
     void didReceiveSyncMessage(IPC::Connection&, IPC::Decoder&, UniqueRef<IPC::Encoder>&);
 
     void backForwardAddItemShared(IPC::Connection&, Ref<FrameState>&&, LoadedWebArchive);
@@ -115,7 +116,7 @@ private:
 
     // IPC messages
     void backForwardAddItem(IPC::Connection&, Ref<FrameState>&&);
-    void backForwardSetChildItem(WebCore::BackForwardFrameItemIdentifier, Ref<FrameState>&&);
+    void backForwardSetChildItem(IPC::Connection&, WebCore::BackForwardFrameItemIdentifier, Ref<FrameState>&&);
     void backForwardClearChildren(WebCore::BackForwardItemIdentifier, WebCore::BackForwardFrameItemIdentifier);
     void backForwardUpdateItem(IPC::Connection&, Ref<FrameState>&&);
     void backForwardGoToItem(WebCore::BackForwardItemIdentifier, CompletionHandler<void(const WebBackForwardListCounts&)>&&);
@@ -129,6 +130,7 @@ private:
     WeakPtr<WebPageProxy> m_page;
     BackForwardListItemVector m_entries;
     std::optional<size_t> m_currentIndex;
+    bool m_handlingProvisionalMessage { false };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -8138,6 +8138,7 @@ void WebPageProxy::didSameDocumentNavigationForFrameViaJS(IPC::Connection& conne
 
     Ref process = WebProcessProxy::fromConnection(connection);
     MESSAGE_CHECK_URL(process, url);
+    MESSAGE_CHECK(process, url.protocolIsFile() || frame->url().isEmpty() || protocolHostAndPortAreEqual(url, frame->url()));
 
     WEBPAGEPROXY_RELEASE_LOG(Loading, "didSameDocumentNavigationForFrameViaJS: frameID=%" PRIu64 ", isMainFrame=%d, type=%u", frameID.toUInt64(), frame->isMainFrame(), enumToUnderlyingType(navigationType));
 

--- a/Source/WebKit/UIProcess/WebPermissionControllerProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPermissionControllerProxy.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "WebPermissionControllerProxy.h"
 
+#include "MessageSenderInlines.h"
 #include "WebPageProxy.h"
 #include "WebPermissionControllerProxyMessages.h"
 #include "WebProcessProxy.h"
@@ -39,6 +40,8 @@
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
 #include <wtf/WeakHashSet.h>
+
+#define MESSAGE_CHECK_COMPLETION(assertion, completion) MESSAGE_CHECK_COMPLETION_BASE(assertion, m_process->connection(), completion)
 
 namespace WebKit {
 
@@ -67,6 +70,7 @@ void WebPermissionControllerProxy::deref() const
 
 void WebPermissionControllerProxy::query(const WebCore::ClientOrigin& clientOrigin, const WebCore::PermissionDescriptor& descriptor, std::optional<WebPageProxyIdentifier> identifier, WebCore::PermissionQuerySource source, CompletionHandler<void(std::optional<WebCore::PermissionState>)>&& completionHandler)
 {
+    MESSAGE_CHECK_COMPLETION(identifier || (source == WebCore::PermissionQuerySource::SharedWorker || source == WebCore::PermissionQuerySource::ServiceWorker), completionHandler(std::nullopt));
     auto webPageProxy = identifier ? RefPtr { m_process->webPage(identifier.value()) } : mostReasonableWebPageProxy(clientOrigin.topOrigin, source);
 
     if (!webPageProxy) {

--- a/Source/WebKit/UIProcess/glib/ScreenManager.cpp
+++ b/Source/WebKit/UIProcess/glib/ScreenManager.cpp
@@ -38,12 +38,12 @@ ScreenManager& ScreenManager::singleton()
     return manager;
 }
 
-PlatformDisplayID ScreenManager::displayID(PlatformScreen* screen) const
+PlatformDisplayID ScreenManager::displayID(NativePlatformScreen* screen) const
 {
     return m_screenToDisplayIDMap.get(screen);
 }
 
-PlatformScreen* ScreenManager::screen(PlatformDisplayID displayID) const
+NativePlatformScreen* ScreenManager::screen(PlatformDisplayID displayID) const
 {
     for (const auto& iter : m_screenToDisplayIDMap) {
         if (iter.value == displayID)
@@ -52,13 +52,13 @@ PlatformScreen* ScreenManager::screen(PlatformDisplayID displayID) const
     return nullptr;
 }
 
-void ScreenManager::addScreen(PlatformScreen* screen)
+void ScreenManager::addScreen(NativePlatformScreen* screen)
 {
     m_screens.append(screen);
     m_screenToDisplayIDMap.add(screen, generatePlatformDisplayID(screen));
 }
 
-void ScreenManager::removeScreen(PlatformScreen* screen)
+void ScreenManager::removeScreen(NativePlatformScreen* screen)
 {
     m_screenToDisplayIDMap.remove(screen);
     m_screens.removeFirstMatching([screen](const auto& item) {

--- a/Source/WebKit/UIProcess/glib/ScreenManager.h
+++ b/Source/WebKit/UIProcess/glib/ScreenManager.h
@@ -35,10 +35,10 @@
 
 #if PLATFORM(GTK)
 typedef struct _GdkMonitor GdkMonitor;
-using PlatformScreen = GdkMonitor;
+using NativePlatformScreen = GdkMonitor;
 #elif PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
 typedef struct _WPEScreen WPEScreen;
-using PlatformScreen = WPEScreen;
+using NativePlatformScreen = WPEScreen;
 #endif
 
 namespace WebKit {
@@ -51,8 +51,8 @@ class ScreenManager {
 public:
     static ScreenManager& singleton();
 
-    PlatformDisplayID displayID(PlatformScreen*) const;
-    PlatformScreen* screen(PlatformDisplayID) const;
+    PlatformDisplayID displayID(NativePlatformScreen*) const;
+    NativePlatformScreen* screen(PlatformDisplayID) const;
     PlatformDisplayID primaryDisplayID() const { return m_primaryDisplayID; }
 
     WebCore::ScreenProperties collectScreenProperties() const;
@@ -60,15 +60,15 @@ public:
 private:
     ScreenManager();
 
-    static PlatformDisplayID generatePlatformDisplayID(PlatformScreen*);
+    static PlatformDisplayID generatePlatformDisplayID(NativePlatformScreen*);
 
-    void addScreen(PlatformScreen*);
-    void removeScreen(PlatformScreen*);
+    void addScreen(NativePlatformScreen*);
+    void removeScreen(NativePlatformScreen*);
     void updatePrimaryDisplayID();
     void propertiesDidChange() const;
 
-    Vector<GRefPtr<PlatformScreen>, 1> m_screens;
-    HashMap<PlatformScreen*, PlatformDisplayID> m_screenToDisplayIDMap;
+    Vector<GRefPtr<NativePlatformScreen>, 1> m_screens;
+    HashMap<NativePlatformScreen*, PlatformDisplayID> m_screenToDisplayIDMap;
     PlatformDisplayID m_primaryDisplayID { 0 };
 };
 

--- a/Source/WebKit/UIProcess/gtk/ScreenManagerGtk.cpp
+++ b/Source/WebKit/UIProcess/gtk/ScreenManagerGtk.cpp
@@ -154,7 +154,7 @@ ScreenProperties ScreenManager::collectScreenProperties() const
     }
 
     // FIXME: don't use PlatformScreen from the UI process, better use ScreenManager directly.
-    WebCore::setScreenProperties(properties);
+    WebCore::PlatformScreen::updateSingletonProperties(ScreenProperties { properties });
 
     return properties;
 }

--- a/Source/WebKit/UIProcess/wpe/ScreenManagerWPE.cpp
+++ b/Source/WebKit/UIProcess/wpe/ScreenManagerWPE.cpp
@@ -93,7 +93,7 @@ ScreenProperties ScreenManager::collectScreenProperties() const
     }
 
     // FIXME: don't use PlatformScreen from the UI process, better use ScreenManager directly.
-    WebCore::setScreenProperties(properties);
+    WebCore::PlatformScreen::updateSingletonProperties(ScreenProperties { properties });
 
     return properties;
 }

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
@@ -135,7 +135,20 @@ public:
 
     const WebCore::ImageBuffer::Parameters& parameters() const { return m_parameters; }
     const WebCore::ImageBufferBackend::Info& info() const { return m_info; }
+
+    std::unique_ptr<WebCore::SerializedImageBuffer> clone() const final
+    {
+        return std::unique_ptr<WebCore::SerializedImageBuffer>(new RemoteSerializedImageBufferProxy(m_parameters, m_info, m_connection));
+    }
+
 private:
+    RemoteSerializedImageBufferProxy(const WebCore::ImageBuffer::Parameters& parameters, const WebCore::ImageBufferBackend::Info& info, const RefPtr<IPC::Connection>& connection)
+        : m_parameters(parameters)
+        , m_info(info)
+        , m_connection(connection)
+    {
+    }
+
     RefPtr<WebCore::ImageBuffer> sinkIntoImageBuffer() final
     {
         ASSERT_NOT_REACHED();

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -1077,7 +1077,8 @@ double UnifiedPDFPlugin::scaleForActualSize() const
     if (!webPage)
         return 1;
 
-    auto* screenData = WebCore::screenData(webPage->corePage()->displayID());
+    Ref screen = PlatformScreen::singleton();
+    auto* screenData = screen->screenData(webPage->corePage()->displayID());
     if (!screenData)
         return 1;
 

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebBroadcastChannelRegistry.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebBroadcastChannelRegistry.cpp
@@ -116,10 +116,18 @@ void WebBroadcastChannelRegistry::postMessageLocally(const WebCore::PartitionedS
         return;
 
     auto channelIdentifiersForName = channelsForOriginIterator->value;
+
+    size_t numberOfMessagesNeeded = channelIdentifiersForName.size();
+    for (auto& channelIdentifier : channelIdentifiersForName) {
+        if (channelIdentifier == sourceInProcess)
+            --numberOfMessagesNeeded;
+    }
+
     for (auto& channelIdentifier : channelIdentifiersForName) {
         if (channelIdentifier == sourceInProcess)
             continue;
-        WebCore::BroadcastChannel::dispatchMessageTo(channelIdentifier, message.copyRef(), [callbackAggregator] { });
+        auto messageToDispatch = numberOfMessagesNeeded-- > 1 ? message->clone() : WTF::move(message);
+        WebCore::BroadcastChannel::dispatchMessageTo(channelIdentifier, WTF::move(messageToDispatch), [callbackAggregator] { });
     }
 }
 

--- a/Source/WebKit/WebProcess/WebProcess.h
+++ b/Source/WebKit/WebProcess/WebProcess.h
@@ -284,6 +284,14 @@ public:
     void setTextCheckerState(OptionSet<TextCheckerState>);
 
     EventDispatcher& eventDispatcher() { return m_eventDispatcher; }
+    const SharedPreferencesForWebProcess& sharedPreferencesForWebProcessValue() const { return m_sharedPreferencesForWebProcess; }
+
+    const String& uiProcessBundleIdentifier() const { return m_uiProcessBundleIdentifier; }
+    WebCacheStorageProvider& cacheStorageProvider() { return m_cacheStorageProvider.get(); }
+    WebBadgeClient& badgeClient() { return m_badgeClient.get(); }
+    WebBroadcastChannelRegistry& broadcastChannelRegistry() { return m_broadcastChannelRegistry.get(); }
+    WebCookieJar& cookieJar() { return m_cookieJar.get(); }
+    WebSocketChannelManager& webSocketChannelManager() { return m_webSocketChannelManager; }
     Ref<EventDispatcher> protectedEventDispatcher() { return m_eventDispatcher; }
     Ref<WebInspectorInterruptDispatcher> protectedWebInspectorInterruptDispatcher() { return m_webInspectorInterruptDispatcher; }
 #if ENABLE(REMOTE_INSPECTOR) && ENABLE(WEBASSEMBLY)
@@ -306,7 +314,6 @@ public:
     void removeWebTransportSession(WebTransportSessionIdentifier);
 
     std::optional<SharedPreferencesForWebProcess> sharedPreferencesForWebProcess() const { return m_sharedPreferencesForWebProcess; }
-    const SharedPreferencesForWebProcess& sharedPreferencesForWebProcessValue() const { return m_sharedPreferencesForWebProcess; }
     void updateSharedPreferencesForWebProcess(SharedPreferencesForWebProcess sharedPreferencesForWebProcess) { m_sharedPreferencesForWebProcess = WTF::move(sharedPreferencesForWebProcess); }
 
 #if USE(LIBRICE)
@@ -379,8 +386,6 @@ public:
     void releaseSystemMallocMemory();
 #endif
 
-    const String& uiProcessBundleIdentifier() const { return m_uiProcessBundleIdentifier; }
-
     void updateActivePages(const String& overrideDisplayName);
     void getActivePagesOriginsForTesting(CompletionHandler<void(Vector<String>&&)>&&);
     void pageActivityStateDidChange(WebCore::PageIdentifier, OptionSet<WebCore::ActivityState> changed);
@@ -414,8 +419,6 @@ public:
 #if ENABLE(MODEL_PROCESS)
     ModelProcessModelPlayerManager& modelProcessModelPlayerManager() { return m_modelProcessModelPlayerManager.get(); }
 #endif
-    WebCacheStorageProvider& cacheStorageProvider() { return m_cacheStorageProvider.get(); }
-    WebBadgeClient& badgeClient() { return m_badgeClient.get(); }
 #if ENABLE(GPU_PROCESS) && ENABLE(VIDEO)
     RemoteMediaPlayerManager& remoteMediaPlayerManager() { return m_remoteMediaPlayerManager.get(); }
     Ref<RemoteMediaPlayerManager> protectedRemoteMediaPlayerManager();
@@ -424,10 +427,7 @@ public:
     RemoteImageDecoderAVFManager& remoteImageDecoderAVFManager() { return m_remoteImageDecoderAVFManager.get(); }
     Ref<RemoteImageDecoderAVFManager> protectedRemoteImageDecoderAVFManager();
 #endif
-    WebBroadcastChannelRegistry& broadcastChannelRegistry() { return m_broadcastChannelRegistry.get(); }
-    WebCookieJar& cookieJar() { return m_cookieJar.get(); }
     Ref<WebCookieJar> protectedCookieJar();
-    WebSocketChannelManager& webSocketChannelManager() { return m_webSocketChannelManager; }
 
     Ref<WebNotificationManager> protectedNotificationManager();
 
@@ -739,7 +739,7 @@ private:
 #endif
 
 #if PLATFORM(COCOA) || PLATFORM(GTK) || PLATFORM(WPE)
-    void setScreenProperties(const WebCore::ScreenProperties&);
+    void setScreenProperties(WebCore::ScreenProperties&&);
 #endif
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -552,7 +552,7 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
         });
     }
 
-    WebCore::setScreenProperties(parameters.screenProperties);
+    WebCore::PlatformScreen::updateSingletonProperties(WTF::move(parameters.screenProperties));
 
 #if PLATFORM(MAC)
     scrollerStylePreferenceChanged(parameters.useOverlayScrollbars);
@@ -1467,7 +1467,7 @@ void WebProcess::switchFromStaticFontRegistryToUserFontRegistry(Vector<WebKit::S
 #endif
 }
 
-void WebProcess::setScreenProperties(const WebCore::ScreenProperties& properties)
+void WebProcess::setScreenProperties(WebCore::ScreenProperties&& properties)
 {
 #if HAVE(SUPPORT_HDR_DISPLAY)
     auto propertiesWithStyleAffectingOnly = [](auto properties) {
@@ -1478,12 +1478,12 @@ void WebProcess::setScreenProperties(const WebCore::ScreenProperties& properties
         }
         return properties;
     };
-    bool affectsStyle = propertiesWithStyleAffectingOnly(properties) != propertiesWithStyleAffectingOnly(WebCore::getScreenProperties());
+    bool affectsStyle = propertiesWithStyleAffectingOnly(properties) != propertiesWithStyleAffectingOnly(WebCore::PlatformScreen::singleton()->screenProperties());
 #else
     constexpr bool affectsStyle = true;
 #endif
 
-    WebCore::setScreenProperties(properties);
+    WebCore::PlatformScreen::updateSingletonProperties(WTF::move(properties));
     for (auto& page : m_pageMap.values())
         page->screenPropertiesDidChange(affectsStyle);
 #if PLATFORM(MAC)

--- a/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
+++ b/Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm
@@ -890,24 +890,22 @@ static void registerLogClient(bool isDebugLoggingEnabled, std::unique_ptr<LogCli
         if (Thread::currentThreadIsRealtime())
             return;
 
-        auto logChannel = unsafeSpanIncludingNullTerminator(msg->subsystem);
-        if (logChannel.size() > logSubsystemMaxSize)
+        auto logChannel = unsafeSpan(msg->subsystem);
+        if (logChannel.size() >= logSubsystemMaxSize)
             return;
         if (shouldIgnoreLogMessage(logChannel))
             return;
-        auto logCategory = unsafeSpanIncludingNullTerminator(msg->category);
-        if (logCategory.size() > logCategoryMaxSize)
+        auto logCategory = unsafeSpan(msg->category);
+        if (logCategory.size() >= logCategoryMaxSize)
             return;
 
         if (type == OS_LOG_TYPE_FAULT)
             type = OS_LOG_TYPE_ERROR;
 
         if (auto messageString = adoptSystemMalloc(os_log_copy_message_string(msg))) {
-            auto logString = spanConstCast<char>(unsafeSpanIncludingNullTerminator(messageString.get()));
-            if (logString.size() > logStringMaxSize) {
-                logString = logString.first(logStringMaxSize);
-                logString.back() = 0;
-            }
+            auto logString = spanConstCast<char>(unsafeSpan(messageString.get()));
+            if (logString.size() >= logStringMaxSize)
+                logString = logString.first(logStringMaxSize - 1);
             logClient()->log(byteCast<uint8_t>(logChannel), byteCast<uint8_t>(logCategory), byteCast<uint8_t>(logString), type);
         }
     }).get());

--- a/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
+++ b/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
@@ -258,14 +258,14 @@ void WebProcess::platformInitializeWebProcess(WebProcessCreationParameters& para
         FontRenderOptions::singleton().disableHintingForTesting();
 
 #if PLATFORM(GTK)
-    WebCore::setScreenProperties(parameters.screenProperties);
+    WebCore::PlatformScreen::updateSingletonProperties(WTF::move(parameters.screenProperties));
 
     WebCore::SystemSoundManager::singleton().setSystemSoundDelegate(makeUnique<WebSystemSoundDelegate>());
 #endif
 
 #if PLATFORM(WPE) && ENABLE(WPE_PLATFORM)
     if (!m_rendererBufferTransportMode.isEmpty())
-        WebCore::setScreenProperties(parameters.screenProperties);
+        WebCore::PlatformScreen::updateSingletonProperties(WTF::move(parameters.screenProperties));
 #endif
 }
 
@@ -319,10 +319,10 @@ void WebProcess::releaseSystemMallocMemory()
 }
 
 #if PLATFORM(GTK) || PLATFORM(WPE)
-void WebProcess::setScreenProperties(const WebCore::ScreenProperties& properties)
+void WebProcess::setScreenProperties(WebCore::ScreenProperties&& properties)
 {
 #if PLATFORM(GTK) || (PLATFORM(WPE) && ENABLE(WPE_PLATFORM))
-    WebCore::setScreenProperties(properties);
+    WebCore::PlatformScreen::updateSingletonProperties(WTF::move(properties));
 #endif
     for (auto& page : m_pageMap.values())
         page->screenPropertiesDidChange();

--- a/Tools/TestWebKitAPI/Tests/WTF/Vector.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/Vector.cpp
@@ -764,49 +764,49 @@ TEST(WTF_Vector, RemoveAll)
     Vector<CString> vExpected;
     Vector<CString> v2;
     EXPECT_TRUE(v2.isEmpty());
-    EXPECT_FALSE(v2.removeAll("1"));
+    EXPECT_FALSE(v2.removeAll("1"_s));
     EXPECT_TRUE(v2.isEmpty());
 
     v2.fill("1", 10);
     EXPECT_EQ(10U, v2.size());
-    EXPECT_EQ(10U, v2.removeAll("1"));
+    EXPECT_EQ(10U, v2.removeAll("1"_s));
     EXPECT_TRUE(v2.isEmpty());
 
     v2.fill("2", 10);
     EXPECT_EQ(10U, v2.size());
-    EXPECT_EQ(0U, v2.removeAll("1"));
+    EXPECT_EQ(0U, v2.removeAll("1"_s));
     EXPECT_EQ(10U, v2.size());
 
     v2 = {"1", "2", "1", "2", "1", "2", "2", "1", "1", "1"};
     EXPECT_EQ(10U, v2.size());
-    EXPECT_EQ(6U, v2.removeAll("1"));
+    EXPECT_EQ(6U, v2.removeAll("1"_s));
     EXPECT_EQ(4U, v2.size());
-    EXPECT_TRUE(v2.find("1") == notFound);
-    EXPECT_EQ(4U, v2.removeAll("2"));
+    EXPECT_TRUE(v2.find("1"_s) == notFound);
+    EXPECT_EQ(4U, v2.removeAll("2"_s));
     EXPECT_TRUE(v2.isEmpty());
 
     v2 = {"3", "1", "2", "1", "2", "1", "2", "2", "1", "1", "1", "3"};
     EXPECT_EQ(12U, v2.size());
-    EXPECT_EQ(6U, v2.removeAll("1"));
+    EXPECT_EQ(6U, v2.removeAll("1"_s));
     EXPECT_EQ(6U, v2.size());
-    EXPECT_TRUE(v2.find("1") == notFound);
+    EXPECT_TRUE(v2.find("1"_s) == notFound);
     vExpected = {"3", "2", "2", "2", "2", "3"};
     EXPECT_TRUE(v2 == vExpected);
 
-    EXPECT_EQ(4U, v2.removeAll("2"));
+    EXPECT_EQ(4U, v2.removeAll("2"_s));
     EXPECT_EQ(2U, v2.size());
-    EXPECT_TRUE(v2.find("2") == notFound);
+    EXPECT_TRUE(v2.find("2"_s) == notFound);
     vExpected = {"3", "3"};
     EXPECT_TRUE(v2 == vExpected);
 
-    EXPECT_EQ(2U, v2.removeAll("3"));
+    EXPECT_EQ(2U, v2.removeAll("3"_s));
     EXPECT_TRUE(v2.isEmpty());
 
     v2 = {"1", "1", "1", "3", "2", "4", "2", "2", "2", "4", "4", "3"};
     EXPECT_EQ(12U, v2.size());
-    EXPECT_EQ(3U, v2.removeAll("1"));
+    EXPECT_EQ(3U, v2.removeAll("1"_s));
     EXPECT_EQ(9U, v2.size());
-    EXPECT_TRUE(v2.find("1") == notFound);
+    EXPECT_TRUE(v2.find("1"_s) == notFound);
     vExpected = {"3", "2", "4", "2", "2", "2", "4", "4", "3"};
     EXPECT_TRUE(v2 == vExpected);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/ContentFiltering.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/ContentFiltering.mm
@@ -37,11 +37,13 @@
 #import <WebCore/MockContentFilterSettings.h>
 #import <WebKit/WKErrorRef.h>
 #import <WebKit/WKNavigationDelegatePrivate.h>
+#import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKProcessPoolPrivate.h>
 #import <WebKit/WKWebView.h>
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/WKWebsiteDataStorePrivate.h>
 #import <WebKit/_WKDownloadDelegate.h>
+#import <WebKit/_WKFeature.h>
 #import <WebKit/_WKRemoteObjectInterface.h>
 #import <WebKit/_WKRemoteObjectRegistry.h>
 #import <pal/spi/cocoa/NEFilterSourceSPI.h>
@@ -104,6 +106,12 @@ using DecisionPoint = WebCore::MockContentFilterSettings::DecisionPoint;
 static RetainPtr<WKWebViewConfiguration> configurationWithContentFilterSettings(Decision decision, DecisionPoint decisionPoint)
 {
     auto configuration = retainPtr([WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"ContentFilteringPlugIn"]);
+    for (_WKFeature *feature in [WKPreferences _features]) {
+        if ([feature.key isEqualToString:@"AllowTestOnlyMockContentFilterIPC"]) {
+            [[configuration preferences] _setEnabled:YES forFeature:feature];
+            break;
+        }
+    }
     auto contentFilterEnabler = adoptNS([[MockContentFilterEnabler alloc] initWithDecision:decision decisionPoint:decisionPoint]);
     [[configuration processPool] _setObject:contentFilterEnabler.get() forBundleParameter:NSStringFromClass([MockContentFilterEnabler class])];
     return configuration;

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm
@@ -950,6 +950,92 @@ TEST(IPCTestingAPI, AddOriginAccessAllowListEntryAllowedWithTestOnlyIPC)
     EXPECT_WK_STREQ(result, "FETCHED:cross-origin-data");
 }
 
+#if ENABLE(CONTENT_FILTERING)
+
+static NSString *installMockContentFilterAndNavigateVictim(bool allowMockContentFilterIPC)
+{
+    using namespace TestWebKitAPI;
+
+    HTTPServer attackerServer({
+        { "/attacker"_s, { "<!DOCTYPE html>"_s } },
+        { "/evil"_s, { "<!DOCTYPE html><body>REDIRECTED</body>"_s } },
+    });
+    HTTPServer victimServer({
+        { "/victim"_s, { "<!DOCTYPE html><body>ORIGINAL</body>"_s } },
+    });
+
+    auto configA = adoptNS([[WKWebViewConfiguration alloc] init]);
+    for (_WKFeature *feature in [WKPreferences _features]) {
+        if ([feature.key isEqualToString:@"IPCTestingAPIEnabled"])
+            [[configA preferences] _setEnabled:YES forFeature:feature];
+        if ([feature.key isEqualToString:@"AllowTestOnlyMockContentFilterIPC"])
+            [[configA preferences] _setEnabled:allowMockContentFilterIPC forFeature:feature];
+    }
+
+    auto configB = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configB setProcessPool:[configA processPool]];
+
+    auto webViewA = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configA.get()]);
+    auto webViewB = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configB.get()]);
+
+    [webViewA loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%u/attacker", attackerServer.port()]]]];
+    [webViewA _test_waitForDidFinishNavigation];
+
+    [webViewA stringByEvaluatingJavaScript:[NSString stringWithFormat:
+        @"IPC.sendMessage('Networking', 0,"
+        "  IPC.messages.NetworkConnectionToWebProcess_InstallMockContentFilter.name,"
+        "  ["
+        "    { type: 'bool', value: 1 },"
+        "    { type: 'uint8_t', value: 0 },"
+        "    { type: 'bool', value: 0 },"
+        "    { type: 'bool', value: 1 },"
+        "    { type: 'String', value: '' },"
+        "    { type: 'String', value: 'http://127.0.0.1:%u/evil' },"
+        "    { type: 'double', value: 0 }"
+        "  ]"
+        ")", attackerServer.port()]];
+
+    Util::runFor(0.5_s);
+
+    [webViewB loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%u/victim", victimServer.port()]]]];
+    [webViewB _test_waitForDidFinishNavigation];
+
+    NSString *bodyText = [webViewB stringByEvaluatingJavaScript:@"document.body.innerText"];
+
+    if (allowMockContentFilterIPC) {
+        // Reset MockContentFilterSettings since it is a process-global singleton in the NetworkProcess.
+        [webViewA stringByEvaluatingJavaScript:
+            @"IPC.sendMessage('Networking', 0,"
+            "  IPC.messages.NetworkConnectionToWebProcess_InstallMockContentFilter.name,"
+            "  ["
+            "    { type: 'bool', value: 0 },"
+            "    { type: 'uint8_t', value: 0 },"
+            "    { type: 'bool', value: 0 },"
+            "    { type: 'bool', value: 0 },"
+            "    { type: 'String', value: '' },"
+            "    { type: 'String', value: '' },"
+            "    { type: 'double', value: 0 }"
+            "  ]"
+            ")"];
+
+        Util::runFor(0.5_s);
+    }
+
+    return bodyText;
+}
+
+TEST(IPCTestingAPI, InstallMockContentFilterRequiresTestOnlyIPC)
+{
+    EXPECT_WK_STREQ(installMockContentFilterAndNavigateVictim(false), "ORIGINAL");
+}
+
+TEST(IPCTestingAPI, InstallMockContentFilterRedirectsWithTestOnlyIPC)
+{
+    EXPECT_WK_STREQ(installMockContentFilterAndNavigateVictim(true), "REDIRECTED");
+}
+
+#endif // ENABLE(CONTENT_FILTERING)
+
 #endif
 
 #if !HAVE(WK_SECURE_CODING_NSURLREQUEST)

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1386,6 +1386,7 @@ void TestController::resetPreferencesToConsistentValues(const TestOptions& optio
         WKPreferencesSetMinimumFontSize(preferences, 0);
 
         WKPreferencesSetBoolValueForKeyForTesting(preferences, options.allowTestOnlyIPC(), toWK("AllowTestOnlyIPC").get());
+        WKPreferencesSetBoolValueForKeyForTesting(preferences, options.allowTestOnlyMockContentFilterIPC(), toWK("AllowTestOnlyMockContentFilterIPC").get());
         WKPreferencesSetBoolValueForKeyForTesting(preferences, options.allowTestOnlyOriginAccessAllowListIPC(), toWK("AllowTestOnlyOriginAccessAllowListIPC").get());
 
         for (const auto& [key, value] : options.boolWebPreferenceFeatures())

--- a/Tools/WebKitTestRunner/TestOptions.cpp
+++ b/Tools/WebKitTestRunner/TestOptions.cpp
@@ -177,6 +177,7 @@ const TestFeatures& TestOptions::defaults()
         features.boolTestRunnerFeatures = {
             { "allowsLinkPreview", true },
             { "allowTestOnlyIPC", false },
+            { "allowTestOnlyMockContentFilterIPC", true },
             { "allowTestOnlyOriginAccessAllowListIPC", true },
             { "appHighlightsEnabled", false },
             { "dumpJSConsoleLogInStdErr", false },
@@ -260,6 +261,7 @@ const std::unordered_map<std::string, TestHeaderKeyType>& TestOptions::keyTypeMa
         { "allowsLinkPreview", TestHeaderKeyType::BoolTestRunner },
         { "appHighlightsEnabled", TestHeaderKeyType::BoolTestRunner },
         { "allowTestOnlyIPC", TestHeaderKeyType::BoolTestRunner },
+        { "allowTestOnlyMockContentFilterIPC", TestHeaderKeyType::BoolTestRunner },
         { "allowTestOnlyOriginAccessAllowListIPC", TestHeaderKeyType::BoolTestRunner },
         { "dumpJSConsoleLogInStdErr", TestHeaderKeyType::BoolTestRunner },
         { "editable", TestHeaderKeyType::BoolTestRunner },

--- a/Tools/WebKitTestRunner/TestOptions.h
+++ b/Tools/WebKitTestRunner/TestOptions.h
@@ -56,6 +56,7 @@ public:
     bool allowsLinkPreview() const { return boolTestRunnerFeatureValue("allowsLinkPreview"); }
     bool appHighlightsEnabled() const { return boolTestRunnerFeatureValue("appHighlightsEnabled"); }
     bool allowTestOnlyIPC() const { return boolTestRunnerFeatureValue("allowTestOnlyIPC"); }
+    bool allowTestOnlyMockContentFilterIPC() const { return boolTestRunnerFeatureValue("allowTestOnlyMockContentFilterIPC"); }
     bool allowTestOnlyOriginAccessAllowListIPC() const { return boolTestRunnerFeatureValue("allowTestOnlyOriginAccessAllowListIPC"); }
     bool dumpJSConsoleLogInStdErr() const { return boolTestRunnerFeatureValue("dumpJSConsoleLogInStdErr"); }
     bool editable() const { return boolTestRunnerFeatureValue("editable"); }


### PR DESCRIPTION
#### 7d2ba0ec5c0d33cd5c3412829887eb6f866cacd7
<pre>
Cherry-pick 305413.519@safari-7624-branch (19c426cf207c). <a href="https://bugs.webkit.org/show_bug.cgi?id=310175">https://bugs.webkit.org/show_bug.cgi?id=310175</a>

    Bad IPC from WebProcess could cause UIProcess to crash in WebPermissionControllerProxy::mostReasonableWebPageProxy()
    <a href="https://bugs.webkit.org/show_bug.cgi?id=310175">https://bugs.webkit.org/show_bug.cgi?id=310175</a>
    <a href="https://rdar.apple.com/172058081">rdar://172058081</a>

    Reviewed by Sihui Liu and Rupin Mittal.

    Use MESSAGE_CHECK() in WebPermissionControllerProxy::query() to terminate
    the WebProcess in case of bad IPC instead of crashing the UIProcess.

    * Source/WebKit/UIProcess/WebPermissionControllerProxy.cpp:
    (WebKit::WebPermissionControllerProxy::query):

    Identifier: 305413.519@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.540@webkitglib/2.52">https://commits.webkit.org/305877.540@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### e41788ad7bba324d025cd286651a2b64e46dc968
<pre>
Cherry-pick 305413.517@safari-7624-branch (2f6654232966). <a href="https://bugs.webkit.org/show_bug.cgi?id=310069">https://bugs.webkit.org/show_bug.cgi?id=310069</a>

    setRawCookie: cookie.domain unvalidated + commentURL crashes NetworkProcess
    <a href="https://bugs.webkit.org/show_bug.cgi?id=310069">https://bugs.webkit.org/show_bug.cgi?id=310069</a>
    <a href="https://rdar.apple.com/172508832">rdar://172508832</a>

    Reviewed by Rupin Mittal.

    Add message checks in setRawCookie() to validate the Cookie being received.
    Also expand the scope of BLOCK_OBJC_EXCEPTIONS in NetworkStorageSession::setCookies()
    to cover the call to createNSHTTPCookie().

    * Source/WebCore/platform/network/cocoa/NetworkStorageSessionCocoa.mm:
    (WebCore::NetworkStorageSession::setCookies):
    * Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
    (WebKit::NetworkConnectionToWebProcess::setRawCookie):

    Identifier: 305413.517@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.539@webkitglib/2.52">https://commits.webkit.org/305877.539@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 320280e6db8174cf0a813785a346e7b606dcc727
<pre>
Cherry-pick 305413.515@safari-7624-branch (293e2d766d11). <a href="https://bugs.webkit.org/show_bug.cgi?id=310076">https://bugs.webkit.org/show_bug.cgi?id=310076</a>

    IndexedDB Connection/Transaction Identifier Confusion
    <a href="https://bugs.webkit.org/show_bug.cgi?id=310076">https://bugs.webkit.org/show_bug.cgi?id=310076</a>
    <a href="https://rdar.apple.com/172392524">rdar://172392524</a>

    Reviewed by Brady Eidson.

    NetworkStorageManager fails to validate that Connection/Transaction
    identifiers belong to the IPC connection that sent the IPC. This could
    lead to data leakage.

    I added the MESSAGE_CHECK calls inside the IDBStorageRegistry::connection()
    and IDBStorageRegistry::transaction() getter. Those are convenient
    choke-points and it makes it way less likely we forget to add such
    MESSAGE_CHECK when introducing new IPC.

    * Source/WebCore/Modules/indexeddb/server/IDBConnectionToClient.h:
    * Source/WebCore/Modules/indexeddb/server/UniqueIDBDatabaseTransaction.h:
    * Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.cpp:
    (WebKit::IDBStorageRegistry::ensureConnectionToClient):
    (WebKit::IDBStorageRegistry::isValidConnectionForIPC):
    (WebKit::IDBStorageRegistry::connection):
    (WebKit::IDBStorageRegistry::transaction):
    * Source/WebKit/NetworkProcess/storage/IDBStorageRegistry.h:
    * Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
    (WebKit::NetworkStorageManager::openDatabase):
    (WebKit::NetworkStorageManager::deleteDatabase):
    (WebKit::NetworkStorageManager::establishTransaction):
    (WebKit::NetworkStorageManager::databaseConnectionPendingClose):
    (WebKit::NetworkStorageManager::databaseConnectionClosed):
    (WebKit::NetworkStorageManager::abortOpenAndUpgradeNeeded):
    (WebKit::NetworkStorageManager::didFireVersionChangeEvent):
    (WebKit::NetworkStorageManager::didGenerateIndexKeyForRecord):
    (WebKit::NetworkStorageManager::abortTransaction):
    (WebKit::NetworkStorageManager::commitTransaction):
    (WebKit::NetworkStorageManager::didFinishHandlingVersionChangeTransaction):
    (WebKit::NetworkStorageManager::idbTransaction):
    (WebKit::NetworkStorageManager::createObjectStore):
    (WebKit::NetworkStorageManager::deleteObjectStore):
    (WebKit::NetworkStorageManager::renameObjectStore):
    (WebKit::NetworkStorageManager::clearObjectStore):
    (WebKit::NetworkStorageManager::createIndex):
    (WebKit::NetworkStorageManager::deleteIndex):
    (WebKit::NetworkStorageManager::renameIndex):
    (WebKit::NetworkStorageManager::putOrAdd):
    (WebKit::NetworkStorageManager::getRecord):
    (WebKit::NetworkStorageManager::getAllRecords):
    (WebKit::NetworkStorageManager::getCount):
    (WebKit::NetworkStorageManager::deleteRecord):
    (WebKit::NetworkStorageManager::openCursor):
    (WebKit::NetworkStorageManager::iterateCursor):
    (WebKit::NetworkStorageManager::getAllDatabaseNamesAndVersions):
    * Source/WebKit/NetworkProcess/storage/NetworkStorageManager.h:

    Identifier: 305413.515@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.538@webkitglib/2.52">https://commits.webkit.org/305877.538@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 96bda257d3184d70d9470e37c4e50bd1629d79de
<pre>
Cherry-pick 305413.512@safari-7624-branch (d1551df53d97). <a href="https://bugs.webkit.org/show_bug.cgi?id=310073">https://bugs.webkit.org/show_bug.cgi?id=310073</a>

    didSameDocumentNavigationForFrame accepts arbitrary URL, enabling address bar spoofing
    <a href="https://bugs.webkit.org/show_bug.cgi?id=310073">https://bugs.webkit.org/show_bug.cgi?id=310073</a>
    <a href="https://rdar.apple.com/172567659">rdar://172567659</a>

    Reviewed by Ryosuke Niwa.

    Add a MESSAGE_CHECK to validate that the URL&apos;s protocol/host/port match
    the current frame&apos;s URL.

    * Source/WebKit/UIProcess/WebPageProxy.cpp:
    (WebKit::WebPageProxy::didSameDocumentNavigationForFrameViaJS):

    Identifier: 305413.512@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.537@webkitglib/2.52">https://commits.webkit.org/305877.537@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 849a4ed9acb7d549cb72f039dccd22bee9d31847
<pre>
Cherry-pick 305413.511@safari-7624-branch (6381422ae099). <a href="https://bugs.webkit.org/show_bug.cgi?id=309782">https://bugs.webkit.org/show_bug.cgi?id=309782</a>

    Crash in HistoryController::updateForCommit() when calling navigation.reload() during pageswap event handler
    &lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=309782">https://bugs.webkit.org/show_bug.cgi?id=309782</a>&gt;
    &lt;<a href="https://rdar.apple.com/167842846">rdar://167842846</a>&gt;

    Reviewed by Chris Dumez.

    A reload transitioning to committed dispatches a pageswap event, and a
    `navigation.reload()` call inside the pageswap handler does a sync
    policy check that clears the provisional `DocumentLoader`.  After the
    event returns, `HistoryController::updateForCommit()` dereferences the
    now-null `FrameLoader::provisionalDocumentLoader()`.

    Extend the fix from Bug 303364 (which cancelled `navigation.navigate()`
    during pageswap dispatch) to also cancel `navigation.reload()`.  Do
    this by adding the existing `isDispatchingPageSwapEvent()` guard to
    `Navigation::reload()` to match the guard already present in
    `Navigation::navigate()`.

    Test: fast/loader/reload-on-pageswap-crash.html

    * LayoutTests/fast/loader/reload-on-pageswap-crash-expected.txt: Add.
    * LayoutTests/fast/loader/reload-on-pageswap-crash.html: Add.
    * Source/WebCore/page/Navigation.cpp:
    (WebCore::Navigation::reload):

    Identifier: 305413.511@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.536@webkitglib/2.52">https://commits.webkit.org/305877.536@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 3a8a0eb019dab12091f7aacad8c563d5084e759d
<pre>
Cherry-pick 305413.509@safari-7624-branch (246f60f4724f). <a href="https://bugs.webkit.org/show_bug.cgi?id=310068">https://bugs.webkit.org/show_bug.cgi?id=310068</a>

    RELEASE_ASSERT in NetworkConnectionToWebProcess::scheduleResourceLoad() can be abused
    <a href="https://bugs.webkit.org/show_bug.cgi?id=310068">https://bugs.webkit.org/show_bug.cgi?id=310068</a>
    <a href="https://rdar.apple.com/172058188">rdar://172058188</a>

    Reviewed by Ryosuke Niwa and Per Arne Vollan.

    Use a MESSAGE_CHECK instead of a RELEASE_ASSERT() to crash the compromised
    WebContent instead of the network process.

    * Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
    (WebKit::NetworkConnectionToWebProcess::scheduleResourceLoad):

    Identifier: 305413.509@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.535@webkitglib/2.52">https://commits.webkit.org/305877.535@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 70638bafafc7963c4469590c7081106e9015ff39
<pre>
Cherry-pick 305413.502@safari-7624-branch (809e124bf1c2). <a href="https://bugs.webkit.org/show_bug.cgi?id=310077">https://bugs.webkit.org/show_bug.cgi?id=310077</a>

    SpeechRecognition ASSERT Instead of MESSAGE_CHECK for Duplicate Client
    <a href="https://bugs.webkit.org/show_bug.cgi?id=310077">https://bugs.webkit.org/show_bug.cgi?id=310077</a>
    <a href="https://rdar.apple.com/172395253">rdar://172395253</a>

    Reviewed by Sihui Liu.

    Use MESSAGE_CHECK instead of ASSERT to validate the incoming IPC data.

    * Source/WebKit/UIProcess/SpeechRecognitionServer.cpp:
    (WebKit::SpeechRecognitionServer::start):

    Identifier: 305413.502@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.534@webkitglib/2.52">https://commits.webkit.org/305877.534@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### a49c9fd70bf24115487454aaa38a74d39a8debc1
<pre>
Cherry-pick 305413.496@safari-7624-branch (892bd6055fcc). <a href="https://bugs.webkit.org/show_bug.cgi?id=308476">https://bugs.webkit.org/show_bug.cgi?id=308476</a>

    Concurrent HashMap access leads to MTE crashes
    <a href="https://bugs.webkit.org/show_bug.cgi?id=308476">https://bugs.webkit.org/show_bug.cgi?id=308476</a>
    <a href="https://rdar.apple.com/172661039">rdar://172661039</a>

    Reviewed by Kimmo Kinnunen.

    As noted in <a href="https://github.com/apple/WebKit/pull/4641#discussion_r2939229398">https://github.com/apple/WebKit/pull/4641#discussion_r2939229398</a>
    there is a leak introduced and resolve it by removing non-needed variable.

    * Source/WebCore/platform/PlatformScreen.cpp:
    (WebCore::WTF_REQUIRES_LOCK):

    Identifier: 305413.496@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.533@webkitglib/2.52">https://commits.webkit.org/305877.533@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 87ccc4cf870ad77cce60440930a16194c022cc99
<pre>
Cherry-pick 305413.483@safari-7624-branch (962438e00d35). <a href="https://bugs.webkit.org/show_bug.cgi?id=308476">https://bugs.webkit.org/show_bug.cgi?id=308476</a>

    Concurrent HashMap access leads to MTE crashes
    <a href="https://bugs.webkit.org/show_bug.cgi?id=308476">https://bugs.webkit.org/show_bug.cgi?id=308476</a>
    <a href="https://rdar.apple.com/163967950">rdar://163967950</a>

    Reviewed by Kimmo Kinnunen.

    Remove free-standing getScreenProperties() and screenData() functions
    from PlatformScreen which allow accessing either the container or iterators
    within a HashMap as it was discovered in #4632
    that these functions may be called off the main thread.

    Replace with a singleton that has CoW semantics and is resettable, so in the
    case a seperate thread is accessing PlatformScreen, we will have two, or potentially K,
    PlatformScreen instances alive until the other threads release their ref counts.

    * Source/WebCore/html/canvas/GPUCanvasContextCocoa.mm:
    (WebCore::GPUCanvasContextCocoa::updateScreenHeadroomFromScreenProperties):
    * Source/WebCore/platform/PlatformScreen.cpp:
    (WebCore::platformScreenLock):
    (WebCore::platformScreenInstance):
    (WebCore::PlatformScreen::PlatformScreen):
    (WebCore::PlatformScreen::create):
    (WebCore::PlatformScreen::singleton):
    (WebCore::PlatformScreen::screenData const):
    (WebCore::PlatformScreen::primaryScreenDisplayID const):
    (WebCore::PlatformScreen::screenProperties const):
    (WebCore::PlatformScreen::screenContentsFormatsForTesting const):
    (WebCore::PlatformScreen::updateSingletonProperties):
    (WebCore::PlatformScreen::setScreenContentsFormatsForTesting):
    (WebCore::screenProperties): Deleted.
    (WebCore::getScreenProperties): Deleted.
    (WebCore::primaryScreenDisplayID): Deleted.
    (WebCore::setScreenProperties): Deleted.
    (WebCore::screenData): Deleted.
    (WebCore::setScreenContentsFormatsForTesting): Deleted.
    (WebCore::screenContentsFormatsForTesting): Deleted.
    * Source/WebCore/platform/PlatformScreen.h:
    * Source/WebCore/platform/ScreenProperties.h:
    * Source/WebCore/platform/graphics/cocoa/VP9UtilitiesCocoa.mm:
    (WebCore::isVP9CodecConfigurationRecordSupported):
    (WebCore::computeVPParameters):
    * Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp:
    (WebCore::GStreamerRegistryScanner::isConfigurationSupported const):
    * Source/WebCore/platform/gtk/PlatformScreenGtk.cpp:
    (WebCore::screenDepth):
    (WebCore::screenDepthPerComponent):
    (WebCore::fontDPI):
    (WebCore::screenDPI):
    (WebCore::screenRect):
    (WebCore::screenAvailableRect):
    * Source/WebCore/platform/ios/PlatformScreenIOS.mm:
    (WebCore::screenHasInvertedColors):
    (WebCore::screenSupportsExtendedColor):
    (WebCore::screenSupportsHighDynamicRange):
    (WebCore::currentEDRHeadroomForDisplay):
    (WebCore::maxEDRHeadroomForDisplay):
    (WebCore::suppressEDRForDisplay):
    (WebCore::screenPPIFactor):
    (WebCore::screenSize):
    (WebCore::availableScreenSize):
    * Source/WebCore/platform/mac/PlatformScreenMac.mm:
    (WebCore::primaryOpenGLDisplayMask):
    (WebCore::displayMaskForDisplay):
    (WebCore::primaryGPUID):
    (WebCore::gpuIDForDisplay):
    (WebCore::screenIsMonochrome):
    (WebCore::screenHasInvertedColors):
    (WebCore::screenDepth):
    (WebCore::screenDepthPerComponent):
    (WebCore::screenRectForDisplay):
    (WebCore::screenRectForPrimaryScreen):
    (WebCore::currentEDRHeadroomForDisplay):
    (WebCore::maxEDRHeadroomForDisplay):
    (WebCore::suppressEDRForDisplay):
    (WebCore::screenRect):
    (WebCore::screenAvailableRect):
    (WebCore::screenColorSpace):
    (WebCore::screenSupportsExtendedColor):
    (WebCore::screenSupportsHighDynamicRange):
    (WebCore::preferredDynamicRangeMode):
    (WebCore::toUserSpaceForPrimaryScreen):
    (WebCore::screenProperties): Deleted.
    * Source/WebCore/platform/wpe/PlatformScreenWPE.cpp:
    (WebCore::screenDepth):
    (WebCore::screenDepthPerComponent):
    (WebCore::screenDPI):
    (WebCore::screenRect):
    (WebCore::screenAvailableRect):
    * Source/WebCore/testing/Internals.cpp:
    (WebCore::Internals::setScreenContentsFormatsForTesting):
    (WebCore::Internals::primaryScreenDisplayID):
    * Source/WebKit/UIProcess/gtk/ScreenManagerGtk.cpp:
    (WebKit::ScreenManager::collectScreenProperties const):
    * Source/WebKit/UIProcess/wpe/ScreenManagerWPE.cpp:
    (WebKit::ScreenManager::collectScreenProperties const):
    * Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
    (WebKit::UnifiedPDFPlugin::scaleForActualSize const):
    * Source/WebKit/WebProcess/WebProcess.h:
    * Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
    (WebKit::WebProcess::accessibilityFocusedUIElement):
    * Source/WebKit/WebProcess/glib/WebProcessGLib.cpp:
    (WebKit::WebProcess::platformInitializeWebProcess):
    (WebKit::WebProcess::setScreenProperties):

    Identifier: 305413.483@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.532@webkitglib/2.52">https://commits.webkit.org/305877.532@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### e0a2d4da9ed27cba79152522082b709215b55c3f
<pre>
Cherry-pick 305413.477@safari-7624-branch (0de76a6ef7c5). <a href="https://bugs.webkit.org/show_bug.cgi?id=309947">https://bugs.webkit.org/show_bug.cgi?id=309947</a>

    Potential use after free of m_responseDocument in XMLHttpRequest::visitAdditionalChildren()
    <a href="https://bugs.webkit.org/show_bug.cgi?id=309947">https://bugs.webkit.org/show_bug.cgi?id=309947</a>
    <a href="https://rdar.apple.com/172537101">rdar://172537101</a>

    Reviewed by Ryosuke Niwa.

    Potential use after free of m_responseDocument in XMLHttpRequest::visitAdditionalChildren()
    due to multi-threading. visitAdditionalChildren() dereferences m_responseDocument
    on the GC thread while the main thread is running and may null out the RefPtr.

    Address the issue via locking.

    * Source/WebCore/bindings/js/JSXMLHttpRequestCustom.cpp:
    (WebCore::JSXMLHttpRequest::visitAdditionalChildren):
    * Source/WebCore/xml/XMLHttpRequest.cpp:
    (WebCore::XMLHttpRequest::upload):
    (WebCore::XMLHttpRequest::send):
    (WebCore::XMLHttpRequest::sendBytesData):
    (WebCore::XMLHttpRequest::createRequest):
    (WebCore::XMLHttpRequest::clearResponseBuffers):
    (WebCore::XMLHttpRequest::didSendData):
    (WebCore::XMLHttpRequest::dispatchErrorEvents):
    (WebCore::XMLHttpRequest::updateHasRelevantEventListener):
    (WebCore::XMLHttpRequest::visitAdditionalChildren):
    * Source/WebCore/xml/XMLHttpRequest.h:

    Identifier: 305413.477@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.531@webkitglib/2.52">https://commits.webkit.org/305877.531@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 8ab68c07ac0068863cfd9fab2acdec6514c64d3a
<pre>
Cherry-pick 305413.476@safari-7624-branch (645b3e428ffb). <a href="https://bugs.webkit.org/show_bug.cgi?id=309885">https://bugs.webkit.org/show_bug.cgi?id=309885</a>

    Potential use after free of m_stream in ReadableStreamBYOBReader::visitAdditionalChildren()
    <a href="https://bugs.webkit.org/show_bug.cgi?id=309885">https://bugs.webkit.org/show_bug.cgi?id=309885</a>
    <a href="https://rdar.apple.com/172460621">rdar://172460621</a>

    Reviewed by Ryosuke Niwa and Youenn Fablet.

    ReadableStreamBYOBReader::visitAdditionalChildren() runs on the GC
    thread but dereferences m_stream which can get nulled out of the main
    thread.

    Address the issue via locking since we cannot easily ref the stream on
    the GC thread.

    * Source/WebCore/Modules/streams/ReadableStreamBYOBReader.cpp:
    (WebCore::ReadableStreamBYOBReader::~ReadableStreamBYOBReader):
    (WebCore::ReadableStreamBYOBReader::readForBindings):
    (WebCore::ReadableStreamBYOBReader::releaseLock):
    (WebCore::ReadableStreamBYOBReader::cancel):
    (WebCore::ReadableStreamBYOBReader::initialize):
    (WebCore::ReadableStreamBYOBReader::read):
    (WebCore::ReadableStreamBYOBReader::genericRelease):
    (WebCore::ReadableStreamBYOBReader::genericCancel):
    (WebCore::ReadableStreamBYOBReader::isReachableFromOpaqueRoots const):
    (WebCore::ReadableStreamBYOBReader::visitAdditionalChildren):
    * Source/WebCore/Modules/streams/ReadableStreamBYOBReader.h:

    Identifier: 305413.476@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.530@webkitglib/2.52">https://commits.webkit.org/305877.530@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### c622c635b4839041e54dc331ce0e019351304613
<pre>
Cherry-pick 305413.475@safari-7624-branch (97ed68c66545). <a href="https://bugs.webkit.org/show_bug.cgi?id=309776">https://bugs.webkit.org/show_bug.cgi?id=309776</a>

    Race condition in JSXPathResult::visitAdditionalChildren during GC
    <a href="https://bugs.webkit.org/show_bug.cgi?id=309776">https://bugs.webkit.org/show_bug.cgi?id=309776</a>
    &lt;<a href="https://rdar.apple.com/172263146">rdar://172263146</a>&gt;

    Reviewed by Chris Dumez.

    This PR fixes a race condition in JSXPathResult::visitAdditionalChildren
    which results in a use-after-free. The issue is that this function
    iterates over XPathNodeList&apos;s internal vector but XPathNodeList&apos;s member
    functions such as XPathNodeList::firstNode could mutate the vector via
    XPathNodeList::sort, letting a GC thread to do a use-after-free.

    Fixed the bug by guarding the access to m_nodeSet with a lock.

    No new tests since there is no reliable reproduction.

    * Source/WebCore/bindings/js/JSXPathResultCustom.cpp:
    (WebCore::JSXPathResult::visitAdditionalChildren):
    * Source/WebCore/xml/XPathResult.cpp:
    (WebCore::XPathResult::XPathResult):
    (WebCore::XPathResult::~XPathResult):
    (WebCore::XPathResult::convertTo):
    (WebCore::XPathResult::visitAdditionalChildren):
    * Source/WebCore/xml/XPathResult.h:

    Identifier: 305413.475@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.529@webkitglib/2.52">https://commits.webkit.org/305877.529@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### d30e10424c7271a14fab46601551b7c8edf913d0
<pre>
Cherry-pick 305413.472@safari-7624-branch (1a64bedb202e). <a href="https://bugs.webkit.org/show_bug.cgi?id=309882">https://bugs.webkit.org/show_bug.cgi?id=309882</a>

    Potential use after free of m_stream in ReadableStreamDefaultReader::visitAdditionalChildren()
    <a href="https://bugs.webkit.org/show_bug.cgi?id=309882">https://bugs.webkit.org/show_bug.cgi?id=309882</a>
    <a href="https://rdar.apple.com/172458992">rdar://172458992</a>

    Reviewed by Ryosuke Niwa.

    ReadableStreamDefaultReader::visitAdditionalChildren() runs on the GC
    thread but dereferences m_stream which can get nulled out of the main
    thread.

    Address the issue via locking since we cannot easily ref the stream on
    the GC thread.

    * Source/WebCore/Modules/streams/ReadableStreamDefaultReader.cpp:
    (WebCore::ReadableStreamDefaultReader::~ReadableStreamDefaultReader):
    (WebCore::ReadableStreamDefaultReader::read):
    (WebCore::ReadableStreamDefaultReader::releaseLock):
    (WebCore::ReadableStreamDefaultReader::setup):
    (WebCore::ReadableStreamDefaultReader::genericRelease):
    (WebCore::ReadableStreamDefaultReader::cancel):
    (WebCore::ReadableStreamDefaultReader::genericCancel):
    (WebCore::ReadableStreamDefaultReader::stream):
    (WebCore::ReadableStreamDefaultReader::isReachableFromOpaqueRoots const):
    (WebCore::ReadableStreamDefaultReader::visitAdditionalChildren):
    * Source/WebCore/Modules/streams/ReadableStreamDefaultReader.h:
    (WebCore::ReadableStreamDefaultReader::stream): Deleted.

    Identifier: 305413.472@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.528@webkitglib/2.52">https://commits.webkit.org/305877.528@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 3de6996c3e141b7affca369cc12cfbad5988854c
<pre>
Cherry-pick 305413.470@safari-7624-branch (f896e1bfd583). <a href="https://bugs.webkit.org/show_bug.cgi?id=309880">https://bugs.webkit.org/show_bug.cgi?id=309880</a>

    Content extensions should block plugin loads from embed and object elements
    <a href="https://bugs.webkit.org/show_bug.cgi?id=309880">https://bugs.webkit.org/show_bug.cgi?id=309880</a>
    <a href="https://rdar.apple.com/169290430">rdar://169290430</a>

    Reviewed by Anne van Kesteren.

    Plugin content loaded via &lt;embed&gt; and &lt;object&gt; elements was not checked against content extension
    rules. Add a content extension check in HTMLPlugInElement::canLoadURL so that blocked URLs are
    rejected before the wouldLoadAsPlugIn deferral in updateWidget.

    Tests: http/tests/contentextensions/block-embed-element.html
           http/tests/contentextensions/block-object-element.html

    * LayoutTests/http/tests/contentextensions/block-embed-element-expected.txt: Added.
    * LayoutTests/http/tests/contentextensions/block-embed-element.html: Added.
    * LayoutTests/http/tests/contentextensions/block-embed-element.json: Added.
    * LayoutTests/http/tests/contentextensions/block-object-element-expected.txt: Added.
    * LayoutTests/http/tests/contentextensions/block-object-element.html: Added.
    * LayoutTests/http/tests/contentextensions/block-object-element.json: Added.
    * Source/WebCore/html/HTMLPlugInElement.cpp:
    (WebCore::HTMLPlugInElement::canLoadURL const):

    Identifier: 305413.470@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.527@webkitglib/2.52">https://commits.webkit.org/305877.527@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 7626bd78be8a35f2aaaaae3eb257728c68a6a4d7
<pre>
Cherry-pick 305413.464@safari-7624-branch (a5a76108f55d). <a href="https://bugs.webkit.org/show_bug.cgi?id=309861">https://bugs.webkit.org/show_bug.cgi?id=309861</a>

    [JSC] Use span&apos;s length in genericTypedArrayViewProtoFuncSortImpl
    <a href="https://bugs.webkit.org/show_bug.cgi?id=309861">https://bugs.webkit.org/show_bug.cgi?id=309861</a>
    <a href="https://rdar.apple.com/172430021">rdar://172430021</a>

    Reviewed by Yusuke Suzuki and Dan Hecht.

    Constructing a span re-reads the length, which can race with a parallel grow in
    case the TypedArray is backed by a GSAB. Fix the race by using the span&apos;s
    length.

    * JSTests/stress/growable-sharedarraybuffer-parallel-grow-during-prototype-methods.js:
    * Source/JavaScriptCore/runtime/JSGenericTypedArrayViewPrototypeFunctions.h:
    (JSC::genericTypedArrayViewProtoFuncSortImpl):

    Identifier: 305413.464@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.526@webkitglib/2.52">https://commits.webkit.org/305877.526@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 254e0ec143b91b391d0197a1285b21b75ed27ae9
<pre>
Cherry-pick 305413.463@safari-7624-branch (8360fe257449). <a href="https://bugs.webkit.org/show_bug.cgi?id=309504">https://bugs.webkit.org/show_bug.cgi?id=309504</a>

    Don&apos;t log interaction from temporary gesture on storage access rejection
    <a href="https://bugs.webkit.org/show_bug.cgi?id=309504">https://bugs.webkit.org/show_bug.cgi?id=309504</a>
    <a href="https://rdar.apple.com/171546420">rdar://171546420</a>

    Reviewed by Abrar Rahman Protyasha.

    The no-gesture requestStorageAccess() rejection path preserves the user gesture so callers can still
    perform gesture-gated actions like window.open(). However, the temporary UserGestureIndicator was
    created with ProcessInteractionStyle::Immediate, which logged user interaction as a side effect. In
    a popup with an opener, this fabricated interaction triggered requestStorageAccessUnderOpener(),
    silently granting storage access without a prompt.

    Pass ProcessInteractionStyle::Never to prevent interaction logging from the temporary gesture while
    still preserving gesture-gated capabilities.

    Test: http/tests/storageAccess/no-gesture-rejection-should-not-grant-storage-access-under-opener.https.html
    * LayoutTests/http/tests/storageAccess/no-gesture-rejection-should-not-grant-storage-access-under-opener.https-expected.txt: Added.
    * LayoutTests/http/tests/storageAccess/no-gesture-rejection-should-not-grant-storage-access-under-opener.https.html: Added.
    * LayoutTests/http/tests/storageAccess/resources/request-storage-access-without-gesture-and-report-back.html: Added.
    * LayoutTests/http/tests/storageAccess/resources/request-storage-access-without-gesture-in-iframe.html: Added.
    * Source/WebCore/dom/DocumentStorageAccess.cpp:
    (WebCore::DocumentStorageAccess::enableTemporaryTimeUserGesture):

    Identifier: 305413.463@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.525@webkitglib/2.52">https://commits.webkit.org/305877.525@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 344d87a0a63c39d2ec35eecf62adc59df87d29ab
<pre>
Cherry-pick 305413.461@safari-7624-branch (498a2ef7689e). <a href="https://bugs.webkit.org/show_bug.cgi?id=309773">https://bugs.webkit.org/show_bug.cgi?id=309773</a>

    Race condition in JSSubscriber::visitAdditionalChildren during GC
    <a href="https://bugs.webkit.org/show_bug.cgi?id=309773">https://bugs.webkit.org/show_bug.cgi?id=309773</a>
    &lt;<a href="https://rdar.apple.com/172278544">rdar://172278544</a>&gt;

    Reviewed by Chris Dumez.

    This PR fixes a race condition in JSSubscriber::visitAdditionalChildren which results in
    a use-after-free of VoidCallback objects in JSSubscriber::visitAdditionalChildren.

    While Subscriber::teardownCallbacksConcurrently grabs a lock and creates a Vector of
    VoidCallback*, the main thread can still go ahead and destroy VoidCallback while
    a GC thread is calling visitJSFunction on that VoidCallback.

    No new tests since there is no reliable reproduction.

    * Source/WebCore/bindings/js/JSSubscriberCustom.cpp:
    (WebCore::JSSubscriber::visitAdditionalChildren):
    * Source/WebCore/dom/Subscriber.cpp:
    (WebCore::Subscriber::visitAdditionalChildren):
    (): Deleted.
    (WebCore::Subscriber::observerConcurrently): Deleted.
    * Source/WebCore/dom/Subscriber.h:

    Identifier: 305413.461@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.524@webkitglib/2.52">https://commits.webkit.org/305877.524@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### b3f27af532ff6422a2317aaef5b5dd3faecfc103
<pre>
Cherry-pick 305413.459@safari-7624-branch (6b53aa44e133). <a href="https://bugs.webkit.org/show_bug.cgi?id=309091">https://bugs.webkit.org/show_bug.cgi?id=309091</a>

    MESSAGE_CHECK URLs passed in to WebBackForwardListItem backForwardUpdateItem and backForwardSetChildItem
    <a href="https://rdar.apple.com/171104801">rdar://171104801</a>

    Reviewed by Ryosuke Niwa and Per Arne Vollan.

    We do a MESSAGE_CHECK for unexpected file URLs in backForwardAddItemShared.
    These two methods should get the same treatment.

    No new tests (The &quot;success&quot; path of the test would be a crash, which we can&apos;t add.)

    * Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
    (WebKit::ProvisionalPageProxy::didReceiveMessage):
    * Source/WebKit/UIProcess/WebBackForwardList.cpp:
    (WebKit::messageCheckItemURLs):
    (WebKit::WebBackForwardList::backForwardAddItemShared):
    (WebKit::WebBackForwardList::backForwardSetChildItem):
    (WebKit::WebBackForwardList::backForwardUpdateItem):
    (WebKit::WebBackForwardList::didReceiveProvisionalMessage):
    * Source/WebKit/UIProcess/WebBackForwardList.h:

    Identifier: 305413.459@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.523@webkitglib/2.52">https://commits.webkit.org/305877.523@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 326edf0ec425d01339400a01ace53cb301771734
<pre>
Cherry-pick 305413.453@safari-7624-branch (12bfbd5b45c3). <a href="https://bugs.webkit.org/show_bug.cgi?id=309091">https://bugs.webkit.org/show_bug.cgi?id=309091</a>

    Gate InstallMockContentFilter IPC behind AllowTestOnlyIPC
    <a href="https://bugs.webkit.org/show_bug.cgi?id=309091">https://bugs.webkit.org/show_bug.cgi?id=309091</a>
    <a href="https://rdar.apple.com/171645964">rdar://171645964</a>

    Reviewed by Ryosuke Niwa.

    InstallMockContentFilter IPC on NetworkConnectionToWebProcess overwrites
    a process-global MockContentFilterSettings singleton, allowing a
    compromised WebContent process to redirect or block navigations for all
    connections in the NetworkProcess.

    This message is only used by test infrastructure to configure mock
    content filtering. Gate it behind EnabledBy=AllowTestOnlyIPC so it is
    rejected unless the test-only flag is set

    Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm

    * Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
    * Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in:
    * Tools/TestWebKitAPI/Tests/WebKitCocoa/ContentFiltering.mm:
    (configurationWithContentFilterSettings):
    * Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm:
    (InstallMockContentFilterRequiresTestOnlyIPC)):
    (InstallMockContentFilterRedirectsWithTestOnlyIPC)):
    * Tools/WebKitTestRunner/TestController.cpp:
    (WTR::TestController::resetPreferencesToConsistentValues):
    * Tools/WebKitTestRunner/TestOptions.cpp:
    (WTR::TestOptions::defaults):
    (WTR::TestOptions::keyTypeMapping):
    * Tools/WebKitTestRunner/TestOptions.h:
    (WTR::TestOptions::allowTestOnlyMockContentFilterIPC const):

    Identifier: 305413.453@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.522@webkitglib/2.52">https://commits.webkit.org/305877.522@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 998931f6398f2cc9bf92e37608974a496364bf74
<pre>
Cherry-pick 305413.450@safari-7624-branch (8f90147d2654). <a href="https://bugs.webkit.org/show_bug.cgi?id=309665">https://bugs.webkit.org/show_bug.cgi?id=309665</a>

    [CoreIPC] TOCTOU in `logOnBehalfOfWebContent` leads to logging of OOB memory
    <a href="https://bugs.webkit.org/show_bug.cgi?id=309665">https://bugs.webkit.org/show_bug.cgi?id=309665</a>
    <a href="https://rdar.apple.com/170280919">rdar://170280919</a>

    Reviewed by Per Arne Vollan.

    LogOnBehalfOfWebContent is IPC using Streaming IPC from the WebContent
    process to the UIProcess. Some of the parameters are std::span&lt;uint8_t&gt;
    which point to SharedMemory since this is what Streaming IPC is using.
    This can cause trouble as a compromise WebProcess could modify the
    string after sending it over IPC and remove the null terminator for
    example. This can result in TOCTOU bugs since the recipient code relies
    on the strings being null terminated.

    To address the issue, we now:
    1. Send regular spans over IPC, instead of null terminated spans
    2. Upon receipt, we copy them into CStrings right away, which makes them
       null terminated.
    3. The recipient code only uses the CStrings from then on, not the
       original spans.

    This is slightly less efficient but I don&apos;t not see a way to address the
    TOCTOU bugs without doing an extra copy of these strings.

    * Source/JavaScriptCore/dfg/DFGGraph.cpp:
    (JSC::DFG::Graph::dump):
    (JSC::DFG::Graph::dumpBlockHeader):
    * Source/WTF/wtf/text/CString.cpp:
    (WTF::operator==):
    * Source/WTF/wtf/text/CString.h:
    * Source/WTF/wtf/text/StringCommon.h:
    (WTF::operator==):
    * Source/WebKit/Shared/LogStream.cpp:
    (WebKit::LogStream::logOnBehalfOfWebContent):
    * Source/WebKit/WebProcess/cocoa/WebProcessCocoa.mm:
    (WebKit::WebProcess::accessibilityFocusedUIElement):
    * Tools/TestWebKitAPI/Tests/WTF/Vector.cpp:
    (TestWebKitAPI::TEST(WTF_Vector, RemoveAll)):

    Identifier: 305413.450@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.521@webkitglib/2.52">https://commits.webkit.org/305877.521@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 95373912dcb3ee611fad5567f0126bbef9e4f555
<pre>
Cherry-pick 305413.445@safari-7624-branch (5a0c6501d0f5). <a href="https://bugs.webkit.org/show_bug.cgi?id=309626">https://bugs.webkit.org/show_bug.cgi?id=309626</a>

    `SerializedScriptValue::deserialize` cannot be called more than once (affects BroadcastChannel postMessage())
    <a href="https://rdar.apple.com/171134726">rdar://171134726</a>

    Reviewed by Andy Estes and Ryosuke Niwa.

    Since `::deserialize(...)` moves some of the SerializedScriptValue::Internals members, it cannot be called twice.

    This is normally fine, but when a single message has multiple recipients via `BroadcastChannel.postMessage()`,
    it ends up meaning that only the first recipient gets the complete message.

    This patch adds SerializedScriptValue::clone() then uses it in the BroadcastChannel case, making sure each recipient
    gets a full copy of the message.

    Covered by layout tests that exercise each supported `SerializedScriptValue` type.

    Tests: http/tests/broadcastchannel/postmessage-array.html
           http/tests/broadcastchannel/postmessage-arraybuffer.html
           http/tests/broadcastchannel/postmessage-audiodata.html
           http/tests/broadcastchannel/postmessage-blob.html
           http/tests/broadcastchannel/postmessage-boolean.html
           http/tests/broadcastchannel/postmessage-date.html
           http/tests/broadcastchannel/postmessage-domexception.html
           http/tests/broadcastchannel/postmessage-encodedaudiochunk.html
           http/tests/broadcastchannel/postmessage-encodedvideochunk.html
           http/tests/broadcastchannel/postmessage-error.html
           http/tests/broadcastchannel/postmessage-imagebitmap.html
           http/tests/broadcastchannel/postmessage-imagedata.html
           http/tests/broadcastchannel/postmessage-map.html
           http/tests/broadcastchannel/postmessage-mediastreamtrack.html
           http/tests/broadcastchannel/postmessage-null.html
           http/tests/broadcastchannel/postmessage-number.html
           http/tests/broadcastchannel/postmessage-object.html
           http/tests/broadcastchannel/postmessage-regexp.html
           http/tests/broadcastchannel/postmessage-set.html
           http/tests/broadcastchannel/postmessage-sharedarraybuffer.html
           http/tests/broadcastchannel/postmessage-sharedwasmmemory.html
           http/tests/broadcastchannel/postmessage-string.html
           http/tests/broadcastchannel/postmessage-typedarray.html
           http/tests/broadcastchannel/postmessage-videoframe.html
           http/tests/broadcastchannel/postmessage-wasmmodule.html

    * LayoutTests/http/tests/broadcastchannel/.htaccess: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-array-expected.txt: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-array.html: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-arraybuffer-expected.txt: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-arraybuffer.html: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-audiodata-expected.txt: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-audiodata.html: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-blob-expected.txt: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-blob.html: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-boolean-expected.txt: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-boolean.html: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-date-expected.txt: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-date.html: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-domexception-expected.txt: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-domexception.html: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-encodedaudiochunk-expected.txt: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-encodedaudiochunk.html: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-encodedvideochunk-expected.txt: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-encodedvideochunk.html: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-error-expected.txt: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-error.html: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-imagebitmap-expected.txt: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-imagebitmap.html: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-imagedata-expected.txt: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-imagedata.html: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-map-expected.txt: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-map.html: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-mediastreamtrack-expected.txt: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-mediastreamtrack.html: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-null-expected.txt: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-null.html: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-number-expected.txt: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-number.html: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-object-expected.txt: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-object.html: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-regexp-expected.txt: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-regexp.html: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-set-expected.txt: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-set.html: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-sharedarraybuffer-expected.txt: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-sharedarraybuffer.html: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-sharedwasmmemory-expected.txt: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-sharedwasmmemory.html: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-string-expected.txt: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-string.html: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-typedarray-expected.txt: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-typedarray.html: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-videoframe-expected.txt: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-videoframe.html: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-wasmmodule-expected.txt: Added.
    * LayoutTests/http/tests/broadcastchannel/postmessage-wasmmodule.html: Added.
    * LayoutTests/http/tests/broadcastchannel/resources/broadcastchannel-test-harness.js: Added.
    (log):
    (done):
    (w.onmessage):
    (w.onerror):
    (postValue.try):
    (postValue):
    (checkResults):
    (broadcastChannelTest):
    * Source/WebCore/bindings/js/SerializedScriptValue.cpp:
    (WebCore::copyArrayBufferContentsArray):
    (WebCore::SerializedScriptValue::clone const):
    (WebCore::SerializedScriptValue::Internals::clone const):
    * Source/WebCore/bindings/js/SerializedScriptValue.h:
    * Source/WebCore/html/ImageBitmap.cpp:
    (WebCore::DetachedImageBitmap::DetachedImageBitmap):
    * Source/WebCore/html/ImageBitmap.h:
    * Source/WebCore/html/OffscreenCanvas.h:
    (WebCore::DetachedOffscreenCanvas::placeholderSource const):
    * Source/WebCore/platform/graphics/ImageBuffer.cpp:
    * Source/WebCore/platform/graphics/ImageBuffer.h:
    (WebCore::SerializedImageBuffer::clone const):
    * Source/WebCore/platform/mediastream/MediaStreamTrackDataHolder.cpp:
    (WebCore::MediaStreamTrackDataHolder::copy const):
    * Source/WebCore/platform/mediastream/MediaStreamTrackDataHolder.h:
    * Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h:
    (WebKit::RemoteSerializedImageBufferProxy::RemoteSerializedImageBufferProxy):
    * Source/WebKit/WebProcess/WebCoreSupport/WebBroadcastChannelRegistry.cpp:
    (WebKit::WebBroadcastChannelRegistry::postMessageLocally):

    Identifier: 305413.445@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.520@webkitglib/2.52">https://commits.webkit.org/305877.520@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### a6eb1898910fcc41e3088b97c25c1c790354c999
<pre>
Cherry-pick 305413.439@safari-7624-branch (33ae1ab583c7). <a href="https://bugs.webkit.org/show_bug.cgi?id=309626">https://bugs.webkit.org/show_bug.cgi?id=309626</a>

    Bump QoS of the work queue during service worker registrations import
    <a href="https://bugs.webkit.org/show_bug.cgi?id=309626">https://bugs.webkit.org/show_bug.cgi?id=309626</a>
    <a href="https://rdar.apple.com/172236600">rdar://172236600</a>

    Reviewed by Sihui Liu.

    Bump QoS of the work queue during service worker registrations import
    from disk. Navigations are delayed until the import is complete and it
    is thus important to treat the import with high (UserInitiated) priority.

    * Source/WTF/wtf/SuspendableWorkQueue.cpp:
    (WTF::SuspendableWorkQueue::dispatchWithQOS):
    * Source/WTF/wtf/SuspendableWorkQueue.h:
    * Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
    (WebKit::NetworkStorageManager::importServiceWorkerRegistrations):

    Identifier: 305413.439@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.519@webkitglib/2.52">https://commits.webkit.org/305877.519@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 6260312e6296d2908133f4d014d9efff630d7352
<pre>
Cherry-pick 305413.431@safari-7624-branch (b61e7ccad2c2). <a href="https://bugs.webkit.org/show_bug.cgi?id=308636">https://bugs.webkit.org/show_bug.cgi?id=308636</a>

    Use crop dimensions for extension calculation
    <a href="https://rdar.apple.com/171141150">rdar://171141150</a>

    Reviewed by Jean-Yves Avenard.

    We cherry-pick <a href="https://aomedia.googlesource.com/aom/+/7343efd164afc3c0f9f2a212052d77a3d7ea1a49.">https://aomedia.googlesource.com/aom/+/7343efd164afc3c0f9f2a212052d77a3d7ea1a49.</a>

    Identifier: 305413.431@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.518@webkitglib/2.52">https://commits.webkit.org/305877.518@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### d09dbec2a9f205b64d7a62721743e2def4c13dad
<pre>
Cherry-pick 305413.430@safari-7624-branch (04fc2fd260e5). <a href="https://bugs.webkit.org/show_bug.cgi?id=308636">https://bugs.webkit.org/show_bug.cgi?id=308636</a>

    vp9_scale_references: fail if no free buffer is available (Potential &apos;overflow&apos; issue committed to upstream libwebrtc)
    <a href="https://rdar.apple.com/171591634">rdar://171591634</a>

    Reviewed by Jean-Yves Avenard.

    Cherry-pick of <a href="https://github.com/webmproject/libvpx/commit/9a2d3d1f46afbdfa9b9820a9fd3aacb084e65e2f">https://github.com/webmproject/libvpx/commit/9a2d3d1f46afbdfa9b9820a9fd3aacb084e65e2f</a>

    Identifier: 305413.430@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.517@webkitglib/2.52">https://commits.webkit.org/305877.517@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 7b0940dfb681090139c7d33ed9b57306de3dd31b
<pre>
Cherry-pick 305413.429@safari-7624-branch (6d6607033ebc). <a href="https://bugs.webkit.org/show_bug.cgi?id=308636">https://bugs.webkit.org/show_bug.cgi?id=308636</a>

    Fix crashes in RealtimeIncoming*Source destructors by ensuring sink removal before member destruction
    &lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=308636">https://bugs.webkit.org/show_bug.cgi?id=308636</a>&gt;
    &lt;<a href="https://rdar.apple.com/162084447">rdar://162084447</a>&gt;

    Reviewed by Jean-Yves Avenard and Youenn Fablet.

    Crashes occurred when WebRTC audio/video callbacks accessed destroyed
    member variables during object destruction.  The root cause is due to
    C++ destruction-order behavior:  the compiler-generated destructors in
    derived classes (e.g. RealtimeIncomingAudioSourceCocoa) destroy derived
    members before calling the base class destructor, but the base class
    destructor&apos;s stop() call is what removes the audio/video track sink.

    While RTCPeerConnection::doClose() normally stops sources via
    requestToEnd(), there are code paths where the source can reach
    destruction while still producing data -- for example,
    requestToEnd() is blocked if any RealtimeMediaSourceObserver returns
    true from preventSourceFromEnding().  If the source is still producing
    data when destruction begins, the base class destructor&apos;s stop() does
    call RemoveSink() (which properly synchronizes with in-progress OnData
    callbacks via sink_lock_ in RemoteAudioSource), but by that point
    derived members like m_audioBufferList are already destroyed.

    The fix ensures derived destructors call stop() to remove sinks before
    any member destruction occurs.  The base class destructors now contain
    ASSERT(!isProducingData()) to verify subclasses follow this pattern.

    * Source/WebCore/platform/mediastream/RealtimeIncomingAudioSource.cpp:
    (WebCore::RealtimeIncomingAudioSource::~RealtimeIncomingAudioSource):
    * Source/WebCore/platform/mediastream/RealtimeIncomingVideoSource.cpp:
    (WebCore::RealtimeIncomingVideoSource::~RealtimeIncomingVideoSource):
    * Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingAudioSourceLibWebRTC.cpp:
    (WebCore::RealtimeIncomingAudioSourceLibWebRTC::~RealtimeIncomingAudioSourceLibWebRTC): Add.
    * Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingAudioSourceLibWebRTC.h:
    * Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingVideoSourceLibWebRTC.cpp:
    (WebCore::RealtimeIncomingVideoSourceLibWebRTC::~RealtimeIncomingVideoSourceLibWebRTC): Add.
    * Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingVideoSourceLibWebRTC.h:
    * Source/WebCore/platform/mediastream/mac/RealtimeIncomingAudioSourceCocoa.cpp:
    (WebCore::RealtimeIncomingAudioSourceCocoa::~RealtimeIncomingAudioSourceCocoa): Add.
    * Source/WebCore/platform/mediastream/mac/RealtimeIncomingAudioSourceCocoa.h:
    * Source/WebCore/platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.h:
    * Source/WebCore/platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.mm:
    (WebCore::RealtimeIncomingVideoSourceCocoa::~RealtimeIncomingVideoSourceCocoa): Add.

    Identifier: 305413.429@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.516@webkitglib/2.52">https://commits.webkit.org/305877.516@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/70c688aff4f76b398a62ea7d36fad7f0d434635e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163046 "2 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36525 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29724 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171985 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/119492 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164915 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36663 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36527 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126573 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/119492 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166005 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/36663 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/29724 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107149 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/36663 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/36527 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19684 "Unable to build WebKit without PR, please check manually (failure)") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/36663 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/29724 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174488 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23932 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/26347 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/29724 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134884 "Passed tests") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36196 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/36527 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134879 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/36812 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/29724 "Unable to build WebKit without PR, please check manually (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/98767 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24798 "Built successfully and passed tests") | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/36812 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/29724 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195447 "Built successfully") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35692 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/107994 "Failed to checkout and rebase branch from PR 65040") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50909 "Passed tests") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35191 "Unable to build WebKit without PR, please check manually (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35438 "Unable to build WebKit without PR, please check manually (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35339 "Unable to build WebKit without PR, please check manually (failure)") | | | 
<!--EWS-Status-Bubble-End-->