### PR TITLE
REGRESSION (310623@main): Style changes to <option> (or children) do not repaint <select>

### DIFF
--- a/LayoutTests/fast/repaint/select-option-background-color-tracked.html
+++ b/LayoutTests/fast/repaint/select-option-background-color-tracked.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<title>&lt;select&gt; repaints when &lt;option&gt; background-color changes</title>
+<select id="sel" multiple size="4">
+  <option id="opt">A</option>
+  <option>B</option>
+</select>
+<pre id="repaints"></pre>
+<script src="../../resources/ui-helper.js"></script>
+<script>
+if (window.testRunner) {
+  testRunner.dumpAsText();
+  testRunner.waitUntilDone();
+}
+window.addEventListener('load', async () => {
+  await UIHelper.renderingUpdate();
+
+  window.internals?.startTrackingRepaints();
+
+  document.getElementById('opt').style.backgroundColor = 'green';
+
+  await UIHelper.renderingUpdate();
+
+  if (window.internals) {
+    repaints.innerHTML = internals.repaintRectsAsText();
+    internals.stopTrackingRepaints();
+  }
+
+  testRunner?.notifyDone();
+});
+</script>

--- a/LayoutTests/platform/gtk/fast/repaint/select-option-background-color-tracked-expected.txt
+++ b/LayoutTests/platform/gtk/fast/repaint/select-option-background-color-tracked-expected.txt
@@ -1,0 +1,5 @@
+
+(repaint rects
+  (rect 8 8 32 73)
+)
+

--- a/LayoutTests/platform/mac/fast/repaint/select-option-background-color-tracked-expected.txt
+++ b/LayoutTests/platform/mac/fast/repaint/select-option-background-color-tracked-expected.txt
@@ -1,0 +1,5 @@
+
+(repaint rects
+  (rect 8 8 25 57)
+)
+

--- a/LayoutTests/platform/wpe/fast/repaint/select-option-background-color-tracked-expected.txt
+++ b/LayoutTests/platform/wpe/fast/repaint/select-option-background-color-tracked-expected.txt
@@ -1,0 +1,5 @@
+
+(repaint rects
+  (rect 8 8 33 73)
+)
+

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -5867,11 +5867,18 @@ void Element::resetComputedStyle()
     if (!hasRareData() || !elementRareData()->computedStyle())
         return;
 
-    elementRareData()->setComputedStyle(nullptr);
+    auto reset = [](Element& element) {
+        // FIXME: This fires whenever computed style is cleared, even if the new
+        // style ends up identical, so observers may do redundant work.
+        if (element.hasCustomStyleResolveCallbacks() && !element.renderer())
+            element.willResetComputedStyle();
+        element.elementRareData()->setComputedStyle(nullptr);
+    };
+    reset(*this);
     for (Ref child : descendantsOfType<Element>(*this)) {
         if (!child->hasRareData() || !child->elementRareData()->computedStyle() || child->hasDisplayContents() || child->hasDisplayNone())
             continue;
-        child->elementRareData()->setComputedStyle(nullptr);
+        reset(child);
     }
 }
 
@@ -5930,6 +5937,11 @@ void Element::willRecalcStyle(OptionSet<Style::Change>)
 }
 
 void Element::didRecalcStyle(OptionSet<Style::Change>)
+{
+    ASSERT(hasCustomStyleResolveCallbacks());
+}
+
+void Element::willResetComputedStyle()
 {
     ASSERT(hasCustomStyleResolveCallbacks());
 }

--- a/Source/WebCore/dom/Element.h
+++ b/Source/WebCore/dom/Element.h
@@ -792,6 +792,7 @@ public:
 
     virtual void willRecalcStyle(OptionSet<Style::Change>);
     virtual void didRecalcStyle(OptionSet<Style::Change>);
+    virtual void willResetComputedStyle();
     virtual void willAttachRenderers();
     virtual void didAttachRenderers();
     virtual void willDetachRenderers();

--- a/Source/WebCore/html/HTMLOptionElement.cpp
+++ b/Source/WebCore/html/HTMLOptionElement.cpp
@@ -64,7 +64,7 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(HTMLOptionElement);
 using namespace HTMLNames;
 
 HTMLOptionElement::HTMLOptionElement(const QualifiedName& tagName, Document& document)
-    : HTMLElement(tagName, document)
+    : HTMLElement(tagName, document, TypeFlag::HasCustomStyleResolveCallbacks)
 {
     ASSERT(hasTagName(optionTag));
 }
@@ -509,6 +509,14 @@ void HTMLOptionElement::childrenChanged(const ChildChange& change)
             select->optionElementChildrenChanged();
     }
     HTMLElement::childrenChanged(change);
+}
+
+void HTMLOptionElement::willResetComputedStyle()
+{
+    if (RefPtr select = ownerSelectElement()) {
+        if (CheckedPtr selectRenderer = select->renderer())
+            selectRenderer->repaint();
+    }
 }
 
 HTMLSelectElement* HTMLOptionElement::ownerSelectElement() const

--- a/Source/WebCore/html/HTMLOptionElement.h
+++ b/Source/WebCore/html/HTMLOptionElement.h
@@ -102,6 +102,8 @@ private:
 
     void childrenChanged(const ChildChange&) final;
 
+    void willResetComputedStyle() final;
+
     String collectOptionInnerText() const;
     String collectOptionInnerTextCollapsingWhitespace() const;
 


### PR DESCRIPTION
#### 7f4974d34f8fa9965b7ec8a3f760285a0c40270c
<pre>
REGRESSION (310623@main): Style changes to &lt;option&gt; (or children) do not repaint &lt;select&gt;
<a href="https://bugs.webkit.org/show_bug.cgi?id=314947">https://bugs.webkit.org/show_bug.cgi?id=314947</a>
<a href="https://rdar.apple.com/177200878">rdar://177200878</a>

Reviewed by Abrar Rahman Protyasha.

310623@main removed HTMLOptionElement::willResetComputedStyle() on the
assumption that the existing test coverage was sufficient, but the
existing reference test would always repaint before comparison.

So we restore the hook, with two improvements:

- Tighten the dispatch invariant in Element::resetComputedStyle() to
  only fire willResetComputedStyle for elements without a renderer.
  This is relevant in the new world of appearance: base.

- Add a repaint regression test.

The FIXME about firing on no-op style resets moves to the dispatch site,
where the over-eager behavior actually lives.

Canonical link: <a href="https://commits.webkit.org/313466@main">https://commits.webkit.org/313466@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65acb472edd8e454abc31441567f7913b7521971

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163109 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36588 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29809 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172048 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119556 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e8125e01-09c3-4826-8701-f405d34ec9ab) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164978 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36728 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36590 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126636 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89240 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1f47a3e0-1d02-4bfd-bde4-f21c45600d1d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166068 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28843 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146634 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107207 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/715edaf5-e474-4577-bcbf-2069949ec7f1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27890 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26577 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19751 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137782 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24358 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174551 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/26601 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26012 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134946 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36263 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30683 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134938 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/36991 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146153 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98884 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24833 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30190 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22997 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35759 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108120 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35258 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1018 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35505 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35402 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->