### PR TITLE
IntersectionObserverEntry.boundingClientRect ignores GetBoundingClientRectZoomedEnabled

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/bounding-box-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/bounding-box-expected.txt
@@ -3,5 +3,5 @@ PASS Test that the target's border bounding box is used to calculate intersectio
 PASS First rAF.
 PASS target.style.transform = 'translateY(195px)'
 PASS target.style.transform = 'translateY(300px)'
-FAIL target.style.zoom = 2 assert_approx_equals: entries[3].boundingClientRect.left expected 36 +/- 0 but got 18
+PASS target.style.zoom = 2
 

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/zoom-scaled-target-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/zoom-scaled-target-expected.txt
@@ -1,4 +1,4 @@
 
 PASS IntersectionObserver observing elements with css zoom
-FAIL Validate intersection rect assert_approx_equals: entries[0].boundingClientRect.left expected 8 +/- 0 but got 2
+PASS Validate intersection rect
 

--- a/Source/WebCore/page/IntersectionObserver.cpp
+++ b/Source/WebCore/page/IntersectionObserver.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2016-2022 Apple Inc. All rights reserved.
+ * Copyright (C) 2016-2026 Apple Inc. All rights reserved.
  * Copyright (C) 2020 Google Inc. All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -694,12 +694,13 @@ auto IntersectionObserver::updateObservations(const Frame& hostFrame) -> NeedNot
                 ASSERT(intersectionState.absoluteRootBounds);
 
                 RefPtr targetFrameView = target.document().view();
-                targetBoundingClientRect = targetFrameView->absoluteToClientRect(*intersectionState.absoluteTargetRect, target.renderer()->style().usedZoom());
+                auto targetZoomForClient = target.document().zoomForClient(target.renderer()->style());
+                targetBoundingClientRect = targetFrameView->absoluteToClientRect(*intersectionState.absoluteTargetRect, targetZoomForClient);
                 clientRootBounds = hostFrameView->absoluteToLayoutViewportRect(*intersectionState.absoluteRootBounds);
 
                 if (intersectionState.isIntersecting) {
                     ASSERT(intersectionState.absoluteIntersectionRect);
-                    clientIntersectionRect = targetFrameView->absoluteToClientRect(*intersectionState.absoluteIntersectionRect, target.renderer()->style().usedZoom());
+                    clientIntersectionRect = targetFrameView->absoluteToClientRect(*intersectionState.absoluteIntersectionRect, targetZoomForClient);
                 }
             }
 


### PR DESCRIPTION
#### f49916ba6129c4a8ee018f6e8dde4fd153e9ec8f
<pre>
IntersectionObserverEntry.boundingClientRect ignores GetBoundingClientRectZoomedEnabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=314956">https://bugs.webkit.org/show_bug.cgi?id=314956</a>
<a href="https://rdar.apple.com/177250323">rdar://177250323</a>

Reviewed by Simon Fraser.

Element::getBoundingClientRect() routes through Document::zoomForClient(),
which honors the GetBoundingClientRectZoomedEnabled setting and skips the
absolute-to-client zoom division when enabled.

IntersectionObserver::updateObservations bypassed that helper and passed
style().usedZoom() directly to absoluteToClientRect, so its reported
rects were always divided by usedZoom and disagreed with
getBoundingClientRect() under the default pref. Route through
Document::zoomForClient() so the entry rects match.

* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/bounding-box-expected.txt: Progression
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/zoom-scaled-target-expected.txt: Ditto
* Source/WebCore/page/IntersectionObserver.cpp:
(WebCore::IntersectionObserver::updateObservations):

Canonical link: <a href="https://commits.webkit.org/313512@main">https://commits.webkit.org/313512@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0914b9f0fc15f8292997b39aa756d1c3b4369b87

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162914 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36393 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29568 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171852 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119360 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/817f2741-9298-4f1b-a041-963c87c1fd09) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164783 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36941 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36395 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126463 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89081 "17 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/14a38c3d-5681-458a-a570-d1d813b7ec5a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165873 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28928 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146404 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107040 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bae37aa3-c93b-4e7c-91f6-032ef675865b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27974 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26393 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19552 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137867 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24133 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174356 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/23015 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25779 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134773 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36064 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30496 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134768 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36420 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37028 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145929 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98493 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30223 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22766 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35560 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/104726 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35059 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/788 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35306 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35207 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->