### PR TITLE
[JSC] Restore JavaScriptCore.framework's top-level Helpers symlink in sandboxed builds

### DIFF
--- a/Source/JavaScriptCore/Configurations/Base.xcconfig
+++ b/Source/JavaScriptCore/Configurations/Base.xcconfig
@@ -25,7 +25,7 @@
 
 ALWAYS_SEARCH_USER_PATHS = NO;
 ENABLE_USER_SCRIPT_SANDBOXING = YES;
-EXCLUDED_USER_SCRIPT_SANDBOXING_PHASE_NAMES = $(inherited) "Generate Unified Sources" "Generate Derived Sources" "Generate <wtf/Platform.h> args" "Check For Inappropriate Files In Framework" "Check For Inappropriate Macros in External Headers" "Check For Weak VTables and Externals" "Check For Inappropriate Objective-C Class Names" "Check .xcfilelists" "Copy jsc into JavaScriptCore.framework" "Audit SPI use";
+EXCLUDED_USER_SCRIPT_SANDBOXING_PHASE_NAMES = $(inherited) "Generate Unified Sources" "Generate Derived Sources" "Generate <wtf/Platform.h> args" "Check For Inappropriate Files In Framework" "Check For Inappropriate Macros in External Headers" "Check For Weak VTables and Externals" "Check For Inappropriate Objective-C Class Names" "Check .xcfilelists" "Copy jsc into JavaScriptCore.framework" "Audit SPI use" "Create Versions/Current/Helpers symlink";
 
 CLANG_CXX_LANGUAGE_STANDARD = c++2b;
 CLANG_CXX_LIBRARY = libc++;


### PR DESCRIPTION
#### 85258ac002a9cce76f19b45b92c00da559c3e49d
<pre>
[JSC] Restore JavaScriptCore.framework&apos;s top-level Helpers symlink in sandboxed builds
<a href="https://bugs.webkit.org/show_bug.cgi?id=314957">https://bugs.webkit.org/show_bug.cgi?id=314957</a>
<a href="https://rdar.apple.com/177250677">rdar://177250677</a>

Reviewed by Yusuke Suzuki.

The &quot;Create Versions/Current/Helpers symlink&quot; build phase on the All
aggregate target silently fails under user-script sandboxing, leaving
JavaScriptCore.framework without a top-level Helpers symlink pointing
at Versions/Current/Helpers.

The phase declares its output as $(BUILT_PRODUCTS_DIR)/$(WRAPPER_NAME)/Helpers,
but aggregate targets have no WRAPPER_NAME, so the sandbox only grants
write access to $(BUILT_PRODUCTS_DIR)/Helpers. The script itself writes
inside the framework via $(JAVASCRIPTCORE_HELPERS_DIR)/../../.., which
the sandbox blocks. The phase always ends with a 0 exit status, so the
failure goes unreported and the build succeeds with a missing symlink.

This regressed run-jsc-stress-tests after 312482@main, whose new
jscOutsideFramework heuristic checks File.file?(framework + &quot;Helpers&quot; +
&quot;jsc&quot;) to detect CMake mac builds. Without the top-level Helpers
symlink, that check incorrectly identifies Xcode builds as CMake
builds and stages jsc outside the framework. I don&apos;t believe this
changes production builds since those still seem to have a
Versions/Current/Helpers directory containing `jsc`

Add the phase to EXCLUDED_USER_SCRIPT_SANDBOXING_PHASE_NAMES, matching
the treatment of its sibling phases on the same aggregate target
(&quot;Copy jsc into JavaScriptCore.framework&quot;, &quot;Check For Inappropriate
Files In Framework&quot;, &quot;Audit SPI use&quot;).

* Source/JavaScriptCore/Configurations/Base.xcconfig:

Canonical link: <a href="https://commits.webkit.org/313367@main">https://commits.webkit.org/313367@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/edf7e5cf3c3c4c2bfb1732e283296eafa050da0b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162915 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36394 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29563 "Hash edf7e5cf for PR 65046 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171853 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119361 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4333dd51-7ba8-42be-80cd-8e9a1c762dcb) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36498 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36396 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/126464 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/89064 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/03a8904a-16ea-4cdd-9179-425125698e1d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165874 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/28814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/29563 "Hash edf7e5cf for PR 65046 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107041 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/65f272ba-6fc1-49d6-81a3-ff3cf974c3f6) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26394 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19553 "Built successfully") | | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/29563 "Hash edf7e5cf for PR 65046 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174357 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23799 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/23034 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/29563 "Hash edf7e5cf for PR 65046 does not build (failure)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/134774 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36065 "Hash edf7e5cf for PR 65046 does not build (failure)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30497 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134769 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/36244 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/29563 "Hash edf7e5cf for PR 65046 does not build (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98494 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24771 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/29489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/29563 "Hash edf7e5cf for PR 65046 does not build (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195316 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35561 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/104745 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50697 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35060 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35307 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35208 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->