### PR TITLE
[Wasm] JS Wrappers for Wasm Tables Should be Lazily Created

### DIFF
--- a/JSTests/wasm/stress/lazy-table-copy-preserves-laziness.js
+++ b/JSTests/wasm/stress/lazy-table-copy-preserves-laziness.js
@@ -1,0 +1,67 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+// table.copy moves entries between slots without forcing the JS-side
+// representation of a slot to be observed. After copying, the destination
+// slots behave identically to the source slots: call_indirect works on them,
+// table.get returns the same function object as the source, and ref.func to
+// the same function also matches.
+
+let wat = `
+(module
+    (type $sig (func (param i32) (result i32)))
+    (table $t (export "t") 16 16 funcref)
+    (elem (i32.const 0) $a $b $c $d)
+
+    (func $a (param i32) (result i32) (i32.add (local.get 0) (i32.const 1)))
+    (func $b (param i32) (result i32) (i32.add (local.get 0) (i32.const 2)))
+    (func $c (param i32) (result i32) (i32.add (local.get 0) (i32.const 3)))
+    (func $d (param i32) (result i32) (i32.add (local.get 0) (i32.const 4)))
+
+    (func (export "doCopy")
+        (table.copy (i32.const 8) (i32.const 0) (i32.const 4)))
+
+    (func (export "callIndirect") (param i32 i32) (result i32)
+        (call_indirect (type $sig) (local.get 1) (local.get 0)))
+
+    (func (export "refSrc") (result funcref) (ref.func $a))
+)
+`
+
+async function test() {
+    const { t, doCopy, callIndirect, refSrc } = (await instantiate(wat, {}, {})).exports
+
+    // Copy slots 0..3 to 8..11. Nothing has been observed from JS yet.
+    doCopy()
+
+    // call_indirect works on the copied slots.
+    assert.eq(callIndirect(8, 100), 101)  // $a
+    assert.eq(callIndirect(9, 100), 102)  // $b
+    assert.eq(callIndirect(10, 100), 103) // $c
+    assert.eq(callIndirect(11, 100), 104) // $d
+
+    // Observing the destination first still produces a callable function.
+    const aFromDst = t.get(8)
+    assert.eq(typeof aFromDst, "function")
+    assert.eq(aFromDst(50), 51)
+
+    // Source and destination of the copy refer to the same function and
+    // therefore return the same function object.
+    const aFromSrc = t.get(0)
+    assert.eq(aFromSrc === aFromDst, true)
+    assert.eq(refSrc() === aFromDst, true)
+
+    // A different function in the copied range gives a different object,
+    // and source/destination identity holds for it too.
+    const bFromDst = t.get(9)
+    assert.eq(bFromDst !== aFromDst, true)
+    assert.eq(t.get(1) === bFromDst, true)
+    assert.eq(bFromDst(50), 52)
+
+    fullGC()
+    assert.eq(t.get(8) === aFromDst, true)
+    assert.eq(callIndirect(11, 0), 4)
+    assert.eq(t.get(11)(0), 4)
+}
+
+await assert.asyncTest(test())

--- a/JSTests/wasm/stress/lazy-table-cross-instance.js
+++ b/JSTests/wasm/stress/lazy-table-cross-instance.js
@@ -1,0 +1,68 @@
+import { compile } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+// When module A imports module B's table and re-exports it, JS observing the
+// table through A must produce the same function objects as observing it
+// through B, and calling those functions must execute B's code. call_indirect
+// through the imported table must also work without ever observing the slot
+// from JS.
+
+let watB = `
+(module
+    (table $t (export "t") 2 2 funcref)
+    (elem (i32.const 0) $foo $bar)
+
+    (func $foo (export "foo") (param i32) (result i32)
+        (i32.add (local.get 0) (i32.const 1000)))
+
+    (func $bar (export "bar") (param i32) (result i32)
+        (i32.add (local.get 0) (i32.const 2000)))
+)
+`
+
+let watA = `
+(module
+    (type $sig (func (param i32) (result i32)))
+    (import "B" "t" (table $t 2 2 funcref))
+    (export "t" (table $t))
+
+    (func (export "callViaImportedTable") (param i32 i32) (result i32)
+        (call_indirect (type $sig) (local.get 1) (local.get 0)))
+)
+`
+
+async function test() {
+    const moduleB = await compile(watB)
+    const moduleA = await compile(watA)
+
+    const instB = new WebAssembly.Instance(moduleB)
+    const instA = new WebAssembly.Instance(moduleA, { B: { t: instB.exports.t } })
+
+    // call_indirect through the imported table on never-observed slots.
+    assert.eq(instA.exports.callViaImportedTable(0, 5), 1005)
+    assert.eq(instA.exports.callViaImportedTable(1, 5), 2005)
+
+    // Re-exported table aliases B's table.
+    assert.eq(instA.exports.t, instB.exports.t)
+
+    // Reading from A's exported table returns B's exported function objects,
+    // and calling them executes B's code.
+    const fooFromA = instA.exports.t.get(0)
+    assert.eq(fooFromA === instB.exports.foo, true)
+    assert.eq(fooFromA(7), 1007)
+
+    const barFromA = instA.exports.t.get(1)
+    assert.eq(barFromA === instB.exports.bar, true)
+    assert.eq(barFromA(7), 2007)
+
+    // call_indirect continues to work after JS has observed the slots.
+    assert.eq(instA.exports.callViaImportedTable(0, 9), 1009)
+
+    // Identity and behavior survive GC.
+    fullGC()
+    assert.eq(instA.exports.t.get(0) === instB.exports.foo, true)
+    assert.eq(instA.exports.t.get(0)(11), 1011)
+    assert.eq(instA.exports.callViaImportedTable(1, 11), 2011)
+}
+
+await assert.asyncTest(test())

--- a/JSTests/wasm/stress/lazy-table-identity-across-paths.js
+++ b/JSTests/wasm/stress/lazy-table-identity-across-paths.js
@@ -1,0 +1,42 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+// All three ways of getting a funcref for the same internal function should
+// produce the same function object:
+//   1. the exports object
+//   2. ref.func from wasm
+//   3. table.get from JS
+
+let wat = `
+(module
+    (table $t (export "t") 1 1 funcref)
+    (elem (i32.const 0) $foo)
+
+    (func $foo (export "foo") (param i32) (result i32)
+        (i32.add (local.get 0) (i32.const 100)))
+
+    (func (export "refToFoo") (result funcref)
+        (ref.func $foo))
+)
+`
+
+async function test() {
+    const { t, foo, refToFoo } = (await instantiate(wat, {}, {})).exports
+
+    assert.eq(foo(1), 101)
+
+    const fromRefFunc = refToFoo()
+    assert.eq(fromRefFunc === foo, true)
+
+    const fromTable = t.get(0)
+    assert.eq(fromTable === foo, true)
+    assert.eq(fromTable === fromRefFunc, true)
+
+    // Identity holds across GC.
+    fullGC()
+    assert.eq(t.get(0) === foo, true)
+    assert.eq(refToFoo() === foo, true)
+    assert.eq(t.get(0)(5), 105)
+}
+
+await assert.asyncTest(test())

--- a/JSTests/wasm/stress/lazy-table-wrappers.js
+++ b/JSTests/wasm/stress/lazy-table-wrappers.js
@@ -1,0 +1,63 @@
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+// Funcref tables initialized by an element segment are usable from both wasm
+// (call_indirect) and JS (table.get), and the wrappers returned by table.get
+// keep stable identity across repeated reads and across GC.
+
+let wat = `
+(module
+    (type $sig (func (param i32) (result i32)))
+    (table (export "t") 4 4 funcref)
+    (elem (i32.const 0) $a $b $c $d)
+
+    (func $a (param i32) (result i32) (i32.add (local.get 0) (i32.const 10)))
+    (func $b (param i32) (result i32) (i32.add (local.get 0) (i32.const 20)))
+    (func $c (param i32) (result i32) (i32.add (local.get 0) (i32.const 30)))
+    (func $d (param i32) (result i32) (i32.add (local.get 0) (i32.const 40)))
+
+    (func (export "callIndirect") (param i32 i32) (result i32)
+        (call_indirect (type $sig) (local.get 1) (local.get 0))
+    )
+)
+`
+
+async function test() {
+    const { t, callIndirect } = (await instantiate(wat, {}, {})).exports
+
+    // call_indirect on slots that have never been observed from JS.
+    assert.eq(callIndirect(0, 5), 15)
+    assert.eq(callIndirect(1, 5), 25)
+    assert.eq(callIndirect(2, 5), 35)
+    assert.eq(callIndirect(3, 5), 45)
+
+    // First JS observation: the slot becomes a callable function.
+    const f0a = t.get(0)
+    assert.eq(typeof f0a, "function")
+    assert.eq(f0a(7), 17)
+
+    // Repeated reads of the same slot return the same function object.
+    const f0b = t.get(0)
+    assert.eq(f0a === f0b, true)
+
+    // Different slots are distinct functions.
+    const f1 = t.get(1)
+    assert.eq(f1 !== f0a, true)
+    assert.eq(f1(7), 27)
+
+    // Identity survives GC.
+    fullGC()
+    assert.eq(t.get(0) === f0a, true)
+    assert.eq(t.get(1) === f1, true)
+
+    // call_indirect still works after JS has observed (and after GC).
+    assert.eq(callIndirect(0, 100), 110)
+    assert.eq(callIndirect(2, 100), 130)
+
+    // Storing a funcref via JS makes table.get return the very object set.
+    t.set(2, f0a)
+    assert.eq(t.get(2) === f0a, true)
+    assert.eq(callIndirect(2, 5), 15)
+}
+
+await assert.asyncTest(test())

--- a/Source/JavaScriptCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
+++ b/Source/JavaScriptCore/SaferCPPExpectations/UncountedLocalVarsCheckerExpectations
@@ -120,6 +120,7 @@ wasm/WasmOperations.cpp
 wasm/WasmOperationsInlines.h
 wasm/WasmSectionParser.cpp
 wasm/WasmStreamingCompiler.cpp
+wasm/WasmTable.cpp
 wasm/WasmTypeDefinition.cpp
 wasm/WasmWorklist.cpp
 wasm/js/JSWebAssembly.cpp

--- a/Source/JavaScriptCore/wasm/WasmFormat.h
+++ b/Source/JavaScriptCore/wasm/WasmFormat.h
@@ -959,6 +959,7 @@ struct alignas(8) WasmCallableFunction {
 struct WasmToWasmImportableFunction : public WasmCallableFunction {
     WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(WasmToWasmImportableFunction);
     static constexpr ptrdiff_t offsetOfRTT() { return OBJECT_OFFSETOF(WasmToWasmImportableFunction, rtt); }
+
     const RTT* rtt { nullptr };
 };
 using FunctionIndexSpace = Vector<WasmToWasmImportableFunction>;
@@ -973,8 +974,9 @@ struct WasmOrJSImportableFunction : public WasmToWasmImportableFunction {
 
 struct WasmOrJSImportableFunctionCallLinkInfo final : public WasmOrJSImportableFunction {
     WTF_DEPRECATED_MAKE_STRUCT_FAST_ALLOCATED(WasmOrJSImportableFunctionCallLinkInfo);
-    std::unique_ptr<DataOnlyCallLinkInfo> callLinkInfo { };
     static constexpr ptrdiff_t offsetOfCallLinkInfo() { return OBJECT_OFFSETOF(WasmOrJSImportableFunctionCallLinkInfo, callLinkInfo); }
+
+    std::unique_ptr<DataOnlyCallLinkInfo> callLinkInfo { };
 };
 
 #if ASSERT_ENABLED

--- a/Source/JavaScriptCore/wasm/WasmTable.cpp
+++ b/Source/JavaScriptCore/wasm/WasmTable.cpp
@@ -176,7 +176,7 @@ std::optional<uint32_t> Table::grow(uint32_t delta, JSValue defaultValue)
     return newLength;
 }
 
-void Table::copy(const Table* srcTable, uint32_t dstIndex, uint32_t srcIndex)
+void Table::copy(Table* srcTable, uint32_t dstIndex, uint32_t srcIndex)
 {
     ASSERT(isExternrefTable());
     ASSERT(srcTable->isExternrefTable());
@@ -203,7 +203,7 @@ void Table::set(uint32_t index, JSValue value)
     });
 }
 
-JSValue Table::get(uint32_t index) const
+JSValue Table::get(uint32_t index)
 {
     ASSERT(index < length());
     ASSERT(m_owner);
@@ -226,8 +226,14 @@ void Table::visitAggregateImpl(Visitor& visitor)
     }
     case TableElementType::Funcref: {
         auto* table = static_cast<FuncRefTable*>(this);
-        for (unsigned i = 0; i < m_length; ++i)
-            visitor.append(table->m_importableFunctions.get()[i].m_value);
+        for (unsigned i = 0; i < m_length; ++i) {
+            auto& slot = table->m_importableFunctions.get()[i];
+            if (slot.isEmpty())
+                continue;
+            visitor.append(slot.m_value);
+            visitor.append(slot.m_function.targetInstance);
+            visitor.append(slot.m_function.importFunction);
+        }
         break;
     }
     }
@@ -277,7 +283,7 @@ FuncRefTable::FuncRefTable(VM& vm, uint32_t initial, std::optional<uint32_t> max
 
     for (uint32_t i = 0; i < allocatedLength(m_length); ++i) {
         new (&m_importableFunctions.get()[i]) Function();
-        ASSERT(!m_importableFunctions.get()[i].m_function.rtt); // We rely on this in compiled code.
+        ASSERT(m_importableFunctions.get()[i].isEmpty()); // We rely on this in compiled code.
         ASSERT(m_importableFunctions.get()[i].m_value.isNull());
     }
 }
@@ -305,20 +311,59 @@ void FuncRefTable::setFunction(uint32_t index, WebAssemblyFunctionBase* function
     slot.m_value.set(function->instance()->vm(), m_owner, function);
 }
 
+void FuncRefTable::setLazy(uint32_t index, JSWebAssemblyInstance* targetInstance, FunctionSpaceIndex functionIndex)
+{
+    ASSERT(index < length());
+    auto* calleeGroup = targetInstance->calleeGroup();
+    auto wasmCallee = calleeGroup->wasmCalleeFromFunctionIndexSpace(functionIndex);
+    ASSERT(wasmCallee);
+
+    auto& slot = m_importableFunctions.get()[index];
+    slot.m_function = WasmOrJSImportableFunction { };
+    slot.m_function.boxedCallee = wasmCallee.get();
+    slot.m_function.targetInstance.setWithoutWriteBarrier(targetInstance);
+    slot.m_function.entrypointLoadLocation = calleeGroup->entrypointLoadLocationFromFunctionIndexSpace(functionIndex);
+    slot.m_function.rtt = &targetInstance->module().rttFromFunctionIndexSpace(functionIndex);
+
+    slot.m_value.clear();
+    // The struct copy into slot.m_function does not propagate a write barrier for its
+    // embedded WriteBarriers (targetInstance, importFunction), so fire one on m_owner.
+    m_owner->vm().writeBarrier(m_owner);
+}
+
+JSValue FuncRefTable::get(uint32_t index)
+{
+    auto& slot = m_importableFunctions.get()[index];
+    if (JSValue cached = slot.m_value.get())
+        return cached;
+    if (slot.isEmpty())
+        return jsNull();
+
+    auto* wasmCallee = uncheckedDowncast<Wasm::Callee>(slot.m_function.boxedCallee.asNativeCallee());
+    FunctionSpaceIndex functionIndex = wasmCallee->index();
+    JSWebAssemblyInstance* targetInstance = slot.m_function.targetInstance.get();
+    ASSERT(targetInstance);
+    JSValue wrapper = targetInstance->ensureFunctionWrapper(functionIndex);
+    ASSERT(wrapper.isCallable());
+    slot.m_value.set(m_owner->vm(), m_owner, wrapper);
+    return wrapper;
+}
+
 const FuncRefTable::Function& FuncRefTable::function(uint32_t index) const
 {
     return m_importableFunctions.get()[index];
 }
 
-void FuncRefTable::copyFunction(const FuncRefTable* srcTable, uint32_t dstIndex, uint32_t srcIndex)
+void FuncRefTable::copyFunction(FuncRefTable* srcTable, uint32_t dstIndex, uint32_t srcIndex)
 {
     ASSERT(dstIndex < length());
-    if (srcTable->get(srcIndex).isNull()) {
+    const auto& srcSlot = srcTable->m_importableFunctions.get()[srcIndex];
+    if (srcSlot.isEmpty()) {
         clear(dstIndex);
         return;
     }
 
-    m_importableFunctions.get()[dstIndex] = srcTable->function(srcIndex);
+    m_importableFunctions.get()[dstIndex] = srcSlot;
     // Write barrier our owner for good measure.
     m_owner->vm().writeBarrier(m_owner);
 }
@@ -327,7 +372,7 @@ void FuncRefTable::clear(uint32_t index)
 {
     ASSERT(wasmType().isNullable());
     m_importableFunctions.get()[index] = FuncRefTable::Function { };
-    ASSERT(!m_importableFunctions.get()[index].m_function.rtt); // We rely on this in compiled code.
+    ASSERT(m_importableFunctions.get()[index].isEmpty()); // We rely on this in compiled code.
     ASSERT(m_importableFunctions.get()[index].m_value.isNull());
 }
 

--- a/Source/JavaScriptCore/wasm/WasmTable.h
+++ b/Source/JavaScriptCore/wasm/WasmTable.h
@@ -83,10 +83,10 @@ public:
 
     void clear(uint32_t);
     void set(uint32_t, JSValue);
-    JSValue get(uint32_t) const;
+    JSValue get(uint32_t);
 
     std::optional<uint32_t> grow(uint32_t delta, JSValue defaultValue);
-    void copy(const Table* srcTable, uint32_t dstIndex, uint32_t srcIndex);
+    void copy(Table* srcTable, uint32_t dstIndex, uint32_t srcIndex);
 
     DECLARE_VISIT_AGGREGATE;
 
@@ -142,13 +142,15 @@ public:
         WasmOrJSImportableFunction m_function;
         WriteBarrier<Unknown> m_value { NullWriteBarrierTag };
         void* m_padding { nullptr };
+        bool isEmpty() const { return !m_function.rtt; }
         static constexpr ptrdiff_t offsetOfFunction() { return OBJECT_OFFSETOF(Function, m_function); }
         static constexpr ptrdiff_t offsetOfValue() { return OBJECT_OFFSETOF(Function, m_value); }
     };
 
     void setFunction(uint32_t, WebAssemblyFunctionBase*);
+    void setLazy(uint32_t, JSWebAssemblyInstance* targetInstance, FunctionSpaceIndex);
     const Function& NODELETE function(uint32_t) const;
-    void copyFunction(const FuncRefTable* srcTable, uint32_t dstIndex, uint32_t srcIndex);
+    void copyFunction(FuncRefTable* srcTable, uint32_t dstIndex, uint32_t srcIndex);
 
     static constexpr ptrdiff_t offsetOfFunctions() { return OBJECT_OFFSETOF(FuncRefTable, m_importableFunctions); }
     static constexpr ptrdiff_t offsetOfTail() { return WTF::roundUpToMultipleOf<alignof(Function)>(sizeof(FuncRefTable)); }
@@ -168,7 +170,7 @@ public:
 
     void clear(uint32_t);
     void set(uint32_t, JSValue);
-    JSValue get(uint32_t index) const { return m_importableFunctions.get()[index].m_value.get(); }
+    JSValue get(uint32_t index);
 
     void registerInstance(JSWebAssemblyInstance&);
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp
@@ -575,6 +575,15 @@ void JSWebAssemblyInstance::initElementSegment(uint32_t tableIndex, const Elemen
             // for the import.
             // https://bugs.webkit.org/show_bug.cgi?id=165510
             auto functionIndex = Wasm::FunctionSpaceIndex(initialBitsOrIndex);
+            if (!isImportFunction(functionIndex)) {
+                // Install wasm-side metadata only; the JS wrapper is materialized
+                // on demand from table.get. Imports stay eager because their
+                // callees do not carry a recoverable FunctionSpaceIndex.
+                auto* funcRefTable = jsTable->table()->asFuncrefTable();
+                ASSERT(funcRefTable);
+                funcRefTable->setLazy(dstIndex, this, functionIndex);
+                continue;
+            }
             JSValue wrapper = ensureFunctionWrapper(functionIndex);
             ASSERT(wrapper.isCallable());
             jsTable->set(dstIndex, wrapper);


### PR DESCRIPTION
#### ca0c6bb186577b89265aad4fb02ff9042b38442a
<pre>
[Wasm] JS Wrappers for Wasm Tables Should be Lazily Created
<a href="https://bugs.webkit.org/show_bug.cgi?id=314958">https://bugs.webkit.org/show_bug.cgi?id=314958</a>
<a href="https://rdar.apple.com/177252875">rdar://177252875</a>

Reviewed by Yusuke Suzuki.

This is a follow-up to 313362@main, which made WebAssemblyFunction wrappers
and JSToWasmCallees lazy for ref.func / passive-element / host-import paths
but left active element segments eager. Active element segments install
entries through JSWebAssemblyInstance::initElementSegment, which called
ensureFunctionWrapper for every funcref entry and stored the resulting
WebAssemblyFunction (and its boxed JSToWasmCallee) into
FuncRefTable::Function::m_value at instantiation time. Modules with sizable
funcref tables paid that wrapper/callee allocation cost even when the
entries were only ever consumed by wasm-internal call_indirect.

This patch makes the table slot itself lazy. A funcref entry installed by an
element segment now carries only the raw WasmOrJSImportableFunction
metadata (boxedCallee, targetInstance, entrypointLoadLocation, RTT) in
FuncRefTable::Function::m_function; m_value is left null. The JS wrapper is
materialized on demand the first time JS observes the slot via
FuncRefTable::get (table.get / Table.prototype.get / ref.func going through
ensureFunctionWrapper). call_indirect is unaffected because it already
reads m_function via fixed offsets and never depended on m_value.

The materialization path uses the slot&apos;s existing targetInstance:

slot.m_function.targetInstance-&gt;ensureFunctionWrapper(
       slot.m_function.boxedCallee.asNativeCallee()-&gt;index())

For internal functions targetInstance is the table&apos;s owning instance; for
wasm-to-wasm imports it is the source instance, so the returned wrapper
matches the source-instance wrapper that the eager path would have produced.
JS-function imports stay eager because their boxedCallee is the
WasmToJSCallee singleton, whose index() returns a sentinel rather than a
real FunctionSpaceIndex. table.set / table.fill / table.grow with an
existing funcref keep populating m_value as before — the wrapper is already
in hand, and caching it preserves identity for repeated table.get.

Concretely:

* Source/JavaScriptCore/wasm/js/JSWebAssemblyInstance.cpp:
(JSC::JSWebAssemblyInstance::initElementSegment):
on FromRefFunc entries, internal functions delegate to
FuncRefTable::setLazy(dstIndex, this, functionIndex); imports continue
through ensureFunctionWrapper and jsTable-&gt;set as before. Wasm validation
guarantees the destination table is a funcref table when the entry is
FromRefFunc.

* Source/JavaScriptCore/wasm/WasmTable.h:
(JSC::Wasm::FuncRefTable::Function::isEmpty):
new predicate that reads !m_function.rtt; replaces three open-coded checks
in the .cpp.

* Source/JavaScriptCore/wasm/WasmTable.cpp:
(JSC::Wasm::Table::visitAggregateImpl):
appends each funcref slot&apos;s m_value, and for populated slots also the
slot&apos;s m_function.targetInstance and m_function.importFunction directly,
since the transitive reachability chain through m_value no longer exists
for lazy slots.

(JSC::Wasm::FuncRefTable::setLazy):
takes the target JSWebAssemblyInstance and a FunctionSpaceIndex, looks up
the wasm callee, entrypoint, and RTT from that instance&apos;s calleeGroup and
module, installs them into m_function, clears m_value, and fires a write
barrier on the owning JSWebAssemblyTable so the embedded WriteBarriers
are tracked.

(JSC::Wasm::FuncRefTable::get):
now non-const. It returns a cached m_value if set; otherwise, for a
populated slot, it materializes the wrapper via the formula above and
caches it into m_value for subsequent reads. An empty slot (isEmpty())
returns jsNull.

(JSC::Wasm::FuncRefTable::copyFunction):
becomes non-const-srcTable and switches to isEmpty() instead of calling
get(), so table.copy copies the lazy state verbatim without triggering
materialization.

Tests: JSTests/wasm/stress/lazy-table-copy-preserves-laziness.js
       JSTests/wasm/stress/lazy-table-cross-instance.js
       JSTests/wasm/stress/lazy-table-identity-across-paths.js
       JSTests/wasm/stress/lazy-table-wrappers.js

Canonical link: <a href="https://commits.webkit.org/313378@main">https://commits.webkit.org/313378@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a94f24de8161659f53351bb0d43ef13685c434f7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162957 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36436 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29617 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171895 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119403 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/723a813f-0cd5-4b98-bcd2-8bdc010db146) 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/36885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36438 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126501 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89105 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/745e3584-62a9-40dc-9990-5af525324a51) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165916 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/36885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146451 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107077 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/85e5b624-58e6-4b58-9b5e-dc239a974c31) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/36885 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26433 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19595 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/155096 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137625 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24180 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174399 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23843 "Built successfully and passed tests") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/24731 "Found 1 new failure in wasm/WasmConstExprGenerator.cpp") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25827 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134810 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36107 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30536 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134805 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/36516 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145976 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98600 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24778 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/29766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22813 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195358 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35603 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/106421 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50808 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35102 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/835 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35349 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35250 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->