### PR TITLE
[JSC] Use OrderedHashMap for ImportEntries / ExportEntries to make errors deterministic

### DIFF
--- a/JSTests/modules/indirect-export-error.js
+++ b/JSTests/modules/indirect-export-error.js
@@ -14,4 +14,11 @@ Promise.all([
         .then($vm.abort, function (error) {
             shouldBe(String(error), `SyntaxError: Indirectly exported binding name 'default' cannot be resolved by star export entries.`);
         }).catch($vm.abort),
+    // exportEntries iterates in source order (OrderedHashMap), so the reported
+    // name is always the first unresolvable export — not whichever the hash
+    // table happens to place first.
+    import('./indirect-export-error/indirect-export-source-order.js')
+        .then($vm.abort, function (error) {
+            shouldBe(String(error), `SyntaxError: Indirectly exported binding name 'aaa' is not found.`);
+        }).catch($vm.abort),
 ]).catch($vm.abort);

--- a/JSTests/modules/indirect-export-error/indirect-export-source-order-2.js
+++ b/JSTests/modules/indirect-export-error/indirect-export-source-order-2.js
@@ -1,0 +1,1 @@
+// Intentionally empty: none of the names re-exported by indirect-export-source-order.js exist here.

--- a/JSTests/modules/indirect-export-error/indirect-export-source-order.js
+++ b/JSTests/modules/indirect-export-error/indirect-export-source-order.js
@@ -1,0 +1,1 @@
+export { aaa, bbb, ccc, ddd, eee, fff, ggg, hhh } from "./indirect-export-source-order-2.js";

--- a/Source/JavaScriptCore/runtime/AbstractModuleRecord.h
+++ b/Source/JavaScriptCore/runtime/AbstractModuleRecord.h
@@ -31,6 +31,7 @@
 #include <JavaScriptCore/ModuleMap.h>
 #include <JavaScriptCore/ScriptFetchParameters.h>
 #include <JavaScriptCore/ScriptFetcher.h>
+#include <wtf/OrderedHashMap.h>
 #include <wtf/OrderedHashSet.h>
 #include <wtf/RefPtr.h>
 
@@ -105,9 +106,9 @@ public:
         Identifier localName;
     };
 
-    typedef WTF::OrderedHashSet<RefPtr<UniquedStringImpl>, IdentifierRepHash> OrderedIdentifierSet;
-    typedef UncheckedKeyHashMap<RefPtr<UniquedStringImpl>, ImportEntry, IdentifierRepHash, HashTraits<RefPtr<UniquedStringImpl>>> ImportEntries;
-    typedef UncheckedKeyHashMap<RefPtr<UniquedStringImpl>, ExportEntry, IdentifierRepHash, HashTraits<RefPtr<UniquedStringImpl>>> ExportEntries;
+    using OrderedIdentifierSet = WTF::OrderedHashSet<RefPtr<UniquedStringImpl>, IdentifierRepHash>;
+    using ImportEntries = WTF::OrderedHashMap<RefPtr<UniquedStringImpl>, ImportEntry, IdentifierRepHash, HashTraits<RefPtr<UniquedStringImpl>>>;
+    using ExportEntries = WTF::OrderedHashMap<RefPtr<UniquedStringImpl>, ExportEntry, IdentifierRepHash, HashTraits<RefPtr<UniquedStringImpl>>>;
 
     struct ModuleRequest {
         Identifier m_specifier;
@@ -131,8 +132,8 @@ public:
     void addImportEntry(const ImportEntry&);
     void addExportEntry(const ExportEntry&);
 
-    std::optional<ImportEntry> NODELETE tryGetImportEntry(UniquedStringImpl* localName);
-    std::optional<ExportEntry> NODELETE tryGetExportEntry(UniquedStringImpl* exportName);
+    std::optional<ImportEntry> tryGetImportEntry(UniquedStringImpl* localName);
+    std::optional<ExportEntry> tryGetExportEntry(UniquedStringImpl* exportName);
 
     class AsyncEvaluationOrder {
     public:
@@ -246,19 +247,6 @@ private:
 
     // The loader resolves the given module name to the module key. The module key is the unique value to represent this module.
     Identifier m_moduleKey;
-
-    // Currently, we don't keep the occurrence order of the import / export entries.
-    // So, we does not guarantee the order of the errors.
-    // e.g. The import declaration that occurs later than another import declaration may
-    //      throw the error even if the former import declaration also has the invalid content.
-    //
-    //      import ... // (1) this has some invalid content.
-    //      import ... // (2) this also has some invalid content.
-    //
-    //      In the above case, (2) may throw the error earlier than (1)
-    //
-    // But, in all cases, we will throw the syntax error. So except for the content of the syntax error,
-    // there are no differences.
 
     // Map localName -> ImportEntry.
     ImportEntries m_importEntries;


### PR DESCRIPTION
#### 4d67159942bc845b4ae5bc20cdb2e8eff225df4f
<pre>
[JSC] Use OrderedHashMap for ImportEntries / ExportEntries to make errors deterministic
<a href="https://bugs.webkit.org/show_bug.cgi?id=314961">https://bugs.webkit.org/show_bug.cgi?id=314961</a>
<a href="https://rdar.apple.com/177255964">rdar://177255964</a>

Reviewed by Sosuke Suzuki.

Previously our consolidated errors are randomly picked based on
hash value&apos;s ordering. But now we use OrderedHashMap for
ImportEntries / ExportEntries so we can report the first SyntaxError
based on insertion order.

Tests: JSTests/modules/indirect-export-error/indirect-export-source-order-2.js
       JSTests/modules/indirect-export-error/indirect-export-source-order.js

* JSTests/modules/indirect-export-error.js:
* JSTests/modules/indirect-export-error/indirect-export-source-order-2.js: Added.
* JSTests/modules/indirect-export-error/indirect-export-source-order.js: Added.
* Source/JavaScriptCore/runtime/AbstractModuleRecord.h:

Canonical link: <a href="https://commits.webkit.org/313400@main">https://commits.webkit.org/313400@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05922082de78047e17f3d13c174084b549439178

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162938 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36417 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29592 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171876 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119384 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/49adea20-0c01-472a-9b69-0398f49a0f93) 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/36909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36419 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126485 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89089 "17 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9fd3bb4f-5cd2-4f7c-a767-88f1f56d0e64) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165897 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/36909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146428 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107061 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/93aab83c-2757-4111-aec3-1cb8bafe8b49) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/36909 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26417 "Found 2 new API test failures: TestWebKitAPI.WKWebExtensionContext.TopLevelThrowInModuleBackground, TestWebKitAPI.EnhancedSecurityPolicies.OpenerThenSelfNavigationWithSiteIsolation (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19576 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/155077 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137599 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24157 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174380 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23824 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/23687 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25804 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134793 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36088 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30520 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134788 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/36772 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145953 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98557 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24792 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/30016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22790 "Found 1 new test failure: scrollingcoordinator/mac/latching/horizontal-overflow-back-swipe.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195339 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35584 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/105379 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50747 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35083 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/812 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35330 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35231 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->