### PR TITLE
[JSC] Make `sizeof(PropertyTable)` 32byte from 40byte

### DIFF
--- a/Source/JavaScriptCore/runtime/PropertyTable.cpp
+++ b/Source/JavaScriptCore/runtime/PropertyTable.cpp
@@ -61,10 +61,10 @@ PropertyTable* PropertyTable::clone(VM& vm, unsigned initialCapacity, const Prop
 PropertyTable::PropertyTable(VM& vm, unsigned initialCapacity)
     : JSCell(vm, vm.propertyTableStructure.get())
     , m_indexSize(sizeForCapacity(initialCapacity))
-    , m_indexMask(m_indexSize - 1)
-    , m_indexVector()
     , m_keyCount(0)
+    , m_indexVector()
     , m_deletedCount(0)
+    , m_deletedListHead(EmptyEntryIndex)
 {
     ASSERT(isPowerOfTwo(m_indexSize));
     bool isCompact = tableCapacity() < UINT8_MAX;
@@ -75,10 +75,10 @@ PropertyTable::PropertyTable(VM& vm, unsigned initialCapacity)
 PropertyTable::PropertyTable(VM& vm, const PropertyTable& other)
     : JSCell(vm, vm.propertyTableStructure.get())
     , m_indexSize(other.m_indexSize)
-    , m_indexMask(other.m_indexMask)
-    , m_indexVector(allocateIndexVector(other.isCompact(), other.m_indexSize))
     , m_keyCount(other.m_keyCount)
+    , m_indexVector(allocateIndexVector(other.isCompact(), other.m_indexSize))
     , m_deletedCount(other.m_deletedCount)
+    , m_deletedListHead(other.m_deletedListHead)
 {
     ASSERT(isPowerOfTwo(m_indexSize));
     ASSERT(isCompact() == other.isCompact());
@@ -88,20 +88,15 @@ PropertyTable::PropertyTable(VM& vm, const PropertyTable& other)
         entry.key()->ref();
         return IterationStatus::Continue;
     });
-
-    // Copy the m_deletedOffsets vector.
-    Vector<PropertyOffset>* otherDeletedOffsets = other.m_deletedOffsets.get();
-    if (otherDeletedOffsets)
-        m_deletedOffsets = makeUnique<Vector<PropertyOffset>>(*otherDeletedOffsets);
 }
 
 PropertyTable::PropertyTable(VM& vm, unsigned initialCapacity, const PropertyTable& other)
     : JSCell(vm, vm.propertyTableStructure.get())
-    , m_indexSize(sizeForCapacity(initialCapacity))
-    , m_indexMask(m_indexSize - 1)
-    , m_indexVector()
+    , m_indexSize(sizeForCapacity(std::max(initialCapacity, other.m_keyCount + other.m_deletedCount)))
     , m_keyCount(0)
+    , m_indexVector()
     , m_deletedCount(0)
+    , m_deletedListHead(EmptyEntryIndex)
 {
     ASSERT(isPowerOfTwo(m_indexSize));
     ASSERT(initialCapacity >= other.m_keyCount);
@@ -109,20 +104,76 @@ PropertyTable::PropertyTable(VM& vm, unsigned initialCapacity, const PropertyTab
     m_indexVector = allocateZeroedIndexVector(isCompact, m_indexSize);
     ASSERT(this->isCompact() == isCompact);
 
+    if (isCompact == other.isCompact()) {
+        // compact -> compact transition allows us to just copy entries which preserves deleted entries linked-list.
+        // We only need to rebuild the index vector for the new size.
+        unsigned oldUsedCount = other.usedCount();
+        withIndexVector([&](auto* vector) {
+            auto* table = tableFromIndexVector(vector);
+            other.withIndexVector([&](const auto* oldVector) {
+                const auto* oldTable = tableFromIndexVector(oldVector, other.m_indexSize);
+                if (oldUsedCount)
+                    memcpy(table, oldTable, oldUsedCount * sizeof(*table));
+            });
+
+            unsigned indexMask = m_indexSize - 1;
+            for (unsigned i = 0; i < oldUsedCount; ++i) {
+                auto& entry = table[i];
+                if (isDeletedKey(entry.key()))
+                    continue;
+                unsigned hash = IdentifierRepHash::hash(entry.key());
+                unsigned probeCount = 0;
+                unsigned index = hash & indexMask;
+                while (vector[index] != EmptyEntryIndex) {
+                    ++probeCount;
+                    index = (index + probeCount) & indexMask;
+                }
+                vector[index] = i + 1;
+                entry.key()->ref();
+            }
+        });
+        m_keyCount = other.m_keyCount;
+        m_deletedCount = other.m_deletedCount;
+        m_deletedListHead = other.m_deletedListHead;
+        return;
+    }
+
+    // compact -> non-compact transition. Entry sizes differ, so we can't memcpy.
+    // Reinsert live entries via reinsert() (which compacts them) and rebuild the deleted list
+    // by walking it once with a tail pointer.
     withIndexVector([&](auto* vector) {
         auto* table = tableFromIndexVector(vector);
+
         other.forEachProperty([&](auto& entry) {
             ASSERT(canInsert(entry));
             reinsert(vector, table, entry);
             entry.key()->ref();
             return IterationStatus::Continue;
         });
-    });
 
-    // Copy the m_deletedOffsets vector.
-    Vector<PropertyOffset>* otherDeletedOffsets = other.m_deletedOffsets.get();
-    if (otherDeletedOffsets)
-        m_deletedOffsets = makeUnique<Vector<PropertyOffset>>(*otherDeletedOffsets);
+        other.withIndexVector([&](const auto* oldVector) {
+            const auto* oldTable = tableFromIndexVector(oldVector, other.m_indexSize);
+            unsigned newTail = EmptyEntryIndex;
+            unsigned head = other.m_deletedListHead;
+            while (head != EmptyEntryIndex) {
+                ASSERT(isDeletedKey(oldTable[head - 1].key()));
+                PropertyOffset offset = oldTable[head - 1].offset();
+                unsigned next = decodeNextDeletedIndex(oldTable[head - 1].key());
+
+                unsigned entryIndex = usedCount() + 1;
+                ASSERT(entryIndex - 1 < tableCapacity() + 1);
+                table[entryIndex - 1] = ValueType(encodeDeletedKey(EmptyEntryIndex), offset, /* attributes */ 0);
+                if (newTail == EmptyEntryIndex)
+                    m_deletedListHead = entryIndex;
+                else
+                    table[newTail - 1].setKey(encodeDeletedKey(entryIndex));
+                newTail = entryIndex;
+                ++m_deletedCount;
+
+                head = next;
+            }
+        });
+    });
 }
 
 void PropertyTable::finishCreation(VM& vm)
@@ -213,16 +264,49 @@ bool PropertyTable::isFrozen() const
 PropertyOffset PropertyTable::renumberPropertyOffsets(JSObject* object, unsigned inlineCapacity, Vector<JSValue>& values)
 {
     ASSERT(values.size() == size());
-    unsigned i = 0;
     PropertyOffset offset = invalidOffset;
-    forEachPropertyMutable([&](auto& entry) {
-        values[i] = object->getDirect(entry.offset());
-        offset = offsetForPropertyNumber(i, inlineCapacity);
-        entry.setOffset(offset);
-        ++i;
-        return IterationStatus::Continue;
+
+    withIndexVector([&](auto* vector) {
+        auto* table = tableFromIndexVector(vector);
+        unsigned oldUsedCount = usedCount();
+
+        // Rebuild the index vector from scratch as we compact, so we zero it out first.
+        if (m_indexSize)
+            memset(vector, 0, m_indexSize * sizeof(*vector));
+
+        unsigned writeIndex = 0;
+        unsigned indexMask = m_indexSize - 1;
+        for (unsigned readIndex = 0; readIndex < oldUsedCount; ++readIndex) {
+            auto& entry = table[readIndex];
+            if (isDeletedKey(entry.key()))
+                continue;
+
+            // Save the live property's value at its current (old) offset, then assign a new
+            // sequential offset.
+            values[writeIndex] = object->getDirect(entry.offset());
+            offset = offsetForPropertyNumber(writeIndex, inlineCapacity);
+            entry.setOffset(offset);
+
+            // Move the entry to writeIndex. (No-op when writeIndex == readIndex.)
+            if (writeIndex != readIndex)
+                table[writeIndex] = entry;
+
+            // Hash the entry into the freshly-zeroed index vector at its new position.
+            unsigned hash = IdentifierRepHash::hash(table[writeIndex].key());
+            unsigned probeCount = 0;
+            unsigned index = hash & indexMask;
+            while (vector[index] != EmptyEntryIndex) {
+                ++probeCount;
+                index = (index + probeCount) & indexMask;
+            }
+            vector[index] = writeIndex + 1;
+            ++writeIndex;
+        }
     });
-    clearDeletedOffsets();
+
+    // After compaction there are no tombstones and no reusable offsets.
+    m_deletedCount = 0;
+    m_deletedListHead = EmptyEntryIndex;
     return offset;
 }
 
@@ -233,7 +317,7 @@ inline void PropertyTable::forEachPropertyMutable(const Functor& functor)
         auto* cursor = tableFromIndexVector(vector);
         auto* end = tableEndFromIndexVector(vector);
         for (; cursor != end; ++cursor) {
-            if (cursor->key() == PROPERTY_MAP_DELETED_ENTRY_KEY)
+            if (isDeletedKey(cursor->key()))
                 continue;
             if (functor(*cursor) == IterationStatus::Done)
                 return;

--- a/Source/JavaScriptCore/runtime/PropertyTable.h
+++ b/Source/JavaScriptCore/runtime/PropertyTable.h
@@ -33,8 +33,6 @@
 #define DUMP_PROPERTYMAP_STATS 0
 #define DUMP_PROPERTYMAP_COLLISIONS 0
 
-#define PROPERTY_MAP_DELETED_ENTRY_KEY ((UniquedStringImpl*)1)
-
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
 namespace JSC {
@@ -145,12 +143,6 @@ public:
     // Number of slots in the property storage array in use, included deletedOffsets.
     unsigned propertyStorageSize() const;
 
-    // Used to maintain a list of unused entries in the property storage.
-    void clearDeletedOffsets();
-    bool hasDeletedOffset();
-    PropertyOffset takeDeletedOffset();
-    void addDeletedOffset(PropertyOffset);
-    
     PropertyOffset nextOffset(PropertyOffset inlineCapacity);
 
     // Copy this PropertyTable, ensuring the copy has at least the capacity provided.
@@ -175,11 +167,31 @@ private:
 
     void finishCreation(VM&);
 
+    // Used to maintain a list of unused entries in the property storage.
+    bool hasDeletedOffset();
+    PropertyOffset takeDeletedOffset();
+
     // Used to insert a value known not to be in the table, and where we know capacity to be available.
     template<typename Index, typename Entry>
     void reinsert(Index*, Entry*, const ValueType& entry);
 
     static bool canFitInCompact(const ValueType& entry) { return entry.offset() <= UINT8_MAX; }
+
+    // A tombstone's key encodes its next-deleted entry index as ((nextIndex << 1) | 1).
+    // A live key's low bit is always clear (UniquedStringImpl is pointer-aligned).
+    static bool isDeletedKey(KeyType key)
+    {
+        return std::bit_cast<uintptr_t>(key) & 1;
+    }
+    static KeyType encodeDeletedKey(unsigned nextIndex)
+    {
+        return std::bit_cast<KeyType>((static_cast<uintptr_t>(nextIndex) << 1) | 1);
+    }
+    static unsigned decodeNextDeletedIndex(KeyType key)
+    {
+        ASSERT(isDeletedKey(key));
+        return static_cast<unsigned>(std::bit_cast<uintptr_t>(key) >> 1);
+    }
 
     // Rehash the table. Used to grow, or to recover deleted slots.
     void rehash(VM&, unsigned newCapacity, bool canStayCompact);
@@ -284,22 +296,22 @@ private:
     static constexpr uintptr_t isCompactFlag = 0x1;
     static constexpr uintptr_t indexVectorMask = ~isCompactFlag;
 
-    unsigned m_indexSize;
-    unsigned m_indexMask;
-    uintptr_t m_indexVector;
-    unsigned m_keyCount;
-    unsigned m_deletedCount;
-    std::unique_ptr<Vector<PropertyOffset>> m_deletedOffsets;
+    unsigned m_indexSize { 0 };
+    unsigned m_keyCount { 0 };
+    uintptr_t m_indexVector { 0 };
+    unsigned m_deletedCount { 0 };
+    unsigned m_deletedListHead { EmptyEntryIndex };
 
     static constexpr unsigned MinimumTableSize = 16;
     static_assert(MinimumTableSize >= 16, "compact index is uint8_t and we should keep 16 byte aligned entries after this array");
 };
+static_assert(sizeof(PropertyTable) <= 32, "PropertyTable needs to be very small");
 
 template<typename Index, typename Entry>
 PropertyTable::FindResult PropertyTable::findImpl(const Index* indexVector, const Entry* table, const KeyType& key)
 {
     unsigned hash = IdentifierRepHash::hash(key);
-    unsigned indexMask = m_indexMask;
+    unsigned indexMask = m_indexSize - 1;
     unsigned probeCount = 0;
     unsigned index = hash & indexMask;
 
@@ -313,7 +325,6 @@ PropertyTable::FindResult PropertyTable::findImpl(const Index* indexVector, cons
             return FindResult { entryIndex, index, invalidOffset, 0 };
         const auto& entry = table[entryIndex - 1];
         if (key == entry.key()) {
-            ASSERT(!m_deletedOffsets || !m_deletedOffsets->contains(entry.offset()));
             return FindResult { entryIndex, index, entry.offset(), entry.attributes() };
         }
 
@@ -344,7 +355,7 @@ inline std::tuple<PropertyOffset, unsigned> PropertyTable::get(const KeyType& ke
 {
     ASSERT(key);
     ASSERT(key->isAtom() || key->isSymbol());
-    ASSERT(key != PROPERTY_MAP_DELETED_ENTRY_KEY);
+    ASSERT(!isDeletedKey(key));
 
     if (!m_keyCount)
         return std::tuple { invalidOffset, 0 };
@@ -355,8 +366,6 @@ inline std::tuple<PropertyOffset, unsigned> PropertyTable::get(const KeyType& ke
 
 [[nodiscard]] inline std::tuple<PropertyOffset, unsigned, bool> PropertyTable::add(VM& vm, const ValueType& entry)
 {
-    ASSERT(!m_deletedOffsets || !m_deletedOffsets->contains(entry.offset()));
-
     // Look for a value with a matching key already in the array.
     FindResult result = find(entry.key());
     if (result.offset != invalidOffset)
@@ -401,12 +410,14 @@ inline void PropertyTable::remove(VM& vm, KeyType key, unsigned entryIndex, unsi
     ++propertyTableStats->numRemoves;
 #endif
 
-    // Replace this one element with the deleted sentinel. Also clear out
-    // the entry so we can iterate all the entries as needed.
+    // Replace this index slot with the deleted sentinel and tombstone the entry, encoding
+    // the next-deleted entry index into the entry's key. The entry's offset is preserved
+    // so it can be reused by a future nextOffset() call.
     withIndexVector([&](auto* vector) {
         vector[index] = deletedEntryIndex();
-        tableFromIndexVector(vector)[entryIndex - 1].setKey(PROPERTY_MAP_DELETED_ENTRY_KEY);
+        tableFromIndexVector(vector)[entryIndex - 1].setKey(encodeDeletedKey(m_deletedListHead));
     });
+    m_deletedListHead = entryIndex;
     key->deref();
 
     ASSERT(m_keyCount >= 1);
@@ -450,30 +461,41 @@ inline bool PropertyTable::isEmpty() const
 
 inline unsigned PropertyTable::propertyStorageSize() const
 {
-    return size() + (m_deletedOffsets ? m_deletedOffsets->size() : 0);
-}
-
-inline void PropertyTable::clearDeletedOffsets()
-{
-    m_deletedOffsets = nullptr;
+    // Walk the deleted linked list to count reusable offsets. This is only used by debug
+    // consistency checks and is bounded by the rehash threshold (~25% of m_indexSize),
+    // and is O(1) in the steady state when no deletions are pending.
+    unsigned available = 0;
+    if (m_deletedListHead != EmptyEntryIndex) {
+        withIndexVector([&](const auto* vector) {
+            const auto* table = tableFromIndexVector(vector);
+            unsigned head = m_deletedListHead;
+            while (head != EmptyEntryIndex) {
+                const auto& entry = table[head - 1];
+                ASSERT(isDeletedKey(entry.key()));
+                head = decodeNextDeletedIndex(entry.key());
+                ++available;
+            }
+        });
+    }
+    return size() + available;
 }
 
 inline bool PropertyTable::hasDeletedOffset()
 {
-    return m_deletedOffsets && !m_deletedOffsets->isEmpty();
+    return m_deletedListHead != EmptyEntryIndex;
 }
 
 inline PropertyOffset PropertyTable::takeDeletedOffset()
 {
-    return m_deletedOffsets->takeLast();
-}
-
-inline void PropertyTable::addDeletedOffset(PropertyOffset offset)
-{
-    if (!m_deletedOffsets)
-        m_deletedOffsets = makeUnique<Vector<PropertyOffset>>();
-    ASSERT(!m_deletedOffsets->contains(offset));
-    m_deletedOffsets->append(offset);
+    ASSERT(m_deletedListHead != EmptyEntryIndex);
+    unsigned entryIndex = m_deletedListHead;
+    return withIndexVector([&](auto* vector) -> PropertyOffset {
+        auto& entry = tableFromIndexVector(vector)[entryIndex - 1];
+        ASSERT(isDeletedKey(entry.key()));
+        PropertyOffset offset = entry.offset();
+        m_deletedListHead = decodeNextDeletedIndex(entry.key());
+        return offset;
+    });
 }
 
 inline PropertyOffset PropertyTable::nextOffset(PropertyOffset inlineCapacity)
@@ -498,10 +520,7 @@ inline PropertyTable* PropertyTable::copy(VM& vm, unsigned newCapacity)
 #ifndef NDEBUG
 inline size_t PropertyTable::sizeInMemory()
 {
-    size_t result = sizeof(PropertyTable) + dataSize(isCompact());
-    if (m_deletedOffsets)
-        result += (m_deletedOffsets->capacity() * sizeof(PropertyOffset));
-    return result;
+    return sizeof(PropertyTable) + dataSize(isCompact());
 }
 #endif
 
@@ -517,7 +536,7 @@ inline void PropertyTable::reinsert(Index* indexVector, Entry* table, const Valu
     ASSERT(canInsert(entry));
 
     unsigned hash = IdentifierRepHash::hash(entry.key());
-    unsigned indexMask = m_indexMask;
+    unsigned indexMask = m_indexSize - 1;
     unsigned probeCount = 0;
     unsigned index = hash & indexMask;
 
@@ -550,12 +569,17 @@ inline void PropertyTable::rehash(VM& vm, unsigned newCapacity, bool canStayComp
     bool oldIsCompact = oldIndexVector & isCompactFlag;
     unsigned oldIndexSize = m_indexSize;
     unsigned oldUsedCount = usedCount();
+    unsigned oldDeletedListHead = m_deletedListHead;
     size_t oldDataSize = dataSize(oldIsCompact, oldIndexSize);
 
-    m_indexSize = sizeForCapacity(newCapacity);
-    m_indexMask = m_indexSize - 1;
+    // Conservative bound: usedCount() = keyCount + deletedCount may include orphan tombstones
+    // (created by renumberPropertyOffsets()) that we will drop, but counting only the active
+    // list entries would require an extra walk just to size the table. The over-estimate at most
+    // pushes us past the next power-of-two boundary in sizeForCapacity().
+    m_indexSize = sizeForCapacity(std::max(newCapacity, m_keyCount + m_deletedCount));
     m_keyCount = 0;
     m_deletedCount = 0;
+    m_deletedListHead = EmptyEntryIndex;
 
     // Once table gets non-compact, we do not change it back to compact again.
     // This is because some of property offset can be larger than UINT8_MAX already.
@@ -564,13 +588,38 @@ inline void PropertyTable::rehash(VM& vm, unsigned newCapacity, bool canStayComp
     withIndexVector([&](auto* vector) {
         auto* table = tableFromIndexVector(vector);
         withIndexVector(oldIndexVector, [&](const auto* oldVector) {
-            const auto* oldCursor = tableFromIndexVector(oldVector, oldIndexSize);
+            const auto* oldTable = tableFromIndexVector(oldVector, oldIndexSize);
+
+            // Reinsert live entries; this compacts them to entry indices 1..keyCount.
+            const auto* oldCursor = oldTable;
             const auto* oldEnd = oldCursor + oldUsedCount;
             for (; oldCursor != oldEnd; ++oldCursor) {
-                if (oldCursor->key() == PROPERTY_MAP_DELETED_ENTRY_KEY)
+                if (isDeletedKey(oldCursor->key()))
                     continue;
                 ASSERT(canInsert(*oldCursor));
                 reinsert(vector, table, *oldCursor);
+            }
+
+            // Walk the old linked list once and rebuild it forward in the new table using a tail
+            // pointer. This preserves LIFO order without staging offsets in a separate buffer.
+            unsigned newTail = EmptyEntryIndex;
+            unsigned head = oldDeletedListHead;
+            while (head != EmptyEntryIndex) {
+                ASSERT(isDeletedKey(oldTable[head - 1].key()));
+                PropertyOffset offset = oldTable[head - 1].offset();
+                unsigned next = decodeNextDeletedIndex(oldTable[head - 1].key());
+
+                unsigned entryIndex = usedCount() + 1;
+                ASSERT(entryIndex - 1 < tableCapacity() + 1);
+                table[entryIndex - 1] = ValueType(encodeDeletedKey(EmptyEntryIndex), offset, /* attributes */ 0);
+                if (newTail == EmptyEntryIndex)
+                    m_deletedListHead = entryIndex;
+                else
+                    table[newTail - 1].setKey(encodeDeletedKey(entryIndex));
+                newTail = entryIndex;
+                ++m_deletedCount;
+
+                head = next;
             }
         });
     });
@@ -588,7 +637,7 @@ inline unsigned PropertyTable::deletedEntryIndex() const { return tableCapacity(
 template<typename T>
 inline T* PropertyTable::skipDeletedEntries(T* valuePtr, T* endValuePtr)
 {
-    while (valuePtr < endValuePtr && valuePtr->key() == PROPERTY_MAP_DELETED_ENTRY_KEY)
+    while (valuePtr < endValuePtr && isDeletedKey(valuePtr->key()))
         ++valuePtr;
     return valuePtr;
 }
@@ -651,7 +700,7 @@ inline void PropertyTable::forEachProperty(const Functor& functor) const
         const auto* cursor = tableFromIndexVector(vector);
         const auto* end = tableEndFromIndexVector(vector);
         for (; cursor != end; ++cursor) {
-            if (cursor->key() == PROPERTY_MAP_DELETED_ENTRY_KEY)
+            if (isDeletedKey(cursor->key()))
                 continue;
             if (functor(*cursor) == IterationStatus::Done)
                 return;

--- a/Source/JavaScriptCore/runtime/Structure.cpp
+++ b/Source/JavaScriptCore/runtime/Structure.cpp
@@ -499,8 +499,8 @@ PropertyTable* Structure::materializePropertyTable(VM& vm, bool setPropertyTable
         case TransitionKind::PropertyDeletion: {
             auto [offset, attributes] = table->take(vm, structure->m_transitionPropertyName.get());
             ASSERT_UNUSED(offset, offset != invalidOffset);
+            ASSERT_UNUSED(offset, offset == structure->transitionOffset());
             UNUSED_VARIABLE(attributes);
-            table->addDeletedOffset(structure->transitionOffset());
             break;
         }
         case TransitionKind::PropertyAttributeChange: {

--- a/Source/JavaScriptCore/runtime/StructureInlines.h
+++ b/Source/JavaScriptCore/runtime/StructureInlines.h
@@ -315,8 +315,6 @@ inline PropertyOffset Structure::remove(VM& vm, PropertyName propertyName, const
 
     setIsQuickPropertyAccessAllowedForEnumeration(false);
 
-    table->addDeletedOffset(offset);
-
     PropertyOffset newMaxOffset = maxOffset();
 
     func(locker, offset, newMaxOffset);


### PR DESCRIPTION
#### 5dbbd8251e340ad692b1decf1c502cc6062d4d18
<pre>
[JSC] Make `sizeof(PropertyTable)` 32byte from 40byte
<a href="https://bugs.webkit.org/show_bug.cgi?id=314965">https://bugs.webkit.org/show_bug.cgi?id=314965</a>
<a href="https://rdar.apple.com/177259137">rdar://177259137</a>

Reviewed by NOBODY (OOPS!).

WIP: still exploring. There is an issue which needs to be resolved.

if we construct linked-list in the deleted offsets marked with tombstone,
we do not need to have an additional Vector recording deleted offsets.
Pointer has 48bits and one bit is for tombstone marking. Then it can keep
large enough information for deleted offsets. This patch implements this idea,
then we do not need to have a vector. Furthremore, we can remove m_indexMask
too since it is always `m_indexSize - 1`, thus we can reduce sizeof(PropertyTable)
from 40 to 32, which makes one-level smaller in the size-class.

* Source/JavaScriptCore/runtime/PropertyTable.cpp:
(JSC::PropertyTable::PropertyTable):
(JSC::PropertyTable::renumberPropertyOffsets):
(JSC::PropertyTable::forEachPropertyMutable):
* Source/JavaScriptCore/runtime/PropertyTable.h:
(JSC::PropertyTable::findImpl):
(JSC::PropertyTable::get):
(JSC::PropertyTable::add):
(JSC::PropertyTable::remove):
(JSC::PropertyTable::propertyStorageSize const):
(JSC::PropertyTable::hasDeletedOffset):
(JSC::PropertyTable::takeDeletedOffset):
(JSC::PropertyTable::sizeInMemory):
(JSC::PropertyTable::reinsert):
(JSC::PropertyTable::rehash):
(JSC::PropertyTable::skipDeletedEntries):
(JSC::PropertyTable::forEachProperty const):
(JSC::PropertyTable::clearDeletedOffsets): Deleted.
(JSC::PropertyTable::addDeletedOffset): Deleted.
* Source/JavaScriptCore/runtime/Structure.cpp:
(JSC::Structure::materializePropertyTable):
* Source/JavaScriptCore/runtime/StructureInlines.h:
(JSC::Structure::remove):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5dbbd8251e340ad692b1decf1c502cc6062d4d18

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162937 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36416 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29598 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171875 "Hash 5dbbd825 for PR 65054 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119383 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c998776b-5a13-4f4c-9625-fc4adb0e853e) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36910 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36418 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/171875 "Hash 5dbbd825 for PR 65054 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89088 "1 flakes 18 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/05ac1954-2f05-46eb-b88b-cd214d058a9c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165896 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28922 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146434 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/171875 "Hash 5dbbd825 for PR 65054 does not build (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fa694291-6562-4251-9768-20d63fcbd5eb) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27968 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26416 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19575 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/155076 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137861 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24163 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174379 "Hash 5dbbd825 for PR 65054 does not build (failure)") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23823 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/23679 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25810 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/174379 "Hash 5dbbd825 for PR 65054 does not build (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36087 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30519 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/174379 "Hash 5dbbd825 for PR 65054 does not build (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37013 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145959 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98556 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30215 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22796 "Passed tests") | [❌ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195338 "Hash 5dbbd825 for PR 65054 does not build (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35583 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/105370 "Found 1 new failure in wasm/WasmConstExprGenerator.cpp") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/35/builds/195338 "Hash 5dbbd825 for PR 65054 does not build (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35082 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/818 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35329 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35230 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->