### PR TITLE
IntersectionObserver reports incorrect bounds for SVG element targets

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/svg-clipped-rect-target-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/svg-clipped-rect-target-expected.txt
@@ -1,6 +1,6 @@
 
 PASS IntersectionObserver observing a clipped SVG <rect> element
-FAIL First rAF. assert_approx_equals: entries[0].boundingClientRect.left expected 108 +/- 0 but got 8
-FAIL document.scrollingElement.scrollTop = 300 assert_approx_equals: entries[1].boundingClientRect.left expected 108 +/- 0 but got 8
-FAIL document.scrollingElement.scrollTop = 100 assert_approx_equals: entries[2].boundingClientRect.left expected 108 +/- 0 but got 8
+PASS First rAF.
+FAIL document.scrollingElement.scrollTop = 300 assert_approx_equals: entries[1].intersectionRect.left expected 118 +/- 0 but got 108
+PASS document.scrollingElement.scrollTop = 100
 

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/svg-container-element-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/svg-container-element-expected.txt
@@ -1,5 +1,5 @@
 
 PASS IntersectionObserver observing an SVG container element changing position
-FAIL First rAF. assert_approx_equals: entries[0].boundingClientRect.right expected 108 +/- 1 but got 8
-FAIL Change inner svg element assert_approx_equals: entries[1].boundingClientRect.right expected 108 +/- 1 but got 8
+PASS First rAF.
+PASS Change inner svg element
 

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/svg-group-target-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/svg-group-target-expected.txt
@@ -1,6 +1,6 @@
 
 PASS IntersectionObserver observing an SVG <g> element
-FAIL First rAF. assert_approx_equals: entries[0].boundingClientRect.left expected 108 +/- 0 but got 8
-FAIL descendant rect translated down by 150 units (out of SVG viewport) assert_equals: entries.length expected 2 but got 1
-FAIL descendant rect translated down by 100 units assert_equals: entries.length expected 3 but got 1
+PASS First rAF.
+PASS descendant rect translated down by 150 units (out of SVG viewport)
+PASS descendant rect translated down by 100 units
 

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/svg-image-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/svg-image-expected.txt
@@ -1,5 +1,5 @@
 
 PASS IntersectionObserver observing an SVG image element changing position
-FAIL First rAF. assert_approx_equals: entries[0].boundingClientRect.right expected 108 +/- 0 but got 8
-FAIL change image location assert_equals: entries.length expected 2 but got 1
+PASS First rAF.
+PASS change image location
 

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/svg-intersection-with-fractional-bounds-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/svg-intersection-with-fractional-bounds-expected.txt
@@ -1,6 +1,6 @@
 
 PASS IntersectionObserver observing an SVG <rect> with fractional bounds element
-FAIL Initial Observation assert_approx_equals: entries[0].boundingClientRect.left expected 9 +/- 0.0001 but got 8
-FAIL Intersection observation after scrolling 300 assert_approx_equals: entries[1].boundingClientRect.left expected 9 +/- 0.0001 but got 8
-FAIL Intersection observation after scrolling 100 assert_approx_equals: entries[2].boundingClientRect.left expected 9 +/- 0.0001 but got 8
+PASS Initial Observation
+PASS Intersection observation after scrolling 300
+PASS Intersection observation after scrolling 100
 

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/svg-rect-target-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/svg-rect-target-expected.txt
@@ -1,6 +1,6 @@
 
 PASS IntersectionObserver observing an SVG <rect> element
-FAIL First rAF. assert_approx_equals: entries[0].boundingClientRect.left expected 108 +/- 0 but got 8
-FAIL document.scrollingElement.scrollTop = 300 assert_approx_equals: entries[1].boundingClientRect.left expected 108 +/- 0 but got 8
-FAIL document.scrollingElement.scrollTop = 100 assert_approx_equals: entries[2].boundingClientRect.left expected 108 +/- 0 but got 8
+PASS First rAF.
+PASS document.scrollingElement.scrollTop = 300
+PASS document.scrollingElement.scrollTop = 100
 

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/svg-stroke-change-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/svg-stroke-change-expected.txt
@@ -1,5 +1,5 @@
 
 PASS IntersectionObserver observing an SVG element while its stroke is changed
-FAIL First rAF. assert_approx_equals: entries[0].boundingClientRect.right expected 108 +/- 0 but got 8
-FAIL change stroke assert_equals: entries.length expected 2 but got 1
+PASS First rAF.
+PASS change stroke
 

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/svg-target-changes-position-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/svg-target-changes-position-expected.txt
@@ -1,5 +1,5 @@
 
 PASS IntersectionObserver observing an SVG element changing position
-FAIL First rAF. assert_approx_equals: entries[0].boundingClientRect.right expected 108 +/- 0 but got 8
-FAIL Move SVG element up assert_equals: entries.length expected 2 but got 1
+PASS First rAF.
+PASS Move SVG element up
 

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/svg-transformed-rect-target-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/svg-transformed-rect-target-expected.txt
@@ -1,6 +1,6 @@
 
 PASS IntersectionObserver observing an SVG <rect> element with changing 'transform'
-FAIL First rAF. assert_approx_equals: entries[0].boundingClientRect.left expected 108 +/- 0 but got 8
-FAIL translated down by 150 units (out of SVG viewport) assert_approx_equals: entries[1].boundingClientRect.left expected 108 +/- 0 but got 8
-FAIL translated down by 50 units assert_equals: entries.length expected 3 but got 2
+PASS First rAF.
+PASS translated down by 150 units (out of SVG viewport)
+PASS translated down by 50 units
 

--- a/Source/WebCore/page/IntersectionObserver.cpp
+++ b/Source/WebCore/page/IntersectionObserver.cpp
@@ -44,6 +44,7 @@
 #include "IntersectionObserverCallback.h"
 #include "IntersectionObserverEntry.h"
 #include "JSNodeCustom.h"
+#include "LegacyRenderSVGModelObject.h"
 #include "LocalDOMWindow.h"
 #include "Logging.h"
 #include "Performance.h"
@@ -52,6 +53,7 @@
 #include "RenderInline.h"
 #include "RenderLineBreak.h"
 #include "RenderObjectInlines.h"
+#include "RenderSVGModelObject.h"
 #include "RenderView.h"
 #include "StyleKeyword+Logging.h"
 #include "StylePrimitiveNumericTypes+Conversions.h"
@@ -567,7 +569,12 @@ auto IntersectionObserver::computeIntersectionState(const IntersectionObserverRe
         if (CheckedPtr renderLineBreak = dynamicDowncast<RenderLineBreak>(targetRenderer.get()))
             return renderLineBreak->linesBoundingBox();
 
-        // FIXME: Implement for SVG etc.
+        if (CheckedPtr svgModelObject = dynamicDowncast<RenderSVGModelObject>(*targetRenderer))
+            return svgModelObject->borderBoxRectEquivalent();
+
+        if (CheckedPtr legacySVGModelObject = dynamicDowncast<LegacyRenderSVGModelObject>(*targetRenderer))
+            return enclosingLayoutRect(legacySVGModelObject->strokeBoundingBox());
+
         return { };
     }();
 

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp
@@ -79,6 +79,14 @@ std::optional<FloatRect> LegacyRenderSVGModelObject::computeFloatVisibleRectInCo
     return SVGRenderSupport::computeFloatVisibleRectInContainer(*this, rect, container, context);
 }
 
+auto LegacyRenderSVGModelObject::computeVisibleRectsInContainer(const RepaintRects& rects, const RenderLayerModelObject* container, VisibleRectContext context) const -> std::optional<RepaintRects>
+{
+    auto floatRect = computeFloatVisibleRectInContainer(rects.clippedOverflowRect, container, context);
+    if (!floatRect)
+        return std::nullopt;
+    return RepaintRects { enclosingLayoutRect(*floatRect) };
+}
+
 void LegacyRenderSVGModelObject::mapLocalToContainer(const RenderLayerModelObject* ancestorContainer, TransformState& transformState, OptionSet<MapCoordinatesMode>, bool* wasFixed) const
 {
     SVGRenderSupport::mapLocalToContainer(*this, ancestorContainer, transformState, wasFixed);

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.h
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.h
@@ -53,6 +53,7 @@ public:
     RepaintRects rectsForRepaintingAfterLayout(const RenderLayerModelObject* repaintContainer, RepaintOutlineBounds) const override;
 
     std::optional<FloatRect> computeFloatVisibleRectInContainer(const FloatRect&, const RenderLayerModelObject* container, VisibleRectContext) const final;
+    std::optional<RepaintRects> computeVisibleRectsInContainer(const RepaintRects&, const RenderLayerModelObject* container, VisibleRectContext) const override;
     LayoutRect outlineBoundsForRepaint(const RenderLayerModelObject* repaintContainer, const RenderGeometryMap* = nullptr) const final;
 
     void boundingRects(Vector<LayoutRect>&, const LayoutPoint& accumulatedOffset) const final;


### PR DESCRIPTION
#### 32267a41143df67780edfd3edf5b600aac60053b
<pre>
IntersectionObserver reports incorrect bounds for SVG element targets
<a href="https://bugs.webkit.org/show_bug.cgi?id=314966">https://bugs.webkit.org/show_bug.cgi?id=314966</a>
<a href="https://rdar.apple.com/177260411">rdar://177260411</a>

Reviewed by Simon Fraser.

IntersectionObserver::computeIntersectionState() returned an empty
LayoutRect for SVG renderers (&quot;FIXME: Implement for SVG etc.&quot;), so
boundingClientRect / intersectionRect for SVG &lt;rect&gt;, &lt;g&gt;, &lt;image&gt;, etc.
were anchored at the document origin instead of the element&apos;s actual
position.

On the legacy SVG path, LegacyRenderSVGModelObject inherited
RenderObject&apos;s computeVisibleRectsInContainer, which walks parents
without applying SVG transforms or the SVG viewport clip. As a result,
intersectionRect was reported in SVG userspace coordinates instead of
CSS pixels when the &lt;svg&gt; had a viewBox with a non-1:1 scale.

Modern (LBSE) RenderSVGModelObject already overrides
computeVisibleRectsInContainer through computeVisibleRectsInSVGContainer,
which applies the layer transform of the anonymous viewport container
(carrying the viewBox-&gt;viewport scale via m_supplementalLayerTransform),
so the LBSE rect-walking path is correct once the local target bounds
are populated.

* Source/WebCore/page/IntersectionObserver.cpp:
(WebCore::IntersectionObserver::computeIntersectionState):
Compute localTargetBounds for SVG renderers using
borderBoxRectEquivalent() (modern) or strokeBoundingBox() (legacy),
matching the local rect that absoluteQuads() already feeds to
localToAbsoluteQuad() on those renderers.
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.h:
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGModelObject.cpp:
(WebCore::LegacyRenderSVGModelObject::computeVisibleRectsInContainer):
Override to delegate to computeFloatVisibleRectInContainer, which
already walks the SVG transform chain through SVGRenderSupport. Mirrors
the pattern in RenderSVGBlock::computeVisibleRectsInContainer for its
non-LBSE branch.

&gt; Progressions:
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/svg-clipped-rect-target-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/svg-container-element-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/svg-group-target-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/svg-image-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/svg-intersection-with-fractional-bounds-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/svg-rect-target-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/svg-stroke-change-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/svg-target-changes-position-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/svg-transformed-rect-target-expected.txt:

Canonical link: <a href="https://commits.webkit.org/313596@main">https://commits.webkit.org/313596@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/18e5199fd97af88341e42a18e19c40f274e384cf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163424 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36907 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30123 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172364 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119871 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ea7f9939-df20-43a0-a452-02ee1f3a1286) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165293 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37236 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36907 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126915 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89460 "layout-tests (failure)") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166383 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29186 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146913 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107473 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28239 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26862 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20066 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138127 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24636 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174868 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27528 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26292 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135219 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36577 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30962 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135205 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36475 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37362 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146431 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99319 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30509 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23276 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36073 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108970 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35570 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1301 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35818 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35718 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->