### PR TITLE
[Gardening] Update Test Expectations for Windows Bot

### DIFF
--- a/LayoutTests/platform/win/TestExpectations
+++ b/LayoutTests/platform/win/TestExpectations
@@ -165,6 +165,7 @@ http/tests/security/contentSecurityPolicy/video-with-http-url-allowed-by-csp-med
 http/tests/security/mixedContent/insecure-audio-video-in-main-frame-UpgradeMixedContent.html [ Skip ]
 http/wpt/service-workers/media-range-request.html [ Skip ]
 imported/w3c/web-platform-tests/css/selectors/invalidation/media-pseudo-classes-in-has.html [ Skip ]
+imported/w3c/web-platform-tests/css/selectors/invalidation/is-pseudo-containing-sibling-relationship-in-has.html [ Skip ] # Flaky
 imported/w3c/web-platform-tests/css/selectors/media [ Skip ]
 media/audio-data-url.html [ Skip ]
 media/audio-mpeg-supported.html [ Skip ]
@@ -703,6 +704,9 @@ http/tests/cache/willsendrequest-returns-null-for-memory-cache-load.html [ Failu
 http/tests/cache/memory-cache-pruning.html [ Pass Timeout ]
 http/tests/cache/disk-cache/disk-cache-media-small.html [ Pass Timeout ]
 
+# Crash
+http/tests/cache/cached-main-resource.html [ Skip ]
+
 # Second link click interrupts current download
 http/tests/download/anchor-load-after-download.html [ Skip ]
 
@@ -787,6 +791,7 @@ http/tests/navigation/page-cache-mediakeysession.html [ Skip ] # Failure
 http/tests/navigation/ping-attribute/anchor-ping-and-follow-redirect-when-sending-ping.html [ Skip ] # Failure
 http/tests/navigation/post-frames-goback1-uncached.html [ Skip ] # Failure
 http/tests/navigation/redirect-to-fragment2.html [ Skip ] # Failure
+http/tests/navigation/redirect-to-random-url-versus-memory-cache.html [ Skip ] # Flaky
 http/tests/navigation/error404-basic.html [ Skip ] # Missing
 http/tests/navigation/error404-goback.html [ Skip ] # Missing
 http/tests/navigation/javascriptlink-frames.html [ Skip ] # Missing
@@ -918,6 +923,7 @@ http/tests/security/local-video-poster-from-remote.html [ Skip ] # Failure
 http/tests/security/local-video-source-from-remote.html [ Skip ] # Failure
 http/tests/security/local-video-src-from-remote.html [ Skip ] # Failure
 http/tests/security/module-no-mime-type.html [ Skip ] # Failure
+http/tests/security/no-indexeddb-from-sandbox.html [ Skip ] # Crash
 http/tests/security/sync-xhr-partition.html [ Skip ] # Failure
 http/tests/security/video-cross-origin-accessfailure.html [ Skip ] # Failure
 http/tests/security/video-cross-origin-accesssameorigin.html [ Skip ] # Timeout on Buildbot
@@ -1902,6 +1908,7 @@ streams/readable-stream-byob-request-worker.html [ Skip ]
 imported/w3c/web-platform-tests/cookiestore [ Skip ]
 imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies.tentative.https.html [ Skip ]
 http/tests/cookies/cookie-store-set-secure.https.html [ Skip ]
+cookies/cookie-store-start-listening-for-change-with-null-url-crash.html [ Skip ] # crash
 http/tests/navigation/ping-attribute/anchor-cookie.html [ Skip ]
 http/tests/navigation/ping-attribute/cross-site-url-anchor-cookie-preexisting-cookie.html [ Skip ]
 http/tests/navigation/ping-attribute/cross-site-url-anchor-cookie.html [ Skip ]
@@ -3371,6 +3378,7 @@ fast/css/css-imports.html [ Skip ]
 fast/css/css1_forward_compatible_parsing.html [ Skip ]
 fast/css/css3-nth-child.html [ Skip ]
 fast/css/css3-space-in-nth-and-lang.html [ Skip ]
+fast/css/css-anchor-position/anchor-positioned-select-picker.html [ Skip ] # timeout
 fast/css/disabled-author-styles.html [ Skip ]
 fast/css/dynamic-sibling-selector.html [ Skip ]
 fast/css/empty-body-test.html [ Skip ]

--- a/LayoutTests/platform/win/editing/smart-lists/different-list-styles-do-not-merge-expected.txt
+++ b/LayoutTests/platform/win/editing/smart-lists/different-list-styles-do-not-merge-expected.txt
@@ -1,0 +1,18 @@
+Adjacent lists with different marker styles (disc and dash) should not merge into a single list. After a blank line, typing a different marker type produces a separate list.
+| "* A"
+| <div>
+|   "* B"
+| <div>
+|   "C"
+| <div>
+|   <br>
+| <div>
+|   "* D"
+| <div>
+|   "* E"
+| <div>
+|   <br>
+| <div>
+|   "- A"
+| <div>
+|   "- B<#selection-caret>"

--- a/LayoutTests/platform/win/editing/smart-lists/inserting-space-after-bullet-point-generates-empty-list-expected.txt
+++ b/LayoutTests/platform/win/editing/smart-lists/inserting-space-after-bullet-point-generates-empty-list-expected.txt
@@ -1,0 +1,4 @@
+Typing "* A" + Enter + "* " with no text after the second marker should still produce an unordered list where the second list item is empty (contains a placeholder br).
+| "* A"
+| <div>
+|   "* <#selection-caret>"

--- a/LayoutTests/platform/win/editing/smart-lists/inserting-space-after-em-dash-generates-dashed-list-expected.txt
+++ b/LayoutTests/platform/win/editing/smart-lists/inserting-space-after-em-dash-generates-dashed-list-expected.txt
@@ -1,0 +1,4 @@
+Typing the em-dash character (U+2014) followed by a space at the start of two consecutive lines should auto-convert them into an unordered dashed list, with the em-dash character in the custom list-style-type marker.
+| "— Hello"
+| <div>
+|   "— World<#selection-caret>"

--- a/LayoutTests/platform/win/editing/smart-lists/inserting-space-after-en-dash-generates-dashed-list-expected.txt
+++ b/LayoutTests/platform/win/editing/smart-lists/inserting-space-after-en-dash-generates-dashed-list-expected.txt
@@ -1,0 +1,4 @@
+Typing the en-dash character (U+2013) followed by a space at the start of two consecutive lines should auto-convert them into an unordered dashed list, with the en-dash character in the custom list-style-type marker.
+| "– Hello"
+| <div>
+|   "– World<#selection-caret>"

--- a/LayoutTests/platform/win/editing/smart-lists/inserting-space-after-hyphen-minus-generates-dashed-list-expected.txt
+++ b/LayoutTests/platform/win/editing/smart-lists/inserting-space-after-hyphen-minus-generates-dashed-list-expected.txt
@@ -1,0 +1,4 @@
+Typing "- " (hyphen-minus, U+002D) at the start of two consecutive lines should auto-convert them into an unordered dashed list, using the hyphen-minus character in the custom list-style-type marker.
+| "- Hello"
+| <div>
+|   "- World<#selection-caret>"

--- a/LayoutTests/platform/win/editing/smart-lists/inserting-space-after-multi-digit-number-generates-ordered-list-expected.txt
+++ b/LayoutTests/platform/win/editing/smart-lists/inserting-space-after-multi-digit-number-generates-ordered-list-expected.txt
@@ -1,0 +1,4 @@
+Typing a multi-digit number (up to 3 digits) followed by ". " at the start of two consecutive lines should auto-convert them into an ordered list whose start attribute matches the first number typed.
+| "123. Hello"
+| <div>
+|   "125. World<#selection-caret>"

--- a/LayoutTests/platform/win/editing/smart-lists/inserting-space-after-number-generates-ordered-list-expected.txt
+++ b/LayoutTests/platform/win/editing/smart-lists/inserting-space-after-number-generates-ordered-list-expected.txt
@@ -1,0 +1,11 @@
+Typing a single digit followed by "." or ")" plus space at the start of two consecutive lines should auto-convert them into an ordered (decimal) list. Both delimiters are accepted.
+
+Period delimiter:
+| "1. Hello"
+| <div>
+|   "2. World<#selection-caret>"
+
+Parenthesis delimiter:
+| "1) Hello"
+| <div>
+|   "2) World<#selection-caret>"

--- a/LayoutTests/platform/win/editing/smart-lists/inserting-space-after-unicode-hyphen-generates-dashed-list-expected.txt
+++ b/LayoutTests/platform/win/editing/smart-lists/inserting-space-after-unicode-hyphen-generates-dashed-list-expected.txt
@@ -1,0 +1,4 @@
+Typing the Unicode hyphen character (U+2010) followed by a space at the start of two consecutive lines should auto-convert them into an unordered dashed list, with the hyphen character in the custom list-style-type marker.
+| "‐ Hello"
+| <div>
+|   "‐ World<#selection-caret>"

--- a/LayoutTests/platform/win/editing/smart-lists/inserting-space-and-text-after-bullet-point-generates-list-with-text-expected.txt
+++ b/LayoutTests/platform/win/editing/smart-lists/inserting-space-and-text-after-bullet-point-generates-list-with-text-expected.txt
@@ -1,0 +1,11 @@
+Typing "* " at the start of two consecutive lines should auto-convert them into an unordered disc list. Both the ASCII asterisk (U+002A) and the bullet character (U+2022) should trigger the same conversion.
+
+Asterisk (U+002A):
+| "* Hello"
+| <div>
+|   "* World<#selection-caret>"
+
+Bullet (U+2022):
+| "• Hello"
+| <div>
+|   "• World<#selection-caret>"

--- a/LayoutTests/platform/win/editing/smart-lists/list-merges-with-previous-list-if-possible-expected.txt
+++ b/LayoutTests/platform/win/editing/smart-lists/list-merges-with-previous-list-if-possible-expected.txt
@@ -1,0 +1,12 @@
+Consecutive ordered-list items separated by non-list content and a blank line should still merge into a single ordered list, preserving the start attribute of the first list.
+| "1. A"
+| <div>
+|   "2. B"
+| <div>
+|   "C"
+| <div>
+|   <br>
+| <div>
+|   "5. D"
+| <div>
+|   "6. E<#selection-caret>"

--- a/LayoutTests/platform/win/editing/smart-lists/list-preserves-typing-style-expected.txt
+++ b/LayoutTests/platform/win/editing/smart-lists/list-preserves-typing-style-expected.txt
@@ -1,0 +1,15 @@
+When bold, italic, and underline are toggled on before typing marker-style lines, smart-list conversion should preserve the active typing style â€” including on a subsequent line typed without an explicit marker.
+| <b>
+|   <i>
+|     <u>
+|       "1. this is styled text"
+| <div>
+|   <b>
+|     <i>
+|       <u>
+|         "2. this is styled text"
+| <div>
+|   <b>
+|     <i>
+|       <u>
+|         "this is styled text<#selection-caret>"

--- a/LayoutTests/platform/win/editing/smart-lists/newline-on-empty-list-element-removes-plain-text-markers-expected.txt
+++ b/LayoutTests/platform/win/editing/smart-lists/newline-on-empty-list-element-removes-plain-text-markers-expected.txt
@@ -1,0 +1,8 @@
+Pressing Enter on an empty list item (double newline) should break out of the list, moving the following text "C" outside the list as its own block.
+| "* A"
+| <div>
+|   "* B"
+| <div>
+|   <br>
+| <div>
+|   "C<#selection-caret>"

--- a/LayoutTests/platform/win/editing/smart-lists/ordered-list-starting-from-non-one-sets-start-attribute-expected.txt
+++ b/LayoutTests/platform/win/editing/smart-lists/ordered-list-starting-from-non-one-sets-start-attribute-expected.txt
@@ -1,0 +1,4 @@
+Typing an ordered list whose first item starts at a number greater than 1 should produce an ol element whose start attribute matches the first number typed.
+| "5. A"
+| <div>
+|   "6. B<#selection-caret>"

--- a/LayoutTests/platform/win/editing/smart-lists/ordered-markers-with-different-delimiters-generate-list-expected.txt
+++ b/LayoutTests/platform/win/editing/smart-lists/ordered-markers-with-different-delimiters-generate-list-expected.txt
@@ -1,0 +1,4 @@
+Ordered-list markers on consecutive lines should be treated as compatible even when they use different delimiters (period and parenthesis), producing a single ordered list.
+| "1. A"
+| <div>
+|   "2) B<#selection-caret>"

--- a/LayoutTests/platform/win/editing/smart-lists/ordered-smart-list-rtl-expected.txt
+++ b/LayoutTests/platform/win/editing/smart-lists/ordered-smart-list-rtl-expected.txt
@@ -1,0 +1,4 @@
+Smart-list conversion should work inside a right-to-left contenteditable. Typing "1. تفاحة" + Enter + "2. برتقال" should produce an ordered list containing the Arabic text.
+| "1. تفاحة"
+| <div>
+|   "2. برتقال<#selection-caret>"

--- a/LayoutTests/platform/win/editing/smart-lists/space-inside-list-element-does-not-activate-smart-lists-expected.txt
+++ b/LayoutTests/platform/win/editing/smart-lists/space-inside-list-element-does-not-activate-smart-lists-expected.txt
@@ -1,0 +1,6 @@
+Smart-list conversion should not fire when the selection is already inside a list element. After typing two bulleted items, typing "1. Hi" on a third list item inserts the literal text into the existing list rather than creating a new ordered list.
+| "* A"
+| <div>
+|   "* B"
+| <div>
+|   "1. Hi<#selection-caret>"


### PR DESCRIPTION
#### 1c151774c8cc88b80e69f8f28bcd29c417eb069e
<pre>
[Gardening] Update Test Expectations for Windows Bot
<a href="https://bugs.webkit.org/show_bug.cgi?id=314967">https://bugs.webkit.org/show_bug.cgi?id=314967</a>
<a href="https://rdar.apple.com/177261035">rdar://177261035</a>

Unreviewed Test Gardening.

* LayoutTests/platform/win/TestExpectations:
* LayoutTests/platform/win/editing/smart-lists/different-list-styles-do-not-merge-expected.txt: Added.
* LayoutTests/platform/win/editing/smart-lists/inserting-space-after-bullet-point-generates-empty-list-expected.txt: Added.
* LayoutTests/platform/win/editing/smart-lists/inserting-space-after-em-dash-generates-dashed-list-expected.txt: Added.
* LayoutTests/platform/win/editing/smart-lists/inserting-space-after-en-dash-generates-dashed-list-expected.txt: Added.
* LayoutTests/platform/win/editing/smart-lists/inserting-space-after-hyphen-minus-generates-dashed-list-expected.txt: Added.
* LayoutTests/platform/win/editing/smart-lists/inserting-space-after-multi-digit-number-generates-ordered-list-expected.txt: Added.
* LayoutTests/platform/win/editing/smart-lists/inserting-space-after-number-generates-ordered-list-expected.txt: Added.
* LayoutTests/platform/win/editing/smart-lists/inserting-space-after-unicode-hyphen-generates-dashed-list-expected.txt: Added.
* LayoutTests/platform/win/editing/smart-lists/inserting-space-and-text-after-bullet-point-generates-list-with-text-expected.txt: Added.
* LayoutTests/platform/win/editing/smart-lists/list-merges-with-previous-list-if-possible-expected.txt: Added.
* LayoutTests/platform/win/editing/smart-lists/list-preserves-typing-style-expected.txt: Added.
* LayoutTests/platform/win/editing/smart-lists/newline-on-empty-list-element-removes-plain-text-markers-expected.txt: Added.
* LayoutTests/platform/win/editing/smart-lists/ordered-list-starting-from-non-one-sets-start-attribute-expected.txt: Added.
* LayoutTests/platform/win/editing/smart-lists/ordered-markers-with-different-delimiters-generate-list-expected.txt: Added.
* LayoutTests/platform/win/editing/smart-lists/ordered-smart-list-rtl-expected.txt: Added.
* LayoutTests/platform/win/editing/smart-lists/space-inside-list-element-does-not-activate-smart-lists-expected.txt: Added.

Canonical link: <a href="https://commits.webkit.org/313374@main">https://commits.webkit.org/313374@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c22ede3cc089fd4a90316d3c850ae06f50845f0d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162942 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36421 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29599 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171880 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119388 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a3db4483-258d-4663-b9c4-74d1198aee68) 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/36905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36423 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126489 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89092 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e832f2c0-d759-4d30-bb9c-86b99fc559a5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165901 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/36905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146437 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107065 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5ccb9223-6d96-4053-bb23-58e252aa3a52) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/36905 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26420 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19580 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137604 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24166 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174384 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25813 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134798 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36092 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30523 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134793 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36353 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/36376 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145962 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98565 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/29624 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22799 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35588 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35087 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/821 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35334 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35235 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->