### PR TITLE
[CMake] Swift compiler wrapper accidentally invalidates the CMake cache (which then silently corrupts your build)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,23 +111,16 @@ if (SWIFT_REQUIRED)
     endif ()
 
     # Override Swift compiler to a wrapper script to work around the
-    # fact pkg-config feeds CFLAGS even to swiftc.
-    # Guard against cache poisoning: if CMAKE_Swift_COMPILER already IS the
-    # wrapper (from a previous configure), find the real compiler via 'which'.
+    # fact CMake feeds incorrect flags to swiftc.
     set(_swift_wrapper "${CMAKE_SOURCE_DIR}/Tools/Scripts/swift/swiftc-wrapper.sh")
     if (CMAKE_Swift_COMPILER STREQUAL _swift_wrapper)
-        execute_process(COMMAND which swiftc RESULT_VARIABLE _which_retcode OUTPUT_VARIABLE _real_swiftc OUTPUT_STRIP_TRAILING_WHITESPACE)
-        if (NOT _which_retcode EQUAL 0)
-            message(FATAL_ERROR "swiftc not found in PATH")
-        endif ()
+        find_program(ORIGINAL_Swift_COMPILER NAMES swiftc REQUIRED)
     else ()
-        set(_real_swiftc "${CMAKE_Swift_COMPILER}")
+        set(ORIGINAL_Swift_COMPILER "${CMAKE_Swift_COMPILER}" CACHE FILEPATH "Original Swift compiler" FORCE)
     endif ()
-    set(ORIGINAL_Swift_COMPILER "${_real_swiftc}" CACHE FILEPATH "Original Swift compiler" FORCE)
-    set(CMAKE_Swift_COMPILER "${_swift_wrapper}" CACHE FILEPATH "Swift compiler wrapper" FORCE)
+    set(CMAKE_Swift_COMPILER "${_swift_wrapper}")
     add_compile_options($<$<COMPILE_LANGUAGE:Swift>:--original-swift-compiler=${ORIGINAL_Swift_COMPILER}>)
     unset(_swift_wrapper)
-    unset(_real_swiftc)
 endif ()
 
 # -----------------------------------------------------------------------------

--- a/Source/cmake/WebKitCommon.cmake
+++ b/Source/cmake/WebKitCommon.cmake
@@ -6,6 +6,31 @@
 if (NOT HAS_RUN_WEBKIT_COMMON)
     set(HAS_RUN_WEBKIT_COMMON TRUE)
 
+    # Preset values are not replayed on auto-reconfigure; if CMake's "compiler
+    # changed" path wipes the cache, these silently revert. Stamp them outside
+    # the cache and refuse to proceed if any go missing.
+    set(WEBKIT_IDENTITY_VARS CMAKE_BUILD_TYPE PORT DEVELOPER_MODE ENABLE_SANITIZERS CMAKE_IOS_SIMULATOR)
+    set(_config_stamp "${CMAKE_BINARY_DIR}/.webkit-config-stamp")
+    if (EXISTS "${_config_stamp}")
+        file(STRINGS "${_config_stamp}" _stamp_lines)
+        foreach (_line IN LISTS _stamp_lines)
+            if (_line MATCHES "^([^=]+)=(.*)$")
+                set(_var "${CMAKE_MATCH_1}")
+                set(_prev "${CMAKE_MATCH_2}")
+                if (NOT DEFINED CACHE{${_var}})
+                    message(FATAL_ERROR
+                        "${_var} is not in the CMake cache, but this build directory was "
+                        "previously configured with ${_var}='${_prev}'. The cache was "
+                        "probably wiped by an auto-reconfigure (\"You have changed "
+                        "variables that require your cache to be deleted\"). Re-run "
+                        "'cmake --preset <name>' to restore your configuration, or "
+                        "delete the build directory.")
+                endif ()
+            endif ()
+        endforeach ()
+        unset(_stamp_lines)
+    endif ()
+
     if (NOT CMAKE_BUILD_TYPE)
         message(WARNING "No CMAKE_BUILD_TYPE value specified, defaulting to RelWithDebInfo.")
         set(CMAKE_BUILD_TYPE "RelWithDebInfo" CACHE STRING "Choose the type of build." FORCE)
@@ -63,6 +88,16 @@ if (NOT HAS_RUN_WEBKIT_COMMON)
     endif ()
 
     string(TOLOWER ${PORT} WEBKIT_PORT_DIR)
+
+    set(_stamp_content "")
+    foreach (_var IN LISTS WEBKIT_IDENTITY_VARS)
+        if (DEFINED CACHE{${_var}})
+            string(APPEND _stamp_content "${_var}=$CACHE{${_var}}\n")
+        endif ()
+    endforeach ()
+    file(WRITE "${_config_stamp}" "${_stamp_content}")
+    unset(_stamp_content)
+    unset(_config_stamp)
 
     # -----------------------------------------------------------------------------
     # Determine the compiler


### PR DESCRIPTION
#### 2459de318e37dcfd7f181ebd909b84ed643bc864
<pre>
[CMake] Swift compiler wrapper accidentally invalidates the CMake cache (which then silently corrupts your build)
<a href="https://bugs.webkit.org/show_bug.cgi?id=314972">https://bugs.webkit.org/show_bug.cgi?id=314972</a>
<a href="https://rdar.apple.com/177267115">rdar://177267115</a>

Reviewed by Adrian Taylor.

We currently set CMAKE_Swift_COMPILER as a CACHE FORCE after
enable_language(Swift) has already recorded the real swiftc.

Bug 1: On the next reconfigure (e.g. after CMakeLists.txt changes),
enable_language(Swift) records the the real swiftc, CMake sees the
cached compiler doesn&apos;t match the recorded one, decides the compiler
changed, and deletes the CMake cache.

Bug 2: When there&apos;s no CMake cache, we silently reconfigure to a set of
defaults that might not match your build (e.g. Debug =&gt; RelWithDebInfo).

* CMakeLists.txt: Set the Swift compiler as a normal variable, like we
do for C++. Since the cache isn&apos;t touched, the compiler-change check
never fires.

* Source/cmake/WebKitCommon.cmake: If we lose the cache, fail the build
instead of silently dropping preset values like CMAKE_BUILD_TYPE.

Canonical link: <a href="https://commits.webkit.org/313411@main">https://commits.webkit.org/313411@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4c72711dc9bdd853331b51aefe9851b0d41c16ff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162981 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36460 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29643 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171919 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119427 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e2569079-2ccc-41a3-a089-6785bfa833bb) 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/36861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36462 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126518 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89123 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5f5b0b1d-338f-4cba-84f6-07817d9715cf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165940 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/36861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146474 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107094 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c8be7984-84be-43fe-9190-610de5e5f024) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/36861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26454 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19619 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/155120 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137648 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174423 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23867 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25850 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134828 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36131 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30557 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134823 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/36836 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145999 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98647 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24802 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/30075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22836 "Found 1 new test failure: imported/w3c/web-platform-tests/dom/nodes/moveBefore/throws-exception.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195382 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35627 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50835 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35126 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/858 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35373 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35274 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->