### PR TITLE
FileSystemHandle: isSameEntry() needs to call ensureIdentifier() on both handles

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-isSameEntry.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-isSameEntry.https.any-expected.txt
@@ -10,4 +10,6 @@ PASS isSameEntry comparing a file to a directory returns false
 PASS isSameEntry comparing two files pointing to the same path returns true
 PASS isSameEntry comparing two directories pointing to the same path returns true
 PASS isSameEntry comparing a file to a directory of the same path returns false
+PASS isSameEntry with a file handle that was just cloned via postMessage
+PASS isSameEntry with a directory handle that was just cloned via postMessage
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-isSameEntry.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-isSameEntry.https.any.worker-expected.txt
@@ -10,4 +10,6 @@ PASS isSameEntry comparing a file to a directory returns false
 PASS isSameEntry comparing two files pointing to the same path returns true
 PASS isSameEntry comparing two directories pointing to the same path returns true
 PASS isSameEntry comparing a file to a directory of the same path returns false
+PASS isSameEntry with a file handle that was just cloned via postMessage
+PASS isSameEntry with a directory handle that was just cloned via postMessage
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/script-tests/FileSystemBaseHandle-isSameEntry.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/script-tests/FileSystemBaseHandle-isSameEntry.js
@@ -105,3 +105,28 @@ directory_test(async (t, root_dir) => {
       await file_handle.isSameEntry(dir_handle),
       'a file and directory handle pointing at the same path should not be considered the same entry');
 }, 'isSameEntry comparing a file to a directory of the same path returns false');
+
+async function clone_handle_via_message_channel(handle) {
+  const channel = new MessageChannel();
+  return new Promise((resolve, reject) => {
+    channel.port2.onmessage = event => resolve(event.data);
+    channel.port2.onmessageerror = () => reject(new Error('messageerror'));
+    channel.port1.postMessage(handle);
+  });
+}
+
+directory_test(async (t, root_dir) => {
+  const handle = await createEmptyFile('mtime.txt', root_dir);
+  const cloned = await clone_handle_via_message_channel(handle);
+
+  assert_true(await handle.isSameEntry(cloned));
+  assert_true(await cloned.isSameEntry(handle));
+}, 'isSameEntry with a file handle that was just cloned via postMessage');
+
+directory_test(async (t, root_dir) => {
+  const subdir = await createDirectory('subdir-name', root_dir);
+  const cloned = await clone_handle_via_message_channel(subdir);
+
+  assert_true(await subdir.isSameEntry(cloned));
+  assert_true(await cloned.isSameEntry(subdir));
+}, 'isSameEntry with a directory handle that was just cloned via postMessage');

--- a/Source/WebCore/Modules/filesystem/FileSystemHandle.cpp
+++ b/Source/WebCore/Modules/filesystem/FileSystemHandle.cpp
@@ -139,8 +139,13 @@ void FileSystemHandle::isSameEntry(FileSystemHandle& handle, DOMPromiseDeferred<
         if (!success)
             return promise.reject(Exception { ExceptionCode::InvalidStateError, "Handle is invalid"_s });
 
-        protect(m_connection)->isSameEntry(*m_identifier, handle->identifier(), [promise = WTF::move(promise)](auto result) mutable {
-            promise.settle(WTF::move(result));
+        handle->ensureIdentifier([this, protectedThis = WTF::move(protectedThis), handle, promise = WTF::move(promise)](bool success) mutable {
+            if (!success)
+                return promise.reject(Exception { ExceptionCode::InvalidStateError, "Handle is invalid"_s });
+
+            protect(m_connection)->isSameEntry(*m_identifier, handle->identifier(), [promise = WTF::move(promise)](auto result) mutable {
+                promise.settle(WTF::move(result));
+            });
         });
     });
 }


### PR DESCRIPTION
#### ae2ef22d44ed6734cd09938021681f5732ac8d87
<pre>
FileSystemHandle: isSameEntry() needs to call ensureIdentifier() on both handles
<a href="https://bugs.webkit.org/show_bug.cgi?id=314973">https://bugs.webkit.org/show_bug.cgi?id=314973</a>

Reviewed by Sihui Liu.

isSameEntry only called ensureIdentifier on `this`; the other handle&apos;s
m_identifier was assumed to already be set. That assumption holds when
the handle was created via getFileHandle / getDirectoryHandle, since
the WebProcess gets a FileSystemHandleIdentifier as part of the
roundtrip. It does not hold for a handle that was deserialized from
postMessage / structuredClone: the deserializer constructs the handle
with an empty Markable&lt;FileSystemHandleIdentifier&gt; and calls
markAsUnresolved, so handle-&gt;identifier() (which is *m_identifier)
release-asserts in Markable.h.

Test: imported/w3c/web-platform-tests/fs/script-tests/FileSystemBaseHandle-isSameEntry.js

Upstream: <a href="https://github.com/web-platform-tests/wpt/pull/59933">https://github.com/web-platform-tests/wpt/pull/59933</a>
Canonical link: <a href="https://commits.webkit.org/313396@main">https://commits.webkit.org/313396@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/adc975b82dbed93d106fd54a823f7e38000dce3c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162949 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36428 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29608 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171887 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119395 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/76ce2825-fa5a-494d-967d-ddf6f9c79816) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164818 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/36896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36430 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126494 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89098 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/48c81f01-8642-4bdd-ad24-d978968f3b8b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165908 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/36896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146443 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107070 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/845cbc3f-6b3a-4efb-a517-c34b24862818) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/36896 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26426 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19587 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137612 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24172 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174391 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/24084 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25819 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134803 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36099 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30529 "Found 1 new test failure: imported/w3c/web-platform-tests/dom/events/Event-timestamp-high-resolution.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134798 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/36792 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145968 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98584 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24790 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/30036 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22805 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35595 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/105780 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35094 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/827 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35341 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35242 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->