### PR TITLE
Root FileSystemDirectoryHandle should have a non-null name

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-isSameEntry.https.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-isSameEntry.https.any-expected.txt
@@ -12,4 +12,5 @@ PASS isSameEntry comparing two directories pointing to the same path returns tru
 PASS isSameEntry comparing a file to a directory of the same path returns false
 PASS isSameEntry with a file handle that was just cloned via postMessage
 PASS isSameEntry with a directory handle that was just cloned via postMessage
+PASS isSameEntry with a root directory handle that was just cloned via postMessage
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-isSameEntry.https.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/FileSystemBaseHandle-isSameEntry.https.any.worker-expected.txt
@@ -12,4 +12,5 @@ PASS isSameEntry comparing two directories pointing to the same path returns tru
 PASS isSameEntry comparing a file to a directory of the same path returns false
 PASS isSameEntry with a file handle that was just cloned via postMessage
 PASS isSameEntry with a directory handle that was just cloned via postMessage
+PASS isSameEntry with a root directory handle that was just cloned via postMessage
 

--- a/LayoutTests/imported/w3c/web-platform-tests/fs/script-tests/FileSystemBaseHandle-isSameEntry.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/fs/script-tests/FileSystemBaseHandle-isSameEntry.js
@@ -130,3 +130,10 @@ directory_test(async (t, root_dir) => {
   assert_true(await subdir.isSameEntry(cloned));
   assert_true(await cloned.isSameEntry(subdir));
 }, 'isSameEntry with a directory handle that was just cloned via postMessage');
+
+directory_test(async (t, root_dir) => {
+  const cloned = await clone_handle_via_message_channel(root_dir);
+
+  assert_true(await root_dir.isSameEntry(cloned));
+  assert_true(await cloned.isSameEntry(root_dir));
+}, 'isSameEntry with a root directory handle that was just cloned via postMessage');

--- a/Source/WebCore/Modules/storage/StorageManager.cpp
+++ b/Source/WebCore/Modules/storage/StorageManager.cpp
@@ -146,7 +146,7 @@ void StorageManager::fileSystemGetDirectory(DOMPromiseDeferred<IDLInterface<File
             return promise.reject(Exception { ExceptionCode::InvalidStateError, "Context has stopped"_s });
         }
 
-        Ref handle = FileSystemDirectoryHandle::create(*context, { }, info.globalIdentifier, info.identifier, protect(*info.connection));
+        Ref handle = FileSystemDirectoryHandle::create(*context, String { emptyString() }, info.globalIdentifier, info.identifier, protect(*info.connection));
         promise.resolve(handle);
     });
 }


### PR DESCRIPTION
#### 378b40e2ab38ff17805958a8fd864ab3dc82daa9
<pre>
Root FileSystemDirectoryHandle should have a non-null name
<a href="https://bugs.webkit.org/show_bug.cgi?id=314974">https://bugs.webkit.org/show_bug.cgi?id=314974</a>

Reviewed by Sihui Liu.

navigator.storage.getDirectory() constructed the root
FileSystemDirectoryHandle with a null string for its name argument.
Round-tripping the handle through structured clone results in an
empty string. This means that isSameEntry() will treat them
differently. The specification uses an empty string so follow that.

Test: imported/w3c/web-platform-tests/fs/script-tests/FileSystemBaseHandle-isSameEntry.js

Upstream: <a href="https://github.com/web-platform-tests/wpt/pull/59933">https://github.com/web-platform-tests/wpt/pull/59933</a>
Canonical link: <a href="https://commits.webkit.org/313397@main">https://commits.webkit.org/313397@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b770376821ea4a2041021b3130fd17b7e0b5e96a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163044 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36523 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29721 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171983 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119490 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/07df66f5-341e-4b7e-9d5c-7c501706dfeb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164913 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/36796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36525 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126570 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89175 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b5450fc9-410f-48e7-ba2c-657b4a3923e0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166003 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/36796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146547 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107146 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/74b2b78a-cffa-4db0-b7f2-b5f732615f08) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/36796 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26512 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19682 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137714 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24277 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174486 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/26034 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25923 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134881 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36194 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30615 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134876 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36364 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/36802 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146072 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98763 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/30044 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/22910 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35690 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/107694 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35189 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/931 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35436 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35337 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->