### PR TITLE
[WPE] WPE/TestWebKitWebView:/webkit/WebKitWebView/snapshot constantly fails in WPE legacy mode

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestWebKitWebView.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestWebKitWebView.cpp
@@ -1316,8 +1316,12 @@ static void testWebViewSnapshot(SnapshotWebViewTest* test, gconstpointer)
 #else
     g_assert_nonnull(snapshot1.get());
     g_assert_true(WEBKIT_IS_IMAGE(snapshot1.get()));
-    g_assert_cmpint(webkit_image_get_width(snapshot1.get()), ==, 50);
-    g_assert_cmpint(webkit_image_get_height(snapshot1.get()), ==, 50);
+#if ENABLE(WPE_PLATFORM)
+    if (test->m_display) {
+        g_assert_cmpint(webkit_image_get_width(snapshot1.get()), ==, 50);
+        g_assert_cmpint(webkit_image_get_height(snapshot1.get()), ==, 50);
+    }
+#endif
 #endif
 
     // Select all text in the WebView, request a snapshot ignoring selection.

--- a/Tools/TestWebKitAPI/glib/WebKitGLib/TestMain.h
+++ b/Tools/TestWebKitAPI/glib/WebKitGLib/TestMain.h
@@ -202,7 +202,7 @@ public:
     {
         // Don't make warnings fatal when creating the backend, since atk produces warnings when a11y bus is not running.
         removeLogFatalFlag(G_LOG_LEVEL_WARNING);
-        auto* headlessBackend = new WPEToolingBackends::HeadlessViewBackend(800, 600);
+        auto* headlessBackend = new WPEToolingBackends::HeadlessViewBackend(1024, 768);
         addLogFatalFlag(G_LOG_LEVEL_WARNING);
         // Make the view initially hidden for consistency with GTK tests.
         wpe_view_backend_remove_activity_state(headlessBackend->backend(), wpe_view_activity_state_visible | wpe_view_activity_state_focused);


### PR DESCRIPTION
#### 1b2f28930b98b164db31341ab47d1776adfae40c
<pre>
[WPE] WPE/TestWebKitWebView:/webkit/WebKitWebView/snapshot constantly fails in WPE legacy mode
<a href="https://bugs.webkit.org/show_bug.cgi?id=314980">https://bugs.webkit.org/show_bug.cgi?id=314980</a>

Reviewed by Adrian Perez de Castro.

The default size of the view is 800x600 while the test expects 1024x768.
Update the default size and skip the resize test as it doesn&apos;t work with
the legacy API.

* Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestWebKitWebView.cpp:
(testWebViewSnapshot):
* Tools/TestWebKitAPI/glib/WebKitGLib/TestMain.h:
(Test::createWebViewBackend):

Canonical link: <a href="https://commits.webkit.org/313379@main">https://commits.webkit.org/313379@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eda3f66010aa5ca6fadbfa6fe02be778aff34b14

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162963 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36442 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29637 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171901 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119409 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164832 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/36876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36444 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126505 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89108 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165922 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/36876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146470 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107081 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/36876 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26438 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19601 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137632 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24199 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174405 "Built successfully") | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/25846 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134814 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36113 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30541 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134809 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/36554 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/145995 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98617 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24779 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/29801 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/22832 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35609 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35108 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/854 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35355 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35256 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->