### PR TITLE
Cherry-pick 312180@main (856e4464ec42). https://bugs.webkit.org/show_bug.cgi?id=313387

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4818,6 +4818,7 @@ webgl/2.0.y/conformance2/state/gl-object-get-calls.html [ Pass Slow ]
 webgl/2.0.y/conformance2/transform_feedback/transform_feedback.html [ Pass ]
 webgl/2.0.y/conformance2/transform_feedback/simultaneous_binding.html [ Pass ]
 webgl/2.0.y/conformance2/textures/misc/tex-unpack-params-with-flip-y-and-premultiply-alpha.html [ Pass ]
+webgl/2.0.y/conformance2/textures/misc/compressed-tex-image.html [ Pass ]
 
 webgl/2.0.y/conformance2/offscreencanvas [ Pass ]
 

--- a/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
+++ b/Source/WebCore/html/canvas/WebGL2RenderingContext.cpp
@@ -1160,6 +1160,8 @@ void WebGL2RenderingContext::compressedTexImage2D(GCGLenum target, GCGLint level
     }
     if (!validateTexture2DBinding("compressedTexImage2D"_s, target))
         return;
+    if (!validateCompressedTexFormat("compressedTexImage2D"_s, internalformat))
+        return;
     graphicsContextGL()->compressedTexImage2D(target, level, internalformat, width, height, border, imageSize, offset);
 }
 
@@ -1174,6 +1176,8 @@ void WebGL2RenderingContext::compressedTexImage2D(GCGLenum target, GCGLint level
         return;
     }
     if (!validateTexture2DBinding("compressedTexImage2D"_s, target))
+        return;
+    if (!validateCompressedTexFormat("compressedTexImage2D"_s, internalformat))
         return;
     auto slice = sliceArrayBufferView("compressedTexImage2D"_s, srcData, srcOffset, srcLengthOverride);
     if (!slice)
@@ -1193,6 +1197,8 @@ void WebGL2RenderingContext::compressedTexImage3D(GCGLenum target, GCGLint level
     }
     if (!validateTexture3DBinding("compressedTexImage3D"_s, target))
         return;
+    if (!validateCompressedTexFormat("compressedTexImage3D"_s, internalformat))
+        return;
     graphicsContextGL()->compressedTexImage3D(target, level, internalformat, width, height, depth, border, imageSize, offset);
 }
 
@@ -1207,6 +1213,8 @@ void WebGL2RenderingContext::compressedTexImage3D(GCGLenum target, GCGLint level
         return;
     }
     if (!validateTexture3DBinding("compressedTexImage3D"_s, target))
+        return;
+    if (!validateCompressedTexFormat("compressedTexImage3D"_s, internalformat))
         return;
     auto slice = sliceArrayBufferView("compressedTexImage3D"_s, srcData, srcOffset, srcLengthOverride);
     if (!slice)
@@ -1239,6 +1247,8 @@ void WebGL2RenderingContext::compressedTexSubImage2D(GCGLenum target, GCGLint le
     }
     if (!validateTexture2DBinding("compressedTexImage2D"_s, target))
         return;
+    if (!validateCompressedTexFormat("compressedTexSubImage2D"_s, format))
+        return;
     graphicsContextGL()->compressedTexSubImage2D(target, level, xoffset, yoffset, width, height, format, imageSize, offset);
 }
 
@@ -1253,6 +1263,8 @@ void WebGL2RenderingContext::compressedTexSubImage2D(GCGLenum target, GCGLint le
         return;
     }
     if (!validateTexture2DBinding("compressedTexSubImage2D"_s, target))
+        return;
+    if (!validateCompressedTexFormat("compressedTexSubImage2D"_s, format))
         return;
     auto slice = sliceArrayBufferView("compressedTexSubImage2D"_s, srcData, srcOffset, srcLengthOverride);
     if (!slice)
@@ -1272,6 +1284,8 @@ void WebGL2RenderingContext::compressedTexSubImage3D(GCGLenum target, GCGLint le
     }
     if (!validateTexture3DBinding("compressedTexSubImage3D"_s, target))
         return;
+    if (!validateCompressedTexFormat("compressedTexSubImage3D"_s, format))
+        return;
     graphicsContextGL()->compressedTexSubImage3D(target, level, xoffset, yoffset, zoffset, width, height, depth, format, imageSize, offset);
 }
 
@@ -1286,6 +1300,8 @@ void WebGL2RenderingContext::compressedTexSubImage3D(GCGLenum target, GCGLint le
         return;
     }
     if (!validateTexture3DBinding("compressedTexSubImage3D"_s, target))
+        return;
+    if (!validateCompressedTexFormat("compressedTexSubImage3D"_s, format))
         return;
     auto slice = sliceArrayBufferView("compressedTexSubImage3D"_s, srcData, srcOffset, srcLengthOverride);
     if (!slice)

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp
@@ -1287,6 +1287,8 @@ void WebGLRenderingContextBase::compressedTexImage2D(GCGLenum target, GCGLint le
         return;
     if (!validateTexture2DBinding("compressedTexImage2D"_s, target))
         return;
+    if (!validateCompressedTexFormat("compressedTexImage2D"_s, internalformat))
+        return;
     graphicsContextGL()->compressedTexImage2D(target, level, internalformat, width, height, border, data.byteLength(), data.span());
 }
 
@@ -1295,6 +1297,8 @@ void WebGLRenderingContextBase::compressedTexSubImage2D(GCGLenum target, GCGLint
     if (isContextLost())
         return;
     if (!validateTexture2DBinding("compressedTexSubImage2D"_s, target))
+        return;
+    if (!validateCompressedTexFormat("compressedTexSubImage2D"_s, format))
         return;
     graphicsContextGL()->compressedTexSubImage2D(target, level, xoffset, yoffset, width, height, format, data.byteLength(), data.span());
 }
@@ -3723,6 +3727,15 @@ bool WebGLRenderingContextBase::validateTexFunc(TexImageFunctionID functionID, T
             if (!validateSettableTexInternalFormat(functionName, format))
                 return false;
         }
+    }
+    return true;
+}
+
+bool WebGLRenderingContextBase::validateCompressedTexFormat(ASCIILiteral functionName, GCGLenum format)
+{
+    if (!m_compressedTextureFormats.contains(format)) {
+        synthesizeGLError(GraphicsContextGL::INVALID_ENUM, functionName, "invalid format"_s);
+        return false;
     }
     return true;
 }

--- a/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
+++ b/Source/WebCore/html/canvas/WebGLRenderingContextBase.h
@@ -905,6 +905,8 @@ protected:
     bool validateTexFunc(TexImageFunctionID, TexFuncValidationSourceType, GCGLenum target, GCGLint level, GCGLenum internalformat, GCGLsizei width,
         GCGLsizei height, GCGLsizei depth, GCGLint border, GCGLenum format, GCGLenum type, GCGLint xoffset, GCGLint yoffset, GCGLint zoffset);
 
+    bool validateCompressedTexFormat(ASCIILiteral functionName, GCGLenum format);
+
     // Helper function to check input parameters for functions {copy}Tex{Sub}Image.
     // Generates GL error and returns false if parameters are invalid.
     bool validateTexFuncParameters(TexImageFunctionID,


### PR DESCRIPTION
#### 093e61a7cc7384322f1f61df99b120bdb9c473cd
<pre>
Cherry-pick 312180@main (856e4464ec42). <a href="https://bugs.webkit.org/show_bug.cgi?id=313387">https://bugs.webkit.org/show_bug.cgi?id=313387</a>

    WebGL: compressedTexImage does not check if the texture format has been enabled
    <a href="https://bugs.webkit.org/show_bug.cgi?id=313387">https://bugs.webkit.org/show_bug.cgi?id=313387</a>
    <a href="https://rdar.apple.com/175652171">rdar://175652171</a>

    Reviewed by Dan Glastonbury.

    Fix and enable
    webgl/2.0.y/conformance2/textures/misc/compressed-tex-image.html

    Check the compressed texture allow list before forwarding the call.

    * LayoutTests/TestExpectations:
    * Source/WebCore/html/canvas/WebGL2RenderingContext.cpp:
    (WebCore::WebGL2RenderingContext::compressedTexImage2D):
    (WebCore::WebGL2RenderingContext::compressedTexImage3D):
    (WebCore::WebGL2RenderingContext::compressedTexSubImage2D):
    (WebCore::WebGL2RenderingContext::compressedTexSubImage3D):
    * Source/WebCore/html/canvas/WebGLRenderingContextBase.cpp:
    (WebCore::WebGLRenderingContextBase::compressedTexImage2D):
    (WebCore::WebGLRenderingContextBase::compressedTexSubImage2D):
    (WebCore::WebGLRenderingContextBase::validateCompressedTexFormat):
    * Source/WebCore/html/canvas/WebGLRenderingContextBase.h:

    Canonical link: <a href="https://commits.webkit.org/312180@main">https://commits.webkit.org/312180@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.514@webkitglib/2.52">https://commits.webkit.org/305877.514@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7d82c4d4041406e1509cbd41e574f25a24f5696

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162977 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36456 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29638 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171915 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/119423 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164846 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36583 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36458 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126515 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/119423 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165936 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/36583 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/29638 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107091 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/36583 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/36458 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19615 "Unable to build WebKit without PR, please check manually (failure)") | 
| [⏳ 🛠 🧪 jsc ](https://ews-build.webkit.org/#/builders/JSC-Tests-EWS "Waiting in queue, processing has not started yet") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/36583 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/29638 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174419 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/25530 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/29638 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134825 "Passed tests") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36127 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/36458 "Unable to build WebKit without PR, please check manually (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134820 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/36584 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/29638 "Unable to build WebKit without PR, please check manually (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/98637 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24781 "Built successfully and passed tests") | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/36584 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/29638 "Unable to build WebKit without PR, please check manually (failure)") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35623 "Unable to build WebKit without PR, please check manually (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/107207 "Failed to checkout and rebase branch from PR 65070") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35122 "Unable to build WebKit without PR, please check manually (failure)") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35369 "Unable to build WebKit without PR, please check manually (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35270 "Failed to compile WebKit") | | | 
<!--EWS-Status-Bubble-End-->