### PR TITLE
"Open [Image/Video] in New Tab" contextual menu item caused double percent-encoding for unencoded URLs

### DIFF
--- a/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.mm
+++ b/Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.mm
@@ -31,6 +31,7 @@
 #import "WebPageProxy.h"
 #import "_WKFrameHandleInternal.h"
 #import <WebCore/WebCoreObjCExtras.h>
+#import <wtf/URL.h>
 
 #if PLATFORM(MAC) || HAVE(UIKIT_WITH_MOUSE_SUPPORT)
 
@@ -48,7 +49,12 @@
 
 static NSURL *URLFromString(const WTF::String& urlString)
 {
-    return urlString.isEmpty() ? nil : [NSURL URLWithString:urlString.createNSString().get()];
+    // Avoid +[NSURL URLWithString:], which re-encodes the path when it contains characters
+    // that WebCore's URL parser leaves literal (e.g. '[' and ']'), double-encoding the
+    // existing %XX sequences. CFURLCreateAbsoluteURLWithBytes preserves them.
+    if (urlString.isEmpty())
+        return nil;
+    return WTF::URL { urlString }.createNSURL().autorelease();
 }
 
 - (NSURL *)absoluteImageURL

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ContextMenuTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ContextMenuTests.mm
@@ -308,6 +308,30 @@ TEST(ContextMenuTests, HitTestResultDoesNotContainEmptyURLs)
     Util::run(&gotProposedMenu);
 }
 
+TEST(ContextMenuTests, HitTestResultImageURLNotDoubleEncoded)
+{
+    RetainPtr delegate = adoptNS([[TestUIDelegate alloc] init]);
+
+    __block bool gotProposedMenu = false;
+    [delegate setGetContextMenuFromProposedMenu:^(NSMenu *menu, _WKContextMenuElementInfo *elementInfo, id<NSSecureCoding>, void (^completion)(NSMenu *)) {
+        _WKHitTestResult *hitTestResult = elementInfo.hitTestResult;
+        EXPECT_NOT_NULL(hitTestResult);
+        EXPECT_WK_STREQ(@"file:///flower%20%5BA%5D.jpg", hitTestResult.absoluteImageURL.absoluteString);
+        completion(nil);
+        gotProposedMenu = true;
+    }];
+
+    NSString *html = @"<body style='margin:0'><img src='flower [A].jpg' width='400' height='400'>";
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 400, 400)]);
+    [webView setUIDelegate:delegate.get()];
+    [webView synchronouslyLoadHTMLString:html baseURL:[NSURL URLWithString:@"file:///"]];
+    [webView waitForNextPresentationUpdate];
+
+    [webView mouseDownAtPoint:NSMakePoint(200, 200) simulatePressure:NO withFlags:0 eventType:NSEventTypeRightMouseDown];
+    [webView mouseUpAtPoint:NSMakePoint(200, 200) withFlags:0 eventType:NSEventTypeRightMouseUp];
+    Util::run(&gotProposedMenu);
+}
+
 #if ENABLE(CONTEXT_MENU_QR_CODE_DETECTION)
 
 static NSString *qrCodeSVGString()


### PR DESCRIPTION
#### 656a3201fd4ea2421700d9fa0f3a97de1987bfde
<pre>
&quot;Open [Image/Video] in New Tab&quot; contextual menu item caused double percent-encoding for unencoded URLs
<a href="https://bugs.webkit.org/show_bug.cgi?id=314975">https://bugs.webkit.org/show_bug.cgi?id=314975</a>
<a href="https://rdar.apple.com/177297247">rdar://177297247</a>

Reviewed by Darin Adler.

WebCore&apos;s URL parser leaves some characters literal in the path (e.g. &apos;[&apos; and &apos;]&apos; per the
WHATWG URL spec), so `flower [A].jpg` becomes `flower%20[A].jpg`. +[NSURL URLWithString:]
reacts to those literal characters by re-encoding the whole path, turning the existing %20
into %2520 and yielding `flower%2520%5BA%5D.jpg`.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ContextMenuTests.mm

* Source/WebKit/Shared/API/Cocoa/_WKHitTestResult.mm:
(URLFromString): Go through WTF::URL::createNSURL() (CFURLCreateAbsoluteURLWithBytes)
instead of +[NSURL URLWithString:], so that there is no opportunity for disagreement between
different URL implementations.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ContextMenuTests.mm:
(TestWebKitAPI::TEST(ContextMenuTests, HitTestResultImageURLNotDoubleEncoded)):

Canonical link: <a href="https://commits.webkit.org/313430@main">https://commits.webkit.org/313430@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/09db1372d56f23bfde961a9f28411facbe5ac668

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163100 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36579 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29792 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172039 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119546 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7c49037a-952f-44a4-b235-29c2791a52b2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164969 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36719 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36581 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126623 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89229 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f07292de-c774-4233-a894-be380d47e101) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166059 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/28830 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146620 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107198 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f708b6ac-256f-4fac-90ca-3e3892e2c385) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27877 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26568 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19738 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137760 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24341 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174542 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/26525 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25988 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134935 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36250 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30675 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134930 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36381 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/36966 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146136 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98868 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/30166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22976 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35746 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108102 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35245 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/995 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35492 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35393 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->