### PR TITLE
Disclosure counter styles are not correctly oriented in sideways writing modes

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/disclosure-styles-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/disclosure-styles-expected.html
@@ -72,3 +72,27 @@
 <p dir="ltr">&#x25bc;&nbsp;closed ltr
 <p dir="rtl">&#x25b2;&nbsp;closed rtl
 </div>
+<div style="writing-mode: sideways-lr; height: 10em;">
+<ul dir="ltr">
+  <li class="t-u">closed ltr
+  <li class="t-r">open ltr
+</ul>
+<ul dir="rtl">
+  <li class="t-d">closed rtl
+  <li class="t-r">open rtl
+</ul>
+<p dir="ltr">&#x25b2;&nbsp;closed ltr
+<p dir="rtl">&#x25bc;&nbsp;closed rtl
+</div>
+<div style="writing-mode: sideways-rl; height: 10em;">
+<ul dir="ltr">
+  <li class="t-d">closed ltr
+  <li class="t-l">open ltr
+</ul>
+<ul dir="rtl">
+  <li class="t-u">closed rtl
+  <li class="t-l">open rtl
+</ul>
+<p dir="ltr">&#x25bc;&nbsp;closed ltr
+<p dir="rtl">&#x25b2;&nbsp;closed rtl
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/disclosure-styles-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/disclosure-styles-ref.html
@@ -73,3 +73,27 @@
 <p dir="ltr">&#x25bc;&nbsp;closed ltr
 <p dir="rtl">&#x25b2;&nbsp;closed rtl
 </div>
+<div style="writing-mode: sideways-lr; height: 10em;">
+<ul dir="ltr">
+  <li class="t-u">closed ltr
+  <li class="t-r">open ltr
+</ul>
+<ul dir="rtl">
+  <li class="t-d">closed rtl
+  <li class="t-r">open rtl
+</ul>
+<p dir="ltr">&#x25b2;&nbsp;closed ltr
+<p dir="rtl">&#x25bc;&nbsp;closed rtl
+</div>
+<div style="writing-mode: sideways-rl; height: 10em;">
+<ul dir="ltr">
+  <li class="t-d">closed ltr
+  <li class="t-l">open ltr
+</ul>
+<ul dir="rtl">
+  <li class="t-u">closed rtl
+  <li class="t-l">open rtl
+</ul>
+<p dir="ltr">&#x25bc;&nbsp;closed ltr
+<p dir="rtl">&#x25b2;&nbsp;closed rtl
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/disclosure-styles.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/disclosure-styles.html
@@ -59,3 +59,27 @@
   <p dir="ltr">closed ltr
   <p dir="rtl">closed rtl
 </div>
+<div style="writing-mode: sideways-lr; height: 10em;">
+  <ul dir="ltr">
+    <li class="closed">closed ltr
+    <li class="open">open ltr
+  </ul>
+  <ul dir="rtl">
+    <li class="closed">closed rtl
+    <li class="open">open rtl
+  </ul>
+  <p dir="ltr">closed ltr
+  <p dir="rtl">closed rtl
+</div>
+<div style="writing-mode: sideways-rl; height: 10em;">
+  <ul dir="ltr">
+    <li class="closed">closed ltr
+    <li class="open">open ltr
+  </ul>
+  <ul dir="rtl">
+    <li class="closed">closed rtl
+    <li class="open">open rtl
+  </ul>
+  <p dir="ltr">closed ltr
+  <p dir="rtl">closed rtl
+</div>

--- a/Source/WebCore/css/CSSRegisteredCounterStyle.cpp
+++ b/Source/WebCore/css/CSSRegisteredCounterStyle.cpp
@@ -243,9 +243,18 @@ static String counterForSystemCJK(int number, const std::array<char16_t, 17>& ta
 
 String CSSRegisteredCounterStyle::counterForSystemDisclosureClosed(WritingMode writingMode)
 {
-    if (writingMode.isVerticalTypographic())
-        return span(writingMode.isInlineTopToBottom() ? blackDownPointingTriangle : blackUpPointingTriangle);
-    return span(writingMode.isBidiLTR() ? blackRightPointingTriangle : blackLeftPointingTriangle);
+    switch (writingMode.inlineDirection()) {
+    case FlowDirection::TopToBottom:
+        return span(blackDownPointingTriangle);
+    case FlowDirection::BottomToTop:
+        return span(blackUpPointingTriangle);
+    case FlowDirection::LeftToRight:
+        return span(blackRightPointingTriangle);
+    case FlowDirection::RightToLeft:
+        return span(blackLeftPointingTriangle);
+    }
+    ASSERT_NOT_REACHED();
+    return { };
 }
 
 String CSSRegisteredCounterStyle::counterForSystemDisclosureOpen(WritingMode writingMode)


### PR DESCRIPTION
#### 0d5e71e5e4c660cfdbb0542327203de7d4136ceb
<pre>
Disclosure counter styles are not correctly oriented in sideways writing modes
<a href="https://bugs.webkit.org/show_bug.cgi?id=287505">https://bugs.webkit.org/show_bug.cgi?id=287505</a>
<a href="https://rdar.apple.com/144635565">rdar://144635565</a>

Reviewed by NOBODY (OOPS!).

In sideways-lr and sideways-rl, disclosure-closed rendered a horizontal
arrow because `counterForSystemDisclosureClosed` gated its vertical branch
on `WritingMode::isVerticalTypographic()`, which is true only for
vertical-lr and vertical-rl. Sideways modes fell through to the horizontal
`isBidiLTR()` branch and produced an arrow along the (horizontal) block
axis instead of along the (vertical) inline axis.

Per CSS Counter Styles 3, the closed state must point in the inline-end
direction. Therefore switch on `WritingMode::inlineDirection()`, mirroring
the structure of `counterForSystemDisclosureOpen`, which already switches
on `blockDirection()` for the block-end direction.

* LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/disclosure-styles-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/disclosure-styles-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/counter-style-at-rule/disclosure-styles.html:
* Source/WebCore/css/CSSRegisteredCounterStyle.cpp:
(WebCore::CSSRegisteredCounterStyle::counterForSystemDisclosureClosed):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d5e71e5e4c660cfdbb0542327203de7d4136ceb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162989 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36468 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29654 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171928 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119435 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e379de79-5a52-4d1a-a71d-ef03d72dafbe) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164858 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36851 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36470 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126526 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89132 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c1100e89-c9ac-4c58-a1ed-48d2b3377cad) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165948 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28897 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146486 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107102 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5becdc5f-cb61-4846-80c9-6d0df038f2a2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27943 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26462 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19627 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137834 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24215 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174431 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/25473 "Found 1 new failure in wasm/WasmConstExprGenerator.cpp") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25862 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134836 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36139 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30565 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134831 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37005 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146011 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98661 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30203 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22848 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35635 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/107152 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35134 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/870 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35381 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35282 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->