### PR TITLE
Out of line CSS Calc Variant types

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -1141,6 +1141,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
 
     css/calc/CSSCalcOperator.h
     css/calc/CSSCalcRandomCachingKey.h
+    css/calc/CSSCalcRandomSharingOptions.h
     css/calc/CSSCalcSymbolTable.h
     css/calc/CSSCalcTree.h
     css/calc/CSSCalcType.h

--- a/Source/WebCore/css/CSSGradientValue.cpp
+++ b/Source/WebCore/css/CSSGradientValue.cpp
@@ -33,6 +33,7 @@
 #include "CSSPrimitiveNumericTypes+Serialization.h"
 #include "ColorInterpolation.h"
 #include "StyleBuilderState.h"
+#include "StyleCalculationValue.h"
 #include "StyleGradientImage.h"
 #include "StylePrimitiveNumericTypes+Conversions.h"
 #include <wtf/text/StringBuilder.h>

--- a/Source/WebCore/css/CSSPrimitiveValue.cpp
+++ b/Source/WebCore/css/CSSPrimitiveValue.cpp
@@ -170,6 +170,16 @@ CSSPrimitiveValue::~CSSPrimitiveValue()
     }
 }
 
+Ref<const CSSCalc::Value> CLANG_POINTER_CONVERSION CSSCalc::protect(const CSSCalc::Value& value)
+{
+    return value;
+}
+
+RefPtr<const CSSCalc::Value> CLANG_POINTER_CONVERSION CSSCalc::protect(const CSSCalc::Value* value)
+{
+    return value;
+}
+
 static CSSPrimitiveValue* valueFromPool(std::span<AlignedStorage<CSSPrimitiveValue>> pool, double value)
 {
     // Casting to a signed integer first since casting a negative floating point value to an unsigned

--- a/Source/WebCore/css/CSSPrimitiveValue.h
+++ b/Source/WebCore/css/CSSPrimitiveValue.h
@@ -22,7 +22,6 @@
 
 #pragma once
 
-#include <WebCore/CSSCalcValue.h>
 #include <WebCore/CSSPrimitiveNumericUnits.h>
 #include <WebCore/CSSValue.h>
 #include <WebCore/CSSValueKeywords.h>
@@ -37,6 +36,12 @@ class CSSToLengthConversionData;
 class FontCascade;
 class RenderStyle;
 class RenderView;
+
+namespace CSSCalc {
+class Value;
+Ref<const Value> CLANG_POINTER_CONVERSION protect(const Value&);
+RefPtr<const Value> CLANG_POINTER_CONVERSION protect(const Value*);
+}
 
 template<typename> class ExceptionOr;
 
@@ -80,7 +85,7 @@ public:
     {
         auto visitor = WTF::makeVisitor(std::forward<F>(f)...);
         if (isCalculated())
-            return visitor(protect(*m_value.calc));
+            SUPPRESS_FORWARD_DECL_ARG return visitor(protect(*m_value.calc));
         return visitor(Raw { primitiveUnitType(), m_value.number });
     }
 

--- a/Source/WebCore/css/CSSPropertyInitialValues.cpp
+++ b/Source/WebCore/css/CSSPropertyInitialValues.cpp
@@ -29,6 +29,7 @@
 
 #include "CSSBorderImageSliceValue.h"
 #include "CSSBorderImageWidthValue.h"
+#include "CSSCalcValue.h"
 #include "CSSKeywordValueInlines.h"
 #include "CSSOffsetRotateValue.h"
 #include "CSSPrimitiveValue.h"

--- a/Source/WebCore/css/CSSViewValue.h
+++ b/Source/WebCore/css/CSSViewValue.h
@@ -30,6 +30,7 @@
 
 #include "CSSPrimitiveValue.h"
 #include "RenderStyleConstants.h"
+#include <wtf/Function.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/css/DeprecatedCSSOMPrimitiveValue.cpp
+++ b/Source/WebCore/css/DeprecatedCSSOMPrimitiveValue.cpp
@@ -28,6 +28,7 @@
 #include "DeprecatedCSSOMPrimitiveValue.h"
 
 #include "CSSAttrValue.h"
+#include "CSSCalcValue.h"
 #include "CSSColorValue.h"
 #include "CSSCounterValue.h"
 #include "CSSCustomIdentValue.h"

--- a/Source/WebCore/css/ShorthandSerializer.cpp
+++ b/Source/WebCore/css/ShorthandSerializer.cpp
@@ -27,6 +27,7 @@
 #include "ShorthandSerializer.h"
 
 #include "CSSBorderImageWidthValue.h"
+#include "CSSCalcValue.h"
 #include "CSSCustomIdentValue.h"
 #include "CSSGridAutoFlowValue.h"
 #include "CSSGridLineValue.h"

--- a/Source/WebCore/css/calc/CSSCalcRandomCachingKey.h
+++ b/Source/WebCore/css/calc/CSSCalcRandomCachingKey.h
@@ -24,7 +24,7 @@
 
 #pragma once
 
-#include <WebCore/CSSCalcTree.h>
+#include <WebCore/CSSCalcRandomSharingOptions.h>
 #include <WebCore/StyleCustomIdent.h>
 #include <optional>
 #include <wtf/HashFunctions.h>
@@ -36,19 +36,19 @@ namespace CSSCalc {
 
 struct RandomCachingKey {
     using Identifier = Variant<
-        Random::SharingOptions::Auto,
+        RandomSharingOptions::Auto,
         Style::CustomIdent,
         WTF::HashTableDeletedValueType,
         WTF::HashTableEmptyValueType
     >;
     Identifier identifier;
 
-    RandomCachingKey(const Random::SharingOptions::Auto& identifier)
+    RandomCachingKey(const RandomSharingOptions::Auto& identifier)
         : identifier { identifier }
     {
     }
 
-    RandomCachingKey(Random::SharingOptions::Auto&& identifier)
+    RandomCachingKey(RandomSharingOptions::Auto&& identifier)
         : identifier { WTF::move(identifier) }
     {
     }
@@ -63,12 +63,12 @@ struct RandomCachingKey {
     {
     }
 
-    RandomCachingKey(Variant<Random::SharingOptions::Auto, Style::CustomIdent>&& identifier)
+    RandomCachingKey(Variant<RandomSharingOptions::Auto, Style::CustomIdent>&& identifier)
         : identifier { convertToIdentifier(WTF::move(identifier)) }
     {
     }
 
-    RandomCachingKey(const Variant<Random::SharingOptions::Auto, Style::CustomIdent>& identifier)
+    RandomCachingKey(const Variant<RandomSharingOptions::Auto, Style::CustomIdent>& identifier)
         : identifier { convertToIdentifier(identifier) }
     {
     }
@@ -89,12 +89,12 @@ struct RandomCachingKey {
     bool operator==(const RandomCachingKey&) const = default;
 
 private:
-    static Identifier convertToIdentifier(Variant<Random::SharingOptions::Auto, Style::CustomIdent>&& identifier)
+    static Identifier convertToIdentifier(Variant<RandomSharingOptions::Auto, Style::CustomIdent>&& identifier)
     {
         return WTF::switchOn(WTF::move(identifier), [](auto&& alternative) { return Identifier { WTF::move(alternative) }; });
     }
 
-    static Identifier convertToIdentifier(const Variant<Random::SharingOptions::Auto, Style::CustomIdent>& identifier)
+    static Identifier convertToIdentifier(const Variant<RandomSharingOptions::Auto, Style::CustomIdent>& identifier)
     {
         return WTF::switchOn(identifier, [](const auto& alternative) { return Identifier { alternative }; });
     }
@@ -111,7 +111,7 @@ struct CSSCalcRandomCachingKeyHash {
         Hasher hasher;
         add(hasher, key.identifier.index());
         WTF::switchOn(key.identifier,
-            [&](const WebCore::CSSCalc::Random::SharingOptions::Auto& autoValue) {
+            [&](const WebCore::CSSCalc::RandomSharingOptions::Auto& autoValue) {
                 add(hasher, autoValue.property);
                 add(hasher, autoValue.index);
             },

--- a/Source/WebCore/css/calc/CSSCalcRandomSharingOptions.h
+++ b/Source/WebCore/css/calc/CSSCalcRandomSharingOptions.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2024-2025 Samuel Weinig <sam@webkit.org>
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include <WebCore/CSSCustomIdent.h>
+#include <WebCore/CSSValueKeywords.h>
+#include <optional>
+#include <wtf/Variant.h>
+
+namespace WebCore {
+
+enum CSSPropertyID : uint16_t;
+
+namespace CSSCalc {
+
+// <random-value-sharing> = [ [ auto | <dashed-ident> ] || element-scoped ] | fixed <number [0,1]>
+struct RandomSharingOptions {
+    struct Auto {
+        CSSPropertyID property;
+        unsigned index;
+
+        bool operator==(const Auto&) const = default;
+    };
+    Variant<Auto, CSS::CustomIdent> identifier;
+    std::optional<CSS::Keyword::ElementScoped> elementScoped;
+
+    bool operator==(const RandomSharingOptions&) const = default;
+};
+
+} // namespace CSSCalc
+} // namespace WebCore

--- a/Source/WebCore/css/calc/CSSCalcTree.h
+++ b/Source/WebCore/css/calc/CSSCalcTree.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/CSSCalcRandomSharingOptions.h>
 #include <WebCore/CSSCalcType.h>
 #include <WebCore/CSSCustomIdent.h>
 #include <WebCore/CSSPrimitiveNumeric.h>
@@ -761,18 +762,7 @@ struct Random {
     static constexpr auto id = CSSValueRandom;
 
     // <random-value-sharing> = [ [ auto | <dashed-ident> ] || element-scoped ] | fixed <number [0,1]>
-    struct SharingOptions {
-        struct Auto {
-            CSSPropertyID property;
-            unsigned index;
-
-            bool operator==(const Auto&) const = default;
-        };
-        Variant<Auto, CSS::CustomIdent> identifier;
-        std::optional<CSS::Keyword::ElementScoped> elementScoped;
-
-        bool operator==(const SharingOptions&) const = default;
-    };
+    using SharingOptions = RandomSharingOptions;
     struct SharingFixed {
         CSS::Number<CSS::ClosedUnitRange> value;
 

--- a/Source/WebCore/css/parser/CSSPropertyParser.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParser.cpp
@@ -69,6 +69,7 @@
 #include "CSSWideKeyword.h"
 #include "ComputedStyleDependencies.h"
 #include "StyleBuilder.h"
+#include "StyleCalculationValue.h"
 #include "StyleCustomIdent.h"
 #include "StyleCustomProperty.h"
 #include "StylePrimitiveNumericTypes+CSSValueConversion.h"

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Timeline.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Timeline.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "CSSPropertyParserConsumer+Timeline.h"
 
+#include "CSSCalcValue.h"
 #include "CSSParserContext.h"
 #include "CSSParserTokenRange.h"
 #include "CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h"

--- a/Source/WebCore/css/typedom/CSSNumericValue.cpp
+++ b/Source/WebCore/css/typedom/CSSNumericValue.cpp
@@ -35,6 +35,7 @@
 #include "CSSCalcTree+Parser.h"
 #include "CSSCalcTree+Simplification.h"
 #include "CSSCalcTree.h"
+#include "CSSCalcValue.h"
 #include "CSSMathClamp.h"
 #include "CSSMathInvert.h"
 #include "CSSMathMax.h"

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapper.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapper.h
@@ -129,7 +129,7 @@ template<typename Numeric, CSS::SpecificKeyword... Ks> struct LengthWrapperBase 
 
              if (opaqueType == indexForFixed)       return visitor(Fixed { m_value.value() });
         else if (opaqueType == indexForPercentage)  return visitor(Percentage { m_value.value() });
-        else if (opaqueType == indexForCalc)        return visitor(Calc { m_value.calculationValue() });
+        else if (opaqueType == indexForCalc)        SUPPRESS_FORWARD_DECL_ARG return visitor(Calc { m_value.calculationValue() });
 
         RELEASE_ASSERT_NOT_REACHED();
     }

--- a/Source/WebCore/style/values/primitives/StyleLengthWrapperData.h
+++ b/Source/WebCore/style/values/primitives/StyleLengthWrapperData.h
@@ -24,11 +24,15 @@
 
 #pragma once
 
-#include <WebCore/StyleCalculationValue.h>
 #include <WebCore/StyleZoomPrimitives.h>
+#include <wtf/Ref.h>
 
 namespace WebCore {
 namespace Style {
+
+namespace Calculation {
+class Value;
+}
 
 enum class LengthWrapperDataKind : uint8_t {
     Default,

--- a/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
+++ b/Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h
@@ -31,7 +31,6 @@
 #include "CSSToLengthConversionData.h"
 #include "FloatConversion.h"
 #include "StyleBuilderState.h"
-#include "StyleCalculationValue.h"
 #include "StylePrimitiveNumericTypes.h"
 #include "StylePrimitiveNumericTypes+Rounding.h"
 

--- a/Source/WebCore/style/values/primitives/StyleUnevaluatedCalculation.cpp
+++ b/Source/WebCore/style/values/primitives/StyleUnevaluatedCalculation.cpp
@@ -59,6 +59,11 @@ UnevaluatedCalculationBase& UnevaluatedCalculationBase::operator=(UnevaluatedCal
 
 UnevaluatedCalculationBase::~UnevaluatedCalculationBase() = default;
 
+Ref<Calculation::Value> CLANG_POINTER_CONVERSION Calculation::protect(Calculation::Value& value)
+{
+    return value;
+}
+
 double UnevaluatedCalculationBase::evaluate(double percentageBasis, ZoomFactor zoom) const
 {
     return protect(m_calc)->evaluate(percentageBasis, zoom);

--- a/Source/WebCore/style/values/primitives/StyleUnevaluatedCalculation.h
+++ b/Source/WebCore/style/values/primitives/StyleUnevaluatedCalculation.h
@@ -34,6 +34,7 @@ namespace Style {
 namespace Calculation {
 class Value;
 struct Child;
+Ref<Value> CLANG_POINTER_CONVERSION protect(Value&);
 }
 
 struct ZoomFactor;


### PR DESCRIPTION
#### c22b96fcd756836c692875b9f08d6f99651f235d
<pre>
Out of line CSS Calc Variant types
<a href="https://bugs.webkit.org/show_bug.cgi?id=314989">https://bugs.webkit.org/show_bug.cgi?id=314989</a>
&lt;<a href="https://rdar.apple.com/problem/177297919">rdar://problem/177297919</a>&gt;

Reviewed by Elliott Williams.

Saves ~5s wall time in a clean build.

Use forward declaration to avoid pulling in CSSCalcTree.h when it isn&apos;t needed.

* Source/WebCore/Headers.cmake:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Source/WebCore/css/CSSGradientValue.cpp:
* Source/WebCore/css/CSSPrimitiveValue.cpp:
(WebCore::CSSCalc::protect):
* Source/WebCore/css/CSSPrimitiveValue.h:
* Source/WebCore/css/CSSPropertyInitialValues.cpp:
* Source/WebCore/css/CSSViewValue.h:
* Source/WebCore/css/DeprecatedCSSOMPrimitiveValue.cpp:
* Source/WebCore/css/ShorthandSerializer.cpp:
* Source/WebCore/css/calc/CSSCalcRandomCachingKey.h:
(WebCore::CSSCalc::RandomCachingKey::RandomCachingKey):
(WebCore::CSSCalc::RandomCachingKey::convertToIdentifier):
(WTF::CSSCalcRandomCachingKeyHash::hash):
* Source/WebCore/css/calc/CSSCalcRandomSharingOptions.h: Added.
* Source/WebCore/css/calc/CSSCalcTree.h:
* Source/WebCore/css/parser/CSSPropertyParser.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Timeline.cpp:
* Source/WebCore/style/values/primitives/StyleLengthWrapper.h:
(WebCore::Style::LengthWrapperBase::switchOn const):
* Source/WebCore/style/values/primitives/StyleLengthWrapperData.h:
* Source/WebCore/style/values/primitives/StylePrimitiveNumericTypes+Conversions.h:
* Source/WebCore/style/values/primitives/StyleUnevaluatedCalculation.cpp:
(WebCore::Style::Calculation::protect):
* Source/WebCore/style/values/primitives/StyleUnevaluatedCalculation.h:

Canonical link: <a href="https://commits.webkit.org/313498@main">https://commits.webkit.org/313498@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe780cc0a6fd60d01c1ba0fab715423f67e06acf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163281 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36763 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29979 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172220 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119728 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/db244533-3f2b-455b-ac9d-8a219416b86b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165150 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37090 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36763 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126792 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/89386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0edb2324-a4b8-4345-9fc4-3d34faaf2c82) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166240 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29062 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146786 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107359 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/277c3267-f853-4300-b321-bbb0d059db16) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28108 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26736 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19922 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138002 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24510 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174723 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27177 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26165 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135098 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36432 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30838 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135090 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37219 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146305 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99159 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24848 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30391 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23150 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35928 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108598 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35427 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1175 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35674 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35575 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->