### PR TITLE
[Skia] Render unaccelerated tiles as RGBA when the Skia compositor is enabled

### DIFF
--- a/LayoutTests/compositing/animation/repaint-after-clearing-shared-backing.html
+++ b/LayoutTests/compositing/animation/repaint-after-clearing-shared-backing.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html>
     <head>
+        <meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-200">
         <style>
             .background {
                 position: absolute;

--- a/LayoutTests/compositing/overlap-blending/nested-overlap.html
+++ b/LayoutTests/compositing/overlap-blending/nested-overlap.html
@@ -1,6 +1,6 @@
 <html>
     <head>
-        <meta name="fuzzy" content="maxDifference=0-1; totalPixels=40000">
+        <meta name="fuzzy" content="maxDifference=0-3; totalPixels=40000">
         <style>
             div {
                 -webkit-transform: translateZ(0);

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/outline-005.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/outline-005.html
@@ -6,7 +6,7 @@
   <meta name=flags content="should">
   <meta name=assert content="To the extent that the outline follows the border edge, it should follow the border-radius curve.">
   <!-- Allow slight color differences where the outline and the background intersect -->
-  <meta name=fuzzy content="0-2;0-100">
+  <meta name=fuzzy content="0-4;0-100">
   <link rel="match" href="../reference/ref-filled-green-100px-square.xht">
   <link rel=help href="https://drafts.csswg.org/css-ui-3/#outline-props">
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-object-fit-none.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-object-fit-none.html
@@ -4,6 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:vmpstr@chromium.org">
 <link rel="match" href="content-object-fit-none-ref.html">
+<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-400">
 <script src="/common/reftest-wait.js"></script>
 <style>
 #target {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-rendering-invalidation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-rendering-invalidation.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:bokan@chromium.org">
 <link rel="match" href="pseudo-rendering-invalidation-ref.html">
-<meta name="fuzzy" content="maxDifference=0-20; totalPixels=0-300">
+<meta name="fuzzy" content="maxDifference=0-20; totalPixels=0-600">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/snapshot-containing-block-absolute.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/snapshot-containing-block-absolute.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:bokan@chromium.org">
 <link rel="match" href="snapshot-containing-block-absolute-ref.html">
-<meta name="fuzzy" content="maxDifference=0-20; totalPixels=0-100">
+<meta name="fuzzy" content="maxDifference=0-20; totalPixels=0-300">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/snapshot-containing-block-static.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/snapshot-containing-block-static.html
@@ -4,7 +4,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-view-transitions-1/">
 <link rel="author" href="mailto:bokan@chromium.org">
 <link rel="match" href="snapshot-containing-block-static-ref.html">
-<meta name="fuzzy" content="maxDifference=0-20; totalPixels=0-100">
+<meta name="fuzzy" content="maxDifference=0-20; totalPixels=0-300">
 
 <script src="/common/reftest-wait.js"></script>
 <style>

--- a/Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp
@@ -180,7 +180,8 @@ void SkiaBackingStore::Tile::update(const IntRect& dirtyRect, const IntRect& til
         }
     } else if (tryEnsureSurface(tileRect.size(), buffer)) {
         auto& unacceleratedBuffer = static_cast<CoordinatedUnacceleratedTileBuffer&>(buffer);
-        auto imageInfo = SkImageInfo::Make(dirtyRect.width(), dirtyRect.height(), kBGRA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
+        auto colorType = unacceleratedBuffer.pixelFormat() == PixelFormat::RGBA8 ? kRGBA_8888_SkColorType : kBGRA_8888_SkColorType;
+        auto imageInfo = SkImageInfo::Make(dirtyRect.width(), dirtyRect.height(), colorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
         SkPixmap pixmap(imageInfo, unacceleratedBuffer.data(), unacceleratedBuffer.stride());
         m_surface->writePixels(pixmap, dirtyRect.x(), dirtyRect.y());
     }

--- a/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
@@ -75,7 +75,8 @@ static bool canPerformAcceleratedRendering()
     return ProcessCapabilities::canUseAcceleratedBuffers() && PlatformDisplay::sharedDisplay().skiaGLContext();
 }
 
-SkiaPaintingEngine::SkiaPaintingEngine()
+SkiaPaintingEngine::SkiaPaintingEngine(UseSkiaForComposition useSkiaForComposition)
+    : m_useSkiaForComposition(useSkiaForComposition)
 {
     if (canPerformAcceleratedRendering()) {
         if (auto numberOfGPUThreads = numberOfGPUPaintingThreads())
@@ -90,9 +91,9 @@ SkiaPaintingEngine::SkiaPaintingEngine()
 
 SkiaPaintingEngine::~SkiaPaintingEngine() = default;
 
-std::unique_ptr<SkiaPaintingEngine> SkiaPaintingEngine::create()
+std::unique_ptr<SkiaPaintingEngine> SkiaPaintingEngine::create(UseSkiaForComposition useSkiaForComposition)
 {
-    return makeUnique<SkiaPaintingEngine>();
+    return makeUnique<SkiaPaintingEngine>(useSkiaForComposition);
 }
 
 void SkiaPaintingEngine::paintIntoGraphicsContext(const GraphicsLayer& layer, GraphicsContext& context, const IntRect& dirtyRect, bool contentsOpaque, float contentsScale) const
@@ -126,7 +127,12 @@ Ref<CoordinatedTileBuffer> SkiaPaintingEngine::createBuffer(RenderingMode render
         return CoordinatedAcceleratedTileBuffer::create(BitmapTexturePool::singleton().acquireTexture(size, textureFlags));
     }
 
-    return CoordinatedUnacceleratedTileBuffer::create(size, contentsOpaque ? CoordinatedTileBuffer::NoFlags : CoordinatedTileBuffer::SupportsAlpha);
+    // The Skia compositor uploads CPU tiles via SkSurface::writePixels() into RGBA
+    // textures, so render them directly as RGBA to avoid a per-pixel BGRA->RGBA
+    // conversion on every upload. The TextureMapper compositor keeps BGRA, since it
+    // uploads raw and swizzles in the sampling shader.
+    auto pixelFormat = m_useSkiaForComposition == UseSkiaForComposition::Yes ? PixelFormat::RGBA8 : PixelFormat::BGRA8;
+    return CoordinatedUnacceleratedTileBuffer::create(size, contentsOpaque ? CoordinatedTileBuffer::NoFlags : CoordinatedTileBuffer::SupportsAlpha, pixelFormat);
 }
 
 RefPtr<SkiaGPUAtlas> SkiaPaintingEngine::createAtlas(const SkiaImageAtlasLayout& layout, AtlasUploadCondition& uploadCondition, bool& needsUploadFence)

--- a/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h
@@ -45,14 +45,16 @@ class SkiaImageAtlasLayout;
 class SkiaRecordingResult;
 enum class RenderingMode : uint8_t;
 
+enum class UseSkiaForComposition : bool { No, Yes };
+
 class SkiaPaintingEngine {
     WTF_MAKE_TZONE_ALLOCATED(SkiaPaintingEngine);
     WTF_MAKE_NONCOPYABLE(SkiaPaintingEngine);
 public:
-    SkiaPaintingEngine();
+    explicit SkiaPaintingEngine(UseSkiaForComposition);
     ~SkiaPaintingEngine();
 
-    static std::unique_ptr<SkiaPaintingEngine> create();
+    static std::unique_ptr<SkiaPaintingEngine> create(UseSkiaForComposition);
 
     static unsigned numberOfCPUPaintingThreads();
     static unsigned numberOfGPUPaintingThreads();
@@ -71,6 +73,8 @@ private:
     void paintIntoGraphicsContext(const GraphicsLayer&, GraphicsContext&, const IntRect&, bool contentsOpaque, float contentsScale) const;
     RefPtr<SkiaGPUAtlas> createAtlas(const SkiaImageAtlasLayout&, AtlasUploadCondition&, bool& needsUploadFence);
     bool tryReuseCachedAtlases(SkiaRecordingResult&, unsigned fingerprint);
+
+    UseSkiaForComposition m_useSkiaForComposition { UseSkiaForComposition::No };
 
     RefPtr<WorkerPool> m_paintingWorkerPool;
     RefPtr<WorkQueue> m_uploadWorkQueue;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.cpp
@@ -112,15 +112,17 @@ void CoordinatedTileBuffer::waitUntilPaintingComplete()
     });
 }
 
-Ref<CoordinatedTileBuffer> CoordinatedUnacceleratedTileBuffer::create(const IntSize& size, Flags flags)
+Ref<CoordinatedTileBuffer> CoordinatedUnacceleratedTileBuffer::create(const IntSize& size, Flags flags, PixelFormat pixelFormat)
 {
-    return adoptRef(*new CoordinatedUnacceleratedTileBuffer(size, flags));
+    return adoptRef(*new CoordinatedUnacceleratedTileBuffer(size, flags, pixelFormat));
 }
 
-CoordinatedUnacceleratedTileBuffer::CoordinatedUnacceleratedTileBuffer(const IntSize& size, Flags flags)
+CoordinatedUnacceleratedTileBuffer::CoordinatedUnacceleratedTileBuffer(const IntSize& size, Flags flags, PixelFormat pixelFormat)
     : CoordinatedTileBuffer(flags)
     , m_size(size)
+    , m_pixelFormat(pixelFormat)
 {
+    ASSERT(pixelFormat == PixelFormat::BGRA8 || pixelFormat == PixelFormat::RGBA8);
     const auto checkedArea = size.area() * 4;
     m_data = MallocSpan<unsigned char>::tryZeroedMalloc(checkedArea);
 
@@ -146,7 +148,8 @@ bool CoordinatedUnacceleratedTileBuffer::tryEnsureSurface()
     if (m_surface)
         return true;
 
-    auto imageInfo = SkImageInfo::Make(m_size.width(), m_size.height(), kBGRA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
+    auto colorType = m_pixelFormat == PixelFormat::RGBA8 ? kRGBA_8888_SkColorType : kBGRA_8888_SkColorType;
+    auto imageInfo = SkImageInfo::Make(m_size.width(), m_size.height(), colorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
     // FIXME: ref buffer and unref on release proc?
     auto properties = FontRenderOptions::singleton().createSurfaceProps();
     m_surface = SkSurfaces::WrapPixels(imageInfo, data(), imageInfo.minRowBytes64(), &properties);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.h
@@ -104,7 +104,7 @@ private:
 
 class CoordinatedUnacceleratedTileBuffer final : public CoordinatedTileBuffer {
 public:
-    WEBCORE_EXPORT static Ref<CoordinatedTileBuffer> create(const IntSize&, Flags);
+    WEBCORE_EXPORT static Ref<CoordinatedTileBuffer> create(const IntSize&, Flags, PixelFormat = PixelFormat::BGRA8);
     WEBCORE_EXPORT virtual ~CoordinatedUnacceleratedTileBuffer();
 
     int stride() const { return m_size.width() * 4; }
@@ -112,10 +112,10 @@ public:
     const unsigned char* data() const { return m_data.span().data(); }
     unsigned char* data() { return m_data.mutableSpan().data(); }
 
-    PixelFormat pixelFormat() const { return PixelFormat::BGRA8; }
+    PixelFormat pixelFormat() const { return m_pixelFormat; }
 
 private:
-    CoordinatedUnacceleratedTileBuffer(const IntSize&, Flags);
+    CoordinatedUnacceleratedTileBuffer(const IntSize&, Flags, PixelFormat);
 
     bool isBackedByOpenGL() const final { return false; }
     IntSize size() const final { return m_size; }
@@ -126,6 +126,7 @@ private:
 
     MallocSpan<unsigned char> m_data;
     IntSize m_size;
+    PixelFormat m_pixelFormat { PixelFormat::BGRA8 };
 
     enum class PaintingState {
         InProgress,

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -71,7 +71,7 @@ std::unique_ptr<LayerTreeHost> LayerTreeHost::create(WebPage& webPage)
 LayerTreeHost::LayerTreeHost(WebPage& webPage)
     : m_webPage(webPage)
     , m_sceneState(CoordinatedSceneState::create())
-    , m_skiaPaintingEngine(SkiaPaintingEngine::create())
+    , m_skiaPaintingEngine(SkiaPaintingEngine::create(webPage.corePage()->settings().useSkiaForComposition() ? UseSkiaForComposition::Yes : UseSkiaForComposition::No))
 {
     {
         auto& rootLayer = m_sceneState->rootLayer();

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.cpp
@@ -77,7 +77,7 @@ LayerTreeHost::LayerTreeHost(WebPage& webPage, WebCore::PlatformDisplayID displa
 #if USE(CAIRO)
     , m_paintingEngine(Cairo::PaintingEngine::create())
 #elif USE(SKIA)
-    , m_skiaPaintingEngine(SkiaPaintingEngine::create())
+    , m_skiaPaintingEngine(SkiaPaintingEngine::create(UseSkiaForComposition::No))
 #endif
 {
     {


### PR DESCRIPTION
#### f3218060f8e9735b6e22c1a24fe0b975bdf11fab
<pre>
[Skia] Render unaccelerated tiles as RGBA when the Skia compositor is enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=314990">https://bugs.webkit.org/show_bug.cgi?id=314990</a>

Reviewed by NOBODY (OOPS!).

The Skia compositor uploads CPU-rendered tiles via SkSurface::writePixels()
into kRGBA_8888 texture-backed surfaces. Since CoordinatedUnacceleratedTileBuffer
produced BGRA8 pixels, writePixels() performed a full per-pixel BGRA-&gt;RGBA
conversion of every dirty region on every tile, every frame. The TextureMapper
compositor never paid this cost: it uploads the BGRA bytes raw into the RGBA
texture and defers the swizzle to the sampling shader via
BitmapTexture::colorConvertFlags(). The Skia compositor used to defer the
swizzle similarly, applying a swapRedBlueMatrix color filter at draw time, but
<a href="https://commits.webkit.org/313079@main">313079@main</a> intentionally removed that draw-time filter and moved the BGRA-&gt;RGBA
conversion to upload time in order to prepare batched image drawing support.
As a consequence CPU-rendered tiles now pay the per-pixel conversion in
writePixels(), which regressed CPU rendering (visible on MotionMark) once the
Skia compositor became the default.

Make CoordinatedUnacceleratedTileBuffer&apos;s pixel format a construction-time
choice (defaulting to BGRA8) and have SkiaPaintingEngine select RGBA8 when the
Skia compositor is active, so writePixels() becomes a plain copy. The Cairo and
TextureMapper-compositor consumers keep the BGRA8 default and are unchanged
(TextureMapper still uploads raw and swizzles in the shader). SkiaBackingStore
now derives the source pixmap color type from the buffer&apos;s actual pixel format.

A few reftests show additional changed pixels, therefore a few fuzzy factors
had to be tuned.

* Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp:
(WebCore::SkiaBackingStore::Tile::update):
* Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp:
(WebCore::SkiaPaintingEngine::SkiaPaintingEngine):
(WebCore::SkiaPaintingEngine::create):
(WebCore::SkiaPaintingEngine::createBuffer const):
* Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.cpp:
(WebCore::CoordinatedUnacceleratedTileBuffer::create):
(WebCore::CoordinatedUnacceleratedTileBuffer::CoordinatedUnacceleratedTileBuffer):
(WebCore::CoordinatedUnacceleratedTileBuffer::tryEnsureSurface):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::LayerTreeHost):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.cpp:
(WebKit::LayerTreeHost::LayerTreeHost):
* LayoutTests/compositing/animation/repaint-after-clearing-shared-backing.html:
* LayoutTests/compositing/overlap-blending/nested-overlap.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/outline-005.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/old-content-object-fit-none.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/pseudo-rendering-invalidation.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/snapshot-containing-block-absolute.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-view-transitions/snapshot-containing-block-static.html:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f3218060f8e9735b6e22c1a24fe0b975bdf11fab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163054 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36533 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29737 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171993 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119500 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164923 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36672 "Hash f3218060 for PR 65078 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36535 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126580 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89182 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166013 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/36672 "Hash f3218060 for PR 65078 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146560 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107156 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/36672 "Hash f3218060 for PR 65078 does not build (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26520 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19692 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/36672 "Hash f3218060 for PR 65078 does not build (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24290 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174496 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/26092 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25936 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134891 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36204 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30623 "Found 1 new test failure: media/media-source/media-source-real-scrub-then-play.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134886 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37047 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146085 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98777 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30237 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22924 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35700 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/107748 "Built successfully") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35199 "Hash f3218060 for PR 65078 does not build (failure)") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/944 "") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35446 "Hash f3218060 for PR 65078 does not build (failure)") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35347 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->