### PR TITLE
[CMake] Standardize -Wunsafe-buffer-usage flags

### DIFF
--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1732,11 +1732,10 @@ set(JavaScriptCore_INTERFACE_DEPENDENCIES
 WEBKIT_FRAMEWORK_DECLARE(JavaScriptCore)
 WEBKIT_INCLUDE_CONFIG_FILES_IF_EXISTS()
 
-if (NOT WIN32)
+if (ENABLE_UNSAFE_BUFFER_USAGE_WARNING)
     WEBKIT_ADD_TARGET_CXX_FLAGS(JavaScriptCore
         -Wunsafe-buffer-usage
         -Wunsafe-buffer-usage-in-libc-call
-        -Wno-unsafe-buffer-usage-in-format-attr-call
     )
 endif ()
 

--- a/Source/WTF/wtf/CMakeLists.txt
+++ b/Source/WTF/wtf/CMakeLists.txt
@@ -832,11 +832,10 @@ set(WTF_INTERFACE_DEPENDENCIES WTF_CopyHeaders)
 WEBKIT_FRAMEWORK_DECLARE(WTF)
 WEBKIT_INCLUDE_CONFIG_FILES_IF_EXISTS()
 
-if (PORT STREQUAL GTK OR PORT STREQUAL WPE)
+if (ENABLE_UNSAFE_BUFFER_USAGE_WARNING)
     WEBKIT_ADD_TARGET_CXX_FLAGS(WTF
         -Wunsafe-buffer-usage
         -Wunsafe-buffer-usage-in-libc-call
-        -Wno-unsafe-buffer-usage-in-format-attr-call
     )
 endif ()
 

--- a/Source/WebCore/CMakeLists.txt
+++ b/Source/WebCore/CMakeLists.txt
@@ -2794,11 +2794,10 @@ if (ENABLE_WEBCORE_TEST_SUPPORT)
 endif ()
 WEBKIT_INCLUDE_CONFIG_FILES_IF_EXISTS()
 
-if (PORT STREQUAL GTK OR PORT STREQUAL WPE)
+if (ENABLE_UNSAFE_BUFFER_USAGE_WARNING)
     WEBKIT_ADD_TARGET_CXX_FLAGS(WebCore
         -Wunsafe-buffer-usage
         -Wunsafe-buffer-usage-in-libc-call
-        -Wno-unsafe-buffer-usage-in-format-attr-call
     )
 endif ()
 

--- a/Source/WebCore/PAL/pal/CMakeLists.txt
+++ b/Source/WebCore/PAL/pal/CMakeLists.txt
@@ -146,11 +146,10 @@ if (SWIFT_REQUIRED AND NOT (PORT STREQUAL GTK OR PORT STREQUAL WPE))
     )
 endif ()
 
-if (PORT STREQUAL GTK OR PORT STREQUAL WPE)
+if (ENABLE_UNSAFE_BUFFER_USAGE_WARNING)
     WEBKIT_ADD_TARGET_CXX_FLAGS(PAL
         -Wunsafe-buffer-usage
         -Wunsafe-buffer-usage-in-libc-call
-        -Wno-unsafe-buffer-usage-in-format-attr-call
     )
 endif ()
 

--- a/Source/WebKit/CMakeLists.txt
+++ b/Source/WebKit/CMakeLists.txt
@@ -929,11 +929,10 @@ WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER(WebKit WebKit
     "${WebKit_SWIFT_INTEROP_MODULE_PATH}"
     "${WebKit_DERIVED_SOURCES_DIR}/WebKit-Swift-CPP.h")
 
-if (PORT STREQUAL GTK OR PORT STREQUAL WPE)
+if (ENABLE_UNSAFE_BUFFER_USAGE_WARNING)
     WEBKIT_ADD_TARGET_CXX_FLAGS(WebKit
         -Wunsafe-buffer-usage
         -Wunsafe-buffer-usage-in-libc-call
-        -Wno-unsafe-buffer-usage-in-format-attr-call
     )
 endif ()
 

--- a/Source/cmake/OptionsGTK.cmake
+++ b/Source/cmake/OptionsGTK.cmake
@@ -7,6 +7,9 @@ SET_PROJECT_VERSION(2 53 2)
 
 set(USER_AGENT_BRANDING "" CACHE STRING "Branding to add to user agent string")
 
+set(ENABLE_UNSAFE_BUFFER_USAGE_WARNING ON)
+WEBKIT_PREPEND_GLOBAL_COMPILER_FLAGS(-Wno-unsafe-buffer-usage-in-format-attr-call)
+
 # Update Source/WTF/wtf/Platform.h to match required GLib versions.
 find_package(GLib 2.70.0 REQUIRED COMPONENTS GioUnix Thread Module)
 find_package(Cairo 1.16.0 REQUIRED)

--- a/Source/cmake/OptionsWPE.cmake
+++ b/Source/cmake/OptionsWPE.cmake
@@ -5,6 +5,9 @@ SET_PROJECT_VERSION(2 53 2)
 
 set(USER_AGENT_BRANDING "" CACHE STRING "Branding to add to user agent string")
 
+set(ENABLE_UNSAFE_BUFFER_USAGE_WARNING ON)
+WEBKIT_PREPEND_GLOBAL_COMPILER_FLAGS(-Wno-unsafe-buffer-usage-in-format-attr-call)
+
 # Update Source/WTF/wtf/Platform.h to match required GLib versions.
 find_package(GLib 2.70.0 REQUIRED COMPONENTS GioUnix Thread Module)
 find_package(HarfBuzz 2.7.4 REQUIRED COMPONENTS ICU)

--- a/Source/cmake/WebKitCompilerFlags.cmake
+++ b/Source/cmake/WebKitCompilerFlags.cmake
@@ -152,6 +152,8 @@ macro(WEBKIT_ADD_TARGET_CXX_FLAGS _target)
 endmacro()
 
 
+option(ENABLE_UNSAFE_BUFFER_USAGE_WARNING "Build with -Wunsafe-buffer-usage" OFF)
+
 option(DEVELOPER_MODE_FATAL_WARNINGS "Build with warnings as errors if DEVELOPER_MODE is also enabled" ON)
 set(DEVELOPER_MODE_CXX_FLAGS)
 if (DEVELOPER_MODE AND DEVELOPER_MODE_FATAL_WARNINGS)


### PR DESCRIPTION
#### 5780e754ea9b4c86d6c9c61f486ae67f960dc2ae
<pre>
[CMake] Standardize -Wunsafe-buffer-usage flags
<a href="https://bugs.webkit.org/show_bug.cgi?id=314991">https://bugs.webkit.org/show_bug.cgi?id=314991</a>
<a href="https://rdar.apple.com/177299438">rdar://177299438</a>

Reviewed by Adrian Perez de Castro.

-Wunsafe-buffer-usage is in a subtly mixed state across Mac / GTK / WPE.

1. Create a central location for -Wunsafe-buffer-usage, so that it is either ON
or OFF.

2. The standard definition of -Wunsafe-buffer-usage includes libc warnings
(since the alternative misses important well-known buffer overflows).

3. GTK and WPE opt out of libc warnings in their port-specific configs (as
previously decided by GTK and WPE maintainers).

4. Darwin ports keep -Wunsafe-buffer-usage off for now, pending a fix for
<a href="https://github.com/llvm/llvm-project/pull/198006">https://github.com/llvm/llvm-project/pull/198006</a>, since we are using CMake
for our fast at-desk build and we don&apos;t want to regress build time.

* Source/JavaScriptCore/CMakeLists.txt:
* Source/WTF/wtf/CMakeLists.txt:
* Source/WebCore/CMakeLists.txt:
* Source/WebCore/PAL/pal/CMakeLists.txt:
* Source/WebKit/CMakeLists.txt:
* Source/cmake/OptionsGTK.cmake:
* Source/cmake/OptionsWPE.cmake:
* Source/cmake/WebKitCompilerFlags.cmake:

Canonical link: <a href="https://commits.webkit.org/313391@main">https://commits.webkit.org/313391@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dad653a08022d82ba5e781fd0942a38be8ad6336

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/162996 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36475 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29665 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171935 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119442 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/785673b5-2bb0-4659-a5cd-eef69267286d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164865 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/36843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36477 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126530 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89137 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/116a8f4e-0a54-47d5-920c-476030ec9477) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165955 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/36843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146494 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107106 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2322379c-35c8-457b-bd38-9e7b1d5925e8) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/36843 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26468 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19634 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/155135 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137664 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24223 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174438 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23882 "Built successfully and passed tests") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/25606 "Found 1 new failure in wasm/WasmConstExprGenerator.cpp") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25870 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134840 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36146 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30571 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134835 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/36738 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146019 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98672 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24787 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/29984 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22856 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195397 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35642 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/107277 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50858 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35141 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/878 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35388 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35289 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->