### PR TITLE
CSS Container Style Queries: fails when container has display: contents

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/display-contents-style-query-descendant-restyle-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/display-contents-style-query-descendant-restyle-expected.txt
@@ -1,0 +1,4 @@
+
+PASS Initial style() container match applies under both rendered and display:contents containers
+PASS Restyling a descendant must not lose the style() container match when the container is display:contents
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/display-contents-style-query-descendant-restyle.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/display-contents-style-query-descendant-restyle.html
@@ -1,0 +1,41 @@
+<!doctype html>
+<title>CSS Container Queries Test: style() container with display:contents survives descendant restyle</title>
+<link rel="help" href="https://drafts.csswg.org/css-conditional-5/#style-container">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/cq-testcommon.js"></script>
+<style>
+  @container style(--green) {
+    .test {
+      background-color: rgb(0, 128, 0);
+    }
+  }
+  .test.toggled {
+    outline: 1px solid black;
+  }
+</style>
+<div id="rendered" style="--green: ;">
+  <div id="rendered-target" class="test"></div>
+</div>
+<div id="contents" style="--green: ; display: contents;">
+  <div id="contents-target" class="test"></div>
+</div>
+<script>
+  setup(() => assert_implements_style_container_queries());
+
+  const green = "rgb(0, 128, 0)";
+
+  test(() => {
+    assert_equals(getComputedStyle(document.getElementById("rendered-target")).backgroundColor, green);
+    assert_equals(getComputedStyle(document.getElementById("contents-target")).backgroundColor, green);
+  }, "Initial style() container match applies under both rendered and display:contents containers");
+
+  test(() => {
+    document.getElementById("rendered-target").classList.add("toggled");
+    document.getElementById("contents-target").classList.add("toggled");
+    assert_equals(getComputedStyle(document.getElementById("rendered-target")).backgroundColor, green,
+      "Rendered container: descendant restyle keeps style() container match");
+    assert_equals(getComputedStyle(document.getElementById("contents-target")).backgroundColor, green,
+      "display:contents container: descendant restyle keeps style() container match");
+  }, "Restyling a descendant must not lose the style() container match when the container is display:contents");
+</script>

--- a/Source/WebCore/style/StyleUpdate.cpp
+++ b/Source/WebCore/style/StyleUpdate.cpp
@@ -77,20 +77,14 @@ const RenderStyle* Update::elementStyle(const Element& element) const
 {
     if (auto* update = elementUpdate(element))
         return update->style.get();
-    auto* renderer = element.renderer();
-    if (!renderer)
-        return nullptr;
-    return &renderer->style();
+    return element.renderOrDisplayContentsStyle();
 }
 
 RenderStyle* Update::elementStyle(const Element& element)
 {
     if (auto* update = elementUpdate(element))
         return update->style.get();
-    auto* renderer = element.renderer();
-    if (!renderer)
-        return nullptr;
-    return &renderer->mutableStyle();
+    return const_cast<RenderStyle*>(element.renderOrDisplayContentsStyle());
 }
 
 void Update::addElement(Element& element, Element* parent, ElementUpdate&& elementUpdate)


### PR DESCRIPTION
#### 93785137d0d1b8d929ae16aaec342101a9ca4eea
<pre>
CSS Container Style Queries: fails when container has display: contents
<a href="https://bugs.webkit.org/show_bug.cgi?id=301871">https://bugs.webkit.org/show_bug.cgi?id=301871</a>
<a href="https://rdar.apple.com/164414720">rdar://164414720</a>

Reviewed by Antti Koivisto.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

When a descendant of a `display: contents` ancestor is re-resolved
(e.g. on :hover), `Style::Update::elementStyle()` returned nullptr for
that ancestor: it had no pending update entry this pass and no renderer
to read a style from. `styleForContainer()` then bailed and
`@container style(...)` silently stopped matching, dropping any
properties the rule was applying.

Fix this at the source: `Update::elementStyle()` now reads from
`Element::renderOrDisplayContentsStyle()` whenever there is no pending
update entry. That helper already returns the `displayContentsOrNoneStyle`
for `display: contents` elements and the renderer&apos;s style otherwise (or
nullptr when there is no renderer), so a single call covers all cases.
Behavior is unchanged for elements with a renderer, and `display: none`
elements still resolve to nullptr.

This makes the fix benefit every caller of `Update::elementStyle()`
rather than only the container query evaluator.

Test: imported/w3c/web-platform-tests/css/css-conditional/container-queries/display-contents-style-query-descendant-restyle.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/display-contents-style-query-descendant-restyle-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/display-contents-style-query-descendant-restyle.html: Added.
* Source/WebCore/style/StyleUpdate.cpp:
(WebCore::Style::Update::elementStyle const):
(WebCore::Style::Update::elementStyle):

Canonical link: <a href="https://commits.webkit.org/313677@main">https://commits.webkit.org/313677@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ef7e32ffea28b1240a23dbccb946c147ac26348

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163763 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37247 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30466 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172785 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165632 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37578 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37246 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127201 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121014 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166722 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29487 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147222 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107750 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28534 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27164 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20556 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138433 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24939 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175310 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28139 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26607 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135507 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36917 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31270 "Found 1 new test failure: http/tests/subresource-integrity/sri-enabled-with-setting.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135483 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36530 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37702 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146734 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99821 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30802 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23588 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36413 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109558 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35910 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1618 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36160 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36057 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->