### PR TITLE
Safari's main thread is blocked for 58ms reading cookies

### DIFF
--- a/Source/WebKit/Platform/IPC/Connection.h
+++ b/Source/WebKit/Platform/IPC/Connection.h
@@ -491,6 +491,13 @@ public:
 
     using AsyncReplyHandler = ConnectionAsyncReplyHandler;
     Error sendMessageWithAsyncReply(UniqueRef<Encoder>&&, AsyncReplyHandler, OptionSet<SendOption> sendOptions, std::optional<ThreadQOS> = std::nullopt);
+
+    struct AsyncReplyHandlerWithDispatcher {
+        CompletionHandler<void(Connection*, std::unique_ptr<Decoder>&&)> completionHandler;
+        Markable<AsyncReplyID> replyID;
+    };
+    Error sendMessageWithAsyncReplyWithDispatcher(UniqueRef<Encoder>&&, AsyncReplyHandlerWithDispatcher&&, OptionSet<SendOption> sendOptions, std::optional<ThreadQOS> = std::nullopt);
+
     std::pair<UniqueRef<Encoder>, SyncRequestID> createSyncMessageEncoder(MessageName, uint64_t destinationID);
     DecoderOrError sendSyncMessage(SyncRequestID, UniqueRef<Encoder>&&, Timeout, OptionSet<SendSyncOption> sendSyncOptions);
     Error sendSyncReply(UniqueRef<Encoder>&&);
@@ -541,6 +548,9 @@ public:
 
     template<typename T, typename C> static AsyncReplyHandler makeAsyncReplyHandler(C&& completionHandler, ThreadLikeAssertion callThread = CompletionHandlerCallThread::AnyThread);
 
+    template<typename T, typename C> static AsyncReplyHandlerWithDispatcher makeAsyncReplyHandlerWithDispatcher(C&& completionHandler, GuaranteedSerialFunctionDispatcher&);
+    template<typename T, typename PC, typename Promise> static AsyncReplyHandlerWithDispatcher makeAsyncReplyHandlerWithDispatcher(typename Promise::Producer&&);
+
     CompletionHandler<void(Connection*, Decoder*)> takeAsyncReplyHandler(AsyncReplyID);
 
     template<typename T, typename C> static void callReply(Connection*, Decoder&, C&&);
@@ -578,17 +588,9 @@ private:
     void platformOpen();
     void platformInvalidate();
 
-    struct AsyncReplyHandlerWithDispatcher {
-        CompletionHandler<void(Connection*, std::unique_ptr<Decoder>&&)> completionHandler;
-        Markable<AsyncReplyID> replyID;
-    };
-
     bool isAsyncReplyHandlerWithDispatcher(AsyncReplyID);
     CompletionHandler<void(Connection*, std::unique_ptr<Decoder>&&)> takeAsyncReplyHandlerWithDispatcher(AsyncReplyID);
-    template<typename T, typename C> static AsyncReplyHandlerWithDispatcher makeAsyncReplyHandlerWithDispatcher(C&& completionHandler, GuaranteedSerialFunctionDispatcher&);
-    template<typename T, typename PC, typename Promise> static AsyncReplyHandlerWithDispatcher makeAsyncReplyHandlerWithDispatcher(typename Promise::Producer&&);
 
-    Error sendMessageWithAsyncReplyWithDispatcher(UniqueRef<Encoder>&&, AsyncReplyHandlerWithDispatcher&&, OptionSet<SendOption> sendOptions, std::optional<ThreadQOS> = std::nullopt);
     // Utility methods to avoid code duplication.
     template<typename T, typename C> static CompletionHandler<void(Connection*, Decoder*)> makeAsyncReplyCompletionHandler(C&& completionHandler, ThreadLikeAssertion);
     template<typename T> static CompletionHandler<void(Decoder*)> makeAsyncReplyCompletionHandler(typename T::Promise::Producer&&, ThreadLikeAssertion);

--- a/Source/WebKit/UIProcess/API/APIHTTPCookieStore.cpp
+++ b/Source/WebKit/UIProcess/API/APIHTTPCookieStore.cpp
@@ -34,6 +34,7 @@
 #include <WebCore/Cookie.h>
 #include <WebCore/HTTPCookieAcceptPolicy.h>
 #include <wtf/CallbackAggregator.h>
+#include <wtf/CrossThreadCopier.h>
 
 #if PLATFORM(IOS_FAMILY)
 #include "DefaultWebBrowserChecks.h"
@@ -54,45 +55,87 @@ HTTPCookieStore::~HTTPCookieStore()
     ASSERT(m_observers.isEmptyIgnoringNullReferences());
 }
 
+#if ENABLE(APP_BOUND_DOMAINS)
+static Vector<WebCore::Cookie> filterCookiesByAppBoundDomains(Vector<WebCore::Cookie>&& cookies, const HashSet<WebCore::RegistrableDomain>& appBoundDomains)
+{
+    if (appBoundDomains.isEmpty())
+        return cookies;
+
+    return WTF::compactMap(WTF::move(cookies), [&](auto&& cookie) -> std::optional<WebCore::Cookie> {
+        if (appBoundDomains.contains(WebCore::RegistrableDomain::uncheckedCreateFromHost(cookie.domain)))
+            return WTF::move(cookie);
+        return std::nullopt;
+    });
+}
+#endif
+
 void HTTPCookieStore::filterAppBoundCookies(Vector<WebCore::Cookie>&& cookies, CompletionHandler<void(Vector<WebCore::Cookie>&&)>&& completionHandler)
 {
 #if ENABLE(APP_BOUND_DOMAINS)
     if (!m_owningDataStore)
         return completionHandler({ });
-    RefPtr { m_owningDataStore.get() }->getAppBoundDomains([cookies = WTF::move(cookies), completionHandler = WTF::move(completionHandler)] (auto& domains) mutable {
-        Vector<WebCore::Cookie> appBoundCookies;
-        if (!domains.isEmpty() && !isFullWebBrowserOrRunningTest()) {
-            for (auto& cookie : WTF::move(cookies)) {
-                if (domains.contains(WebCore::RegistrableDomain::uncheckedCreateFromHost(cookie.domain)))
-                    appBoundCookies.append(WTF::move(cookie));
-            }
-        } else
-            appBoundCookies = WTF::move(cookies);
-        completionHandler(WTF::move(appBoundCookies));
+    protect(m_owningDataStore)->getAppBoundDomains([cookies = WTF::move(cookies), completionHandler = WTF::move(completionHandler)] (auto& domains) mutable {
+        HashSet<WebCore::RegistrableDomain> appBoundDomains;
+        if (!isFullWebBrowserOrRunningTest())
+            appBoundDomains = domains;
+        completionHandler(filterCookiesByAppBoundDomains(WTF::move(cookies), appBoundDomains));
     });
 #else
     completionHandler(WTF::move(cookies));
 #endif
 }
 
-void HTTPCookieStore::cookies(CompletionHandler<void(Vector<WebCore::Cookie>&&)>&& completionHandler)
+template<typename Message>
+void HTTPCookieStore::fetchCookies(Message&& message, CompletionHandler<void(Vector<WebCore::Cookie>&&)>&& completionHandler, RefPtr<WorkQueue> replyQueue)
 {
-    if (RefPtr networkProcess = networkProcessLaunchingIfNecessary()) {
-        networkProcess->sendWithAsyncReply(Messages::WebCookieManager::GetAllCookies(m_sessionID), [this, protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler)] (Vector<WebCore::Cookie>&& cookies) mutable {
+    RefPtr networkProcess = networkProcessLaunchingIfNecessary();
+    if (!networkProcess) {
+        if (replyQueue)
+            replyQueue->dispatch([completionHandler = WTF::move(completionHandler)]() mutable { completionHandler({ }); });
+        else
+            completionHandler({ });
+        return;
+    }
+
+    if (!replyQueue) {
+        // Existing main-thread path: reply lands on main, then filter on main.
+        networkProcess->sendWithAsyncReply(std::forward<Message>(message), [this, protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler)] (Vector<WebCore::Cookie>&& cookies) mutable {
             filterAppBoundCookies(WTF::move(cookies), WTF::move(completionHandler));
         });
-    } else
-        completionHandler({ });
+        return;
+    }
+
+#if ENABLE(APP_BOUND_DOMAINS)
+    // Resolve app-bound domains on the main thread first, then send the IPC with the reply
+    // dispatched on replyQueue. The filtering itself happens on replyQueue using the captured set.
+    RefPtr dataStore = m_owningDataStore;
+    if (!dataStore) {
+        replyQueue->dispatch([completionHandler = WTF::move(completionHandler)]() mutable { completionHandler({ }); });
+        return;
+    }
+    dataStore->getAppBoundDomains([message = std::forward<Message>(message), completionHandler = WTF::move(completionHandler), replyQueue = WTF::move(replyQueue), networkProcess = WTF::move(networkProcess)] (auto& domains) mutable {
+        HashSet<WebCore::RegistrableDomain> appBoundDomains;
+        if (!domains.isEmpty() && !isFullWebBrowserOrRunningTest())
+            appBoundDomains = crossThreadCopy(domains);
+        networkProcess->sendWithAsyncReplyOnDispatcher(WTF::move(message), *replyQueue, [completionHandler = WTF::move(completionHandler), appBoundDomains = WTF::move(appBoundDomains), replyQueue = protect(*replyQueue)] (Vector<WebCore::Cookie>&& cookies) mutable {
+            assertIsCurrent(replyQueue);
+            completionHandler(filterCookiesByAppBoundDomains(WTF::move(cookies), appBoundDomains));
+        });
+    });
+#else
+    // No app-bound filtering needed. Send IPC with reply directly on replyQueue.
+    networkProcess->sendWithAsyncReplyOnDispatcher(std::forward<Message>(message), *replyQueue, WTF::move(completionHandler));
+#endif
 }
 
-void HTTPCookieStore::cookiesForURL(WTF::URL&& url, CompletionHandler<void(Vector<WebCore::Cookie>&&)>&& completionHandler)
+void HTTPCookieStore::cookies(CompletionHandler<void(Vector<WebCore::Cookie>&&)>&& completionHandler, RefPtr<WorkQueue> replyQueue)
 {
-    if (RefPtr networkProcess = networkProcessLaunchingIfNecessary()) {
-        networkProcess->sendWithAsyncReply(Messages::WebCookieManager::GetCookies(m_sessionID, url), [this, protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler)] (Vector<WebCore::Cookie>&& cookies) mutable {
-            filterAppBoundCookies(WTF::move(cookies), WTF::move(completionHandler));
-        });
-    } else
-        completionHandler({ });
+    fetchCookies(Messages::WebCookieManager::GetAllCookies(m_sessionID), WTF::move(completionHandler), WTF::move(replyQueue));
+}
+
+void HTTPCookieStore::cookiesForURL(WTF::URL&& url, CompletionHandler<void(Vector<WebCore::Cookie>&&)>&& completionHandler, RefPtr<WorkQueue> replyQueue)
+{
+    fetchCookies(Messages::WebCookieManager::GetCookies(m_sessionID, WTF::move(url)), WTF::move(completionHandler), WTF::move(replyQueue));
 }
 
 void HTTPCookieStore::setCookies(Vector<WebCore::Cookie>&& cookies, CompletionHandler<void()>&& completionHandler)

--- a/Source/WebKit/UIProcess/API/APIHTTPCookieStore.h
+++ b/Source/WebKit/UIProcess/API/APIHTTPCookieStore.h
@@ -33,6 +33,7 @@
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/WeakHashSet.h>
 #include <wtf/WeakPtr.h>
+#include <wtf/WorkQueue.h>
 
 #if USE(SOUP)
 #include "SoupCookiePersistentStorageType.h"
@@ -67,8 +68,8 @@ public:
 
     virtual ~HTTPCookieStore();
 
-    void cookies(CompletionHandler<void(Vector<WebCore::Cookie>&&)>&&);
-    void cookiesForURL(WTF::URL&&, CompletionHandler<void(Vector<WebCore::Cookie>&&)>&&);
+    void cookies(CompletionHandler<void(Vector<WebCore::Cookie>&&)>&&, RefPtr<WTF::WorkQueue> replyQueue = nullptr);
+    void cookiesForURL(WTF::URL&&, CompletionHandler<void(Vector<WebCore::Cookie>&&)>&&, RefPtr<WTF::WorkQueue> replyQueue = nullptr);
     void setCookies(Vector<WebCore::Cookie>&&, CompletionHandler<void()>&&);
     void deleteCookie(const WebCore::Cookie&, CompletionHandler<void()>&&);
     void deleteCookiesForHostnames(const Vector<WTF::String>&, CompletionHandler<void()>&&);
@@ -98,6 +99,9 @@ private:
     HTTPCookieStore(WebKit::WebsiteDataStore&);
     WebKit::NetworkProcessProxy* networkProcessIfExists();
     WebKit::NetworkProcessProxy* networkProcessLaunchingIfNecessary();
+
+    template<typename Message>
+    void fetchCookies(Message&&, CompletionHandler<void(Vector<WebCore::Cookie>&&)>&&, RefPtr<WTF::WorkQueue> replyQueue);
 
     PAL::SessionID m_sessionID;
     WeakPtr<WebKit::WebsiteDataStore> m_owningDataStore;

--- a/Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.mm
@@ -33,10 +33,13 @@
 #import <pal/spi/cf/CFNetworkSPI.h>
 #import <wtf/BlockPtr.h>
 #import <wtf/HashMap.h>
+#import <wtf/NeverDestroyed.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/RunLoop.h>
 #import <wtf/TZoneMallocInlines.h>
 #import <wtf/URL.h>
 #import <wtf/WeakObjCPtr.h>
+#import <wtf/WorkQueue.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
@@ -75,6 +78,23 @@ static NSArray<NSHTTPCookie *> *coreCookiesToNSCookies(const Vector<WebCore::Coo
 
         return cookie.createNSHTTPCookie().autorelease();
     }).autorelease();
+}
+
+static WorkQueue& cookieConversionQueueSingleton()
+{
+    static NeverDestroyed<Ref<WorkQueue>> queue = WorkQueue::create("com.apple.WebKit.WKHTTPCookieStoreCookieConversion"_s);
+    return queue.get();
+}
+
+static CompletionHandler<void(Vector<WebCore::Cookie>&&)> makeCookieConversionHandler(bool isOptInCookiePartitioningEnabled, void (^completionHandler)(NSArray<NSHTTPCookie *> *))
+{
+    return { [isOptInCookiePartitioningEnabled, handler = makeBlockPtr(completionHandler)](Vector<WebCore::Cookie>&& cookies) mutable {
+        assertIsCurrent(cookieConversionQueueSingleton());
+        RetainPtr nsCookies = coreCookiesToNSCookies(cookies, isOptInCookiePartitioningEnabled);
+        RunLoop::mainSingleton().dispatch([handler = WTF::move(handler), nsCookies = WTF::move(nsCookies)] {
+            handler.get()(nsCookies.get());
+        });
+    }, CompletionHandlerCallThread::AnyThread };
 }
 
 class WKHTTPCookieStoreObserver : public API::HTTPCookieStoreObserver {
@@ -122,11 +142,7 @@ WK_OBJECT_DISABLE_DISABLE_KVC_IVAR_ACCESS;
 
 - (void)getAllCookies:(void (^)(NSArray<NSHTTPCookie *> *))completionHandler
 {
-    bool isOptInCookiePartitioningEnabled = _cookieStore->isOptInCookiePartitioningEnabled();
-    protect(*_cookieStore)->cookies([isOptInCookiePartitioningEnabled, handler = adoptNS([completionHandler copy])](const Vector<WebCore::Cookie>& cookies) {
-        auto rawHandler = (void (^)(NSArray<NSHTTPCookie *> *))handler.get();
-        rawHandler(coreCookiesToNSCookies(cookies, isOptInCookiePartitioningEnabled));
-    });
+    protect(*_cookieStore)->cookies(makeCookieConversionHandler(_cookieStore->isOptInCookiePartitioningEnabled(), completionHandler), &cookieConversionQueueSingleton());
 }
 
 - (void)setCookie:(NSHTTPCookie *)cookie completionHandler:(void (^)(void))completionHandler
@@ -224,10 +240,7 @@ static WKCookiePolicy NODELETE toWKCookiePolicy(WebCore::HTTPCookieAcceptPolicy 
 
 - (void)getCookiesForURL:(NSURL *)url completionHandler:(void (^)(NSArray<NSHTTPCookie *> *))completionHandler
 {
-    bool isOptInCookiePartitioningEnabled = _cookieStore->isOptInCookiePartitioningEnabled();
-    protect(*_cookieStore)->cookiesForURL(url, [isOptInCookiePartitioningEnabled, handler = makeBlockPtr(completionHandler)] (const Vector<WebCore::Cookie>& cookies) {
-        handler.get()(coreCookiesToNSCookies(cookies, isOptInCookiePartitioningEnabled));
-    });
+    protect(*_cookieStore)->cookiesForURL(url, makeCookieConversionHandler(_cookieStore->isOptInCookiePartitioningEnabled(), completionHandler), &cookieConversionQueueSingleton());
 }
 #pragma mark WKObject protocol implementation
 

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp
@@ -252,20 +252,46 @@ bool AuxiliaryProcessProxy::wasTerminated() const
 
 bool AuxiliaryProcessProxy::sendMessage(UniqueRef<IPC::Encoder>&& encoder, OptionSet<IPC::SendOption> sendOptions, std::optional<IPC::Connection::AsyncReplyHandler> asyncReplyHandler, ShouldStartProcessThrottlerActivity shouldStartProcessThrottlerActivity)
 {
+    ReplyHandler handler;
+    if (asyncReplyHandler)
+        handler = WTF::move(*asyncReplyHandler);
+    return sendMessageImpl(WTF::move(encoder), sendOptions, WTF::move(handler), shouldStartProcessThrottlerActivity);
+}
+
+bool AuxiliaryProcessProxy::sendMessageWithDispatcher(UniqueRef<IPC::Encoder>&& encoder, OptionSet<IPC::SendOption> sendOptions, IPC::Connection::AsyncReplyHandlerWithDispatcher&& asyncReplyHandler, ShouldStartProcessThrottlerActivity shouldStartProcessThrottlerActivity)
+{
+    return sendMessageImpl(WTF::move(encoder), sendOptions, ReplyHandler { WTF::move(asyncReplyHandler) }, shouldStartProcessThrottlerActivity);
+}
+
+bool AuxiliaryProcessProxy::sendMessageImpl(UniqueRef<IPC::Encoder>&& encoder, OptionSet<IPC::SendOption> sendOptions, ReplyHandler&& asyncReplyHandler, ShouldStartProcessThrottlerActivity shouldStartProcessThrottlerActivity)
+{
     // FIXME: We should turn this into a RELEASE_ASSERT().
     ASSERT(isMainRunLoop());
     if (!isMainRunLoop()) {
         callOnMainRunLoop([protectedThis = Ref { *this }, encoder = WTF::move(encoder), sendOptions, asyncReplyHandler = WTF::move(asyncReplyHandler), shouldStartProcessThrottlerActivity]() mutable {
-            protectedThis->sendMessage(WTF::move(encoder), sendOptions, WTF::move(asyncReplyHandler), shouldStartProcessThrottlerActivity);
+            protectedThis->sendMessageImpl(WTF::move(encoder), sendOptions, WTF::move(asyncReplyHandler), shouldStartProcessThrottlerActivity);
         });
         return true;
     }
 
-    if (asyncReplyHandler && canSendMessage() && shouldStartProcessThrottlerActivity == ShouldStartProcessThrottlerActivity::Yes) {
-        auto completionHandler = WTF::move(asyncReplyHandler->completionHandler);
-        asyncReplyHandler->completionHandler = [activity = protect(throttler())->quietBackgroundActivity(description(encoder->messageName())), completionHandler = WTF::move(completionHandler)](IPC::Connection* connection, IPC::Decoder* decoder) mutable {
-            completionHandler(connection, decoder);
-        };
+    if (!std::holds_alternative<std::monostate>(asyncReplyHandler) && canSendMessage() && shouldStartProcessThrottlerActivity == ShouldStartProcessThrottlerActivity::Yes) {
+        auto activity = protect(throttler())->quietBackgroundActivity(description(encoder->messageName()));
+        WTF::switchOn(asyncReplyHandler,
+            [](std::monostate&) { },
+            [&](IPC::Connection::AsyncReplyHandler& handler) {
+                auto inner = WTF::move(handler.completionHandler);
+                handler.completionHandler = [activity = WTF::move(activity), inner = WTF::move(inner)](IPC::Connection* connection, IPC::Decoder* decoder) mutable {
+                    inner(connection, decoder);
+                };
+            },
+            [&](IPC::Connection::AsyncReplyHandlerWithDispatcher& handler) {
+                // The handler runs on the dispatcher, so the activity must be released on the main thread separately.
+                auto inner = WTF::move(handler.completionHandler);
+                handler.completionHandler = { [activity = WTF::move(activity), inner = WTF::move(inner)](IPC::Connection* connection, std::unique_ptr<IPC::Decoder>&& decoder) mutable {
+                    inner(connection, WTF::move(decoder));
+                    RunLoop::mainSingleton().dispatch([activity = WTF::move(activity)] { });
+                }, CompletionHandlerCallThread::AnyThread };
+            });
     }
 
     switch (state()) {
@@ -275,26 +301,47 @@ bool AuxiliaryProcessProxy::sendMessage(UniqueRef<IPC::Encoder>&& encoder, Optio
         return true;
 
     case State::Running:
-        if (asyncReplyHandler) {
-            if (protect(connection())->sendMessageWithAsyncReply(WTF::move(encoder), WTF::move(*asyncReplyHandler), sendOptions) == IPC::Error::NoError)
-                return true;
-        } else {
-            if (protect(connection())->sendMessage(WTF::move(encoder), sendOptions) == IPC::Error::NoError)
-                return true;
-        }
+        if (sendOverConnection(protect(this->connection()), WTF::move(encoder), asyncReplyHandler, sendOptions) == IPC::Error::NoError)
+            return true;
         break;
 
     case State::Terminated:
         break;
     }
 
-    if (asyncReplyHandler && asyncReplyHandler->completionHandler) {
-        RunLoop::currentSingleton().dispatch([completionHandler = WTF::move(asyncReplyHandler->completionHandler)]() mutable {
-            completionHandler(nullptr, nullptr);
+    WTF::switchOn(asyncReplyHandler,
+        [](std::monostate&) { },
+        [](IPC::Connection::AsyncReplyHandler& handler) {
+            if (handler.completionHandler) {
+                RunLoop::currentSingleton().dispatch([completionHandler = WTF::move(handler.completionHandler)]() mutable {
+                    completionHandler(nullptr, nullptr);
+                });
+            }
+        },
+        [](IPC::Connection::AsyncReplyHandlerWithDispatcher& handler) {
+            // The handler internally dispatches onto its dispatcher, so this is safe to call from main.
+            if (handler.completionHandler)
+                handler.completionHandler(nullptr, nullptr);
         });
-    }
 
     return false;
+}
+
+IPC::Error AuxiliaryProcessProxy::sendOverConnection(IPC::Connection& connection, UniqueRef<IPC::Encoder>&& encoder, ReplyHandler& asyncReplyHandler, OptionSet<IPC::SendOption> sendOptions)
+{
+    return WTF::switchOn(asyncReplyHandler,
+        [&](std::monostate&) { return connection.sendMessage(WTF::move(encoder), sendOptions); },
+        [&](IPC::Connection::AsyncReplyHandler& handler) { return connection.sendMessageWithAsyncReply(WTF::move(encoder), WTF::move(handler), sendOptions); },
+        [&](IPC::Connection::AsyncReplyHandlerWithDispatcher& handler) { return connection.sendMessageWithAsyncReplyWithDispatcher(WTF::move(encoder), WTF::move(handler), sendOptions); });
+}
+
+void AuxiliaryProcessProxy::drainPendingMessages(IPC::Connection& connection)
+{
+    for (auto&& message : std::exchange(m_pendingMessages, { })) {
+        if (!shouldSendPendingMessage(message.encoder.get()))
+            continue;
+        sendOverConnection(connection, WTF::move(message.encoder), message.asyncReplyHandler, message.sendOptions);
+    }
 }
 
 bool AuxiliaryProcessProxy::sendMessageAfterResuming(Vector<uint8_t>&& coalescingKey, UniqueRef<IPC::Encoder>&& encoder)
@@ -386,14 +433,7 @@ void AuxiliaryProcessProxy::didFinishLaunching(ProcessLauncher* launcher, IPC::C
         });
     });
 
-    for (auto&& pendingMessage : std::exchange(m_pendingMessages, { })) {
-        if (!shouldSendPendingMessage(pendingMessage))
-            continue;
-        if (pendingMessage.asyncReplyHandler)
-            connection->sendMessageWithAsyncReply(WTF::move(pendingMessage.encoder), WTF::move(*pendingMessage.asyncReplyHandler), pendingMessage.sendOptions);
-        else
-            connection->sendMessage(WTF::move(pendingMessage.encoder), pendingMessage.sendOptions);
-    }
+    drainPendingMessages(*connection);
 
 #if USE(RUNNINGBOARD)
     protect(throttler())->didConnectToProcess(*this);
@@ -431,9 +471,13 @@ void AuxiliaryProcessProxy::wakeUpTemporarilyForIPC()
 void AuxiliaryProcessProxy::replyToPendingMessages()
 {
     ASSERT(isMainRunLoop());
-    for (auto& pendingMessage : std::exchange(m_pendingMessages, { })) {
-        if (pendingMessage.asyncReplyHandler)
-            pendingMessage.asyncReplyHandler->completionHandler(nullptr, nullptr);
+    for (auto&& message : std::exchange(m_pendingMessages, { })) {
+        WTF::switchOn(message.asyncReplyHandler,
+            [](std::monostate&) { },
+            [](auto& handler) {
+                if (handler.completionHandler)
+                    handler.completionHandler(nullptr, nullptr);
+            });
     }
 }
 

--- a/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
+++ b/Source/WebKit/UIProcess/AuxiliaryProcessProxy.h
@@ -122,6 +122,12 @@ public:
         return sendWithAsyncReply(std::forward<T>(message), std::forward<C>(completionHandler), destinationID.toUInt64(), sendOptions, shouldStartProcessThrottlerActivity);
     }
 
+    // Like sendWithAsyncReply(), but the reply is dispatched on the provided dispatcher (e.g. a WorkQueue) instead of the
+    // Connection's main-run-loop dispatcher. Like sendWithAsyncReply(), this takes a ProcessThrottler activity by default
+    // to keep the process alive while the IPC is in flight; the activity is released on the main thread after the reply
+    // has been dispatched onto the provided dispatcher.
+    template<typename T, typename C> std::optional<AsyncReplyID> sendWithAsyncReplyOnDispatcher(T&&, GuaranteedSerialFunctionDispatcher&, C&&, uint64_t destinationID = 0, OptionSet<IPC::SendOption> = { }, ShouldStartProcessThrottlerActivity = ShouldStartProcessThrottlerActivity::Yes);
+
     template<typename T, typename RawValue>
     bool send(T&& message, const ObjectIdentifierGenericBase<RawValue>& destinationID, OptionSet<IPC::SendOption> sendOptions = { })
     {
@@ -184,6 +190,7 @@ public:
 
     bool canSendMessage() const { return state() != State::Terminated;}
     bool sendMessage(UniqueRef<IPC::Encoder>&&, OptionSet<IPC::SendOption>, std::optional<IPC::Connection::AsyncReplyHandler> = std::nullopt, ShouldStartProcessThrottlerActivity = ShouldStartProcessThrottlerActivity::Yes);
+    bool sendMessageWithDispatcher(UniqueRef<IPC::Encoder>&&, OptionSet<IPC::SendOption>, IPC::Connection::AsyncReplyHandlerWithDispatcher&&, ShouldStartProcessThrottlerActivity = ShouldStartProcessThrottlerActivity::Yes);
     bool sendMessageAfterResuming(Vector<uint8_t>&& coalescingKey, UniqueRef<IPC::Encoder>&&);
 
     void replyToPendingMessages();
@@ -266,13 +273,14 @@ protected:
     virtual void getLaunchOptions(ProcessLauncher::LaunchOptions&);
     virtual void platformGetLaunchOptions(ProcessLauncher::LaunchOptions&) { }
 
+    using ReplyHandler = Variant<std::monostate, IPC::Connection::AsyncReplyHandler, IPC::Connection::AsyncReplyHandlerWithDispatcher>;
     struct PendingMessage {
         UniqueRef<IPC::Encoder> encoder;
         OptionSet<IPC::SendOption> sendOptions;
-        std::optional<IPC::Connection::AsyncReplyHandler> asyncReplyHandler;
+        ReplyHandler asyncReplyHandler;
     };
 
-    virtual bool shouldSendPendingMessage(const PendingMessage&) { return true; }
+    virtual bool shouldSendPendingMessage(const IPC::Encoder&) { return true; }
 
     void beginResponsivenessChecks();
 
@@ -307,6 +315,10 @@ private:
 
     // Connection::Client
     void requestRemoteProcessTermination() final;
+
+    bool sendMessageImpl(UniqueRef<IPC::Encoder>&&, OptionSet<IPC::SendOption>, ReplyHandler&&, ShouldStartProcessThrottlerActivity);
+    static IPC::Error sendOverConnection(IPC::Connection&, UniqueRef<IPC::Encoder>&&, ReplyHandler&, OptionSet<IPC::SendOption>);
+    void drainPendingMessages(IPC::Connection&);
 
     const Ref<ResponsivenessTimer> m_responsivenessTimer;
     Vector<PendingMessage> m_pendingMessages;
@@ -385,6 +397,20 @@ std::optional<AuxiliaryProcessProxy::AsyncReplyID> AuxiliaryProcessProxy::sendWi
     auto handler = IPC::Connection::makeAsyncReplyHandler<T>(std::forward<C>(completionHandler));
     auto replyID = handler.replyID;
     if (sendMessage(WTF::move(encoder), sendOptions, WTF::move(handler), shouldStartProcessThrottlerActivity))
+        return replyID;
+    return std::nullopt;
+}
+
+template<typename T, typename C>
+std::optional<AuxiliaryProcessProxy::AsyncReplyID> AuxiliaryProcessProxy::sendWithAsyncReplyOnDispatcher(T&& message, GuaranteedSerialFunctionDispatcher& dispatcher, C&& completionHandler, uint64_t destinationID, OptionSet<IPC::SendOption> sendOptions, ShouldStartProcessThrottlerActivity shouldStartProcessThrottlerActivity)
+{
+    static_assert(!T::isSync, "Async message expected");
+
+    auto encoder = makeUniqueRef<IPC::Encoder>(T::name(), destinationID);
+    message.encode(encoder.get());
+    auto handler = IPC::Connection::makeAsyncReplyHandlerWithDispatcher<T>(std::forward<C>(completionHandler), dispatcher);
+    auto replyID = handler.replyID;
+    if (sendMessageWithDispatcher(WTF::move(encoder), sendOptions, WTF::move(handler), shouldStartProcessThrottlerActivity))
         return replyID;
     return std::nullopt;
 }

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -615,10 +615,10 @@ void WebProcessProxy::platformGetLaunchOptions(ProcessLauncher::LaunchOptions& l
 }
 #endif
 
-bool WebProcessProxy::shouldSendPendingMessage(const PendingMessage& message)
+bool WebProcessProxy::shouldSendPendingMessage(const IPC::Encoder& encoder)
 {
-    if (message.encoder->messageName() == IPC::MessageName::WebPage_LoadRequestWaitingForProcessLaunch) {
-        auto decoder = IPC::Decoder::create(message.encoder->span(), { });
+    if (encoder.messageName() == IPC::MessageName::WebPage_LoadRequestWaitingForProcessLaunch) {
+        auto decoder = IPC::Decoder::create(encoder.span(), { });
         ASSERT(decoder);
         if (!decoder)
             return false;
@@ -642,8 +642,9 @@ bool WebProcessProxy::shouldSendPendingMessage(const PendingMessage& message)
         } else
             ASSERT_NOT_REACHED();
         return false;
-    } else if (message.encoder->messageName() == IPC::MessageName::WebPage_GoToBackForwardItemWaitingForProcessLaunch) {
-        auto decoder = IPC::Decoder::create(message.encoder->span(), { });
+    }
+    if (encoder.messageName() == IPC::MessageName::WebPage_GoToBackForwardItemWaitingForProcessLaunch) {
+        auto decoder = IPC::Decoder::create(encoder.span(), { });
         ASSERT(decoder);
         if (!decoder)
             return false;

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -635,7 +635,7 @@ private:
     void platformGetLaunchOptions(ProcessLauncher::LaunchOptions&) override;
     void connectionWillOpen(IPC::Connection&) override;
     void processWillShutDown(IPC::Connection&) override;
-    bool shouldSendPendingMessage(const PendingMessage&) final;
+    bool shouldSendPendingMessage(const IPC::Encoder&) final;
     
 #if PLATFORM(COCOA)
     void cacheMediaMIMETypesInternal(const Vector<String>&);


### PR DESCRIPTION
#### 37640aba9e2b0e54cd39a4bc9b5c815730f3f36d
<pre>
Safari&apos;s main thread is blocked for 58ms reading cookies
<a href="https://bugs.webkit.org/show_bug.cgi?id=314994">https://bugs.webkit.org/show_bug.cgi?id=314994</a>
<a href="https://rdar.apple.com/177212630">rdar://177212630</a>

Reviewed by Alex Christensen.

The IPC reply for `WebCookieManager::GetAllCookies` and `GetCookies` is currently
dispatched on the main thread, where the per-cookie work in
`coreCookiesToNSCookies()` (decoding `Vector&lt;WebCore::Cookie&gt;` from IPC bytes
and constructing one `NSHTTPCookie` per entry) compounds into a ~60ms hang
when the cookie store is large.

To avoid this:

- Add `IPC::Connection::AsyncReplyHandlerWithDispatcher` /
  `makeAsyncReplyHandlerWithDispatcher` / `sendMessageWithAsyncReplyWithDispatcher`
  to the public section of `Connection`, mirroring how their
  non-dispatcher counterparts are already public.

- Add `AuxiliaryProcessProxy::sendWithAsyncReplyOnDispatcher()` that
  forwards to the connection&apos;s `sendWithAsyncReplyOnDispatcher` and
  preserves the existing launching-state queuing behavior via a new
  `PendingMessageWithDispatcher` vector.

- Add an optional `RefPtr&lt;WorkQueue&gt; replyQueue` parameter to
  `API::HTTPCookieStore::cookies()` and `cookiesForURL()`. When provided,
  the IPC reply (and therefore the `Vector&lt;WebCore::Cookie&gt;` decoding)
  is dispatched on that queue. App-bound-domain resolution still happens
  on the main thread before sending the IPC, with the resolved domain
  set captured (via `crossThreadCopy()`) for filtering on the queue
  with no additional main-thread hop. On non-iOS builds, no filtering
  is needed and the IPC reply is delivered straight to the queue.

- In `WKHTTPCookieStore`, route `-getAllCookies:` and `-getCookiesForURL:`
  through a dedicated `cookieConversionQueueSingleton()`, build the
  `NSArray&lt;NSHTTPCookie *&gt;` there, then dispatch back to the main run
  loop to invoke the user&apos;s completion block.

No new tests, covered by existing WKHTTPCookieStore API tests.

* Source/WebKit/Platform/IPC/Connection.h:
Move `AsyncReplyHandlerWithDispatcher`, `makeAsyncReplyHandlerWithDispatcher`,
and `sendMessageWithAsyncReplyWithDispatcher` from the private section to the
public section so external callers (e.g. `AuxiliaryProcessProxy`) can use them.

* Source/WebKit/UIProcess/API/APIHTTPCookieStore.cpp:
(API::filterCookiesByAppBoundDomains): New file-scope helper using
`WTF::compactMap()` to filter a cookie vector against an app-bound domain set.
(API::HTTPCookieStore::filterAppBoundCookies):
(API::HTTPCookieStore::fetchCookies): New private template factoring out the
shared body of `cookies()` and `cookiesForURL()`. When `replyQueue` is null
the existing main-thread path is preserved verbatim. When non-null, on
`ENABLE(APP_BOUND_DOMAINS)` we resolve the domains on main, then send the
IPC with the reply on the work queue and filter inline there using the
captured set; otherwise we send the IPC with the reply on the work queue
without any filtering.
(API::HTTPCookieStore::cookies):
(API::HTTPCookieStore::cookiesForURL): Now one-line wrappers around
`fetchCookies()`. Parameter type switched to `Function&lt;...&gt;` since the
callback may run off the construction thread.

* Source/WebKit/UIProcess/API/APIHTTPCookieStore.h:
* Source/WebKit/UIProcess/API/Cocoa/WKHTTPCookieStore.mm:
(cookieConversionQueueSingleton): New static `WorkQueue` for cookie
conversion work.
(-[WKHTTPCookieStore getAllCookies:]):
(-[WKHTTPCookieStore getCookiesForURL:completionHandler:]): Pass the
conversion queue to `cookies()` / `cookiesForURL()`. Build the
`NSArray&lt;NSHTTPCookie *&gt;` on the queue and dispatch back to the main
run loop to invoke the user&apos;s block.
* Source/WebKit/UIProcess/AuxiliaryProcessProxy.cpp:
(WebKit::AuxiliaryProcessProxy::sendMessageWithDispatcher): New helper
mirroring `sendMessage`, with launching-state queuing into
`m_pendingMessagesWithDispatcher`.
(WebKit::AuxiliaryProcessProxy::didFinishLaunching): Drain
`m_pendingMessagesWithDispatcher` after `m_pendingMessages`.
(WebKit::AuxiliaryProcessProxy::replyToPendingMessages): Also invoke null
replies for queued dispatcher-routed handlers.

* Source/WebKit/UIProcess/AuxiliaryProcessProxy.h:
(WebKit::AuxiliaryProcessProxy::sendWithAsyncReplyOnDispatcher):

Canonical link: <a href="https://commits.webkit.org/313783@main">https://commits.webkit.org/313783@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9924c9b2dc2e5d92622bdcd1eb2b74eb0702dd86

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164099 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37583 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30802 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173128 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b95dceec-106b-4e28-b8fe-9a7b2757c208) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37916 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37583 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127484 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121350 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6f42d9f6-5505-47a6-91dc-cc15866558d1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167058 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29771 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147516 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108032 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/247533be-965c-47fa-94a4-48960b476692) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28817 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27442 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20892 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138718 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175654 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28475 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26901 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135796 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37253 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31556 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 13 flakes 5 failures; Uploaded test results; 11 flakes 4 failures; Compiled WebKit (warnings); 3 failures; Passed layout tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135766 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38039 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147028 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100251 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24982 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31068 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23884 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36849 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109894 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36246 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1934 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36496 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36396 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->