### PR TITLE
(313296@main) ASSERTION FAILED: m_samples.decodeOrder().findSampleWithDecodeKey

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
+++ b/Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm
@@ -1515,6 +1515,16 @@ void MediaPlayerPrivateWebM::didProvideMediaDataForTrackId(Ref<MediaSampleAVFObj
         return;
     TrackBuffer& trackBuffer = it->second;
 
+    // WebM MediaRecorder may generate consecutive audio packets with identical (DTS, PTS).
+    // We disambiguate with 1 micro second bumps.
+    DecodeOrderSampleMap::KeyType incomingKey { sample->decodeTime(), sample->presentationTime() };
+    while (trackBuffer.samples().decodeOrder().findSampleWithDecodeKey(incomingKey) != trackBuffer.samples().decodeOrder().end()) {
+        MediaTime bumpedPTS = sample->presentationTime() + MediaTime(1, 1000000);
+        MediaTime bumpedDTS = sample->decodeTime() + MediaTime(1, 1000000);
+        sample->setTimestamps(bumpedPTS, bumpedDTS);
+        incomingKey = { bumpedDTS, bumpedPTS };
+    }
+
     trackBuffer.addSample(sample);
 
     // appendCompleted() fires only once per network buffer, so if the file is delivered in large


### PR DESCRIPTION
#### 57e44bb6ce39e7a8f586dc69aac4715ac835d67e
<pre>
(313296@main) ASSERTION FAILED: m_samples.decodeOrder().findSampleWithDecodeKey
<a href="https://bugs.webkit.org/show_bug.cgi?id=314997">https://bugs.webkit.org/show_bug.cgi?id=314997</a>
<a href="https://rdar.apple.com/177312155">rdar://177312155</a>

Reviewed by Youenn Fablet.

Change 313296@main exposed a real problem where samples could be silently
dropped by the MediaPlayerPrivateWebM which at best resulted in invalid
memory tracking and at worse with decoding errors.
The content generated by the MediaRecorder could include content where
the format is changing mid-streams.
MediaRecorder-generated WebM streams can carry consecutive audio packets
with identical (DTS, PTS) keys in their compressed output. The
AudioSampleBufferConverter that produced them sets
OutputPresentationTimeStamp on each compressed packet using a running
m_currentOutputPresentationTimeStamp that only advances by each
packet&apos;s OutputDuration (native duration minus TrimDurationAtStart);
during a converter&apos;s priming phase that delta is zero, so several
consecutive primed packets emerge with the same OutputPT. This is most
visible immediately after an audio-track reconfiguration because
MediaRecorderPrivateEncoder spins up a fresh converter, which goes
through its own priming with the new format.

The SampleMap is keyed on (DTS, PTS) and accounts for sizeInBytes()
unconditionally for eviction; a duplicate key would either trip the
ASSERT in TrackBuffer::addSample or, worse, silently no-op the
insert and skew accounting, for video is would lead to decoding error.
Bump the incoming sample by one microsecond past the colliding entry
so each priming packet remains addressable in the buffer (they are
required as decoder pre-roll); the bump is well withing timeFudgeFactor()
and does not affect seek behaviour.

Covered by existing tests

* Source/WebCore/platform/graphics/cocoa/MediaPlayerPrivateWebM.mm:
(WebCore::MediaPlayerPrivateWebM::didProvideMediaDataForTrackId):

Canonical link: <a href="https://commits.webkit.org/313413@main">https://commits.webkit.org/313413@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb8bf9af86ac86e938fee3329e6ad10af996c7ab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163089 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36568 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29777 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172028 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119535 "Failed to checkout and rebase branch from PR 65086") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/44ca825e-4275-4f5b-a34e-694c704f6323) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164958 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/36752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36570 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/126608 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/119535 "Failed to checkout and rebase branch from PR 65086") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/64191307-c014-4bf1-9f7b-eee2da438931) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166048 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/36752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146593 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107184 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f8ac592b-9e64-4d6c-8c55-1609fee5acec) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/36752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26548 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19727 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137750 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24323 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174531 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/26432 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/25970 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/134921 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36239 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30651 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134916 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36371 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/37051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146118 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98851 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/37051 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22958 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35735 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/108083 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35234 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/977 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35481 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35382 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->