### PR TITLE
[JSC] Merge `ModuleRegistryEntry` error fields into a single field

### DIFF
--- a/Source/JavaScriptCore/runtime/ModuleRegistryEntry.cpp
+++ b/Source/JavaScriptCore/runtime/ModuleRegistryEntry.cpp
@@ -66,9 +66,7 @@ void ModuleRegistryEntry::visitChildrenImpl(JSCell* cell, Visitor& visitor)
     visitor.append(thisObject->m_fetchPromise);
     visitor.append(thisObject->m_modulePromise);
     visitor.append(thisObject->m_loadPromise);
-    visitor.append(thisObject->m_fetchError);
-    visitor.append(thisObject->m_instantiationError);
-    visitor.append(thisObject->m_evaluationError);
+    visitor.append(thisObject->m_error);
 }
 
 DEFINE_VISIT_CHILDREN(ModuleRegistryEntry);
@@ -110,8 +108,8 @@ JSPromise* ModuleRegistryEntry::ensureFetchPromise(JSGlobalObject* globalObject)
     JSPromise* promise = JSPromise::create(vm, globalObject->promiseStructure());
     promise->markAsHandled();
 
-    if (m_fetchError)
-        promise->reject(vm, globalObject, m_fetchError.get());
+    if (m_status == Status::FetchFailed && m_error)
+        promise->reject(vm, globalObject, m_error.get());
 
     m_fetchPromise.set(vm, this, promise);
     return promise;
@@ -145,15 +143,13 @@ JSValue ModuleRegistryEntry::error(JSGlobalObject* globalObject) const
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    if (JSValue fetchError = m_fetchError.get()) {
-        if (auto* errorInstance = dynamicDowncast<ErrorInstance>(fetchError))
-            RELEASE_AND_RETURN(scope, JSModuleLoader::duplicateError(globalObject, errorInstance));
-        RELEASE_AND_RETURN(scope, fetchError);
+    if (JSValue error = m_error.get()) {
+        if (m_status == Status::FetchFailed) {
+            if (auto* errorInstance = dynamicDowncast<ErrorInstance>(error))
+                RELEASE_AND_RETURN(scope, JSModuleLoader::duplicateError(globalObject, errorInstance));
+        }
+        RELEASE_AND_RETURN(scope, error);
     }
-    if (m_instantiationError)
-        RELEASE_AND_RETURN(scope, m_instantiationError.get());
-    if (m_evaluationError)
-        RELEASE_AND_RETURN(scope, m_evaluationError.get());
     if (m_record) {
         if (auto* cyclic = dynamicDowncast<CyclicModuleRecord>(m_record.get()))
             RELEASE_AND_RETURN(scope, cyclic->evaluationError());
@@ -163,17 +159,9 @@ JSValue ModuleRegistryEntry::error(JSGlobalObject* globalObject) const
 
 JSValue ModuleRegistryEntry::fetchError() const
 {
-    return m_fetchError.get();
-}
-
-JSValue ModuleRegistryEntry::instantiationError() const
-{
-    return m_instantiationError.get();
-}
-
-JSValue ModuleRegistryEntry::evaluationError() const
-{
-    return m_evaluationError.get();
+    if (m_status == Status::FetchFailed)
+        return m_error.get();
+    return { };
 }
 
 auto ModuleRegistryEntry::status() const -> Status
@@ -195,7 +183,7 @@ void ModuleRegistryEntry::setFetchError(JSGlobalObject* globalObject, JSValue er
 {
     ASSERT(error);
     VM& vm = globalObject->vm();
-    m_fetchError.set(vm, this, error);
+    m_error.set(vm, this, error);
     if (m_status == Status::New && m_fetchPromise)
         m_fetchPromise->reject(vm, globalObject, error);
     setStatus(Status::FetchFailed);
@@ -204,19 +192,21 @@ void ModuleRegistryEntry::setFetchError(JSGlobalObject* globalObject, JSValue er
 void ModuleRegistryEntry::setInstantiationError(JSGlobalObject* globalObject, JSValue error)
 {
     ASSERT(error);
+    if (m_status == Status::FetchFailed)
+        return;
     VM& vm = globalObject->vm();
-    m_instantiationError.set(vm, this, error);
-    if (m_status != Status::FetchFailed)
-        setStatus(Status::InstantiationFailed);
+    m_error.set(vm, this, error);
+    setStatus(Status::InstantiationFailed);
 }
 
 void ModuleRegistryEntry::setEvaluationError(JSGlobalObject* globalObject, JSValue error)
 {
     ASSERT(error);
+    if (m_status == Status::FetchFailed)
+        return;
     VM& vm = globalObject->vm();
-    m_evaluationError.set(vm, this, error);
-    if (m_status != Status::FetchFailed)
-        setStatus(Status::EvaluationFailed);
+    m_error.set(vm, this, error);
+    setStatus(Status::EvaluationFailed);
 }
 
 void ModuleRegistryEntry::setStatus(Status status)

--- a/Source/JavaScriptCore/runtime/ModuleRegistryEntry.h
+++ b/Source/JavaScriptCore/runtime/ModuleRegistryEntry.h
@@ -75,8 +75,6 @@ public:
     JSPromise* loadPromise() const;
     JSValue error(JSGlobalObject*) const;
     JSValue fetchError() const;
-    JSValue instantiationError() const;
-    JSValue evaluationError() const;
     Status status() const;
 
     void setRecord(VM&, AbstractModuleRecord*);
@@ -102,9 +100,9 @@ private:
     WriteBarrier<JSPromise> m_fetchPromise;
     WriteBarrier<JSPromise> m_modulePromise;
     WriteBarrier<JSPromise> m_loadPromise;
-    WriteBarrier<Unknown> m_fetchError;
-    WriteBarrier<Unknown> m_instantiationError;
-    WriteBarrier<Unknown> m_evaluationError;
+    // The fetch / instantiation / evaluation errors are mutually exclusive: m_status
+    // disambiguates which kind m_error holds (FetchFailed / InstantiationFailed / EvaluationFailed).
+    WriteBarrier<Unknown> m_error;
     Status m_status { Status::New };
 };
 


### PR DESCRIPTION
#### 198caec02193d891c319c60bbb3866b9fdf3495f
<pre>
[JSC] Merge `ModuleRegistryEntry` error fields into a single field
<a href="https://bugs.webkit.org/show_bug.cgi?id=315001">https://bugs.webkit.org/show_bug.cgi?id=315001</a>

Reviewed by Yusuke Suzuki.

ModuleRegistryEntry holds three WriteBarrier&lt;Unknown&gt; error fields
(m_fetchError, m_instantiationError, m_evaluationError) that are
mutually exclusive: only one is ever populated, and m_status already
records which kind of failure occurred (FetchFailed / InstantiationFailed
/ EvaluationFailed). Merge them into a single m_error field disambiguated
by m_status. This shrinks ModuleRegistryEntry from 96 bytes to 80 bytes.

Also drop the unused instantiationError() and evaluationError() accessors,
and tighten setInstantiationError() / setEvaluationError() to early-return
when m_status is already FetchFailed. Previously these would store the
error but leave m_status untouched, making the stored value unobservable
since error() always preferred m_fetchError; the early return preserves
that observable behavior.

* Source/JavaScriptCore/runtime/ModuleRegistryEntry.cpp:
(JSC::ModuleRegistryEntry::visitChildrenImpl):
(JSC::ModuleRegistryEntry::ensureFetchPromise):
(JSC::ModuleRegistryEntry::error const):
(JSC::ModuleRegistryEntry::fetchError const):
(JSC::ModuleRegistryEntry::setFetchError):
(JSC::ModuleRegistryEntry::setInstantiationError):
(JSC::ModuleRegistryEntry::setEvaluationError):
(JSC::ModuleRegistryEntry::instantiationError const): Deleted.
(JSC::ModuleRegistryEntry::evaluationError const): Deleted.
* Source/JavaScriptCore/runtime/ModuleRegistryEntry.h:

Canonical link: <a href="https://commits.webkit.org/313651@main">https://commits.webkit.org/313651@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76dd2a377afc4b3ee3644de4e231d3f12e127c6f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163036 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36515 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29711 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/171975 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119482 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36806 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36517 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126565 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89169 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/165995 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28884 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146538 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107141 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27930 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26507 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19674 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/155175 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137821 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24268 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174478 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23922 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/26026 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25914 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134876 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36186 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30610 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134871 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36507 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/36964 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146063 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98745 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30164 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22901 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195437 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35682 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/107686 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50898 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35181 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/922 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35428 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35329 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->