### PR TITLE
[Skia] Port on-screen FPS counter drawing to Skia compositor

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
@@ -35,15 +35,23 @@
 #include "WebProcess.h"
 #include <WebCore/CoordinatedPlatformLayer.h>
 #include <WebCore/Damage.h>
+#include <WebCore/FontCache.h>
 #include <WebCore/Page.h>
 #include <WebCore/PlatformDisplay.h>
 #include <WebCore/Settings.h>
 #include <WebCore/SkiaCompositingLayer.h>
 #include <WebCore/TextureMapperLayer.h>
 #include <WebCore/TransformationMatrix.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkCanvas.h>
+#include <skia/core/SkFont.h>
+#include <skia/core/SkFontMgr.h>
+#include <skia/core/SkPaint.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #include <wtf/SetForScope.h>
 #include <wtf/SystemTracing.h>
 #include <wtf/TZoneMallocInlines.h>
+#include <wtf/text/StringToIntegerConversion.h>
 
 #if USE(GLIB_EVENT_LOOP)
 #include <wtf/glib/RunLoopSourcePriority.h>
@@ -383,6 +391,9 @@ void ThreadedCompositor::paintToSkiaCanvas(const TransformationMatrix& matrix, c
     }
 #endif
 
+    if (m_fpsCounter.drawsFPS)
+        drawFPSCounter(*canvas);
+
     if (auto* surface = canvas->getSurface())
         PlatformDisplay::sharedDisplay().skiaGrContext()->flushAndSubmit(surface, GrSyncCpu::kNo);
 
@@ -615,6 +626,15 @@ void ThreadedCompositor::initializeFPSCounter()
         m_fpsCounter.exposesFPS = true;
         m_fpsCounter.calculationInterval = interval;
     }
+
+    // WEBKIT_DRAW_FPS=1 additionally renders the FPS as an on-screen overlay,
+    // reusing the calculation interval (which WEBKIT_SHOW_FPS may override).
+    if (const auto* drawFPSEnvironment = getenv("WEBKIT_DRAW_FPS")) {
+        if (auto enabled = parseInteger<unsigned>(StringView::fromLatin1(drawFPSEnvironment)); enabled && *enabled) {
+            m_fpsCounter.exposesFPS = true;
+            m_fpsCounter.drawsFPS = true;
+        }
+    }
 }
 
 void ThreadedCompositor::updateFPSCounter()
@@ -629,13 +649,61 @@ void ThreadedCompositor::updateFPSCounter()
     m_fpsCounter.frameCountSinceLastCalculation++;
     const Seconds delta = MonotonicTime::now() - m_fpsCounter.lastCalculationTimestamp;
     if (delta >= m_fpsCounter.calculationInterval) {
-        WTFSetCounter(FPS, static_cast<int>(std::round(m_fpsCounter.frameCountSinceLastCalculation / delta.seconds())));
+        m_fpsCounter.lastFPS = static_cast<int>(std::round(m_fpsCounter.frameCountSinceLastCalculation / delta.seconds()));
+        WTFSetCounter(FPS, m_fpsCounter.lastFPS);
         if (m_fpsCounter.exposesFPS)
             m_fpsCounter.fps = m_fpsCounter.frameCountSinceLastCalculation / delta.seconds();
         m_fpsCounter.frameCountSinceLastCalculation = 0;
         m_fpsCounter.lastCalculationTimestamp += delta;
     } else if (m_fpsCounter.exposesFPS)
         m_fpsCounter.fps = std::nullopt;
+}
+
+void ThreadedCompositor::drawFPSCounter(SkCanvas& canvas)
+{
+    static SkFont font = [] {
+        constexpr unsigned defaultFontSize = 14;
+        unsigned fontSize = defaultFontSize;
+        if (const auto* fontSizeEnvvar = getenv("WEBKIT_DRAW_FPS_FONT_SIZE")) {
+            if (auto value = parseInteger<unsigned>(StringView::fromLatin1(fontSizeEnvvar)); value && *value)
+                fontSize = *value;
+        }
+        auto typeface = FontCache::forCurrentThread().fontManager().matchFamilyStyle("monospace", SkFontStyle::Bold());
+        SkFont f(typeface, fontSize);
+        f.setEdging(SkFont::Edging::kAntiAlias);
+        f.setSubpixel(true);
+        return f;
+    }();
+
+    // Scale the box padding with the font size so the overlay stays
+    // proportionate at large WEBKIT_DRAW_FPS_FONT_SIZE values
+    // (~3px at the default size of 14).
+    const float padding = font.getSize() * 0.2f;
+
+    if (m_fpsCounter.lastFPS != m_fpsCounter.displayedFPS) {
+        m_fpsCounter.displayedFPS = m_fpsCounter.lastFPS;
+        m_fpsCounter.fpsString = String::number(m_fpsCounter.lastFPS).ascii();
+        SkRect textBounds;
+        font.measureText(m_fpsCounter.fpsString.data(), m_fpsCounter.fpsString.length(), SkTextEncoding::kUTF8, &textBounds);
+        m_fpsCounter.backgroundWidth = textBounds.width() + padding * 2;
+        m_fpsCounter.backgroundHeight = textBounds.height() + padding * 2;
+        m_fpsCounter.textBaseline = -textBounds.fTop + padding;
+    }
+
+    // Drawn in device space at the top-left corner, matching the debug repaint
+    // counter style used by SkiaCompositingLayer.
+    SkAutoCanvasRestore autoRestore(&canvas, true);
+    canvas.resetMatrix();
+
+    SkPaint backgroundPaint;
+    backgroundPaint.setColor(SK_ColorBLACK);
+    backgroundPaint.setStyle(SkPaint::kFill_Style);
+    canvas.drawRect(SkRect::MakeXYWH(0, 0, m_fpsCounter.backgroundWidth, m_fpsCounter.backgroundHeight), backgroundPaint);
+
+    SkPaint textPaint;
+    textPaint.setColor(SK_ColorWHITE);
+    textPaint.setAntiAlias(true);
+    canvas.drawString(m_fpsCounter.fpsString.data(), padding, m_fpsCounter.textBaseline, font, textPaint);
 }
 
 void ThreadedCompositor::fillGLInformation(RenderProcessInfo&& info, CompletionHandler<void(RenderProcessInfo&&)>&& completionHandler)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
@@ -42,6 +42,9 @@
 #include <wtf/TZoneMalloc.h>
 #include <wtf/ThreadSafeRefCounted.h>
 #include <wtf/WorkQueue.h>
+#include <wtf/text/CString.h>
+
+class SkCanvas;
 
 namespace WebCore {
 class TextureMapper;
@@ -117,6 +120,7 @@ private:
 
     void initializeFPSCounter();
     void updateFPSCounter();
+    void drawFPSCounter(SkCanvas&);
 
     const Ref<WorkQueue> m_workQueue;
     CheckedPtr<LayerTreeHost> m_layerTreeHost;
@@ -158,10 +162,19 @@ private:
 
     struct {
         bool exposesFPS { false };
+        bool drawsFPS { false };
         Seconds calculationInterval { 1_s };
         MonotonicTime lastCalculationTimestamp;
         unsigned frameCountSinceLastCalculation { 0 };
+        int lastFPS { 0 };
         std::atomic<std::optional<float>> fps;
+
+        // On-screen overlay state, only used when drawsFPS is set.
+        int displayedFPS { -1 };
+        CString fpsString;
+        float backgroundWidth { 0 };
+        float backgroundHeight { 0 };
+        float textBaseline { 0 };
     } m_fpsCounter;
 
 #if ENABLE(DAMAGE_TRACKING)


### PR DESCRIPTION
#### f0778172ad363380d48023982bd6de538a2e4e21
<pre>
[Skia] Port on-screen FPS counter drawing to Skia compositor
<a href="https://bugs.webkit.org/show_bug.cgi?id=315003">https://bugs.webkit.org/show_bug.cgi?id=315003</a>

Reviewed by Carlos Garcia Campos.

The on-screen FPS overlay was specific to the TextureMapper path
(TextureMapperFPSCounter). Draw a Skia counterpart directly from
ThreadedCompositor so an on-screen FPS overlay is also available when
the Skia compositor is enabled.

The existing WEBKIT_SHOW_FPS envvar keeps its behavior (logging the
FPS to the console, with its value setting the calculation interval in
seconds). A new WEBKIT_DRAW_FPS=1 envvar additionally renders the
on-screen overlay, reusing that calculation interval.
WEBKIT_DRAW_FPS_FONT_SIZE configures the overlay font size (defaults to 14).

* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp:
(WebKit::ThreadedCompositor::paintToSkiaCanvas):
(WebKit::ThreadedCompositor::initializeFPSCounter):
(WebKit::ThreadedCompositor::updateFPSCounter):
(WebKit::ThreadedCompositor::drawFPSCounter):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h:

Canonical link: <a href="https://commits.webkit.org/313409@main">https://commits.webkit.org/313409@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cb175e6297244752f3937fa6b6fb0578568360fa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163072 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36551 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29756 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172011 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119518 "Built successfully") 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/36769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36553 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126594 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89197 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166031 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/36769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146574 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107170 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/36769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26535 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19710 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137738 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174514 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/26357 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25950 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134908 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36222 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30638 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134903 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36369 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/36890 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146099 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98814 "Built successfully") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/30133 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22938 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35718 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108002 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35217 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/958 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35464 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35365 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->