### PR TITLE
[JSC] test262 fail: test/built-ins/TypedArrayConstructors/ctors/typedarray-arg/throw-type-error-before-custom-proto-access.js

### DIFF
--- a/JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-biguint64.js
+++ b/JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-biguint64.js
@@ -1,0 +1,38 @@
+//@ runDefault("--jitPolicyScale=0.1", "--useConcurrentJIT=0")
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+function test(size) {
+    const array = new BigUint64Array(size);
+    return array;
+}
+noInline(test);
+
+let result = 0;
+
+// warm up
+for (let i = 0; i < testLoopCount; ++i) {
+    const size = 1.0;
+    const len = test(size).length;
+    result += len;
+}
+
+// At this point, the function should be compiled down to the DFG/FTL
+
+// This checks the compliance to the step 9 |ToIndex(firstArgument)| of https://tc39.es/ecma262/2026/#sec-typedarray
+shouldThrow('compliant with ToIndex(firstArgument)', () => {
+    test(Number.POSITIVE_INFINITY);
+}, RangeError, 'length larger than (2 ** 53) - 1');

--- a/JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-bitint64.js
+++ b/JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-bitint64.js
@@ -1,0 +1,38 @@
+//@ runDefault("--jitPolicyScale=0.1", "--useConcurrentJIT=0")
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+function test(size) {
+    const array = new BigInt64Array(size);
+    return array;
+}
+noInline(test);
+
+let result = 0;
+
+// warm up
+for (let i = 0; i < testLoopCount; ++i) {
+    const size = 1.0;
+    const len = test(size).length;
+    result += len;
+}
+
+// At this point, the function should be compiled down to the DFG/FTL
+
+// This checks the compliance to the step 9 |ToIndex(firstArgument)| of https://tc39.es/ecma262/2026/#sec-typedarray
+shouldThrow('compliant with ToIndex(firstArgument)', () => {
+    test(Number.POSITIVE_INFINITY);
+}, RangeError, 'length larger than (2 ** 53) - 1');

--- a/JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-float16array.js
+++ b/JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-float16array.js
@@ -1,0 +1,38 @@
+//@ runDefault("--jitPolicyScale=0.1", "--useConcurrentJIT=0")
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+function test(size) {
+    const array = new Float16Array(size);
+    return array;
+}
+noInline(test);
+
+let result = 0;
+
+// warm up
+for (let i = 0; i < testLoopCount; ++i) {
+    const size = 1.0;
+    const len = test(size).length;
+    result += len;
+}
+
+// At this point, the function should be compiled down to the DFG/FTL
+
+// This checks the compliance to the step 9 |ToIndex(firstArgument)| of https://tc39.es/ecma262/2026/#sec-typedarray
+shouldThrow('compliant with ToIndex(firstArgument)', () => {
+    test(Number.POSITIVE_INFINITY);
+}, RangeError, 'length larger than (2 ** 53) - 1');

--- a/JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-float32array.js
+++ b/JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-float32array.js
@@ -1,0 +1,38 @@
+//@ runDefault("--jitPolicyScale=0.1", "--useConcurrentJIT=0")
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+function test(size) {
+    const array = new Float32Array(size);
+    return array;
+}
+noInline(test);
+
+let result = 0;
+
+// warm up
+for (let i = 0; i < testLoopCount; ++i) {
+    const size = 1.0;
+    const len = test(size).length;
+    result += len;
+}
+
+// At this point, the function should be compiled down to the DFG/FTL
+
+// This checks the compliance to the step 9 |ToIndex(firstArgument)| of https://tc39.es/ecma262/2026/#sec-typedarray
+shouldThrow('compliant with ToIndex(firstArgument)', () => {
+    test(Number.POSITIVE_INFINITY);
+}, RangeError, 'length larger than (2 ** 53) - 1');

--- a/JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-float64array.js
+++ b/JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-float64array.js
@@ -1,0 +1,38 @@
+//@ runDefault("--jitPolicyScale=0.1", "--useConcurrentJIT=0")
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+function test(size) {
+    const array = new Float64Array(size);
+    return array;
+}
+noInline(test);
+
+let result = 0;
+
+// warm up
+for (let i = 0; i < testLoopCount; ++i) {
+    const size = 1.0;
+    const len = test(size).length;
+    result += len;
+}
+
+// At this point, the function should be compiled down to the DFG/FTL
+
+// This checks the compliance to the step 9 |ToIndex(firstArgument)| of https://tc39.es/ecma262/2026/#sec-typedarray
+shouldThrow('compliant with ToIndex(firstArgument)', () => {
+    test(Number.POSITIVE_INFINITY);
+}, RangeError, 'length larger than (2 ** 53) - 1');

--- a/JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-int16array.js
+++ b/JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-int16array.js
@@ -1,0 +1,38 @@
+//@ runDefault("--jitPolicyScale=0.1", "--useConcurrentJIT=0")
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+function test(size) {
+    const array = new Uint16Array(size);
+    return array;
+}
+noInline(test);
+
+let result = 0;
+
+// warm up
+for (let i = 0; i < testLoopCount; ++i) {
+    const size = 1.0;
+    const len = test(size).length;
+    result += len;
+}
+
+// At this point, the function should be compiled down to the DFG/FTL
+
+// This checks the compliance to the step 9 |ToIndex(firstArgument)| of https://tc39.es/ecma262/2026/#sec-typedarray
+shouldThrow('compliant with ToIndex(firstArgument)', () => {
+    test(Number.POSITIVE_INFINITY);
+}, RangeError, 'length larger than (2 ** 53) - 1');

--- a/JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-int32array.js
+++ b/JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-int32array.js
@@ -1,0 +1,38 @@
+//@ runDefault("--jitPolicyScale=0.1", "--useConcurrentJIT=0")
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+function test(size) {
+    const array = new Int32Array(size);
+    return array;
+}
+noInline(test);
+
+let result = 0;
+
+// warm up
+for (let i = 0; i < testLoopCount; ++i) {
+    const size = 1.0;
+    const len = test(size).length;
+    result += len;
+}
+
+// At this point, the function should be compiled down to the DFG/FTL
+
+// This checks the compliance to the step 9 |ToIndex(firstArgument)| of https://tc39.es/ecma262/2026/#sec-typedarray
+shouldThrow('compliant with ToIndex(firstArgument)', () => {
+    test(Number.POSITIVE_INFINITY);
+}, RangeError, 'length larger than (2 ** 53) - 1');

--- a/JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-int8array.js
+++ b/JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-int8array.js
@@ -1,0 +1,38 @@
+//@ runDefault("--jitPolicyScale=0.1", "--useConcurrentJIT=0")
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+function test(size) {
+    const array = new Int8Array(size);
+    return array;
+}
+noInline(test);
+
+let result = 0;
+
+// warm up
+for (let i = 0; i < testLoopCount; ++i) {
+    const size = 1.0;
+    const len = test(size).length;
+    result += len;
+}
+
+// At this point, the function should be compiled down to the DFG/FTL
+
+// This checks the compliance to the step 9 |ToIndex(firstArgument)| of https://tc39.es/ecma262/2026/#sec-typedarray
+shouldThrow('compliant with ToIndex(firstArgument)', () => {
+    test(Number.POSITIVE_INFINITY);
+}, RangeError, 'length larger than (2 ** 53) - 1');

--- a/JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-uint16array.js
+++ b/JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-uint16array.js
@@ -1,0 +1,38 @@
+//@ runDefault("--jitPolicyScale=0.1", "--useConcurrentJIT=0")
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+function test(size) {
+    const array = new Uint16Array(size);
+    return array;
+}
+noInline(test);
+
+let result = 0;
+
+// warm up
+for (let i = 0; i < testLoopCount; ++i) {
+    const size = 1.0;
+    const len = test(size).length;
+    result += len;
+}
+
+// At this point, the function should be compiled down to the DFG/FTL
+
+// This checks the compliance to the step 9 |ToIndex(firstArgument)| of https://tc39.es/ecma262/2026/#sec-typedarray
+shouldThrow('compliant with ToIndex(firstArgument)', () => {
+    test(Number.POSITIVE_INFINITY);
+}, RangeError, 'length larger than (2 ** 53) - 1');

--- a/JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-uint32array.js
+++ b/JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-uint32array.js
@@ -1,0 +1,38 @@
+//@ runDefault("--jitPolicyScale=0.1", "--useConcurrentJIT=0")
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+function test(size) {
+    const array = new Uint32Array(size);
+    return array;
+}
+noInline(test);
+
+let result = 0;
+
+// warm up
+for (let i = 0; i < testLoopCount; ++i) {
+    const size = 1.0;
+    const len = test(size).length;
+    result += len;
+}
+
+// At this point, the function should be compiled down to the DFG/FTL
+
+// This checks the compliance to the step 9 |ToIndex(firstArgument)| of https://tc39.es/ecma262/2026/#sec-typedarray
+shouldThrow('compliant with ToIndex(firstArgument)', () => {
+    test(Number.POSITIVE_INFINITY);
+}, RangeError, 'length larger than (2 ** 53) - 1');

--- a/JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-uint8array.js
+++ b/JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-uint8array.js
@@ -1,0 +1,38 @@
+//@ runDefault("--jitPolicyScale=0.1", "--useConcurrentJIT=0")
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+function test(size) {
+    const array = new Uint8Array(size);
+    return array;
+}
+noInline(test);
+
+let result = 0;
+
+// warm up
+for (let i = 0; i < testLoopCount; ++i) {
+    const size = 1.0;
+    const len = test(size).length;
+    result += len;
+}
+
+// At this point, the function should be compiled down to the DFG/FTL
+
+// This checks the compliance to the step 9 |ToIndex(firstArgument)| of https://tc39.es/ecma262/2026/#sec-typedarray
+shouldThrow('compliant with ToIndex(firstArgument)', () => {
+    test(Number.POSITIVE_INFINITY);
+}, RangeError, 'length larger than (2 ** 53) - 1');

--- a/JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-uint8clampledarray.js
+++ b/JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-uint8clampledarray.js
@@ -1,0 +1,38 @@
+//@ runDefault("--jitPolicyScale=0.1", "--useConcurrentJIT=0")
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+function test(size) {
+    const array = new Uint8ClampedArray(size);
+    return array;
+}
+noInline(test);
+
+let result = 0;
+
+// warm up
+for (let i = 0; i < testLoopCount; ++i) {
+    const size = 1.0;
+    const len = test(size).length;
+    result += len;
+}
+
+// At this point, the function should be compiled down to the DFG/FTL
+
+// This checks the compliance to the step 9 |ToIndex(firstArgument)| of https://tc39.es/ecma262/2026/#sec-typedarray
+shouldThrow('compliant with ToIndex(firstArgument)', () => {
+    test(Number.POSITIVE_INFINITY);
+}, RangeError, 'length larger than (2 ** 53) - 1');

--- a/JSTests/stress/typedarray-constructor-toindex-length-before-allocatetypedarray-if-1st-arg-not-object.js
+++ b/JSTests/stress/typedarray-constructor-toindex-length-before-allocatetypedarray-if-1st-arg-not-object.js
@@ -1,0 +1,49 @@
+// The original is https://github.com/tc39/test262/blob/b1f9a0aea3e5d12563680ba3c8eee275774f9316/test/built-ins/TypedArrayConstructors/ctors/typedarray-arg/throw-type-error-before-custom-proto-access.js
+
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+const newTarget = function () { }.bind(null);
+Object.defineProperty(newTarget, "prototype", {
+    get() {
+        throw new Error('this should not be caught');
+    },
+});
+
+const TEST_TARGET = [
+    BigInt64Array,
+    BigUint64Array,
+    Float16Array,
+    Float32Array,
+    Float64Array,
+    Int16Array,
+    Int32Array,
+    Int8Array,
+    Uint16Array,
+    Uint32Array,
+    Uint8Array,
+    Uint8ClampedArray,
+];
+
+for (const Ctor of TEST_TARGET) {
+    const label = Ctor.name;
+
+    // https://tc39.es/ecma262/2026/#sec-typedarray
+    // If the 1st argument is not an Object,
+    // the step 9 |ToIndex(firstArgument)| should be executed before the step 10 |AllocateTypedArray|.
+    shouldThrow(label, () => {
+        Reflect.construct(Ctor, [Symbol()], newTarget);
+    }, TypeError, 'Cannot convert a symbol to a number');
+}

--- a/JSTests/test262/expectations.yaml
+++ b/JSTests/test262/expectations.yaml
@@ -43,9 +43,6 @@ test/built-ins/TypedArray/prototype/slice/speciesctor-return-same-buffer-with-of
 test/built-ins/TypedArrayConstructors/ctors/object-arg/iterated-array-changed-by-tonumber.js:
   default: 'Test262Error: Expected SameValue(«NaN», «2») to be true (Testing with Float64Array and makePassthrough.)'
   strict mode: 'Test262Error: Expected SameValue(«NaN», «2») to be true (Testing with Float64Array and makePassthrough.)'
-test/built-ins/TypedArrayConstructors/ctors/typedarray-arg/throw-type-error-before-custom-proto-access.js:
-  default: 'Test262Error: Expected a TypeError but got a Test262Error (Testing with Float64Array and makePassthrough.)'
-  strict mode: 'Test262Error: Expected a TypeError but got a Test262Error (Testing with Float64Array and makePassthrough.)'
 test/built-ins/Uint8Array/prototype/setFromBase64/trailing-garbage-empty.js:
   default: 'SyntaxError: Uint8Array.prototype.setFromBase64 requires a valid base64 string'
   strict mode: 'SyntaxError: Uint8Array.prototype.setFromBase64 requires a valid base64 string'

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -2779,7 +2779,7 @@ JSC_DEFINE_JIT_OPERATION(operationNewArrayBuffer, JSCell*, (VM* vmPointer, Struc
         if (auto* arrayBuffer = dynamicDowncast<JSArrayBuffer>(firstValue)) \
             isResizableOrGrowableShared = arrayBuffer->isResizableOrGrowableShared(); \
         Structure* structure = globalObject->typedArrayStructure(Type##type, isResizableOrGrowableShared); \
-        OPERATION_RETURN(scope, reinterpret_cast<char*>(constructGenericTypedArrayViewWithArguments<JS##type##Array>(globalObject, structure, firstValue, 0, std::nullopt))); \
+        OPERATION_RETURN(scope, reinterpret_cast<char*>(operationConstructGenericTypedArrayViewWithOneArgumentImpl<JS##type##Array>(globalObject, structure, firstValue))); \
     } \
 
     FOR_EACH_TYPED_ARRAY_TYPE_EXCLUDING_DATA_VIEW(JSC_TYPED_ARRAY_OPERATIONS)

--- a/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h
+++ b/Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h
@@ -38,6 +38,8 @@
 #include "JSTypedArrays.h"
 #include "MathCommon.h"
 #include "StructureCreateInlines.h"
+#include <cstddef>
+#include <optional>
 #include <wtf/Assertions.h>
 #include <wtf/text/ASCIILiteral.h>
 
@@ -163,8 +165,8 @@ inline JSObject* constructGenericTypedArrayViewWithArguments(JSGlobalObject* glo
     if (JSArrayBuffer* jsBuffer = dynamicDowncast<JSArrayBuffer>(firstValue))
         RELEASE_AND_RETURN(scope, constructGenericTypedArrayViewWithArrayBuffer<ViewClass>(globalObject, structure, jsBuffer, offset, lengthOpt));
 
-    ASSERT(!offset && !lengthOpt);
-    
+    ASSERT(!offset);
+
     // For everything but DataView, we allow construction with any of:
     // - Another array. This creates a copy of the of that array.
     // - A primitive. This creates a new typed array of that length and zero-initializes it.
@@ -250,10 +252,29 @@ inline JSObject* constructGenericTypedArrayViewWithArguments(JSGlobalObject* glo
         return result;
     }
 
-    size_t length = firstValue.toIndex(globalObject, "length"_s);
-    RETURN_IF_EXCEPTION(scope, nullptr);
+    ASSERT(!offset && lengthOpt.has_value());
+    ASSERT(!firstValue.isObject());
 
+    size_t length = lengthOpt.value();
     RELEASE_AND_RETURN(scope, ViewClass::create(globalObject, structure, length));
+}
+
+template<typename ViewClass>
+inline JSObject* operationConstructGenericTypedArrayViewWithOneArgumentImpl(JSGlobalObject* globalObject, Structure* structure, JSValue firstValue)
+{
+    static_assert(ViewClass::TypedArrayStorageType != TypeDataView);
+
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    std::optional<size_t> length;
+    if (!firstValue.isObject()) {
+        // the step 9 of https://tc39.es/ecma262/2026/#sec-typedarray
+        length = firstValue.toIndex(globalObject, "length"_s);
+        RETURN_IF_EXCEPTION(scope, { });
+    }
+
+    RELEASE_AND_RETURN(scope, constructGenericTypedArrayViewWithArguments<ViewClass>(globalObject, structure, firstValue, 0,  length));
 }
 
 // This is equivalent to https://tc39.es/ecma262/#sec-typedarray
@@ -306,6 +327,12 @@ ALWAYS_INLINE EncodedJSValue constructGenericTypedArrayViewImpl(JSGlobalObject* 
             }
         }
     } else {
+        if (!firstValue.isObject()) {
+            // the step 9 of https://tc39.es/ecma262/2026/#sec-typedarray
+            length = firstValue.toIndex(globalObject, "length"_s);
+            RETURN_IF_EXCEPTION(scope, { });
+        }
+
         structure = JSC_GET_DERIVED_STRUCTURE(vm, typedArrayStructureWithTypedArrayType<ViewClass::TypedArrayStorageType>, newTarget, callFrame->jsCallee());
         RETURN_IF_EXCEPTION(scope, { });
     }


### PR DESCRIPTION
#### b50d777c02d0b7be29979e7c0fe50d678918cb09
<pre>
[JSC] test262 fail: test/built-ins/TypedArrayConstructors/ctors/typedarray-arg/throw-type-error-before-custom-proto-access.js
<a href="https://bugs.webkit.org/show_bug.cgi?id=314063">https://bugs.webkit.org/show_bug.cgi?id=314063</a>

Reviewed by Yusuke Suzuki.

According to the spec <a href="https://tc39.es/ecma262/2026/#sec-typedarray">https://tc39.es/ecma262/2026/#sec-typedarray</a>
If the 1st argument of `new TypedArray(value)` is not an Object,
the step 9 |ToIndex(firstArgument)| should be executed before the step 10 |AllocateTypedArray|.

The current DFG/FTL implementation invoke the runtime code as a slow path
for the 1st argument is not int32/int52rep (DFG node would be `NewTypedArray(UntypedUse)`).
Then |ToIndex(firstArgument)| is also delegated to the runtime.

To simplify this flow, this patch introduce `operationConstructGenericTypedArrayViewWithOneArgumentImpl()`.

This patch adds new 2 kind of tests:

1. Simple port of test262&apos;s test/built-ins/TypedArrayConstructors/ctors/typedarray-arg/throw-type-error-before-custom-proto-access.js.
2. DFG/FTL delegate |ToIndex(firstArgument)| properly.
    - Test variants named as typedarray-constructor-jit-compliant-toindex-firstarg-*

Tests: JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-biguint64.js
       JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-bitint64.js
       JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-float16array.js
       JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-float32array.js
       JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-float64array.js
       JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-int16array.js
       JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-int32array.js
       JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-int8array.js
       JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-uint16array.js
       JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-uint32array.js
       JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-uint8array.js
       JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-uint8clampledarray.js
       JSTests/stress/typedarray-constructor-toindex-length-before-allocatetypedarray-if-1st-arg-not-object.js

* JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-biguint64.js: Added.
(shouldThrow):
* JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-bitint64.js: Added.
(shouldThrow):
* JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-float16array.js: Added.
(shouldThrow):
* JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-float32array.js: Added.
(shouldThrow):
* JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-float64array.js: Added.
(shouldThrow):
* JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-int16array.js: Added.
(shouldThrow):
* JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-int32array.js: Added.
(shouldThrow):
* JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-int8array.js: Added.
(shouldThrow):
* JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-uint16array.js: Added.
(shouldThrow):
* JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-uint32array.js: Added.
(shouldThrow):
* JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-uint8array.js: Added.
(shouldThrow):
* JSTests/stress/typedarray-constructor-jit-compliant-toindex-firstarg-uint8clampledarray.js: Added.
(shouldThrow):
* JSTests/stress/typedarray-constructor-toindex-length-before-allocatetypedarray-if-1st-arg-not-object.js: Added.
(shouldThrow):
(const.newTarget):
* JSTests/test262/expectations.yaml:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
* Source/JavaScriptCore/runtime/JSGenericTypedArrayViewConstructorInlines.h:
(JSC::constructGenericTypedArrayViewWithArguments):
(JSC::operationConstructGenericTypedArrayViewWithOneArgumentImpl):
(JSC::constructGenericTypedArrayViewImpl):

Canonical link: <a href="https://commits.webkit.org/316237@main">https://commits.webkit.org/316237@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/807852455b24b6f6f52611f4f78cef60f5829c47

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/171838 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/45755 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39173 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181141 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/129392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47040 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45395 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/133681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/129392 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/174796 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/37070 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/154177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114153 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/35702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/33966 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/29891 "Built successfully") | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/2719 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/146127 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/33687 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/183809 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/33097 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/36425 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/38164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/142389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45422 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142280 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46102 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/30531 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/110737 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26084 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37378 "Passed tests") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/117790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/204516 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/44620 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54622 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44020 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44252 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44079 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->