### PR TITLE
Remove unnecessary work in AudioMediaStreamTrackRendererCocoa::setAudioOutputDevice

### DIFF
--- a/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererCocoa.cpp
@@ -112,13 +112,12 @@ void AudioMediaStreamTrackRendererCocoa::reset()
 
 void AudioMediaStreamTrackRendererCocoa::setAudioOutputDevice(const String& deviceID)
 {
-    auto registeredDataSource = m_registeredDataSource;
+    ASSERT(isMainThread());
 
-    setRegisteredDataSource(nullptr);
+    if (RefPtr registeredDataSource = std::exchange(m_registeredDataSource, nullptr))
+        rendererUnit().removeSource(m_deviceID, *registeredDataSource);
 
     m_deviceID = deviceID;
-    setRegisteredDataSource(WTF::move(registeredDataSource));
-
     m_shouldRecreateDataSource = true;
 }
 
@@ -126,7 +125,7 @@ void AudioMediaStreamTrackRendererCocoa::setRegisteredDataSource(RefPtr<AudioSam
 {
     ASSERT(isMainThread());
 
-    if (RefPtr registeredDataSource = m_registeredDataSource)
+    if (RefPtr registeredDataSource = std::exchange(m_registeredDataSource, nullptr))
         rendererUnit().removeSource(m_deviceID, *registeredDataSource);
 
     if (!m_outputDescription)
@@ -177,7 +176,7 @@ void AudioMediaStreamTrackRendererCocoa::pushSamples(const MediaTime& sampleTime
             if (RefPtr protectedThis = weakThis.get())
                 protectedThis->setRegisteredDataSource(WTF::move(newSource));
         });
-        m_dataSource = dataSource;
+        m_dataSource = WTF::move(dataSource);
         m_shouldRecreateDataSource = false;
     }
 

--- a/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/AudioMediaStreamTrackRendererUnit.cpp
@@ -162,7 +162,7 @@ void AudioMediaStreamTrackRendererUnit::Unit::close()
 void AudioMediaStreamTrackRendererUnit::Unit::addSource(Ref<AudioSampleDataSource>&& source)
 {
 #if !RELEASE_LOG_DISABLED
-    protect(source->logger())->logAlways(LogWebRTC, "AudioMediaStreamTrackRendererUnit::addSource ", source->logIdentifier());
+    protect(source->logger())->logAlways(LogWebRTC, "AudioMediaStreamTrackRendererUnit::Unit::addSource ", source->logIdentifier());
 #endif
     assertIsMainThread();
 
@@ -183,7 +183,7 @@ void AudioMediaStreamTrackRendererUnit::Unit::addSource(Ref<AudioSampleDataSourc
 bool AudioMediaStreamTrackRendererUnit::Unit::removeSource(AudioSampleDataSource& source)
 {
 #if !RELEASE_LOG_DISABLED
-    protect(source.logger())->logAlways(LogWebRTC, "AudioMediaStreamTrackRendererUnit::removeSource ", source.logIdentifier());
+    protect(source.logger())->logAlways(LogWebRTC, "AudioMediaStreamTrackRendererUnit::Unit::removeSource ", source.logIdentifier());
 #endif
     assertIsMainThread();
 
@@ -223,7 +223,7 @@ void AudioMediaStreamTrackRendererUnit::Unit::retrieveFormatDescription(Completi
 void AudioMediaStreamTrackRendererUnit::Unit::start()
 {
     assertIsMainThread();
-    RELEASE_LOG(WebRTC, "AudioMediaStreamTrackRendererUnit::start");
+    RELEASE_LOG(WebRTC, "AudioMediaStreamTrackRendererUnit::Unit::start");
 
     m_internalUnit->start();
 }
@@ -231,14 +231,14 @@ void AudioMediaStreamTrackRendererUnit::Unit::start()
 void AudioMediaStreamTrackRendererUnit::Unit::stop()
 {
     assertIsMainThread();
-    RELEASE_LOG(WebRTC, "AudioMediaStreamTrackRendererUnit::stop");
+    RELEASE_LOG(WebRTC, "AudioMediaStreamTrackRendererUnit::Unit::stop");
 
     m_internalUnit->stop();
 }
 
 void AudioMediaStreamTrackRendererUnit::Unit::reset()
 {
-    RELEASE_LOG(WebRTC, "AudioMediaStreamTrackRendererUnit::reset");
+    RELEASE_LOG(WebRTC, "AudioMediaStreamTrackRendererUnit::Unit::reset");
     if (!isMainThread()) {
         callOnMainThread([weakThis = ThreadSafeWeakPtr { *this }] {
             if (RefPtr strongThis = weakThis.get())


### PR DESCRIPTION
#### 38478bb7dfd4214b504be3366bed4b05b5ddab85
<pre>
Remove unnecessary work in AudioMediaStreamTrackRendererCocoa::setAudioOutputDevice
<a href="https://rdar.apple.com/177332591">rdar://177332591</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=315008">https://bugs.webkit.org/show_bug.cgi?id=315008</a>

Reviewed by NOBODY (OOPS!).

AudioMediaStreamTrackRendererCocoa::setAudioOutputDevice was removing the registered data source from the renderer unit
and immediately re-adding it under the new device ID via setRegisteredDataSource.
That re-registration is unnecessary as we also set m_shouldRecreateDataSource to true,
so the next pushSamples call will rebuild and re-register a fresh data source anyway.

We drop the registered source from the old device, update m_deviceID, and let the recreation path on the next pushSamples handle re-registration.
We also add a main-thread assertion to match setRegisteredDataSource.

We use std::exchange in setRegisteredDataSource so m_registeredDataSource is cleared as it is handed to removeSource as a fly-by fix.
We also update some logs so that they use the right class name (&quot;::Unit&quot; was missing).
We do a small ref count improvement by std::moving the local dataSource into m_dataSource in AudioMediaStreamTrackRendererCocoaushSamples.

Covered by existing tests.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38478bb7dfd4214b504be3366bed4b05b5ddab85

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163066 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36545 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29749 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172005 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119512 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3dda9952-d5db-4645-a420-a2de2774dcfb) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164935 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36774 "Failed to checkout and rebase branch from PR 65096") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36547 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126589 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89196 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5d4a2c44-db3b-4389-8706-cc9d2d5725b3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166025 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/36774 "Failed to checkout and rebase branch from PR 65096") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146573 "Found 1 new API test failure: TestWebKitAPI.WebKit2.SpeechRecognitionErrorWhenStartingAudioCaptureOnDifferentPage (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107165 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6907af3a-9587-4b57-b203-f89bd9848839) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/36774 "Failed to checkout and rebase branch from PR 65096") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26531 "Found 11 new API test failures: TestWebKitAPI.WKWebExtensionContext.TopLevelThrowInModuleBackground, TestWebKitAPI.WKWebExtensionContext.SyntaxErrorInBackground, TestWebKitAPI.WKWebExtensionContext.UncaughtScriptErrorInBackground, TestWebKitAPI.WKWebExtensionContext.LoadNonExistentImage, TestWebKitAPI.WKWebExtensionContext.UnhandledPromiseRejectionInBackground, TestWebKitAPI.WKWebExtensionContext.UncaughtScriptErrorInServiceWorkerBackground, TestWebKitAPI.WebKit2.WebRTCAndRemoteCommands, TestWebKitAPI.WebKit2.SpeechRecognitionErrorWhenStartingAudioCaptureOnDifferentPage, TestWebKitAPI.WKWebExtensionContext.CallingMissingBrowserAPIInBackground, TestWebKitAPI.WKWebExtensionContext.UncaughtScriptErrorInMainWorldContentScript ... (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19704 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137734 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24303 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174508 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/26339 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25949 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134903 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36216 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30634 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134898 "Passed tests") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/36985 "Failed to checkout and rebase branch from PR 65096") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146098 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98805 "Built successfully") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30110 "Unexpected infrastructure issue, retrying build") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22937 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35712 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/107985 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35211 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/957 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35458 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35359 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->