### PR TITLE
[GTK][WPE] Skia Compositor: use SkCanvas::drawImageRect instead of SkSurface::writePixels to upload BGRA buffers to textures

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp
@@ -31,6 +31,7 @@
 #include "CoordinatedTileBuffer.h"
 #include "PlatformDisplay.h"
 #include "SkiaPaintingEngine.h"
+#include "SkiaUtilities.h"
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkColorSpace.h>
 #include <skia/gpu/ganesh/GrBackendSurface.h>
@@ -149,6 +150,9 @@ void SkiaBackingStore::Tile::update(const IntRect& dirtyRect, const IntRect& til
         m_surface = nullptr;
     }
 
+    auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
+    ASSERT(grContext);
+
     if (buffer.isBackedByOpenGL()) {
         auto& acceleratedBuffer = static_cast<CoordinatedAcceleratedTileBuffer&>(buffer);
         acceleratedBuffer.serverWait();
@@ -165,24 +169,21 @@ void SkiaBackingStore::Tile::update(const IntRect& dirtyRect, const IntRect& til
                     static_cast<BitmapTexture*>(userData)->deref();
                 }, &texture.leakRef());
             } else {
-                auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
                 m_surface = SkSurfaces::WrapBackendTexture(grContext, backendTexture, kTopLeft_GrSurfaceOrigin, 0, kRGBA_8888_SkColorType, SkColorSpace::MakeSRGB(), nullptr, +[](void* userData) {
                     static_cast<BitmapTexture*>(userData)->deref();
                 }, &texture.leakRef());
             }
         } else if (tryEnsureSurface(tileRect.size(), buffer)) {
-            auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
             auto image = SkImages::BorrowTextureFrom(grContext, backendTexture, kTopLeft_GrSurfaceOrigin, kRGBA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
-            SkPaint paint;
-            paint.setBlendMode(SkBlendMode::kSrc);
-            m_surface->getCanvas()->drawImageRect(image, SkRect::MakeWH(dirtyRect.width(), dirtyRect.height()), SkRect::Make(SkIRect(dirtyRect)),
-                SkSamplingOptions(SkFilterMode::kNearest, SkMipmapMode::kNone), &paint, SkCanvas::kFast_SrcRectConstraint);
+            SkiaUtilities::paintImageRectToSurface(m_surface, image, dirtyRect);
         }
     } else if (tryEnsureSurface(tileRect.size(), buffer)) {
         auto& unacceleratedBuffer = static_cast<CoordinatedUnacceleratedTileBuffer&>(buffer);
         auto imageInfo = SkImageInfo::Make(dirtyRect.width(), dirtyRect.height(), kBGRA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
         SkPixmap pixmap(imageInfo, unacceleratedBuffer.data(), unacceleratedBuffer.stride());
-        m_surface->writePixels(pixmap, dirtyRect.x(), dirtyRect.y());
+        auto image = SkImages::RasterFromPixmap(pixmap, nullptr, nullptr);
+        SkiaUtilities::paintImageRectToSurface(m_surface, image, dirtyRect);
+        grContext->flushAndSubmit(m_surface.get(), GrSyncCpu::kNo);
     }
 
     WTFEndSignpost(this, SkiaBackingStoreTileUpdate);

--- a/Source/WebCore/platform/graphics/skia/SkiaUtilities.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaUtilities.cpp
@@ -36,6 +36,7 @@
 #include "PlatformDisplay.h"
 
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkCanvas.h>
 #include <skia/gpu/ganesh/SkImageGanesh.h>
 #include <skia/gpu/ganesh/SkSurfaceGanesh.h>
 #include <skia/gpu/ganesh/gl/GrGLBackendSurface.h>
@@ -122,6 +123,15 @@ std::unique_ptr<GLFence> flushAndSubmitWithFence(GrDirectContext* grContext)
 {
     grContext->flush();
     return createFenceAfterFlush(grContext);
+}
+
+void paintImageRectToSurface(sk_sp<SkSurface>& surface, const sk_sp<SkImage>& image, const FloatRect& rect)
+{
+    ASSERT(surface && surface->getCanvas());
+    SkPaint paint;
+    paint.setBlendMode(SkBlendMode::kSrc);
+    surface->getCanvas()->drawImageRect(image, SkRect::MakeWH(rect.width(), rect.height()), SkRect(rect),
+        SkSamplingOptions(SkFilterMode::kNearest, SkMipmapMode::kNone), &paint, SkCanvas::kFast_SrcRectConstraint);
 }
 
 SkBlendMode toSkiaBlendMode(BlendMode blendMode, std::optional<CompositeOperator> operation)

--- a/Source/WebCore/platform/graphics/skia/SkiaUtilities.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaUtilities.h
@@ -81,6 +81,10 @@ std::unique_ptr<GLFence> flushAndSubmitImageWithFence(GrDirectContext*, const sk
 // supported or creation fails, and returns nullptr.
 std::unique_ptr<GLFence> flushAndSubmitWithFence(GrDirectContext*);
 
+// Paint image into surface at given rectangle using source over blend mode.
+// This is used to upload pixels to the GPU.
+void paintImageRectToSurface(sk_sp<SkSurface>&, const sk_sp<SkImage>&, const FloatRect&);
+
 SkBlendMode toSkiaBlendMode(BlendMode, std::optional<CompositeOperator> = std::nullopt);
 
 } // namespace SkiaUtilities

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.cpp
@@ -134,7 +134,8 @@ bool CoordinatedPlatformLayerBufferNativeImage::tryEnsureBuffer(UseSkiaForCompos
         if (!surface)
             return false;
 
-        surface->writePixels(pixmap, 0, 0);
+        auto image = SkImages::RasterFromPixmap(pixmap, nullptr, nullptr);
+        SkiaUtilities::paintImageRectToSurface(surface, image, FloatRect({ }, m_size));
     } else
         texture->updateContents(pixmap.addr(), IntRect(IntPoint(), m_size), IntPoint(), image->imageInfo().minRowBytes(), PixelFormat::BGRA8);
 #endif


### PR DESCRIPTION
#### 0862297dc1936603eb7417ea3f16c06304c2f7c7
<pre>
[GTK][WPE] Skia Compositor: use SkCanvas::drawImageRect instead of SkSurface::writePixels to upload BGRA buffers to textures
<a href="https://bugs.webkit.org/show_bug.cgi?id=315011">https://bugs.webkit.org/show_bug.cgi?id=315011</a>

Reviewed by Nikolas Zimmermann.

When using SkSurface::writePixels the BGRA to RGBA conversion is always
done by CPU before pixels are uploaded. With SkCanvas::drawImageRect is
the GL platform supports BGRA, the pixels are uploaded as BGRA and then
converted by the GPU before painting.

* Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp:
(WebCore::SkiaBackingStore::Tile::update):
* Source/WebCore/platform/graphics/skia/SkiaUtilities.cpp:
(WebCore::SkiaUtilities::paintImageRectToSurface):
* Source/WebCore/platform/graphics/skia/SkiaUtilities.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.cpp:
(WebCore::CoordinatedPlatformLayerBufferNativeImage::tryEnsureBuffer):

Canonical link: <a href="https://commits.webkit.org/313410@main">https://commits.webkit.org/313410@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77b1ab9754a44c6860d93fa0b51c8a4361ad4a72

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163079 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36558 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29765 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172018 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119525 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164948 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/36766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36560 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126601 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/89204 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166038 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/36766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146590 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107177 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/36766 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26540 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19717 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137744 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24320 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174521 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/26392 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25966 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134914 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36229 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30643 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134909 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/36908 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146115 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98826 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24801 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/30145 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22955 "Failed to checkout and rebase branch from PR 65100") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35725 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108035 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35224 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/974 "Passed tests") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35471 "Hash 77b1ab97 for PR 65100 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35372 "Hash 77b1ab97 for PR 65100 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->