### PR TITLE
[Skia] Optimize SkiaCompositingLayer repaint counter drawing

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -558,7 +558,6 @@ void SkiaCompositingLayer::paintSelf(SkCanvas& canvas, PaintContext& context)
     if (m_repaintCount) {
         constexpr float pointSize = 14;
         constexpr float padding = 3;
-        auto counterString = String::number(*m_repaintCount).ascii();
 
         static SkFont font = [] {
             auto typeface = FontCache::forCurrentThread().fontManager().matchFamilyStyle("monospace", SkFontStyle::Bold());
@@ -568,10 +567,15 @@ void SkiaCompositingLayer::paintSelf(SkCanvas& canvas, PaintContext& context)
             return f;
         }();
 
-        SkRect textBounds;
-        font.measureText(counterString.data(), counterString.length(), SkTextEncoding::kUTF8, &textBounds);
-        float textWidth = textBounds.width() + padding * 2;
-        float textHeight = textBounds.height() + padding * 2;
+        if (m_repaintCountOverlay.count != m_repaintCount) {
+            m_repaintCountOverlay.count = m_repaintCount;
+            m_repaintCountOverlay.string = String::number(*m_repaintCount).ascii();
+            SkRect textBounds;
+            font.measureText(m_repaintCountOverlay.string.data(), m_repaintCountOverlay.string.length(), SkTextEncoding::kUTF8, &textBounds);
+            m_repaintCountOverlay.backgroundWidth = textBounds.width() + padding * 2;
+            m_repaintCountOverlay.backgroundHeight = textBounds.height() + padding * 2;
+            m_repaintCountOverlay.baselineOffset = -textBounds.fTop + padding;
+        }
 
         SkAutoCanvasRestore autoRestore(&canvas, true);
         canvas.resetMatrix();
@@ -579,12 +583,12 @@ void SkiaCompositingLayer::paintSelf(SkCanvas& canvas, PaintContext& context)
         SkPaint backgroundPaint;
         backgroundPaint.setColor(m_debugBorder ? SkColor(m_debugBorder->color) : SK_ColorBLACK);
         backgroundPaint.setStyle(SkPaint::kFill_Style);
-        canvas.drawRect(SkRect::MakeXYWH(deviceOrigin.x(), deviceOrigin.y(), textWidth, textHeight), backgroundPaint);
+        canvas.drawRect(SkRect::MakeXYWH(deviceOrigin.x(), deviceOrigin.y(), m_repaintCountOverlay.backgroundWidth, m_repaintCountOverlay.backgroundHeight), backgroundPaint);
 
         SkPaint textPaint;
         textPaint.setColor(SK_ColorWHITE);
         textPaint.setAntiAlias(true);
-        canvas.drawString(counterString.data(), deviceOrigin.x() + padding, deviceOrigin.y() - textBounds.fTop + padding, font, textPaint);
+        canvas.drawString(m_repaintCountOverlay.string.data(), deviceOrigin.x() + padding, deviceOrigin.y() + m_repaintCountOverlay.baselineOffset, font, textPaint);
     }
 }
 

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
@@ -47,6 +47,7 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #include <wtf/MonotonicTime.h>
 #include <wtf/RefCountedAndCanMakeWeakPtr.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/text/CString.h>
 
 namespace WebCore {
 class CoordinatedAnimatedBackingStoreClient;
@@ -228,6 +229,18 @@ private:
     Color m_contentsSolidColor;
     std::optional<DebugBorder> m_debugBorder;
     std::optional<unsigned> m_repaintCount;
+
+    // Cached repaint-counter overlay shaping, recomputed only when the count
+    // changes rather than on every composite of this layer. count is the
+    // value string/geometry were computed for.
+    struct {
+        std::optional<unsigned> count;
+        CString string;
+        float backgroundWidth { 0 };
+        float backgroundHeight { 0 };
+        float baselineOffset { 0 };
+    } m_repaintCountOverlay;
+
     std::optional<Filter> m_filter;
     struct {
         sk_sp<SkImageFilter> filter;


### PR DESCRIPTION
#### 7b846fecb22f12a6edf42a33367768e188374bd9
<pre>
[Skia] Optimize SkiaCompositingLayer repaint counter drawing
<a href="https://bugs.webkit.org/show_bug.cgi?id=315016">https://bugs.webkit.org/show_bug.cgi?id=315016</a>

Reviewed by Carlos Garcia Campos.

The debug repaint counter recomputed its string and re-measured its
text geometry on every composite of the layer, even though the count
only changes when the layer actually repaints its content. Cache the
shaped string and geometry, recomputing only when the count changes,
matching the on-screen FPS counter in ThreadedCompositor (PR #65093).

* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
(WebCore::SkiaCompositingLayer::paintSelf):
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h:

Canonical link: <a href="https://commits.webkit.org/313408@main">https://commits.webkit.org/313408@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0a6f784ce0f9023d0d9d829a6dfc17f2c5ca06c9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163075 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36554 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29760 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172014 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119521 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164944 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/36767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36556 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126597 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/89200 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166034 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/36767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146583 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107173 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/36767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26538 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19713 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137740 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24313 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174517 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/26360 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/25959 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134910 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36225 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30641 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134905 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36370 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/36894 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146108 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98817 "Built successfully") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/30132 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22948 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35721 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108005 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35220 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/967 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35467 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35368 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->