### PR TITLE
[Debug] WTF.AutomaticThreadTemporaryStop is a flaky assertion crash

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WTF/AutomaticThread.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/AutomaticThread.cpp
@@ -255,10 +255,10 @@ TEST(WTF, AutomaticThreadTemporaryStop)
     }
     thread->waitUntilHasStarted(2);
 
-    // Shut it down.
-    thread->appendWorkItem(Exit { });
     {
         Locker locker { *lock };
+        // Shut it down.
+        thread->appendWorkItem(Exit { });
         condition->notifyOne(locker);
     }
     thread->waitUntilHasStopped(2);
@@ -310,10 +310,10 @@ TEST(WTF, AutomaticThreadTemporaryStopWhileRunning)
     thread->waitUntilHasStopped(1);
     CachedData::waitUntil(0);
 
-    // Shut it down.
-    thread->appendWorkItem(Exit { });
     {
         Locker locker { *lock };
+        // Shut it down.
+        thread->appendWorkItem(Exit { });
         condition->notifyOne(locker);
     }
     thread->waitUntilHasStopped(2);


### PR DESCRIPTION
#### 668b5e5a8de4a8e0b085eedd66b0e13cdc8b25ed
<pre>
[Debug] WTF.AutomaticThreadTemporaryStop is a flaky assertion crash
<a href="https://bugs.webkit.org/show_bug.cgi?id=315015">https://bugs.webkit.org/show_bug.cgi?id=315015</a>

Reviewed by Claudio Saavedra.

When the test shuts down the AutomaticThread, it does so by submitting
an item that will result in a PollResult::Stop and then notifying the
thread. That leaves a small window of opportunity for the thread to
process the Stop and exit. This causes start() to hit the m_isRunning
assertion.

Ensure the AutomaticThread can&apos;t exit before being notified by holding
the lock between the action of submitting the Exit work item and
notifying it.

Canonical link: <a href="https://commits.webkit.org/313870@main">https://commits.webkit.org/313870@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a6ed5126977e3ab35647c9a84443d22458e807ca

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163077 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36556 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29767 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172016 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119523 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164946 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36768 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37786 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126598 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89202 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166036 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28871 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146584 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107174 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27918 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27619 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19715 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137809 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24314 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174519 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25960 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134911 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36227 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31747 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134906 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36640 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37012 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146109 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98819 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30210 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22949 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37052 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35222 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/968 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35469 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35370 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->