### PR TITLE
[JSC] Skip intermediate promise allocation for non-thenable elements in Promise combinators

### DIFF
--- a/JSTests/microbenchmarks/promise-all-non-thenable-object.js
+++ b/JSTests/microbenchmarks/promise-all-non-thenable-object.js
@@ -1,0 +1,8 @@
+const array = [];
+for (let i = 0; i < 12; i++)
+    array.push({ value: i });
+
+for (var i = 0; i < 1e4; ++i)
+    Promise.all(array);
+
+drainMicrotasks();

--- a/JSTests/microbenchmarks/promise-all-non-thenable.js
+++ b/JSTests/microbenchmarks/promise-all-non-thenable.js
@@ -1,0 +1,8 @@
+const array = [];
+for (let i = 0; i < 12; i++)
+    array.push(i);
+
+for (var i = 0; i < 1e4; ++i)
+    Promise.all(array);
+
+drainMicrotasks();

--- a/JSTests/microbenchmarks/promise-all-settled-non-thenable.js
+++ b/JSTests/microbenchmarks/promise-all-settled-non-thenable.js
@@ -1,0 +1,8 @@
+const array = [];
+for (let i = 0; i < 12; i++)
+    array.push(i);
+
+for (var i = 0; i < 1e4; ++i)
+    Promise.allSettled(array);
+
+drainMicrotasks();

--- a/JSTests/microbenchmarks/promise-race-non-thenable.js
+++ b/JSTests/microbenchmarks/promise-race-non-thenable.js
@@ -1,0 +1,8 @@
+const array = [];
+for (let i = 0; i < 12; i++)
+    array.push(i);
+
+for (var i = 0; i < 1e4; ++i)
+    Promise.race(array);
+
+drainMicrotasks();

--- a/JSTests/stress/promise-combinator-non-thenable-element.js
+++ b/JSTests/stress/promise-combinator-non-thenable-element.js
@@ -1,0 +1,197 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: actual=${JSON.stringify(actual)} expected=${JSON.stringify(expected)}`);
+}
+
+function shouldThrow(func, errorMessage) {
+    let errorThrown = false;
+    try { func(); } catch (e) {
+        errorThrown = true;
+        if (String(e) !== errorMessage)
+            throw new Error(`bad error: ${e}`);
+    }
+    if (!errorThrown)
+        throw new Error("not thrown");
+}
+
+const log = [];
+function tick(label) { Promise.resolve().then(() => log.push(label)); }
+
+async function main() {
+    // Promise.all over primitives, non-thenable objects, and promises.
+    {
+        const obj = { a: 1 };
+        const p = Promise.resolve("p");
+        const result = await Promise.all([1, "two", obj, p, null, undefined, 3.5, true, Symbol.for("s"), 4n]);
+        shouldBe(result.length, 10);
+        shouldBe(result[0], 1);
+        shouldBe(result[1], "two");
+        shouldBe(result[2], obj);
+        shouldBe(result[3], "p");
+        shouldBe(result[4], null);
+        shouldBe(result[5], undefined);
+        shouldBe(result[6], 3.5);
+        shouldBe(result[7], true);
+        shouldBe(result[8], Symbol.for("s"));
+        shouldBe(result[9], 4n);
+    }
+
+    // Microtask ordering must be unchanged: each non-thenable element still
+    // burns exactly one tick before the outer promise resolves, so the "all"
+    // callback (queued by the 3rd element job) drains after the 4 ticks that
+    // were already queued at that point.
+    {
+        log.length = 0;
+        Promise.all([1, 2, 3]).then(() => log.push("all"));
+        tick("a"); tick("b"); tick("c"); tick("d");
+        for (var i = 0; i < 8; ++i)
+            await null;
+        shouldBe(JSON.stringify(log), '["a","b","c","d","all"]');
+    }
+
+    // Promise.allSettled
+    {
+        const obj = { foo: 1 };
+        const result = await Promise.allSettled([1, obj, Promise.reject("err"), null]);
+        shouldBe(result.length, 4);
+        shouldBe(result[0].status, "fulfilled");
+        shouldBe(result[0].value, 1);
+        shouldBe(result[1].status, "fulfilled");
+        shouldBe(result[1].value, obj);
+        shouldBe(result[2].status, "rejected");
+        shouldBe(result[2].reason, "err");
+        shouldBe(result[3].status, "fulfilled");
+        shouldBe(result[3].value, null);
+    }
+
+    // Promise.any — all rejecting except one non-thenable.
+    {
+        const result = await Promise.any([Promise.reject("a"), 42, Promise.reject("b")]);
+        shouldBe(result, 42);
+    }
+    {
+        let aggregate;
+        try {
+            await Promise.any([Promise.reject("x"), Promise.reject("y")]);
+        } catch (e) { aggregate = e; }
+        shouldBe(aggregate instanceof AggregateError, true);
+    }
+
+    // Promise.race — first non-thenable wins.
+    {
+        const result = await Promise.race([1, 2, Promise.resolve(3)]);
+        shouldBe(result, 1);
+    }
+    {
+        const never = new Promise(() => {});
+        const result = await Promise.race([never, "fast"]);
+        shouldBe(result, "fast");
+    }
+
+    // Thenable elements still go through Promise.resolve(thenable) machinery.
+    {
+        let calls = 0;
+        const thenable = {
+            then(resolve, reject) { calls++; resolve(99); }
+        };
+        const result = await Promise.all([1, thenable, 2]);
+        shouldBe(JSON.stringify(result), '[1,99,2]');
+        shouldBe(calls, 1);
+    }
+
+    // Object that gains `then` via Object.prototype.then must not take the
+    // non-thenable fast path: the watchpoint must drop us into the
+    // Promise.resolve(thenable) machinery for plain objects.
+    {
+        const plain = { plain: true };
+        let plainObjectAdopted = false;
+        Object.prototype.then = function (resolve) {
+            if (this === plain)
+                plainObjectAdopted = true;
+            resolve("hijacked");
+        };
+        try {
+            // Note: the result array also goes through the hijacked then.
+            const result = await Promise.all([1, plain, 2]);
+            shouldBe(result, "hijacked");
+            shouldBe(plainObjectAdopted, true);
+        } finally {
+            delete Object.prototype.then;
+        }
+    }
+
+    // A Structure cached as DefinitelyNonThenable before the watchpoint fires
+    // must not be treated as non-thenable afterward.
+    {
+        class Box { constructor(value) { this.value = value; } }
+        const result1 = await Promise.all([new Box(1), new Box(2)]);
+        shouldBe(result1[0].value, 1);
+        shouldBe(result1[1].value, 2);
+
+        let boxAdopted = false;
+        Object.prototype.then = function (resolve) {
+            if (this instanceof Box)
+                boxAdopted = true;
+            resolve("hijacked");
+        };
+        try {
+            await Promise.all([new Box(3)]);
+            shouldBe(boxAdopted, true);
+        } finally {
+            delete Object.prototype.then;
+        }
+    }
+
+    // Promise subclass with custom Symbol.species must not take the fast path.
+    {
+        class MyPromise extends Promise {
+            static get [Symbol.species]() { return Promise; }
+        }
+        const result = await Promise.all([1, MyPromise.resolve(2), 3]);
+        shouldBe(JSON.stringify(result), "[1,2,3]");
+    }
+
+    // A crafted Promise.prototype.then must be invoked per element, even for non-thenable ones.
+    {
+        const originalThen = Promise.prototype.then;
+        const counted = (combinator, elements) => {
+            let thenCalls = 0;
+            Promise.prototype.then = function (onFulfilled, onRejected) {
+                thenCalls++;
+                return originalThen.call(this, onFulfilled, onRejected);
+            };
+            try {
+                Promise[combinator](elements);
+            } finally {
+                Promise.prototype.then = originalThen;
+            }
+            return thenCalls;
+        };
+        shouldBe(counted("all", [1, "two", null]) >= 3, true);
+        shouldBe(counted("allSettled", [1, "two", null]) >= 3, true);
+        shouldBe(counted("any", [1, "two", null]) >= 3, true);
+        shouldBe(counted("race", [1, "two", null]) >= 3, true);
+
+        Promise.prototype.then = function (onFulfilled, onRejected) {
+            return originalThen.call(this, onFulfilled, onRejected);
+        };
+        try {
+            const result = await Promise.all([1, "two", null, true]);
+            shouldBe(JSON.stringify(result), '[1,"two",null,true]');
+        } finally {
+            Promise.prototype.then = originalThen;
+        }
+    }
+
+    // Empty iterable.
+    {
+        const result = await Promise.all([]);
+        shouldBe(result.length, 0);
+    }
+}
+
+let failed = null;
+main().catch((e) => { failed = e; });
+drainMicrotasks();
+if (failed)
+    throw failed;

--- a/Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp
@@ -154,6 +154,20 @@ static bool NODELETE isFastPromiseConstructor(JSGlobalObject* globalObject, JSVa
     return true;
 }
 
+static ALWAYS_INLINE bool canSkipIntermediatePromise(JSGlobalObject* globalObject, JSValue value)
+{
+    if (!globalObject->promiseThenWatchpointSet().isStillValid()) [[unlikely]]
+        return false;
+    if (!value.isCell())
+        return true;
+    JSCell* cell = value.asCell();
+    if (cell->type() == JSPromiseType)
+        return false;
+    if (!cell->isObject())
+        return true;
+    return isDefinitelyNonThenable(uncheckedDowncast<JSObject>(cell), globalObject);
+}
+
 static JSObject* promiseRaceSlow(JSGlobalObject* globalObject, CallFrame* callFrame, JSValue thisValue)
 {
     VM& vm = globalObject->vm();
@@ -266,6 +280,12 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncRace, (JSGlobalObject* globalObje
     JSFunction* reject = nullptr;
     forEachInIterable(globalObject, iterable, [&](VM& vm, JSGlobalObject* globalObject, JSValue value) {
         auto scope = DECLARE_THROW_SCOPE(vm);
+
+        if (canSkipIntermediatePromise(globalObject, value)) {
+            scope.release();
+            globalObject->queueMicrotask(vm, InternalMicrotask::PromiseRaceResolveJob, static_cast<uint8_t>(JSPromise::Status::Fulfilled), promise, value, promise);
+            return;
+        }
 
         JSPromise* nextPromise = JSPromise::resolvedPromise(globalObject, value);
         RETURN_IF_EXCEPTION(scope, void());
@@ -478,6 +498,16 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAll, (JSGlobalObject* globalObjec
 
         values->putDirectIndex(globalObject, index, jsUndefined());
         RETURN_IF_EXCEPTION(scope, void());
+
+        if (canSkipIntermediatePromise(globalObject, value)) {
+            uint64_t count = globalContext->remainingElementsCount().toIndex(globalObject, "count exceeds size"_s);
+            RETURN_IF_EXCEPTION(scope, void());
+            globalContext->setRemainingElementsCount(vm, jsNumber(count + 1));
+            scope.release();
+            globalObject->queueMicrotask(vm, InternalMicrotask::PromiseAllResolveJob, static_cast<uint8_t>(JSPromise::Status::Fulfilled), globalContext, value, jsNumber(index));
+            ++index;
+            return;
+        }
 
         JSPromise* nextPromise = JSPromise::resolvedPromise(globalObject, value);
         RETURN_IF_EXCEPTION(scope, void());
@@ -800,6 +830,16 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAllSettled, (JSGlobalObject* glob
 
         values->putDirectIndex(globalObject, index, jsUndefined());
         RETURN_IF_EXCEPTION(scope, void());
+
+        if (canSkipIntermediatePromise(globalObject, value)) {
+            uint64_t count = globalContext->remainingElementsCount().toIndex(globalObject, "count exceeds size"_s);
+            RETURN_IF_EXCEPTION(scope, void());
+            globalContext->setRemainingElementsCount(vm, jsNumber(count + 1));
+            scope.release();
+            globalObject->queueMicrotask(vm, InternalMicrotask::PromiseAllSettledResolveJob, static_cast<uint8_t>(JSPromise::Status::Fulfilled), globalContext, value, jsNumber(index));
+            ++index;
+            return;
+        }
 
         JSPromise* nextPromise = JSPromise::resolvedPromise(globalObject, value);
         RETURN_IF_EXCEPTION(scope, void());
@@ -1273,6 +1313,16 @@ JSC_DEFINE_HOST_FUNCTION(promiseConstructorFuncAny, (JSGlobalObject* globalObjec
 
         errors->putDirectIndex(globalObject, index, jsUndefined());
         RETURN_IF_EXCEPTION(scope, void());
+
+        if (canSkipIntermediatePromise(globalObject, value)) {
+            uint64_t count = globalContext->remainingElementsCount().toIndex(globalObject, "count exceeds size"_s);
+            RETURN_IF_EXCEPTION(scope, void());
+            globalContext->setRemainingElementsCount(vm, jsNumber(count + 1));
+            scope.release();
+            globalObject->queueMicrotask(vm, InternalMicrotask::PromiseAnyResolveJob, static_cast<uint8_t>(JSPromise::Status::Fulfilled), globalContext, value, jsNumber(index));
+            ++index;
+            return;
+        }
 
         JSPromise* nextPromise = JSPromise::resolvedPromise(globalObject, value);
         RETURN_IF_EXCEPTION(scope, void());


### PR DESCRIPTION
#### 4ed24b821a126ef9290f356535e9b6b0ce06208f
<pre>
[JSC] Skip intermediate promise allocation for non-thenable elements in Promise combinators
<a href="https://bugs.webkit.org/show_bug.cgi?id=315017">https://bugs.webkit.org/show_bug.cgi?id=315017</a>

Reviewed by Yusuke Suzuki.

Promise.all / allSettled / any / race call `Promise.resolve(value).then(...)` for each element.
When `value` is not observably thenable, `Promise.resolve(value)` allocates a fresh fulfilled
JSPromise that exists only to queue one microtask and is then immediately garbage. This patch
queues that microtask directly for provably non-thenable elements, saving one 32-byte cell each
without changing any observable ordering or behavior.

                                              Baseline                  Patched

promise-all-non-thenable                   3.9187+-0.1276     ^      2.6620+-0.0957        ^ definitely 1.4721x faster
promise-all-non-thenable-object            4.1062+-0.1207     ^      2.8683+-0.0837        ^ definitely 1.4315x faster
promise-all-settled-non-thenable           4.2607+-0.1511     ^      3.0175+-0.0930        ^ definitely 1.4120x faster
promise-race-non-thenable                  2.3936+-0.0667     ^      1.4035+-0.0555        ^ definitely 1.7055x faster

Tests: JSTests/microbenchmarks/promise-all-non-thenable-object.js
       JSTests/microbenchmarks/promise-all-non-thenable.js
       JSTests/microbenchmarks/promise-all-settled-non-thenable.js
       JSTests/microbenchmarks/promise-race-non-thenable.js
       JSTests/stress/promise-combinator-non-thenable-element.js

* JSTests/microbenchmarks/promise-all-non-thenable-object.js: Added.
* JSTests/microbenchmarks/promise-all-non-thenable.js: Added.
* JSTests/microbenchmarks/promise-all-settled-non-thenable.js: Added.
* JSTests/microbenchmarks/promise-race-non-thenable.js: Added.
* JSTests/stress/promise-combinator-non-thenable-element.js: Added.
(shouldBe):
(async main.Object.prototype.then):
(async main.Box):
(async main.MyPromise.get Symbol):
(async main.MyPromise):
(async main):
* Source/JavaScriptCore/runtime/JSPromiseConstructor.cpp:
(JSC::isNonThenable):
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/313576@main">https://commits.webkit.org/313576@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5cb50c96af5b40f194460111c280dd4c1b317d69

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163513 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36997 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30216 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172453 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119962 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37328 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36996 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126996 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89529 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166472 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29273 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146996 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107550 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26947 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20156 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/155664 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/138219 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24715 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174958 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/24404 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27889 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26377 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135301 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36666 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31049 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135283 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36460 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37452 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146510 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99491 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30587 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23360 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195915 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36162 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109308 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51073 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35660 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1385 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35910 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35807 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->