### PR TITLE
[JSC] Inline StringSubstring in DFG / FTL in the same way to StringSlice / StringSubstr

### DIFF
--- a/JSTests/stress/string-substring-strength-reduction.js
+++ b/JSTests/stress/string-substring-strength-reduction.js
@@ -1,0 +1,51 @@
+function shouldBe(actual, expected) {
+    if (!Object.is(actual, expected)) {
+        throw new Error(`Bad value: ${actual}!`);
+    }
+}
+
+// Each function uses literal constants so the strength-reduction phase
+// can fold the StringSubstring node into a constant string.
+const cases = [
+    [() => "ABCDE".substring(0, 5), "ABCDE"],
+    [() => "ABCDE".substring(1, 4), "BCD"],
+    [() => "ABCDE".substring(2), "CDE"],
+    [() => "ABCDE".substring(0), "ABCDE"],
+    [() => "ABCDE".substring(2, 2), ""],
+    [() => "ABCDE".substring(3, 3), ""],
+    // Swap (start > end)
+    [() => "ABCDE".substring(4, 1), "BCD"],
+    [() => "ABCDE".substring(5, 0), "ABCDE"],
+    // Out-of-range / negative clamping
+    [() => "ABCDE".substring(-2, 2), "AB"],
+    [() => "ABCDE".substring(2, -2), "AB"],
+    [() => "ABCDE".substring(-5, -1), ""],
+    [() => "ABCDE".substring(-100, 100), "ABCDE"],
+    [() => "ABCDE".substring(2, 100), "CDE"],
+    [() => "ABCDE".substring(100, 2), "CDE"],
+    [() => "ABCDE".substring(5), ""],
+    [() => "ABCDE".substring(100), ""],
+    [() => "ABCDE".substring(100, 100), ""],
+    // Single character
+    [() => "ABCDE".substring(0, 1), "A"],
+    [() => "ABCDE".substring(4, 5), "E"],
+    [() => "ABCDE".substring(-1, 1), "A"],
+    // Identity (start=0, end=length)
+    [() => "ABCDE".substring(0, 5), "ABCDE"],
+    // Empty source string
+    [() => "".substring(0, 10), ""],
+    [() => "".substring(-1, 1), ""],
+    [() => "".substring(5, 1), ""],
+    // Unicode (constant string with surrogates)
+    [() => "𠮷野家".substring(0, 2), "𠮷"],
+    [() => "𠮷野家".substring(2, 99), "野家"],
+    [() => "𠮷野家".substring(-10, 10), "𠮷野家"],
+];
+
+for (const [fn, expected] of cases)
+    noInline(fn);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    for (const [fn, expected] of cases)
+        shouldBe(fn(), expected);
+}

--- a/JSTests/stress/string-substring.js
+++ b/JSTests/stress/string-substring.js
@@ -97,4 +97,16 @@ for (var i = 0; i < testLoopCount; i++) {
     shouldBe(str.substring(0, 0), "");
     shouldBe(str.substring(0, -0), "");
     shouldBe(str.substring(-0, 0), "");
+
+    // rope strings (force ConcatString path)
+    const rope = "foo" + (i & 1 ? "bar" : "baz");
+    shouldBe(rope.substring(0, 3), "foo");
+    shouldBe(rope.substring(3, 6), i & 1 ? "bar" : "baz");
+    shouldBe(rope.substring(2, 3), "o");
+    shouldBe(rope.substring(-3, 3), "foo");
+    shouldBe(rope.substring(2, 100), i & 1 ? "obar" : "obaz");
+    shouldBe(rope.substring(100, 2), i & 1 ? "obar" : "obaz");
+    shouldBe(rope.substring(100), "");
+    shouldBe(rope.substring(2, -1), "fo");
+    shouldBe(rope.substring(2, 2), "");
 }

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -1791,35 +1791,90 @@ void SpeculativeJIT::compileStringSlice(Node* node)
 void SpeculativeJIT::compileStringSubstring(Node* node)
 {
     SpeculateCellOperand string(this, node->child1());
-
     SpeculateInt32Operand start(this, node->child2());
-    if (node->child3()) {
-        SpeculateInt32Operand end(this, node->child3());
-
-        GPRReg stringGPR = string.gpr();
-        GPRReg startGPR = start.gpr();
-        GPRReg endGPR = end.gpr();
-
-        speculateString(node->child1(), stringGPR);
-
-        flushRegisters();
-        GPRFlushedCallResult result(this);
-        GPRReg resultGPR = result.gpr();
-        callOperation(operationStringSubstringWithEnd, resultGPR, LinkableConstant::globalObject(*this, node), stringGPR, startGPR, endGPR);
-        cellResult(resultGPR, node);
-        return;
-    }
+    std::optional<SpeculateInt32Operand> end;
+    GPRTemporary temp(this);
+    GPRTemporary temp2(this);
+    GPRTemporary startIndex(this);
 
     GPRReg stringGPR = string.gpr();
     GPRReg startGPR = start.gpr();
+    GPRReg endGPR = InvalidGPRReg;
+    if (node->child3()) {
+        end.emplace(this, node->child3());
+        endGPR = end->gpr();
+    }
+    GPRReg tempGPR = temp.gpr();
+    GPRReg temp2GPR = temp2.gpr();
+    GPRReg startIndexGPR = startIndex.gpr();
 
     speculateString(node->child1(), stringGPR);
 
-    flushRegisters();
-    GPRFlushedCallResult result(this);
-    GPRReg resultGPR = result.gpr();
-    callOperation(operationStringSubstring, resultGPR, LinkableConstant::globalObject(*this, node), stringGPR, startGPR);
-    cellResult(resultGPR, node);
+    loadPtr(Address(stringGPR, JSString::offsetOfValue()), tempGPR);
+    Jump isRope;
+    if (canBeRope(node->child1()))
+        isRope = branchIfRopeStringImpl(tempGPR);
+    load32(Address(tempGPR, StringImpl::lengthMemoryOffset()), temp2GPR);
+
+    emitPopulateSubstringIndex(node->child2(), startGPR, temp2GPR, startIndexGPR);
+    if (endGPR != InvalidGPRReg)
+        emitPopulateSubstringIndex(node->child3(), endGPR, temp2GPR, tempGPR);
+    else
+        move(temp2GPR, tempGPR);
+
+    // Swap so startIndexGPR = min, tempGPR = max. temp2GPR (length) is no longer needed.
+    move(startIndexGPR, temp2GPR);
+    moveConditionally32(LessThan, tempGPR, startIndexGPR, tempGPR, startIndexGPR, startIndexGPR);
+    moveConditionally32(GreaterThan, temp2GPR, tempGPR, temp2GPR, tempGPR, tempGPR);
+
+    sub32(startIndexGPR, tempGPR);
+
+    JumpList doneCases;
+    JumpList slowCases;
+
+    VM& vm = this->vm();
+
+    auto nonEmptyCase = branchTest32(NonZero, tempGPR);
+    loadLinkableConstant(LinkableConstant(*this, jsEmptyString(vm)), tempGPR);
+    doneCases.append(jump());
+
+    nonEmptyCase.link(this);
+    // Inline single-character fast path when size == 1.
+    slowCases.append(branch32(NotEqual, tempGPR, TrustedImm32(1)));
+
+    // Refill StringImpl* here.
+    loadPtr(Address(stringGPR, JSString::offsetOfValue()), temp2GPR);
+    loadPtr(Address(temp2GPR, StringImpl::dataOffset()), tempGPR);
+
+    zeroExtend32ToWord(startIndexGPR, startIndexGPR);
+    auto is16Bit = branchTest32(Zero, Address(temp2GPR, StringImpl::flagsOffset()), TrustedImm32(StringImpl::flagIs8Bit()));
+
+    load8(BaseIndex(tempGPR, startIndexGPR, TimesOne, 0), tempGPR);
+    auto cont8Bit = jump();
+
+    is16Bit.link(this);
+    load16(BaseIndex(tempGPR, startIndexGPR, TimesTwo, 0), tempGPR);
+
+    auto bigCharacter = branch32(Above, tempGPR, TrustedImm32(maxSingleCharacterString));
+
+    cont8Bit.link(this);
+
+    lshift32(TrustedImm32(sizeof(void*) == 4 ? 2 : 3), tempGPR);
+    addPtr(TrustedImmPtr(vm.smallStrings.singleCharacterStrings()), tempGPR);
+    loadPtr(Address(tempGPR), tempGPR);
+
+    addSlowPathGenerator(slowPathCall(bigCharacter, this, operationSingleCharacterString, tempGPR, TrustedImmPtr(&vm), tempGPR));
+    addSlowPathGenerator(slowPathCall(slowCases, this, operationStringSubstr, tempGPR, LinkableConstant::globalObject(*this, node), stringGPR, startIndexGPR, tempGPR));
+
+    if (isRope.isSet()) {
+        if (endGPR != InvalidGPRReg)
+            addSlowPathGenerator(slowPathCall(isRope, this, operationStringSubstringWithEnd, tempGPR, LinkableConstant::globalObject(*this, node), stringGPR, startGPR, endGPR));
+        else
+            addSlowPathGenerator(slowPathCall(isRope, this, operationStringSubstring, tempGPR, LinkableConstant::globalObject(*this, node), stringGPR, startGPR));
+    }
+
+    doneCases.link(this);
+    cellResult(tempGPR, node);
 }
 
 void SpeculativeJIT::compileStringSubstr(Node* node)
@@ -9927,6 +9982,23 @@ void SpeculativeJIT::emitPopulateSliceIndex(Edge& target, std::optional<GPRReg> 
     move(lengthGPR, resultGPR);
 
     done.link(this);
+}
+
+void SpeculativeJIT::emitPopulateSubstringIndex(Edge& target, GPRReg indexGPR, GPRReg lengthGPR, GPRReg resultGPR)
+{
+    if (target->isInt32Constant()) {
+        int32_t value = target->asInt32();
+        if (value <= 0) {
+            move(TrustedImm32(0), resultGPR);
+            return;
+        }
+        move(TrustedImm32(value), resultGPR);
+        moveConditionally32(LessThan, lengthGPR, resultGPR, lengthGPR, resultGPR, resultGPR);
+        return;
+    }
+
+    moveConditionally32(LessThan, indexGPR, lengthGPR, indexGPR, lengthGPR, resultGPR);
+    moveConditionally32(LessThan, resultGPR, TrustedImm32(0), TrustedImm32(0), resultGPR, resultGPR);
 }
 
 void SpeculativeJIT::compileArraySlice(Node* node)

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1890,6 +1890,7 @@ public:
     void emitGetCallee(CodeOrigin, GPRReg calleeGPR);
     void emitGetArgumentStart(CodeOrigin, GPRReg startGPR);
     void emitPopulateSliceIndex(Edge&, std::optional<GPRReg> indexGPR, GPRReg lengthGPR, GPRReg resultGPR);
+    void emitPopulateSubstringIndex(Edge&, GPRReg indexGPR, GPRReg lengthGPR, GPRReg resultGPR);
     
     // Generate an OSR exit fuzz check. Returns Jump() if OSR exit fuzz is not enabled, or if
     // it's in training mode.

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -8426,6 +8426,29 @@ IGNORE_CLANG_WARNINGS_END
         return std::make_pair(startIndex, endBoundary);
     }
 
+    std::pair<LValue, LValue> populateSubstringRange(LValue start, LValue end, LValue length)
+    {
+        // end can be nullptr.
+        ASSERT(start);
+        ASSERT(length);
+
+        auto pickIndex = [&] (LValue index) {
+            return m_out.select(m_out.greaterThanOrEqual(index, m_out.int32Zero),
+                m_out.select(m_out.above(index, length), length, index),
+                m_out.int32Zero);
+        };
+
+        LValue endBoundary = length;
+        if (end)
+            endBoundary = pickIndex(end);
+        LValue startIndex = pickIndex(start);
+
+        LValue swap = m_out.greaterThan(startIndex, endBoundary);
+        LValue from = m_out.select(swap, endBoundary, startIndex);
+        LValue to = m_out.select(swap, startIndex, endBoundary);
+        return std::make_pair(from, to);
+    }
+
     void compileArraySlice()
     {
         JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
@@ -20203,10 +20226,93 @@ IGNORE_CLANG_WARNINGS_END
     void compileStringSubstring()
     {
         JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
+        LBasicBlock lengthCheckCase = m_out.newBlock();
+        LBasicBlock emptyCase = m_out.newBlock();
+        LBasicBlock notEmptyCase = m_out.newBlock();
+        LBasicBlock oneCharCase = m_out.newBlock();
+        LBasicBlock is8Bit = m_out.newBlock();
+        LBasicBlock is16Bit = m_out.newBlock();
+        LBasicBlock bitsContinuation = m_out.newBlock();
+        LBasicBlock bigCharacter = m_out.newBlock();
+        LBasicBlock slowCase = m_out.newBlock();
+        LBasicBlock ropeSlowCase = m_out.newBlock();
+        LBasicBlock continuation = m_out.newBlock();
+
+        LValue string = lowString(m_node->child1());
+        LValue start = lowInt32(m_node->child2());
+        LValue end = nullptr;
         if (m_node->child3())
-            setJSValue(vmCall(pointerType(), operationStringSubstringWithEnd, weakPointer(globalObject), lowString(m_node->child1()), lowInt32(m_node->child2()), lowInt32(m_node->child3())));
+            end = lowInt32(m_node->child3());
+        m_out.branch(isRopeString(string, m_node->child1()), rarely(ropeSlowCase), usually(lengthCheckCase));
+
+        LBasicBlock lastNext = m_out.appendTo(lengthCheckCase, emptyCase);
+        LValue stringImpl = m_out.loadPtr(string, m_heaps.JSString_value);
+        LValue length;
+        if (auto stringLength = tryGetConstantStringLength(m_node->child1()))
+            length = m_out.constInt32(*stringLength);
         else
-            setJSValue(vmCall(pointerType(), operationStringSubstring, weakPointer(globalObject), lowString(m_node->child1()), lowInt32(m_node->child2())));
+            length = m_out.load32NonNegative(stringImpl, m_heaps.StringImpl_length);
+
+        auto range = populateSubstringRange(start, end, length);
+        LValue from = range.first;
+        LValue to = range.second;
+        LValue span = m_out.sub(to, from);
+        m_out.branch(m_out.lessThanOrEqual(span, m_out.int32Zero), unsure(emptyCase), unsure(notEmptyCase));
+
+        Vector<ValueFromBlock, 5> results;
+
+        m_out.appendTo(emptyCase, notEmptyCase);
+        results.append(m_out.anchor(weakPointer(jsEmptyString(vm()))));
+        m_out.jump(continuation);
+
+        m_out.appendTo(notEmptyCase, oneCharCase);
+        m_out.branch(m_out.equal(span, m_out.int32One), unsure(oneCharCase), unsure(slowCase));
+
+        m_out.appendTo(oneCharCase, is8Bit);
+        LValue storage = m_out.loadPtr(stringImpl, m_heaps.StringImpl_data);
+        m_out.branch(
+            m_out.testIsZero32(
+                m_out.load32(stringImpl, m_heaps.StringImpl_hashAndFlags),
+                m_out.constInt32(StringImpl::flagIs8Bit())),
+            unsure(is16Bit), unsure(is8Bit));
+
+        m_out.appendTo(is8Bit, is16Bit);
+        ValueFromBlock char8Bit = m_out.anchor(m_out.load8ZeroExt32(m_out.baseIndex(m_heaps.characters8, storage, m_out.zeroExtPtr(from))));
+        m_out.jump(bitsContinuation);
+
+        m_out.appendTo(is16Bit, bigCharacter);
+        LValue char16BitValue = m_out.load16ZeroExt32(m_out.baseIndex(m_heaps.characters16, storage, m_out.zeroExtPtr(from)));
+        ValueFromBlock char16Bit = m_out.anchor(char16BitValue);
+        m_out.branch(
+            m_out.above(char16BitValue, m_out.constInt32(maxSingleCharacterString)),
+            rarely(bigCharacter), usually(bitsContinuation));
+
+        m_out.appendTo(bigCharacter, bitsContinuation);
+        results.append(m_out.anchor(vmCall(
+            Int64, operationSingleCharacterString,
+            m_vmValue, char16BitValue)));
+        m_out.jump(continuation);
+
+        m_out.appendTo(bitsContinuation, slowCase);
+        LValue character = m_out.phi(Int32, char8Bit, char16Bit);
+        LValue smallStrings = m_out.constIntPtr(vm().smallStrings.singleCharacterStrings());
+        results.append(m_out.anchor(m_out.loadPtr(m_out.baseIndex(
+            m_heaps.singleCharacterStrings, smallStrings, m_out.zeroExtPtr(character)))));
+        m_out.jump(continuation);
+
+        m_out.appendTo(slowCase, ropeSlowCase);
+        results.append(m_out.anchor(vmCall(pointerType(), operationStringSubstr, weakPointer(globalObject), string, from, span)));
+        m_out.jump(continuation);
+
+        m_out.appendTo(ropeSlowCase, continuation);
+        if (end)
+            results.append(m_out.anchor(vmCall(pointerType(), operationStringSubstringWithEnd, weakPointer(globalObject), string, start, end)));
+        else
+            results.append(m_out.anchor(vmCall(pointerType(), operationStringSubstring, weakPointer(globalObject), string, start)));
+        m_out.jump(continuation);
+
+        m_out.appendTo(continuation, lastNext);
+        setJSValue(m_out.phi(pointerType(), results));
     }
 
     void compileStringSubstr()


### PR DESCRIPTION
#### e9cbd980be3bb5ca7dbb0f389dbac2b32278436b
<pre>
[JSC] Inline StringSubstring in DFG / FTL in the same way to StringSlice / StringSubstr
<a href="https://bugs.webkit.org/show_bug.cgi?id=315018">https://bugs.webkit.org/show_bug.cgi?id=315018</a>
<a href="https://rdar.apple.com/177338394">rdar://177338394</a>

Reviewed by NOBODY (OOPS!).

Let&apos;s just do inlined index handling in StringSubstring, which is
similarly done in StringSlice / StringSubstr.

Test: JSTests/stress/string-substring-strength-reduction.js

* JSTests/stress/string-substring-strength-reduction.js: Added.
(shouldBe):
* JSTests/stress/string-substring.js:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::compileStringSubstring):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::populateSubstringRange):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9cbd980be3bb5ca7dbb0f389dbac2b32278436b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163081 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36560 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29772 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172020 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119527 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/95481537-d6d5-47b7-895e-bfb9a4fae550) 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36700 "Hash e9cbd980 for PR 65105 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36562 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126603 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89207 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9781dc87-f4ff-4386-b5bd-a9008a3bafcc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166040 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/36700 "Hash e9cbd980 for PR 65105 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146592 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107179 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/88c15ffd-3a86-4ad8-9faa-89c621401120) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/36700 "Hash e9cbd980 for PR 65105 does not build (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26543 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19719 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/155220 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/36700 "Hash e9cbd980 for PR 65105 does not build (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24322 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174523 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23967 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/26404 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25968 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134916 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36231 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30646 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134911 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37058 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146117 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98828 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30244 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22957 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195482 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35727 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108047 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50940 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35226 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/976 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35473 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35374 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->