### PR TITLE
[JSC] Inline Map / Set forEach iteration in DFG and FTL

### DIFF
--- a/JSTests/microbenchmarks/map-for-each.js
+++ b/JSTests/microbenchmarks/map-for-each.js
@@ -13,7 +13,7 @@ var globalSum = 0;
     var map = createMap(COUNT);
     var sum = 0;
 
-    for (var i = 0; i < 1e2; ++i) {
+    for (var i = 0; i < 5e2; ++i) {
         sum = 0;
         map.forEach(function (value, key) {
             sum += key;

--- a/JSTests/microbenchmarks/set-for-each.js
+++ b/JSTests/microbenchmarks/set-for-each.js
@@ -13,7 +13,7 @@ var globalSum = 0;
     var set = createSet(COUNT);
     var sum = 0;
 
-    for (var i = 0; i < 1e2; ++i) {
+    for (var i = 0; i < 5e2; ++i) {
         sum = 0;
         set.forEach(function (item) {
             sum += item;

--- a/JSTests/stress/map-set-foreach-mutation.js
+++ b/JSTests/stress/map-set-foreach-mutation.js
@@ -1,0 +1,188 @@
+function shouldBe(actual, expected, msg) {
+    if (actual !== expected)
+        throw new Error((msg ? msg + ": " : "") + "expected " + expected + " but got " + actual);
+}
+
+function shouldThrow(func, errorMessage) {
+    var errorThrown = false;
+    try {
+        func();
+    } catch (e) {
+        errorThrown = true;
+        if (String(e) !== errorMessage)
+            throw new Error("expected error '" + errorMessage + "' but got '" + e + "'");
+    }
+    if (!errorThrown)
+        throw new Error("expected to throw");
+}
+
+// Empty Map / Set: forEach should not invoke the callback at all.
+function testEmpty() {
+    var calls = 0;
+    new Map().forEach(() => calls++);
+    new Set().forEach(() => calls++);
+    shouldBe(calls, 0, "empty");
+}
+noInline(testEmpty);
+
+// Delete a not-yet-visited entry inside the callback: the deleted entry must be skipped.
+function testDeleteDuringMap() {
+    var m = new Map();
+    for (var i = 0; i < 10; i++) m.set(i, i * 10);
+    var visited = [];
+    m.forEach((v, k) => { visited.push(k); if (k === 3) m.delete(5); });
+    shouldBe(visited.join(","), "0,1,2,3,4,6,7,8,9", "delete during Map.forEach");
+}
+noInline(testDeleteDuringMap);
+
+function testDeleteDuringSet() {
+    var s = new Set();
+    for (var i = 0; i < 10; i++) s.add(i);
+    var visited = [];
+    s.forEach((v) => { visited.push(v); if (v === 3) s.delete(5); });
+    shouldBe(visited.join(","), "0,1,2,3,4,6,7,8,9", "delete during Set.forEach");
+}
+noInline(testDeleteDuringSet);
+
+// Delete the entry currently being visited: should not affect already-yielded value.
+function testDeleteSelf() {
+    var m = new Map();
+    for (var i = 0; i < 5; i++) m.set(i, i);
+    var visited = [];
+    m.forEach((v, k) => { visited.push(k); m.delete(k); });
+    shouldBe(visited.join(","), "0,1,2,3,4", "delete self");
+    shouldBe(m.size, 0, "delete self size");
+}
+noInline(testDeleteSelf);
+
+// Add entries inside the callback: new entries must be visited (in insertion order).
+function testAddDuring() {
+    var m = new Map();
+    for (var i = 0; i < 3; i++) m.set(i, i);
+    var visited = [];
+    m.forEach((v, k) => { visited.push(k); if (k === 1) { m.set(3, 3); m.set(4, 4); } });
+    shouldBe(visited.join(","), "0,1,2,3,4", "add during Map.forEach");
+}
+noInline(testAddDuring);
+
+// Trigger a rehash inside the callback: iteration must continue on the new (rehashed) table.
+function testRehashDuring() {
+    var m = new Map();
+    for (var i = 0; i < 4; i++) m.set(i, i);
+    var visited = [];
+    m.forEach((v, k) => {
+        visited.push(k);
+        if (k === 1) {
+            for (var j = 100; j < 130; j++) m.set(j, j);
+        }
+    });
+    shouldBe(visited.length, 34, "rehash during Map.forEach count");
+    shouldBe(visited[0], 0);
+    shouldBe(visited[1], 1);
+    shouldBe(visited[2], 2);
+    shouldBe(visited[3], 3);
+    shouldBe(visited[4], 100);
+    shouldBe(visited[33], 129);
+}
+noInline(testRehashDuring);
+
+// Trigger multiple rehashes that produce a chain of obsolete tables.
+function testMultiRehashDuring() {
+    var m = new Map();
+    for (var i = 0; i < 4; i++) m.set(i, i);
+    var visited = [];
+    var rehashCount = 0;
+    m.forEach((v, k) => {
+        visited.push(k);
+        if (rehashCount < 5) {
+            rehashCount++;
+            var base = 1000 * rehashCount;
+            for (var j = 0; j < 30; j++) m.set(base + j, base + j);
+        }
+    });
+    shouldBe(visited.length, 4 + 5 * 30, "multi rehash count");
+    shouldBe(visited[0], 0);
+    shouldBe(visited[3], 3);
+    shouldBe(visited[4], 1000);
+    shouldBe(visited[visited.length - 1], 5029);
+}
+noInline(testMultiRehashDuring);
+
+// Clear inside the callback: iteration must stop after the current entry.
+function testClearDuring() {
+    var m = new Map();
+    for (var i = 0; i < 10; i++) m.set(i, i);
+    var visited = [];
+    m.forEach((v, k) => { visited.push(k); if (k === 3) m.clear(); });
+    shouldBe(visited.join(","), "0,1,2,3", "clear during Map.forEach");
+}
+noInline(testClearDuring);
+
+function testClearDuringSet() {
+    var s = new Set();
+    for (var i = 0; i < 10; i++) s.add(i);
+    var visited = [];
+    s.forEach((v) => { visited.push(v); if (v === 3) s.clear(); });
+    shouldBe(visited.join(","), "0,1,2,3", "clear during Set.forEach");
+}
+noInline(testClearDuringSet);
+
+// Heavy tombstone density (delete-heavy) before forEach: tombstone skip loop runs many iterations.
+function testTombstoneHeavy() {
+    var m = new Map();
+    for (var i = 0; i < 100; i++) m.set(i, i);
+    for (var i = 1; i < 100; i++) m.delete(i);  // keep only entry 0
+    var visited = [];
+    m.forEach((v, k) => visited.push(k));
+    shouldBe(visited.join(","), "0", "tombstone heavy");
+}
+noInline(testTombstoneHeavy);
+
+// Callback throws: exception must propagate, no crash.
+function testCallbackThrows() {
+    var m = new Map();
+    for (var i = 0; i < 5; i++) m.set(i, i);
+    var visited = [];
+    shouldThrow(() => {
+        m.forEach((v, k) => { visited.push(k); if (k === 2) throw new Error("boom"); });
+    }, "Error: boom");
+    shouldBe(visited.join(","), "0,1,2", "callback throws");
+}
+noInline(testCallbackThrows);
+
+// Delete then re-add the same key inside the callback: re-added key must be visited again.
+function testDeleteReAdd() {
+    var m = new Map();
+    for (var i = 0; i < 4; i++) m.set(i, i);
+    var visited = [];
+    var done = false;
+    m.forEach((v, k) => { visited.push(k); if (k === 1 && !done) { done = true; m.delete(0); m.set(0, 0); } });
+    shouldBe(visited.join(","), "0,1,2,3,0", "delete then re-add");
+}
+noInline(testDeleteReAdd);
+
+// thisArg is passed to the callback.
+function testThisArg() {
+    var m = new Map([[1, "a"], [2, "b"]]);
+    var thisArg = { tag: 42 };
+    var got = [];
+    m.forEach(function (v, k) { got.push(this.tag); }, thisArg);
+    shouldBe(got.join(","), "42,42", "thisArg");
+}
+noInline(testThisArg);
+
+for (var iter = 0; iter < 1e3; iter++) {
+    testEmpty();
+    testDeleteDuringMap();
+    testDeleteDuringSet();
+    testDeleteSelf();
+    testAddDuring();
+    testRehashDuring();
+    testMultiRehashDuring();
+    testClearDuring();
+    testClearDuringSet();
+    testTombstoneHeavy();
+    testCallbackThrows();
+    testDeleteReAdd();
+    testThisArg();
+}

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -14820,6 +14820,72 @@ void SpeculativeJIT::compileMapIteratorValue(Node* node)
 
 void SpeculativeJIT::compileMapIterationNext(Node* node)
 {
+#if USE(JSVALUE64)
+    bool isMap = node->bucketOwnerType() == BucketOwnerType::Map;
+
+    SpeculateCellOperand mapStorage(this, node->child1());
+    SpeculateInt32Operand entry(this, node->child2());
+    GPRTemporary scratch1(this);
+    GPRTemporary scratch2(this);
+    GPRTemporary result(this);
+
+    GPRReg mapStorageGPR = mapStorage.gpr();
+    GPRReg entryGPR = entry.gpr();
+    GPRReg scratchGPR1 = scratch1.gpr();
+    GPRReg scratchGPR2 = scratch2.gpr();
+    GPRReg resultGPR = result.gpr();
+
+    speculateCellButterfly(node->child1(), mapStorageGPR);
+
+    uint8_t entrySize = isMap ? JSMap::Helper::EntrySize : JSSet::Helper::EntrySize;
+    uint32_t capacityIndex = isMap ? JSMap::Helper::capacityIndex() : JSSet::Helper::capacityIndex();
+    uint32_t hashTableStartIndex = isMap ? JSMap::Helper::hashTableStartIndex() : JSSet::Helper::hashTableStartIndex();
+    uint32_t iterationEntryIndex = isMap ? JSMap::Helper::iterationEntryIndex() : JSSet::Helper::iterationEntryIndex();
+
+    JITCompiler::JumpList slowCases;
+    JITCompiler::JumpList notFound;
+    JITCompiler::JumpList doneCases;
+
+    notFound.append(branchLinkableConstant(JITCompiler::Equal, mapStorageGPR, LinkableConstant(*this, vm().orderedHashTableSentinel())));
+
+    // Check if storage is obsolete.
+    load64(Address(mapStorageGPR, JSCellButterfly::offsetOfData() + (isMap ? JSMap::Helper::aliveEntryCountIndex() : JSSet::Helper::aliveEntryCountIndex()) * sizeof(uint64_t)), scratchGPR1);
+    slowCases.append(branchIfNotInt32(JSValueRegs { scratchGPR1 }));
+
+    // entryKeyIndex = hashTableStartIndex + capacity + entry * entrySize
+    load32(Address(mapStorageGPR, JSCellButterfly::offsetOfData() + capacityIndex * sizeof(uint64_t)), scratchGPR2);
+    add32(TrustedImm32(hashTableStartIndex), scratchGPR2);
+    if (entrySize == 3) {
+        lshift32(entryGPR, TrustedImm32(1), scratchGPR1);
+        add32(entryGPR, scratchGPR1);
+    } else if (entrySize == 2)
+        add32(entryGPR, entryGPR, scratchGPR1);
+    add32(scratchGPR1, scratchGPR2);
+    move(entryGPR, scratchGPR1);
+
+    auto loopStart = label();
+    load64(BaseIndex(mapStorageGPR, scratchGPR2, TimesEight, JSCellButterfly::offsetOfData()), resultGPR);
+    notFound.append(branchTest64(JITCompiler::Zero, resultGPR));
+    auto found = branchLinkableConstant(JITCompiler::NotEqual, resultGPR, LinkableConstant(*this, vm().orderedHashTableDeletedValue()));
+    add32(TrustedImm32(1), scratchGPR1);
+    add32(TrustedImm32(entrySize), scratchGPR2);
+    jump().linkTo(loopStart, this);
+
+    found.link(this);
+    // The iterationEntry slot is not initialized by tryCreate, so write the full int32-encoded JSValue.
+    boxInt32(scratchGPR1, JSValueRegs { scratchGPR1 });
+    store64(scratchGPR1, Address(mapStorageGPR, JSCellButterfly::offsetOfData() + iterationEntryIndex * sizeof(uint64_t)));
+    move(mapStorageGPR, resultGPR);
+    doneCases.append(jump());
+
+    notFound.link(this);
+    loadLinkableConstant(LinkableConstant(*this, vm().orderedHashTableSentinel()), resultGPR);
+
+    addSlowPathGenerator(slowPathCall(slowCases, this, isMap ? operationMapIterationNext : operationSetIterationNext, NeedToSpill, ExceptionCheckRequirement::CheckNotNeeded, resultGPR, LinkableConstant::globalObject(*this, node), mapStorageGPR, entryGPR));
+
+    doneCases.link(this);
+    cellResult(resultGPR, node);
+#else
     SpeculateCellOperand mapStorage(this, node->child1());
     SpeculateInt32Operand entry(this, node->child2());
 
@@ -14836,53 +14902,85 @@ void SpeculativeJIT::compileMapIterationNext(Node* node)
     else
         callOperation(operationSetIterationNext, resultRegs, LinkableConstant::globalObject(*this, node), mapStorageGPR, entryGPR);
     cellResult(resultRegs.payloadGPR(), node);
+#endif
 }
 
 void SpeculativeJIT::compileMapIterationEntry(Node* node)
 {
+    bool isMap = node->bucketOwnerType() == BucketOwnerType::Map;
+
     SpeculateCellOperand mapStorage(this, node->child1());
+    GPRTemporary scratch1(this);
+    GPRTemporary scratch2(this);
+
     GPRReg mapStorageGPR = mapStorage.gpr();
+    auto resultRegs = JSValueRegs::withTwoAvailableRegs(scratch1.gpr(), scratch2.gpr());
 
     speculateCellButterfly(node->child1(), mapStorageGPR);
 
-    flushRegisters();
-    JSValueRegsFlushedCallResult result(this);
-    JSValueRegs resultRegs = result.regs();
-    if (node->bucketOwnerType() == BucketOwnerType::Map)
-        callOperation(operationMapIterationEntry, resultRegs, LinkableConstant::globalObject(*this, node), mapStorageGPR);
-    else
-        callOperation(operationSetIterationEntry, resultRegs, LinkableConstant::globalObject(*this, node), mapStorageGPR);
+    uint32_t iterationEntryIndex = isMap ? JSMap::Helper::iterationEntryIndex() : JSSet::Helper::iterationEntryIndex();
+    loadValue(Address(mapStorageGPR, JSCellButterfly::offsetOfData() + iterationEntryIndex * sizeof(uint64_t)), resultRegs);
     jsValueResult(resultRegs, node);
 }
 
 void SpeculativeJIT::compileMapIterationEntryKey(Node* node)
 {
+    bool isMap = node->bucketOwnerType() == BucketOwnerType::Map;
+
     SpeculateCellOperand mapStorage(this, node->child1());
+    GPRTemporary scratch1(this);
+    GPRTemporary scratch2(this);
+
     GPRReg mapStorageGPR = mapStorage.gpr();
+    GPRReg scratchGPR1 = scratch1.gpr();
+    GPRReg scratchGPR2 = scratch2.gpr();
+    auto resultRegs = JSValueRegs::withTwoAvailableRegs(scratchGPR1, scratchGPR2);
 
     speculateCellButterfly(node->child1(), mapStorageGPR);
 
-    flushRegisters();
-    JSValueRegsFlushedCallResult result(this);
-    JSValueRegs resultRegs = result.regs();
-    if (node->bucketOwnerType() == BucketOwnerType::Map)
-        callOperation(operationMapIterationEntryKey, resultRegs, LinkableConstant::globalObject(*this, node), mapStorageGPR);
-    else
-        callOperation(operationSetIterationEntryKey, resultRegs, LinkableConstant::globalObject(*this, node), mapStorageGPR);
+    uint32_t iterationEntryIndex = isMap ? JSMap::Helper::iterationEntryIndex() : JSSet::Helper::iterationEntryIndex();
+    uint32_t capacityIndex = isMap ? JSMap::Helper::capacityIndex() : JSSet::Helper::capacityIndex();
+    uint32_t hashTableStartIndex = isMap ? JSMap::Helper::hashTableStartIndex() : JSSet::Helper::hashTableStartIndex();
+    load32(Address(mapStorageGPR, JSCellButterfly::offsetOfData() + iterationEntryIndex * sizeof(uint64_t)), scratchGPR1);
+    if (isMap) {
+        static_assert(JSMap::Helper::EntrySize == 3);
+        lshift32(scratchGPR1, TrustedImm32(1), scratchGPR2);
+        add32(scratchGPR1, scratchGPR2);
+    } else {
+        static_assert(JSSet::Helper::EntrySize == 2);
+        add32(scratchGPR1, scratchGPR1, scratchGPR2);
+    }
+    load32(Address(mapStorageGPR, JSCellButterfly::offsetOfData() + capacityIndex * sizeof(uint64_t)), scratchGPR1);
+    add32(scratchGPR1, scratchGPR2);
+    add32(TrustedImm32(hashTableStartIndex), scratchGPR2);
+
+    loadValue(BaseIndex(mapStorageGPR, scratchGPR2, TimesEight, JSCellButterfly::offsetOfData()), resultRegs);
     jsValueResult(resultRegs, node);
 }
 
 void SpeculativeJIT::compileMapIterationEntryValue(Node* node)
 {
+    ASSERT(node->bucketOwnerType() == BucketOwnerType::Map);
     SpeculateCellOperand mapStorage(this, node->child1());
+    GPRTemporary scratch1(this);
+    GPRTemporary scratch2(this);
+
     GPRReg mapStorageGPR = mapStorage.gpr();
+    GPRReg scratchGPR1 = scratch1.gpr();
+    GPRReg scratchGPR2 = scratch2.gpr();
+    auto resultRegs = JSValueRegs::withTwoAvailableRegs(scratchGPR1, scratchGPR2);
 
     speculateCellButterfly(node->child1(), mapStorageGPR);
 
-    flushRegisters();
-    JSValueRegsFlushedCallResult result(this);
-    JSValueRegs resultRegs = result.regs();
-    callOperation(operationMapIterationEntryValue, resultRegs, LinkableConstant::globalObject(*this, node), mapStorageGPR);
+    load32(Address(mapStorageGPR, JSCellButterfly::offsetOfData() + JSMap::Helper::iterationEntryIndex() * sizeof(uint64_t)), scratchGPR1);
+    static_assert(JSMap::Helper::EntrySize == 3);
+    lshift32(scratchGPR1, TrustedImm32(1), scratchGPR2);
+    add32(scratchGPR1, scratchGPR2);
+    load32(Address(mapStorageGPR, JSCellButterfly::offsetOfData() + JSMap::Helper::capacityIndex() * sizeof(uint64_t)), scratchGPR1);
+    add32(scratchGPR1, scratchGPR2);
+    add32(TrustedImm32(JSMap::Helper::hashTableStartIndex() + /* value offset */ 1), scratchGPR2);
+
+    loadValue(BaseIndex(mapStorageGPR, scratchGPR2, TimesEight, JSCellButterfly::offsetOfData()), resultRegs);
     jsValueResult(resultRegs, node);
 }
 

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -16259,37 +16259,127 @@ IGNORE_CLANG_WARNINGS_END
     void compileMapIterationNext()
     {
         JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
+        bool isMap = m_node->bucketOwnerType() == BucketOwnerType::Map;
         LValue mapStorage = lowCell(m_node->child1());
         LValue entry = lowInt32(m_node->child2());
 
-        LValue result = vmCall(Int64, m_node->bucketOwnerType() == BucketOwnerType::Map ? operationMapIterationNext : operationSetIterationNext, weakPointer(globalObject), mapStorage, entry);
-        setJSValue(result);
+        LBasicBlock checkObsolete = m_out.newBlock();
+        LBasicBlock fastPath = m_out.newBlock();
+        LBasicBlock loop = m_out.newBlock();
+        LBasicBlock checkIfDeleted = m_out.newBlock();
+        LBasicBlock foundEntry = m_out.newBlock();
+        LBasicBlock notFound = m_out.newBlock();
+        LBasicBlock slowPath = m_out.newBlock();
+        LBasicBlock continuation = m_out.newBlock();
+
+        // They are strongly held by VM, so it is safe to embed them as raw constants.
+        LValue sentinel = m_out.constIntPtr(std::bit_cast<void*>(vm().orderedHashTableSentinel()));
+        LValue deletedValue = m_out.constIntPtr(std::bit_cast<void*>(vm().orderedHashTableDeletedValue()));
+
+        m_out.branch(m_out.equal(mapStorage, sentinel), rarely(notFound), usually(checkObsolete));
+
+        // Check if storage is obsolete (first field is a Cell pointer, not an Int32 JSValue).
+        LBasicBlock lastNext = m_out.appendTo(checkObsolete, fastPath);
+        LValue butterfly = toButterfly(mapStorage);
+        LValue aliveEntryCount = m_out.load64(m_out.baseIndex(m_heaps.indexedContiguousProperties, butterfly, m_out.constIntPtr(isMap ? JSMap::Helper::aliveEntryCountIndex() : JSSet::Helper::aliveEntryCountIndex())));
+        m_out.branch(isNotInt32(aliveEntryCount), rarely(slowPath), usually(fastPath));
+
+        // Fast path: iterate through entries to find next non-deleted entry.
+        m_out.appendTo(fastPath, loop);
+        LValue bucketCount = m_out.load32(m_out.baseIndex(m_heaps.indexedContiguousProperties, butterfly, m_out.constIntPtr(isMap ? JSMap::Helper::capacityIndex() : JSSet::Helper::capacityIndex())));
+        LValue dataTableStartIndex = m_out.add(m_out.constInt32(isMap ? JSMap::Helper::hashTableStartIndex() : JSSet::Helper::hashTableStartIndex()), bucketCount);
+        LValue entrySize = m_out.constIntPtr(isMap ? JSMap::Helper::EntrySize : JSSet::Helper::EntrySize);
+
+        ValueFromBlock initialEntry = m_out.anchor(entry);
+        ValueFromBlock initialEntryIndex;
+        if (isMap) {
+            static_assert(JSMap::Helper::EntrySize == 3);
+            LValue multiplied = m_out.add(entry, m_out.shl(entry, m_out.constInt32(1)));
+            initialEntryIndex = m_out.anchor(m_out.zeroExtPtr(m_out.add(dataTableStartIndex, multiplied)));
+        } else {
+            static_assert(JSSet::Helper::EntrySize == 2);
+            LValue multiplied = m_out.add(entry, entry);
+            initialEntryIndex = m_out.anchor(m_out.zeroExtPtr(m_out.add(dataTableStartIndex, multiplied)));
+        }
+        m_out.jump(loop);
+
+        m_out.appendTo(loop, checkIfDeleted);
+        LValue currentEntry = m_out.phi(Int32, initialEntry);
+        LValue entryIndex = m_out.phi(pointerType(), initialEntryIndex);
+        LValue key = m_out.load64(m_out.baseIndex(m_heaps.indexedContiguousProperties, butterfly, entryIndex));
+        m_out.branch(m_out.isZero64(key), unsure(notFound), unsure(checkIfDeleted));
+
+        // Check if key is deleted.
+        m_out.appendTo(checkIfDeleted, foundEntry);
+        LValue nextEntry = m_out.add(currentEntry, m_out.constInt32(1));
+        LValue nextEntryIndex = m_out.add(entryIndex, entrySize);
+        m_out.addIncomingToPhi(currentEntry, m_out.anchor(nextEntry));
+        m_out.addIncomingToPhi(entryIndex, m_out.anchor(nextEntryIndex));
+        m_out.branch(m_out.equal(key, deletedValue), unsure(loop), unsure(foundEntry));
+
+        // Found a valid entry: record it in storage[iterationEntryIndex] and return the storage.
+        // The iterationEntry slot is not initialized by tryCreate, so write the full int32-encoded JSValue.
+        m_out.appendTo(foundEntry, notFound);
+        m_out.store64(boxInt32(currentEntry), m_out.baseIndex(m_heaps.indexedContiguousProperties, butterfly, m_out.constIntPtr(isMap ? JSMap::Helper::iterationEntryIndex() : JSSet::Helper::iterationEntryIndex())));
+        ValueFromBlock foundResult = m_out.anchor(mapStorage);
+        m_out.jump(continuation);
+
+        m_out.appendTo(notFound, slowPath);
+        ValueFromBlock notFoundResult = m_out.anchor(sentinel);
+        m_out.jump(continuation);
+
+        // Slow path: call the operation (for obsolete tables).
+        m_out.appendTo(slowPath, continuation);
+        ValueFromBlock slowResult = m_out.anchor(vmCall(Int64, isMap ? operationMapIterationNext : operationSetIterationNext, weakPointer(globalObject), mapStorage, entry));
+        m_out.jump(continuation);
+
+        m_out.appendTo(continuation, lastNext);
+        setJSValue(m_out.phi(Int64, foundResult, notFoundResult, slowResult));
     }
 
     void compileMapIterationEntry()
     {
-        JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
+        bool isMap = m_node->bucketOwnerType() == BucketOwnerType::Map;
         LValue storage = lowCell(m_node->child1());
-        auto operation = m_node->bucketOwnerType() == BucketOwnerType::Map ? operationMapIterationEntry : operationSetIterationEntry;
-        LValue result = vmCall(Int64, operation, weakPointer(globalObject), storage);
+        LValue butterfly = toButterfly(storage);
+        LValue result = m_out.load64(m_out.baseIndex(m_heaps.indexedContiguousProperties, butterfly, m_out.constIntPtr(isMap ? JSMap::Helper::iterationEntryIndex() : JSSet::Helper::iterationEntryIndex())));
         setJSValue(result);
     }
 
     void compileMapIterationEntryKey()
     {
-        JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
+        bool isMap = m_node->bucketOwnerType() == BucketOwnerType::Map;
         LValue storage = lowCell(m_node->child1());
-        auto operation = m_node->bucketOwnerType() == BucketOwnerType::Map ? operationMapIterationEntryKey : operationSetIterationEntryKey;
-        LValue result = vmCall(Int64, operation, weakPointer(globalObject), storage);
-        setJSValue(result);
+        LValue butterfly = toButterfly(storage);
+        LValue entry = m_out.load32(m_out.baseIndex(m_heaps.indexedContiguousProperties, butterfly, m_out.constIntPtr(isMap ? JSMap::Helper::iterationEntryIndex() : JSSet::Helper::iterationEntryIndex())));
+        LValue bucketCount = m_out.load32(m_out.baseIndex(m_heaps.indexedContiguousProperties, butterfly, m_out.constIntPtr(isMap ? JSMap::Helper::capacityIndex() : JSSet::Helper::capacityIndex())));
+
+        LValue multiplied;
+        if (isMap) {
+            static_assert(JSMap::Helper::EntrySize == 3);
+            multiplied = m_out.add(entry, m_out.shl(entry, m_out.constInt32(1)));
+        } else {
+            static_assert(JSSet::Helper::EntrySize == 2);
+            multiplied = m_out.add(entry, entry);
+        }
+        LValue entryInButterfly = m_out.add(m_out.constInt32(isMap ? JSMap::Helper::hashTableStartIndex() : JSSet::Helper::hashTableStartIndex()), m_out.add(bucketCount, multiplied));
+        LValue key = m_out.load64(m_out.baseIndex(m_heaps.indexedContiguousProperties, butterfly, m_out.zeroExtPtr(entryInButterfly)));
+        setJSValue(key);
     }
 
     void compileMapIterationEntryValue()
     {
-        JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
+        ASSERT(m_node->bucketOwnerType() == BucketOwnerType::Map);
         LValue storage = lowCell(m_node->child1());
-        LValue result = vmCall(Int64, operationMapIterationEntryValue, weakPointer(globalObject), storage);
-        setJSValue(result);
+        LValue butterfly = toButterfly(storage);
+        LValue entry = m_out.load32(m_out.baseIndex(m_heaps.indexedContiguousProperties, butterfly, m_out.constIntPtr(JSMap::Helper::iterationEntryIndex())));
+        LValue bucketCount = m_out.load32(m_out.baseIndex(m_heaps.indexedContiguousProperties, butterfly, m_out.constIntPtr(JSMap::Helper::capacityIndex())));
+
+        static_assert(JSMap::Helper::EntrySize == 3);
+        LValue multiplied = m_out.add(entry, m_out.shl(entry, m_out.constInt32(1)));
+        LValue entryInButterfly = m_out.add(m_out.constInt32(JSMap::Helper::hashTableStartIndex() + /* value offset */ 1), m_out.add(bucketCount, multiplied));
+        LValue value = m_out.load64(m_out.baseIndex(m_heaps.indexedContiguousProperties, butterfly, m_out.zeroExtPtr(entryInButterfly)));
+        setJSValue(value);
     }
 
     void compileMapStorage()


### PR DESCRIPTION
#### fe892886f77fc2d2315b271a238010ab20c7acb1
<pre>
[JSC] Inline Map / Set forEach iteration in DFG and FTL
<a href="https://bugs.webkit.org/show_bug.cgi?id=315020">https://bugs.webkit.org/show_bug.cgi?id=315020</a>

Reviewed by NOBODY (OOPS!).

Map.prototype.forEach and Set.prototype.forEach iterate via four
@linkTimeConstant helpers (@mapIterationNext, @mapIterationEntry,
@mapIterationEntryKey, @mapIterationEntryValue), all of which were
unconditionally lowered to runtime calls in DFG and FTL — 4 vmCalls per
iteration, dominating the actual work of a few memory loads.  The for-of
path through MapIteratorNext is already fully inlined, so this brings
forEach to parity by reusing the same lowering structure: tombstone-
skipping fast loop, with obsolete tables and the sentinel storage bailing
out to the C++ slow path.

                                     ToT                     Patched

    map-for-each              8.1454+-0.1446     ^      4.8790+-0.3198     ^ definitely 1.6695x faster
    set-for-each              7.3377+-0.1599     ^      4.8137+-0.1361     ^ definitely 1.5244x faster

Test: JSTests/stress/map-set-foreach-mutation.js

* JSTests/microbenchmarks/map-for-each.js:
* JSTests/microbenchmarks/set-for-each.js:
* JSTests/stress/map-set-foreach-mutation.js: Added.
(shouldBe):
(testEmpty):
(testDeleteDuringMap):
(testDeleteDuringSet):
(testDeleteSelf):
(testAddDuring):
(testRehashDuring):
(testMultiRehashDuring):
(testClearDuring):
(testClearDuringSet):
(testTombstoneHeavy):
(testCallbackThrows):
(testDeleteReAdd):
(testThisArg):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe892886f77fc2d2315b271a238010ab20c7acb1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163084 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36563 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29778 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172023 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119530 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36760 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36565 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126606 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89209 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166043 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28867 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146595 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107182 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27914 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26545 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19722 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/155223 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137805 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24325 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174526 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23970 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/26410 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25972 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134919 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36234 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30648 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134914 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37038 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146120 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98837 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30231 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22960 "Found 1 new test failure: imported/w3c/web-platform-tests/dom/nodes/moveBefore/throws-exception.html (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195485 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35730 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108065 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50942 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35229 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/979 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35476 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35377 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->