### PR TITLE
[Media] timeupdate event can dispatch ahead of 'seeking' under stress

### DIFF
--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -1645,8 +1645,6 @@ webkit.org/b/221100 imported/w3c/web-platform-tests/webaudio/the-audio-api/the-a
 
 webkit.org/b/222205 css3/calc/transforms-translate.html [ Pass ImageOnlyFailure ]
 
-webkit.org/b/314792 imported/w3c/web-platform-tests/media-source/mediasource-duration.html [ Pass Failure ]
-
 webkit.org/b/222573 media/media-fullscreen-pause-inline.html [ Pass Failure ]
 
 webkit.org/b/222692 inspector/page/empty-or-missing-resources.html [ Pass Timeout ]

--- a/Source/WebCore/html/HTMLMediaElement.cpp
+++ b/Source/WebCore/html/HTMLMediaElement.cpp
@@ -1191,7 +1191,10 @@ void HTMLMediaElement::pauseAfterDetachedTask()
     if (m_inActiveDocument)
         return;
 
-    if (m_videoFullscreenMode != VideoFullscreenModePictureInPicture && m_networkState > NETWORK_EMPTY && !m_wasInterruptedForInvisibleAutoplay)
+    // Don't pause during an in-flight seek: pause()'s spec-mandated 'timeupdate' would race
+    // with the seek's own seeking/timeupdate/seeked events, and listeners attached to the
+    // (now-detached) element by an active test still receive these events.
+    if (m_videoFullscreenMode != VideoFullscreenModePictureInPicture && m_networkState > NETWORK_EMPTY && !m_wasInterruptedForInvisibleAutoplay && !m_seeking)
         pause();
     if (m_videoFullscreenMode == VideoFullscreenModeStandard && !protect(document())->quirks().needsNowPlayingFullscreenSwapQuirk())
         exitFullscreen();
@@ -3936,6 +3939,14 @@ void HTMLMediaElement::seekWithTolerance(const SeekTarget& target, bool fromDOM)
     // 4 - Set the seeking IDL attribute to true.
     // The flag will be cleared when the engine tells us the time has actually changed.
     setSeeking(true);
+
+    // Drop any periodic timeupdate already on the task queue. For fromDOM=true seeks,
+    // seekTask runs asynchronously, so a periodic timeupdate queued by
+    // playbackProgressTimerFired just before setCurrentTime could otherwise dispatch
+    // ahead of 'seeking'. The m_seeking guard in scheduleTimeupdateEvent suppresses any
+    // periodic queued in the window between this point and seekTask running.
+    m_periodicTimeupdateCancellationGroup.cancel();
+
     if (m_playing) {
         if (m_lastSeekTime < now)
             addPlayedRange(m_lastSeekTime, now);
@@ -4041,13 +4052,6 @@ void HTMLMediaElement::seekTask()
     m_lastSeekTime = time;
     m_pendingSeekType = thisSeekType;
     setSeeking(true);
-
-    // Before scheduling the 'seeking' event, drop any queued periodic timeupdate
-    // task. Without this, a periodic timeupdate queued by playbackProgressTimerFired
-    // just before setCurrentTime could dispatch ahead of 'seeking', producing the
-    // spec-incorrect event ordering observed in mediasource-duration.html. The
-    // seek-completion timeupdate is queued separately by finishSeek and survives.
-    m_periodicTimeupdateCancellationGroup.cancel();
 
     // 10 - Queue a task to fire a simple event named seeking at the element.
     scheduleEvent(eventNames().seekingEvent);
@@ -5901,10 +5905,13 @@ void HTMLMediaElement::mediaPlayerTimeChanged()
     if (m_seekRequested && m_readyState >= HAVE_CURRENT_DATA && !protect(player())->seeking())
         finishSeek();
 
-    // Always call scheduleTimeupdateEvent when the media engine reports a time discontinuity,
-    // it will only queue a 'timeupdate' event if we haven't already posted one at the current
-    // movie time.
-    else
+    // Otherwise schedule a discontinuity 'timeupdate' (per the spec's timeupdate event
+    // definition: "the current playback position changed [...] in an especially
+    // interesting way, for example discontinuously"). Skip while m_seeking is true:
+    // the seek's own seeking/timeupdate/seeked events would race with this one, and
+    // m_seekRequested is still false in the gap before seekTask runs so the if-branch
+    // above can't catch it.
+    else if (!m_seeking)
         scheduleTimeupdateEvent(false);
 
 #if ENABLE(MEDIA_SOURCE)


### PR DESCRIPTION
#### d27194909794562e8ec457840a31ca25362817e5
<pre>
[Media] timeupdate event can dispatch ahead of &apos;seeking&apos; under stress
<a href="https://bugs.webkit.org/show_bug.cgi?id=314792">https://bugs.webkit.org/show_bug.cgi?id=314792</a>
<a href="https://rdar.apple.com/177044662">rdar://177044662</a>

Reviewed by Eric Carlson.

imported/w3c/web-platform-tests/media-source/mediasource-duration.html
test 2 (&quot;Test appendBuffer completes previous seek to truncated duration&quot;)
intermittently fails with:

  assert_equals: Event types match. expected &quot;seeking&quot; but got &quot;timeupdate&quot;

A `timeupdate` event dispatches ahead of the seek&apos;s `seeking` event,
violating the spec-required ordering for the seek algorithm&apos;s events.

The test&apos;s flow:

  1. play() and append all media to a SourceBuffer.
  2. mediaElement.currentTime = duration / 2; wait for seeking, timeupdate,
     seeked.
  3. sourceBuffer.remove(truncatedDuration = duration / 4, Infinity) —
     removes data covering the current playback position.
  4. Wait for sourceBuffer&apos;s updateend.
  5. mediaSource.duration = truncatedDuration — the duration-change
     algorithm internally seeks to the new (smaller) duration.
  6. Expect &apos;seeking&apos; as the next event on the media element.

Three independent race windows can each let a `timeupdate` slip in front of
that &apos;seeking&apos;:

(a) `seekWithTolerance` synchronously sets `m_seeking = true` and queues
`seekTask`. For fromDOM=true seeks, `seekTask` runs asynchronously, and the
existing cancel of `m_periodicTimeupdateCancellationGroup` lived inside
`seekTask` — too late: a `playbackProgressTimer` periodic `timeupdate`
queued just before `setCurrentTime` already dispatches before `seekTask`
runs. Move the cancel up into `seekWithTolerance`, right after
`setSeeking(true)`, so it runs in the same synchronous chain as
`setCurrentTime`. The existing `m_seeking` guard in
`scheduleTimeupdateEvent` continues to suppress any new periodic queued in
the window between the cancel and `seekTask` running.

(b) `mediaPlayerTimeChanged`&apos;s else-branch unconditionally calls
`scheduleTimeupdateEvent(false)` for media-engine-reported time
discontinuities. Between `seekWithTolerance` setting `m_seeking = true` and
`seekTask` running, `m_seekRequested` is still `false` (it is set inside
`seekTask`), so the if-branch above (which calls `finishSeek` only when
`m_seekRequested` is set and the player has stopped seeking) cannot catch
this case and the else-branch fires a `timeupdate` that races ahead of
&apos;seeking&apos;. Gate the call on `!m_seeking` so the seek&apos;s own
seeking/timeupdate/seeked events take over once a seek is in flight; this
covers both the pre-`seekTask` gap and the period while the player itself
is still seeking.

(c) When a media element is detached from the document during an in-flight
seek, `pauseAfterDetachedTask` calls `pause()`, which schedules a
spec-mandated `timeupdate` from `pauseInternal`. The element retains its
event listeners after detach, so an active sibling test (notably a
parallel async_test in the same WPT page) still observes this `timeupdate`,
racing with the seek&apos;s `seeking`. Skip the `pause()` call when `m_seeking`
is true — the seek path will fire the relevant events when it completes.

The four spec-mandated `scheduleEvent(timeupdate)` paths (`pauseInternal`,
`setReadyState`&apos;s readyState-drop branch, `seekTask`&apos;s noSeekRequired
short-circuit, and `finishSeek`&apos;s step-16 timeupdate) remain
non-cancellable; only periodic and discontinuity timeupdates are routed
through the cancellation group / suppressed during seek.

No new layout test: mediasource-duration.html (already in the tree) is the
regression sentinel for this race.

* Source/WebCore/html/HTMLMediaElement.cpp:
(WebCore::HTMLMediaElement::pauseAfterDetachedTask):
(WebCore::HTMLMediaElement::seekWithTolerance):
(WebCore::HTMLMediaElement::seekTask):
(WebCore::HTMLMediaElement::mediaPlayerTimeChanged):

Canonical link: <a href="https://commits.webkit.org/313447@main">https://commits.webkit.org/313447@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f09e5023136a2bb83c187016b807010e33bdb2fb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163163 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36644 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29861 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172102 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119610 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165032 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36972 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36645 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126684 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/89284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cc46af4a-cd06-4265-ab49-78e3f458f8fb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166122 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/28956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146678 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107253 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fd10d56c-e694-423e-a8e7-8bab1f73337f) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28002 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26632 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19802 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24402 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174605 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/26762 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26057 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134990 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36314 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30734 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134982 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36389 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37100 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146197 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98974 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30287 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23041 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35810 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108171 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35309 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1064 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35556 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35456 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->