### PR TITLE
[Skia] Add damage region visualization overlays

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
@@ -91,7 +91,17 @@ ThreadedCompositor::ThreadedCompositor(WebPage& webPage, LayerTreeHost& layerTre
 
     initializeFPSCounter();
 #if ENABLE(DAMAGE_TRACKING)
-    m_damage.visualizer = TextureMapperDamageVisualizer::create();
+    if (m_useSkia) {
+        // WEBKIT_SHOW_DAMAGE=N renders the frame damage rects, insetting them
+        // by N-1 pixels (mirrors TextureMapperDamageVisualizer's behavior).
+        if (const auto* showDamageVariable = getenv("WEBKIT_SHOW_DAMAGE")) {
+            if (auto value = parseInteger<unsigned>(StringView::fromLatin1(showDamageVariable)); value && *value) {
+                m_damage.showSkiaDamage = true;
+                m_damage.skiaDamageMargin = *value - 1;
+            }
+        }
+    } else
+        m_damage.visualizer = TextureMapperDamageVisualizer::create();
 #endif
 
     updateSceneAttributes(webPage.size(), webPage.deviceScaleFactor());
@@ -253,7 +263,7 @@ void ThreadedCompositor::setSize(const IntSize& size, float deviceScaleFactor)
 void ThreadedCompositor::setDamagePropagationFlags(std::optional<OptionSet<DamagePropagationFlags>> flags)
 {
     m_damage.flags = flags;
-    if (m_damage.visualizer && m_damage.flags) {
+    if ((m_damage.visualizer || m_damage.showSkiaDamage) && m_damage.flags) {
         // We don't use damage when rendering layers if the visualizer is enabled, because we need to make sure the whole
         // frame is invalidated in the next paint so that previous damage rects are cleared.
         m_damage.flags->remove(DamagePropagationFlags::UseForCompositing);
@@ -388,6 +398,17 @@ void ThreadedCompositor::paintToSkiaCanvas(const TransformationMatrix& matrix, c
 
         if (!frameDamage->isEmpty())
             m_surface->setFrameDamage(WTF::move(*frameDamage));
+    }
+#endif
+
+#if ENABLE(DAMAGE_TRACKING)
+    if (m_damage.showSkiaDamage) {
+        if (auto damage = m_surface->frameDamage())
+            drawSkiaDamage(*canvas, damage);
+
+        // When the damage visualizer is active we cannot send the original damage to the platform, as the
+        // damage rects visualized in the previous frame may not get erased if the platform uses damage.
+        m_surface->setFrameDamage(Damage(size, Damage::Mode::Full));
     }
 #endif
 
@@ -705,6 +726,19 @@ void ThreadedCompositor::drawFPSCounter(SkCanvas& canvas)
     textPaint.setAntiAlias(true);
     canvas.drawString(m_fpsCounter.fpsString.data(), padding, m_fpsCounter.textBaseline, font, textPaint);
 }
+
+#if ENABLE(DAMAGE_TRACKING)
+void ThreadedCompositor::drawSkiaDamage(SkCanvas& canvas, const std::optional<WebCore::Damage>& damage)
+{
+    SkPaint paint;
+    paint.setStyle(SkPaint::kFill_Style);
+    paint.setColor(SkColorSetARGB(200, 255, 0, 0));
+
+    const auto margin = static_cast<SkScalar>(m_damage.skiaDamageMargin);
+    for (const auto& rect : *damage)
+        canvas.drawRect(SkRect::MakeXYWH(rect.x() - margin, rect.y() - margin, rect.width() + margin * 2, rect.height() + margin * 2), paint);
+}
+#endif
 
 void ThreadedCompositor::fillGLInformation(RenderProcessInfo&& info, CompletionHandler<void(RenderProcessInfo&&)>&& completionHandler)
 {

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
@@ -121,6 +121,9 @@ private:
     void initializeFPSCounter();
     void updateFPSCounter();
     void drawFPSCounter(SkCanvas&);
+#if ENABLE(DAMAGE_TRACKING)
+    void drawSkiaDamage(SkCanvas&, const std::optional<WebCore::Damage>&);
+#endif
 
     const Ref<WorkQueue> m_workQueue;
     CheckedPtr<LayerTreeHost> m_layerTreeHost;
@@ -181,6 +184,10 @@ private:
     struct {
         std::optional<OptionSet<DamagePropagationFlags>> flags;
         std::unique_ptr<WebCore::TextureMapperDamageVisualizer> visualizer;
+
+        bool showSkiaDamage { false };
+        unsigned skiaDamageMargin { 0 };
+
         std::atomic<bool> shouldNotifyFrameDamageForTesting { false };
     } m_damage;
 #endif


### PR DESCRIPTION
#### 9b2205348498cf71f859084f609e85048aec5d60
<pre>
[Skia] Add damage region visualization overlays
<a href="https://bugs.webkit.org/show_bug.cgi?id=315021">https://bugs.webkit.org/show_bug.cgi?id=315021</a>

Reviewed by Carlos Garcia Campos.

The damage visualization overlay was specific to the TextureMapper path
(TextureMapperDamageVisualizer). Add a Skia counterpart so
WEBKIT_SHOW_DAMAGE also works when the Skia compositor is enabled.

Following the on-screen FPS counter approach, the Skia damage
visualization is drawn directly from ThreadedCompositor to the SkCanvas
rather than introducing a separate class. As with the TextureMapper
visualizer, while it is active the whole frame is invalidated each paint
so previously visualized damage rects get erased: damage is excluded
from compositing and the frame damage sent to the platform is forced to
Full.

* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp:
(WebKit::m_renderTimer):
(WebKit::ThreadedCompositor::setDamagePropagationFlags):
(WebKit::ThreadedCompositor::paintToSkiaCanvas):
(WebKit::ThreadedCompositor::drawSkiaDamage):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h:

Canonical link: <a href="https://commits.webkit.org/313476@main">https://commits.webkit.org/313476@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf3756054e2728b2350104d0f2782e7e2b2e376d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163090 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36569 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29797 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172029 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119536 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36753 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36571 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126612 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89232 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166049 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28865 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146608 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107188 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27912 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26551 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19728 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137803 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174532 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/26450 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25985 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134925 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36240 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30654 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134920 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37031 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146133 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98853 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24839 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30225 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22983 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35736 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108092 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35235 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/992 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35482 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35383 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->