### PR TITLE
[Swift GTK] Reland: Cease to need to declare header dependencies

### DIFF
--- a/Source/WebCore/PAL/pal/CMakeLists.txt
+++ b/Source/WebCore/PAL/pal/CMakeLists.txt
@@ -117,13 +117,6 @@ if (SWIFT_REQUIRED AND NOT (PORT STREQUAL GTK OR PORT STREQUAL WPE))
         list(APPEND PAL_SWIFT_EXTRA_OPTIONS "-Xcc" "-I${CMAKE_BINARY_DIR}/ICU/Headers")
     endif ()
 
-    # Declare a header-only dependency for WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER below.
-    set(PAL_SWIFT_HEADER_DEPENDS
-        PAL_CopyHeaders
-        WTF_CopyHeaders
-        bmalloc_CopyHeaders
-    )
-
     WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER(PAL pal
         "${PAL_FRAMEWORK_HEADERS_DIR}/pal"
         "PALSwift-Generated.h")

--- a/Source/WebKit/PlatformCocoa.cmake
+++ b/Source/WebKit/PlatformCocoa.cmake
@@ -172,18 +172,6 @@ set(WebKit_SWIFT_INCLUDE_DIRECTORIES
     "${WEBKIT_DIR}/Platform/spi/ios"
 )
 
-# Targets that stage the headers the -typecheck/-emit-clang-header pass reads.
-# Declaring these lets WEBKIT_TARGET_ADD_SWIFT_SOURCES detach the header
-# command from cmake_object_order_depends_target_WebKit so it starts once
-# headers are copied instead of waiting for WebCore/WebKitLegacy to link.
-set(WebKit_SWIFT_HEADER_DEPENDS
-    PAL_CopyHeaders
-    WTF_CopyHeaders
-    WebKit_CopyHeaders
-    bmalloc_CopyHeaders
-    bmalloc_CopyPrivateHeaders
-)
-
 file(WRITE "${CMAKE_BINARY_DIR}/WebKit/WebPushDaemonStubs.cpp"
 "#include \"config.h\"\n#if ENABLE(WEB_PUSH_NOTIFICATIONS)\nnamespace WebKit {\nint WebPushDaemonMain(int, char**) { return 1; }\nint WebPushToolMain(int, char**) { return 1; }\n}\n#endif\n")
 list(APPEND WebKit_SOURCES "${CMAKE_BINARY_DIR}/WebKit/WebPushDaemonStubs.cpp")

--- a/Source/cmake/WebKitMacros.cmake
+++ b/Source/cmake/WebKitMacros.cmake
@@ -727,6 +727,38 @@ macro(WEBKIT_CREATE_SYMLINK target src dest)
         COMMENT "Create symlink from ${src} to ${dest}")
 endmacro()
 
+function(_webkit_setup_swift_header_deps _target _stamp _header)
+    # Discover _CopyHeaders/_CopyPrivateHeaders targets for this target and its
+    # direct framework dependencies. Called via cmake_language(DEFER CALL ...)
+    # so targets declared after WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER
+    # (e.g. ${_target}_CopyHeaders itself) are visible to if(TARGET ...).
+    set(_candidates "${_target}")
+    if (DEFINED ${_target}_FRAMEWORKS)
+        list(APPEND _candidates ${${_target}_FRAMEWORKS})
+    endif ()
+    set(_deps "")
+    foreach (_lib IN LISTS _candidates)
+        foreach (_suffix IN ITEMS _CopyHeaders _CopyPrivateHeaders)
+            if (TARGET "${_lib}${_suffix}")
+                list(APPEND _deps "${_lib}${_suffix}")
+            endif ()
+        endforeach ()
+    endforeach ()
+    list(REMOVE_DUPLICATES _deps)
+
+    if (_deps)
+        # Wrap the header-generation command in its own custom target so it
+        # does NOT inherit cmake_object_order_depends_target_${_target} (which
+        # would gate it on every link dependency). It can start as soon as the
+        # relevant headers are staged.
+        add_custom_target(${_target}_SwiftCxxHeader DEPENDS ${_stamp})
+        add_dependencies(${_target}_SwiftCxxHeader ${_deps})
+        add_dependencies(${_target} ${_target}_SwiftCxxHeader)
+    else ()
+        target_sources(${_target} PRIVATE ${_header})
+    endif ()
+endfunction()
+
 macro(WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER _target _module_name _interop_module_path _output_header)
     if (SWIFT_REQUIRED)
         set_target_properties(${_target} PROPERTIES Swift_MODULE_NAME ${_module_name})
@@ -937,18 +969,10 @@ macro(WEBKIT_SETUP_SWIFT_AND_GENERATE_SWIFT_CPP_INTEROP_HEADER _target _module_n
             COMMAND_EXPAND_LISTS)
 
         target_include_directories(${_target} PUBLIC ${_header_base_path})
-        if (DEFINED ${_target}_SWIFT_HEADER_DEPENDS)
-            # The -emit-clang-header pass only needs the staged headers it actually
-            # reads, not the target's linked frameworks. When the caller names
-            # those header-producing targets, wrap the command in its own
-            # custom target so it does NOT inherit
-            # cmake_object_order_depends_target_${_target} (which would gate it
-            # on every link dependency) and can start as soon as headers exist.
-            add_custom_target(${_target}_SwiftCxxHeader DEPENDS ${_header_stamp_path})
-            add_dependencies(${_target}_SwiftCxxHeader ${${_target}_SWIFT_HEADER_DEPENDS})
-            add_dependencies(${_target} ${_target}_SwiftCxxHeader)
-        else ()
-            target_sources(${_target} PRIVATE ${_header_stamp_path})
-        endif ()
+        # Defer dependency wiring until end-of-directory so if(TARGET ...) inside
+        # _webkit_setup_swift_header_deps sees targets declared after this macro
+        # call (e.g. ${_target}_CopyHeaders is often created later in the same file).
+        cmake_language(DEFER CALL _webkit_setup_swift_header_deps
+            "${_target}" "${_header_stamp_path}" "${_header_path}")
     endif ()
 endmacro()


### PR DESCRIPTION
#### a31f7b2bc05b7eec6a816ff7996c554f5f36e3b4
<pre>
[Swift GTK] Reland: Cease to need to declare header dependencies
<a href="https://bugs.webkit.org/show_bug.cgi?id=314448">https://bugs.webkit.org/show_bug.cgi?id=314448</a>

Reviewed by Geoffrey Garen and Richard Robinson.

We previously hard-coded a list of header-copying dependencies which needed to
be completed before WebKit was able to generate C++ bindings to its internal
Swift APIs. Instead of hard-coding this list, calculate it automatically.

This was previously reverted erroneously due to a build failure that was
actually caused by <a href="https://commits.webkit.org/313188@main.">https://commits.webkit.org/313188@main.</a> This is an
identical reland.

Canonical link: <a href="https://commits.webkit.org/313419@main">https://commits.webkit.org/313419@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e9df3f381c380e790916b203a555084efbe461e8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163093 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36572 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29783 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172032 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119539 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/726c1d56-5e30-40e1-b48b-fd5d3e12d411) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164962 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/36756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36574 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126616 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/89217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/254aed1a-d801-4838-b19b-7ef3b8bbae6f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166052 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/36756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146601 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107191 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/85036ac2-c321-4e4d-a684-32535765636e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/36756 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26554 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19731 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/155232 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137757 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24331 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174535 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/23979 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/26476 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/25978 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134928 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36243 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30657 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134923 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36373 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/37049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146126 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98858 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/37049 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/22966 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195494 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35739 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108095 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50952 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35238 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/985 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35485 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35386 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->