### PR TITLE
Occasional crash in CollectionIndexCache::~CollectionIndexCache while running moveBefore tests.

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/Node-moveBefore-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/Node-moveBefore-expected.txt
@@ -21,7 +21,7 @@ PASS moveBefore() with a non-{Element, CharacterData} throws a HierarchyRequestE
 PASS moveBefore with an Element or CharacterData succeeds
 PASS moveBefore on a paragraph's Text node child
 PASS moveBefore with reference child whose parent is NOT the destination parent (context node) throws a NotFoundError.
-FAIL moveBefore() returns undefined assert_array_equals: expected property 0 to be Element node <div></div> but got Element node <div></div> (expected array [Element node <div></div>, Element node <div></div>] got object "[object NodeList]")
+PASS moveBefore() returns undefined
 PASS Moving a node before itself should not move the node
 PASS Moving a node from a disconnected container to a disconnected new parent without a shared ancestor throws a HIERARCHY_REQUEST_ERR
 PASS Moving a node from a disconnected container to a disconnected new parent in the same tree succeeds

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/iframe-document-preserve.window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/iframe-document-preserve.window-expected.txt
@@ -5,5 +5,5 @@ PASS moveBefore(): cross-origin iframe is preserved: remove new parent
 PASS moveBefore(): cross-origin iframe is preserved: remove self
 PASS moveBefore(): cross-origin iframe is preserved: remove self via replaceChildren()
 PASS moveBefore(): cross-origin iframe is preserved: remove self via innerHTML
-FAIL window.frames ordering does not change due to moveBefore() assert_equals: iframe3 comes first in DOM after moveBefore expected "iframe3" but got "iframe1"
+PASS window.frames ordering does not change due to moveBefore()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-name-map-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-name-map-expected.txt
@@ -1,6 +1,6 @@
 
 
-FAIL moveBefore() correctly updates name map when moving into shadow root assert_equals: expected 0 but got 1
+PASS moveBefore() correctly updates name map when moving into shadow root
 PASS moveBefore() correctly updates window map
-FAIL moveBefore() correctly updates name map ordering in document assert_equals: expected Element node <img name="duplicate"></img> but got Element node <img name="duplicate"></img>
+PASS moveBefore() correctly updates name map ordering in document
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/script-move-before-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/script-move-before-expected.txt
@@ -1,4 +1,4 @@
 
-PASS Synchronous script execution in HTMLScriptElement during moveBefore should be blocked
-PASS Synchronous script execution in SVGScriptElement during moveBefore should be blocked
+FAIL Synchronous script execution in HTMLScriptElement during moveBefore should be blocked assert_false: <html:script> does not define moving steps which allow script execution. expected false got true
+FAIL Synchronous script execution in SVGScriptElement during moveBefore should be blocked assert_false: <svg:script> does not define moving steps which allow script execution. expected false got true
 

--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/slotchange-events-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/slotchange-events-expected.txt
@@ -1,6 +1,6 @@
 
-FAIL Moving default content into a slot fires 'slotchange' event promise_test: Unhandled rejection with value: "Timeout; slotchange was not fired"
-FAIL Moving default content out of a slot fires 'slotchange' event promise_test: Unhandled rejection with value: "Timeout; slotchange was not fired"
+PASS Moving default content into a slot fires 'slotchange' event
+PASS Moving default content out of a slot fires 'slotchange' event
 FAIL Moving a slottable into and out out of a custom element fires 'slotchange' event promise_test: Unhandled rejection with value: "Timeout; slotchange (whiling moving an element in) was not fired"
 FAIL Moving a slot runs the assign slottables algorithm promise_test: Unhandled rejection with value: "Timeout; slotchange was not fired2"
 

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -1470,6 +1470,8 @@ ExceptionOr<void> ContainerNode::moveBefore(Node& node, RefPtr<Node>&& refChild)
 
     // FIXME(281223): Run NodeIterator and live range pre-remove steps.
 
+    auto removalChildChange = makeChildChangeForRemoval(node, ChildChange::Source::API);
+
     {
         WidgetHierarchyUpdatesSuspensionScope suspendWidgetHierarchyUpdates;
         ScriptDisallowedScope::InMainThread scriptDisallowedScope;
@@ -1517,6 +1519,11 @@ ExceptionOr<void> ContainerNode::moveBefore(Node& node, RefPtr<Node>&& refChild)
                 CustomElementReactionQueue::enqueueConnectedMoveCallbackIfNeeded(*element);
         }
     }
+
+    // FIXME: Add a new type for ChildChange.
+
+    oldParent->childrenChanged(removalChildChange);
+    childrenChanged(makeChildChangeForInsertion(*this, node, refChild, ChildChange::Source::API, ReplacedAllChildren::No));
 
     // FIXME(281223): Queue tree mutation records.
 


### PR DESCRIPTION
#### 958ef3d92e6ebcdd41023564aacef0f3d5d9a72a
<pre>
Occasional crash in CollectionIndexCache::~CollectionIndexCache while running moveBefore tests.
<a href="https://bugs.webkit.org/show_bug.cgi?id=315034">https://bugs.webkit.org/show_bug.cgi?id=315034</a>
<a href="https://rdar.apple.com/177337493">rdar://177337493</a>

Reviewed by Simon Fraser.

Notify the parent nodes for a child move so that things like HTMLCollectionCache gets invalidated.

No new tests since existing tests cover this scenario.

More tests progress with this change except script-move-before.html which regresses.

* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/Node-moveBefore-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/iframe-document-preserve.window-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-name-map-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/script-move-before-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/slotchange-events-expected.txt:
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::moveBefore):

Canonical link: <a href="https://commits.webkit.org/313444@main">https://commits.webkit.org/313444@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a789fd4529e71f1f16e6fcfc2ceaae6114d4a0c4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163127 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36608 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29825 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172066 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119574 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b11d446b-d526-44aa-9bbc-0e699c5024a4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/164996 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36747 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36608 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126650 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89250 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6d835c55-77d2-49b0-b9de-b55203ee89b7) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166086 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/28861 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146648 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107220 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e1698fa7-24e7-4688-b514-822e75c4be2b) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27907 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26595 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19766 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137799 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24372 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174569 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/26695 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26027 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134960 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36278 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30699 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134952 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37064 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146167 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98908 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24822 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30249 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23011 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35774 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108135 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35273 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1034 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35520 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35420 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->