### PR TITLE
Sync `css/css-viewport/animations` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/animations/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/animations/w3c-import.log
@@ -1,0 +1,17 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/animations/zoom-interpolation.html

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/animations/zoom-interpolation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/animations/zoom-interpolation-expected.txt
@@ -1,0 +1,204 @@
+
+FAIL CSS Transitions: property <zoom> from neutral to [2] at (-0.3) should be [0.7] assert_equals: expected "0.7 " but got "2 "
+FAIL CSS Transitions: property <zoom> from neutral to [2] at (0) should be [1] assert_equals: expected "1 " but got "2 "
+FAIL CSS Transitions: property <zoom> from neutral to [2] at (0.3) should be [1.3] assert_equals: expected "1.3 " but got "2 "
+FAIL CSS Transitions: property <zoom> from neutral to [2] at (0.6) should be [1.6] assert_equals: expected "1.6 " but got "2 "
+PASS CSS Transitions: property <zoom> from neutral to [2] at (1) should be [2]
+FAIL CSS Transitions: property <zoom> from neutral to [2] at (1.5) should be [2.5] assert_equals: expected "2.5 " but got "2 "
+FAIL CSS Transitions with transition: all: property <zoom> from neutral to [2] at (-0.3) should be [0.7] assert_equals: expected "0.7 " but got "2 "
+FAIL CSS Transitions with transition: all: property <zoom> from neutral to [2] at (0) should be [1] assert_equals: expected "1 " but got "2 "
+FAIL CSS Transitions with transition: all: property <zoom> from neutral to [2] at (0.3) should be [1.3] assert_equals: expected "1.3 " but got "2 "
+FAIL CSS Transitions with transition: all: property <zoom> from neutral to [2] at (0.6) should be [1.6] assert_equals: expected "1.6 " but got "2 "
+PASS CSS Transitions with transition: all: property <zoom> from neutral to [2] at (1) should be [2]
+FAIL CSS Transitions with transition: all: property <zoom> from neutral to [2] at (1.5) should be [2.5] assert_equals: expected "2.5 " but got "2 "
+FAIL CSS Animations: property <zoom> from neutral to [2] at (-0.3) should be [0.7] assert_equals: expected "0.7 " but got "1 "
+PASS CSS Animations: property <zoom> from neutral to [2] at (0) should be [1]
+FAIL CSS Animations: property <zoom> from neutral to [2] at (0.3) should be [1.3] assert_equals: expected "1.3 " but got "1 "
+FAIL CSS Animations: property <zoom> from neutral to [2] at (0.6) should be [1.6] assert_equals: expected "1.6 " but got "1 "
+FAIL CSS Animations: property <zoom> from neutral to [2] at (1) should be [2] assert_equals: expected "2 " but got "1 "
+FAIL CSS Animations: property <zoom> from neutral to [2] at (1.5) should be [2.5] assert_equals: expected "2.5 " but got "1 "
+FAIL Web Animations: property <zoom> from neutral to [2] at (-0.3) should be [0.7] assert_equals: expected "0.7 " but got "1 "
+PASS Web Animations: property <zoom> from neutral to [2] at (0) should be [1]
+FAIL Web Animations: property <zoom> from neutral to [2] at (0.3) should be [1.3] assert_equals: expected "1.3 " but got "1 "
+FAIL Web Animations: property <zoom> from neutral to [2] at (0.6) should be [1.6] assert_equals: expected "1.6 " but got "1 "
+FAIL Web Animations: property <zoom> from neutral to [2] at (1) should be [2] assert_equals: expected "2 " but got "1 "
+FAIL Web Animations: property <zoom> from neutral to [2] at (1.5) should be [2.5] assert_equals: expected "2.5 " but got "1 "
+FAIL CSS Transitions: property <zoom> from [initial] to [2] at (-0.3) should be [0.7] assert_equals: expected "0.7 " but got "2 "
+FAIL CSS Transitions: property <zoom> from [initial] to [2] at (0) should be [1] assert_equals: expected "1 " but got "2 "
+FAIL CSS Transitions: property <zoom> from [initial] to [2] at (0.3) should be [1.3] assert_equals: expected "1.3 " but got "2 "
+FAIL CSS Transitions: property <zoom> from [initial] to [2] at (0.6) should be [1.6] assert_equals: expected "1.6 " but got "2 "
+PASS CSS Transitions: property <zoom> from [initial] to [2] at (1) should be [2]
+FAIL CSS Transitions: property <zoom> from [initial] to [2] at (1.5) should be [2.5] assert_equals: expected "2.5 " but got "2 "
+FAIL CSS Transitions with transition: all: property <zoom> from [initial] to [2] at (-0.3) should be [0.7] assert_equals: expected "0.7 " but got "2 "
+FAIL CSS Transitions with transition: all: property <zoom> from [initial] to [2] at (0) should be [1] assert_equals: expected "1 " but got "2 "
+FAIL CSS Transitions with transition: all: property <zoom> from [initial] to [2] at (0.3) should be [1.3] assert_equals: expected "1.3 " but got "2 "
+FAIL CSS Transitions with transition: all: property <zoom> from [initial] to [2] at (0.6) should be [1.6] assert_equals: expected "1.6 " but got "2 "
+PASS CSS Transitions with transition: all: property <zoom> from [initial] to [2] at (1) should be [2]
+FAIL CSS Transitions with transition: all: property <zoom> from [initial] to [2] at (1.5) should be [2.5] assert_equals: expected "2.5 " but got "2 "
+FAIL CSS Animations: property <zoom> from [initial] to [2] at (-0.3) should be [0.7] assert_equals: expected "0.7 " but got "1 "
+PASS CSS Animations: property <zoom> from [initial] to [2] at (0) should be [1]
+FAIL CSS Animations: property <zoom> from [initial] to [2] at (0.3) should be [1.3] assert_equals: expected "1.3 " but got "1 "
+FAIL CSS Animations: property <zoom> from [initial] to [2] at (0.6) should be [1.6] assert_equals: expected "1.6 " but got "1 "
+FAIL CSS Animations: property <zoom> from [initial] to [2] at (1) should be [2] assert_equals: expected "2 " but got "1 "
+FAIL CSS Animations: property <zoom> from [initial] to [2] at (1.5) should be [2.5] assert_equals: expected "2.5 " but got "1 "
+FAIL Web Animations: property <zoom> from [initial] to [2] at (-0.3) should be [0.7] assert_equals: expected "0.7 " but got "1 "
+PASS Web Animations: property <zoom> from [initial] to [2] at (0) should be [1]
+FAIL Web Animations: property <zoom> from [initial] to [2] at (0.3) should be [1.3] assert_equals: expected "1.3 " but got "1 "
+FAIL Web Animations: property <zoom> from [initial] to [2] at (0.6) should be [1.6] assert_equals: expected "1.6 " but got "1 "
+FAIL Web Animations: property <zoom> from [initial] to [2] at (1) should be [2] assert_equals: expected "2 " but got "1 "
+FAIL Web Animations: property <zoom> from [initial] to [2] at (1.5) should be [2.5] assert_equals: expected "2.5 " but got "1 "
+FAIL CSS Transitions: property <zoom> from [inherit] to [2] at (-0.3) should be [3.3] assert_equals: expected "3.3 " but got "2 "
+FAIL CSS Transitions: property <zoom> from [inherit] to [2] at (0) should be [3] assert_equals: expected "3 " but got "2 "
+FAIL CSS Transitions: property <zoom> from [inherit] to [2] at (0.3) should be [2.7] assert_equals: expected "2.7 " but got "2 "
+FAIL CSS Transitions: property <zoom> from [inherit] to [2] at (0.6) should be [2.4] assert_equals: expected "2.4 " but got "2 "
+PASS CSS Transitions: property <zoom> from [inherit] to [2] at (1) should be [2]
+FAIL CSS Transitions: property <zoom> from [inherit] to [2] at (1.5) should be [1.5] assert_equals: expected "1.5 " but got "2 "
+FAIL CSS Transitions with transition: all: property <zoom> from [inherit] to [2] at (-0.3) should be [3.3] assert_equals: expected "3.3 " but got "2 "
+FAIL CSS Transitions with transition: all: property <zoom> from [inherit] to [2] at (0) should be [3] assert_equals: expected "3 " but got "2 "
+FAIL CSS Transitions with transition: all: property <zoom> from [inherit] to [2] at (0.3) should be [2.7] assert_equals: expected "2.7 " but got "2 "
+FAIL CSS Transitions with transition: all: property <zoom> from [inherit] to [2] at (0.6) should be [2.4] assert_equals: expected "2.4 " but got "2 "
+PASS CSS Transitions with transition: all: property <zoom> from [inherit] to [2] at (1) should be [2]
+FAIL CSS Transitions with transition: all: property <zoom> from [inherit] to [2] at (1.5) should be [1.5] assert_equals: expected "1.5 " but got "2 "
+FAIL CSS Animations: property <zoom> from [inherit] to [2] at (-0.3) should be [3.3] assert_equals: expected "3.3 " but got "1 "
+FAIL CSS Animations: property <zoom> from [inherit] to [2] at (0) should be [3] assert_equals: expected "3 " but got "1 "
+FAIL CSS Animations: property <zoom> from [inherit] to [2] at (0.3) should be [2.7] assert_equals: expected "2.7 " but got "1 "
+FAIL CSS Animations: property <zoom> from [inherit] to [2] at (0.6) should be [2.4] assert_equals: expected "2.4 " but got "1 "
+FAIL CSS Animations: property <zoom> from [inherit] to [2] at (1) should be [2] assert_equals: expected "2 " but got "1 "
+FAIL CSS Animations: property <zoom> from [inherit] to [2] at (1.5) should be [1.5] assert_equals: expected "1.5 " but got "1 "
+FAIL Web Animations: property <zoom> from [inherit] to [2] at (-0.3) should be [3.3] assert_equals: expected "3.3 " but got "1 "
+FAIL Web Animations: property <zoom> from [inherit] to [2] at (0) should be [3] assert_equals: expected "3 " but got "1 "
+FAIL Web Animations: property <zoom> from [inherit] to [2] at (0.3) should be [2.7] assert_equals: expected "2.7 " but got "1 "
+FAIL Web Animations: property <zoom> from [inherit] to [2] at (0.6) should be [2.4] assert_equals: expected "2.4 " but got "1 "
+FAIL Web Animations: property <zoom> from [inherit] to [2] at (1) should be [2] assert_equals: expected "2 " but got "1 "
+FAIL Web Animations: property <zoom> from [inherit] to [2] at (1.5) should be [1.5] assert_equals: expected "1.5 " but got "1 "
+FAIL CSS Transitions: property <zoom> from [unset] to [2] at (-0.3) should be [0.7] assert_equals: expected "0.7 " but got "2 "
+FAIL CSS Transitions: property <zoom> from [unset] to [2] at (0) should be [1] assert_equals: expected "1 " but got "2 "
+FAIL CSS Transitions: property <zoom> from [unset] to [2] at (0.3) should be [1.3] assert_equals: expected "1.3 " but got "2 "
+FAIL CSS Transitions: property <zoom> from [unset] to [2] at (0.6) should be [1.6] assert_equals: expected "1.6 " but got "2 "
+PASS CSS Transitions: property <zoom> from [unset] to [2] at (1) should be [2]
+FAIL CSS Transitions: property <zoom> from [unset] to [2] at (1.5) should be [2.5] assert_equals: expected "2.5 " but got "2 "
+FAIL CSS Transitions with transition: all: property <zoom> from [unset] to [2] at (-0.3) should be [0.7] assert_equals: expected "0.7 " but got "2 "
+FAIL CSS Transitions with transition: all: property <zoom> from [unset] to [2] at (0) should be [1] assert_equals: expected "1 " but got "2 "
+FAIL CSS Transitions with transition: all: property <zoom> from [unset] to [2] at (0.3) should be [1.3] assert_equals: expected "1.3 " but got "2 "
+FAIL CSS Transitions with transition: all: property <zoom> from [unset] to [2] at (0.6) should be [1.6] assert_equals: expected "1.6 " but got "2 "
+PASS CSS Transitions with transition: all: property <zoom> from [unset] to [2] at (1) should be [2]
+FAIL CSS Transitions with transition: all: property <zoom> from [unset] to [2] at (1.5) should be [2.5] assert_equals: expected "2.5 " but got "2 "
+FAIL CSS Animations: property <zoom> from [unset] to [2] at (-0.3) should be [0.7] assert_equals: expected "0.7 " but got "1 "
+PASS CSS Animations: property <zoom> from [unset] to [2] at (0) should be [1]
+FAIL CSS Animations: property <zoom> from [unset] to [2] at (0.3) should be [1.3] assert_equals: expected "1.3 " but got "1 "
+FAIL CSS Animations: property <zoom> from [unset] to [2] at (0.6) should be [1.6] assert_equals: expected "1.6 " but got "1 "
+FAIL CSS Animations: property <zoom> from [unset] to [2] at (1) should be [2] assert_equals: expected "2 " but got "1 "
+FAIL CSS Animations: property <zoom> from [unset] to [2] at (1.5) should be [2.5] assert_equals: expected "2.5 " but got "1 "
+FAIL Web Animations: property <zoom> from [unset] to [2] at (-0.3) should be [0.7] assert_equals: expected "0.7 " but got "1 "
+PASS Web Animations: property <zoom> from [unset] to [2] at (0) should be [1]
+FAIL Web Animations: property <zoom> from [unset] to [2] at (0.3) should be [1.3] assert_equals: expected "1.3 " but got "1 "
+FAIL Web Animations: property <zoom> from [unset] to [2] at (0.6) should be [1.6] assert_equals: expected "1.6 " but got "1 "
+FAIL Web Animations: property <zoom> from [unset] to [2] at (1) should be [2] assert_equals: expected "2 " but got "1 "
+FAIL Web Animations: property <zoom> from [unset] to [2] at (1.5) should be [2.5] assert_equals: expected "2.5 " but got "1 "
+FAIL CSS Transitions: property <zoom> from [1] to [2] at (-5) should be [1] assert_equals: expected "1 " but got "2 "
+FAIL CSS Transitions: property <zoom> from [1] to [2] at (-0.3) should be [0.7] assert_equals: expected "0.7 " but got "2 "
+FAIL CSS Transitions: property <zoom> from [1] to [2] at (0) should be [1] assert_equals: expected "1 " but got "2 "
+FAIL CSS Transitions: property <zoom> from [1] to [2] at (0.3) should be [1.3] assert_equals: expected "1.3 " but got "2 "
+FAIL CSS Transitions: property <zoom> from [1] to [2] at (0.6) should be [1.6] assert_equals: expected "1.6 " but got "2 "
+PASS CSS Transitions: property <zoom> from [1] to [2] at (1) should be [2]
+FAIL CSS Transitions: property <zoom> from [1] to [2] at (1.5) should be [2.5] assert_equals: expected "2.5 " but got "2 "
+FAIL CSS Transitions with transition: all: property <zoom> from [1] to [2] at (-5) should be [1] assert_equals: expected "1 " but got "2 "
+FAIL CSS Transitions with transition: all: property <zoom> from [1] to [2] at (-0.3) should be [0.7] assert_equals: expected "0.7 " but got "2 "
+FAIL CSS Transitions with transition: all: property <zoom> from [1] to [2] at (0) should be [1] assert_equals: expected "1 " but got "2 "
+FAIL CSS Transitions with transition: all: property <zoom> from [1] to [2] at (0.3) should be [1.3] assert_equals: expected "1.3 " but got "2 "
+FAIL CSS Transitions with transition: all: property <zoom> from [1] to [2] at (0.6) should be [1.6] assert_equals: expected "1.6 " but got "2 "
+PASS CSS Transitions with transition: all: property <zoom> from [1] to [2] at (1) should be [2]
+FAIL CSS Transitions with transition: all: property <zoom> from [1] to [2] at (1.5) should be [2.5] assert_equals: expected "2.5 " but got "2 "
+PASS CSS Animations: property <zoom> from [1] to [2] at (-5) should be [1]
+FAIL CSS Animations: property <zoom> from [1] to [2] at (-0.3) should be [0.7] assert_equals: expected "0.7 " but got "1 "
+PASS CSS Animations: property <zoom> from [1] to [2] at (0) should be [1]
+FAIL CSS Animations: property <zoom> from [1] to [2] at (0.3) should be [1.3] assert_equals: expected "1.3 " but got "1 "
+FAIL CSS Animations: property <zoom> from [1] to [2] at (0.6) should be [1.6] assert_equals: expected "1.6 " but got "1 "
+FAIL CSS Animations: property <zoom> from [1] to [2] at (1) should be [2] assert_equals: expected "2 " but got "1 "
+FAIL CSS Animations: property <zoom> from [1] to [2] at (1.5) should be [2.5] assert_equals: expected "2.5 " but got "1 "
+PASS Web Animations: property <zoom> from [1] to [2] at (-5) should be [1]
+FAIL Web Animations: property <zoom> from [1] to [2] at (-0.3) should be [0.7] assert_equals: expected "0.7 " but got "1 "
+PASS Web Animations: property <zoom> from [1] to [2] at (0) should be [1]
+FAIL Web Animations: property <zoom> from [1] to [2] at (0.3) should be [1.3] assert_equals: expected "1.3 " but got "1 "
+FAIL Web Animations: property <zoom> from [1] to [2] at (0.6) should be [1.6] assert_equals: expected "1.6 " but got "1 "
+FAIL Web Animations: property <zoom> from [1] to [2] at (1) should be [2] assert_equals: expected "2 " but got "1 "
+FAIL Web Animations: property <zoom> from [1] to [2] at (1.5) should be [2.5] assert_equals: expected "2.5 " but got "1 "
+FAIL CSS Transitions: property <zoom> from [0.5] to [1.5] at (-5) should be [1] assert_equals: expected "1 " but got "1.5 "
+FAIL CSS Transitions: property <zoom> from [0.5] to [1.5] at (-0.3) should be [0.2] assert_equals: expected "0.2 " but got "1.5 "
+FAIL CSS Transitions: property <zoom> from [0.5] to [1.5] at (0) should be [0.5] assert_equals: expected "0.5 " but got "1.5 "
+FAIL CSS Transitions: property <zoom> from [0.5] to [1.5] at (0.5) should be [1] assert_equals: expected "1 " but got "1.5 "
+PASS CSS Transitions: property <zoom> from [0.5] to [1.5] at (1) should be [1.5]
+FAIL CSS Transitions: property <zoom> from [0.5] to [1.5] at (1.5) should be [2] assert_equals: expected "2 " but got "1.5 "
+FAIL CSS Transitions with transition: all: property <zoom> from [0.5] to [1.5] at (-5) should be [1] assert_equals: expected "1 " but got "1.5 "
+FAIL CSS Transitions with transition: all: property <zoom> from [0.5] to [1.5] at (-0.3) should be [0.2] assert_equals: expected "0.2 " but got "1.5 "
+FAIL CSS Transitions with transition: all: property <zoom> from [0.5] to [1.5] at (0) should be [0.5] assert_equals: expected "0.5 " but got "1.5 "
+FAIL CSS Transitions with transition: all: property <zoom> from [0.5] to [1.5] at (0.5) should be [1] assert_equals: expected "1 " but got "1.5 "
+PASS CSS Transitions with transition: all: property <zoom> from [0.5] to [1.5] at (1) should be [1.5]
+FAIL CSS Transitions with transition: all: property <zoom> from [0.5] to [1.5] at (1.5) should be [2] assert_equals: expected "2 " but got "1.5 "
+PASS CSS Animations: property <zoom> from [0.5] to [1.5] at (-5) should be [1]
+FAIL CSS Animations: property <zoom> from [0.5] to [1.5] at (-0.3) should be [0.2] assert_equals: expected "0.2 " but got "1 "
+FAIL CSS Animations: property <zoom> from [0.5] to [1.5] at (0) should be [0.5] assert_equals: expected "0.5 " but got "1 "
+PASS CSS Animations: property <zoom> from [0.5] to [1.5] at (0.5) should be [1]
+FAIL CSS Animations: property <zoom> from [0.5] to [1.5] at (1) should be [1.5] assert_equals: expected "1.5 " but got "1 "
+FAIL CSS Animations: property <zoom> from [0.5] to [1.5] at (1.5) should be [2] assert_equals: expected "2 " but got "1 "
+PASS Web Animations: property <zoom> from [0.5] to [1.5] at (-5) should be [1]
+FAIL Web Animations: property <zoom> from [0.5] to [1.5] at (-0.3) should be [0.2] assert_equals: expected "0.2 " but got "1 "
+FAIL Web Animations: property <zoom> from [0.5] to [1.5] at (0) should be [0.5] assert_equals: expected "0.5 " but got "1 "
+PASS Web Animations: property <zoom> from [0.5] to [1.5] at (0.5) should be [1]
+FAIL Web Animations: property <zoom> from [0.5] to [1.5] at (1) should be [1.5] assert_equals: expected "1.5 " but got "1 "
+FAIL Web Animations: property <zoom> from [0.5] to [1.5] at (1.5) should be [2] assert_equals: expected "2 " but got "1 "
+FAIL CSS Transitions: property <zoom> from [normal] to [3] at (-0.5) should be [1] assert_equals: expected "1 " but got "3 "
+FAIL CSS Transitions: property <zoom> from [normal] to [3] at (0) should be [1] assert_equals: expected "1 " but got "3 "
+FAIL CSS Transitions: property <zoom> from [normal] to [3] at (0.5) should be [2] assert_equals: expected "2 " but got "3 "
+PASS CSS Transitions: property <zoom> from [normal] to [3] at (1) should be [3]
+FAIL CSS Transitions with transition: all: property <zoom> from [normal] to [3] at (-0.5) should be [1] assert_equals: expected "1 " but got "3 "
+FAIL CSS Transitions with transition: all: property <zoom> from [normal] to [3] at (0) should be [1] assert_equals: expected "1 " but got "3 "
+FAIL CSS Transitions with transition: all: property <zoom> from [normal] to [3] at (0.5) should be [2] assert_equals: expected "2 " but got "3 "
+PASS CSS Transitions with transition: all: property <zoom> from [normal] to [3] at (1) should be [3]
+PASS CSS Animations: property <zoom> from [normal] to [3] at (-0.5) should be [1]
+PASS CSS Animations: property <zoom> from [normal] to [3] at (0) should be [1]
+FAIL CSS Animations: property <zoom> from [normal] to [3] at (0.5) should be [2] assert_equals: expected "2 " but got "1 "
+FAIL CSS Animations: property <zoom> from [normal] to [3] at (1) should be [3] assert_equals: expected "3 " but got "1 "
+PASS Web Animations: property <zoom> from [normal] to [3] at (-0.5) should be [1]
+PASS Web Animations: property <zoom> from [normal] to [3] at (0) should be [1]
+FAIL Web Animations: property <zoom> from [normal] to [3] at (0.5) should be [2] assert_equals: expected "2 " but got "1 "
+FAIL Web Animations: property <zoom> from [normal] to [3] at (1) should be [3] assert_equals: expected "3 " but got "1 "
+FAIL CSS Transitions: property <zoom> from [100%] to [300%] at (0) should be [1] assert_equals: expected "1 " but got "3 "
+FAIL CSS Transitions: property <zoom> from [100%] to [300%] at (0.5) should be [2] assert_equals: expected "2 " but got "3 "
+PASS CSS Transitions: property <zoom> from [100%] to [300%] at (1) should be [3]
+FAIL CSS Transitions with transition: all: property <zoom> from [100%] to [300%] at (0) should be [1] assert_equals: expected "1 " but got "3 "
+FAIL CSS Transitions with transition: all: property <zoom> from [100%] to [300%] at (0.5) should be [2] assert_equals: expected "2 " but got "3 "
+PASS CSS Transitions with transition: all: property <zoom> from [100%] to [300%] at (1) should be [3]
+PASS CSS Animations: property <zoom> from [100%] to [300%] at (0) should be [1]
+FAIL CSS Animations: property <zoom> from [100%] to [300%] at (0.5) should be [2] assert_equals: expected "2 " but got "1 "
+FAIL CSS Animations: property <zoom> from [100%] to [300%] at (1) should be [3] assert_equals: expected "3 " but got "1 "
+PASS Web Animations: property <zoom> from [100%] to [300%] at (0) should be [1]
+FAIL Web Animations: property <zoom> from [100%] to [300%] at (0.5) should be [2] assert_equals: expected "2 " but got "1 "
+FAIL Web Animations: property <zoom> from [100%] to [300%] at (1) should be [3] assert_equals: expected "3 " but got "1 "
+FAIL CSS Transitions: property <zoom> from [50%] to [2] at (0) should be [0.5] assert_equals: expected "0.5 " but got "2 "
+FAIL CSS Transitions: property <zoom> from [50%] to [2] at (0.5) should be [1.25] assert_equals: expected "1.25 " but got "2 "
+PASS CSS Transitions: property <zoom> from [50%] to [2] at (1) should be [2]
+FAIL CSS Transitions with transition: all: property <zoom> from [50%] to [2] at (0) should be [0.5] assert_equals: expected "0.5 " but got "2 "
+FAIL CSS Transitions with transition: all: property <zoom> from [50%] to [2] at (0.5) should be [1.25] assert_equals: expected "1.25 " but got "2 "
+PASS CSS Transitions with transition: all: property <zoom> from [50%] to [2] at (1) should be [2]
+FAIL CSS Animations: property <zoom> from [50%] to [2] at (0) should be [0.5] assert_equals: expected "0.5 " but got "1 "
+FAIL CSS Animations: property <zoom> from [50%] to [2] at (0.5) should be [1.25] assert_equals: expected "1.25 " but got "1 "
+FAIL CSS Animations: property <zoom> from [50%] to [2] at (1) should be [2] assert_equals: expected "2 " but got "1 "
+FAIL Web Animations: property <zoom> from [50%] to [2] at (0) should be [0.5] assert_equals: expected "0.5 " but got "1 "
+FAIL Web Animations: property <zoom> from [50%] to [2] at (0.5) should be [1.25] assert_equals: expected "1.25 " but got "1 "
+FAIL Web Animations: property <zoom> from [50%] to [2] at (1) should be [2] assert_equals: expected "2 " but got "1 "
+FAIL CSS Transitions: property <zoom> from [calc(sibling-index() * 100%)] to [2] at (0) should be [1] assert_equals: expected "1 " but got "2 "
+FAIL CSS Transitions: property <zoom> from [calc(sibling-index() * 100%)] to [2] at (0.5) should be [1.5] assert_equals: expected "1.5 " but got "2 "
+PASS CSS Transitions: property <zoom> from [calc(sibling-index() * 100%)] to [2] at (1) should be [2]
+FAIL CSS Transitions with transition: all: property <zoom> from [calc(sibling-index() * 100%)] to [2] at (0) should be [1] assert_equals: expected "1 " but got "2 "
+FAIL CSS Transitions with transition: all: property <zoom> from [calc(sibling-index() * 100%)] to [2] at (0.5) should be [1.5] assert_equals: expected "1.5 " but got "2 "
+PASS CSS Transitions with transition: all: property <zoom> from [calc(sibling-index() * 100%)] to [2] at (1) should be [2]
+PASS CSS Animations: property <zoom> from [calc(sibling-index() * 100%)] to [2] at (0) should be [1]
+FAIL CSS Animations: property <zoom> from [calc(sibling-index() * 100%)] to [2] at (0.5) should be [1.5] assert_equals: expected "1.5 " but got "1 "
+FAIL CSS Animations: property <zoom> from [calc(sibling-index() * 100%)] to [2] at (1) should be [2] assert_equals: expected "2 " but got "1 "
+PASS Web Animations: property <zoom> from [calc(sibling-index() * 100%)] to [2] at (0) should be [1]
+FAIL Web Animations: property <zoom> from [calc(sibling-index() * 100%)] to [2] at (0.5) should be [1.5] assert_equals: expected "1.5 " but got "1 "
+FAIL Web Animations: property <zoom> from [calc(sibling-index() * 100%)] to [2] at (1) should be [2] assert_equals: expected "2 " but got "1 "
+FAIL Animating zoom affects layout using the interpolated value assert_approx_equals: expected 1.5 +/- 0.01 but got 1
+FAIL transition: all animates zoom changes from :hover assert_approx_equals: expected 1.5 +/- 0.01 but got 2
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/animations/zoom-interpolation.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/animations/zoom-interpolation.html
@@ -1,0 +1,206 @@
+<!DOCTYPE html>
+<meta charset="UTF-8">
+<title>zoom interpolation</title>
+<link rel="help" href="https://drafts.csswg.org/css-viewport/#zoom-property">
+<link rel="help" href="https://github.com/w3c/csswg-drafts/issues/10872">
+<meta name="assert" content="zoom is animated by computed value (number).">
+
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/resources/testdriver.js"></script>
+<script src="/resources/testdriver-actions.js"></script>
+<script src="/resources/testdriver-vendor.js"></script>
+<script src="/css/support/interpolation-testcommon.js"></script>
+
+<style>
+.parent {
+  zoom: 3;
+}
+.target {
+  width: 10px;
+  height: 10px;
+  background: black;
+  zoom: 1;
+}
+</style>
+
+<body>
+<template id="target-template">
+  <div class="parent">
+    <div class="target"></div>
+  </div>
+</template>
+</body>
+
+<script>
+test_interpolation({
+  property: 'zoom',
+  from: neutralKeyframe,
+  to: '2',
+}, [
+  {at: -0.3, expect: '0.7'},
+  {at: 0, expect: '1'},
+  {at: 0.3, expect: '1.3'},
+  {at: 0.6, expect: '1.6'},
+  {at: 1, expect: '2'},
+  {at: 1.5, expect: '2.5'},
+]);
+
+test_interpolation({
+  property: 'zoom',
+  from: 'initial',
+  to: '2',
+}, [
+  {at: -0.3, expect: '0.7'},
+  {at: 0, expect: '1'},
+  {at: 0.3, expect: '1.3'},
+  {at: 0.6, expect: '1.6'},
+  {at: 1, expect: '2'},
+  {at: 1.5, expect: '2.5'},
+]);
+
+test_interpolation({
+  property: 'zoom',
+  from: 'inherit',
+  to: '2',
+}, [
+  {at: -0.3, expect: '3.3'},
+  {at: 0, expect: '3'},
+  {at: 0.3, expect: '2.7'},
+  {at: 0.6, expect: '2.4'},
+  {at: 1, expect: '2'},
+  {at: 1.5, expect: '1.5'},
+]);
+
+test_interpolation({
+  property: 'zoom',
+  from: 'unset',
+  to: '2',
+}, [
+  {at: -0.3, expect: '0.7'},
+  {at: 0, expect: '1'},
+  {at: 0.3, expect: '1.3'},
+  {at: 0.6, expect: '1.6'},
+  {at: 1, expect: '2'},
+  {at: 1.5, expect: '2.5'},
+]);
+
+test_interpolation({
+  property: 'zoom',
+  from: '1',
+  to: '2',
+}, [
+  // at: -5 yields a raw value of -4; zoom is clamped to >= 0, and the legacy
+  // `zoom: 0` -> 1 conversion then folds that to 1.
+  {at: -5, expect: '1'},
+  {at: -0.3, expect: '0.7'},
+  {at: 0, expect: '1'},
+  {at: 0.3, expect: '1.3'},
+  {at: 0.6, expect: '1.6'},
+  {at: 1, expect: '2'},
+  {at: 1.5, expect: '2.5'},
+]);
+
+test_interpolation({
+  property: 'zoom',
+  from: '0.5',
+  to: '1.5',
+}, [
+  {at: -5, expect: '1'},
+  {at: -0.3, expect: '0.2'},
+  {at: 0, expect: '0.5'},
+  {at: 0.5, expect: '1'},
+  {at: 1, expect: '1.5'},
+  {at: 1.5, expect: '2'},
+]);
+
+test_interpolation({
+  property: 'zoom',
+  from: 'normal',
+  to: '3',
+}, [
+  {at: -0.5, expect: '1'},
+  {at: 0, expect: '1'},
+  {at: 0.5, expect: '2'},
+  {at: 1, expect: '3'},
+]);
+
+test_interpolation({
+  property: 'zoom',
+  from: '100%',
+  to: '300%',
+}, [
+  {at: 0, expect: '1'},
+  {at: 0.5, expect: '2'},
+  {at: 1, expect: '3'},
+]);
+
+test_interpolation({
+  property: 'zoom',
+  from: '50%',
+  to: '2',
+}, [
+  {at: 0, expect: '0.5'},
+  {at: 0.5, expect: '1.25'},
+  {at: 1, expect: '2'},
+]);
+
+// Element-dependent percentage: sibling-index() == 1 inside the test
+// template, so calc(sibling-index() * 100%) resolves to 1. This exercises
+// the TreeCountingChecker path in CSSZoomInterpolationType::MaybeConvertValue.
+test_interpolation({
+  property: 'zoom',
+  from: 'calc(sibling-index() * 100%)',
+  to: '2',
+}, [
+  {at: 0, expect: '1'},
+  {at: 0.5, expect: '1.5'},
+  {at: 1, expect: '2'},
+]);
+
+test(() => {
+  const target = document.createElement('div');
+  target.style.width = '10px';
+  target.style.height = '10px';
+  document.body.appendChild(target);
+
+  const animation = target.animate(
+      [{zoom: '1'}, {zoom: '2'}],
+      {duration: 1000, fill: 'both'});
+  animation.pause();
+  animation.currentTime = 500;
+
+  assert_approx_equals(parseFloat(getComputedStyle(target).zoom), 1.5, 0.01);
+  assert_approx_equals(target.getBoundingClientRect().width, 15, 0.01);
+
+  target.remove();
+}, 'Animating zoom affects layout using the interpolated value');
+
+promise_test(async () => {
+  const target = document.createElement('div');
+  target.id = 'hover-target';
+  // 100s duration with -50s delay puts the transition at 50% progress on the
+  // first frame after :hover takes effect, so the sample is deterministic.
+  target.style.cssText = `
+    width: 100px;
+    height: 100px;
+    transition: all 100s linear -50s;
+  `;
+  document.body.appendChild(target);
+
+  const style = document.createElement('style');
+  style.textContent = '#hover-target:hover { zoom: 2; }';
+  document.head.appendChild(style);
+
+  await new test_driver.Actions()
+      .pointerMove(0, 0, {origin: target})
+      .send();
+
+  assert_true(target.matches(':hover'));
+  assert_approx_equals(parseFloat(getComputedStyle(target).zoom), 1.5, 0.01);
+  assert_approx_equals(target.getBoundingClientRect().width, 150, 1);
+
+  target.remove();
+  style.remove();
+}, 'transition: all animates zoom changes from :hover');
+</script>


### PR DESCRIPTION
#### 73a1aa3b2a1cf98a743e17e7edd5cebab323be6b
<pre>
Sync `css/css-viewport/animations` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=315036">https://bugs.webkit.org/show_bug.cgi?id=315036</a>
<a href="https://rdar.apple.com/177367914">rdar://177367914</a>

Reviewed by Brandon Stewart.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/cfd561f4f02050509cda125fad61db66e9fb0f1b">https://github.com/web-platform-tests/wpt/commit/cfd561f4f02050509cda125fad61db66e9fb0f1b</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/animations/w3c-import.log: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/animations/zoom-interpolation-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/animations/zoom-interpolation.html: Added.

Canonical link: <a href="https://commits.webkit.org/313441@main">https://commits.webkit.org/313441@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5dec2bbb3cbf074ec5788cb8aea3a8a0f2a8b78c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163129 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36610 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29827 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172068 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119576 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6ef88bfe-6663-46c8-b1b8-0b2f9656429d) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36749 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36610 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126652 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/89253 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6d5636e2-f851-49e0-b243-dbb7fcab24ac) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166088 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/28862 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146647 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107222 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ea0b1bd0-e4ff-42a6-b116-ab4afc3d2be3) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27908 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26597 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19768 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137800 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24371 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174571 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26026 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134962 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36280 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30701 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134954 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36386 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37066 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146166 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98910 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30252 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23010 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35776 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35275 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1033 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35522 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35422 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->