### PR TITLE
[JSC] Add missing ExitOK after constant folding `then`

### DIFF
--- a/JSTests/stress/dfg-perform-promise-then-one-handler-exit-ok.js
+++ b/JSTests/stress/dfg-perform-promise-then-one-handler-exit-ok.js
@@ -1,0 +1,16 @@
+function opt(a1, a2) {
+    try {
+    } catch (x) {
+    };
+    function a3(a, i) {
+    };
+    with ((Promise.resolve(-0).then(a3))) {
+        byteLength = (({flags: a5, source: a6}) => (({valueOf: a7, throw: a8}) => (new Proxy(Infinity, ((async () => await 9.431092e-317))))))
+    };
+}
+for (let i = 0; i < testLoopCount; i++) {
+    try {
+        opt((Float32Array.prototype.BYTES_PER_ELEMENT), 2.3023e-320);
+    } catch (e) {
+    }
+}

--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -2110,6 +2110,7 @@ private:
                         Edge(inputPromise.node(), KnownCellUse),
                         Edge(handlerEdge.node(), KnownCellUse),
                         Edge(resultPromise.node(), KnownCellUse));
+                    m_insertionSet.insertNode(indexInBlock, SpecNone, ExitOK, node->origin);
                     node->remove(m_graph);
                     changed = true;
                 }


### PR DESCRIPTION
#### 953bc0380f0bb7acb33190e419a709b9d0ffc5a4
<pre>
[JSC] Add missing ExitOK after constant folding `then`
<a href="https://bugs.webkit.org/show_bug.cgi?id=315042">https://bugs.webkit.org/show_bug.cgi?id=315042</a>
<a href="https://rdar.apple.com/177329825">rdar://177329825</a>

Reviewed by Yijia Huang.

313277@main adds constant folding for initial `then` but missed an ExitOK,
which this PR adds. No fix up is needed for the folding of PerformPromiseThen
to PerformPromiseThenOneHandler, but an ExitOK node was missing which tripped
validation.

Test: JSTests/stress/dfg-perform-promise-then-one-handler-exit-ok.js

* JSTests/stress/dfg-perform-promise-then-one-handler-exit-ok.js: Added.
(a3):
(opt):
(async for):
* Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp:
(JSC::DFG::ConstantFoldingPhase::foldConstants):

Canonical link: <a href="https://commits.webkit.org/313451@main">https://commits.webkit.org/313451@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0468d08c1da5dca8f325d6f8c4554d950f04a532

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163152 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36633 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29850 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172091 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119599 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e06813d6-0b8f-43bc-881c-0e047288de2a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36961 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36634 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126674 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/89275 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6436f8fd-2ebd-489f-9062-ea29fee4500a) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166111 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/28949 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146672 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107243 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/86f9e32a-1797-4a5e-89fe-f2114a9266c1) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26622 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19791 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/155297 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137888 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24396 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174594 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/24039 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/26751 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26051 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134982 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36303 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30725 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134974 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36392 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37089 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146191 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98949 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30278 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23035 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195553 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35799 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108160 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50967 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35298 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1058 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35545 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35445 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->