### PR TITLE
[CMake] Subtarget cmake_pch.hxx must include the base prefix header for compiler-launcher builds

### DIFF
--- a/Source/cmake/WebKitMacros.cmake
+++ b/Source/cmake/WebKitMacros.cmake
@@ -208,8 +208,38 @@ endmacro()
 function(WEBKIT_ADD_PREFIX_HEADER_WITH_PARENT _target _base_target _header _parent_header)
     if (COMPILER_IS_CLANG)
         string(JOIN "," _lang_genex ${ARGN})
+        # Emit the base target's prefix header into cmake_pch.hxx ahead of the
+        # subtarget's. The chained -include-pch below already provides its
+        # contents via the AST when the PCH is loaded, but a compiler launcher
+        # (sccache/ccache/icecream) that preprocesses without honoring -Xclang
+        # -include-pch falls back to -include cmake_pch.hxx alone. Without the
+        # base prefix in that file, the leaf prefix's heavy includes see
+        # neither cmakeconfig.h nor the libc headers the base prefix provides.
         target_precompile_headers(${_target} PRIVATE
+            "$<$<COMPILE_LANGUAGE:${_lang_genex}>:${CMAKE_CURRENT_SOURCE_DIR}/${_parent_header}>"
             "$<$<COMPILE_LANGUAGE:${_lang_genex}>:${CMAKE_CURRENT_SOURCE_DIR}/${_header}>")
+        # CMake rewrites cmake_pch.hxx at generate time when this header list
+        # changes, but ninja's depfile-recorded .pch dependency on the .hxx is
+        # not re-evaluated on the regenerate-restart pass, so an incremental
+        # build over a tree with the old .pch compiles TUs against it and
+        # clang fails with "modified since the precompiled header was built".
+        # Track the header list ourselves and remove the stale .pch when it
+        # changes so ninja must rebuild it.
+        set(_pch_dir "${CMAKE_CURRENT_BINARY_DIR}/CMakeFiles/${_target}.dir")
+        set(_pch_sig "${_parent_header};${_header}")
+        if (EXISTS "${_pch_dir}/.pch-header-list")
+            file(READ "${_pch_dir}/.pch-header-list" _old_pch_sig)
+        else ()
+            set(_old_pch_sig "")
+        endif ()
+        if (NOT _old_pch_sig STREQUAL _pch_sig)
+            file(GLOB _stale_pch "${_pch_dir}/cmake_pch.*.pch" "${_pch_dir}/cmake_pch.*.gch")
+            if (_stale_pch)
+                file(REMOVE ${_stale_pch})
+            endif ()
+            file(MAKE_DIRECTORY "${_pch_dir}")
+            file(WRITE "${_pch_dir}/.pch-header-list" "${_pch_sig}")
+        endif ()
         if (APPLE)
             # FIXME: Upstream clang does not appear to propagate parent-PCH state to consumers
             # of the child PCH (webkit.org/b/314763). Until that is root-caused, build the child
@@ -273,7 +303,7 @@ macro(WEBKIT_DEFINE_SUBTARGET_WITH_PREFIX _target _subtarget)
             else ()
                 target_link_libraries(${_target} INTERFACE "${_subobjects}")
             endif ()
-            WEBKIT_ADD_PREFIX_HEADER_WITH_PARENT(${_subtarget} ${_target} ${_arg_PREFIX} "" ${_arg_PREFIX_LANGUAGES})
+            WEBKIT_ADD_PREFIX_HEADER_WITH_PARENT(${_subtarget} ${_target} ${_arg_PREFIX} ${_target}Prefix.h ${_arg_PREFIX_LANGUAGES})
         endif ()
     endif ()
     unset(_arg_PREFIX)


### PR DESCRIPTION
Reviewed by NOBODY (OOPS!).

WEBKIT_ADD_PREFIX_HEADER_WITH_PARENT chains the subtarget PCH on top of
the parent's via -Xclang -include-pch <base>.pch on the leaf PCH stub, so
the leaf prefix headers (JavaScriptCoreJITPrefix.h, WebCore*Prefix.h,
WebKit*Prefix.h) inherit the base prefix's cmakeconfig.h and libc includes
through the AST. Consumers receive -include-pch <leaf>.pch plus a textual
-include <leaf>/cmake_pch.hxx; cmake_pch.hxx contains only the leaf prefix.

Compiler launchers that preprocess locally before dispatching (sccache,
ccache in depend_mode, icecream) do not honor -Xclang -include-pch, so the
fallback path sees only the leaf prefix. The leaf prefix headers either
fail outright (DFGGraph.h reaches CPU.h with size_t undeclared) or include
<wtf/Platform.h> before cmakeconfig.h, after which the TU's own
#include "config.h" pulls in cmakeconfig.h with PlatformEnableCocoa.h's
defaults already defined and -Werror,-Wmacro-redefined fires.

Emit the base target's prefix header into the subtarget's cmake_pch.hxx
ahead of the leaf header so the textual fallback is self-contained. The
chained -include-pch is kept; re-including the (unguarded) base prefix
after loading its PCH is benign because cmake_pch.hxx is under
#pragma clang system_header and every nested include is guarded.

Follow-on to 313056@main, which added cmakeconfig.h/Platform.h to two of
the eight subtarget prefix headers; this covers all of them at the macro
level instead.

* Source/cmake/WebKitMacros.cmake:
(WEBKIT_ADD_PREFIX_HEADER_WITH_PARENT):
(WEBKIT_DEFINE_SUBTARGET_WITH_PREFIX):<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/83f4a9da99b9ab747b0dc931df3831d164027f46

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163184 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36665 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29882 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172123 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119631 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36993 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36666 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126703 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89304 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166143 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28978 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146703 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107272 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28024 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26652 "Found 12 new API test failures: TestWebKitAPI.WKWebExtensionContext.LoadNonExistentImage, TestWebKitAPI.EnhancedSecurityPolicies.OpenerThenSelfNavigationWithSiteIsolation, TestWebKitAPI.WKWebExtensionContext.TopLevelThrowInModuleBackground, TestWebKitAPI.WKWebExtensionAPIDevTools.MessagePassingFromPanelToBackground, TestWebKitAPI.WKWebExtensionAPIDevTools.MessagePassingToBackground, TestWebKitAPI.WKWebExtensionContext.UnhandledPromiseRejectionInBackground, TestWebKitAPI.WKWebExtensionContext.UncaughtScriptErrorInContentScript, TestWebKitAPI.WKWebExtensionContext.UncaughtScriptErrorInBackground, TestWebKitAPI.WKWebExtensionContext.UncaughtScriptErrorInMainWorldContentScript, TestWebKitAPI.WKWebExtensionContext.UncaughtScriptErrorInServiceWorkerBackground ... (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19823 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/155329 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137917 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174626 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/24071 "Built successfully and passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/26783 "Build is in progress. Recent messages:") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26082 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135011 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36335 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30754 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135003 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37121 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146222 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98999 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30306 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23066 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195585 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35831 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50976 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35330 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1090 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35577 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35477 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->