### PR TITLE
[CMake][Mac] mac-tsan: set USE_SYSTEM_MALLOC=ON and guard TSan bindir against uninstrumented reconfigure

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -226,6 +226,10 @@
                     "type": "STRING",
                     "value": "thread"
                 },
+                "USE_SYSTEM_MALLOC": {
+                    "type": "BOOL",
+                    "value": "ON"
+                },
                 "ENABLE_EXPERIMENTAL_FEATURES": {
                     "type": "BOOL",
                     "value": "OFF"

--- a/Source/cmake/OptionsMac.cmake
+++ b/Source/cmake/OptionsMac.cmake
@@ -187,6 +187,11 @@ if (_bindir_name STREQUAL "ASan" AND NOT ENABLE_SANITIZERS MATCHES "address")
         "Build directory '${CMAKE_BINARY_DIR}' is an ASan tree but ENABLE_SANITIZERS='${ENABLE_SANITIZERS}'. "
         "CMakeCache.txt was likely deleted or never configured via the preset. Re-run: cmake --preset mac-asan")
 endif ()
+if (_bindir_name STREQUAL "TSan" AND NOT ENABLE_SANITIZERS MATCHES "thread")
+    message(FATAL_ERROR
+        "Build directory '${CMAKE_BINARY_DIR}' is a TSan tree but ENABLE_SANITIZERS='${ENABLE_SANITIZERS}'. "
+        "CMakeCache.txt was likely deleted or never configured via the preset. Re-run: cmake --preset mac-tsan")
+endif ()
 unset(_bindir_name)
 
 set(bmalloc_LIBRARY_TYPE OBJECT)


### PR DESCRIPTION
#### 6acf180f923eab9c0aef3d85430ad3e1a52afc62
<pre>
[CMake][Mac] mac-tsan: set USE_SYSTEM_MALLOC=ON and guard TSan bindir against uninstrumented reconfigure
<a href="https://bugs.webkit.org/show_bug.cgi?id=315050">https://bugs.webkit.org/show_bug.cgi?id=315050</a>
<a href="https://rdar.apple.com/177376705">rdar://177376705</a>

Reviewed by Geoffrey Garen.

Two fixes for the mac-tsan preset:

1. Set USE_SYSTEM_MALLOC=ON. e05f64d91da made bmalloc force
   BUSE_SYSTEM_MALLOC=1 under __has_feature(thread_sanitizer)
   (BPlatform.h:388), so BUSE_TZONE=0. But WTF&apos;s PlatformUse.h:246 has
   no matching TSan branch, so USE_TZONE_MALLOC stays 1, and
   TZoneMalloc.h:81 #errors &quot;TZones enabled in WTF, but not enabled in
   bmalloc&quot;. Setting USE_SYSTEM_MALLOC at the preset level keeps WTF
   and bmalloc in agreement.

2. Extend the OptionsMac.cmake bindir-name guard to TSan. When a
   ninja-triggered RERUN_CMAKE wipes CMakeCache.txt (&quot;You have changed
   variables that require your cache to be deleted&quot;), the reconfigure
   runs without --preset and silently produces an uninstrumented
   build. The ASan tree already FATAL_ERRORs on this; do the same for
   TSan.

* CMakePresets.json:
* Source/cmake/OptionsMac.cmake:

Canonical link: <a href="https://commits.webkit.org/313486@main">https://commits.webkit.org/313486@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/12752102b23ee2db8130057ddf2dbc101732cc66

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163151 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36632 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29849 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172090 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119598 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0e79603d-c0f9-4a00-b7cd-546f9c4b533f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36960 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36633 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126672 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89274 "Passed tests") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/79862033-ae35-491e-af87-5122db2d02fe) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166110 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28947 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146671 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107242 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/209fcaf1-17f2-4277-8efa-53755a2c3dd2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/27993 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26621 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19790 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/155296 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137886 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174593 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/24038 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26050 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/134981 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36302 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30724 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134973 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36409 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37088 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146190 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98945 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30277 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23034 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195552 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35798 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50966 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35297 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1087 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35544 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35444 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->