### PR TITLE
Scroll view background color doesn't adapt with rest of background on PDFs

### DIFF
--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h
@@ -479,6 +479,7 @@ protected:
     std::optional<WebCore::PageIdentifier> NODELETE pageIdentifier() const;
 
     WebCore::Color pluginBackgroundColor() const;
+    void updateFullFramePluginBackgroundColor();
 
     SingleThreadWeakPtr<PluginView> m_view;
     WeakPtr<WebFrame> m_frame;

--- a/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm
@@ -140,10 +140,7 @@ PDFPluginBase::PDFPluginBase(HTMLPlugInElement& element)
     , m_incrementalPDFLoadingEnabled(element.document().settings().incrementalPDFLoadingEnabled())
 #endif
 {
-    if (isFullFramePlugin()) {
-        Ref document = element.document();
-        RefPtr { document->bodyOrFrameset() }->setInlineStyleProperty(CSSPropertyBackgroundColor, serializationForHTML(pluginBackgroundColor()));
-    }
+    updateFullFramePluginBackgroundColor();
 }
 
 PDFPluginBase::~PDFPluginBase()
@@ -1646,6 +1643,20 @@ Color PDFPluginBase::pluginBackgroundColor() const
     static NeverDestroyed color = roundAndClampToSRGBALossy(RetainPtr { [CocoaColor grayColor].CGColor }.get());
     return color.get();
 #endif
+}
+
+void PDFPluginBase::updateFullFramePluginBackgroundColor()
+{
+    if (!isFullFramePlugin())
+        return;
+
+    RefPtr element = m_element.get();
+    if (!element)
+        return;
+
+    Ref document = element->document();
+    if (RefPtr body = document->bodyOrFrameset())
+        body->setInlineStyleProperty(CSSPropertyBackgroundColor, serializationForHTML(pluginBackgroundColor()));
 }
 
 unsigned PDFPluginBase::countFindMatches(const String& target, WebCore::FindOptions options, unsigned maxMatchCount)

--- a/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
+++ b/Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm
@@ -4946,6 +4946,7 @@ void UnifiedPDFPlugin::effectiveAppearanceDidChange()
     if (RefPtr rootLayer = m_rootLayer)
         rootLayer->setBackgroundColor(pluginBackgroundColor());
 
+    updateFullFramePluginBackgroundColor();
     updateScrollbarOverlayStyle();
 }
 

--- a/Tools/TestWebKitAPI/Helpers/PlatformUtilities.h
+++ b/Tools/TestWebKitAPI/Helpers/PlatformUtilities.h
@@ -109,6 +109,15 @@ static inline ::testing::AssertionResult assertWKStringEqual(const char* expecte
 #define EXPECT_WK_STREQ(expected, actual) \
     EXPECT_PRED_FORMAT2(TestWebKitAPI::Util::assertWKStringEqual, expected, actual)
 
+template<typename T, typename U>
+static inline ::testing::AssertionResult assertWKStringNotEqual(const char* expected_expression, const char* actual_expression, T expected, U actual)
+{
+    return ::testing::internal::CmpHelperSTRNE(expected_expression, actual_expression, Util::toSTD(expected).c_str(), Util::toSTD(actual).c_str());
+}
+
+#define EXPECT_WK_STRNE(expected, actual) \
+    EXPECT_PRED_FORMAT2(TestWebKitAPI::Util::assertWKStringNotEqual, expected, actual)
+
 #endif // !PLATFORM(COCOA) || !__has_feature(modules)
 
 #if PLATFORM(MAC)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm
@@ -1568,6 +1568,30 @@ UNIFIED_PDF_TEST(EmbeddedPDFScrollbarDoesNotAdaptToDarkMode)
     EXPECT_FALSE([pluginNode containsString:@"uses dark appearance for scrollbars"]);
 }
 
+UNIFIED_PDF_TEST(BackgroundColorAdaptsToAppearance)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 600, 600) configuration:configurationForWebViewTestingUnifiedPDF().get() addToWindow:YES]);
+    [webView synchronouslyLoadRequest:[NSURLRequest requestWithURL:[NSBundle.test_resourcesBundle URLForResource:@"test" withExtension:@"pdf"]]];
+
+    [webView forceLightMode];
+    [webView waitForNextPresentationUpdate];
+
+    RetainPtr lightColor = [webView stringByEvaluatingJavaScript:@"document.body.style.backgroundColor"];
+
+    [webView forceDarkMode];
+    [webView waitForNextPresentationUpdate];
+
+    RetainPtr darkColor = [webView stringByEvaluatingJavaScript:@"document.body.style.backgroundColor"];
+
+    EXPECT_GT([lightColor length], 0u);
+    EXPECT_GT([darkColor length], 0u);
+#if HAVE(LIQUID_GLASS)
+    EXPECT_WK_STRNE(lightColor.get(), darkColor.get());
+#else
+    EXPECT_WK_STREQ(lightColor.get(), darkColor.get());
+#endif
+}
+
 } // namespace TestWebKitAPI
 
 #endif // ENABLE(UNIFIED_PDF)


### PR DESCRIPTION
#### 73bbfe7d99dcbb569522d02857be1051ae5014f5
<pre>
Scroll view background color doesn&apos;t adapt with rest of background on PDFs
<a href="https://bugs.webkit.org/show_bug.cgi?id=315051">https://bugs.webkit.org/show_bug.cgi?id=315051</a>
<a href="https://rdar.apple.com/171223676">rdar://171223676</a>

Reviewed by Lily Spiniolas, Tim Horton, and Abrar Rahman Protyasha.

Currently, when switching from light mode to dark mode,
the tab bar remains light and there is a white gap at
the top when scrolling. This is particularly noticable with
a dark colored PDF.

This is because when the effectiveAppearanceDidChange, we do not
update the body background. The body background color is initially set
upon creation via the PDFPluginBase constructor and that&apos;s it.

So, extract that logic from the constructor and put it in a function
that can be called from effectiveAppearanceDidChange and the constructor.
Now, when the appearance mode is changed, the background reflects this
change.

Add an API test that checks for this body background color change. Add
a helper in PlatformUtilities.h that does the inverse of EXPECT_WK_STREQ.

* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.h:
* Source/WebKit/WebProcess/Plugins/PDF/PDFPluginBase.mm:
(WebKit::PDFPluginBase::PDFPluginBase):
(WebKit::PDFPluginBase::updateFullFramePluginBackgroundColor):
* Source/WebKit/WebProcess/Plugins/PDF/UnifiedPDF/UnifiedPDFPlugin.mm:
(WebKit::UnifiedPDFPlugin::effectiveAppearanceDidChange):
* Tools/TestWebKitAPI/Helpers/PlatformUtilities.h:
(TestWebKitAPI::Util::assertWKStringNotEqual):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/UnifiedPDFTests.mm:
(TestWebKitAPI::UNIFIED_PDF_TEST):

Canonical link: <a href="https://commits.webkit.org/313495@main">https://commits.webkit.org/313495@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/deba039433194208d6b33fe0bcb91aff955b3349

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163187 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36668 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29885 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172126 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119634 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aad28c28-1606-480d-9e24-41047218e3d5) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165056 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36996 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36669 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126706 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89307 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c5abe5f6-ea44-4f30-972c-831b5d9bf1ef) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166146 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28982 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146704 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107275 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/701b84da-3588-467d-a86e-cba81e843a77) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28028 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26656 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19826 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137921 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24428 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174629 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/26786 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26083 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135013 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36338 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30758 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135005 "Found 1 new API test failure: WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/itp (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37124 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146223 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99002 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24846 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30310 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23067 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35834 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108195 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35333 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1091 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35580 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35480 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->