### PR TITLE
Add context menu signal to WPEQtView

### DIFF
--- a/Source/WebKit/PlatformWPE.cmake
+++ b/Source/WebKit/PlatformWPE.cmake
@@ -594,6 +594,7 @@ if (ENABLE_WPE_QT_API)
     list(APPEND WPE_QT_API_INSTALLED_HEADERS
         ${WEBKIT_DIR}/UIProcess/API/wpe/qt6/WPEQtView.h
         ${WEBKIT_DIR}/UIProcess/API/wpe/qt6/WPEQtViewLoadRequest.h
+        ${WEBKIT_DIR}/UIProcess/API/wpe/qt6/WPEQtViewContextMenuRequest.h
     )
 
     # FIXME: This should be MODULE, but tests link directly against it. Abusing
@@ -606,6 +607,7 @@ if (ENABLE_WPE_QT_API)
         UIProcess/API/wpe/qt6/WPEQmlExtensionPlugin.cpp
         UIProcess/API/wpe/qt6/WPEQtView.cpp
         UIProcess/API/wpe/qt6/WPEQtViewLoadRequest.cpp
+        UIProcess/API/wpe/qt6/WPEQtViewContextMenuRequest.cpp
     )
     set_target_properties(qtwpe PROPERTIES
         OUTPUT_NAME qtwpe

--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.cpp
@@ -21,6 +21,7 @@
 #include "config.h"
 #include "WPEQtView.h"
 
+#include "WPEQtViewContextMenuRequest.h"
 #include "WPEQtViewLoadRequest.h"
 #include "WPEQtViewLoadRequestPrivate.h"
 #include "WPEQtViewPrivate.h"
@@ -139,6 +140,7 @@ void WPEQtView::createWebView()
     g_signal_connect_swapped(d->m_webView.get(), "notify::estimated-load-progress", G_CALLBACK(notifyLoadProgressCallback), this);
     g_signal_connect(d->m_webView.get(), "load-changed", G_CALLBACK(notifyLoadChangedCallback), this);
     g_signal_connect(d->m_webView.get(), "load-failed", G_CALLBACK(notifyLoadFailedCallback), this);
+    g_signal_connect(d->m_webView.get(), "context-menu", G_CALLBACK(notifyContextMenuCallback), this);
 
     if (!d->m_url.isEmpty())
         webkit_web_view_load_uri(d->m_webView.get(), d->m_url.toString().toUtf8().constData());
@@ -203,6 +205,18 @@ void WPEQtView::notifyLoadFailedCallback(WebKitWebView*, WebKitLoadEvent, const 
 
     auto loadRequest = std::make_unique<WPEQtViewLoadRequest>(QUrl(QString(failingURI)), loadStatus, error->message);
     Q_EMIT view->loadingChanged(loadRequest.get());
+}
+
+gboolean WPEQtView::notifyContextMenuCallback(WebKitWebView*, WebKitContextMenu*, WebKitHitTestResult* result, WPEQtView* view)
+{
+    // The context menu is currently unused. We cannot pass it directly
+    // to the qt signal, which is handled asynchronously, because
+    // WebKit will destroy the context menu when this function returns.
+    // Future implementations may extract the data from the menu in
+    // this function and pass the data to the qt signal.
+    auto contextMenuRequest = WPEQtViewContextMenuRequest(result);
+    view->contextMenuRequested(contextMenuRequest);
+    return TRUE;
 }
 
 void WPEQtView::didUpdateScene()

--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.h
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.h
@@ -32,6 +32,7 @@
 #endif
 
 class WPEQtViewLoadRequest;
+class WPEQtViewContextMenuRequest;
 class WPEQtViewPrivate;
 
 class QT_WPE_EXPORT WPEQtView : public QQuickItem {
@@ -83,6 +84,7 @@ Q_SIGNALS:
     void titleChanged();
     void loadingChanged(WPEQtViewLoadRequest* loadRequest);
     void loadProgressChanged();
+    void contextMenuRequested(WPEQtViewContextMenuRequest);
 
 protected:
     bool errorOccured() const;
@@ -123,6 +125,7 @@ private:
     static void notifyLoadProgressCallback(WPEQtView*);
     static void notifyLoadChangedCallback(WebKitWebView*, WebKitLoadEvent, WPEQtView*);
     static void notifyLoadFailedCallback(WebKitWebView*, WebKitLoadEvent, const gchar* failingURI, GError*, WPEQtView*);
+    static gboolean notifyContextMenuCallback(WebKitWebView*, WebKitContextMenu*, WebKitHitTestResult*, WPEQtView*);
 
     Q_DECLARE_PRIVATE(WPEQtView)
     QScopedPointer<WPEQtViewPrivate> d_ptr;

--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtViewContextMenuRequest.cpp
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtViewContextMenuRequest.cpp
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2026 tusooa <tusooa@kazv.moe>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#include "config.h"
+#include "WPEQtViewContextMenuRequest.h"
+
+WPEQtViewContextMenuRequest::WPEQtViewContextMenuRequest(WebKitHitTestResult* result)
+    : m_context(webkit_hit_test_result_get_context(result))
+    , m_imageUri(webkit_hit_test_result_get_image_uri(result))
+    , m_linkLabel(webkit_hit_test_result_get_link_label(result))
+    , m_linkTitle(webkit_hit_test_result_get_link_title(result))
+    , m_linkUri(webkit_hit_test_result_get_link_uri(result))
+    , m_mediaUri(webkit_hit_test_result_get_media_uri(result))
+{
+}
+
+WPEQtViewContextMenuRequest::~WPEQtViewContextMenuRequest() = default;
+
+bool WPEQtViewContextMenuRequest::contextIsEditable() const
+{
+    return m_context & WEBKIT_HIT_TEST_RESULT_CONTEXT_EDITABLE;
+}
+
+bool WPEQtViewContextMenuRequest::contextIsImage() const
+{
+    return m_context & WEBKIT_HIT_TEST_RESULT_CONTEXT_IMAGE;
+}
+
+bool WPEQtViewContextMenuRequest::contextIsLink() const
+{
+    return m_context & WEBKIT_HIT_TEST_RESULT_CONTEXT_LINK;
+}
+
+bool WPEQtViewContextMenuRequest::contextIsMedia() const
+{
+    return m_context & WEBKIT_HIT_TEST_RESULT_CONTEXT_MEDIA;
+}
+
+bool WPEQtViewContextMenuRequest::contextIsScrollbar() const
+{
+    return m_context & WEBKIT_HIT_TEST_RESULT_CONTEXT_SCROLLBAR;
+}
+
+bool WPEQtViewContextMenuRequest::contextIsSelection() const
+{
+    return m_context & WEBKIT_HIT_TEST_RESULT_CONTEXT_SELECTION;
+}
+
+QString WPEQtViewContextMenuRequest::imageUri() const
+{
+    return m_imageUri;
+}
+
+QString WPEQtViewContextMenuRequest::linkLabel() const
+{
+    return m_linkLabel;
+}
+
+QString WPEQtViewContextMenuRequest::linkTitle() const
+{
+    return m_linkTitle;
+}
+
+QString WPEQtViewContextMenuRequest::linkUri() const
+{
+    return m_linkUri;
+}
+
+QString WPEQtViewContextMenuRequest::mediaUri() const
+{
+    return m_mediaUri;
+}

--- a/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtViewContextMenuRequest.h
+++ b/Source/WebKit/UIProcess/API/wpe/qt6/WPEQtViewContextMenuRequest.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2026 tusooa <tusooa@kazv.moe>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#pragma once
+
+#include "WPEQtView.h"
+
+class QT_WPE_EXPORT WPEQtViewContextMenuRequest {
+    Q_GADGET
+    Q_PROPERTY(bool contextIsEditable READ contextIsEditable)
+    Q_PROPERTY(bool contextIsImage READ contextIsImage)
+    Q_PROPERTY(bool contextIsLink READ contextIsLink)
+    Q_PROPERTY(bool contextIsMedia READ contextIsMedia)
+    Q_PROPERTY(bool contextIsScrollbar READ contextIsScrollbar)
+    Q_PROPERTY(bool contextIsSelection READ contextIsSelection)
+    Q_PROPERTY(QString imageUri READ imageUri)
+    Q_PROPERTY(QString linkLabel READ linkLabel)
+    Q_PROPERTY(QString linkTitle READ linkTitle)
+    Q_PROPERTY(QString linkUri READ linkUri)
+    Q_PROPERTY(QString mediaUri READ mediaUri)
+
+public:
+    WPEQtViewContextMenuRequest(WebKitHitTestResult*);
+    virtual ~WPEQtViewContextMenuRequest();
+    QVariantList menuItems() const;
+    bool contextIsEditable() const;
+    bool contextIsImage() const;
+    bool contextIsLink() const;
+    bool contextIsMedia() const;
+    bool contextIsScrollbar() const;
+    bool contextIsSelection() const;
+    QString imageUri() const;
+    QString linkLabel() const;
+    QString linkTitle() const;
+    QString linkUri() const;
+    QString mediaUri() const;
+
+private:
+    QVariantList m_menuItems;
+    guint m_context;
+    QString m_imageUri;
+    QString m_linkLabel;
+    QString m_linkTitle;
+    QString m_linkUri;
+    QString m_mediaUri;
+};


### PR DESCRIPTION
#### d33f0654a18fa6f497bd89c4cae88554db3e524c
<pre>
Add context menu signal to WPEQtView

<a href="https://bugs.webkit.org/show_bug.cgi?id=312422">https://bugs.webkit.org/show_bug.cgi?id=312422</a>

Reviewed by NOBODY (OOPS!).

This exposes a signal contextMenuRequested to QML which contains the
informaiton about the hit test result. Because the WebKitContextMenu
is only useful during signal emission, it is not exposed. Future
changes may expose the actions associated with the items and trigger
them when needed.

* Source/WebKit/PlatformWPE.cmake:
* Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.cpp:
(WPEQtView::createWebView): Connect to context-menu signal of WebKitWebView.
(WPEQtView::notifyContextMenuCallback): Emit the contextMenuRequested signal in WPEQtView.
* Source/WebKit/UIProcess/API/wpe/qt6/WPEQtView.h:
* Source/WebKit/UIProcess/API/wpe/qt6/WPEQtViewContextMenuRequest.cpp: Added.
(WPEQtViewContextMenuRequest::WPEQtViewContextMenuRequest):
(WPEQtViewContextMenuRequest::contextIsEditable const):
(WPEQtViewContextMenuRequest::contextIsImage const):
(WPEQtViewContextMenuRequest::contextIsLink const):
(WPEQtViewContextMenuRequest::contextIsMedia const):
(WPEQtViewContextMenuRequest::contextIsScrollbar const):
(WPEQtViewContextMenuRequest::contextIsSelection const):
(WPEQtViewContextMenuRequest::imageUri const):
(WPEQtViewContextMenuRequest::linkLabel const):
(WPEQtViewContextMenuRequest::linkTitle const):
(WPEQtViewContextMenuRequest::linkUri const):
(WPEQtViewContextMenuRequest::mediaUri const):
* Source/WebKit/UIProcess/API/wpe/qt6/WPEQtViewContextMenuRequest.h: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d33f0654a18fa6f497bd89c4cae88554db3e524c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170011 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43934 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37347 "Failed to compile WebKit") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179372 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127723 "Built successfully") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45000 "Failed to compile WebKit") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43566 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132516 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/93375 "11 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172970 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/35607 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152949 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113018 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34187 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32657 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28069 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/144681 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32347 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181970 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34781 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36824 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140965 "Build is in progress. Recent messages:Running configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 25 flakes 3 failures; Uploaded test results; layout-tests; Passed layout tests") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43589 "Failed to compile WebKit") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140799 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44278 "Failed to compile WebKit") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29330 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/108624 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36066 "Passed tests") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116180 "Found 108 new failures in platform/graphics/IntRect.cpp, Modules/speech/SpeechRecognitionResult.cpp, platform/audio/cocoa/CARingBuffer.cpp, runtime/IndexingType.cpp, rendering/RenderFlexibleBox.h, Modules/webaudio/ChannelMergerNode.cpp, BindGroup.mm, dom/EventPath.cpp, Modules/speech/SpeechRecognitionResultList.cpp, dom/ImageOverlay.cpp ...") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42789 "Failed to compile WebKit") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7429 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42181 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42436 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42324 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->