### PR TITLE
fix run-api-tests for iOS after webkitexpectationspy

### DIFF
--- a/Tools/Scripts/webkitpy/port/ios.py
+++ b/Tools/Scripts/webkitpy/port/ios.py
@@ -118,18 +118,19 @@ class IOSPort(EmbeddedPort):
 
     def _api_test_platform_cascade(self):
         cascade = []
-        internal_version = self._api_test_version_name(self._os_version, table=INTERNAL_TABLE) if apple_additions() else None
+        version = self.device_version()
+        internal_version = self._api_test_version_name(version, table=INTERNAL_TABLE) if apple_additions() else None
         internal_name = 'ios-{}'.format(internal_version) if internal_version else None
         cascade.append(('ios', internal_name))
 
-        if self._os_version:
-            cascade.append(('ios-{}'.format(self._os_version.major), internal_name))
+        if version:
+            cascade.append(('ios-{}'.format(version.major), internal_name))
 
         if 'simulator' in self.SDK:
             internal_sim_name = 'ios-{}-simulator'.format(internal_version) if internal_version else None
             cascade.append(('ios-simulator', internal_sim_name))
-            if self._os_version:
-                cascade.append(('ios-simulator-{}'.format(self._os_version.major), internal_sim_name))
+            if version:
+                cascade.append(('ios-simulator-{}'.format(version.major), internal_sim_name))
 
         return cascade
 
@@ -140,8 +141,9 @@ class IOSPort(EmbeddedPort):
         config = super(IOSPort, self).api_test_current_configuration()
         config['platform'] = 'ios'
 
-        if self._os_version:
-            config['version'] = 'ios{}'.format(self._os_version.major)
+        version = self.device_version()
+        if version:
+            config['version'] = 'ios{}'.format(version.major)
 
         config['hardware'] = 'simulator' if 'simulator' in self.SDK else 'device'
 


### PR DESCRIPTION
#### ec7c608e63b2363bb8ce39a966bee0e883eb528d
<pre>
fix run-api-tests for iOS after webkitexpectationspy
<a href="https://bugs.webkit.org/show_bug.cgi?id=315054">https://bugs.webkit.org/show_bug.cgi?id=315054</a>
<a href="https://rdar.apple.com/177379149">rdar://177379149</a>

Reviewed by Abrar Rahman Protyasha.

* Tools/Scripts/webkitpy/port/ios.py:
(IOSPort._api_test_platform_cascade):
(IOSPort.api_test_current_configuration):

Canonical link: <a href="https://commits.webkit.org/313445@main">https://commits.webkit.org/313445@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ff7b4bb5d155aaefc076398ba5db4d5b0ab534e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163156 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36637 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29854 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172095 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119603 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1ad2ffcd-2e99-4b92-b223-ea1555ab2b1d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165025 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36965 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36638 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/126678 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/89279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8b885e14-0153-4543-be16-f023a7d1a5c8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166115 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/28953 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146675 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107247 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/79c7188d-a80f-46bf-a2ca-bce7c8fc216d) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/162477 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/27999 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19795 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137892 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24399 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174598 "Built successfully") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/26054 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/134986 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36307 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30729 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134978 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36388 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37093 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146194 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98956 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30281 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/23038 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35803 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35302 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1061 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35549 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35449 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->