### PR TITLE
Cherry-pick(s) ff676342841b. rdar://173969087

### DIFF
--- a/Source/WebCore/platform/graphics/Color.h
+++ b/Source/WebCore/platform/graphics/Color.h
@@ -439,7 +439,11 @@ inline Color::~Color()
 {
     if (isOutOfLine())
         asOutOfLine().deref();
+<<<<<<< HEAD
     secureZeroBytes(m_colorAndFlags);
+=======
+    secureMemsetSpan(singleElementSpan(m_colorAndFlags), 0);
+>>>>>>> ff676342841b ([MTE] Harden `WebCore::Color` and `WebCore::Color::OutOfLineComponents` objects)
 }
 
 inline bool Color::isValid() const


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://173969087 to main. The following sources [d47452669e1a] will still need to be cherry-picked once the conflict is resolved.

```Cherry-pick ff676342841b. rdar://173969087

    [MTE] Harden `WebCore::Color` and `WebCore::Color::OutOfLineComponents` objects
    <https://bugs.webkit.org/show_bug.cgi?id=306157>
    <rdar://168435437>

    Reviewed by Darin Adler.

    `WebCore::Color` is made of a single field that contains flags in the upper bits
     and can eventually contain a pointer to an `OutOfLineComponents` as well.

    This compact pointer is untagged by libpas, so we should manually clear it
    to prevent any security issues if the Color object is Use After Free'd.

    * Source/WebCore/platform/graphics/Color.h:
    (WebCore::Color::~Color):

    Identifier: 305413.270@safari-7624-branch

```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/57e25f66f8db71bdb960a1df0eac3c91695575d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163157 "1 style error") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36638 "Hash 57e25f66 for PR 65139 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29855 "Hash 57e25f66 for PR 65139 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172096 "Hash 57e25f66 for PR 65139 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119604 "Hash 57e25f66 for PR 65139 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165026 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36966 "Hash 57e25f66 for PR 65139 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36639 "Hash 57e25f66 for PR 65139 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/172096 "Hash 57e25f66 for PR 65139 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/119604 "Hash 57e25f66 for PR 65139 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166116 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/36966 "Hash 57e25f66 for PR 65139 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/29855 "Hash 57e25f66 for PR 65139 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/172096 "Hash 57e25f66 for PR 65139 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/36966 "Hash 57e25f66 for PR 65139 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/36639 "Hash 57e25f66 for PR 65139 does not build (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19796 "Hash 57e25f66 for PR 65139 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/36966 "Hash 57e25f66 for PR 65139 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/29855 "Hash 57e25f66 for PR 65139 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174599 "Failed to compile WebKit") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/26756 "Failed to build and analyze WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/29855 "Hash 57e25f66 for PR 65139 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/174599 "Failed to compile WebKit") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36308 "Hash 57e25f66 for PR 65139 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/36639 "Hash 57e25f66 for PR 65139 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/174599 "Failed to compile WebKit") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37094 "Hash 57e25f66 for PR 65139 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/29855 "Hash 57e25f66 for PR 65139 does not build (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98961 "Hash 57e25f66 for PR 65139 does not build (failure)") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/37094 "Hash 57e25f66 for PR 65139 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/29855 "Hash 57e25f66 for PR 65139 does not build (failure)") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35804 "Hash 57e25f66 for PR 65139 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108165 "Failed to build and analyze WebKit") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35303 "Hash 57e25f66 for PR 65139 does not build (failure)") | [⏳ 🧪 mac-site-isolation ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Site-Isolation-Tests-EWS "Waiting in queue, processing has not started yet") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35550 "Hash 57e25f66 for PR 65139 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35450 "Hash 57e25f66 for PR 65139 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->