### PR TITLE
Remove N^3 walk of the frame tree

### DIFF
--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -1322,8 +1322,6 @@ void LocalFrameView::didLayout(SingleThreadWeakPtr<RenderElement> layoutRoot, bo
     m_frame->invalidateContentEventRegionsIfNeeded(LocalFrame::InvalidateContentEventRegionsReason::Layout);
     document->invalidateRenderingDependentRegions();
 
-    updateCanBlitOnScrollRecursively();
-
     updateScrollGeometryContentSize();
 
     handleDeferredScrollUpdateAfterContentSizeChange();
@@ -1603,15 +1601,9 @@ bool LocalFrameView::useSlowRepaintsIfNotOverlapped() const
     return useSlowRepaints(false);
 }
 
-void LocalFrameView::updateCanBlitOnScrollRecursively()
+bool LocalFrameView::canBlitOnScroll() const
 {
-    for (RefPtr<Frame> frame = m_frame.ptr(); frame; frame = frame->tree().traverseNext(m_frame.ptr())) {
-        RefPtr localFrame = dynamicDowncast<LocalFrame>(frame);
-        if (!localFrame)
-            continue;
-        if (RefPtr view = localFrame->view())
-            view->setCanBlitOnScroll(!view->useSlowRepaints());
-    }
+    return !useSlowRepaints();
 }
 
 bool LocalFrameView::usesCompositedScrolling() const
@@ -1708,7 +1700,8 @@ NativeScrollbarVisibility LocalFrameView::verticalNativeScrollbarVisibility() co
 void LocalFrameView::setCannotBlitToWindow()
 {
     m_cannotBlitToWindow = true;
-    updateCanBlitOnScrollRecursively();
+    if (platformWidget())
+        setCanBlitOnScroll(!useSlowRepaints());
 }
 
 void LocalFrameView::addSlowRepaintObject(RenderElement& renderer)
@@ -1727,7 +1720,8 @@ void LocalFrameView::addSlowRepaintObject(RenderElement& renderer)
     if (hadSlowRepaintObjects)
         return;
 
-    updateCanBlitOnScrollRecursively();
+    if (platformWidget())
+        setCanBlitOnScroll(!useSlowRepaints());
 }
 
 void LocalFrameView::removeSlowRepaintObject(RenderElement& renderer)
@@ -1745,7 +1739,8 @@ void LocalFrameView::removeSlowRepaintObject(RenderElement& renderer)
         return;
 
     m_slowRepaintObjects = nullptr;
-    updateCanBlitOnScrollRecursively();
+    if (platformWidget())
+        setCanBlitOnScroll(!useSlowRepaints());
 }
 
 bool LocalFrameView::hasSlowRepaintObject(const RenderElement& renderer) const
@@ -1771,7 +1766,7 @@ void LocalFrameView::addViewportConstrainedObject(RenderLayerModelObject& object
     if (!m_viewportConstrainedObjects->contains(object)) {
         m_viewportConstrainedObjects->add(object);
         if (platformWidget())
-            updateCanBlitOnScrollRecursively();
+            setCanBlitOnScroll(!useSlowRepaints());
 
         if (RefPtr scrollingCoordinator = this->scrollingCoordinator())
             scrollingCoordinator->frameViewFixedObjectsDidChange(*this);
@@ -1789,9 +1784,8 @@ void LocalFrameView::removeViewportConstrainedObject(RenderLayerModelObject& obj
         if (RefPtr scrollingCoordinator = this->scrollingCoordinator())
             scrollingCoordinator->frameViewFixedObjectsDidChange(*this);
 
-        // FIXME: In addFixedObject() we only call this if there's a platform widget,
-        // why isn't the same check being made here?
-        updateCanBlitOnScrollRecursively();
+        if (platformWidget())
+            setCanBlitOnScroll(!useSlowRepaints());
 
         if (RefPtr<Page> page = m_frame->page())
             page->chrome().client().didAddOrRemoveViewportConstrainedObjects();
@@ -2993,7 +2987,8 @@ void LocalFrameView::setIsOverlapped(bool isOverlapped)
         return;
 
     m_isOverlapped = isOverlapped;
-    updateCanBlitOnScrollRecursively();
+    if (platformWidget())
+        setCanBlitOnScroll(!useSlowRepaints());
 }
 
 void LocalFrameView::setContentIsOpaque(bool contentIsOpaque)
@@ -3002,7 +2997,8 @@ void LocalFrameView::setContentIsOpaque(bool contentIsOpaque)
         return;
 
     m_contentIsOpaque = contentIsOpaque;
-    updateCanBlitOnScrollRecursively();
+    if (platformWidget())
+        setCanBlitOnScroll(!useSlowRepaints());
 }
 
 void LocalFrameView::restoreScrollbar()

--- a/Source/WebCore/page/LocalFrameView.h
+++ b/Source/WebCore/page/LocalFrameView.h
@@ -790,6 +790,7 @@ private:
     explicit LocalFrameView(LocalFrame&);
 
     bool isLocalFrameView() const final { return true; }
+    bool canBlitOnScroll() const final;
     bool scrollContentsFastPath(const IntSize& scrollDelta, const IntRect& rectToScroll, const IntRect& clipRect) final;
     void scrollContentsSlowPath(const IntRect& updateRect) final;
 
@@ -815,7 +816,6 @@ private:
     friend class RenderWidget;
     bool useSlowRepaints(bool considerOverlap = true) const;
     bool useSlowRepaintsIfNotOverlapped() const;
-    void updateCanBlitOnScrollRecursively();
     bool shouldLayoutAfterContentsResized() const;
     
     void cancelScheduledScrollToFocusedElement();

--- a/Source/WebCore/platform/ScrollView.cpp
+++ b/Source/WebCore/platform/ScrollView.cpp
@@ -177,12 +177,8 @@ void ScrollView::setCanHaveScrollbars(bool canScroll)
 
 void ScrollView::setCanBlitOnScroll(bool b)
 {
-    if (platformWidget()) {
+    if (platformWidget())
         platformSetCanBlitOnScroll(b);
-        return;
-    }
-
-    m_canBlitOnScroll = b;
 }
 
 bool ScrollView::canBlitOnScroll() const
@@ -190,7 +186,7 @@ bool ScrollView::canBlitOnScroll() const
     if (platformWidget())
         return platformCanBlitOnScroll();
 
-    return m_canBlitOnScroll;
+    return true;
 }
 
 void ScrollView::setPaintsEntireContents(bool paintsEntireContents)

--- a/Source/WebCore/platform/ScrollView.h
+++ b/Source/WebCore/platform/ScrollView.h
@@ -182,7 +182,7 @@ public:
     // Whether or not a scroll view will blit visible contents when it is scrolled. Blitting is disabled in situations
     // where it would cause rendering glitches (such as with fixed backgrounds or when the view is partially transparent).
     void setCanBlitOnScroll(bool);
-    bool canBlitOnScroll() const;
+    virtual bool canBlitOnScroll() const;
 
     // There are at least three types of contentInset. Usually we just care about WebCoreInset, which is the inset
     // that is set on a Page that requires WebCore to move its layers to accomodate the inset. However, there are platform
@@ -584,10 +584,6 @@ private:
 
     bool m_prohibitsScrolling { false };
     bool m_allowsUnclampedScrollPosition { false };
-
-    // This bool is unused on Mac OS because we directly ask the platform widget
-    // whether it is safe to blit on scroll.
-    bool m_canBlitOnScroll { true };
 
     bool m_scrollbarsSuppressed { false };
     bool m_inUpdateScrollbars { false };


### PR DESCRIPTION
#### 8f2ae6345b744749a1a278bfce8e6a5a22bca12e
<pre>
Remove N^3 walk of the frame tree
<a href="https://bugs.webkit.org/show_bug.cgi?id=265326">https://bugs.webkit.org/show_bug.cgi?id=265326</a>
<a href="https://rdar.apple.com/119052584">rdar://119052584</a>

Reviewed by NOBODY (OOPS!).

This optimization was shipped by chrome in 2014 here:
<a href="https://codereview.chromium.org/162753008">https://codereview.chromium.org/162753008</a>

The general idea is to remove walks up and down the frame tree
during layout that sets the m_canBlitOnScroll bit and instead
compute it on demand before scrolling.

* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::didLayout):
(WebCore::LocalFrameView::canBlitOnScroll const):
(WebCore::LocalFrameView::setCannotBlitToWindow):
(WebCore::LocalFrameView::addSlowRepaintObject):
(WebCore::LocalFrameView::removeSlowRepaintObject):
(WebCore::LocalFrameView::addViewportConstrainedObject):
(WebCore::LocalFrameView::removeViewportConstrainedObject):
(WebCore::LocalFrameView::setIsOverlapped):
(WebCore::LocalFrameView::setContentIsOpaque):
(WebCore::LocalFrameView::updateCanBlitOnScrollRecursively): Deleted.
* Source/WebCore/page/LocalFrameView.h:
* Source/WebCore/platform/ScrollView.cpp:
(WebCore::ScrollView::setCanBlitOnScroll):
(WebCore::ScrollView::canBlitOnScroll const):
* Source/WebCore/platform/ScrollView.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8f2ae6345b744749a1a278bfce8e6a5a22bca12e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163355 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36838 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30053 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172294 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119802 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/49995f7c-c0a9-4c3e-906b-f6ee8ad1dee1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165224 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37165 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36838 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126859 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89429 "2 flakes 2 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4641fa93-51c0-47c2-84b6-c8c1aec16d43) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166314 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29125 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146856 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107426 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9e5105a5-be30-4f2d-9795-474f5620e0d1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28171 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26805 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19996 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138066 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24580 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174798 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27399 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26236 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135172 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36507 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30904 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135155 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37293 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146375 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99247 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30455 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23220 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36003 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108844 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35501 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1245 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35749 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35649 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->