### PR TITLE
[Site Isolation] http/tests/security/cross-origin-blob-transfer.html is flaky on post-commit CI bots

### DIFF
--- a/LayoutTests/http/tests/security/cross-origin-blob-transfer-expected.txt
+++ b/LayoutTests/http/tests/security/cross-origin-blob-transfer-expected.txt
@@ -1,17 +1,4 @@
-PASS successfullyParsed is true
 
-TEST COMPLETE
 
-Summary
-
-Harness status: OK
-
-Found 1 tests
-
-1 Pass
-Details
-
-Result	Test Name	Message
-Pass	Test for creating blob in iframe and then transferring it cross-origin.	
-Asserts run
+PASS Test for creating blob in iframe and then transferring it cross-origin.
 

--- a/LayoutTests/http/tests/security/cross-origin-blob-transfer.html
+++ b/LayoutTests/http/tests/security/cross-origin-blob-transfer.html
@@ -1,29 +1,20 @@
-<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN">
+<!DOCTYPE html>
 <html>
 <head>
-<script src="../../../../resources/testharness.js"></script>
-<script src="../../../../resources/js-test-pre.js"></script>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
 </head>
 <body>
 <script>
-if (self.testRunner)
-    testRunner.waitUntilDone();
-
-var test = async_test("Test for creating blob in iframe and then transferring it cross-origin.");
-
-window.addEventListener("message", (e) => {
-    e.data.text().then(t => {
-        assert_equals(t, "Blob content")
-        test.done();
-        if (self.testRunner)
-            testRunner.notifyDone();
-    });
-});
-
-assert_equals(window.location.origin, "http://127.0.0.1:8000");
-var successfullyParsed = true;
+async_test(t => {
+    assert_equals(window.location.origin, "http://127.0.0.1:8000");
+    window.addEventListener("message", t.step_func(e => {
+        e.data.text().then(t.step_func_done(text => {
+            assert_equals(text, "Blob content");
+        }));
+    }));
+}, "Test for creating blob in iframe and then transferring it cross-origin.");
 </script>
-<script src="../../../../resources/js-test-post.js"></script>
-<iframe src="http://localhost:8000/security/resources/iframe-cross-origin-blob-transfer.html">
+<iframe src="http://localhost:8000/security/resources/iframe-cross-origin-blob-transfer.html"></iframe>
 </body>
 </html>


### PR DESCRIPTION
#### fff9c1acbb11bcf9542fb6e3512856fc9ac03afd
<pre>
[Site Isolation] http/tests/security/cross-origin-blob-transfer.html is flaky on post-commit CI bots
<a href="https://bugs.webkit.org/show_bug.cgi?id=315056">https://bugs.webkit.org/show_bug.cgi?id=315056</a>
<a href="https://rdar.apple.com/177382438">rdar://177382438</a>

Reviewed by Sihui Liu and Anne van Kesteren.

http/tests/security/cross-origin-blob-transfer.html is flaky on macOS site isolation bots with the following diff:

```
--- /Volumes/Data/worker/Apple-Tahoe-Release-WK2-Site-Isolation-Tree-Tests/build/layout-test-results/http/tests/security/cross-origin-blob-transfer-expected.txt
+++ /Volumes/Data/worker/Apple-Tahoe-Release-WK2-Site-Isolation-Tree-Tests/build/layout-test-results/http/tests/security/cross-origin-blob-transfer-actual.txt
@@ -2,16 +2,4 @@

 TEST COMPLETE

-Summary
-
-Harness status: OK
-
-Found 1 tests
-
-1 Pass
-Details
-
-Result Test Name       Message
-Pass   Test for creating blob in iframe and then transferring it cross-origin.
-Asserts run
-
+Running, 1 complete, 0 remain
```

This failure happens since the test uses both testharness and WKTR to indicate when the test is complete:
```
  window.addEventListener(&quot;message&quot;, (e) =&gt; {
      e.data.text().then(t =&gt; {
          assert_equals(t, &quot;Blob content&quot;)
          test.done();                      // (A) testharness completion
          if (self.testRunner)
              testRunner.notifyDone();      // (B) WKTR completion
      });
  });
```

This leads to a potential race where the DOM gets dumped (B) before testharness&apos;s timer
(A) gets a chance to render the summary table. The dump captures only the in-progress
Running, 1 complete, 0 remain status line that testharness writes during the test.

This patch updates the test to only use the functionality exposed by testharness.js.
I removed the explicit call to testRunner.notifyDone() and the usage of js-test-pre/post.js
(which also called testRunner.notifyDone()), load testharnessreport.js,
and use t.step_func and t.step_func_done so the harness owns completion.
testharnessreport.js calls testRunner.notifyDone() from add_completion_callback,
which fires only after testharness has fully finished, eliminating the race.
testharnessreport.js also calls setup({output: false}), so the verbose
&lt;table&gt; summary is no longer emitted (updated -expected.txt to the single PASS line).

This patch is a speculative fix to attempt to fix
http/tests/security/cross-origin-blob-transfer.html
from failing flakily with site isolation.

* LayoutTests/http/tests/security/cross-origin-blob-transfer-expected.txt:
* LayoutTests/http/tests/security/cross-origin-blob-transfer.html:

Canonical link: <a href="https://commits.webkit.org/313508@main">https://commits.webkit.org/313508@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a059111aae32e3caad61a326e678196ceae2cd1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163174 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36655 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29872 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172113 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119621 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36983 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36656 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126693 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89295 "1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166133 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28969 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146693 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107262 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28015 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26642 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19813 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137908 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24417 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174616 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26072 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135001 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36325 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30744 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134993 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36417 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37111 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146212 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98986 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30296 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23056 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35821 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35320 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1079 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35567 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35467 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->