### PR TITLE
Cross-origin XMLHttpRequest triggers additional extension permissions request

### DIFF
--- a/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
+++ b/Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm
@@ -1754,10 +1754,16 @@ void WebExtensionContext::resourceLoadDidCompleteWithError(WebPageProxyIdentifie
 {
     RefPtr tab = getTab(pageID);
 
-    // If a Fetch or XHR fails due to CORS, prompt the user for permission to the URL. This won’t help the failed request, but future requests might succeed if the user grants access.
+    // If a Fetch or XHR fails due to CORS, prompt the user for permission to the URL
+    // if the URL of the frame where the request originated corresponds to this extension.
+    // This won't help the failed request, but future requests might succeed if the user
+    // grants permission.
     if (error.isAccessControl() && (loadInfo.type == ResourceLoadInfo::Type::Fetch || loadInfo.type == ResourceLoadInfo::Type::XMLHTTPRequest)) {
-        RELEASE_LOG_ERROR(Extensions, "Requesting permission to access URL due to CORS failure: %{sensitive}s", loadInfo.originalURL.string().utf8().data());
-        requestPermissionToAccessURLs({ loadInfo.originalURL }, tab, nullptr, GrantOnCompletion::Yes, { PermissionStateOptions::RequestedWithTabsPermission, PermissionStateOptions::IncludeOptionalPermissions });
+        RefPtr<WebFrameProxy> originatingFrame = loadInfo.frameID ? WebFrameProxy::webFrame(*loadInfo.frameID) : nullptr;
+        if (originatingFrame && isURLForThisExtension(originatingFrame->url())) {
+            RELEASE_LOG_ERROR(Extensions, "Requesting permission to access URL due to CORS failure: %{sensitive}s", loadInfo.originalURL.string().utf8().data());
+            requestPermissionToAccessURLs({ loadInfo.originalURL }, tab, nullptr, GrantOnCompletion::Yes, { PermissionStateOptions::RequestedWithTabsPermission, PermissionStateOptions::IncludeOptionalPermissions });
+        }
     }
 
     if (!hasPermissionToSendWebRequestEvent(tab.get(), response.url(), loadInfo))

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIPermissions.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIPermissions.mm
@@ -1305,6 +1305,44 @@ TEST(WKWebExtensionAPIPermissions, CORSUsingXHRWithoutGrantingPermission)
     EXPECT_EQ(promptCount, 2ul);
 }
 
+// rdar://154866064 — the CORS-failure auto-prompt in `WebExtensionContext::resourceLoadDidCompleteWithError`
+// should only fire when the failed CORS request comes from a page belonging to this extension, not the webpage.
+TEST(WKWebExtensionAPIPermissions, CORSFailureFromPageDoesNotPromptExtension)
+{
+    auto *pageScript = Util::constructScript(@[
+        @"<script>",
+        @"  fetch('http://127.0.0.1:' + location.port + '/subresource')",
+        @"    .then(() => browser.test.notifyFail('Page fetch unexpectedly succeeded; CORS should have blocked it'))",
+        @"    .catch(() => browser.test.notifyPass())",
+        @"</script>"
+    ]);
+
+    TestWebKitAPI::HTTPServer server({
+        { "/"_s, { { { "Content-Type"_s, "text/html"_s } }, pageScript } },
+        { "/subresource"_s, { { { "Content-Type"_s, "application/json"_s } }, "{ \"testKey\": \"testValue\" }"_s } }
+    }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto *backgroundScript = Util::constructScript(@[
+        @"browser.test.sendMessage('Load Tab')"
+    ]);
+
+    auto manager = Util::loadExtension(corsManifest, @{ @"background.js": backgroundScript });
+
+    __block size_t promptCount = 0;
+    manager.get().internalDelegate.promptForPermissionToAccessURLs = ^(id<WKWebExtensionTab>, NSSet<NSURL *> *requestedURLs, void (^completionHandler)(NSSet<NSURL *> *allowedURLs, NSDate *)) {
+        ++promptCount;
+        completionHandler(NSSet.set, nil);
+    };
+
+    [manager runUntilTestMessage:@"Load Tab"];
+
+    [manager.get().defaultTab.webView loadRequest:server.requestWithLocalhost()];
+
+    [manager run];
+
+    EXPECT_EQ(promptCount, 0ul);
+}
+
 } // namespace TestWebKitAPI
 
 #endif // ENABLE(WK_WEB_EXTENSIONS)


### PR DESCRIPTION
#### 97721a87040f669230513a75ee14c742cbe1cac1
<pre>
Cross-origin XMLHttpRequest triggers additional extension permissions request
<a href="https://rdar.apple.com/154866064">rdar://154866064</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=295336">https://bugs.webkit.org/show_bug.cgi?id=295336</a>

Reviewed by Brian Weinstein and Timothy Hatcher.

When an XHR or Fetch request failed in a given tab due to CORS, the CORS-failure auto-prompt in
`WebExtensionContext::resourceLoadDidCompleteWithError` was requesting permission for any extension
which implicitly or explicitly requested access to the URL targeted by the failed request. This
would cause the user to see many permission prompts from extensions for no apparent reason on pages
where many requests fail due to CORS (for example, pages embedding many ads). Granting this
permission only affects the success of future CORS requests which originate from extension pages;
therefore, we should only eagerly present these permission prompts for failed CORS requests which
were initiated from pages associated with this extension.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIPermissions.mm

* Source/WebKit/UIProcess/Extensions/Cocoa/WebExtensionContextCocoa.mm:
(WebKit::WebExtensionContext::resourceLoadDidCompleteWithError):
    Only request permission for the failed URL if the load came from a frame whose URL is associated
    with this extension.
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPIPermissions.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPIPermissions, CORSFailureFromPageDoesNotPromptExtension)):

Canonical link: <a href="https://commits.webkit.org/313506@main">https://commits.webkit.org/313506@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2513ea11bcc1d38edc99586e1e72dad13aef6de4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163177 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36658 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29875 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172116 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119624 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b1e4eb4d-cae7-4b58-b04d-6dcb05bda236) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165046 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36986 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36659 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126697 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89299 "1 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166136 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28972 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146690 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107266 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/59548022-c887-4109-999f-38957d9627d4) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28018 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26645 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19816 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137911 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24414 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174619 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/26776 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26069 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135004 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36328 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30747 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134996 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37114 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146209 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/98991 "The change is no longer eligible for processing.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24853 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30300 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23053 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35824 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108185 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35323 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1076 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35570 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35470 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->