### PR TITLE
Pahawh Hmong text is misrendered because it takes the simple text path

### DIFF
--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -923,6 +923,10 @@ FontCascade::CodePath FontCascade::characterRangeCodePath(std::span<const char16
                 return CodePath::Complex;
             if (supplementaryCharacter < 0x11CC0) // Marchen
                 return CodePath::Complex;
+            if (supplementaryCharacter < 0x16B00)
+                continue;
+            if (supplementaryCharacter < 0x16B90) // Pahawh Hmong
+                return CodePath::Complex;
             if (supplementaryCharacter < 0x1E900)
                 continue;
             if (supplementaryCharacter < 0x1E960) // Adlam

--- a/Tools/TestWebKitAPI/Tests/WebCore/FontCascade.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/FontCascade.cpp
@@ -38,6 +38,19 @@ static void testCodePath(char16_t codePoint, CodePath codePath)
     EXPECT_EQ(codePath, FontCascade::characterRangeCodePath(std::span<char16_t>(target))) << "target: " << static_cast<int>(target[0]);
 }
 
+static std::array<char16_t, 2> surrogatePair(char32_t supplementaryCharacter)
+{
+    char16_t high = 0xD800 + ((supplementaryCharacter - 0x10000) >> 10);
+    char16_t low = 0xDC00 + ((supplementaryCharacter - 0x10000) & 0x3FF);
+    return { high, low };
+}
+
+static void testSupplementaryCodePath(char32_t codePoint, CodePath codePath)
+{
+    auto target = surrogatePair(codePoint);
+    EXPECT_EQ(codePath, FontCascade::characterRangeCodePath(std::span<char16_t>(target))) << "target: U+" << std::hex << static_cast<uint32_t>(codePoint);
+}
+
 struct CodePathRange {
     char16_t start;
     char16_t end;
@@ -128,5 +141,15 @@ TEST(FontCascadeTest, characterRangeCodePath_NonSurrogates)
     testCodePathRange({ 0xFE00, 0xFE0F, CodePath::Complex });
     // U+FE20 through U+FE2F Combining half marks
     testCodePathRange({ 0xFE20, 0xFE2F, CodePath::Complex });
+}
+
+// Testing characterRangeCodePath for supplementary-plane codepoints
+TEST(FontCascadeTest, characterRangeCodePath_Surrogates)
+{
+    // U+16B00 through U+16B8F Pahawh Hmong
+    testSupplementaryCodePath(0x16B00, CodePath::Complex);
+    testSupplementaryCodePath(0x16B16, CodePath::Complex);
+    testSupplementaryCodePath(0x16B30, CodePath::Complex);
+    testSupplementaryCodePath(0x16B8F, CodePath::Complex);
 }
 }


### PR DESCRIPTION
#### 091658231ee493c8dee437d68731248b154b2081
<pre>
Pahawh Hmong text is misrendered because it takes the simple text path
<a href="https://bugs.webkit.org/show_bug.cgi?id=315062">https://bugs.webkit.org/show_bug.cgi?id=315062</a>
<a href="https://rdar.apple.com/167446860">rdar://167446860</a>

Reviewed by Brent Fulgham.

The supplementary-character table in FontCascade::characterRangeCodePath does
not include the Pahawh Hmong block (U+16B00 - U+16B8F), so runs containing
those codepoints fall through to the simple text path which does not position
Pahawh Hmong tone marks correctly. Therefore add the range to the table so
Pahawh Hmong is shaped on the complex text path, which positions the marks
correctly.

* Source/WebCore/platform/graphics/FontCascade.cpp:
(WebCore::FontCascade::characterRangeCodePath):
* Tools/TestWebKitAPI/Tests/WebCore/FontCascade.cpp:
(TestWebKitAPI::surrogatePair):
(TestWebKitAPI::testSupplementaryCodePath):
(TEST):

Canonical link: <a href="https://commits.webkit.org/313458@main">https://commits.webkit.org/313458@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3edb39354014328c6b6204793106de46d16474c8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163181 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36662 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29879 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172120 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119628 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/019c3c79-eda2-431e-8a00-0c55a7a54bfe) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165050 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36990 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36663 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126701 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89301 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166140 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/28977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146697 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107270 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a11c2122-075f-46f4-a942-e09a35cd2729) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26649 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19820 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24421 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174623 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/26780 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26076 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135009 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36332 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30751 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135001 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36397 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37118 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146216 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98996 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30304 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23060 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35828 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108189 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35327 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1083 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35574 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35474 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->