### PR TITLE
[macOS iOS] imported/w3c/web-platform-tests/dom/events/Event-timestamp-high-resolution.https.html is a flaky text failure.

### DIFF
--- a/Source/WebCore/page/Performance.cpp
+++ b/Source/WebCore/page/Performance.cpp
@@ -193,7 +193,7 @@ Seconds Performance::relativeTimeFromTimeOriginInReducedResolutionSeconds(Monoto
 
 DOMHighResTimeStamp Performance::relativeTimeFromTimeOriginInReducedResolution(MonotonicTime timestamp) const
 {
-    return relativeTimeFromTimeOriginInReducedResolutionSeconds(timestamp).milliseconds();
+    return ReducedResolutionSeconds::fromSeconds(relativeTimeFromTimeOriginInReducedResolutionSeconds(timestamp)).milliseconds();
 }
 
 MonotonicTime Performance::monotonicTimeFromRelativeTime(DOMHighResTimeStamp relativeTime) const


### PR DESCRIPTION
#### 71ab16845dd1b3a4d43d2578a3a27afb98690981
<pre>
[macOS iOS] imported/w3c/web-platform-tests/dom/events/Event-timestamp-high-resolution.https.html is a flaky text failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=315060">https://bugs.webkit.org/show_bug.cgi?id=315060</a>
<a href="https://rdar.apple.com/177386345">rdar://177386345</a>

Reviewed by NOBODY (OOPS!).

Root cause: Event::timeStampForBindings exposes the reduced timestamp via
Performance::relativeTimeFromTimeOriginInReducedResolution, which converts to ms via
plain Seconds::milliseconds() (= seconds()*1000) and so reintroduces the sub-microsecond
IEEE-754 noise that ReducedResolutionSeconds::milliseconds() (used by Performance::now)
is designed to round away. For underlying reduced values like 0.009000000000000001 s,
performance.now() returns 9.0 while e.timeStamp returns 9.000000000000002, breaking the
spec invariant before &lt;= e.timeStamp &lt;= after.

Changed Performance::relativeTimeFromTimeOriginInReducedResolution in
Source/WebCore/page/Performance.cpp:194-197 to wrap the reduced-resolution Seconds in a
ReducedResolutionSeconds before converting to milliseconds. Previously it called
Seconds::milliseconds() (plain seconds()*1000), which left sub-microsecond IEEE-754 noise
in the result. Now both UA-observable surfaces — performance.now() and event.timeStamp —
funnel their millisecond conversion through ReducedResolutionSeconds::milliseconds(),
which rounds at microsecond precision (per the contract documented at
Source/WTF/wtf/ReducedResolutionSeconds.h:35-58). This restores the spec invariant
before &lt;= e.timeStamp &lt;= after that the test asserts.

* Source/WebCore/page/Performance.cpp:
(WebCore::Performance::relativeTimeFromTimeOriginInReducedResolution const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71ab16845dd1b3a4d43d2578a3a27afb98690981

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163180 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36661 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29878 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172119 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119627 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165049 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36989 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36662 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126700 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89300 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166139 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/28974 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146695 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107269 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28020 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26650 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19819 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137913 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24419 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174622 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/26779 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26074 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135007 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36331 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30752 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/134999 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37117 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146214 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98995 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30302 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23058 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35827 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108188 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35326 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1081 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35573 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35473 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->