### PR TITLE
InlineMap RefPtr tests should drain the RefLogger buffer

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WTF/InlineMap.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/InlineMap.cpp
@@ -971,40 +971,50 @@ TEST(WTF_InlineMap, StringKeysGrowth)
 TEST(WTF_InlineMap, RefPtrKeys)
 {
     // RefPtr objects work as map keys, looked up by raw pointer.
-    DerivedRefLogger a("a");
-    DerivedRefLogger b("b");
-    DerivedRefLogger c("c");
+    {
+        DerivedRefLogger a("a");
+        DerivedRefLogger b("b");
+        DerivedRefLogger c("c");
 
-    InlineMap<RefPtr<RefLogger>, int, 5> map;
+        InlineMap<RefPtr<RefLogger>, int, 5> map;
 
-    map.add(RefPtr<RefLogger>(&a), 1);
-    map.add(RefPtr<RefLogger>(&b), 2);
-    map.add(RefPtr<RefLogger>(&c), 3);
+        map.add(RefPtr<RefLogger>(&a), 1);
+        map.add(RefPtr<RefLogger>(&b), 2);
+        map.add(RefPtr<RefLogger>(&c), 3);
 
-    EXPECT_EQ(map.size(), 3u);
-    EXPECT_TRUE(map.contains(&a));
-    EXPECT_TRUE(map.contains(&b));
-    EXPECT_TRUE(map.contains(&c));
+        EXPECT_EQ(map.size(), 3u);
+        EXPECT_TRUE(map.contains(&a));
+        EXPECT_TRUE(map.contains(&b));
+        EXPECT_TRUE(map.contains(&c));
 
-    EXPECT_EQ(map.find(&a)->value, 1);
-    EXPECT_EQ(map.find(&b)->value, 2);
-    EXPECT_EQ(map.find(&c)->value, 3);
+        EXPECT_EQ(map.find(&a)->value, 1);
+        EXPECT_EQ(map.find(&b)->value, 2);
+        EXPECT_EQ(map.find(&c)->value, 3);
+    }
+
+    // Drain the RefLogger log so subsequent tests start clean.
+    takeLogStr();
 }
 
 TEST(WTF_InlineMap, RefPtrValues)
 {
     // RefPtr objects work as map values.
-    DerivedRefLogger a("a");
-    DerivedRefLogger b("b");
+    {
+        DerivedRefLogger a("a");
+        DerivedRefLogger b("b");
 
-    InlineMap<unsigned, RefPtr<RefLogger>, 5, IntHash<unsigned>> map;
+        InlineMap<unsigned, RefPtr<RefLogger>, 5, IntHash<unsigned>> map;
 
-    map.add(1, RefPtr<RefLogger>(&a));
-    map.add(2, RefPtr<RefLogger>(&b));
+        map.add(1, RefPtr<RefLogger>(&a));
+        map.add(2, RefPtr<RefLogger>(&b));
 
-    EXPECT_EQ(map.size(), 2u);
-    EXPECT_EQ(map.find(1)->value.get(), &a);
-    EXPECT_EQ(map.find(2)->value.get(), &b);
+        EXPECT_EQ(map.size(), 2u);
+        EXPECT_EQ(map.find(1)->value.get(), &a);
+        EXPECT_EQ(map.find(2)->value.get(), &b);
+    }
+
+    // Drain the RefLogger log so subsequent tests start clean.
+    takeLogStr();
 }
 
 TEST(WTF_InlineMap, RefKeys)


### PR DESCRIPTION
#### 645b6c45a3893abfb98761d4d1ff44c8aff16d59
<pre>
InlineMap RefPtr tests should drain the RefLogger buffer
<a href="https://bugs.webkit.org/show_bug.cgi?id=315058">https://bugs.webkit.org/show_bug.cgi?id=315058</a>
<a href="https://rdar.apple.com/177385221">rdar://177385221</a>

Reviewed by Dan Hecht.

WTF_InlineMap.RefPtrKeys and RefPtrValues leave ref()/deref() entries in the global
RefLogger buffer, so the very next test (WTF_InlineMap.RefKeys) sees the accumulated
activity instead of just its own.

This patch wraps each test body in an inner scope so the RefPtrs are destroyed first, then
calls takeLogStr() to clear the log, matching the pattern in other WTF tests.

Tests: self-testing.
Canonical link: <a href="https://commits.webkit.org/313454@main">https://commits.webkit.org/313454@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/177815f3e2e4490e3b7cbb9bf0c76f6a8a06874d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163182 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36663 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29880 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172121 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119629 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bb368cfa-34f8-4f23-961c-f26ead944cad) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165051 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/36991 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36664 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126702 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/89302 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166141 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/28976 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146700 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107271 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28022 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26651 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19821 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137915 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24424 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174624 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26079 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135008 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36333 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30753 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135000 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36394 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37119 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146219 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/98997 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30305 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23063 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35829 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35328 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1086 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35575 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35475 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->