### PR TITLE
ASSERTION FAILED: m_renderBlock.ptr() != subtreeScrollbarChangesState->subtreeRoot.ptr().

### DIFF
--- a/LayoutTests/scrollbars/subtree-root-self-scrollbar-change-during-relayout-crash-expected.txt
+++ b/LayoutTests/scrollbars/subtree-root-self-scrollbar-change-during-relayout-crash-expected.txt
@@ -1,0 +1,3 @@
+PASS if no crash.
+
+

--- a/LayoutTests/scrollbars/subtree-root-self-scrollbar-change-during-relayout-crash.html
+++ b/LayoutTests/scrollbars/subtree-root-self-scrollbar-change-during-relayout-crash.html
@@ -1,0 +1,36 @@
+<html>
+    <head>
+        <script>
+            if (window.testRunner)
+                testRunner.dumpAsText();
+        </script>
+        <style>
+            .outer {
+                width: max-content;
+                overflow: auto;
+                height: 100px;
+            }
+            .wrapper {
+                width: 300px;
+                overflow-x: auto;
+            }
+            .wrapper-content {
+                width: 500px;
+                height: 50px;
+            }
+            .tall {
+                width: 50px;
+                height: 300px;
+            }
+        </style>
+    </head>
+    <body>
+        <p>PASS if no crash.</p>
+        <div class="outer">
+            <div class="wrapper">
+                <div class="wrapper-content"></div>
+            </div>
+            <div class="tall"></div>
+        </div>
+    </body>
+</html>

--- a/Source/WebCore/rendering/SubtreeScrollbarChangesState.cpp
+++ b/Source/WebCore/rendering/SubtreeScrollbarChangesState.cpp
@@ -27,7 +27,6 @@
 #include "SubtreeScrollbarChangesState.h"
 
 #include "HTMLTextAreaElement.h"
-#include "LayoutScope.h"
 #include "LocalFrameViewLayoutContext.h"
 #include "RenderBlock.h"
 #include "RenderElementInlines.h"
@@ -105,7 +104,6 @@ SubtreeScrollbarChangesHandler::~SubtreeScrollbarChangesHandler()
         rendererWithScrollbarChange->setNeedsPreferredWidthsUpdate(MarkingBehavior::MarkContainingBlockChain, subtreeRoot.ptr());
     }
 
-    auto scope = LayoutScope { subtreeRoot };
     subtreeRoot->setNeedsLayout(MarkingBehavior::MarkOnlyThis);
     subtreeRoot->layoutBlock(RelayoutChildren::Yes);
 }


### PR DESCRIPTION
#### 537cc2c75cc31a12535eb98b9bc6e597508a1405
<pre>
ASSERTION FAILED: m_renderBlock.ptr() != subtreeScrollbarChangesState-&gt;subtreeRoot.ptr().
<a href="https://bugs.webkit.org/show_bug.cgi?id=315108">https://bugs.webkit.org/show_bug.cgi?id=315108</a>
<a href="https://rdar.apple.com/problem/177442629">rdar://problem/177442629</a>

Reviewed by Alan Baradlay.

When the destructor for SubtreeScrollbarChangesHandler runs and we end
up in the scenario where we are handling the changes at the subtree root
level (i.e. another descendant was not able to handle the scrollbar
changes), we end up relaying out the subtree root which includes
creating a LayoutScope before the call to layoutBlock.

The problem with that is that LayoutScope will create a
RelayoutScopeForScrollbarChange. In RelayoutScopeForScrollbarChange
detects a change in the scrollbar at that point we will end up deferring
the scrollbar handling to be done later by the renderer that initiated
the tracking. That is not right since *the renderer that initiated the
tracking is the one that gained a scrollbar* and that is what triggers
the assertion we added in 313323@main.

ASSERT(m_renderBlock.ptr() != subtreeScrollbarChangesState-&gt;subtreeRoot.ptr());

However, the inner LayoutScope is redundant. The outer LayoutScope in
RenderBlock::layout() already wraps the subtree root and runs after
SubtreeScrollbarChangesStateScope is destroyed, so any self-scrollbar change
that surfaces during the relayout flows through the regular (non-deferred)
self-relayout path in ~RelayoutScopeForScrollbarChange instead of trying to
re-enqueue itself onto a state that is about to disappear.

* LayoutTests/scrollbars/subtree-root-self-scrollbar-change-during-relayout-crash-expected.txt: Added.
* LayoutTests/scrollbars/subtree-root-self-scrollbar-change-during-relayout-crash.html: Added.
A regression test where an intrinsic-width subtree root (width: max-content,
overflow: auto, fixed height) has both a fixed-width descendant that gains a
horizontal scrollbar mid-layout and enough content to require its own
vertical scrollbar. Without the fix this asserts in debug builds.

* Source/WebCore/rendering/SubtreeScrollbarChangesState.cpp:
(WebCore::SubtreeScrollbarChangesHandler::~SubtreeScrollbarChangesHandler):
Drop the inner LayoutScope wrapping the subtree-root relayout (and the now
unused LayoutScope.h include). The outer LayoutScope in RenderBlock::layout()
runs after the SubtreeScrollbarChangesState is cleared and handles
updateScrollInfoAfterLayout for the subtree root through the normal path.

Canonical link: <a href="https://commits.webkit.org/313537@main">https://commits.webkit.org/313537@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54289e0a42810aa2b59f66fe543f3a2f036ee358

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163298 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36781 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29996 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172237 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119745 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165167 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37108 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36781 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126807 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89398 "1 flakes 3 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166257 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29080 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146801 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107374 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/285c8f4b-be83-40e1-8982-a4c983605418) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28126 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26755 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19939 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138021 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24525 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174741 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27288 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26180 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135112 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36449 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30856 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135104 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36437 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37236 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146320 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99178 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30406 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23165 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35945 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108723 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35444 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1190 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35691 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35592 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->