### PR TITLE
[CMake] Avoid unnecessary rebuilds after CMake preset reconfigure

### DIFF
--- a/Source/WebGPU/WebGPU/CMakeLists.txt
+++ b/Source/WebGPU/WebGPU/CMakeLists.txt
@@ -121,7 +121,7 @@ target_compile_definitions(WebGPU PRIVATE
 )
 
 # Generate an empty cmakeconfig.h for the WebGPU target
-file(WRITE ${CMAKE_CURRENT_BINARY_DIR}/cmakeconfig.h "")
+file(CONFIGURE OUTPUT ${CMAKE_CURRENT_BINARY_DIR}/cmakeconfig.h CONTENT "")
 target_include_directories(WebGPU PRIVATE ${CMAKE_CURRENT_BINARY_DIR})
 
 target_compile_options(WebGPU PRIVATE -std=c++2b -fobjc-arc)

--- a/Source/WebKit/PlatformCocoa.cmake
+++ b/Source/WebKit/PlatformCocoa.cmake
@@ -173,7 +173,7 @@ set(WebKit_SWIFT_INCLUDE_DIRECTORIES
     "${WEBKIT_DIR}/Platform/spi/ios"
 )
 
-file(WRITE "${CMAKE_BINARY_DIR}/WebKit/WebPushDaemonStubs.cpp"
+file(CONFIGURE OUTPUT "${CMAKE_BINARY_DIR}/WebKit/WebPushDaemonStubs.cpp" CONTENT
 "#include \"config.h\"\n#if ENABLE(WEB_PUSH_NOTIFICATIONS)\nnamespace WebKit {\nint WebPushDaemonMain(int, char**) { return 1; }\nint WebPushToolMain(int, char**) { return 1; }\n}\n#endif\n")
 list(APPEND WebKit_SOURCES "${CMAKE_BINARY_DIR}/WebKit/WebPushDaemonStubs.cpp")
 

--- a/Source/WebKit/PlatformMac.cmake
+++ b/Source/WebKit/PlatformMac.cmake
@@ -84,7 +84,7 @@ set(WebKit_SWIFT_INTEROP_MODULE_PATH "${WEBKIT_DIR}/Modules/Internal")
 # WebCore:: types it uses are reachable transitively via WebKit_Internal headers.
 set(WebKit_CMAKE_MODULEMAP_DIR "${CMAKE_BINARY_DIR}/WebKit/SwiftModules")
 file(MAKE_DIRECTORY "${WebKit_CMAKE_MODULEMAP_DIR}")
-file(WRITE "${WebKit_CMAKE_MODULEMAP_DIR}/module.modulemap"
+file(CONFIGURE OUTPUT "${WebKit_CMAKE_MODULEMAP_DIR}/module.modulemap" CONTENT
 "module WebCore_Private [system] {
     requires cplusplus
     header \"${WebCore_PRIVATE_FRAMEWORK_HEADERS_DIR}/WebCore/DiagnosticLoggingKeys.h\"

--- a/Source/cmake/OptionsCocoa.cmake
+++ b/Source/cmake/OptionsCocoa.cmake
@@ -105,7 +105,7 @@ unset(_additions_found)
 if (EXISTS "/usr/local/include/WebKitAdditions" AND NOT EXISTS "/usr/local/include/AppleFeatures/AppleFeatures.h")
     set(_apple_features_stub "${CMAKE_BINARY_DIR}/generated-stubs/AppleFeatures")
     file(MAKE_DIRECTORY "${_apple_features_stub}")
-    file(WRITE "${_apple_features_stub}/AppleFeatures.h"
+    file(CONFIGURE OUTPUT "${_apple_features_stub}/AppleFeatures.h" CONTENT
         "/* Auto-generated stub -- AppleFeatures not available in this SDK. */\n")
     add_compile_options("$<$<NOT:$<COMPILE_LANGUAGE:Swift>>:-isystem${CMAKE_BINARY_DIR}/generated-stubs>")
     message(STATUS "AppleFeatures stub generated (WebKitAdditions present, AppleFeatures SDK absent)")

--- a/Source/cmake/WebKitCCache.cmake
+++ b/Source/cmake/WebKitCCache.cmake
@@ -17,12 +17,13 @@ if (NOT "$ENV{WK_USE_CCACHE}" STREQUAL "NO" AND NOT CMAKE_CXX_COMPILER_LAUNCHER)
             # worktrees of the same checkout (-fdebug-prefix-map handles the
             # debug-info side; CCACHE_BASEDIR handles the command-line side).
             set(_ccache_launcher "${CMAKE_BINARY_DIR}/ccache-launcher")
-            file(WRITE "${_ccache_launcher}"
-                "#!/bin/sh\n"
-                "export CCACHE_BASEDIR='${CMAKE_SOURCE_DIR}'\n"
-                "export CCACHE_NOHASHDIR=true\n"
-                "export CCACHE_SLOPPINESS='pch_defines,time_macros,include_file_mtime,include_file_ctime'\n"
-                "exec '${CCACHE_FOUND}' \"$@\"\n")
+            file(CONFIGURE OUTPUT "${_ccache_launcher}" CONTENT
+"#!/bin/sh
+export CCACHE_BASEDIR='${CMAKE_SOURCE_DIR}'
+export CCACHE_NOHASHDIR=true
+export CCACHE_SLOPPINESS='pch_defines,time_macros,include_file_mtime,include_file_ctime'
+exec '${CCACHE_FOUND}' \"$@\"
+")
             file(CHMOD "${_ccache_launcher}" PERMISSIONS
                 OWNER_READ OWNER_WRITE OWNER_EXECUTE GROUP_READ GROUP_EXECUTE WORLD_READ WORLD_EXECUTE)
             message(STATUS "Enabling ccache: Setting ccache prefix via ${_ccache_launcher} (CCACHE_BASEDIR=${CMAKE_SOURCE_DIR}).")

--- a/Tools/PlatformMac.cmake
+++ b/Tools/PlatformMac.cmake
@@ -15,7 +15,7 @@ if (ENABLE_WEBKIT_TEST_RUNNER AND ENABLE_WEBKIT)
     # LayoutTestHelper locks screen color profile during test runs (mac.py:start_helper).
     # FIXME: Stub config.h works around DRT/config.h pulling in JSC headers.
     # https://bugs.webkit.org/show_bug.cgi?id=312070
-    file(WRITE "${CMAKE_BINARY_DIR}/LayoutTestHelper-stub/config.h"
+    file(CONFIGURE OUTPUT "${CMAKE_BINARY_DIR}/LayoutTestHelper-stub/config.h" CONTENT
         "// Stub: https://bugs.webkit.org/show_bug.cgi?id=312070\n#include <wtf/Platform.h>\n")
     add_executable(LayoutTestHelper DumpRenderTree/mac/LayoutTestHelper.m)
     target_include_directories(LayoutTestHelper BEFORE PRIVATE

--- a/Tools/Scripts/rewrite-compile-commands
+++ b/Tools/Scripts/rewrite-compile-commands
@@ -29,9 +29,11 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import argparse
+import hashlib
 import json
 import os
 import re
+import sys
 
 parser = argparse.ArgumentParser(
     description='This tool takes the compile_commands.json output by CMake and expands any UnifiedSources in it to regular sources.'
@@ -45,10 +47,24 @@ args = parser.parse_args()
 source_dir = args.source_dir
 build_dir = args.build_dir
 
+# CMake regenerates the input on every reconfigure with a fresh mtime even when
+# content is identical, so ninja keeps invoking us. Short-circuit on input hash.
+with open(args.input_file, 'rb') as f:
+    input_data = f.read()
+input_hash = hashlib.sha256(input_data).hexdigest()
+hash_sentinel = args.output_file + '.input_hash'
+try:
+    with open(hash_sentinel) as f:
+        last_hash = f.read().strip()
+except FileNotFoundError:
+    last_hash = None
+
+if last_hash == input_hash and os.path.exists(args.output_file):
+    sys.exit(0)
+
 generated_compile_commands = []
 
-with open(args.input_file) as f:
-    compile_commands = json.load(f)
+compile_commands = json.loads(input_data)
 
 for entry in compile_commands:
     entry_file = entry['file']
@@ -97,5 +113,16 @@ output_directory = os.path.dirname(args.output_file)
 if not os.path.isdir(output_directory):
     os.makedirs(output_directory)
 
-with open(args.output_file, 'w') as f:
-    json.dump(generated_compile_commands, f, indent=2)
+new_content = json.dumps(generated_compile_commands, indent=2)
+try:
+    with open(args.output_file) as f:
+        existing_content = f.read()
+except FileNotFoundError:
+    existing_content = None
+
+if new_content != existing_content:
+    with open(args.output_file, 'w') as f:
+        f.write(new_content)
+
+with open(hash_sentinel, 'w') as f:
+    f.write(input_hash)


### PR DESCRIPTION
#### 9da1138b4ab4c394bece0e4d56a2590b41ed8dc6
<pre>
[CMake] Avoid unnecessary rebuilds after CMake preset reconfigure
<a href="https://bugs.webkit.org/show_bug.cgi?id=315061">https://bugs.webkit.org/show_bug.cgi?id=315061</a>
<a href="https://rdar.apple.com/177387522">rdar://177387522</a>

Reviewed by Pascoe.

Several CMake helpers wrote generated build inputs (the ccache
launcher, a Swift modulemap, a WebPushDaemon stub, an empty WebGPU
cmakeconfig.h, a LayoutTestHelper stub config.h, an AppleFeatures
stub) using file(WRITE), which is unconditional and always bumps the
mtime. The rewrite-compile-commands script did the same. As a result,
every reconfigure marked a chunk of PCHs and generated sources stale
even when their content was identical, forcing ~70 build steps and a
framework relink.

Switch those writes to file(CONFIGURE OUTPUT ... CONTENT ...) and
teach rewrite-compile-commands to compare before writing. Both only
update the file when content actually differs, so mtimes stay stable
across no-op reconfigures.

This drops the no changes reconfigure + rebuild time from ~50s to ~1s.

* Source/WebGPU/WebGPU/CMakeLists.txt:
* Source/WebKit/PlatformCocoa.cmake:
* Source/WebKit/PlatformMac.cmake:
* Source/cmake/OptionsCocoa.cmake:
* Source/cmake/WebKitCCache.cmake:
* Tools/PlatformMac.cmake:
* Tools/Scripts/rewrite-compile-commands:

Canonical link: <a href="https://commits.webkit.org/313460@main">https://commits.webkit.org/313460@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/98885e193b268956f7918259428da532e2234783

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163203 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36684 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29901 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172142 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119650 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9c0a0025-b32f-4972-a6a8-e8e69fda3ef7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165072 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37012 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36685 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126721 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/89321 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166162 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/28996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146717 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107290 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28042 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19842 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/155348 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24441 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174645 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/24090 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/26802 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26096 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135029 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36354 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30774 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135021 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36399 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37140 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146236 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99027 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30327 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23080 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195604 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35850 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108211 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50984 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35349 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1104 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35596 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35496 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->