### PR TITLE
[JSC] Add new `DateNow` DFG node

### DIFF
--- a/JSTests/microbenchmarks/date-now-elapsed.js
+++ b/JSTests/microbenchmarks/date-now-elapsed.js
@@ -1,0 +1,7 @@
+var sum = 0;
+var start = Date.now();
+for (var i = 0; i < 1e6; ++i) {
+    var diff = Date.now() - start;
+    if (diff >= 0 && diff < 1e9)
+        sum += diff;
+}

--- a/JSTests/microbenchmarks/date-now.js
+++ b/JSTests/microbenchmarks/date-now.js
@@ -1,0 +1,3 @@
+var sum = 0;
+for (var i = 0; i < 1e6; ++i)
+    sum += Date.now();

--- a/JSTests/stress/date-now-jit.js
+++ b/JSTests/stress/date-now-jit.js
@@ -1,0 +1,41 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual);
+}
+
+// Date.now() must return a finite, non-negative integer through all JIT tiers.
+function basic() {
+    return Date.now();
+}
+noInline(basic);
+
+for (var i = 0; i < testLoopCount; ++i) {
+    var t = basic();
+    shouldBe(typeof t, 'number');
+    shouldBe(Number.isFinite(t), true);
+    shouldBe(Number.isInteger(t), true);
+    shouldBe(t >= 0, true);
+}
+
+// Two Date.now() calls inside the same hot function must not be CSE'd into
+// one, and the call inside the loop must not be LICM-hoisted out. If either
+// happened, the loop below would never observe the clock advancing and the
+// spin guard would fire.
+function spinUntilAdvance() {
+    var start = Date.now();
+    var spin = 0;
+    var t;
+    do {
+        t = Date.now();
+        if (++spin > 1e8)
+            throw new Error('Date.now() did not advance after ' + spin + ' iterations; likely CSE/LICM bug');
+    } while (t === start);
+    return t - start;
+}
+noInline(spinUntilAdvance);
+
+for (var i = 0; i < 200; ++i) {
+    var diff = spinUntilAdvance();
+    if (diff <= 0)
+        throw new Error('Date.now() went backwards: diff=' + diff);
+}

--- a/Source/JavaScriptCore/dfg/DFGAbstractHeap.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractHeap.h
@@ -72,6 +72,7 @@ namespace JSC { namespace DFG {
     macro(HeapObjectCount) /* Used to reflect the fact that some allocations reveal object identity */\
     macro(RegExpState) \
     macro(MathDotRandomState) \
+    macro(WallClock) \
     macro(JSDateFields) \
     macro(JSGlobalProxy_target) \
     macro(JSMapFields) \
@@ -337,6 +338,7 @@ public:
         case HeapObjectCount:
         case RegExpState:
         case MathDotRandomState:
+        case WallClock:
         case JSDateFields:
         case JSGlobalProxy_target:
         case JSMapFields:

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -1508,6 +1508,11 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         break;
     }
 
+    case DateNow: {
+        setNonCellTypeForNode(node, SpecDoubleReal);
+        break;
+    }
+
     case ArithRound:
     case ArithFloor:
     case ArithCeil:

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -3838,6 +3838,14 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             setResult(addToGraph(ArithRandom));
             return CallOptimizationResult::Inlined;
         }
+
+        case DateNowIntrinsic: {
+            if (!is64Bit())
+                return CallOptimizationResult::DidNothing;
+            insertChecks();
+            setResult(addToGraph(DateNow));
+            return CallOptimizationResult::Inlined;
+        }
             
         case DFGTrueIntrinsic: {
             insertChecks();

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -393,6 +393,11 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         write(MathDotRandomState);
         return;
 
+    case DateNow:
+        read(WallClock);
+        write(WallClock);
+        return;
+
     case EnumeratorNextUpdatePropertyName: {
         def(PureValue(node, node->enumeratorMetadata().toRaw()));
         return;

--- a/Source/JavaScriptCore/dfg/DFGCloneHelper.h
+++ b/Source/JavaScriptCore/dfg/DFGCloneHelper.h
@@ -208,6 +208,7 @@ BasicBlock* CloneHelper::cloneBlock(BasicBlock* const block, const CustomizeSucc
     CLONE_STATUS(DataViewGetInt, Common) \
     CLONE_STATUS(DataViewSet, Common) \
     CLONE_STATUS(DateGetTime, Common) \
+    CLONE_STATUS(DateNow, Common) \
     CLONE_STATUS(DateSetTime, Common) \
     CLONE_STATUS(Dec, Common) \
     CLONE_STATUS(DeleteById, Common) \

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -91,6 +91,7 @@ bool doesGC(Graph& graph, Node* node)
     case ArithPow:
     case ArithSqrt:
     case ArithRandom:
+    case DateNow:
     case ArithRound:
     case ArithFloor:
     case ArithCeil:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -888,7 +888,8 @@ private:
             break;
         }
 
-        case ArithRandom: {
+        case ArithRandom:
+        case DateNow: {
             node->setResult(NodeResultDouble);
             break;
         }

--- a/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
@@ -919,6 +919,7 @@ bool LoopUnrollingPhase::LoopData::isNumericComputationNode(Node* node)
     case ArithF16Round:
     case ArithPow:
     case ArithRandom:
+    case DateNow:
     case ArithRound:
     case ArithFloor:
     case ArithCeil:

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -655,6 +655,7 @@ namespace JSC { namespace DFG {
     macro(DataViewGetByteLength, NodeResultInt32) \
     macro(DataViewGetByteLengthAsInt52, NodeResultInt52) \
     /* Date access */ \
+    macro(DateNow, NodeMustGenerate | NodeResultDouble) \
     macro(DateGetInt32OrNaN, NodeResultJS) \
     macro(DateGetTime, NodeResultDouble) \
     macro(DateSetTime, NodeMustGenerate | NodeResultDouble) \

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -5883,6 +5883,11 @@ JSC_DEFINE_JIT_OPERATION(operationGetPrototypeOf, EncodedJSValue, (JSGlobalObjec
     OPERATION_RETURN(scope, JSValue::encode(value.getPrototype(globalObject)));
 }
 
+JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationDateNow, double, (void))
+{
+    return jsCurrentTime();
+}
+
 JSC_DEFINE_JIT_OPERATION(operationDateGetFullYear, EncodedJSValue, (VM* vmPointer, DateInstance* date))
 {
     VM& vm = *vmPointer;

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -464,6 +464,7 @@ JSC_DECLARE_JIT_OPERATION(operationNewObjectWithButterflyWithIndexingHeaderAndVe
 
 JSC_DECLARE_JIT_OPERATION(operationLinkDirectCall, void, (DirectCallLinkInfo*, JSFunction*));
 
+JSC_DECLARE_NOEXCEPT_JIT_OPERATION(operationDateNow, double, (void));
 JSC_DECLARE_JIT_OPERATION(operationDateGetFullYear, EncodedJSValue, (VM*, DateInstance*));
 JSC_DECLARE_JIT_OPERATION(operationDateGetUTCFullYear, EncodedJSValue, (VM*, DateInstance*));
 JSC_DECLARE_JIT_OPERATION(operationDateGetMonth, EncodedJSValue, (VM*, DateInstance*));

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1268,6 +1268,11 @@ private:
             break;
         }
 
+        case DateNow: {
+            setPrediction(SpecDoubleReal);
+            break;
+        }
+
         case MapOrSetDelete:
         case DeleteByVal:
         case DeleteById:

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -817,6 +817,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case StringReplaceAll:
     case StringReplaceRegExp:
     case ArithRandom:
+    case DateNow:
     case ArithIMul:
     case TryGetById:
     case StringLocaleCompare:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -18222,6 +18222,14 @@ void SpeculativeJIT::compileStringStartsOrEndsWith(Node* node)
     unblessedBooleanResult(resultGPR, node);
 }
 
+void SpeculativeJIT::compileDateNow(Node* node)
+{
+    flushRegisters();
+    FPRResult result(this);
+    callOperationWithoutExceptionCheck(operationDateNow, result.fpr());
+    doubleResult(result.fpr(), node);
+}
+
 void SpeculativeJIT::compileGlobalIsNaN(Node* node)
 {
     switch (node->child1().useKind()) {

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1810,6 +1810,7 @@ public:
 #endif
     void compileStringSplit(Node*);
     void compileStringMatch(Node*);
+    void compileDateNow(Node*);
     void compileDateGet(Node*);
     void compileDateSet(Node*);
     void compileGlobalIsNaN(Node*);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -4547,6 +4547,7 @@ void SpeculativeJIT::compile(Node* node)
     case DataViewGetInt:
     case DataViewGetFloat:
     case DataViewSet:
+    case DateNow:
     case DateGetInt32OrNaN:
     case DateGetTime:
     case DateSetTime:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -6391,6 +6391,10 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case DateNow:
+        compileDateNow(node);
+        break;
+
     case DateGetInt32OrNaN:
     case DateGetTime:
         compileDateGet(node);

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -511,6 +511,7 @@ inline CapabilityLevel canCompile(Node* node)
     case DataViewGetInt:
     case DataViewGetFloat:
     case DataViewSet:
+    case DateNow:
     case DateGetInt32OrNaN:
     case DateGetTime:
     case DateSetTime:

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -1944,6 +1944,9 @@ private:
             compileFilterICStatus();
             codeGenerationResult = CodeGenerationResult::NotGenerated;
             break;
+        case DateNow:
+            compileDateNow();
+            break;
         case DateGetInt32OrNaN:
         case DateGetTime:
             compileDateGet();
@@ -21432,6 +21435,11 @@ IGNORE_CLANG_WARNINGS_END
                 RELEASE_ASSERT_NOT_REACHED();
             }
         }
+    }
+
+    void compileDateNow()
+    {
+        setDouble(vmCall(Double, operationDateNow));
     }
 
     void compileDateGet()

--- a/Source/JavaScriptCore/jit/CCallHelpers.h
+++ b/Source/JavaScriptCore/jit/CCallHelpers.h
@@ -667,8 +667,10 @@ private:
     template<typename OperationType, unsigned numGPRArgs, unsigned numGPRSources, unsigned numFPRArgs, unsigned numFPRSources, unsigned numCrossSources, unsigned extraGPRArgs, unsigned nonArgGPRs, unsigned extraPoke, typename... Args>
     ALWAYS_INLINE void setupArgumentsEntryImpl(ArgCollection<numGPRArgs, numGPRSources, numFPRArgs, numFPRSources, numCrossSources, extraGPRArgs, nonArgGPRs, extraPoke> argSourceRegs, Args... args)
     {
-        using FirstArgumentType = typename FunctionTraits<OperationType>::template ArgumentType<0>;
-        if constexpr (std::same_as<FirstArgumentType, CallFrame*>) {
+        if constexpr (!FunctionTraits<OperationType>::arity) {
+            static_assert(!sizeof...(Args), "Basic sanity check");
+            setupArgumentsImpl<OperationType>(argSourceRegs);
+        } else if constexpr (std::same_as<typename FunctionTraits<OperationType>::template ArgumentType<0>, CallFrame*>) {
 #if USE(JSVALUE64)
             // This only really works for 64-bit since jsvalue regs mess things up for 32-bit...
             static_assert(FunctionTraits<OperationType>::cCallArity() == sizeof...(Args) + 1, "Basic sanity check; Did you explicitly pass callFrameRegister for the first argument?");

--- a/Source/JavaScriptCore/runtime/DateConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/DateConstructor.cpp
@@ -48,7 +48,7 @@ const ClassInfo DateConstructor::s_info = { "Function"_s, &InternalFunction::s_i
 @begin dateConstructorTable
   parse     dateParse   DontEnum|Function 1
   UTC       dateUTC     DontEnum|Function 7
-  now       dateNow     DontEnum|Function 0
+  now       dateNow     DontEnum|Function 0 DateNowIntrinsic
 @end
 */
 

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -71,6 +71,7 @@ namespace JSC {
     macro(BooleanConstructorIntrinsic) \
     macro(CharCodeAtIntrinsic) \
     macro(CharAtIntrinsic) \
+    macro(DateNowIntrinsic) \
     macro(DatePrototypeGetTimeIntrinsic) \
     macro(DatePrototypeGetFullYearIntrinsic) \
     macro(DatePrototypeGetUTCFullYearIntrinsic) \


### PR DESCRIPTION
#### d53865edf63b4dc3620a616e60cbd9d48c6345bc
<pre>
[JSC] Add new `DateNow` DFG node
<a href="https://bugs.webkit.org/show_bug.cgi?id=315065">https://bugs.webkit.org/show_bug.cgi?id=315065</a>

Reviewed by Yusuke Suzuki.

Add a DateNow DFG node so that Date.now() is inlined in DFG and FTL
instead of going through a host function call. The implementation is
a simple direct call to operationDateNow.

                          TipOfTree                  Patched

    date-now               25.5180+-0.3178     ^     21.5319+-0.2979        ^ definitely 1.1851x faster
    date-now-elapsed       24.4737+-0.2168     ^     20.4836+-0.1619        ^ definitely 1.1948x faster

Tests: JSTests/microbenchmarks/date-now-elapsed.js
       JSTests/microbenchmarks/date-now.js
       JSTests/stress/date-now-jit.js

* JSTests/microbenchmarks/date-now-elapsed.js: Added.
* JSTests/microbenchmarks/date-now.js: Added.
* JSTests/stress/date-now-jit.js: Added.
(shouldBe):
(basic):
(spinUntilAdvance):
* Source/JavaScriptCore/dfg/DFGAbstractHeap.h:
(JSC::DFG::AbstractHeap::superKind):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGCloneHelper.h:
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp:
(JSC::DFG::LoopUnrollingPhase::LoopData::isNumericComputationNode):
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/runtime/DateConstructor.cpp:
* Source/JavaScriptCore/runtime/Intrinsic.h:

Canonical link: <a href="https://commits.webkit.org/313578@main">https://commits.webkit.org/313578@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aa669ab46ab0fffbf553ddad59b51141f734cf4b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163515 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36999 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30218 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172455 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119964 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37330 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36998 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126999 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89528 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166474 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29271 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147004 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107553 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28320 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26949 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20158 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/155666 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138217 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24723 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174960 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/24406 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27891 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26385 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135307 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36668 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31051 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135289 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36461 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37454 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146518 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99493 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30593 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23368 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195917 "Built successfully") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36164 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109310 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51074 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35662 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1393 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35912 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35809 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->