### PR TITLE
Follow-up to "[Build perf] Add harness script for running build commands and reporting to perf dashboard"

### DIFF
--- a/Tools/Scripts/measure-build-time
+++ b/Tools/Scripts/measure-build-time
@@ -17,7 +17,7 @@ log = logging.getLogger('measure-build-time')
 
 SCRIPTS = Path(__file__).parent
 
-# --- Tests and subtests ----------------------------------------------------- 
+# --- Tests and subtests -----------------------------------------------------
 
 class Task:
     name: str
@@ -95,10 +95,10 @@ def parse_timing_summary(log_fd: IO[bytes]) -> dict[str, int]:
     """Extract per-phase timing from Xcode's Build Timing Summary section."""
 
     # The build log might be very long, but the timing summary is always at
-    # the end. Only search the final 8K of the log.
+    # the end. Only search the final 1MB of the log.
     log_fd.seek(0, os.SEEK_END)
     size = log_fd.tell()
-    log_fd.seek(max(0, size - 8192))
+    log_fd.seek(max(0, size - 2**20))
     match = XCODE_TIMING_SUMMARY_RE.search(log_fd.read().decode('utf-8', errors='replace'))
     if not match:
         return {}
@@ -159,10 +159,8 @@ def run_test(name: str, command: str, stdout_filter: str | None = None) -> TestR
 
 # --- Test runner ------------------------------------------------------------
 
-DEFAULT_MAKE_COMMAND = ('make ARGS="' + ' '.join((
-                            '-showBuildTimingSummary',
-                            'COMPILATION_CACHE_ENABLE_CACHING=NO',
-                        )) + '"')
+DEFAULT_MAKE_COMMAND = ('make -C {workspace_dir} {configuration} '
+                        'ARGS=-showBuildTimingSummary')
 
 def main() -> None:
     logging.basicConfig(
@@ -177,18 +175,19 @@ def main() -> None:
     cmd_parser = parser.add_mutually_exclusive_group(required=True)
     cmd_parser.add_argument('--build-command',
                             help='Shell command to run the build')
-    cmd_parser.add_argument('--make', dest='build_command', action='store_const',
-                            const=DEFAULT_MAKE_COMMAND,
+    cmd_parser.add_argument('--make', action='store_true',
                             help='Use a default Make invocation to build WebKit. '
                             'Does not set configuration or workspace (use set-webkit-configuration).')
     parser.add_argument('--build-dir', type=Path,
                         help='Path to top-level build directory (deleted by `clean` test)')
     parser.add_argument('--source-dir', type=Path,
                         help='Path to WebKit checkout used for incremental build testing')
+    parser.add_argument('--configuration', default='debug',
+                        help='Build configuration to use (default: debug)')
     parser.add_argument('--tests', nargs='+', default=[t.name for t in AVAILABLE_TESTS],
                         choices=[t.name for t in AVAILABLE_TESTS],
                         help='Which tests to run (default: all). Will skip test dependencies which are not listed.')
-    parser.add_argument('--metric-key', default='BuildTime-Unspecified',
+    parser.add_argument('--metric-key',
                         help='Top-level test key in the results. '
                         'Can be omitted, but must be provided when emitting a real benchmark score.')
     parser.add_argument('--stdout-filter', default=None,
@@ -205,6 +204,15 @@ def main() -> None:
         ).rstrip())
     if not args.source_dir:
         args.source_dir = SCRIPTS.parent.parent
+    if args.make:
+        internal_dir = args.source_dir / '../Internal/WebKit'
+        args.build_command = DEFAULT_MAKE_COMMAND.format(
+            configuration=args.configuration.lower(),
+            workspace_dir=str(internal_dir if internal_dir.exists() else args.source_dir)
+        )
+    if not args.metric_key:
+        # e.g. "BuildTime-Debug"
+        args.metric_key = f'BuildTime-{args.configuration.capitalize()}'
 
     # Read each test's `depends` lists to compute a topological order to run
     # all the tests. Does NOT perform cycle detection.
@@ -220,7 +228,7 @@ def main() -> None:
                 edges[T2].remove(T)
                 if not edges[T2]:
                     roots.add(T2)
-            
+
 
     tests: dict[str, TestResult] = {}
     for T in plan:


### PR DESCRIPTION
#### 478a3cd61e644e1881fd9add712816cd79117582
<pre>
Follow-up to &quot;[Build perf] Add harness script for running build commands and reporting to perf dashboard&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=314769">https://bugs.webkit.org/show_bug.cgi?id=314769</a>
<a href="https://rdar.apple.com/177021487">rdar://177021487</a>

Unreviewed. Fix some assumptions about configuration and working
directory needed for CI deployment.

* Tools/Scripts/measure-build-time:
(run_build):
(main):

Canonical link: <a href="https://commits.webkit.org/313455@main">https://commits.webkit.org/313455@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b7cfb2570b7adb3bb0c90ee79fb4aad6358cdf5a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163201 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36682 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/29899 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/172140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/119648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165070 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37010 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36683 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/172140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/119648 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166160 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/28995 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/146719 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/172140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26669 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/19840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137934 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/24443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/174643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/26098 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/174643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36352 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30771 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/174643 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37138 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/146238 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/99025 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24827 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/30322 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/23082 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35848 "Built successfully") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/35347 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/1106 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/35594 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/35494 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->