### PR TITLE
[JSC] Add `ArithSign` DFG node

### DIFF
--- a/JSTests/microbenchmarks/math-sign-double.js
+++ b/JSTests/microbenchmarks/math-sign-double.js
@@ -1,0 +1,14 @@
+//@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
+function benchDouble(n) {
+    let sum = 0;
+    for (let i = 0; i < n; i++) {
+        let x = ((i * 0x9E3779B9) | 0) * 1.5;
+        sum += Math.sign(x);
+    }
+    return sum;
+}
+noInline(benchDouble);
+
+let result;
+for (let i = 0; i < 100; i++)
+    result = benchDouble(1e6);

--- a/JSTests/microbenchmarks/math-sign-int32.js
+++ b/JSTests/microbenchmarks/math-sign-int32.js
@@ -1,0 +1,14 @@
+//@ skip if $model == "Apple Watch Series 3" # added by mark-jsc-stress-test.py
+function benchInt(n) {
+    let sum = 0;
+    for (let i = 0; i < n; i++) {
+        let x = ((i * 0x9E3779B9) | 0);
+        sum += Math.sign(x);
+    }
+    return sum;
+}
+noInline(benchInt);
+
+let result;
+for (let i = 0; i < 100; i++)
+    result = benchInt(1e6);

--- a/JSTests/stress/math-sign-basics.js
+++ b/JSTests/stress/math-sign-basics.js
@@ -1,0 +1,239 @@
+function mathSignOnInteger(value)
+{
+    return Math.sign(value);
+}
+noInline(mathSignOnInteger);
+
+// *** Test simple cases on integers. ***
+function testMathSignOnIntegers()
+{
+    // Bounds.
+    var signZero = mathSignOnInteger(0);
+    if (signZero !== 0)
+        throw "mathSignOnInteger(0) = " + signZero;
+
+    var signIntMin = mathSignOnInteger(-2147483648);
+    if (signIntMin !== -1)
+        throw "mathSignOnInteger(-2147483648) = " + signIntMin;
+
+    var signIntMax = mathSignOnInteger(2147483647);
+    if (signIntMax !== 1)
+        throw "mathSignOnInteger(2147483647) = " + signIntMax;
+
+    // Simple values.
+    var signMinusOne = mathSignOnInteger(-1);
+    if (signMinusOne !== -1)
+        throw "mathSignOnInteger(-1) = " + signMinusOne;
+
+    var signOne = mathSignOnInteger(1);
+    if (signOne !== 1)
+        throw "mathSignOnInteger(1) = " + signOne;
+
+    var signFortyTwo = mathSignOnInteger(42);
+    if (signFortyTwo !== 1)
+        throw "mathSignOnInteger(42) = " + signFortyTwo;
+
+    var signMinusFortyTwo = mathSignOnInteger(-42);
+    if (signMinusFortyTwo !== -1)
+        throw "mathSignOnInteger(-42) = " + signMinusFortyTwo;
+}
+noInline(testMathSignOnIntegers);
+
+for (var i = 0; i < 1e4; ++i) {
+    testMathSignOnIntegers();
+}
+
+// Make sure we don't do anything stupid when the type is unexpected.
+function verifySignWithObject()
+{
+    var signObject = mathSignOnInteger({ valueOf: function() { return 7; } });
+    if (signObject !== 1)
+        throw "mathSignOnInteger({ valueOf: function() { return 7; } }) = " + signObject;
+
+    var signNegObject = mathSignOnInteger({ valueOf: function() { return -7; } });
+    if (signNegObject !== -1)
+        throw "mathSignOnInteger({ valueOf: function() { return -7; } }) = " + signNegObject;
+
+    var signString = mathSignOnInteger("WebKit");
+    if (!isNaN(signString))
+        throw "mathSignOnInteger(\"WebKit\") = " + signString;
+}
+noInline(verifySignWithObject);
+
+for (var i = 0; i < 1e4; ++i) {
+    verifySignWithObject();
+}
+
+// *** Test simple cases on doubles. ***
+function mathSignOnDouble(value)
+{
+    return Math.sign(value);
+}
+noInline(mathSignOnDouble);
+
+function testMathSignOnDoubles()
+{
+    var signNaN = mathSignOnDouble(NaN);
+    if (!isNaN(signNaN))
+        throw "mathSignOnDouble(NaN) = " + signNaN;
+
+    var signPositiveZero = mathSignOnDouble(0.0);
+    if (!Object.is(signPositiveZero, 0))
+        throw "mathSignOnDouble(0.0) = " + signPositiveZero;
+
+    var signNegativeZero = mathSignOnDouble(-0.0);
+    if (!Object.is(signNegativeZero, -0))
+        throw "mathSignOnDouble(-0.0) = " + signNegativeZero;
+
+    var signPositiveInfinity = mathSignOnDouble(Infinity);
+    if (signPositiveInfinity !== 1)
+        throw "mathSignOnDouble(Infinity) = " + signPositiveInfinity;
+
+    var signNegativeInfinity = mathSignOnDouble(-Infinity);
+    if (signNegativeInfinity !== -1)
+        throw "mathSignOnDouble(-Infinity) = " + signNegativeInfinity;
+
+    var signMinValue = mathSignOnDouble(Number.MIN_VALUE);
+    if (signMinValue !== 1)
+        throw "mathSignOnDouble(Number.MIN_VALUE) = " + signMinValue;
+
+    var signNegMinValue = mathSignOnDouble(-Number.MIN_VALUE);
+    if (signNegMinValue !== -1)
+        throw "mathSignOnDouble(-Number.MIN_VALUE) = " + signNegMinValue;
+
+    var signMaxValue = mathSignOnDouble(Number.MAX_VALUE);
+    if (signMaxValue !== 1)
+        throw "mathSignOnDouble(Number.MAX_VALUE) = " + signMaxValue;
+
+    var signEpsilon = mathSignOnDouble(Number.EPSILON);
+    if (signEpsilon !== 1)
+        throw "mathSignOnDouble(Number.EPSILON) = " + signEpsilon;
+
+    var signPositiveFractional = mathSignOnDouble(0.5);
+    if (signPositiveFractional !== 1)
+        throw "mathSignOnDouble(0.5) = " + signPositiveFractional;
+
+    var signNegativeFractional = mathSignOnDouble(-0.5);
+    if (signNegativeFractional !== -1)
+        throw "mathSignOnDouble(-0.5) = " + signNegativeFractional;
+}
+noInline(testMathSignOnDoubles);
+
+for (var i = 0; i < 1e4; ++i) {
+    testMathSignOnDoubles();
+}
+
+// *** Unusual arguments. ***
+function mathSignNoArguments()
+{
+    return Math.sign();
+}
+noInline(mathSignNoArguments);
+
+function mathSignTooManyArguments(a, b, c)
+{
+    return Math.sign(a, b, c);
+}
+noInline(mathSignTooManyArguments);
+
+for (var i = 0; i < 1e4; ++i) {
+    var signNoArguments = mathSignNoArguments();
+    if (!isNaN(signNoArguments))
+        throw "Math.sign() = " + signNoArguments;
+
+    var signTooManyArguments = mathSignTooManyArguments(2, 3, 5);
+    if (signTooManyArguments !== 1)
+        throw "mathSignTooManyArguments(2, 3, 5) = " + signTooManyArguments;
+}
+
+// *** Constant as arguments. ***
+function testMathSignOnConstants()
+{
+    var signZero = Math.sign(0);
+    if (!Object.is(signZero, 0))
+        throw "Math.sign(0) = " + signZero;
+
+    var signNegativeZero = Math.sign(-0.0);
+    if (!Object.is(signNegativeZero, -0))
+        throw "Math.sign(-0.0) = " + signNegativeZero;
+
+    var signNaN = Math.sign(NaN);
+    if (!isNaN(signNaN))
+        throw "Math.sign(NaN) = " + signNaN;
+
+    var signPositive = Math.sign(42);
+    if (signPositive !== 1)
+        throw "Math.sign(42) = " + signPositive;
+
+    var signNegative = Math.sign(-42);
+    if (signNegative !== -1)
+        throw "Math.sign(-42) = " + signNegative;
+
+    var signPositiveDouble = Math.sign(42.5);
+    if (signPositiveDouble !== 1)
+        throw "Math.sign(42.5) = " + signPositiveDouble;
+
+    var signNegativeDouble = Math.sign(-42.5);
+    if (signNegativeDouble !== -1)
+        throw "Math.sign(-42.5) = " + signNegativeDouble;
+
+    var signIntMin = Math.sign(-2147483648);
+    if (signIntMin !== -1)
+        throw "Math.sign(-2147483648) = " + signIntMin;
+
+    var signInfinity = Math.sign(Infinity);
+    if (signInfinity !== 1)
+        throw "Math.sign(Infinity) = " + signInfinity;
+
+    var signNegativeInfinity = Math.sign(-Infinity);
+    if (signNegativeInfinity !== -1)
+        throw "Math.sign(-Infinity) = " + signNegativeInfinity;
+}
+noInline(testMathSignOnConstants);
+
+for (var i = 0; i < 1e4; ++i) {
+    testMathSignOnConstants();
+}
+
+// *** Type Coercion ***
+function mathSignStructTransition(value)
+{
+    return Math.sign(value);
+}
+noInline(mathSignStructTransition);
+
+function testMathSignOnStructTransition()
+{
+    var signObj1 = mathSignStructTransition({ valueOf: function() { return -1; } });
+    if (signObj1 !== -1)
+        throw "mathSignStructTransition({ valueOf: function() { return -1; } }) = " + signObj1;
+
+    var signObj2 = mathSignStructTransition({ a: "a", valueOf: function() { return 5; } });
+    if (signObj2 !== 1)
+        throw "mathSignStructTransition({ a: 'a', valueOf: function() { return 5; } }) = " + signObj2;
+
+    var signString = mathSignStructTransition("-3");
+    if (signString !== -1)
+        throw "mathSignStructTransition(\"-3\") = " + signString;
+
+    var signTrue = mathSignStructTransition(true);
+    if (signTrue !== 1)
+        throw "mathSignStructTransition(true) = " + signTrue;
+
+    var signFalse = mathSignStructTransition(false);
+    if (!Object.is(signFalse, 0))
+        throw "mathSignStructTransition(false) = " + signFalse;
+
+    var signNull = mathSignStructTransition(null);
+    if (!Object.is(signNull, 0))
+        throw "mathSignStructTransition(null) = " + signNull;
+
+    var signUndefined = mathSignStructTransition(undefined);
+    if (!isNaN(signUndefined))
+        throw "mathSignStructTransition(undefined) = " + signUndefined;
+}
+noInline(testMathSignOnStructTransition);
+
+for (var i = 0; i < 1e4; ++i) {
+    testMathSignOnStructTransition();
+}

--- a/JSTests/stress/math-sign-double-then-object.js
+++ b/JSTests/stress/math-sign-double-then-object.js
@@ -1,0 +1,36 @@
+// Tests OSR exit from the DoubleRepUse ArithSign path when an object sneaks in.
+
+function shouldBe(actual, expected, message) {
+    if (!Object.is(actual, expected))
+        throw new Error(message + ": expected " + expected + ", got " + actual);
+}
+
+function test(value) {
+    return Math.sign(value);
+}
+noInline(test);
+
+// Warm up with double inputs to lock in DoubleRepUse speculation.
+for (var i = 0; i < 1e5; ++i) {
+    shouldBe(test(1.5), 1, "test(1.5)");
+    shouldBe(test(-1.5), -1, "test(-1.5)");
+    shouldBe(test(0.0), 0, "test(0.0)");
+    shouldBe(test(-0.0), -0, "test(-0.0)");
+    shouldBe(test(NaN), NaN, "test(NaN)");
+}
+
+// Trigger OSR exit by passing an object with valueOf.
+let count = 0;
+shouldBe(test({ valueOf() { count++; return 7; } }), 1, "test(object)");
+shouldBe(count, 1, "valueOf called once");
+shouldBe(test({ valueOf() { count++; return -7; } }), -1, "test(neg object)");
+shouldBe(count, 2, "valueOf called twice");
+shouldBe(test("3"), 1, "test(string)");
+shouldBe(test(undefined), NaN, "test(undefined)");
+
+// Recompile and verify both paths still work.
+for (var i = 0; i < 1e5; ++i) {
+    shouldBe(test(0.25), 1, "test(0.25) recompiled");
+    shouldBe(test(-0.25), -1, "test(-0.25) recompiled");
+    shouldBe(test({ valueOf() { return -5; } }), -1, "test(object) recompiled");
+}

--- a/JSTests/stress/math-sign-int32-then-double.js
+++ b/JSTests/stress/math-sign-int32-then-double.js
@@ -1,0 +1,40 @@
+// Tests OSR exit from the Int32Use ArithSign path when a double sneaks in,
+// and verifies the result type stays consistent across recompilation.
+
+function shouldBe(actual, expected, message) {
+    if (!Object.is(actual, expected))
+        throw new Error(message + ": expected " + expected + " (" + (1/expected) + "), got " + actual + " (" + (1/actual) + ")");
+}
+
+function test(value) {
+    return Math.sign(value);
+}
+noInline(test);
+
+// Warm up with Int32 inputs to lock in Int32Use speculation.
+for (var i = 0; i < 1e5; ++i) {
+    shouldBe(test(1), 1, "test(1)");
+    shouldBe(test(-1), -1, "test(-1)");
+    shouldBe(test(0), 0, "test(0)");
+    shouldBe(test(2147483647), 1, "test(INT_MAX)");
+    shouldBe(test(-2147483648), -1, "test(INT_MIN)");
+}
+
+// Trigger OSR exit by passing doubles. Verify ±0 and NaN passthrough.
+shouldBe(test(0.5), 1, "test(0.5) after Int32 warmup");
+shouldBe(test(-0.5), -1, "test(-0.5) after Int32 warmup");
+shouldBe(test(-0.0), -0, "test(-0.0) after Int32 warmup");
+shouldBe(test(0.0), 0, "test(0.0) after Int32 warmup");
+shouldBe(test(NaN), NaN, "test(NaN) after Int32 warmup");
+shouldBe(test(Infinity), 1, "test(Infinity) after Int32 warmup");
+shouldBe(test(-Infinity), -1, "test(-Infinity) after Int32 warmup");
+
+// Recompile with mixed inputs, confirm both paths still work.
+for (var i = 0; i < 1e5; ++i) {
+    shouldBe(test(2.5), 1, "test(2.5) recompiled");
+    shouldBe(test(-2.5), -1, "test(-2.5) recompiled");
+    shouldBe(test(-0.0), -0, "test(-0.0) recompiled");
+    shouldBe(test(NaN), NaN, "test(NaN) recompiled");
+    shouldBe(test(3), 1, "test(3) recompiled");
+    shouldBe(test(-3), -1, "test(-3) recompiled");
+}

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -1485,6 +1485,35 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         break;
     }
 
+    case ArithSign: {
+        JSValue child = forNode(node->child1()).value();
+        switch (node->child1().useKind()) {
+        case Int32Use:
+            if (std::optional<double> number = child.toNumberFromPrimitive()) {
+                JSValue result = jsNumber(Math::sign(*number));
+                if (result.isInt32()) {
+                    setConstant(node, result);
+                    break;
+                }
+            }
+            setNonCellTypeForNode(node, SpecInt32Only);
+            break;
+        case DoubleRepUse:
+            if (std::optional<double> number = child.toNumberFromPrimitive()) {
+                setConstant(node, jsDoubleNumber(Math::sign(*number)));
+                break;
+            }
+            setNonCellTypeForNode(node, typeOfDoubleAbs(forNode(node->child1()).m_type));
+            break;
+        default:
+            DFG_ASSERT(m_graph, node, node->child1().useKind() == UntypedUse, node->child1().useKind());
+            clobberWorld();
+            setNonCellTypeForNode(node, SpecBytecodeNumber);
+            break;
+        }
+        break;
+    }
+
     case ArithPow: {
         JSValue childY = forNode(node->child2()).value();
         if (childY && childY.isNumber()) {

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -2593,6 +2593,19 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             return CallOptimizationResult::Inlined;
         }
 
+        case SignIntrinsic: {
+            if (argumentCountIncludingThis == 1) {
+                // Math.sign()
+                insertChecks();
+                setResult(addToGraph(JSConstant, OpInfo(m_constantNaN)));
+                return CallOptimizationResult::Inlined;
+            }
+
+            insertChecks();
+            setResult(addToGraph(ArithSign, get(virtualRegisterForArgumentIncludingThis(1, registerOffset))));
+            return CallOptimizationResult::Inlined;
+        }
+
         case MinIntrinsic:
         case MaxIntrinsic:
             handleMinMax(resultOperand, intrinsic == MinIntrinsic ? ArithMin : ArithMax, registerOffset, argumentCountIncludingThis, insertChecks);

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -340,6 +340,13 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
             clobberTop();
         return;
 
+    case ArithSign:
+        if (node->child1().useKind() == Int32Use || node->child1().useKind() == DoubleRepUse)
+            def(PureValue(node));
+        else
+            clobberTop();
+        return;
+
     case ArithClz32:
         if (node->child1().useKind() == Int32Use || node->child1().useKind() == KnownInt32Use)
             def(PureValue(node));

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -86,6 +86,7 @@ bool doesGC(Graph& graph, Node* node)
     case ArithNegate:
     case ArithIMul:
     case ArithAbs:
+    case ArithSign:
     case ArithMin:
     case ArithMax:
     case ArithPow:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -856,6 +856,24 @@ private:
             break;
         }
 
+        case ArithSign: {
+            if (node->child1()->shouldSpeculateInt32OrBoolean()
+                && node->canSpeculateInt32(FixupPass)) {
+                fixIntOrBooleanEdge(node->child1());
+                node->clearFlags(NodeMustGenerate);
+                node->setResult(NodeResultInt32);
+                break;
+            }
+
+            if (node->child1()->shouldSpeculateNotCellNorBigInt()) {
+                fixDoubleOrBooleanEdge(node->child1());
+                node->clearFlags(NodeMustGenerate);
+            } else
+                fixEdge<UntypedUse>(node->child1());
+            node->setResult(NodeResultDouble);
+            break;
+        }
+
         case ValuePow: {
             if (m_graph.binaryArithShouldSpeculateHeapBigInt(node)) {
                 fixEdge<HeapBigIntUse>(node->child1());

--- a/Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp
@@ -1567,7 +1567,17 @@ private:
                 setRelationship(Relationship(node, m_zero, Relationship::GreaterThan, -1));
             break;
         }
-            
+
+        case ArithSign: {
+            if (node->child1().useKind() != Int32Use)
+                break;
+
+            // ArithSign returns -1, 0, or 1 for Int32 inputs.
+            setRelationship(Relationship(node, m_zero, Relationship::GreaterThan, -2));
+            setRelationship(Relationship(node, m_zero, Relationship::LessThan, 2));
+            break;
+        }
+
         case ArithAdd: {
             // We're only interested in int32 additions and we currently only know how to
             // handle the non-wrapping ones.

--- a/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
@@ -914,6 +914,7 @@ bool LoopUnrollingPhase::LoopData::isNumericComputationNode(Node* node)
     case ArithDiv:
     case ArithMod:
     case ArithAbs:
+    case ArithSign:
     case ArithMin:
     case ArithMax:
     case ArithFRound:

--- a/Source/JavaScriptCore/dfg/DFGMayExit.cpp
+++ b/Source/JavaScriptCore/dfg/DFGMayExit.cpp
@@ -251,6 +251,13 @@ ExitMode mayExitImpl(Graph& graph, Node* node, StateType& state)
             break;
         return Exits;
 
+    case ArithSign:
+        if (isInt32(node->child1().useKind()))
+            break;
+        if (node->child1().useKind() == DoubleRepUse)
+            break;
+        return Exits;
+
     case ArithMin:
     case ArithMax:
         if (isInt32(graph.child(node, 0).useKind()))

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -169,6 +169,7 @@ namespace JSC { namespace DFG {
     macro(ArithDiv, NodeResultNumber | NodeMustGenerate) \
     macro(ArithMod, NodeResultNumber | NodeMustGenerate) \
     macro(ArithAbs, NodeResultNumber | NodeMustGenerate) \
+    macro(ArithSign, NodeResultNumber | NodeMustGenerate) \
     macro(ArithMin, NodeResultNumber | NodeHasVarArgs) \
     macro(ArithMax, NodeResultNumber | NodeHasVarArgs) \
     macro(ArithFRound, NodeResultDouble | NodeMustGenerate) \

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -693,6 +693,19 @@ JSC_DEFINE_JIT_OPERATION(operationArithAbs, double, (JSGlobalObject* globalObjec
     OPERATION_RETURN(scope, std::abs(a));
 }
 
+JSC_DEFINE_JIT_OPERATION(operationArithSign, double, (JSGlobalObject* globalObject, EncodedJSValue encodedOp1))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue op1 = JSValue::decode(encodedOp1);
+    double a = op1.toNumber(globalObject);
+    OPERATION_RETURN_IF_EXCEPTION(scope, PNaN);
+    OPERATION_RETURN(scope, Math::sign(a));
+}
+
 JSC_DEFINE_JIT_OPERATION(operationArithClz32, UCPUStrictInt32, (JSGlobalObject* globalObject, EncodedJSValue encodedOp1))
 {
     VM& vm = globalObject->vm();

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -100,6 +100,7 @@ JSC_DECLARE_JIT_OPERATION(operationValuePow, EncodedJSValue, (JSGlobalObject*, E
 JSC_DECLARE_JIT_OPERATION(operationInc, EncodedJSValue, (JSGlobalObject*, EncodedJSValue encodedOp1));
 JSC_DECLARE_JIT_OPERATION(operationDec, EncodedJSValue, (JSGlobalObject*, EncodedJSValue encodedOp1));
 JSC_DECLARE_JIT_OPERATION(operationArithAbs, double, (JSGlobalObject*, EncodedJSValue encodedOp1));
+JSC_DECLARE_JIT_OPERATION(operationArithSign, double, (JSGlobalObject*, EncodedJSValue encodedOp1));
 JSC_DECLARE_JIT_OPERATION(operationArithClz32, UCPUStrictInt32, (JSGlobalObject*, EncodedJSValue encodedOp1));
 JSC_DECLARE_JIT_OPERATION(operationArithFRound, double, (JSGlobalObject*, EncodedJSValue encodedOp1));
 JSC_DECLARE_JIT_OPERATION(operationArithF16Round, double, (JSGlobalObject*, EncodedJSValue encodedOp1));

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -563,7 +563,8 @@ private:
             break;
         }
 
-        case ArithAbs: {
+        case ArithAbs:
+        case ArithSign: {
             SpeculatedType childPrediction = node->child1()->prediction();
             if (isInt32OrBooleanSpeculation(childPrediction)
                 && node->canSpeculateInt32(m_pass))
@@ -890,13 +891,14 @@ private:
         }
 
         case ArithAbs:
+        case ArithSign:
             DoubleBallot ballot;
             if (node->child1()->shouldSpeculateNumber()
                 && !m_graph.unaryArithShouldSpeculateInt32(node, m_pass))
                 ballot = VoteDouble;
             else
                 ballot = VoteValue;
-                
+
             m_graph.voteNode(node->child1(), ballot, weight);
             break;
                 
@@ -1639,6 +1641,7 @@ private:
         case ArithDiv:
         case ArithMod:
         case ArithAbs:
+        case ArithSign:
         case GetByVal:
         case MultiGetByVal:
         case ToThis:

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -220,6 +220,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case ArithDiv:
     case ArithMod:
     case ArithAbs:
+    case ArithSign:
     case ArithMin:
     case ArithMax:
     case ArithPow:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -5399,6 +5399,61 @@ void SpeculativeJIT::compileArithAbs(Node* node)
     }
 }
 
+void SpeculativeJIT::compileArithSign(Node* node)
+{
+    switch (node->child1().useKind()) {
+    case Int32Use: {
+        SpeculateInt32Operand op1(this, node->child1());
+        GPRTemporary result(this, Reuse, op1);
+        GPRTemporary scratch(this);
+
+        GPRReg op1GPR = op1.gpr();
+        GPRReg resultGPR = result.gpr();
+        GPRReg scratchGPR = scratch.gpr();
+
+        rshift32(op1GPR, TrustedImm32(31), scratchGPR);
+        neg32(op1GPR, resultGPR);
+        urshift32(TrustedImm32(31), resultGPR);
+        or32(scratchGPR, resultGPR);
+        strictInt32Result(resultGPR, node);
+        break;
+    }
+
+    case DoubleRepUse: {
+        SpeculateDoubleOperand op1(this, node->child1());
+        FPRTemporary result(this);
+        FPRTemporary scratch(this);
+        FPRTemporary zero(this);
+
+        FPRReg op1FPR = op1.fpr();
+        FPRReg resultFPR = result.fpr();
+        FPRReg scratchFPR = scratch.fpr();
+        FPRReg zeroFPR = zero.fpr();
+
+        // moveDoubleConditionallyDoubleWithZero is not available on x86_64, so we materialize zero instead.
+        moveZeroToDouble(zeroFPR);
+        move64ToDouble(TrustedImm64(std::bit_cast<uint64_t>(1.0)), scratchFPR);
+        moveDoubleConditionallyDouble(DoubleGreaterThanAndOrdered, op1FPR, zeroFPR, scratchFPR, op1FPR, resultFPR);
+        move64ToDouble(TrustedImm64(std::bit_cast<uint64_t>(-1.0)), scratchFPR);
+        moveDoubleConditionallyDouble(DoubleLessThanAndOrdered, op1FPR, zeroFPR, scratchFPR, resultFPR, resultFPR);
+
+        doubleResult(resultFPR, node);
+        break;
+    }
+
+    default: {
+        DFG_ASSERT(m_graph, node, node->child1().useKind() == UntypedUse, node->child1().useKind());
+        JSValueOperand op1(this, node->child1());
+        JSValueRegs op1Regs = op1.jsValueRegs();
+        flushRegisters();
+        FPRResult result(this);
+        callOperation(operationArithSign, result.fpr(), LinkableConstant::globalObject(*this, node), op1Regs);
+        doubleResult(result.fpr(), node);
+        break;
+    }
+    }
+}
+
 void SpeculativeJIT::compileArithClz32(Node* node)
 {
     if (node->child1().useKind() == Int32Use || node->child1().useKind() == KnownInt32Use) {

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1601,6 +1601,7 @@ public:
     void compileMakeRope(Node*);
     void compileMakeAtomString(Node*);
     void compileArithAbs(Node*);
+    void compileArithSign(Node*);
     void compileArithClz32(Node*);
     void compileArithSub(Node*);
     void compileIncOrDec(Node*);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -2486,6 +2486,10 @@ void SpeculativeJIT::compile(Node* node)
         compileArithAbs(node);
         break;
 
+    case ArithSign:
+        compileArithSign(node);
+        break;
+
     case ArithMin:
     case ArithMax: {
         compileArithMinMax(node);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -3665,7 +3665,11 @@ void SpeculativeJIT::compile(Node* node)
     case ArithAbs:
         compileArithAbs(node);
         break;
-        
+
+    case ArithSign:
+        compileArithSign(node);
+        break;
+
     case ArithMin:
     case ArithMax: {
         compileArithMinMax(node);

--- a/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp
@@ -130,6 +130,7 @@ private:
         case ArithTrunc:
         case ArithSqrt:
         case ArithAbs:
+        case ArithSign:
         case ArithNegate:
         case ArithUnary: {
             if (foldPurifyNaNOnUnary(m_node))

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -120,6 +120,7 @@ inline CapabilityLevel canCompile(DFG::Node* node)
     case ArithMin:
     case ArithMax:
     case ArithAbs:
+    case ArithSign:
     case ArithPow:
     case ArithRandom:
     case ArithRound:

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -866,6 +866,9 @@ private:
         case ArithAbs:
             compileArithAbs();
             break;
+        case ArithSign:
+            compileArithSign();
+            break;
         case ValuePow:
             compileValuePow();
             break;
@@ -3538,6 +3541,39 @@ private:
             DFG_ASSERT(m_graph, m_node, m_node->child1().useKind() == UntypedUse, m_node->child1().useKind());
             LValue argument = lowJSValue(m_node->child1());
             LValue result = vmCall(Double, operationArithAbs, weakPointer(globalObject), argument);
+            setDouble(result);
+            break;
+        }
+        }
+    }
+
+    void compileArithSign()
+    {
+        JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
+        switch (m_node->child1().useKind()) {
+        case Int32Use: {
+            LValue value = lowInt32(m_node->child1());
+
+            LValue mask = m_out.aShr(value, m_out.constInt32(31));
+            LValue bit = m_out.lShr(m_out.neg(value), m_out.constInt32(31));
+            setInt32(m_out.bitOr(mask, bit));
+            break;
+        }
+
+        case DoubleRepUse: {
+            LValue value = lowDouble(m_node->child1());
+            LValue zero = m_out.constDouble(0.0);
+            LValue isPositive = m_out.doubleGreaterThan(value, zero);
+            LValue isNegative = m_out.doubleLessThan(value, zero);
+            LValue result = m_out.select(isPositive, m_out.constDouble(1.0), m_out.select(isNegative, m_out.constDouble(-1.0), value));
+            setDouble(result);
+            break;
+        }
+
+        default: {
+            DFG_ASSERT(m_graph, m_node, m_node->child1().useKind() == UntypedUse, m_node->child1().useKind());
+            LValue argument = lowJSValue(m_node->child1());
+            LValue result = vmCall(Double, operationArithSign, weakPointer(globalObject), argument);
             setDouble(result);
             break;
         }

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -43,6 +43,7 @@ namespace JSC {
     macro(ATanhIntrinsic) \
     macro(MinIntrinsic) \
     macro(MaxIntrinsic) \
+    macro(SignIntrinsic) \
     macro(SqrtIntrinsic) \
     macro(SinIntrinsic) \
     macro(CbrtIntrinsic) \

--- a/Source/JavaScriptCore/runtime/MathCommon.h
+++ b/Source/JavaScriptCore/runtime/MathCommon.h
@@ -335,6 +335,15 @@ ALWAYS_INLINE double jsMinDouble(double lhs, double rhs)
 #endif
 }
 
+ALWAYS_INLINE double sign(double value)
+{
+    if (value > 0)
+        return 1;
+    if (value < 0)
+        return -1;
+    return value; // NaN, +0.0, -0.0
+}
+
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(truncDouble, double, (double));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(truncFloat, float, (float));
 JSC_DECLARE_NOEXCEPT_JIT_OPERATION(ceilDouble, double, (double));

--- a/Source/JavaScriptCore/runtime/MathObject.cpp
+++ b/Source/JavaScriptCore/runtime/MathObject.cpp
@@ -117,7 +117,7 @@ void MathObject::finishCreation(VM& vm, JSGlobalObject* globalObject)
     putDirectNativeFunctionWithoutTransition(vm, globalObject, Identifier::fromString(vm, "pow"_s), 2, mathProtoFuncPow, ImplementationVisibility::Public, PowIntrinsic, static_cast<unsigned>(PropertyAttribute::DontEnum));
     putDirectNativeFunctionWithoutTransition(vm, globalObject, Identifier::fromString(vm, "random"_s), 0, mathProtoFuncRandom, ImplementationVisibility::Public, RandomIntrinsic, static_cast<unsigned>(PropertyAttribute::DontEnum));
     putDirectNativeFunctionWithoutTransition(vm, globalObject, Identifier::fromString(vm, "round"_s), 1, mathProtoFuncRound, ImplementationVisibility::Public, RoundIntrinsic, static_cast<unsigned>(PropertyAttribute::DontEnum));
-    putDirectNativeFunctionWithoutTransition(vm, globalObject, Identifier::fromString(vm, "sign"_s), 1, mathProtoFuncSign, ImplementationVisibility::Public, NoIntrinsic, static_cast<unsigned>(PropertyAttribute::DontEnum));
+    putDirectNativeFunctionWithoutTransition(vm, globalObject, Identifier::fromString(vm, "sign"_s), 1, mathProtoFuncSign, ImplementationVisibility::Public, SignIntrinsic, static_cast<unsigned>(PropertyAttribute::DontEnum));
     putDirectNativeFunctionWithoutTransition(vm, globalObject, Identifier::fromString(vm, "sin"_s), 1, mathProtoFuncSin, ImplementationVisibility::Public, SinIntrinsic, static_cast<unsigned>(PropertyAttribute::DontEnum));
     putDirectNativeFunctionWithoutTransition(vm, globalObject, Identifier::fromString(vm, "sinh"_s), 1, mathProtoFuncSinh, ImplementationVisibility::Public, SinhIntrinsic, static_cast<unsigned>(PropertyAttribute::DontEnum));
     putDirectNativeFunctionWithoutTransition(vm, globalObject, Identifier::fromString(vm, "sqrt"_s), 1, mathProtoFuncSqrt, ImplementationVisibility::Public, SqrtIntrinsic, static_cast<unsigned>(PropertyAttribute::DontEnum));
@@ -345,12 +345,7 @@ JSC_DEFINE_HOST_FUNCTION(mathProtoFuncRound, (JSGlobalObject* globalObject, Call
 
 JSC_DEFINE_HOST_FUNCTION(mathProtoFuncSign, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
-    double arg = callFrame->argument(0).toNumber(globalObject);
-    if (std::isnan(arg))
-        return JSValue::encode(jsNaN());
-    if (!arg)
-        return JSValue::encode(std::signbit(arg) ? jsNumber(-0.0) : jsNumber(0));
-    return JSValue::encode(jsNumber(std::signbit(arg) ? -1 : 1));
+    return JSValue::encode(jsNumber(Math::sign(callFrame->argument(0).toNumber(globalObject))));
 }
 
 JSC_DEFINE_HOST_FUNCTION(mathProtoFuncSin, (JSGlobalObject* globalObject, CallFrame* callFrame))


### PR DESCRIPTION
#### bd332901dbe6256a27465791c7a123306df462a4
<pre>
[JSC] Add `ArithSign` DFG node
<a href="https://bugs.webkit.org/show_bug.cgi?id=315071">https://bugs.webkit.org/show_bug.cgi?id=315071</a>

Reviewed by NOBODY (OOPS!).

Math.sign is currently a host function call with no intrinsic. This
patch introduces SignIntrinsic and an ArithSign DFG node so the
computation can be inlined in DFG and FTL, mirroring ArithAbs.

For Int32Use, the result is `(x &gt;&gt; 31) | ((-x) &gt;&gt;&gt; 31)`, which evaluates
to -1, 0, or 1 with no overflow check; FTL lowers this to three ARM64
instructions. For DoubleRepUse, the result is two selects that return the
input itself when neither comparison is true, preserving NaN, +0.0, and
-0.0 per spec steps 2-4. UntypedUse calls a slow path.

Tests: JSTests/microbenchmarks/math-sign-double.js
       JSTests/microbenchmarks/math-sign-int32.js
       JSTests/stress/math-sign-basics.js
       JSTests/stress/math-sign-double-then-object.js
       JSTests/stress/math-sign-int32-then-double.js

* JSTests/microbenchmarks/math-sign-double.js: Added.
(benchDouble):
* JSTests/microbenchmarks/math-sign-int32.js: Added.
(benchInt):
* JSTests/stress/math-sign-basics.js: Added.
(mathSignOnInteger):
(testMathSignOnIntegers):
(verifySignWithObject.signObject.mathSignOnInteger):
(verifySignWithObject.signNegObject.mathSignOnInteger):
(verifySignWithObject):
(mathSignOnDouble):
(testMathSignOnDoubles):
(mathSignNoArguments):
(mathSignTooManyArguments):
(testMathSignOnConstants):
(mathSignStructTransition):
(testMathSignOnStructTransition.signObj1.mathSignStructTransition):
(testMathSignOnStructTransition.signObj2.mathSignStructTransition):
(testMathSignOnStructTransition):
* JSTests/stress/math-sign-double-then-object.js: Added.
(shouldBe):
(test):
(shouldBe.test.valueOf):
(i.shouldBe.test.valueOf):
* JSTests/stress/math-sign-int32-then-double.js: Added.
(shouldBe):
(test):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGIntegerRangeOptimizationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp:
(JSC::DFG::LoopUnrollingPhase::LoopData::isNumericComputationNode):
* Source/JavaScriptCore/dfg/DFGMayExit.cpp:
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGStrengthReductionPhase.cpp:
(JSC::DFG::StrengthReductionPhase::handleNode):
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileArithAbs):
(JSC::FTL::DFG::LowerDFGToB3::compileArithSign):
* Source/JavaScriptCore/runtime/Intrinsic.h:
* Source/JavaScriptCore/runtime/MathCommon.h:
(JSC::Math::sign):
* Source/JavaScriptCore/runtime/MathObject.cpp:
(JSC::MathObject::finishCreation):
(JSC::JSC_DEFINE_HOST_FUNCTION):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd332901dbe6256a27465791c7a123306df462a4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165628 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39118 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32699 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174670 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122883 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39454 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39122 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128715 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90639 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168587 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31046 "Found 2 new test failures: fast/events/touch/ios/touch-event-regions-layer-tree/mousemove-mouseup.html fast/forms/ios/drag-range-track.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148803 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109239 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30083 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-images/gradients-with-border.html imported/w3c/web-platform-tests/css/css-images/multiple-position-color-stop-linear.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28717 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22750 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157785 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139976 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26501 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177194 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26521 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30106 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28207 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137040 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39187 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32861 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136973 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39875 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148297 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102365 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32256 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25164 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/198870 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38386 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111459 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53414 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37782 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3245 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38028 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37926 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->