### PR TITLE
backListCount()/forwardListCount() don't match the sizes of the backList() and forwardList() arrays

### DIFF
--- a/Source/WebKit/UIProcess/API/C/WKBackForwardListRef.cpp
+++ b/Source/WebKit/UIProcess/API/C/WKBackForwardListRef.cpp
@@ -65,12 +65,14 @@ void WKBackForwardListClear(WKBackForwardListRef listRef)
 
 unsigned WKBackForwardListGetBackListCount(WKBackForwardListRef listRef)
 {
-    return toImpl(listRef)->backListCount();
+    RefPtr impl = toImpl(listRef);
+    return impl->backListCountForAPI();
 }
 
 unsigned WKBackForwardListGetForwardListCount(WKBackForwardListRef listRef)
 {
-    return toImpl(listRef)->forwardListCount();
+    RefPtr impl = toImpl(listRef);
+    return impl->forwardListCountForAPI();
 }
 
 WKArrayRef WKBackForwardListCopyBackListWithLimit(WKBackForwardListRef listRef, unsigned limit)

--- a/Source/WebKit/UIProcess/API/glib/WebKitBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitBackForwardList.cpp
@@ -229,7 +229,7 @@ guint webkit_back_forward_list_get_length(WebKitBackForwardList* backForwardList
 
     WebKitBackForwardListPrivate* priv = backForwardList->priv;
     guint currentItem = webkit_back_forward_list_get_current_item(backForwardList) ? 1 : 0;
-    return priv->backForwardItems->backListCount() + priv->backForwardItems->forwardListCount() + currentItem;
+    return priv->backForwardItems->backListCountForAPI() + priv->backForwardItems->forwardListCountForAPI() + currentItem;
 }
 
 /**
@@ -245,7 +245,7 @@ GList* webkit_back_forward_list_get_back_list(WebKitBackForwardList* backForward
 {
     g_return_val_if_fail(WEBKIT_IS_BACK_FORWARD_LIST(backForwardList), 0);
 
-    return webkit_back_forward_list_get_back_list_with_limit(backForwardList, backForwardList->priv->backForwardItems->backListCount());
+    return webkit_back_forward_list_get_back_list_with_limit(backForwardList, backForwardList->priv->backForwardItems->backListCountForAPI());
 }
 
 /**
@@ -280,7 +280,7 @@ GList* webkit_back_forward_list_get_forward_list(WebKitBackForwardList* backForw
 {
     g_return_val_if_fail(WEBKIT_IS_BACK_FORWARD_LIST(backForwardList), 0);
 
-    return webkit_back_forward_list_get_forward_list_with_limit(backForwardList, backForwardList->priv->backForwardItems->forwardListCount());
+    return webkit_back_forward_list_get_forward_list_with_limit(backForwardList, backForwardList->priv->backForwardItems->forwardListCountForAPI());
 }
 
 /**

--- a/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
+++ b/Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp
@@ -941,12 +941,12 @@ void WebAutomationSession::traverseHistoryInBrowsingContext(const Inspector::Pro
 
 #if ENABLE(BACK_FORWARD_LIST_SWIFT)
     WebBackForwardListWrapper& backForwardList = page->backForwardListWrapper();
-    unsigned backCount = backForwardList.backListCount();
-    unsigned forwardCount = backForwardList.forwardListCount();
+    unsigned backCount = backForwardList.backListCountForAPI();
+    unsigned forwardCount = backForwardList.forwardListCountForAPI();
 #else
     Ref backForwardList = page->backForwardListWrapper();
-    unsigned backCount = backForwardList->backListCount();
-    unsigned forwardCount = backForwardList->forwardListCount();
+    unsigned backCount = backForwardList->backListCountForAPI();
+    unsigned forwardCount = backForwardList->forwardListCountForAPI();
 #endif
     int currentIndex = static_cast<int>(backCount);
     int targetIndex = currentIndex + delta;

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -333,46 +333,82 @@ std::pair<RefPtr<WebBackForwardListItem>, size_t> WebBackForwardList::itemAtInde
     return { { m_entries[index] }, index };
 }
 
-unsigned WebBackForwardList::backListCount() const
+unsigned WebBackForwardList::rawBackListEntryCount() const
 {
     ASSERT(!m_currentIndex || *m_currentIndex < m_entries.size());
 
     return m_page && m_currentIndex ? *m_currentIndex : 0;
 }
 
-unsigned WebBackForwardList::forwardListCount() const
+unsigned WebBackForwardList::rawForwardListEntryCount() const
 {
     ASSERT(!m_currentIndex || *m_currentIndex < m_entries.size());
 
     return m_page && m_currentIndex ? m_entries.size() - (*m_currentIndex + 1) : 0;
 }
 
-WebBackForwardListCounts WebBackForwardList::counts() const
+unsigned WebBackForwardList::backListCountForAPI() const
 {
-    return WebBackForwardListCounts { backListCount(), forwardListCount() };
+    auto listInfo = backListWithLimitInternal(rawBackListEntryCount(), MakeAPIArray::No);
+    return listInfo.first;
+}
+
+unsigned WebBackForwardList::forwardListCountForAPI() const
+{
+    auto listInfo = forwardListWithLimitInternal(rawForwardListEntryCount(), MakeAPIArray::No);
+    return listInfo.first;
+}
+
+WebBackForwardListCounts WebBackForwardList::rawCounts() const
+{
+    return WebBackForwardListCounts { rawBackListEntryCount(), rawForwardListEntryCount() };
 }
 
 Ref<API::Array> WebBackForwardList::backList() const
 {
-    return backListAsAPIArrayWithLimit(backListCount());
+    return backListAsAPIArrayWithLimit(rawBackListEntryCount());
 }
 
 Ref<API::Array> WebBackForwardList::forwardList() const
 {
-    return forwardListAsAPIArrayWithLimit(forwardListCount());
+    return forwardListAsAPIArrayWithLimit(rawForwardListEntryCount());
 }
 
 Ref<API::Array> WebBackForwardList::backListAsAPIArrayWithLimit(unsigned limit) const
 {
+    auto listInfo = backListWithLimitInternal(limit, MakeAPIArray::Yes);
+    RELEASE_ASSERT(listInfo.second);
+    return listInfo.second.releaseNonNull();
+}
+
+Ref<API::Array> WebBackForwardList::forwardListAsAPIArrayWithLimit(unsigned limit) const
+{
+    auto listInfo = forwardListWithLimitInternal(limit, MakeAPIArray::Yes);
+    RELEASE_ASSERT(listInfo.second);
+    return listInfo.second.releaseNonNull();
+}
+
+static std::pair<unsigned, RefPtr<API::Array>> makeListPairResult(Vector<RefPtr<API::Object>>&& vector, WebBackForwardList::MakeAPIArray makeAPIArray)
+{
+    std::pair<unsigned, RefPtr<API::Array>> result;
+    result.first = vector.size();
+    if (makeAPIArray == WebBackForwardList::MakeAPIArray::Yes)
+        result.second = vector.size() ? API::Array::create(WTF::move(vector)) : API::Array::create();
+
+    return result;
+}
+
+std::pair<unsigned, RefPtr<API::Array>> WebBackForwardList::backListWithLimitInternal(unsigned limit, MakeAPIArray makeAPIArray) const
+{
     ASSERT(!m_currentIndex || *m_currentIndex < m_entries.size());
 
     if (!m_page || !m_currentIndex)
-        return API::Array::create();
+        return makeListPairResult({ }, makeAPIArray);
 
-    unsigned backListSize = static_cast<unsigned>(backListCount());
+    unsigned backListSize = rawBackListEntryCount();
     unsigned size = std::min(backListSize, limit);
     if (!size)
-        return API::Array::create();
+        return makeListPairResult({ }, makeAPIArray);
 
     ASSERT(backListSize >= size);
 
@@ -380,18 +416,18 @@ Ref<API::Array> WebBackForwardList::backListAsAPIArrayWithLimit(unsigned limit) 
         Vector<RefPtr<API::Object>> vector;
 
         size_t nextStartingIndex = *m_currentIndex;
-        while (backListSize) {
+        while (size) {
             auto item = itemStartingAtIndexSkippingItemsAddedByJSWithoutUserGesture(NavigationDirection::Backward, nextStartingIndex);
             if (item.first)
                 vector.append(item.first);
 
-            if (!item.first || !--backListSize || !item.second)
+            if (!item.first || !--size || !item.second)
                 break;
             nextStartingIndex = item.second;
         }
         vector.reverse();
 
-        return API::Array::create(WTF::move(vector));
+        return makeListPairResult(WTF::move(vector), makeAPIArray);
     }
 
     size_t startIndex = backListSize - size;
@@ -401,19 +437,19 @@ Ref<API::Array> WebBackForwardList::backListAsAPIArrayWithLimit(unsigned limit) 
         SUPPRESS_UNCOUNTED_LAMBDA_CAPTURE return m_entries[startIndex + i].ptr();
     });
 
-    return API::Array::create(WTF::move(vector));
+    return makeListPairResult(WTF::move(vector), makeAPIArray);
 }
 
-Ref<API::Array> WebBackForwardList::forwardListAsAPIArrayWithLimit(unsigned limit) const
+std::pair<unsigned, RefPtr<API::Array>> WebBackForwardList::forwardListWithLimitInternal(unsigned limit, MakeAPIArray makeAPIArray) const
 {
     ASSERT(!m_currentIndex || *m_currentIndex < m_entries.size());
 
     if (!m_page || !m_currentIndex)
-        return API::Array::create();
+        return makeListPairResult({ }, makeAPIArray);
 
-    unsigned size = std::min(static_cast<unsigned>(forwardListCount()), limit);
+    unsigned size = std::min(rawForwardListEntryCount(), limit);
     if (!size)
-        return API::Array::create();
+        return makeListPairResult({ }, makeAPIArray);
 
     if (shouldSkipItemsWithoutUserGestureForWebKitAPI()) {
         Vector<RefPtr<API::Object>> vector;
@@ -429,7 +465,7 @@ Ref<API::Array> WebBackForwardList::forwardListAsAPIArrayWithLimit(unsigned limi
             nextStartingIndex = item.second;
         }
 
-        return API::Array::create(WTF::move(vector));
+        return makeListPairResult(WTF::move(vector), makeAPIArray);
     }
 
     size_t startIndex = *m_currentIndex + 1;
@@ -437,7 +473,7 @@ Ref<API::Array> WebBackForwardList::forwardListAsAPIArrayWithLimit(unsigned limi
         return m_entries[startIndex + i].ptr();
     });
 
-    return API::Array::create(WTF::move(vector));
+    return makeListPairResult(WTF::move(vector), makeAPIArray);
 }
 
 void WebBackForwardList::removeAllItems()
@@ -816,7 +852,7 @@ void WebBackForwardList::backForwardGoToItem(BackForwardItemIdentifier itemID, C
     // Any real new load in the committed process would have cleared m_provisionalPage.
     if (RefPtr webPageProxy = m_page.get()) {
         if (webPageProxy->hasProvisionalPage())
-            return completionHandler(counts());
+            return completionHandler(rawCounts());
     }
 
     backForwardGoToItemShared(itemID, WTF::move(completionHandler));
@@ -830,14 +866,14 @@ void WebBackForwardList::backForwardListContainsItem(WebCore::BackForwardItemIde
 void WebBackForwardList::backForwardGoToItemShared(BackForwardItemIdentifier itemID, CompletionHandler<void(const WebBackForwardListCounts&)>&& completionHandler)
 {
     if (RefPtr webPageProxy = m_page.get())
-        MESSAGE_CHECK_COMPLETION(Ref { webPageProxy->legacyMainFrameProcess() }, !WebKit::isInspectorPage(*webPageProxy), completionHandler(counts()));
+        MESSAGE_CHECK_COMPLETION(Ref { webPageProxy->legacyMainFrameProcess() }, !WebKit::isInspectorPage(*webPageProxy), completionHandler(rawCounts()));
 
     RefPtr item = itemForID(itemID);
     if (!item)
-        return completionHandler(counts());
+        return completionHandler(rawCounts());
 
     goToItem(*item);
-    completionHandler(counts());
+    completionHandler(rawCounts());
 }
 
 void WebBackForwardList::backForwardAllItems(FrameIdentifier frameID, CompletionHandler<void(Vector<Ref<FrameState>>&&)>&& completionHandler)
@@ -864,7 +900,7 @@ void WebBackForwardList::backForwardItemAtIndexForWebContent(int32_t delta, Fram
 
 void WebBackForwardList::backForwardListCounts(CompletionHandler<void(WebBackForwardListCounts&&)>&& completionHandler)
 {
-    completionHandler(counts());
+    completionHandler(rawCounts());
 }
 
 FrameState* WebBackForwardList::findFrameStateInItem(WebCore::BackForwardItemIdentifier itemID, WebCore::FrameIdentifier parentFrameID, uint64_t childFrameIndex)
@@ -936,24 +972,24 @@ RefPtr<WebBackForwardListItem> WebBackForwardListWrapper::itemAtDeltaFromCurrent
     return m_impl->itemAtDeltaFromCurrentIndex(index, allowSkipping == AllowSkippingBackForwardItems::Yes ? true : false);
 }
 
-unsigned WebBackForwardListWrapper::backListCount() const
+unsigned WebBackForwardListWrapper::backListCountForAPI() const
 {
-    return m_impl->backListCount();
+    return m_impl->backListCountForAPI();
 }
 
-unsigned WebBackForwardListWrapper::forwardListCount() const
+unsigned WebBackForwardListWrapper::forwardListCountForAPI() const
 {
-    return m_impl->forwardListCount();
+    return m_impl->forwardListCountForAPI();
 }
 
 Ref<API::Array> WebBackForwardListWrapper::backList() const
 {
-    return backListAsAPIArrayWithLimit(backListCount());
+    return backListAsAPIArrayWithLimit(backListCountForAPI());
 }
 
 Ref<API::Array> WebBackForwardListWrapper::forwardList() const
 {
-    return forwardListAsAPIArrayWithLimit(forwardListCount());
+    return forwardListAsAPIArrayWithLimit(forwardListCountForAPI());
 }
 
 Ref<API::Array> WebBackForwardListWrapper::backListAsAPIArrayWithLimit(unsigned limit) const

--- a/Source/WebKit/UIProcess/WebBackForwardList.h
+++ b/Source/WebKit/UIProcess/WebBackForwardList.h
@@ -80,8 +80,8 @@ public:
 
     RefPtr<WebBackForwardListItem> goBackItemSkippingItemsWithoutUserGesture() const;
     RefPtr<WebBackForwardListItem> goForwardItemSkippingItemsWithoutUserGesture() const;
-    unsigned NODELETE backListCount() const;
-    unsigned NODELETE forwardListCount() const;
+    unsigned backListCountForAPI() const;
+    unsigned forwardListCountForAPI() const;
 
     Ref<API::Array> backList() const;
     Ref<API::Array> forwardList() const;
@@ -106,6 +106,8 @@ public:
 
     String loggingString() const;
 
+    enum class MakeAPIArray : bool { No, Yes };
+
 private:
     explicit WebBackForwardList(WebPageProxy&);
 
@@ -113,11 +115,17 @@ private:
     std::pair<RefPtr<WebBackForwardListItem>, size_t> itemStartingAtIndexSkippingItemsAddedByJSWithoutUserGesture(NavigationDirection, size_t startingIndex) const;
     std::pair<RefPtr<WebBackForwardListItem>, size_t> itemAtIndexWithoutSkipping(size_t) const;
 
+    std::pair<unsigned, RefPtr<API::Array>> backListWithLimitInternal(unsigned limit, MakeAPIArray) const;
+    std::pair<unsigned, RefPtr<API::Array>> forwardListWithLimitInternal(unsigned limit, MakeAPIArray) const;
+
+    unsigned NODELETE rawBackListEntryCount() const;
+    unsigned NODELETE rawForwardListEntryCount() const;
+
     void addItem(Ref<WebBackForwardListItem>&&);
     void addChildItem(WebCore::FrameIdentifier, Ref<FrameState>&&);
     void didRemoveItem(WebBackForwardListItem&);
     const BackForwardListItemVector& entries() const LIFETIME_BOUND { return m_entries; }
-    WebBackForwardListCounts NODELETE counts() const;
+    WebBackForwardListCounts NODELETE rawCounts() const;
     Ref<FrameState> completeFrameStateForNavigation(Ref<FrameState>&&);
 
     // IPC messages
@@ -169,8 +177,8 @@ public:
     Ref<API::Array> backList() const;
     Ref<API::Array> forwardList() const;
 
-    unsigned backListCount() const;
-    unsigned forwardListCount() const;
+    unsigned backListCountForAPI() const;
+    unsigned forwardListCountForAPI() const;
 
     Ref<API::Array> backListAsAPIArrayWithLimit(unsigned limit) const;
     Ref<API::Array> forwardListAsAPIArrayWithLimit(unsigned limit) const;

--- a/Source/WebKit/UIProcess/WebBackForwardList.swift
+++ b/Source/WebKit/UIProcess/WebBackForwardList.swift
@@ -441,7 +441,7 @@ final class WebBackForwardList {
         return (entries[index], index)
     }
 
-    func backListCount() -> Int {
+    private func rawBackListEntryCount() -> Int {
         assertValidIndex()
 
         guard page.__convertToBool() else {
@@ -455,7 +455,7 @@ final class WebBackForwardList {
         return currentIndex
     }
 
-    func forwardListCount() -> Int {
+    private func rawForwardListEntryCount() -> Int {
         assertValidIndex()
 
         guard page.__convertToBool() else {
@@ -469,32 +469,67 @@ final class WebBackForwardList {
         return entries.count - (currentIndex + 1)
     }
 
-    private func counts() -> WebKit.WebBackForwardListCounts {
-        WebKit.WebBackForwardListCounts(backCount: UInt32(backListCount()), forwardCount: UInt32(forwardListCount()))
+    private enum MakeAPIArray {
+        case no
+        case yes
+    }
+
+    func backListCountForAPI() -> Int {
+        backListWithLimitInternal(limit: UInt(rawBackListEntryCount()), makeAPIArray: .no).count
+    }
+
+    func forwardListCountForAPI() -> Int {
+        forwardListWithLimitInternal(limit: UInt(rawForwardListEntryCount()), makeAPIArray: .no).count
+    }
+
+    private func rawCounts() -> WebKit.WebBackForwardListCounts {
+        WebKit.WebBackForwardListCounts(backCount: UInt32(rawBackListEntryCount()), forwardCount: UInt32(rawForwardListEntryCount()))
+    }
+
+    private static func makeListPairResult(
+        items: [WebKit.WebBackForwardListItem],
+        makeAPIArray: MakeAPIArray
+    ) -> (count: Int, array: API.RefAPIArray?) {
+        let count = items.count
+        guard makeAPIArray == .yes else {
+            return (count: count, array: nil)
+        }
+        let array = count > 0 ? API.Array.create(list: items.map { WebKit.toAPIObject($0) }) : API.Array.create()
+        return (count: count, array: array)
     }
 
     func backListAsAPIArrayWithLimit(limit: UInt) -> API.RefAPIArray {
+        // swift-format-ignore: NeverForceUnwrap
+        backListWithLimitInternal(limit: limit, makeAPIArray: .yes).array!
+    }
+
+    func forwardListAsAPIArrayWithLimit(limit: UInt) -> API.RefAPIArray {
+        // swift-format-ignore: NeverForceUnwrap
+        forwardListWithLimitInternal(limit: limit, makeAPIArray: .yes).array!
+    }
+
+    private func backListWithLimitInternal(limit: UInt, makeAPIArray: MakeAPIArray) -> (count: Int, array: API.RefAPIArray?) {
         assertValidIndex()
 
         guard page.__convertToBool() else {
-            return API.Array.create()
+            return WebBackForwardList.makeListPairResult(items: [], makeAPIArray: makeAPIArray)
         }
 
         guard let unwrappedCurrentIndex = currentIndex else {
-            return API.Array.create()
+            return WebBackForwardList.makeListPairResult(items: [], makeAPIArray: makeAPIArray)
         }
 
-        var backListSize = backListCount()
-        let size = min(backListSize, Int(limit))
+        let backListSize = rawBackListEntryCount()
+        var size = min(backListSize, Int(limit))
         guard size > 0 else {
-            return API.Array.create()
+            return WebBackForwardList.makeListPairResult(items: [], makeAPIArray: makeAPIArray)
         }
         assert(backListSize >= size)
 
         guard !WebBackForwardList.shouldSkipItemsWithoutUserGestureForWebKitAPI else {
             var items: [WebKit.WebBackForwardListItem] = []
             var nextStartingIndex = unwrappedCurrentIndex
-            while backListSize > 0 {
+            while size > 0 {
                 let result = itemStartingAtIndexSkippingItemsAddedByJSWithoutUserGesture(
                     direction: .backward,
                     startingIndex: nextStartingIndex
@@ -502,34 +537,35 @@ final class WebBackForwardList {
                 if let item = result.item {
                     items.append(item)
                 }
-                backListSize -= 1
-                if result.item == nil || backListSize == 0 || result.index == 0 {
+                size -= 1
+                if result.item == nil || size == 0 || result.index == 0 {
                     break
                 }
                 nextStartingIndex = result.index
             }
             items.reverse()
-            return API.Array.create(list: items.map { WebKit.toAPIObject($0) })
+            return WebBackForwardList.makeListPairResult(items: items, makeAPIArray: makeAPIArray)
         }
 
         let startIndex = backListSize - size
-        return API.Array.create(list: entries[startIndex..<startIndex + size].map { WebKit.toAPIObject($0) })
+        let backItems = Array(entries[startIndex..<startIndex + size])
+        return WebBackForwardList.makeListPairResult(items: backItems, makeAPIArray: makeAPIArray)
     }
 
-    func forwardListAsAPIArrayWithLimit(limit: UInt) -> API.RefAPIArray {
+    private func forwardListWithLimitInternal(limit: UInt, makeAPIArray: MakeAPIArray) -> (count: Int, array: API.RefAPIArray?) {
         assertValidIndex()
 
         guard page.__convertToBool() else {
-            return API.Array.create()
+            return WebBackForwardList.makeListPairResult(items: [], makeAPIArray: makeAPIArray)
         }
 
         guard let unwrappedCurrentIndex = currentIndex else {
-            return API.Array.create()
+            return WebBackForwardList.makeListPairResult(items: [], makeAPIArray: makeAPIArray)
         }
 
-        var size = min(forwardListCount(), Int(limit))
+        var size = min(rawForwardListEntryCount(), Int(limit))
         guard size > 0 else {
-            return API.Array.create()
+            return WebBackForwardList.makeListPairResult(items: [], makeAPIArray: makeAPIArray)
         }
 
         guard !WebBackForwardList.shouldSkipItemsWithoutUserGestureForWebKitAPI else {
@@ -549,11 +585,12 @@ final class WebBackForwardList {
                 }
                 nextStartingIndex = result.index
             }
-            return API.Array.create(list: items.map { WebKit.toAPIObject($0) })
+            return WebBackForwardList.makeListPairResult(items: items, makeAPIArray: makeAPIArray)
         }
 
         let startIndex = unwrappedCurrentIndex + 1
-        return API.Array.create(list: entries[startIndex..<startIndex + size].map { WebKit.toAPIObject($0) })
+        let forwardItems = Array(entries[startIndex..<startIndex + size])
+        return WebBackForwardList.makeListPairResult(items: forwardItems, makeAPIArray: makeAPIArray)
     }
 
     func removeAllItems() {
@@ -1052,7 +1089,7 @@ final class WebBackForwardList {
         // value. Since the load is really going on in a new provisional process, we want to ignore such requests from the committed process.
         // Any real new load in the committed process would have cleared m_provisionalPage.
         if let webPageProxy = page.get(), webPageProxy.hasProvisionalPage() {
-            completionHandler.pointee(consuming: counts())
+            completionHandler.pointee(consuming: rawCounts())
             return
         }
 
@@ -1073,7 +1110,7 @@ final class WebBackForwardList {
         if let webPageProxy = page.get() {
             if messageCheckCompletion(
                 process: WebKit.RefWebProcessProxy(webPageProxy.legacyMainFrameProcess()),
-                completionHandler: { completionHandler.pointee(consuming: counts()) },
+                completionHandler: { completionHandler.pointee(consuming: rawCounts()) },
                 !WebKit.isInspectorPage(webPageProxy)
             ) {
                 return
@@ -1084,7 +1121,7 @@ final class WebBackForwardList {
             goToItem(item: item)
         }
 
-        completionHandler.pointee(consuming: counts())
+        completionHandler.pointee(consuming: rawCounts())
     }
 
     func backForwardAllItems(
@@ -1119,7 +1156,7 @@ final class WebBackForwardList {
     }
 
     func backForwardListCounts(completionHandler: CompletionHandlers.WebBackForwardList.BackForwardListCountsCompletionHandler) {
-        completionHandler.pointee(consuming: counts())
+        completionHandler.pointee(consuming: rawCounts())
     }
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKBackForwardListTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKBackForwardListTests.mm
@@ -33,11 +33,15 @@
 #import "Helpers/cocoa/TestUIDelegate.h"
 #import "Helpers/cocoa/TestWKWebView.h"
 #import "TestURLSchemeHandler.h"
+#import <WebKit/WKArray.h>
 #import <WebKit/WKBackForwardListItemPrivate.h>
 #import <WebKit/WKBackForwardListPrivate.h>
+#import <WebKit/WKBackForwardListRef.h>
 #import <WebKit/WKNavigationDelegatePrivate.h>
 #import <WebKit/WKNavigationPrivate.h>
+#import <WebKit/WKPagePrivate.h>
 #import <WebKit/WKProcessPoolPrivate.h>
+#import <WebKit/WKRetainPtr.h>
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/WKWebViewPrivateForTesting.h>
 #import <WebKit/_WKFrameTreeNode.h>
@@ -532,6 +536,23 @@ struct SkipItemsBackForwardListFixture {
     RetainPtr<NSURL> url3;
 };
 
+@interface WKWebView (WKBackForwardListTestingPrivate)
+- (WKPageRef)_pageForTesting;
+@end
+
+static void verifyBackForwardListCountsMatchArraySizes(WKWebView *webView)
+{
+    WKBackForwardListRef list = WKPageGetBackForwardList([webView _pageForTesting]);
+
+    unsigned forwardCount = WKBackForwardListGetForwardListCount(list);
+    auto forwardArray = adoptWK(WKBackForwardListCopyForwardListWithLimit(list, forwardCount));
+    EXPECT_EQ(static_cast<size_t>(forwardCount), WKArrayGetSize(forwardArray.get()));
+
+    unsigned backCount = WKBackForwardListGetBackListCount(list);
+    auto backArray = adoptWK(WKBackForwardListCopyBackListWithLimit(list, backCount));
+    EXPECT_EQ(static_cast<size_t>(backCount), WKArrayGetSize(backArray.get()));
+}
+
 // Builds the back/forward list:
 // url1 -> url2 -> url2#a (no user gesture) -> url2#b (no user gesture) -> url2#c (no user gesture) -> url3 **
 static SkipItemsBackForwardListFixture setupBackForwardListWithItemsWithoutUserGesture(NOESCAPE Function<void(WKWebView *, ASCIILiteral destination)>&& navigate)
@@ -609,6 +630,7 @@ static SkipItemsBackForwardListFixture setupBackForwardListWithItemsWithoutUserG
 
     EXPECT_EQ([webView backForwardList].backList.count, 2U);
     EXPECT_EQ([webView backForwardList].forwardList.count, 0U);
+    verifyBackForwardListCountsMatchArraySizes(webView.get());
 
     SkipItemsBackForwardListFixture fixture;
     fixture.webView = WTF::move(webView);
@@ -631,6 +653,7 @@ static void runBackForwardNavigationSkipsItemsWithoutUserGestureCheck(const Skip
     EXPECT_STREQ([fixture.webView URL].absoluteString.UTF8String, expectedURLString.get().UTF8String);
     EXPECT_EQ([fixture.webView backForwardList].backList.count, 1U);
     EXPECT_EQ([fixture.webView backForwardList].forwardList.count, 1U);
+    verifyBackForwardListCountsMatchArraySizes(fixture.webView.get());
 
     // Let's go back again.
     [fixture.webView goBack];
@@ -641,6 +664,7 @@ static void runBackForwardNavigationSkipsItemsWithoutUserGestureCheck(const Skip
     EXPECT_STREQ([fixture.webView URL].absoluteString.UTF8String, [fixture.url1 absoluteString].UTF8String);
     EXPECT_EQ([fixture.webView backForwardList].backList.count, 0U);
     EXPECT_EQ([fixture.webView backForwardList].forwardList.count, 2U);
+    verifyBackForwardListCountsMatchArraySizes(fixture.webView.get());
 
     // Now let's go forward.
     [fixture.webView goForward];
@@ -652,6 +676,7 @@ static void runBackForwardNavigationSkipsItemsWithoutUserGestureCheck(const Skip
     EXPECT_STREQ([fixture.webView URL].absoluteString.UTF8String, expectedURLString.get().UTF8String);
     EXPECT_EQ([fixture.webView backForwardList].backList.count, 1U);
     EXPECT_EQ([fixture.webView backForwardList].forwardList.count, 1U);
+    verifyBackForwardListCountsMatchArraySizes(fixture.webView.get());
 
     // Let's go forward again.
     [fixture.webView goForward];
@@ -662,6 +687,7 @@ static void runBackForwardNavigationSkipsItemsWithoutUserGestureCheck(const Skip
 
     EXPECT_EQ([fixture.webView backForwardList].backList.count, 2U);
     EXPECT_EQ([fixture.webView backForwardList].forwardList.count, 0U);
+    verifyBackForwardListCountsMatchArraySizes(fixture.webView.get());
 }
 
 // Phase 2 check: mutating — leaves state on url2#b. Must run after the Phase 1 check.
@@ -675,6 +701,7 @@ static void runJSHistoryBackDoesNotSkipItemsWithoutUserGestureCheck(const SkipIt
     EXPECT_STREQ([fixture.webView URL].absoluteString.UTF8String, expectedURLString.get().UTF8String);
     EXPECT_EQ([fixture.webView backForwardList].backList.count, 1U);
     EXPECT_EQ([fixture.webView backForwardList].forwardList.count, 1U);
+    verifyBackForwardListCountsMatchArraySizes(fixture.webView.get());
 
     [fixture.webView _evaluateJavaScriptWithoutUserGesture:@"history.back();" completionHandler:^(id, NSError *) { }];
     [fixture.navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
@@ -682,6 +709,7 @@ static void runJSHistoryBackDoesNotSkipItemsWithoutUserGestureCheck(const SkipIt
     EXPECT_STREQ([fixture.webView URL].absoluteString.UTF8String, expectedURLString.get().UTF8String);
     EXPECT_EQ([fixture.webView backForwardList].backList.count, 1U);
     EXPECT_EQ([fixture.webView backForwardList].forwardList.count, 1U);
+    verifyBackForwardListCountsMatchArraySizes(fixture.webView.get());
 }
 
 // Test fixtures: the back/forward list setup is built once per fixture (via SetUpTestSuite)
@@ -753,6 +781,37 @@ TEST_F(WKBackForwardListSkipItemsPushStateAfterEvaluateJSTest, BackForwardNaviga
 TEST_F(WKBackForwardListSkipItemsPushStateAfterEvaluateJSTest, JSHistoryBackDoesNotSkipItemsWithoutUserGesture)
 {
     runJSHistoryBackDoesNotSkipItemsWithoutUserGestureCheck(*s_fixture);
+}
+
+TEST(WKBackForwardList, BackForwardListAsAPIArrayWithLimitRespectsLimit)
+{
+    // bf list: url1 -> url2 -> url2#a (no UG) -> url2#b (no UG) -> url2#c (no UG) -> url3 **
+    // Raw back entry count is 5; the filter only exposes 2 items in the back list (url1, url2).
+    auto fixture = setupBackForwardListWithItemsWithoutUserGesture(pushStateNavigate);
+    EXPECT_EQ([fixture.webView backForwardList].backList.count, 2U);
+
+    WKBackForwardListRef list = WKPageGetBackForwardList([fixture.webView _pageForTesting]);
+
+    // Limit must cap the array; once limit exceeds the visible count, the visible count is the cap.
+    EXPECT_EQ(0u, WKArrayGetSize(adoptWK(WKBackForwardListCopyBackListWithLimit(list, 0)).get()));
+    EXPECT_EQ(1u, WKArrayGetSize(adoptWK(WKBackForwardListCopyBackListWithLimit(list, 1)).get()));
+    EXPECT_EQ(2u, WKArrayGetSize(adoptWK(WKBackForwardListCopyBackListWithLimit(list, 2)).get()));
+    EXPECT_EQ(2u, WKArrayGetSize(adoptWK(WKBackForwardListCopyBackListWithLimit(list, 3)).get()));
+    EXPECT_EQ(2u, WKArrayGetSize(adoptWK(WKBackForwardListCopyBackListWithLimit(list, 100)).get()));
+
+    // Navigate to url1 so the visible items are in the forward list:
+    [fixture.webView goBack];
+    [fixture.navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+    [fixture.webView goBack];
+    [fixture.navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+    EXPECT_STREQ([fixture.webView URL].absoluteString.UTF8String, [fixture.url1 absoluteString].UTF8String);
+    EXPECT_EQ([fixture.webView backForwardList].forwardList.count, 2U);
+
+    EXPECT_EQ(0u, WKArrayGetSize(adoptWK(WKBackForwardListCopyForwardListWithLimit(list, 0)).get()));
+    EXPECT_EQ(1u, WKArrayGetSize(adoptWK(WKBackForwardListCopyForwardListWithLimit(list, 1)).get()));
+    EXPECT_EQ(2u, WKArrayGetSize(adoptWK(WKBackForwardListCopyForwardListWithLimit(list, 2)).get()));
+    EXPECT_EQ(2u, WKArrayGetSize(adoptWK(WKBackForwardListCopyForwardListWithLimit(list, 3)).get()));
+    EXPECT_EQ(2u, WKArrayGetSize(adoptWK(WKBackForwardListCopyForwardListWithLimit(list, 100)).get()));
 }
 
 TEST(WKBackForwardList, BackForwardNavigationSkipsItemsWithoutUserGestureSubframe)


### PR DESCRIPTION
#### b8c772853573b3ad3fe83cdb92b49bf72cdafea7
<pre>
backListCount()/forwardListCount() don&apos;t match the sizes of the backList() and forwardList() arrays
<a href="https://rdar.apple.com/176640408">rdar://176640408</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=315072">https://bugs.webkit.org/show_bug.cgi?id=315072</a>

Reviewed by Chris Dumez.

This broke with the &quot;Skip back/forward items at the API level&quot; changes in 311688@main and 311799@main

After those changes, the backList()/forwardList() would return arrays with skipped items, but the old
&quot;get me the back/forward list count&quot; APIs didn&apos;t do the skipping.

Some clients were mixing and matching those, and they were having a bad time.

This PR does some renaming for clarity, and makes the &quot;count&quot; methods just return the size of the
calculated array, ensuring the same calculations are used across the board.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKBackForwardListTests.mm

* Source/WebKit/UIProcess/API/C/WKBackForwardListRef.cpp:
(WKBackForwardListGetBackListCount):
(WKBackForwardListGetForwardListCount):
* Source/WebKit/UIProcess/API/glib/WebKitBackForwardList.cpp:
(webkit_back_forward_list_get_length):
(webkit_back_forward_list_get_back_list):
(webkit_back_forward_list_get_forward_list):
* Source/WebKit/UIProcess/Automation/WebAutomationSession.cpp:
(WebKit::WebAutomationSession::traverseHistoryInBrowsingContext):
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::rawBackListEntryCount const):
(WebKit::WebBackForwardList::rawForwardListEntryCount const):
(WebKit::WebBackForwardList::backListCountForAPI const):
(WebKit::WebBackForwardList::forwardListCountForAPI const):
(WebKit::WebBackForwardList::counts const):
(WebKit::WebBackForwardList::backList const):
(WebKit::WebBackForwardList::forwardList const):
(WebKit::WebBackForwardList::backListAsAPIArrayWithLimit const):
(WebKit::WebBackForwardList::forwardListAsAPIArrayWithLimit const):
(WebKit::WebBackForwardListWrapper::backListCountForAPI const):
(WebKit::WebBackForwardListWrapper::forwardListCountForAPI const):
(WebKit::WebBackForwardListWrapper::backList const):
(WebKit::WebBackForwardListWrapper::forwardList const):
(WebKit::WebBackForwardList::backListCount const): Deleted.
(WebKit::WebBackForwardList::forwardListCount const): Deleted.
(WebKit::WebBackForwardListWrapper::backListCount const): Deleted.
(WebKit::WebBackForwardListWrapper::forwardListCount const): Deleted.
* Source/WebKit/UIProcess/WebBackForwardList.h:
* Source/WebKit/UIProcess/WebBackForwardList.swift:
(Direction.rawBackListEntryCount):
(Direction.rawForwardListEntryCount):
(Direction.backListCountForAPI):
(Direction.forwardListCountForAPI):
(Direction.counts):
(Direction.backListAsAPIArrayWithLimit(_:)):
(Direction.forwardListAsAPIArrayWithLimit(_:)):
(Direction.backListCount): Deleted.
(Direction.forwardListCount): Deleted.
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKBackForwardListTests.mm:
(verifyBackForwardListCountsMatchArraySizes):
(setupBackForwardListWithItemsWithoutUserGesture):
(runBackForwardNavigationSkipsItemsWithoutUserGestureCheck):
(runJSHistoryBackDoesNotSkipItemsWithoutUserGestureCheck):

Canonical link: <a href="https://commits.webkit.org/313516@main">https://commits.webkit.org/313516@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8e6377062b533b03d647e5d537d2c8ab2f27ef11

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163323 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36806 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30021 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172262 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119770 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9d7419d0-5b21-4d5c-a712-683f77332640) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165192 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37133 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36806 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126830 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/89411 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166282 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29100 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146823 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107397 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28146 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26777 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19964 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/138041 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24547 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174766 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27356 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26203 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135136 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36475 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30876 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135127 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36423 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37261 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146342 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99209 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30426 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23187 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35970 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108790 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35469 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1212 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35717 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35617 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->