### PR TITLE
[JSC] Use scratch buffer for ObjectDefinePropertyFromFields

### DIFF
--- a/JSTests/stress/object-define-property-fields-spilled-arg.js
+++ b/JSTests/stress/object-define-property-fields-spilled-arg.js
@@ -1,0 +1,25 @@
+// Regression test for a DFG/FTL frame layout bug. operationObjectDefinePropertyFromFields
+// used to take 9 GPR args, exceeding ARM64's 8-arg-register budget (and x86_64's 6).
+// The 9th argument was poked to [sp + 0], but maxFrameExtentForSlowPathCall is 0 on
+// those targets, so [sp + 0] aliased the lowest spill slot and corrupted whatever was
+// spilled there. Here, the spilled value happens to be the function argument that
+// later feeds a ValueAdd; reading the corrupted slot crashed in operationValueAddNotNumber.
+// The fix passes the six descriptor slots through a scratch buffer instead of as
+// direct C-call arguments, keeping the operation at four GPR args.
+
+function opt(input) {
+    Object.defineProperty((function (t, x) { t.y = x; }), 'reject', { get: (({ valueOf: (/(?<!x)y/.test(input)), c: -5.3049894784e-314, this: 1_000_000 }).prototype &&= "ab") });
+    a2 = ["ab"];
+    try {
+        let combined = a2 + input;
+        class Inner {
+            method() { return combined; }
+            delete = ((unused) => this.species)();
+        }
+    } catch (x) { }
+}
+for (let i = 0; i < testLoopCount; i++) {
+    try {
+        opt(-5.3049894784e-314);
+    } catch (e) { }
+}

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -39,6 +39,7 @@
 #include "ConcatKeyAtomStringCacheInlines.h"
 #include "DFGDriver.h"
 #include "DFGJITCode.h"
+#include "DFGNode.h"
 #include "DFGToFTLDeferredCompilationCallback.h"
 #include "DFGToFTLForOSREntryDeferredCompilationCallback.h"
 #include "DateInstance.h"
@@ -2219,22 +2220,32 @@ JSC_DEFINE_JIT_OPERATION(operationObjectDefineProperty, void, (JSGlobalObject* g
     OPERATION_RETURN(scope);
 }
 
-JSC_DEFINE_JIT_OPERATION(operationObjectDefinePropertyFromFields, void, (JSGlobalObject* globalObject, JSObject* target, EncodedJSValue encodedKey, EncodedJSValue encodedEnumerable, EncodedJSValue encodedConfigurable, EncodedJSValue encodedValue, EncodedJSValue encodedWritable, EncodedJSValue encodedGetter, EncodedJSValue encodedSetter))
+JSC_DEFINE_JIT_OPERATION(operationObjectDefinePropertyFromFields, void, (JSGlobalObject* globalObject, JSObject* target, EncodedJSValue encodedKey, EncodedJSValue* descriptorBuffer))
 {
     VM& vm = globalObject->vm();
     CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
     JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    JSValue enumerable;
+    JSValue configurable;
+    JSValue value;
+    JSValue writable;
+    JSValue getter;
+    JSValue setter;
+    {
+        ActiveScratchBufferScope activeScratchBufferScope(ScratchBuffer::fromData(descriptorBuffer), Node::numberOfDescriptorSlots);
+
+        enumerable = JSValue::decode(descriptorBuffer[Node::EnumerableSlot]);
+        configurable = JSValue::decode(descriptorBuffer[Node::ConfigurableSlot]);
+        value = JSValue::decode(descriptorBuffer[Node::ValueSlot]);
+        writable = JSValue::decode(descriptorBuffer[Node::WritableSlot]);
+        getter = JSValue::decode(descriptorBuffer[Node::GetSlot]);
+        setter = JSValue::decode(descriptorBuffer[Node::SetSlot]);
+    }
+
     auto propertyName = JSValue::decode(encodedKey).toPropertyKey(globalObject);
     OPERATION_RETURN_IF_EXCEPTION(scope);
-
-    JSValue enumerable = JSValue::decode(encodedEnumerable);
-    JSValue configurable = JSValue::decode(encodedConfigurable);
-    JSValue value = JSValue::decode(encodedValue);
-    JSValue writable = JSValue::decode(encodedWritable);
-    JSValue getter = JSValue::decode(encodedGetter);
-    JSValue setter = JSValue::decode(encodedSetter);
 
     PropertyDescriptor desc;
     if (enumerable)

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -204,7 +204,7 @@ JSC_DECLARE_JIT_OPERATION(operationPutByIdWithThisStrict, void, (JSGlobalObject*
 JSC_DECLARE_JIT_OPERATION(operationPutByValWithThis, void, (JSGlobalObject*, EncodedJSValue, EncodedJSValue, EncodedJSValue, EncodedJSValue));
 JSC_DECLARE_JIT_OPERATION(operationPutByValWithThisStrict, void, (JSGlobalObject*, EncodedJSValue, EncodedJSValue, EncodedJSValue, EncodedJSValue));
 JSC_DECLARE_JIT_OPERATION(operationObjectDefineProperty, void, (JSGlobalObject*, JSObject*, EncodedJSValue, JSObject*));
-JSC_DECLARE_JIT_OPERATION(operationObjectDefinePropertyFromFields, void, (JSGlobalObject*, JSObject*, EncodedJSValue, EncodedJSValue, EncodedJSValue, EncodedJSValue, EncodedJSValue, EncodedJSValue, EncodedJSValue));
+JSC_DECLARE_JIT_OPERATION(operationObjectDefinePropertyFromFields, void, (JSGlobalObject*, JSObject*, EncodedJSValue, EncodedJSValue*));
 JSC_DECLARE_JIT_OPERATION(operationDefineDataProperty, void, (JSGlobalObject*, JSObject*, EncodedJSValue, EncodedJSValue, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationDefineDataPropertyString, void, (JSGlobalObject*, JSObject*, JSString*, EncodedJSValue, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationDefineDataPropertyStringIdent, void, (JSGlobalObject*, JSObject*, UniquedStringImpl*, EncodedJSValue, int32_t));

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -14583,35 +14583,35 @@ void SpeculativeJIT::compileObjectDefinePropertyFromFields(Node* node)
     // Children layout:
     //   [0] target (ObjectUse)
     //   [1] key (UntypedUse)
-    //   [2] enumerable  (UntypedUse or JSConstant(empty) if absent)
-    //   [3] configurable
-    //   [4] value
-    //   [5] writable
-    //   [6] get
-    //   [7] set
+    //   [2..7] descriptor slots, indexed by Node::DescriptorSlot
+    //          (UntypedUse or JSConstant(empty) if absent).
     SpeculateCellOperand target(this, m_graph.varArgChild(node, 0));
     JSValueOperand key(this, m_graph.varArgChild(node, 1));
-    JSValueOperand enumerable(this, m_graph.varArgChild(node, 2));
-    JSValueOperand configurable(this, m_graph.varArgChild(node, 3));
-    JSValueOperand value(this, m_graph.varArgChild(node, 4));
-    JSValueOperand writable(this, m_graph.varArgChild(node, 5));
-    JSValueOperand getter(this, m_graph.varArgChild(node, 6));
-    JSValueOperand setter(this, m_graph.varArgChild(node, 7));
+    GPRTemporary buffer(this);
 
     GPRReg targetGPR = target.gpr();
     JSValueRegs keyRegs = key.jsValueRegs();
-    JSValueRegs enumerableRegs = enumerable.jsValueRegs();
-    JSValueRegs configurableRegs = configurable.jsValueRegs();
-    JSValueRegs valueRegs = value.jsValueRegs();
-    JSValueRegs writableRegs = writable.jsValueRegs();
-    JSValueRegs getterRegs = getter.jsValueRegs();
-    JSValueRegs setterRegs = setter.jsValueRegs();
+    GPRReg bufferGPR = buffer.gpr();
 
     speculateObject(m_graph.varArgChild(node, 0), targetGPR);
 
+    constexpr size_t scratchSize = sizeof(EncodedJSValue) * Node::numberOfDescriptorSlots;
+    ScratchBuffer* scratchBuffer = vm().scratchBufferForSize(scratchSize);
+    EncodedJSValue* scratchData = static_cast<EncodedJSValue*>(scratchBuffer->dataBuffer());
+
+    move(TrustedImmPtr(scratchData), bufferGPR);
+    for (unsigned slot = 0; slot < Node::numberOfDescriptorSlots; ++slot) {
+        JSValueOperand operand(this, m_graph.varArgChild(node, slot + 2));
+        storeValue(operand.jsValueRegs(), Address(bufferGPR, sizeof(EncodedJSValue) * slot));
+        operand.use();
+    }
+
+    target.use();
+    key.use();
+
     flushRegisters();
-    callOperation(operationObjectDefinePropertyFromFields, LinkableConstant::globalObject(*this, node), targetGPR, keyRegs, enumerableRegs, configurableRegs, valueRegs, writableRegs, getterRegs, setterRegs);
-    noResult(node);
+    callOperation(operationObjectDefinePropertyFromFields, LinkableConstant::globalObject(*this, node), targetGPR, keyRegs, bufferGPR);
+    noResult(node, UseChildrenCalledExplicitly);
 }
 
 void SpeculativeJIT::emitAllocateButterfly(GPRReg storageResultGPR, GPRReg sizeGPR, GPRReg scratch1, GPRReg scratch2, GPRReg scratch3, JumpList& slowCases)

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -5593,13 +5593,14 @@ private:
         ASSERT(m_graph.varArgNumChildren(m_node) == 8);
         LValue target = lowObject(m_graph.varArgChild(m_node, 0));
         LValue key = lowJSValue(m_graph.varArgChild(m_node, 1));
-        LValue enumerable = lowJSValue(m_graph.varArgChild(m_node, 2));
-        LValue configurable = lowJSValue(m_graph.varArgChild(m_node, 3));
-        LValue value = lowJSValue(m_graph.varArgChild(m_node, 4));
-        LValue writable = lowJSValue(m_graph.varArgChild(m_node, 5));
-        LValue getter = lowJSValue(m_graph.varArgChild(m_node, 6));
-        LValue setter = lowJSValue(m_graph.varArgChild(m_node, 7));
-        vmCall(Void, operationObjectDefinePropertyFromFields, weakPointer(globalObject), target, key, enumerable, configurable, value, writable, getter, setter);
+
+        constexpr size_t scratchSize = sizeof(EncodedJSValue) * Node::numberOfDescriptorSlots;
+        ScratchBuffer* scratchBuffer = vm().scratchBufferForSize(scratchSize);
+        EncodedJSValue* buffer = static_cast<EncodedJSValue*>(scratchBuffer->dataBuffer());
+        for (unsigned slot = 0; slot < Node::numberOfDescriptorSlots; ++slot)
+            m_out.store64(lowJSValue(m_graph.varArgChild(m_node, slot + 2)), m_out.absolute(buffer + slot));
+
+        vmCall(Void, operationObjectDefinePropertyFromFields, weakPointer(globalObject), target, key, m_out.constIntPtr(buffer));
     }
 
     void compileDefineAccessorProperty()


### PR DESCRIPTION
#### 59a20ddcb9ca0eecd9bd88bce32ffc8900c4fbcb
<pre>
[JSC] Use scratch buffer for ObjectDefinePropertyFromFields
<a href="https://bugs.webkit.org/show_bug.cgi?id=315074">https://bugs.webkit.org/show_bug.cgi?id=315074</a>
<a href="https://rdar.apple.com/177332941">rdar://177332941</a>

Reviewed by Keith Miller.

ObjectDefinePropertyFromFields is calling an operation with 9
parameters. But ARM64 / x64 right now only supports up to 6 register
parameters. And our DFG JIT is currently assuming that ARM64 / x64 never
uses stack for parameter passing. This patch fixes this issue by using
scratch buffer for fields.

Test: JSTests/stress/object-define-property-fields-spilled-arg.js

* JSTests/stress/object-define-property-fields-spilled-arg.js: Added.
(opt.try.Inner.prototype.method):
(opt.try.Inner):
(opt.get a2):
(opt):
(i.catch):
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileObjectDefinePropertyFromFields):

Canonical link: <a href="https://commits.webkit.org/313474@main">https://commits.webkit.org/313474@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a825a1fbbb45307e35138850884ce9fc91113b81

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163220 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36701 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29918 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172159 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119667 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37029 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36702 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126737 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89338 "5 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0c497503-8a4d-42b2-ac45-2a3ec42c419e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166179 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29012 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146734 "Found 1 new API test failure: TestWebKitAPI.WritingTools.ProofreadingWithImage (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107305 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26687 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19860 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/155365 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137951 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24458 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174662 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/24107 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/26819 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26113 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135044 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36371 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30789 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135036 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37157 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146253 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99058 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24837 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30340 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23097 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195622 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35867 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108228 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50991 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35366 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1122 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35613 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35513 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->