### PR TITLE
[CMake] Add argv-translation shim for TestWebKitAPI on Mac

### DIFF
--- a/Tools/TestWebKitAPI/PlatformMac.cmake
+++ b/Tools/TestWebKitAPI/PlatformMac.cmake
@@ -3,8 +3,9 @@ find_library(QUARTZCORE_LIBRARY QuartzCore)
 
 set(TESTWEBKITAPI_RUNTIME_OUTPUT_DIRECTORY "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}")
 
-# Use the generic gtest runner (not App/mac/main.mm which is the Xcode .app entry point).
-set(_test_main_SOURCES generic/main.cpp)
+# Mirrors Runner/TestWebKitAPI.swift (the Xcode @main). Drop and switch to the
+# Swift runner once the CMake port supports Swift + Swift Testing.
+set(_test_main_SOURCES generic/main.mm)
 
 # TestWTF
 list(APPEND TestWTF_SOURCES

--- a/Tools/TestWebKitAPI/generic/main.mm
+++ b/Tools/TestWebKitAPI/generic/main.mm
@@ -1,0 +1,228 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Mirrors Runner/TestWebKitAPI.swift (the Xcode @main). Drop and switch to the
+// Swift runner once the CMake port supports Swift + Swift Testing.
+
+#import "config.h"
+
+#import "Runner/TestsController.h"
+
+#import <Cocoa/Cocoa.h>
+#import <objc/runtime.h>
+#import <string>
+#import <vector>
+#import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
+
+namespace {
+
+void resetPersistentDomain()
+{
+    [[NSUserDefaults standardUserDefaults] removePersistentDomainForName:@"TestWebKitAPI"];
+}
+
+NSMutableDictionary *mutableArgumentDomain()
+{
+    NSDictionary *current = [[NSUserDefaults standardUserDefaults] volatileDomainForName:NSArgumentDomain];
+    if (current)
+        return [current mutableCopy];
+    return [NSMutableDictionary dictionary];
+}
+
+void writeArgumentDomain(NSDictionary *domain)
+{
+    [[NSUserDefaults standardUserDefaults] setVolatileDomain:domain forName:NSArgumentDomain];
+}
+
+void applyAlwaysSetDefaults()
+{
+    NSMutableDictionary *args = mutableArgumentDomain();
+    // FIXME: Switch to overlay scrollbars (the platform default) once tests are updated.
+    args[@"NSOverlayScrollersEnabled"] = @NO;
+    args[@"AppleShowScrollBars"] = @"Always";
+    // FIXME: Remove once rdar://159372811 is fixed.
+    args[@"NSEventConcurrentProcessingEnabled"] = @NO;
+    writeArgumentDomain(args);
+}
+
+void setBoolArgumentDomain(NSString *key, BOOL value)
+{
+    NSMutableDictionary *args = mutableArgumentDomain();
+    args[key] = @(value);
+    writeArgumentDomain(args);
+}
+
+void forceSiteIsolation()
+{
+    Class cls = NSClassFromString(@"WKPreferences");
+    SEL sel = NSSelectorFromString(@"_forceSiteIsolationAlwaysOnForTesting");
+    if (!cls || ![cls respondsToSelector:sel])
+        return;
+    // performSelector returns void; the leak warning is spurious.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+    [(id)cls performSelector:sel];
+#pragma clang diagnostic pop
+}
+
+std::vector<std::string> translateArgv(int argc, char** argv)
+{
+    std::vector<std::string> out;
+    out.reserve(argc + 8);
+
+    if (argc > 0)
+        out.emplace_back(argv[0]);
+
+    std::vector<std::string> posFilters;
+    std::vector<std::string> negFilters;
+    bool listTests = false;
+    bool force = false;
+    bool pretty = false;
+    bool hasRepetitions = false;
+    std::string repetitions;
+
+    auto needsValue = [&](int& i, const char* /*flag*/) -> const char* {
+        if (i + 1 >= argc)
+            return nullptr;
+        return argv[++i];
+    };
+
+    for (int i = 1; i < argc; ++i) {
+        std::string token { argv[i] };
+
+        if (token == "--filter") {
+            if (const char* value = needsValue(i, "--filter"))
+                posFilters.emplace_back(value);
+            continue;
+        }
+        if (token == "--skip") {
+            if (const char* value = needsValue(i, "--skip"))
+                negFilters.emplace_back(value);
+            continue;
+        }
+        if (token == "--repetitions") {
+            if (const char* value = needsValue(i, "--repetitions")) {
+                repetitions = value;
+                hasRepetitions = true;
+            }
+            continue;
+        }
+        if (token == "--list-tests") {
+            listTests = true;
+            continue;
+        }
+        if (token == "--force") {
+            force = true;
+            continue;
+        }
+        if (token == "--pretty") {
+            pretty = true;
+            continue;
+        }
+
+        if (token == "--site-isolation") {
+            forceSiteIsolation();
+            continue;
+        }
+        if (token == "--remote-layer-tree") {
+            setBoolArgumentDomain(@"WebKit2UseRemoteLayerTreeDrawingArea", YES);
+            continue;
+        }
+        if (token == "--no-remote-layer-tree") {
+            setBoolArgumentDomain(@"WebKit2UseRemoteLayerTreeDrawingArea", NO);
+            continue;
+        }
+        if (token == "--use-gpu-process") {
+            setBoolArgumentDomain(@"WebKit2GPUProcessForDOMRendering", YES);
+            continue;
+        }
+        if (token == "--no-use-gpu-process") {
+            setBoolArgumentDomain(@"WebKit2GPUProcessForDOMRendering", NO);
+            continue;
+        }
+        if (token == "--parallel")
+            continue;
+
+        out.push_back(WTF::move(token));
+    }
+
+    if (listTests)
+        out.emplace_back("--gtest_list_tests");
+
+    if (pretty)
+        out.emplace_back("--gtest_brief=0");
+
+    if (force)
+        out.emplace_back("--gtest_also_run_disabled_tests");
+
+    // gtest treats a leading '-' in --gtest_filter as "exclude only".
+    if (!posFilters.empty() || !negFilters.empty()) {
+        std::string filter = "--gtest_filter=";
+        for (size_t i = 0; i < posFilters.size(); ++i) {
+            if (i)
+                filter += ':';
+            filter += posFilters[i];
+        }
+        if (!negFilters.empty()) {
+            filter += '-';
+            for (size_t i = 0; i < negFilters.size(); ++i) {
+                if (i)
+                    filter += ':';
+                filter += negFilters[i];
+            }
+        }
+        out.push_back(WTF::move(filter));
+    }
+
+    if (hasRepetitions)
+        out.emplace_back("--gtest_repeat=" + repetitions);
+
+    return out;
+}
+
+} // namespace
+
+int main(int argc, char** argv)
+{
+    @autoreleasepool {
+        WTF::enableAllSDKAlignedBehaviors();
+        resetPersistentDomain();
+        applyAlwaysSetDefaults();
+
+        auto translated = translateArgv(argc, argv);
+
+        std::vector<char*> ptrs;
+        ptrs.reserve(translated.size() + 1);
+        for (auto& s : translated)
+            ptrs.push_back(s.data());
+        ptrs.push_back(nullptr);
+        int newArgc = static_cast<int>(translated.size());
+
+        // Instantiate NSApp; some tests rely on it being non-nil.
+        (void)[NSApplication sharedApplication];
+
+        return TestWebKitAPI::TestsController::singleton().run(newArgc, ptrs.data()) ? EXIT_SUCCESS : EXIT_FAILURE;
+    }
+}


### PR DESCRIPTION
#### 6557c69a86eb3ba5f1fd774017cb944316fe0be5
<pre>
[CMake] Add argv-translation shim for TestWebKitAPI on Mac
<a href="https://bugs.webkit.org/show_bug.cgi?id=315075">https://bugs.webkit.org/show_bug.cgi?id=315075</a>
<a href="https://rdar.apple.com/177401011">rdar://177401011</a>

Reviewed by Richard Robinson.

generic/main.cpp hands argv straight to gtest, so the Swift-runner-equivalent
flags that run-api-tests emits — --filter, --list-tests, --site-isolation,
--force, --remote-layer-tree, etc. — silently no-op under the CMake build.

Add generic/main.mm as the Apple-port entrypoint, mirroring
Runner/{TestWebKitAPI,GoogleTestsController}.swift: translates Swift-runner
flags into --gtest_* equivalents, invokes +[WKPreferences
_forceSiteIsolationAlwaysOnForTesting] reflectively for --site-isolation,
sets NSArgumentDomain bools for the layer-tree / GPU-process toggles, and
applies the once-per-process setup (persistent-domain reset, NSApp
instantiation, WTF::enableAllSDKAlignedBehaviors).

Flip _test_main_SOURCES in PlatformMac.cmake to the new file. Non-Apple
ports (GTK/WPE/Win) keep generic/main.cpp.

* Tools/TestWebKitAPI/PlatformMac.cmake:
* Tools/TestWebKitAPI/generic/main.mm: Added.
(main):

Canonical link: <a href="https://commits.webkit.org/313517@main">https://commits.webkit.org/313517@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0b1200565693c8751a906951d9fd2f160f0a4475

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163210 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36691 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29908 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172149 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119657 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165079 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37019 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36692 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126729 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89330 "Passed tests") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166169 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29005 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146726 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107297 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bd03addd-cbed-4037-8d6f-76b2f781a99b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28051 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26677 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19849 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137944 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24450 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174652 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26105 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135036 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36361 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30779 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135028 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36425 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37147 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146245 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99037 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30333 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23089 "Too many flaky failures: fast/text/zero-width-shaping-font-mismatch.html, http/tests/cookies/same-site/popup-same-site-with-post-form.html, http/tests/media/clearkey/clear-key-hls-aes128.html, http/tests/misc/mask-image-accept.html, http/tests/navigation/page-cache-xhr-in-pagehide.html, http/tests/resourceLoadStatistics/downgraded-referrer-for-navigation-with-link-query-from-prevalent-resource.html, http/tests/security/beforeload-iframe-server-redirect.html, http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py, http/tests/security/mixedContent/insecure-image-in-main-frame-UpgradeMixedContent.html, http/tests/site-isolation/frame-index.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35857 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35356 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1113 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35603 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35503 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->