### PR TITLE
[Tools] linux_get_crash_log: Revamp crash log generation for Linux layout tests

### DIFF
--- a/Tools/Scripts/webkitpy/__init__.py
+++ b/Tools/Scripts/webkitpy/__init__.py
@@ -130,6 +130,7 @@ if sys.platform == 'linux':
     AutoInstall.register(Package('websocket', Version(1, 8, 0), pypi_name='websocket-client'))
     AutoInstall.register(Package('selenium', Version(4, 24, 0), wheel=True, implicit_deps=['websocket']))
     AutoInstall.register(Package('filetype', Version(1, 2, 0), wheel=True))
+    AutoInstall.register(Package('inotify_simple', Version(2, 0, 1), wheel=True))
 else:
     AutoInstall.register(Package('selenium', Version(4, 12, 0), wheel=True))
 

--- a/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
+++ b/Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py
@@ -31,6 +31,7 @@
 import logging
 import optparse
 import os
+import sys
 import traceback
 
 from webkitpy.common.host import Host
@@ -565,6 +566,12 @@ def run(port, options, args, logging_stream):
                 _log.debug('Enabled coredumps for test run')
             except (ModuleNotFoundError, ValueError, OSError) as e:
                 _log.error('Failed to enable coredumps: %s' % str(e))
+        if sys.platform.startswith('linux'):
+            try:
+                from webkitpy.port.linux_get_crash_log import GDBCrashLogStartupHandler
+                GDBCrashLogStartupHandler()
+            except (OSError, ImportError) as e:
+                _log.error(f'Failed to initialize crash log handler: {e}')
 
         _set_up_derived_options(port, options)
         manager = Manager(port, options, printer)

--- a/Tools/Scripts/webkitpy/port/glib.py
+++ b/Tools/Scripts/webkitpy/port/glib.py
@@ -157,6 +157,9 @@ class GLibPort(Port):
         # LibRice logging, example: RICE_LOG=trace.
         self._copy_values_from_environ_with_prefix(environment, 'RICE_')
 
+        # For GDB debuginfod support.
+        self._copy_values_from_environ_with_prefix(environment, 'DEBUGINFOD_')
+
         if self.get_option("leaks"):
             # Turn off GLib memory optimisations https://wiki.gnome.org/Valgrind.
             environment['G_SLICE'] = 'always-malloc'

--- a/Tools/Scripts/webkitpy/port/linux_get_crash_log.py
+++ b/Tools/Scripts/webkitpy/port/linux_get_crash_log.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2013 University of Szeged
-# This module is a refactoring from gtk.py, Copyright (C) 2013 Igalia S.L
+# Copyright (C) 2013, 2026 Igalia S.L.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -11,7 +11,7 @@
 # copyright notice, this list of conditions and the following disclaimer
 # in the documentation and/or other materials provided with the
 # distribution.
-#     * Neither the name of Google Inc. nor the names of its
+#     * Neither the name of the copyright holder nor the names of its
 # contributors may be used to endorse or promote products derived from
 # this software without specific prior written permission.
 #
@@ -27,20 +27,615 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import datetime
+import fcntl
+import json
+import logging
 import os
 import re
+import resource
+import requests
+import shutil
 import subprocess
+import sys
 import tempfile
+import threading
 import time
 
-from webkitcorepy import string_utils
+try:
+    import inotify_simple
+except ImportError:
+    inotify_simple = None
 
+from contextlib import nullcontext
+from enum import Enum
+
+if sys.version_info < (3, 11):
+    class StrEnum(str, Enum):
+        def __str__(self):
+            return self.value
+else:
+    from enum import StrEnum
+
+from webkitcorepy import string_utils
+from webkitpy.common.memoized import memoized
 from webkitpy.common.system.executive import ScriptError
 from webkitpy.common.webkit_finder import WebKitFinder
 
 
+class PrefixAdapter(logging.LoggerAdapter):
+    def process(self, msg, kwargs):
+        return f"[crash-logger] {msg}", kwargs
+
+    def log(self, level, msg, *args, **kwargs):
+        # process() doesn't see the level, so prepend the level name here
+        super().log(level, f"{logging.getLevelName(level)}: {msg}", *args, **kwargs)
+
+
+_log = PrefixAdapter(logging.getLogger(__name__), extra={})
+
+
+class LockFile:
+    def __init__(self, path, slots=1, log_wait_each_seconds=0):
+        self.path = path
+        self._fd = None
+        self._locked_path = None
+        self._slots = max(1, slots)
+        self._log_wait_seconds = max(0, log_wait_each_seconds)
+
+    def acquire(self):
+        if self._log_wait_seconds:
+            stop_logging_event = threading.Event()
+            logging_thread = threading.Thread(target=self._log_waiter, args=(stop_logging_event,), daemon=True)
+            logging_thread.start()
+        try:
+            if self._slots == 1:
+                self._acquire_single()
+            else:
+                self._acquire_multi()
+        finally:
+            if self._log_wait_seconds:
+                stop_logging_event.set()
+                logging_thread.join()
+
+    def _try_claim(self, fd, path):
+        try:
+            # Returns True if fd is still the current file on disk and claims it.
+            if os.fstat(fd.fileno()).st_ino == os.stat(path).st_ino:
+                fd.write(str(os.getpid()))
+                fd.flush()
+                self._fd = fd
+                self._locked_path = path
+                return True
+        except FileNotFoundError:
+            pass  # File deleted between open() and stat()
+        return False
+
+    def _acquire_single(self):
+        while True:
+            fd = open(self.path, 'w')
+            fcntl.flock(fd, fcntl.LOCK_EX)
+            if self._try_claim(fd, self.path):
+                # Valid lock acquired.
+                return
+            # Retry because we got the lock on a deleted file.
+            fcntl.flock(fd, fcntl.LOCK_UN)
+            fd.close()
+
+    def _acquire_multi(self):
+        paths = [f"{self.path}.{i}" for i in range(self._slots)]
+        while True:
+            for path in paths:
+                fd = open(path, 'w')
+                try:
+                    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                except BlockingIOError:
+                    fd.close()
+                    continue
+                if self._try_claim(fd, path):
+                    return
+                fcntl.flock(fd, fcntl.LOCK_UN)
+                fd.close()
+            time.sleep(1)
+
+    def release(self):
+        if self._fd:
+            os.unlink(self._locked_path)  # Remove file first.
+            fcntl.flock(self._fd, fcntl.LOCK_UN)
+            self._fd.close()
+            self._fd = None
+            self._locked_path = None
+
+    def _log_waiter(self, stop_event):
+        if self._slots == 1:
+            msg = f"waiting for lockfile '{self.path}' to be released..."
+        else:
+            msg = f"waiting for a free slot on lockfiles '{self.path}.*' ({self._slots} slots all busy)..."
+        while not stop_event.wait(self._log_wait_seconds):
+            _log.debug(msg)
+
+    def __enter__(self):
+        self.acquire()
+        return self
+
+    def __exit__(self, *_):
+        self.release()
+
+
+CORE_PATTERN_RECOMMEND_COMMAND = "echo /var/tmp/core-%f-pid_%p.dump | sudo tee /proc/sys/kernel/core_pattern"
+
+
+class CoreDumpMethod(StrEnum):
+    Unknown = 'unknown'
+    Abspath = 'abspath'
+    Coredumpctl = 'coredumpctl'
+
+
+# Env vars to allow advanced fine tuning of this crash logger
+class CrashLogEnvVars(StrEnum):
+    allow_unreliable_fallback_to_latest_coredump = 'WEBKIT_CRASHLOG_ALLOW_UNRELIABLE_FALLBACK_TO_LATEST_COREDUMP'
+    core_dumps_autodelete = 'WEBKIT_CORE_DUMPS_AUTODELETE'
+    gdb_concurrent_execution_limit = 'WEBKIT_CRASHLOG_GDB_CONCURRENT_EXECUTION_LIMIT'
+
+
+class CrashLogUtils:
+
+    @staticmethod
+    def get_gdb_concurrent_execution_limit():
+        # 0 means no limit
+        max_concurrent_gdb_processes = os.environ.get(CrashLogEnvVars.gdb_concurrent_execution_limit, '0')
+        if max_concurrent_gdb_processes.isnumeric():
+            return int(max_concurrent_gdb_processes)
+        _log.warning(f"Value passed is not a number: {CrashLogEnvVars.gdb_concurrent_execution_limit}={max_concurrent_gdb_processes}")
+        return 0
+
+    @staticmethod
+    @memoized
+    def _get_gdb_lock_configuration():
+        max_concurrent_gdb_processes = CrashLogUtils.get_gdb_concurrent_execution_limit()
+        if max_concurrent_gdb_processes:
+            for base in ('/run/lock', os.environ.get('XDG_RUNTIME_DIR'), tempfile.gettempdir(), '/tmp', '/var/tmp'):
+                if not base:
+                    continue
+                lock_base_dir = os.path.join(base, f'webkit-crashlog-{os.getuid()}')
+                try:
+                    os.makedirs(lock_base_dir, exist_ok=True)
+                    if os.path.isdir(lock_base_dir) and os.access(lock_base_dir, os.W_OK | os.X_OK):
+                        return os.path.join(lock_base_dir, 'gdb-serial-execution.lock'), max_concurrent_gdb_processes
+                except OSError:
+                    continue
+            _log.warning("No writable directory found for the gdb lock. GDB processes will not be serialized.")
+        return None
+
+    # Memoize only the lockfile path but not the lockfile object, which should be unique for each caller.
+    @staticmethod
+    def get_gdb_lock():
+        lock_configuration = CrashLogUtils._get_gdb_lock_configuration()
+        if lock_configuration:
+            lock_path, slots = lock_configuration
+            return LockFile(lock_path, slots=slots, log_wait_each_seconds=60)
+        return nullcontext()
+
+    @staticmethod
+    def get_thread_info_file_name(pid):
+        return f'threadinfo-{pid}.txt'
+
+    @staticmethod
+    @memoized
+    def get_thread_data_dir():
+        return os.path.join(tempfile.gettempdir(), f'webkit-crashlog-thread-name-data-{os.getuid()}')
+
+    @staticmethod
+    @memoized
+    def get_temp_dir_for_coredumpctl_dumps():
+        def is_tmpfs(path):
+            real_path = os.path.realpath(path)
+            with open('/proc/mounts') as f:
+                for line in f:
+                    fields = line.split()
+                    if fields[1] == real_path and fields[2] == 'tmpfs':
+                        return True
+            return False
+
+        def check_and_return_subdir(tmp_dir):
+            tmp_dir = os.path.join(tmp_dir, 'webkit-coredumpctl-dumps')
+            os.makedirs(tmp_dir, exist_ok=True)
+            _log.debug(f"Temporal directory for dumping cores with coredumpctl: {tmp_dir}")
+            return tmp_dir
+
+        candidates = []
+        for tmp_dir in [tempfile.gettempdir(), '/var/tmp']:
+            if os.access(tmp_dir, os.W_OK | os.X_OK) and not is_tmpfs(tmp_dir):
+                candidates.append(tmp_dir)
+
+        if not candidates:
+            _log.warning("Can't find a writable temporary directory not backed by tmpfs. This may cause OOM issues when dumping large coredumps from Debug builds.")
+            return check_and_return_subdir(tempfile.gettempdir())
+
+        if len(candidates) == 1:
+            return check_and_return_subdir(candidates[0])
+
+        # Pick the second option (/var/tmp) if it has significantly more free space (+1GB diff)
+        if shutil.disk_usage(candidates[1]).free - shutil.disk_usage(candidates[0]).free > 1024**3:
+            return check_and_return_subdir(candidates[1])
+        return check_and_return_subdir(candidates[0])
+
+    @staticmethod
+    def allow_unreliable_fallback_to_latest_coredump():
+        # If this is enabled then instead of giving up when it can't find the coredump by the pid,
+        # it will pick the last one available, and that is unreliable with several parallel workers.
+        return os.environ.get(CrashLogEnvVars.allow_unreliable_fallback_to_latest_coredump, '0') == '1'
+
+    @staticmethod
+    def expand_core_pattern_and_detect_variable_specifiers(core_pattern):
+        # Expand the format specifiers that don't change between different
+        # crashes of the same user session and detect if there are any other
+        # variable format specifiers in the string after resolving those.
+        rlimit_core = resource.getrlimit(resource.RLIMIT_CORE)[0]
+        if rlimit_core == resource.RLIM_INFINITY:
+            rlimit_core = 2**64 - 1
+
+        fixed_format_specifiers = {
+            '%u': str(os.getuid()),
+            '%g': str(os.getgid()),
+            '%h': os.uname().nodename,
+            '%c': str(rlimit_core),
+        }
+
+        core_pattern = core_pattern.replace('%%', '\x00')
+        for format_specifier, value in fixed_format_specifiers.items():
+            core_pattern = core_pattern.replace(format_specifier, value)
+        core_pattern = core_pattern.rstrip('%')
+
+        # Check before restoring literal %
+        has_variable_format_specifiers = '%' in core_pattern
+        core_pattern = core_pattern.replace('\x00', '%')
+
+        return core_pattern, has_variable_format_specifiers
+
+    @staticmethod
+    def determine_coredump_method_and_dir():
+        coredump_method = CoreDumpMethod.Unknown
+        coredump_pattern = None
+        coredump_directory = None
+        coredump_directory_has_variable_format_specifiers = False
+        with open("/proc/sys/kernel/core_pattern", "r") as f:
+            core_pattern = f.read().strip()
+        if core_pattern.startswith("/"):
+            coredump_directory = os.path.dirname(core_pattern)
+            if '%' in coredump_directory:
+                coredump_directory, coredump_directory_has_variable_format_specifiers = CrashLogUtils.expand_core_pattern_and_detect_variable_specifiers(coredump_directory)
+            coredump_pattern = os.path.basename(core_pattern)
+            coredump_method = CoreDumpMethod.Abspath
+            # When coredump_pattern doesn't include %p but core_uses_pid is 1 then the kernel appends .%p
+            if '%p' not in core_pattern.replace('%%', ''):
+                with open("/proc/sys/kernel/core_uses_pid", "r") as f:
+                    core_uses_pid = f.read().strip()
+                    if core_uses_pid == "1":
+                        coredump_pattern += '.%p'
+        elif any(core_pattern.startswith(s) for s in ("|", "@")):
+            # pipe to program or socket
+            if 'systemd' in core_pattern and shutil.which('coredumpctl'):
+                coredump_method = CoreDumpMethod.Coredumpctl
+                coredump_directory = '/var/lib/systemd/coredump'
+        return coredump_method, coredump_pattern, coredump_directory, coredump_directory_has_variable_format_specifiers
+
+    @staticmethod
+    def core_pattern_to_regex(core_pattern, generate_regex_for_pid_match=False):
+        """
+        Convert a core_pattern string to a regex, mirroring kernel expansion rules:
+          %%        -> literal %
+          %<NUL>    -> dropped (% at end of string)
+          %<valid>  -> .+   (non-empty, the kernel always writes something)
+          %<other>  -> dropped (both % and the char)
+          See: https://www.kernel.org/doc/html/latest/admin-guide/sysctl/kernel.html#core-pattern
+        """
+        valid_specifiers = set("pPiIugdsthecfECF")
+        pid_capture_emitted = False
+        result = []
+        i = 0
+        while i < len(core_pattern):
+            if core_pattern[i] != "%":
+                result.append(re.escape(core_pattern[i]))
+                i += 1
+                continue
+
+            # we have a '%'
+            if i + 1 >= len(core_pattern):
+                # %<NUL>: drop the %
+                break
+
+            specifier = core_pattern[i + 1]
+            if specifier == "%":
+                result.append("%")          # %% -> literal %
+            elif generate_regex_for_pid_match and specifier == 'p':
+                if pid_capture_emitted:
+                    # Repeated %p instances represent the same crashing PID.
+                    result.append(r'(?P=pid)')
+                else:
+                    result.append(r'(?P<pid>\d+)')
+                    pid_capture_emitted = True
+            elif specifier in valid_specifiers:
+                result.append(".+")         # valid specifier -> wildcard
+            # else: %<other> -> drop both silently
+
+            i += 2
+
+        return "".join(result)
+
+    @staticmethod
+    def are_coredumps_enabled(coredump_method):
+        # RLIMIT_CORE is ignored when the system is configured to pipe core dumps to a program
+        if coredump_method == CoreDumpMethod.Coredumpctl:
+            return True
+        soft, hard = resource.getrlimit(resource.RLIMIT_CORE)
+        return soft != 0
+
+    @staticmethod
+    def are_coredumps_enabled_and_unlimited(coredump_method):
+        if coredump_method == CoreDumpMethod.Coredumpctl:
+            return True
+        soft, hard = resource.getrlimit(resource.RLIMIT_CORE)
+        return soft == resource.RLIM_INFINITY
+
+    @staticmethod
+    def human_readable_size(path):
+        def fmt(size):
+            for unit in ('B', 'KB', 'MB', 'GB', 'TB'):
+                if size < 1024:
+                    return f'{size:.1f} {unit}'
+                size /= 1024
+            return f'{size:.1f} PB'
+
+        st = os.stat(path)
+        logical = st.st_size
+        actual = st.st_blocks * 512
+
+        if logical == actual:
+            return fmt(logical)
+        return f'{fmt(logical)} (sparse, {fmt(actual)} on disk)'
+
+    @staticmethod
+    def make_temp_path(suffix='', prefix='tmp', dir=None):
+        # Safe replacement for the deprecated tempfile.mktemp().
+        fd, path = tempfile.mkstemp(suffix=suffix, prefix=prefix, dir=dir)
+        os.close(fd)
+        return path
+
+    @staticmethod
+    @memoized
+    def in_host_pid_namespace():
+        PROC_PID_INIT_INO = 0xEFFFFFFC  # PROC_PID_INIT_INO from include/linux/proc_ns.h
+        try:
+            return os.stat("/proc/self/ns/pid").st_ino == PROC_PID_INIT_INO
+        except OSError:
+            return True  # assume host namespace when we can't tell
+
+    @staticmethod
+    def core_pattern_has_pid_format_string(core_pattern):
+        pid_regex = CrashLogUtils.core_pattern_to_regex(core_pattern, generate_regex_for_pid_match=True)
+        return '(?P<pid>' in pid_regex
+
+
+# This runs inside a thread that watches (with inotify) the directory where the coredumps are generated
+# And saves the names of the threads of the crashing pid as soon as the coredump is started to be generated,
+# this info is later added into the generated crash log report. Even when it is naturally racy it works
+# pretty well in practice in the case of WebKit coredumps that are big and take time to be generated.
+class ThreadNamesCrashLogCapturer(object):
+
+    def __init__(self):
+        self._webkit_thread_info_crashlog_dir = CrashLogUtils.get_thread_data_dir()
+        try:
+            os.makedirs(self._webkit_thread_info_crashlog_dir, exist_ok=True)
+        except OSError as e:
+            _log.warning(f"Crash log thread name capturer disabled: Failed to create directory {self._webkit_thread_info_crashlog_dir}: {e.strerror}")
+            return
+        if not os.access(self._webkit_thread_info_crashlog_dir, os.W_OK):
+            _log.warning(f"Crash log thread name capturer disabled: Can't write to directory {self._webkit_thread_info_crashlog_dir}")
+            return
+        self._webkit_thread_info_crashlog_lockfile = os.path.join(self._webkit_thread_info_crashlog_dir, "thread-info-watch.lock")
+        self._coredump_method, self._coredump_pattern, self._coredump_directory, self._coredump_directory_has_variable_format_specifiers = CrashLogUtils.determine_coredump_method_and_dir()
+        if self._coredump_method == CoreDumpMethod.Unknown:
+            _log.warning(f"Crash log thread name capturer disabled: Unknown coredump method configured. Please read the help")
+            return
+        if self._coredump_method == CoreDumpMethod.Abspath and not CrashLogUtils.core_pattern_has_pid_format_string(self._coredump_pattern):
+            _log.warning(f"Crash log thread name capturer disabled: The %p format specifier is missing on core_pattern.")
+            return
+        if self._coredump_method == CoreDumpMethod.Abspath and self._coredump_directory_has_variable_format_specifiers:
+            _log.warning(f"Crash log thread name capturer disabled: The coredump directory {self._coredump_directory} has variable format specifiers. Please define a simpler path (only %u %g %h %c specifiers allowed).")
+            return
+        if not self._coredump_directory or not os.path.isdir(self._coredump_directory) or not os.access(self._coredump_directory, os.R_OK | os.X_OK):
+            _log.warning(f"Crash log thread name capturer disabled: Coredump directory not readable: {self._coredump_directory}")
+            return
+        if not CrashLogUtils.are_coredumps_enabled(self._coredump_method):
+            _log.warning(f"Crash log thread name capturer disabled: coredump are not enabled. Please run: ulimit -c unlimited")
+            return
+        self._main_worker_thread = threading.Thread(target=self.watch_coredump_dir, daemon=True, name=f'watch-coredump-dir-{os.getpid()}')
+        self._main_worker_thread.start()
+
+    def _get_regex_for_core_pattern_pid_match(self):
+        regex = None
+        if self._coredump_method == CoreDumpMethod.Coredumpctl:
+            # The format is core.<name>.<uid>.<machine-id>.<pid>.<timestamp>.zst
+            regex = re.compile(r'core\..+?\.\d+\.[a-f0-9]+\.(?P<pid>\d+)\.\d+\.zst')
+        elif self._coredump_method == CoreDumpMethod.Abspath:
+            assert CrashLogUtils.core_pattern_has_pid_format_string(self._coredump_pattern)
+            regex = re.compile(CrashLogUtils.core_pattern_to_regex(self._coredump_pattern, generate_regex_for_pid_match=True))
+        return regex
+
+    def watch_coredump_dir(self):
+        if inotify_simple is None:
+            _log.error(f"Can't start thread info name capturer: inotify_simple python module is not available. Please install it.")
+            return
+        # A lockfile is used to ensure only one watch_coredump_dir is active in the whole system in the given self._webkit_thread_info_crashlog_dir
+        # If several test runners are launched then the other watch_coredump_dir threads will wait until the lockfile is released
+        # This is because we only need one of this threads active at any moment in the whole system, having more than one can lead to race conditions when writing the thread info
+        _log.debug(f"Crash log thread name capturer: watching coredumps directory {self._coredump_directory} and writing thread info to {self._webkit_thread_info_crashlog_dir}")
+        with LockFile(self._webkit_thread_info_crashlog_lockfile):
+            # lock forever on inotify IN_CREATE events in the given directory. Spawns a daemon thread per matching event.
+            inotify = inotify_simple.INotify()
+            # IN_CREATE fires the moment the kernel creates the file, which is the earliest possible moment before the dump is written.
+            watch_flags = inotify_simple.flags.CREATE
+            inotify.add_watch(self._coredump_directory, watch_flags)
+
+            core_pattern_regex_for_pid = self._get_regex_for_core_pattern_pid_match()
+            while True:
+                # inotify.read() blocks until at least one event arrives.
+                # It can return multiple events if they batched up.
+                events = inotify.read()
+                for event in events:
+                    filename = event.name
+                    if not filename:
+                        continue
+                    m = core_pattern_regex_for_pid.fullmatch(filename)
+                    if not m:
+                        continue
+                    pid = m.group('pid')
+                    # Spawn immediately to minimise latency
+                    t = threading.Thread(target=self.handle_coredump, args=(pid,), daemon=True, name=f'coredump-worker-{pid}')
+                    t.start()
+
+    def read_thread_info(self, pid):
+        task_dir = f'/proc/{pid}/task'
+        try:
+            tids = os.listdir(task_dir)
+        except (FileNotFoundError, PermissionError):
+            return None
+
+        threads = {}
+        for tid in tids:
+            comm_path = f'{task_dir}/{tid}/comm'
+            try:
+                with open(comm_path, 'r') as f:
+                    name = f.read().strip()
+            except (FileNotFoundError, PermissionError):
+                # Thread may have exited between listdir and open.
+                name = '<gone>'
+            threads[tid] = name
+
+        return threads
+
+    def handle_coredump(self, pid):
+        # Called in a dedicated thread as soon as the coredump file is created.
+        # Reads thread info and writes it to the threadinfo-${pid}.txt
+        timestamp = datetime.datetime.now().isoformat(timespec='seconds')
+        thread_info = self.read_thread_info(pid)
+        output_path = os.path.join(self._webkit_thread_info_crashlog_dir, CrashLogUtils.get_thread_info_file_name(pid))
+        _log.debug(f'Coredump detected for PID {pid}, saving "/proc/{pid}/task" info to "{output_path}" ...')
+        try:
+            with open(output_path, 'w') as f:
+                f.write(f'# Thread info captured at {timestamp}\n')
+                if thread_info is None:
+                    if self._coredump_method == CoreDumpMethod.Coredumpctl and not CrashLogUtils.in_host_pid_namespace():
+                        f.write(f'# ERROR: Impossible to get thread name info when using the coredumpctl method and running inside a pid namespace.\n')
+                        f.write(f'#        Please disable the pid namespace or switch to using an abspath for kernel.core_pattern.\n')
+                        f.write(f'# {CORE_PATTERN_RECOMMEND_COMMAND}\n')
+                    else:
+                        f.write(f'# ERROR: Process {pid} was already gone when we checked /proc/{pid}/task.\n')
+                elif not thread_info:
+                    # https://www.man7.org/linux/man-pages/man5/proc_pid_task.5.html
+                    f.write(f'# WARNING: No threads found under /proc/{pid}/task (maybe main thread exited before the crash).\n')
+                else:
+                    f.write(f'# Number of threads: {len(thread_info)}\n')
+                    f.write(f'# PID: {pid}\n')
+                    f.write('\n')
+                    f.write(f'{"TID":<12} {"Thread Name"}\n')
+                    f.write(f'{"-"*12} {"-"*20}\n')
+                    for tid, name in sorted(thread_info.items(), key=lambda x: int(x[0])):
+                        f.write(f'{tid:<12} {name}\n')
+        except OSError as e:
+            _log.error(f'Failed to write {output_path}: {e}')
+
+
+# This runs only once when the test suite start, it optionally cleans old cores and old thread-info files,
+# and then starts the thread for generating the thread-info files
+class GDBCrashLogStartupHandler(object):
+    def __init__(self):
+        self._coredump_method, self._coredump_pattern, self._coredump_directory, self._coredump_directory_has_variable_format_specifiers = CrashLogUtils.determine_coredump_method_and_dir()
+        if os.environ.get(CrashLogEnvVars.core_dumps_autodelete, '0') == '1':
+            # Even when we try to clean the coredumps as soon as those are processed sometimes there are uncleaned coredumps (usually caused by crashes not detected by this tooling),
+            # so this opt-in helps to clean those anyway at startup time (used on the bots).
+            if self._coredump_method == CoreDumpMethod.Abspath and os.path.isdir(self._coredump_directory):
+                self.clean_old_coredumps()
+            if os.path.isdir(CrashLogUtils.get_thread_data_dir()):
+                self.clean_old_thread_info_files()
+        # Try to create the dir if is not created already.
+        if self._coredump_method == CoreDumpMethod.Abspath:
+            try:
+                os.makedirs(self._coredump_directory, exist_ok=True)
+            except OSError as e:
+                _log.error(f"Unable to create directory for coredumps {self._coredump_directory}: {e}")
+        elif self._coredump_method == CoreDumpMethod.Coredumpctl and not CrashLogUtils.in_host_pid_namespace():
+            _log.warning("Running inside a pid namespace different than the host. This causes non-reliable crash detection. Please disable the pid namespace or switch to using an abspath for kernel.core_pattern.")
+        elif self._coredump_method == CoreDumpMethod.Unknown:
+            _log.error("Directory for coredumps not defined. Please use coredumpctl or define an abspath at kernel.core_pattern")
+        # Check if the debuginfod server is available to avoid hangs when generating the backtraces if the server is not responding
+        self._check_debuginfod_servers()
+        # Start the thread-info capturer
+        ThreadNamesCrashLogCapturer()
+
+    def _maybe_remove_file_if_old(self, path):
+        # Define old as "more than 30 minutes"
+        is_old = (time.time() - os.path.getmtime(path)) > 1800
+        if is_old:
+            _log.debug(f'Cleaning old file at: {path}')
+            os.remove(path)
+        else:
+            _log.debug(f'Skipping non-old file at: {path}')
+
+    def _is_debuginfod_server_available(self, url, timeout=5):
+        try:
+            r = requests.get(url.rstrip("/") + "/metrics", timeout=timeout)
+        except requests.RequestException:
+            return False
+
+        if r.status_code != 200:
+            return False
+
+        required_markers = ('thread_busy', 'http_requests_total', 'groom', 'debuginfo')
+        return all(marker in r.text for marker in required_markers)
+
+    def _check_debuginfod_servers(self):
+        if 'DEBUGINFOD_URLS' in os.environ:
+            working_debuginfod_servers = []
+            debuginfo_servers = os.environ.get('DEBUGINFOD_URLS').split()
+            if not debuginfo_servers:
+                return
+            for server in debuginfo_servers:
+                if server.startswith('file://'):
+                    working_debuginfod_servers.append(server)
+                elif server.startswith('http://') or server.startswith('https://'):
+                    if self._is_debuginfod_server_available(server):
+                        working_debuginfod_servers.append(server)
+                    else:
+                        _log.warning(f'Disabling debuginfod server {server} which seems offline.')
+                else:
+                    _log.warning(f'Disabling debuginfod server {server}: do not know how to handle it. Only http/https/file URIs are supported.')
+            if working_debuginfod_servers:
+                os.environ['DEBUGINFOD_URLS'] = ' '.join(working_debuginfod_servers)
+            else:
+                del os.environ['DEBUGINFOD_URLS']
+            _log.debug(f'Environment variable DEBUGINFOD_URLS updated to "{os.environ.get("DEBUGINFOD_URLS", "")}"')
+
+    def clean_old_coredumps(self):
+        candidate_coredumps = [os.path.join(self._coredump_directory, f) for f in os.listdir(self._coredump_directory) if os.path.isfile(os.path.join(self._coredump_directory, f))]
+        pattern_re = re.compile(CrashLogUtils.core_pattern_to_regex(self._coredump_pattern))
+        candidate_coredumps = [f for f in candidate_coredumps if pattern_re.fullmatch(os.path.basename(f))]
+        for coredump in candidate_coredumps:
+            self._maybe_remove_file_if_old(coredump)
+
+    def clean_old_thread_info_files(self):
+        webkit_thread_info_crashlog_dir = CrashLogUtils.get_thread_data_dir()
+        if os.path.isdir(webkit_thread_info_crashlog_dir):
+            example_pid = '12345'
+            prefix, suffix = CrashLogUtils.get_thread_info_file_name(example_pid).split(example_pid)
+            for name in os.listdir(webkit_thread_info_crashlog_dir):
+                path = os.path.join(webkit_thread_info_crashlog_dir, name)
+                if os.path.isfile(path) and name.startswith(prefix) and name.endswith(suffix):
+                    self._maybe_remove_file_if_old(path)
+
+
 class GDBCrashLogGenerator(object):
-    _find_pid_regex = re.compile(r'PID: (\d+) \(.*\)')
 
     def __init__(self, executive, name, pid, newer_than, filesystem, path_to_driver, port_name, configuration):
         self.name = name
@@ -52,105 +647,408 @@ class GDBCrashLogGenerator(object):
         self._port_name = port_name
         self._configuration = configuration
         self._webkit_finder = WebKitFinder(filesystem)
+        self._coredump_method, self._coredump_pattern, self._coredump_directory, self._coredump_directory_has_variable_format_specifiers = CrashLogUtils.determine_coredump_method_and_dir()
+        self._webkit_thread_info_crashlog_dir = CrashLogUtils.get_thread_data_dir()
+        self._effective_coredump_pid = None  # this is the pid of the coredump we will end use, ideally is the same than self.pid but not always
+        self._regex_for_core_pattern = None
+        if self._coredump_method == CoreDumpMethod.Abspath:
+            self._regex_for_core_pattern = re.compile(CrashLogUtils.core_pattern_to_regex(self._coredump_pattern, generate_regex_for_pid_match=self._coredump_pattern_has_pid_format_string()))
 
     def _get_gdb_output(self, coredump_path):
         process_name = self._filesystem.join(os.path.dirname(str(self._path_to_driver())), self.name)
-        # GDB may use quite a lot of CPU to generate a backtrace so give it less priority than other tester process to help avoiding timeouts.
-        cmd = ['nice', 'gdb', '-ex', 'thread apply all bt 1024', '--batch', process_name, coredump_path]
-        proc = self._executive.popen(cmd, stdin=None, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        stdout, stderr = proc.communicate()
-        errors = [stderr_line.strip().decode('utf8', 'ignore') for stderr_line in stderr.splitlines()]
+        # GDB may use quite a lot of CPU to generate a backtrace and also lot of RAM (specially on Debug builds)
+        # So, to help to stabilize the system in situations were several crashes happen at the same time on the run
+        # it is possible to configure the maximum number of maximum GDB processes that can run in parallel at a given time
+        # The others requests to generate a backtrace will stay queued and wait for the current ones to finish.
+        # If no limit is applied (the default) then gdb will run with the 'nice' wrapper to at least give it less priority
+        # than other tester process to help avoiding timeouts. But this can starve the system RAM.
+        # On the CI is recommended to set a limit.
+        gdb_cmd_wrapper = [] if CrashLogUtils.get_gdb_concurrent_execution_limit() else ['nice']
+        time_output_tmp = None
+        time_output_content = ""
+        if shutil.which('time'):
+            time_output_tmp = CrashLogUtils.make_temp_path(suffix='.log')
+            gdb_cmd_wrapper += ['time', '-v', f'--output={time_output_tmp}']
+        gdb_cmd = ['gdb', '-iex', 'set debuginfod enabled on',
+                   '-ex', 'thread apply all bt full 1024', '--batch', process_name, coredump_path]
+        with CrashLogUtils.get_gdb_lock():
+            _log.debug(f'Starting GDB process to generate a backtrace for {process_name} (pid {self._effective_coredump_pid})')
+            proc = self._executive.popen(gdb_cmd_wrapper + gdb_cmd, stdin=None, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+            stdout, stderr = proc.communicate()
         if proc.returncode != 0:
             stdout = (b'ERROR: The gdb process exited with non-zero return code %s\n\n' % str(proc.returncode).encode('utf8', 'ignore')) + stdout
-        return (stdout.decode('utf8', 'ignore'), errors)
+        # Read time stats
+        if time_output_tmp and os.path.isfile(time_output_tmp):
+            with open(time_output_tmp, 'r') as f:
+                lines = []
+                for line in f:
+                    line = line.strip()
+                    # Skip lines with zero values: most rusage fields (average sizes, swaps, I/O, signals) are always zero on Linux
+                    # because the kernel never implemented them -- they exist only for compatibility with BSD. See getrusage(2).
+                    if line.endswith(': 0') and 'Exit status' not in line:
+                        continue
+                    lines.append(line)
+                time_output_content = '\n'.join(lines)
+            os.remove(time_output_tmp)
+        return (stdout.decode('utf8', 'ignore'), stderr.decode('utf8', 'ignore'), time_output_content)
 
-    def _get_trace_from_systemd(self, coredumpctl, pid):
+    def _coredump_pattern_has_pid_format_string(self):
+        return CrashLogUtils.core_pattern_has_pid_format_string(self._coredump_pattern)
 
-        # Letting up to 5 seconds for the backtrace to be generated on the systemd side
-        for try_number in range(5):
-            if try_number != 0:
-                # Looping, it means we consider the logs might not be ready yet.
-                time.sleep(1)
+    def _pid_is_valid(self):
+        return self.pid and str(self.pid).isnumeric()
 
-            try:
-                info = self._executive.run_command(coredumpctl + ['info', '--since=@%f' % self.newer_than],
-                    return_stderr=True)
-            except (ScriptError, OSError):
-                continue
+    def _build_warning_msg(self, pid_found=False, name_found=False, last_found=False, nothing_found=False):
+        if pid_found:
+            return None
+        if name_found:
+            return f"Unable to find a coredump matching pid \"{self._pid_representation()}\".\n" +\
+                   f"This coredump was selected by returning the last coredump matching the crashing program name \"{self.name}\".\n" +\
+                   "There is a risk that the selected coredump doesn't match the crashing program.\n" +\
+                   "It is recommended to retry running this test alone to see if it generates a coredump and a backtrace like this one.\n"
+        if last_found:
+            return f"Unable to find a coredump matching pid \"{self._pid_representation()}\" or matching the crashing program name \"{self.name}\".\n" +\
+                   "This coredump was selected by simply returning the last one available.\n" +\
+                   "There is a high risk that the selected coredump doesn't match the crashing program.\n" +\
+                   "It is strongly recommended to retry running this test alone to see if it generates a coredump and a backtrace like this one.\n"
+        if nothing_found:
+            if CrashLogUtils.allow_unreliable_fallback_to_latest_coredump():
+                nothing_found_err = f"Unable to find a coredump matching pid \"{self._pid_representation()}\" or matching the crashing program name \"{self.name}\".\n" +\
+                                    "Unable to find any coredump"
+                if self._coredump_method == CoreDumpMethod.Abspath and self._coredump_pattern_has_pid_format_string():
+                    nothing_found_err += f" matching core_pattern \"{self._coredump_pattern}\""
+                elif self._coredump_method == CoreDumpMethod.Coredumpctl:
+                    nothing_found_err += " with coredumpctl"
+                if self.newer_than:
+                    nothing_found_err += f" newer than \"{self.newer_than}\""
+                nothing_found_err += ".\n"
+            else:
+                nothing_found_err = f"Unable to find a coredump matching pid \"{self._pid_representation()}\"\n" +\
+                                    f"Trying to match the coredump using other heuristics like matching by program name and/or timestamp was not tried,\n" +\
+                                    f"because doing that is unreliable (specially with several parallel workers). If you want to try that for the next run\n" +\
+                                    f"then export this environment variable before starting it: export {CrashLogEnvVars.allow_unreliable_fallback_to_latest_coredump}=1\n" +\
+                                    f"And run the tests without parallel workers (if possible): export NUMBER_OF_PROCESSORS=1\n"
+            return nothing_found_err
+        raise RuntimeError("This should not be reached.")
 
-            found_newer = False
-            # Coredumpctl will use the latest core dump with the specified PID
-            # assume it is the right one.
-            pids = self._find_pid_regex.findall(info)
-            if not pids:
-                continue
+    def _pick_most_recent(self, candidates, **warning_kwargs):
+        if not candidates:
+            return None
+        coredump_match_candidate = max(candidates, key=os.path.getmtime)
+        m = self._regex_for_core_pattern.fullmatch(os.path.basename(coredump_match_candidate))
+        if not m:
+            return None
+        if self._coredump_pattern_has_pid_format_string():
+            self._effective_coredump_pid = m.group('pid')
+        return coredump_match_candidate, self._build_warning_msg(**warning_kwargs)
 
-            pid = pids[0]
-            with tempfile.NamedTemporaryFile() as temp_file:
-                if self._executive.run_command(coredumpctl + ['dump', pid, '--output',
-                        temp_file.name], return_exit_code=True):
+    def _get_coredump_path_with_core_pattern_method(self):
+        can_match_by_pid = self._pid_is_valid() and self._coredump_pattern_has_pid_format_string()
+        for try_number in range(2):
+            candidate_coredumps = [os.path.join(self._coredump_directory, f) for f in os.listdir(self._coredump_directory) if os.path.isfile(os.path.join(self._coredump_directory, f))]
+            pattern_re = re.compile(CrashLogUtils.core_pattern_to_regex(self._coredump_pattern))
+            candidate_coredumps = [f for f in candidate_coredumps if pattern_re.fullmatch(os.path.basename(f)) and (not self.newer_than or os.path.getmtime(f) > self.newer_than)]
+
+            # If we have a pid number then return the last file that matches the pid number ignoring the other format specifiers from core_pattern (if any)
+            if can_match_by_pid:
+                pid_matches = []
+                for coredump in candidate_coredumps:
+                    match = self._regex_for_core_pattern.fullmatch(os.path.basename(coredump))
+                    if match and match.group('pid') == str(self.pid):
+                        pid_matches.append(coredump)
+
+                if pid_matches:
+                    self._effective_coredump_pid = self.pid
+                    return max(pid_matches, key=os.path.getmtime), self._build_warning_msg(pid_found=True)
+
+                # If match by pid doesn't happen then sleep and retry once.
+                # This may help if the system is under high stress and this code runs before the kernel starts to write the coredump to disk
+                # which I'm not sure if that can even happen, but this also helps when two or more workers race to get the same core (one
+                # matching by pid and another(s) by exe name), then the one matching by pid wins because the other has to sleep first.
+                if try_number == 0:
+                    time.sleep(1)
                     continue
 
-                return self._get_gdb_output(temp_file.name)
+                if not CrashLogUtils.allow_unreliable_fallback_to_latest_coredump():
+                    return None, self._build_warning_msg(nothing_found=True)
 
-        return '', []
+            # Try the most recent file matching the program name. This is reached
+            # either because can_match_by_pid is false, or because pid matching
+            # failed and unreliable fallback was explicitly enabled.
+            if self.name:
+                program_matches = [f for f in candidate_coredumps if self.name in os.path.basename(f)]
+                result = self._pick_most_recent(program_matches, name_found=True)
+                if result:
+                    return result
 
-    def generate_crash_log(self, stdout, stderr):
-        pid_representation = str(self.pid or '<unknown>')
-        log_directory = os.environ.get("WEBKIT_CORE_DUMPS_DIRECTORY")
-        errors = []
-        crash_log = ''
-        expected_crash_dump_filename = "core-pid_%s.dump" % pid_representation
-        proc_name = "%s" % (self.name)
-
-        def match_filename(filesystem, directory, filename):
-            if self.pid:
-                return filename == expected_crash_dump_filename
-            return filename.find(self.name) > -1
-
-        # Poor man which, ignore any failure.
-        for coredumpctl in [['coredumpctl'], []]:
-            try:
-                if not self._executive.run_command(coredumpctl, return_exit_code=True):
-                    break
-            except:
+            # Same idea than above, if matching by pid is not possible then sleep 1 also on the first iter
+            # so we have a better chance of a new core appearing on the second iteration.
+            if try_number == 0:
+                time.sleep(1)
                 continue
 
-        if log_directory:
-            dumps = self._filesystem.files_under(
-                log_directory, file_filter=match_filename)
-            if dumps:
-                # Get the most recent coredump matching the pid and/or process name.
-                coredump_path = list(reversed(sorted(dumps)))[0]
-                if not self.newer_than or self._filesystem.mtime(coredump_path) > self.newer_than:
-                    crash_log, errors = self._get_gdb_output(coredump_path)
-                    if os.environ.get('WEBKIT_CORE_DUMPS_AUTODELETE', '0') == '1':
+            if not CrashLogUtils.allow_unreliable_fallback_to_latest_coredump():
+                return None, self._build_warning_msg(nothing_found=True)
+
+            # Reached this point just give the most recent file matching the pattern
+            result = self._pick_most_recent(candidate_coredumps, last_found=True)
+            if result:
+                return result
+
+            # Couldn't find anything.
+            return None, self._build_warning_msg(nothing_found=True)
+
+    def _coredumpctl_dump_core_for_pid(self, coredumpctl_args_for_pid, warnings):
+        temp_file = CrashLogUtils.make_temp_path(dir=CrashLogUtils.get_temp_dir_for_coredumpctl_dumps(), suffix='.dump')
+        warnings = warnings or ""
+        failed = True
+        try:
+            self._executive.run_command(['coredumpctl', '-q', 'dump'] + coredumpctl_args_for_pid + ['--output', temp_file], return_stderr=True)
+            failed = False
+        except ScriptError as e:
+            warnings += f"\nThe coredumpctl program returned an error when trying to dump the core for pid {self._effective_coredump_pid}:\n{e.output}\n"
+        except OSError as e:
+            warnings += f"\nFailed to launch coredumpctl for pid {self._effective_coredump_pid}:\n{e}\n"
+        if failed:
+            if os.path.isfile(temp_file):
+                os.unlink(temp_file)
+            temp_file = None
+        return temp_file, warnings
+
+    def _get_coredump_path_with_coredumpctl_method(self):
+        coredumpctl_args_for_json = []
+        if self.newer_than:
+            coredumpctl_args_for_json.append('--since=@%f' % self.newer_than)
+
+        list_cmd = ["coredumpctl", "-q", "--json=short"] + coredumpctl_args_for_json + ['list']
+
+        can_match_by_pid = self._pid_is_valid() and CrashLogUtils.in_host_pid_namespace()
+        # Retry up to 5 times with 1-second sleeps: systemd-coredump runs as a separate
+        # userspace process, so by the time we ask, it may not yet have  ingested the dump.
+        coredump_entries = []
+        for try_number in range(5):
+            if try_number != 0:
+                time.sleep(1)
+            try:
+                list_output = self._executive.run_command(list_cmd, return_stderr=False)
+            except ScriptError:
+                # coredumpctl exits non-zero when there are no entries in the
+                # requested time window; retry in case the dump shows up soon.
+                continue
+            except OSError as e:
+                warnings = self._build_warning_msg(nothing_found=True)
+                warnings += f"\nFailed to launch coredumpctl:\n{e}\n"
+                return None, warnings
+
+            try:
+                coredump_entries = json.loads(list_output)
+            except json.JSONDecodeError as e:
+                warnings = self._build_warning_msg(nothing_found=True)
+                warnings += f"\nFailed to decode coredumpctl JSON output:\n{e}\n"
+                return None, warnings
+
+            if can_match_by_pid:
+                if any(str(e.get("pid")) == str(self.pid) for e in coredump_entries):
+                    break
+            else:
+                if not self.name:
+                    break  # nothing to wait for
+                # If we don't have pid or we run on a pid namespace then we can only match by name
+                if any(os.path.basename(e.get("exe") or "") == self.name for e in coredump_entries):
+                    break
+
+        if not coredump_entries:
+            return None, self._build_warning_msg(nothing_found=True)
+
+        # 1. Exact pid match
+        if can_match_by_pid:
+            pid_match = next((e for e in coredump_entries if str(e.get("pid")) == str(self.pid)), None)
+            if pid_match:
+                self._effective_coredump_pid = self.pid
+                args = coredumpctl_args_for_json + [f"{self.pid}"]
+                return self._coredumpctl_dump_core_for_pid(args, self._build_warning_msg(pid_found=True))
+
+        # 2. Match by program name only when:
+        #    - pid matching is impossible, or
+        #    - the user explicitly enabled unreliable fallback.
+        if self.name and (not can_match_by_pid or CrashLogUtils.allow_unreliable_fallback_to_latest_coredump()):
+            program_matches = [e for e in coredump_entries if self.name == os.path.basename(e.get("exe") or "")]
+            if program_matches:
+                entry = max(program_matches, key=lambda e: e["time"])
+                self._effective_coredump_pid = entry["pid"]
+                args = coredumpctl_args_for_json + [f"{entry['pid']}"]
+                return self._coredumpctl_dump_core_for_pid(args, self._build_warning_msg(name_found=True))
+
+        if not CrashLogUtils.allow_unreliable_fallback_to_latest_coredump():
+            return None, self._build_warning_msg(nothing_found=True)
+
+        # 3. Latest coredump is always unreliable, so only when explicitly enabled unreliable fallback
+        entry = max(coredump_entries, key=lambda e: e["time"])
+        self._effective_coredump_pid = entry["pid"]
+        args = coredumpctl_args_for_json + [f"{entry['pid']}"]
+        return self._coredumpctl_dump_core_for_pid(args, self._build_warning_msg(last_found=True))
+
+    def _get_coredump_path(self):
+        if self._coredump_method == CoreDumpMethod.Abspath and not self._coredump_directory_has_variable_format_specifiers:
+            return self._get_coredump_path_with_core_pattern_method()
+        elif self._coredump_method == CoreDumpMethod.Coredumpctl:
+            return self._get_coredump_path_with_coredumpctl_method()
+        return None, self._build_warning_msg(nothing_found=True)
+
+    def _get_help_message(self):
+        coredumps_enabled = CrashLogUtils.are_coredumps_enabled(self._coredump_method)
+        coredumps_enabled_and_unlimited = CrashLogUtils.are_coredumps_enabled_and_unlimited(self._coredump_method)
+        tip_msg = "To enable crash logs:\n\n"
+        hmsg = f"Coredump for pid {self._pid_representation()} not found.\n{tip_msg}"
+        if not coredumps_enabled:
+            hmsg += "    - Enable core dumps: ulimit -c unlimited\n"
+        elif not coredumps_enabled_and_unlimited:
+            hmsg += "    - You have coredumps enabled but not unlimited. Please rise the limit: ulimit -c unlimited\n"
+        if self._coredump_method == CoreDumpMethod.Unknown:
+            hmsg += f"    - Either install coredumpctl or execute this command: {CORE_PATTERN_RECOMMEND_COMMAND}\n\n" +\
+                    f"Note: If you opt for the second method you can export {CrashLogEnvVars.core_dumps_autodelete}=1 to automatically clean coredumps after processing those.\n" +\
+                    "      With the first method (coredumpctl) raw coredumps are cleaned automatically and only the compressed ones remain available.\n\n"
+        elif self._coredump_method == CoreDumpMethod.Abspath:
+            if not self._coredump_pattern_has_pid_format_string():
+                hmsg += "    - Please fix the file pattern of your core_pattern. It should contain the \"%p\" format specifier and is also recommended to include \"%f\".\n" +\
+                        f"      Example: {CORE_PATTERN_RECOMMEND_COMMAND} \n\n"
+            if self._coredump_directory_has_variable_format_specifiers:
+                hmsg += "    - Please fix the directory pattern of your core_pattern. Only fixed format specifiers are allowed for the directories (only %u %g %h %c specifiers allowed).\n" +\
+                        f"      Example: {CORE_PATTERN_RECOMMEND_COMMAND} \n\n"
+            elif not os.path.isdir(self._coredump_directory) or not os.access(self._coredump_directory, os.W_OK | os.R_OK | os.X_OK):
+                hmsg += f"    - Please fix the directory {self._coredump_directory} : Either the directory is missing or the current user doesn't have read & write access.\n"
+            else:
+                cd_disk_usage = shutil.disk_usage(self._coredump_directory)
+                cd_free_disk_gb = cd_disk_usage.free / (1024 ** 3)
+                if cd_free_disk_gb <= 20:
+                    hmsg += f"    - Please check the available disk space at {self._coredump_directory}:\n" + \
+                            f"      Only {cd_free_disk_gb} GB free are there. This may not be enough, specially for Debug builds.\n"
+        elif self._coredump_method == CoreDumpMethod.Coredumpctl:
+            hmsg += "    - Please check that the current user has permissions to execute coredumpctl and to dump coredumps from it.\n"
+            coredumpctl_dumps_tmpdir = CrashLogUtils.get_temp_dir_for_coredumpctl_dumps()
+            cd_disk_usage = shutil.disk_usage(self._coredump_directory)
+            cd_free_disk_pct = cd_disk_usage.free / cd_disk_usage.total * 100
+            if cd_free_disk_pct <= 15:
+                hmsg += f"    - Please check the available disk space at {self._coredump_directory}:\n" +\
+                        f"      The 'KeepFree=' default value of systemd-coredump requires more than 15% free and the free disk space is only a {cd_free_disk_pct:.2f}% there.\n"
+            td_disk_usage = shutil.disk_usage(coredumpctl_dumps_tmpdir)
+            td_free_disk_gb = td_disk_usage.free / (1024 ** 3)
+            if td_free_disk_gb <= 20:
+                hmsg += f"    - Please check the available disk space at {coredumpctl_dumps_tmpdir}:\n" +\
+                        f"      Only {td_free_disk_gb} GB free are there. This may not be enough, specially for Debug builds.\n"
+        if hmsg.endswith(tip_msg):
+            # If we can't find a cause for the missing coredump then replace the tip header with a descriptive error.
+            hmsg = hmsg.replace(tip_msg, 'No coredump was generated. Environment seems correctly configured for coredump generation. Cause unknown.\n')
+        return hmsg
+
+    def _get_thread_info_for_effective_pid(self):
+        if self._effective_coredump_pid:
+            thread_info_file = os.path.join(self._webkit_thread_info_crashlog_dir, CrashLogUtils.get_thread_info_file_name(self._effective_coredump_pid))
+            if os.path.isfile(thread_info_file):
+                with open(thread_info_file, 'r') as f:
+                    thread_info_content = f.read()
+                # Clean it: we only need it once
+                os.remove(thread_info_file)
+                return thread_info_content
+            return f"Thread names not available: could not find thread naming info for pid {self._effective_coredump_pid}.\n" +\
+                   f"The thread_info_file was not found at {thread_info_file}\n"
+        return f"Thread names not available: could not find the effective pid for the coredump."
+
+    def _pid_representation(self):
+        return str(self.pid or '<unknown>')
+
+    def _filter_with_cppfilt(self, text):
+        cppfilt_proc = self._executive.popen(['c++filt'], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+        text = cppfilt_proc.communicate(string_utils.encode(text))[0]
+        text = string_utils.decode(text, errors='ignore')
+        return text
+
+    def _underscore_header(self, header, first_header=False):
+        hstr = "" if first_header else "\n\n"
+        underscores = '-' * len(header)
+        hstr += f"{underscores}\n{header}\n{underscores}\n"
+        return hstr
+
+    def generate_crash_log(self, test_stdout, test_stderr):
+        timestamp_start = time.monotonic()
+        time_output = ""
+        gdb_stderr = ""
+        gdb_backtrace = ""
+
+        coredump_path, warnings_found = self._get_coredump_path()
+        coredump_path_was_found = coredump_path and os.path.isfile(coredump_path)
+        if coredump_path_was_found:
+            coredump_hr_size = CrashLogUtils.human_readable_size(coredump_path)
+            should_delete_coredump = self._coredump_method == CoreDumpMethod.Coredumpctl or os.environ.get(CrashLogEnvVars.core_dumps_autodelete, '0') == '1'
+            try:
+                gdb_backtrace, gdb_stderr, time_output = self._get_gdb_output(coredump_path)
+            finally:
+                if should_delete_coredump:
+                    try:
                         os.remove(coredump_path)
-        elif coredumpctl:
-            crash_log, errors = self._get_trace_from_systemd(coredumpctl, pid_representation)
+                    except OSError as e:
+                        _log.error(f'Could not remove {coredump_path}: {e}')
 
-        stderr_lines = errors + string_utils.decode(stderr or '<empty>', errors='ignore').splitlines()
-        errors_str = '\n'.join(('STDERR: ' + stderr_line) for stderr_line in stderr_lines)
-        cppfilt_proc = self._executive.popen(
-            ['c++filt'], stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        errors_str = cppfilt_proc.communicate(string_utils.encode(errors_str))[0]
-        errors_str = string_utils.decode(errors_str, errors='ignore')
+        if test_stderr:
+            test_stderr = self._filter_with_cppfilt(test_stderr)
 
-        if not crash_log:
-            if not log_directory:
-                log_directory = "/path/to/coredumps"
-            core_pattern = self._filesystem.join(log_directory, "core-pid_%p.dump")
-            crash_log = """\
-Coredump %(expected_crash_dump_filename)s not found. To enable crash logs:
+        if gdb_stderr:
+            gdb_stderr = '\n'.join(line for line in gdb_stderr.splitlines() if line.strip())
+            gdb_stderr = self._filter_with_cppfilt(gdb_stderr)
 
-- run this command as super-user: echo "%(core_pattern)s" > /proc/sys/kernel/core_pattern
-- enable core dumps: ulimit -c unlimited
-- set the WEBKIT_CORE_DUMPS_DIRECTORY environment variable: export WEBKIT_CORE_DUMPS_DIRECTORY=%(log_directory)s
+        if not gdb_backtrace:
+            gdb_backtrace = self._get_help_message()
 
-""" % locals()
+        thread_info_data = self._get_thread_info_for_effective_pid()
 
-        return (stderr, """\
-crash log for %(proc_name)s (pid %(pid_representation)s):
+        seconds_elapsed = time.monotonic() - timestamp_start
+        # All data gathered, now print it
+        crash_log = self._underscore_header(f"Crash log for {self.name} (pid {self._pid_representation()})", first_header=True)
+        crash_log += f'Total crash log generation took: {seconds_elapsed:.2f}s\n'
 
-%(crash_log)s
-%(errors_str)s""" % locals())
+        # If we got a coredump for another pid than self.pid or self.pid is unknown then give some extra warnings
+        if coredump_path_was_found:
+            if self._coredump_method == CoreDumpMethod.Abspath:
+                crash_log += f"Coredump file: {coredump_path}\n"
+                crash_log += f"Coredump size: {coredump_hr_size}\n"
+            elif self._coredump_method == CoreDumpMethod.Coredumpctl:
+                crash_log += f"Coredump file dump command: coredumpctl dump {self._effective_coredump_pid} --output {coredump_path}\n"
+                crash_log += f"Coredump uncompressed size: {coredump_hr_size}\n"
+
+            if str(self.pid) != str(self._effective_coredump_pid):
+                if self._coredump_method == CoreDumpMethod.Abspath and not self._coredump_pattern_has_pid_format_string():
+                    crash_log += f"\nWARNING: Cannot verify which pid this coredump belongs to: the kernel.core_pattern lacks the %p format specifier.\n"
+                else:
+                    crash_log += f"\nWARNING: The selected coredump to generate this backtrace was generated for pid {self._effective_coredump_pid}.\n"
+                s = ' ' * len('WARNING: ')
+                if self._pid_is_valid():
+                    if self._coredump_method == CoreDumpMethod.Coredumpctl and not CrashLogUtils.in_host_pid_namespace():
+                        crash_log += f"{s}This is because the test suite runs on a different namespace than the host one where coredumpctl runs.\n"
+                        crash_log += f"{s}TIP: Switch to the abspath method (raw coredump files) which is more reliable in this case:\n"
+                        crash_log += f"{s}    {CORE_PATTERN_RECOMMEND_COMMAND}\n"
+                    else:
+                        crash_log += f"{s}This is because a coredump for pid {self._pid_representation()} couldn't be found and this one was selected.\n"
+                else:
+                    crash_log += f"{s}This is because the pid for the crashing test was not valid ({self._pid_representation()}) and this coredump was selected.\n"
+                crash_log += f"{s}This difference introduces the possibility that the selected coredump was not created by this crashing test.\n\n"
+
+        if warnings_found:
+            crash_log += f"\nWARNING: {warnings_found}\n"
+        if test_stdout:
+            crash_log += self._underscore_header(f"TEST STDOUT")
+            crash_log += test_stdout
+        if test_stderr:
+            crash_log += self._underscore_header(f"TEST STDERR")
+            crash_log += test_stderr
+        crash_log += self._underscore_header(f"THREAD NAMING INFO")
+        crash_log += thread_info_data
+        crash_log += self._underscore_header(f"GDB FULL BACKTRACE")
+        crash_log += f'{gdb_backtrace}\n'
+        if gdb_stderr:
+            crash_log += self._underscore_header(f"GDB STDERR")
+            crash_log += f'{gdb_stderr}\n'
+        if time_output:
+            crash_log += self._underscore_header(f"GDB PROCESS STATS")
+            crash_log += time_output
+
+        return (test_stderr, crash_log)

--- a/Tools/Scripts/webkitpy/port/linux_get_crash_log_unittest.py
+++ b/Tools/Scripts/webkitpy/port/linux_get_crash_log_unittest.py
@@ -1,5 +1,5 @@
 # Copyright (C) 2013 University of Szeged
-# This module is a refactoring from gtk.py, Copyright (C) 2013 Igalia S.L
+# Copyright (C) 2013, 2026 Igalia S.L.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are
@@ -11,7 +11,7 @@
 # copyright notice, this list of conditions and the following disclaimer
 # in the documentation and/or other materials provided with the
 # distribution.
-#     * Neither the name of Google Inc. nor the names of its
+#     * Neither the name of the copyright holder nor the names of its
 # contributors may be used to endorse or promote products derived from
 # this software without specific prior written permission.
 #
@@ -27,49 +27,928 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
+import builtins
+import collections
+import io
 import os
-import sys
+import json
+import re
+import shutil
+import resource
+import tempfile
+import threading
+import time
 import unittest
+from unittest import mock
 
 from webkitpy.common.system.executive_mock import MockExecutive
-from webkitpy.common.system.executive_mock import MockProcess
 from webkitpy.common.system.filesystem_mock import MockFileSystem
-from webkitpy.port.linux_get_crash_log import GDBCrashLogGenerator
+from webkitpy.port.linux_get_crash_log import CoreDumpMethod, CrashLogEnvVars, CrashLogUtils, GDBCrashLogGenerator, LockFile, ThreadNamesCrashLogCapturer
 
 
-class GDBCrashLogGeneratorTest(unittest.TestCase):
-
-    def test_generate_crash_log(self):
-        if sys.platform.startswith('win'):
-            return
-
-        executive = MockExecutive()
-        executive._proc = MockProcess()
-        executive._proc.stdout = 'STDERR: <empty>'
-        generator = GDBCrashLogGenerator(executive, 'DumpRenderTree', 28529, newer_than=None, filesystem=MockFileSystem({'/path/to/coredumps': ''}), path_to_driver=None, port_name="gtk", configuration="Debug")
-
-        core_directory = os.environ.get('WEBKIT_CORE_DUMPS_DIRECTORY', '/path/to/coredumps')
-        core_pattern = generator._filesystem.join(core_directory, "core-pid_%p.dump")
-        mock_empty_crash_log = """\
-crash log for DumpRenderTree (pid 28529):
-
-Coredump core-pid_28529.dump not found. To enable crash logs:
-
-- run this command as super-user: echo "%(core_pattern)s" > /proc/sys/kernel/core_pattern
-- enable core dumps: ulimit -c unlimited
-- set the WEBKIT_CORE_DUMPS_DIRECTORY environment variable: export WEBKIT_CORE_DUMPS_DIRECTORY=%(core_directory)s
+# GDBCrashLogGenerator with determine_coredump_method_and_dir patched
+def _make_generator(name='WebKitWebProcess', pid=12345, coredump_method=None, coredump_pattern='core-pid_%p.dump', coredump_directory='/tmp', has_variable_format_specifiers=False):
+    if coredump_method is None:
+        coredump_method = CoreDumpMethod.Abspath
+    with mock.patch.object(CrashLogUtils, 'determine_coredump_method_and_dir', return_value=(coredump_method, coredump_pattern, coredump_directory, has_variable_format_specifiers)):
+        return GDBCrashLogGenerator(executive=MockExecutive(), name=name, pid=pid, newer_than=None, filesystem=MockFileSystem(), path_to_driver=None, port_name='gtk', configuration='Debug')
 
 
-STDERR: <empty>""" % locals()
+class AreCoredumpsEnabledTest(unittest.TestCase):
 
-        def _mock_gdb_output(self, coredump_path):
-            return (mock_empty_crash_log, [])
+    def test_coredumpctl_always_enabled(self):
+        self.assertTrue(CrashLogUtils.are_coredumps_enabled(CoreDumpMethod.Coredumpctl))
+        self.assertTrue(CrashLogUtils.are_coredumps_enabled_and_unlimited(CoreDumpMethod.Coredumpctl))
 
-        generator._get_gdb_output = _mock_gdb_output
-        stderr, log = generator.generate_crash_log(None, None)
-        self.assertEqual(stderr, None)
-        self.assertMultiLineEqual(log, mock_empty_crash_log)
+    def test_abspath_checks_rlimit(self):
+        with mock.patch('resource.getrlimit', return_value=(0, 0)):
+            self.assertFalse(CrashLogUtils.are_coredumps_enabled(CoreDumpMethod.Abspath))
+        with mock.patch('resource.getrlimit', return_value=(1024, 1024)):
+            self.assertTrue(CrashLogUtils.are_coredumps_enabled(CoreDumpMethod.Abspath))
+            self.assertFalse(CrashLogUtils.are_coredumps_enabled_and_unlimited(CoreDumpMethod.Abspath))
+        with mock.patch('resource.getrlimit', return_value=(resource.RLIM_INFINITY, resource.RLIM_INFINITY)):
+            self.assertTrue(CrashLogUtils.are_coredumps_enabled_and_unlimited(CoreDumpMethod.Abspath))
 
-        generator.newer_than = 0.0
-        self.assertEqual(stderr, None)
-        self.assertMultiLineEqual(log, mock_empty_crash_log)
+
+class CorePatternToRegexTest(unittest.TestCase):
+
+    def test_literal_string_passes_through(self):
+        self.assertEqual(CrashLogUtils.core_pattern_to_regex('core'), 'core')
+
+    def test_specifier_becomes_wildcard(self):
+        # %p -> .+ (non-empty: the kernel always writes something)
+        self.assertEqual(CrashLogUtils.core_pattern_to_regex('core-%p'), r'core\-.+')
+
+    def test_named_pid_capture_group(self):
+        regex = CrashLogUtils.core_pattern_to_regex('core-pid_%p.dump', generate_regex_for_pid_match=True)
+        m = re.fullmatch(regex, 'core-pid_28529.dump')
+        self.assertIsNotNone(m)
+        self.assertEqual(m.group('pid'), '28529')
+
+    def test_pid_capture_only_when_requested(self):
+        without = CrashLogUtils.core_pattern_to_regex('core-%p')
+        with_capture = CrashLogUtils.core_pattern_to_regex('core-%p', generate_regex_for_pid_match=True)
+        self.assertNotIn('(?P<pid>', without)
+        self.assertIn('(?P<pid>', with_capture)
+
+    def test_double_percent_is_literal_percent(self):
+        self.assertEqual(CrashLogUtils.core_pattern_to_regex('core%%'), 'core%')
+
+    def test_trailing_lone_percent_is_dropped(self):
+        # kernel rule: %<NUL> at end -> drop the %
+        self.assertEqual(CrashLogUtils.core_pattern_to_regex('core%'), 'core')
+
+    def test_invalid_specifier_is_dropped(self):
+        # %z isn't valid -> kernel drops both characters silently
+        self.assertEqual(CrashLogUtils.core_pattern_to_regex('core%z'), 'core')
+
+    def test_regex_metacharacters_are_escaped(self):
+        regex = CrashLogUtils.core_pattern_to_regex('core.dump')
+        self.assertIsNotNone(re.fullmatch(regex, 'core.dump'))
+        # The dot should be escaped, so 'X' should not match
+        self.assertIsNone(re.fullmatch(regex, 'coreXdump'))
+
+    def test_full_path_with_multiple_specifiers(self):
+        regex = CrashLogUtils.core_pattern_to_regex('/var/tmp/core/core-%e-%p-%t', generate_regex_for_pid_match=True)
+        m = re.fullmatch(regex, '/var/tmp/core/core-WebKit-1234-1700000000')
+        self.assertIsNotNone(m)
+        self.assertEqual(m.group('pid'), '1234')
+
+
+class ExpandCorePatternTest(unittest.TestCase):
+
+    def test_no_specifiers(self):
+        expanded, has_var = CrashLogUtils.expand_core_pattern_and_detect_variable_specifiers('/var/tmp/core/foo')
+        self.assertEqual(expanded, '/var/tmp/core/foo')
+        self.assertFalse(has_var)
+
+    def test_fixed_specifier_uid_is_expanded(self):
+        expanded, has_var = CrashLogUtils.expand_core_pattern_and_detect_variable_specifiers('/var/tmp/core/u%u/')
+        self.assertEqual(expanded, f'/var/tmp/core/u{os.getuid()}/')
+        self.assertFalse(has_var)
+
+    def test_variable_specifier_pid_is_detected(self):
+        _, has_var = CrashLogUtils.expand_core_pattern_and_detect_variable_specifiers('/var/tmp/core/%p')
+        self.assertTrue(has_var)
+
+    def test_double_percent_preserved_as_literal(self):
+        expanded, has_var = CrashLogUtils.expand_core_pattern_and_detect_variable_specifiers('/var/tmp/core/100%%')
+        self.assertEqual(expanded, '/var/tmp/core/100%')
+        self.assertFalse(has_var)
+
+    def test_trailing_lone_percent_is_dropped(self):
+        expanded, has_var = CrashLogUtils.expand_core_pattern_and_detect_variable_specifiers('/var/tmp/core/foo%')
+        self.assertEqual(expanded, '/var/tmp/core/foo')
+        self.assertFalse(has_var)
+
+
+class HumanReadableSizeTest(unittest.TestCase):
+
+    def _file_of_size(self, size):
+        fd, path = tempfile.mkstemp()
+        try:
+            os.write(fd, b'a' * size)
+        finally:
+            os.close(fd)
+        self.addCleanup(os.unlink, path)
+        return path
+
+    def test_small_file_reports_bytes(self):
+        path = self._file_of_size(512)
+        self.assertIn(' B', CrashLogUtils.human_readable_size(path))
+
+    def test_few_kilobyte_file_reports_kb(self):
+        path = self._file_of_size(4096)
+        self.assertIn(' KB', CrashLogUtils.human_readable_size(path))
+
+    def test_empty_file(self):
+        path = self._file_of_size(0)
+        self.assertEqual(CrashLogUtils.human_readable_size(path), '0.0 B')
+
+
+class MakeTempPathTest(unittest.TestCase):
+
+    def test_creates_a_real_empty_file(self):
+        path = CrashLogUtils.make_temp_path()
+        self.addCleanup(os.unlink, path)
+        self.assertTrue(os.path.isfile(path))
+        self.assertEqual(os.path.getsize(path), 0)
+
+    def test_respects_suffix(self):
+        path = CrashLogUtils.make_temp_path(suffix='.dump')
+        self.addCleanup(os.unlink, path)
+        self.assertTrue(path.endswith('.dump'))
+
+    def test_respects_dir(self):
+        with tempfile.TemporaryDirectory() as d:
+            path = CrashLogUtils.make_temp_path(dir=d)
+            self.assertEqual(os.path.dirname(os.path.realpath(path)), os.path.realpath(d))
+
+    def test_paths_are_unique(self):
+        p1 = CrashLogUtils.make_temp_path()
+        p2 = CrashLogUtils.make_temp_path()
+        self.addCleanup(os.unlink, p1)
+        self.addCleanup(os.unlink, p2)
+        self.assertNotEqual(p1, p2)
+
+
+class LockFileTest(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmpdir, True)
+
+    def test_acquire_creates_and_release_removes_lockfile(self):
+        path = os.path.join(self.tmpdir, 'single.lock')
+        lock = LockFile(path)
+        lock.acquire()
+        self.assertTrue(os.path.exists(path))
+        lock.release()
+        self.assertFalse(os.path.exists(path))
+
+    def test_context_manager(self):
+        path = os.path.join(self.tmpdir, 'cm.lock')
+        with LockFile(path):
+            self.assertTrue(os.path.exists(path))
+        self.assertFalse(os.path.exists(path))
+
+    def test_release_when_not_acquired_is_noop(self):
+        lock = LockFile(os.path.join(self.tmpdir, 'never.lock'))
+        lock.release()
+        self.assertTrue(True)  # Must not raise
+
+    def test_lockfile_contains_pid(self):
+        path = os.path.join(self.tmpdir, 'pid.lock')
+        with LockFile(path):
+            with open(path) as f:
+                self.assertEqual(f.read(), str(os.getpid()))
+
+    def test_single_slot_serializes_two_threads(self):
+        path = os.path.join(self.tmpdir, 'serialize.lock')
+        events = []
+
+        def worker(tag):
+            with LockFile(path):
+                events.append(('in', tag))
+                time.sleep(0.05)
+                events.append(('out', tag))
+
+        t1 = threading.Thread(target=worker, args=('a',))
+        t2 = threading.Thread(target=worker, args=('b',))
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        # Must alternate in/out for the same tag without interleaving
+        self.assertEqual(len(events), 4)
+        self.assertEqual(events[0][0], 'in')
+        self.assertEqual(events[1][0], 'out')
+        self.assertEqual(events[0][1], events[1][1])
+        self.assertEqual(events[2][0], 'in')
+        self.assertEqual(events[3][0], 'out')
+        self.assertEqual(events[2][1], events[3][1])
+
+    def test_multi_slot_allows_concurrent_holders(self):
+        path = os.path.join(self.tmpdir, 'multi.lock')
+        lock1 = LockFile(path, slots=2)
+        lock2 = LockFile(path, slots=2)
+        lock1.acquire()
+        try:
+            # Should not block since slots=2
+            lock2.acquire()
+            try:
+                self.assertNotEqual(lock1._locked_path, lock2._locked_path)
+                self.assertTrue(os.path.exists(lock1._locked_path))
+                self.assertTrue(os.path.exists(lock2._locked_path))
+            finally:
+                lock2.release()
+        finally:
+            lock1.release()
+
+    def test_get_gdb_lock_returns_distinct_lock_instances(self):
+        with mock.patch.object(CrashLogUtils, '_get_gdb_lock_configuration', return_value=('/tmp/gdb.lock', 1)):
+            lock1 = CrashLogUtils.get_gdb_lock()
+            lock2 = CrashLogUtils.get_gdb_lock()
+
+        self.assertIsInstance(lock1, LockFile)
+        self.assertIsInstance(lock2, LockFile)
+        self.assertIsNot(lock1, lock2)
+        self.assertEqual(lock1.path, lock2.path)
+
+
+class GDBCrashLogGeneratorHelpersTest(unittest.TestCase):
+
+    def setUp(self):
+        self.gen = _make_generator(name='WebKitWebProcess', pid=12345)
+
+    def test_pid_representation_known(self):
+        self.assertEqual(self.gen._pid_representation(), '12345')
+
+    def test_pid_representation_none(self):
+        self.gen.pid = None
+        self.assertEqual(self.gen._pid_representation(), '<unknown>')
+
+    def test_pid_is_valid_when_numeric(self):
+        self.assertTrue(self.gen._pid_is_valid())
+
+    def test_pid_is_invalid_when_none(self):
+        self.gen.pid = None
+        self.assertFalse(self.gen._pid_is_valid())
+
+    def test_pid_is_invalid_when_non_numeric_string(self):
+        self.gen.pid = 'unknown'
+        self.assertFalse(self.gen._pid_is_valid())
+
+    def test_pattern_with_pid_specifier(self):
+        self.assertTrue(self.gen._coredump_pattern_has_pid_format_string())
+
+    def test_pattern_without_pid_specifier(self):
+        self.gen._coredump_pattern = 'core'
+        self.assertFalse(self.gen._coredump_pattern_has_pid_format_string())
+
+    def test_underscore_header_basic(self):
+        header = self.gen._underscore_header('SECTION')
+        self.assertTrue(header.startswith('\n\n'))
+        self.assertIn('SECTION', header)
+        self.assertIn('-' * len('SECTION'), header)
+
+    def test_underscore_header_first_omits_leading_newlines(self):
+        header = self.gen._underscore_header('FIRST', first_header=True)
+        self.assertFalse(header.startswith('\n\n'))
+        self.assertIn('FIRST', header)
+
+
+class BuildWarningMsgTest(unittest.TestCase):
+
+    def setUp(self):
+        self.gen = _make_generator(name='WebKitWebProcess', pid=999)
+
+    def test_pid_found_returns_none(self):
+        self.assertIsNone(self.gen._build_warning_msg(pid_found=True))
+
+    def test_name_found_mentions_program_name(self):
+        msg = self.gen._build_warning_msg(name_found=True)
+        self.assertIn('WebKitWebProcess', msg)
+        self.assertIn('matching the crashing program name', msg)
+
+    def test_last_found_warns_high_risk(self):
+        msg = self.gen._build_warning_msg(last_found=True)
+        self.assertIn('high risk', msg)
+
+    def test_nothing_found_default_path_suggests_env_var(self):
+        # The default (env var unset) path of nothing_found should recommend the fallback env var by name.
+        with mock.patch.object(CrashLogUtils, 'allow_unreliable_fallback_to_latest_coredump', return_value=False):
+            msg = self.gen._build_warning_msg(nothing_found=True)
+        self.assertIn(CrashLogEnvVars.allow_unreliable_fallback_to_latest_coredump, msg)
+
+    def test_no_flag_set_raises(self):
+        with self.assertRaises(RuntimeError):
+            self.gen._build_warning_msg()
+
+
+class PickMostRecentTest(unittest.TestCase):
+
+    def setUp(self):
+        self.gen = _make_generator(name='Foo', pid=100)
+        self.tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmpdir, True)
+
+    def _touch(self, name, mtime=None):
+        path = os.path.join(self.tmpdir, name)
+        with open(path, 'w') as f:
+            f.write('')
+        if mtime is not None:
+            os.utime(path, (mtime, mtime))
+        return path
+
+    def test_empty_candidates_returns_none(self):
+        self.assertIsNone(self.gen._pick_most_recent([], last_found=True))
+
+    def test_no_pattern_match_returns_none(self):
+        # File that doesn't match the core_pattern regex
+        p = self._touch('not-a-core.txt')
+        self.assertIsNone(self.gen._pick_most_recent([p], last_found=True))
+
+    def test_picks_newest_and_extracts_pid(self):
+        old = self._touch('core-pid_111.dump', mtime=1000)
+        new = self._touch('core-pid_222.dump', mtime=2000)
+        result = self.gen._pick_most_recent([old, new], last_found=True)
+        self.assertIsNotNone(result)
+        path, warning = result
+        self.assertEqual(path, new)
+        self.assertEqual(self.gen._effective_coredump_pid, '222')
+        self.assertIn('high risk', warning)
+
+    def test_warning_kwargs_passed_through(self):
+        new = self._touch('core-pid_222.dump', mtime=2000)
+        _, warning = self.gen._pick_most_recent([new], name_found=True)
+        self.assertIn('matching the crashing program name', warning)
+
+
+class GenerateCrashLogTest(unittest.TestCase):
+    """End-to-end smoke test with the external dependencies stubbed out."""
+
+    def test_no_coredump_emits_help_message_and_sections(self):
+        gen = _make_generator(name='WebKitTestRunner', pid=28529)
+        gen._get_coredump_path = lambda: (None, None)
+        gen._filter_with_cppfilt = lambda text: text
+        gen._get_thread_info_for_effective_pid = lambda: '(no thread info)\n'
+
+        with mock.patch.object(CrashLogUtils, 'are_coredumps_enabled', return_value=True), \
+             mock.patch.object(CrashLogUtils, 'are_coredumps_enabled_and_unlimited', return_value=True):
+            stderr, log = gen.generate_crash_log('the test stdout', 'the test stderr')
+
+        # generate_crash_log echoes back the (possibly cppfilt-processed) stderr
+        self.assertEqual(stderr, 'the test stderr')
+
+        # Header with process name and pid
+        self.assertIn('WebKitTestRunner', log)
+        self.assertIn('28529', log)
+
+        # Always-present sections
+        for section in ('TEST STDOUT', 'TEST STDERR', 'THREAD NAMING INFO', 'GDB FULL BACKTRACE'):
+            self.assertIn(section, log)
+
+        # The supplied stdout/stderr text appears under those sections
+        self.assertIn('the test stdout', log)
+        self.assertIn('the test stderr', log)
+
+        # The help message replaces the missing backtrace, mentions the pid
+        self.assertIn('Coredump for pid 28529 not found', log)
+
+    def test_stderr_section_skipped_when_no_stderr(self):
+        gen = _make_generator(name='WebKitWebProcess', pid=42)
+        gen._get_coredump_path = lambda: (None, None)
+        gen._filter_with_cppfilt = lambda text: text
+        gen._get_thread_info_for_effective_pid = lambda: '(none)\n'
+
+        with mock.patch.object(CrashLogUtils, 'are_coredumps_enabled', return_value=True), \
+             mock.patch.object(CrashLogUtils, 'are_coredumps_enabled_and_unlimited', return_value=True):
+            _, log = gen.generate_crash_log('stdout content', '')
+
+        self.assertIn('TEST STDOUT', log)
+        self.assertNotIn('TEST STDERR', log)
+
+
+class DetermineCoredumpMethodAndDirTest(unittest.TestCase):
+
+    def _run_with_core_pattern(self, core_pattern, coredumpctl_path=None):
+        with mock.patch('builtins.open', mock.mock_open(read_data=core_pattern + '\n')), \
+             mock.patch('shutil.which', return_value=coredumpctl_path):
+            return CrashLogUtils.determine_coredump_method_and_dir()
+
+    def test_abspath_method_simple(self):
+        method, pattern, directory, has_var = self._run_with_core_pattern('/var/tmp/core/core-%e-%p.dump')
+        self.assertEqual(method, CoreDumpMethod.Abspath)
+        self.assertEqual(pattern, 'core-%e-%p.dump')
+        self.assertEqual(directory, '/var/tmp/core')
+        self.assertFalse(has_var)
+
+    def test_abspath_with_fixed_specifier_in_dir(self):
+        # %u is fixed for the session (the uid) so it expands at config time and the directory is NOT flagged as variable.
+        method, pattern, directory, has_var = self._run_with_core_pattern('/var/tmp/core/u%u/core-%p')
+        self.assertEqual(method, CoreDumpMethod.Abspath)
+        self.assertEqual(directory, f'/var/tmp/core/u{os.getuid()}')
+        self.assertFalse(has_var)
+
+    def test_abspath_with_variable_specifier_in_dir(self):
+        # %p in the directory changes per crash: flagged as variable.
+        method, _, _, has_var = self._run_with_core_pattern('/var/tmp/core/%p/core')
+        self.assertEqual(method, CoreDumpMethod.Abspath)
+        self.assertTrue(has_var)
+
+    def test_systemd_pipe_with_coredumpctl_present(self):
+        method, _, directory, _ = self._run_with_core_pattern('|/usr/lib/systemd/systemd-coredump %P %u', coredumpctl_path='/usr/bin/coredumpctl')
+        self.assertEqual(method, CoreDumpMethod.Coredumpctl)
+        self.assertEqual(directory, '/var/lib/systemd/coredump')
+
+    def test_systemd_pipe_without_coredumpctl_program(self):
+        method, _, _, _ = self._run_with_core_pattern('|/usr/lib/systemd/systemd-coredump %P', coredumpctl_path=None)
+        # coredumpctl isn't on PATH: we can't use the systemd path, method is Unknown.
+        self.assertEqual(method, CoreDumpMethod.Unknown)
+
+    def test_pipe_to_non_systemd_program(self):
+        method, _, _, _ = self._run_with_core_pattern('|/usr/share/apport/apport %P', coredumpctl_path='/usr/bin/coredumpctl')
+        # Apport pipe handler, not systemd-coredump: Unknown.
+        self.assertEqual(method, CoreDumpMethod.Unknown)
+
+    def test_unknown_when_pattern_is_relative(self):
+        # A relative name (no leading '/', '|', or '@') means "in the crashing
+        # process's CWD", which we can't reliably use. Treated as Unknown.
+        method, _, _, _ = self._run_with_core_pattern('core')
+        self.assertEqual(method, CoreDumpMethod.Unknown)
+
+
+class GetTempDirForCoredumpctlDumpsTest(unittest.TestCase):
+
+    def setUp(self):
+        # Clear the @memoized cache so each test case gets fresh probing logic.
+        CrashLogUtils.__dict__['get_temp_dir_for_coredumpctl_dumps'].__func__._results_cache.clear()
+        # /proc/mounts is opened once per is_tmpfs() call (twice total).
+        # Tests override `self.proc_mounts_contents` to mark a path as tmpfs.
+        self.proc_mounts_contents = "proc /proc proc rw 0 0\n"
+        self.writable = {'/tmp': True, '/var/tmp': True}
+        self.free = {'/tmp': 100 * 1024 ** 3, '/var/tmp': 100 * 1024 ** 3}
+        self._disk_usage = collections.namedtuple('disk_usage', ['total', 'used', 'free'])
+
+    def _run(self):
+        real_open = builtins.open
+
+        def fake_open(path, *args, **kwargs):
+            if path == '/proc/mounts':
+                return io.StringIO(self.proc_mounts_contents)
+            return real_open(path, *args, **kwargs)
+
+        with mock.patch('tempfile.gettempdir', return_value='/tmp'), \
+             mock.patch('os.access', side_effect=lambda p, mode: self.writable.get(p, False)), \
+             mock.patch('os.path.realpath', side_effect=lambda p: p), \
+             mock.patch('builtins.open', side_effect=fake_open), \
+             mock.patch('shutil.disk_usage', side_effect=lambda p: self._disk_usage(0, 0, self.free[p])), \
+             mock.patch('os.makedirs') as makedirs:
+            result = CrashLogUtils.get_temp_dir_for_coredumpctl_dumps()
+        return result, makedirs
+
+    def test_picks_tmp_when_only_tmp_writable(self):
+        self.writable = {'/tmp': True, '/var/tmp': False}
+        result, makedirs = self._run()
+        self.assertEqual(result, '/tmp/webkit-coredumpctl-dumps')
+        makedirs.assert_called_once_with('/tmp/webkit-coredumpctl-dumps', exist_ok=True)
+
+    def test_picks_var_tmp_when_only_var_tmp_writable(self):
+        self.writable = {'/tmp': False, '/var/tmp': True}
+        result, _ = self._run()
+        self.assertEqual(result, '/var/tmp/webkit-coredumpctl-dumps')
+
+    def test_picks_tmp_when_free_space_is_similar(self):
+        # Both writable, identical free space: preserves the order (tmp first).
+        result, _ = self._run()
+        self.assertEqual(result, '/tmp/webkit-coredumpctl-dumps')
+
+    def test_picks_var_tmp_when_substantially_more_free(self):
+        # /var/tmp has +2 GB more than /tmp: prefer /var/tmp.
+        self.free = {'/tmp': 1 * 1024 ** 3, '/var/tmp': 3 * 1024 ** 3}
+        result, _ = self._run()
+        self.assertEqual(result, '/var/tmp/webkit-coredumpctl-dumps')
+
+    def test_skips_tmpfs_mount(self):
+        # /tmp is tmpfs (bad for big coredumps): /var/tmp wins.
+        self.proc_mounts_contents = "tmpfs /tmp tmpfs rw 0 0\n"
+        result, _ = self._run()
+        self.assertEqual(result, '/var/tmp/webkit-coredumpctl-dumps')
+
+    def test_falls_back_to_tmp_when_nothing_usable(self):
+        # Neither writable: function warns and still returns a tmp subdir.
+        self.writable = {'/tmp': False, '/var/tmp': False}
+        result, _ = self._run()
+        self.assertEqual(result, '/tmp/webkit-coredumpctl-dumps')
+
+
+class ThreadNamesCrashLogCapturerTest(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmpdir, True)
+        self.capturer = ThreadNamesCrashLogCapturer.__new__(ThreadNamesCrashLogCapturer)
+        self.capturer._coredump_method = CoreDumpMethod.Abspath
+        self.capturer._webkit_thread_info_crashlog_dir = self.tmpdir
+
+    def _read_output(self, pid):
+        path = os.path.join(self.tmpdir, CrashLogUtils.get_thread_info_file_name(pid))
+        self.assertTrue(os.path.isfile(path), f'expected output file at {path}')
+        with open(path) as f:
+            return f.read()
+
+    def test_capturer_is_disabled_when_pattern_only_contains_literal_percent_p(self):
+        with mock.patch.object(CrashLogUtils, 'get_thread_data_dir', return_value=self.tmpdir), \
+             mock.patch.object(CrashLogUtils, 'determine_coredump_method_and_dir', return_value=(CoreDumpMethod.Abspath, 'core-%%p.dump', self.tmpdir, False)), \
+             mock.patch('os.access', return_value=True), \
+             mock.patch('threading.Thread') as thread_constructor:
+            ThreadNamesCrashLogCapturer()
+        thread_constructor.assert_not_called()
+
+    def test_repeated_pid_specifiers_reuse_the_same_pid_capture(self):
+        regex = CrashLogUtils.core_pattern_to_regex('core-%p-again-%p.dump', generate_regex_for_pid_match=True,)
+
+        match = re.fullmatch(regex, 'core-1234-again-1234.dump')
+        self.assertIsNotNone(match)
+        self.assertEqual(match.group('pid'), '1234')
+
+        # Both %p expansions refer to the same crashing PID, so a different
+        # second PID should not match.
+        self.assertIsNone(re.fullmatch(regex, 'core-1234-again-5678.dump'))
+
+    def test_writes_thread_table_when_threads_present(self):
+        threads = {'100': 'main', '101': 'gc-worker', '102': 'io-thread'}
+        with mock.patch.object(self.capturer, 'read_thread_info', return_value=threads):
+            self.capturer.handle_coredump('9999')
+
+        content = self._read_output('9999')
+        self.assertIn('# Thread info captured at', content)
+        self.assertIn('# Number of threads: 3', content)
+        self.assertIn('# PID: 9999', content)
+        for tid, name in threads.items():
+            self.assertIn(tid, content)
+            self.assertIn(name, content)
+        # TIDs should be sorted numerically. Each thread row starts on its own line.
+        idx_100 = content.find('\n100')
+        idx_101 = content.find('\n101')
+        idx_102 = content.find('\n102')
+        self.assertTrue(0 < idx_100 < idx_101 < idx_102)
+
+    def test_writes_error_when_process_already_gone(self):
+        with mock.patch.object(self.capturer, 'read_thread_info', return_value=None):
+            self.capturer.handle_coredump('1234')
+
+        content = self._read_output('1234')
+        self.assertIn('ERROR', content)
+        self.assertIn('1234 was already gone', content)
+        # Headers/table should NOT appear in the error case
+        self.assertNotIn('# Number of threads', content)
+        self.assertNotIn('# PID:', content)
+        self.assertNotIn('TID', content)
+
+    def test_writes_warning_when_no_threads_found(self):
+        with mock.patch.object(self.capturer, 'read_thread_info', return_value={}):
+            self.capturer.handle_coredump('1234')
+
+        content = self._read_output('1234')
+        self.assertIn('WARNING', content)
+        self.assertIn('No threads found', content)
+        self.assertNotIn('# Number of threads', content)
+
+    def test_full_path_through_fake_proc_task(self):
+        # Drive handle_coredump through the real read_thread_info, with the
+        # /proc/<pid>/task lookups faked at the os.listdir / open layer.
+        fake_pid = '9999'
+        fake_tids = ['100', '101', '102']
+        fake_comms = {'100': 'main\n', '101': 'gc-worker\n', '102': 'io-thread\n'}
+        task_dir = f'/proc/{fake_pid}/task'
+
+        real_listdir = os.listdir
+        real_open = builtins.open
+
+        def fake_listdir(path):
+            if path == task_dir:
+                return list(fake_tids)
+            return real_listdir(path)
+
+        def fake_open(path, *args, **kwargs):
+            for tid, name in fake_comms.items():
+                if path == f'{task_dir}/{tid}/comm':
+                    return io.StringIO(name)
+            return real_open(path, *args, **kwargs)
+
+        with mock.patch('os.listdir', side_effect=fake_listdir), \
+             mock.patch('builtins.open', side_effect=fake_open):
+            self.capturer.handle_coredump(fake_pid)
+
+        content = self._read_output(fake_pid)
+        self.assertIn('# Number of threads: 3', content)
+        self.assertIn(f'# PID: {fake_pid}', content)
+        for name in fake_comms.values():
+            self.assertIn(name.strip(), content)
+
+
+# Build a directory of fake coredump files with controlled mtimes and check that the selection logic
+# returns the right file for various queries (pid match, name fallback, newer_than filtering).
+# Uses a real tempdir so os.listdir / os.path.getmtime work without patching.
+class GetCoredumpPathTest(unittest.TestCase):
+
+    def setUp(self):
+        self.tmpdir = tempfile.mkdtemp()
+        self.addCleanup(shutil.rmtree, self.tmpdir, True)
+        self.gen = _make_generator(
+            name='WebKitWebProcess',
+            pid=222,
+            coredump_pattern='core-%e-pid_%p.dump',
+            coredump_directory=self.tmpdir,
+        )
+
+    def _touch(self, name, mtime):
+        path = os.path.join(self.tmpdir, name)
+        with open(path, 'w') as f:
+            f.write('')
+        os.utime(path, (mtime, mtime))
+        return path
+
+    def test_matches_by_pid_when_available(self):
+        # Multiple coredumps in the dir, one matching our pid.
+        self._touch('core-OtherProcess-pid_111.dump', mtime=1000)
+        expected = self._touch('core-WebKitWebProcess-pid_222.dump', mtime=2000)
+        self._touch('core-WebKitWebProcess-pid_333.dump', mtime=3000)  # newer but wrong pid
+
+        # Patch out the retry sleep so the test runs fast.
+        with mock.patch('time.sleep'):
+            path, warning = self.gen._get_coredump_path_with_core_pattern_method()
+
+        self.assertEqual(path, expected)
+        self.assertEqual(self.gen._effective_coredump_pid, 222)
+        # pid match: no warning
+        self.assertIsNone(warning)
+
+    def test_matches_by_pid_when_pattern_contains_literal_percent_p(self):
+        gen = _make_generator(name='WebKitWebProcess', pid=222, coredump_pattern='core-%%p-pid_%p.dump', coredump_directory=self.tmpdir)
+
+        expected = self._touch('core-%p-pid_222.dump', mtime=2000)
+        self._touch('core-%p-pid_111.dump', mtime=3000)
+
+        with mock.patch('time.sleep'):
+            path, warning = gen._get_coredump_path_with_core_pattern_method()
+
+        self.assertEqual(path, expected)
+        self.assertEqual(gen._effective_coredump_pid, 222)
+        self.assertIsNone(warning)
+
+    def test_does_not_fall_back_to_name_when_pid_match_is_possible_and_fallback_is_disabled(self):
+        # pid 222 is valid and the pattern contains %p, so matching by pid is possible.
+        # There are matching program-name coredumps, but none for pid 222.
+        self._touch('core-WebKitWebProcess-pid_111.dump', mtime=1000)
+        self._touch('core-WebKitWebProcess-pid_333.dump', mtime=2000)
+
+        with mock.patch('time.sleep') as sleep, \
+             mock.patch.object(CrashLogUtils, 'allow_unreliable_fallback_to_latest_coredump', return_value=False):
+            path, warning = self.gen._get_coredump_path_with_core_pattern_method()
+
+        self.assertIsNone(path)
+        self.assertIn(CrashLogEnvVars.allow_unreliable_fallback_to_latest_coredump, warning)
+        sleep.assert_called_once_with(1)
+
+    def test_falls_back_to_name_when_pid_match_is_possible_and_fallback_is_enabled(self):
+        # pid 222 is valid and the pattern contains %p, so matching by pid is possible.
+        # There is no pid match, but unreliable fallback is explicitly enabled.
+        self._touch('core-OtherProcess-pid_111.dump', mtime=1000)
+        expected = self._touch('core-WebKitWebProcess-pid_555.dump', mtime=2000)
+
+        with mock.patch('time.sleep') as sleep, \
+             mock.patch.object(CrashLogUtils, 'allow_unreliable_fallback_to_latest_coredump', return_value=True):
+            path, warning = self.gen._get_coredump_path_with_core_pattern_method()
+
+        self.assertEqual(path, expected)
+        self.assertEqual(self.gen._effective_coredump_pid, '555')
+        self.assertIn('matching the crashing program name', warning)
+        sleep.assert_called_once_with(1)
+
+    def test_falls_back_to_name_when_pid_is_invalid_and_fallback_is_disabled(self):
+        # With no valid pid, matching by pid is impossible, so name-based matching
+        # is allowed even without the unreliable-fallback env var.
+        self.gen.pid = None
+
+        self._touch('core-OtherProcess-pid_111.dump', mtime=1000)
+        expected = self._touch('core-WebKitWebProcess-pid_555.dump', mtime=2000)
+
+        with mock.patch('time.sleep') as sleep, \
+             mock.patch.object(CrashLogUtils, 'allow_unreliable_fallback_to_latest_coredump', return_value=False):
+            path, warning = self.gen._get_coredump_path_with_core_pattern_method()
+
+        self.assertEqual(path, expected)
+        self.assertEqual(self.gen._effective_coredump_pid, '555')
+        self.assertIn('matching the crashing program name', warning)
+        sleep.assert_not_called()
+
+    def test_falls_back_to_name_when_core_pattern_cannot_match_pid_and_fallback_is_disabled(self):
+        # pid 222 is valid, but this core_pattern does not contain %p, so matching
+        # by pid is impossible. Name-based matching is allowed without the env var.
+        gen = _make_generator(
+            name='WebKitWebProcess',
+            pid=222,
+            coredump_pattern='core-%e.dump',
+            coredump_directory=self.tmpdir,
+        )
+
+        self._touch('core-OtherProcess.dump', mtime=1000)
+        expected = self._touch('core-WebKitWebProcess.dump', mtime=2000)
+
+        with mock.patch('time.sleep') as sleep, \
+             mock.patch.object(CrashLogUtils, 'allow_unreliable_fallback_to_latest_coredump', return_value=False):
+            path, warning = gen._get_coredump_path_with_core_pattern_method()
+
+        self.assertEqual(path, expected)
+        self.assertIsNone(gen._effective_coredump_pid)
+        self.assertIn('matching the crashing program name', warning)
+        sleep.assert_not_called()
+
+    def test_pid_match_on_second_attempt_wins_over_existing_name_match(self):
+        # If pid matching is possible, the function waits one retry before taking
+        # the unreliable name fallback. If the exact pid match appears during that
+        # window, it must win.
+        name_match = self._touch('core-WebKitWebProcess-pid_333.dump', mtime=1000)
+        expected = os.path.join(self.tmpdir, 'core-WebKitWebProcess-pid_222.dump')
+
+        def create_pid_match(_seconds):
+            with open(expected, 'w') as f:
+                f.write('')
+            os.utime(expected, (2000, 2000))
+
+        with mock.patch('time.sleep', side_effect=create_pid_match) as sleep, \
+             mock.patch.object(CrashLogUtils, 'allow_unreliable_fallback_to_latest_coredump', return_value=True):
+            path, warning = self.gen._get_coredump_path_with_core_pattern_method()
+
+        self.assertEqual(path, expected)
+        self.assertNotEqual(path, name_match)
+        self.assertEqual(self.gen._effective_coredump_pid, 222)
+        self.assertIsNone(warning)
+        sleep.assert_called_once_with(1)
+
+    def test_pattern_with_literal_percent_p_has_no_pid_specifier(self):
+        self.gen._coredump_pattern = 'core-%%p.dump'
+        self.assertFalse(self.gen._coredump_pattern_has_pid_format_string())
+
+    def test_pid_lookup_ignores_filename_with_extra_suffix(self):
+        matching_core = self._touch('core-WebKitWebProcess-pid_12345.dump', mtime=1000, )
+        self._touch('core-WebKitWebProcess-pid_12345.dump.bak', mtime=2000, )
+
+        gen = _make_generator(name='WebKitWebProcess', pid=12345, coredump_pattern='core-%f-pid_%p.dump', coredump_directory=self.tmpdir)
+        with mock.patch('time.sleep'):
+            coredump_path, warning = gen._get_coredump_path_with_core_pattern_method()
+
+        self.assertEqual(coredump_path, matching_core)
+        self.assertIsNone(warning)
+        self.assertEqual(gen._effective_coredump_pid, 12345)
+
+    def test_returns_none_without_unreliable_fallback(self):
+        # No pid match and fallback disabled: no path, warning recommending the env var.
+        self._touch('core-OtherProcess-pid_111.dump', mtime=1000)
+
+        with mock.patch('time.sleep'), \
+             mock.patch.object(CrashLogUtils, 'allow_unreliable_fallback_to_latest_coredump', return_value=False):
+            path, warning = self.gen._get_coredump_path_with_core_pattern_method()
+
+        self.assertIsNone(path)
+        self.assertIn(CrashLogEnvVars.allow_unreliable_fallback_to_latest_coredump, warning)
+
+    def test_filters_by_newer_than(self):
+        # Older-than-cutoff coredump for the pid should be excluded.
+        self._touch('core-WebKitWebProcess-pid_222.dump', mtime=1000)
+        self.gen.newer_than = 1500
+
+        with mock.patch('time.sleep'), \
+             mock.patch.object(CrashLogUtils, 'allow_unreliable_fallback_to_latest_coredump',
+                               return_value=False):
+            path, _ = self.gen._get_coredump_path_with_core_pattern_method()
+
+        self.assertIsNone(path)
+
+
+class GetCoredumpPathWithCoredumpctlTest(unittest.TestCase):
+
+    def setUp(self):
+        self.gen = _make_generator(name='WebKitWebProcess', pid=222, coredump_method=CoreDumpMethod.Coredumpctl)
+
+    def _entries_json(self, *entries):
+        return json.dumps(list(entries))
+
+    def _entry(self, pid, exe, time='2026-05-19T12:00:00+0000'):
+        return {'pid': pid, 'exe': exe, 'time': time}
+
+    def _dump_core_side_effect(self, args, warning):
+        return '/tmp/dumped-core', warning
+
+    def test_matches_by_pid_when_pid_is_valid_and_in_host_namespace(self):
+        entries = self._entries_json(
+            self._entry(111, '/usr/libexec/WebKitWebProcess'),
+            self._entry(222, '/usr/libexec/WebKitWebProcess'),
+        )
+
+        with mock.patch.object(CrashLogUtils, 'in_host_pid_namespace', return_value=True), \
+             mock.patch.object(CrashLogUtils, 'allow_unreliable_fallback_to_latest_coredump', return_value=False), \
+             mock.patch.object(self.gen._executive, 'run_command', return_value=entries), \
+             mock.patch.object(self.gen, '_coredumpctl_dump_core_for_pid', side_effect=self._dump_core_side_effect) as dump_core:
+            path, warning = self.gen._get_coredump_path_with_coredumpctl_method()
+
+        self.assertEqual(path, '/tmp/dumped-core')
+        self.assertIsNone(warning)
+        self.assertEqual(self.gen._effective_coredump_pid, 222)
+        dump_core.assert_called_once_with(['222'], None)
+
+    def test_does_not_fall_back_to_name_when_pid_match_is_possible_and_fallback_is_disabled(self):
+        # Same executable name exists, but no entry for pid 222.
+        entries = self._entries_json(
+            self._entry(111, '/usr/libexec/WebKitWebProcess'),
+            self._entry(333, '/usr/libexec/WebKitWebProcess'),
+        )
+
+        with mock.patch.object(CrashLogUtils, 'in_host_pid_namespace', return_value=True), \
+             mock.patch.object(CrashLogUtils, 'allow_unreliable_fallback_to_latest_coredump', return_value=False), \
+             mock.patch.object(self.gen._executive, 'run_command', return_value=entries) as run_command, \
+             mock.patch.object(self.gen, '_coredumpctl_dump_core_for_pid') as dump_core, \
+             mock.patch('time.sleep'):
+            path, warning = self.gen._get_coredump_path_with_coredumpctl_method()
+
+        self.assertIsNone(path)
+        self.assertIn(CrashLogEnvVars.allow_unreliable_fallback_to_latest_coredump, warning)
+        dump_core.assert_not_called()
+        self.assertEqual(run_command.call_count, 5)
+
+    def test_falls_back_to_name_when_pid_match_is_possible_but_fallback_is_enabled(self):
+        entries = self._entries_json(
+            self._entry(111, '/usr/libexec/WebKitWebProcess', time='2026-05-19T12:00:00+0000'),
+            self._entry(333, '/usr/libexec/WebKitWebProcess', time='2026-05-19T12:01:00+0000'),
+        )
+
+        with mock.patch.object(CrashLogUtils, 'in_host_pid_namespace', return_value=True), \
+             mock.patch.object(CrashLogUtils, 'allow_unreliable_fallback_to_latest_coredump', return_value=True), \
+             mock.patch.object(self.gen._executive, 'run_command', return_value=entries) as run_command, \
+             mock.patch.object(self.gen, '_coredumpctl_dump_core_for_pid', side_effect=self._dump_core_side_effect) as dump_core, \
+             mock.patch('time.sleep'):
+            path, warning = self.gen._get_coredump_path_with_coredumpctl_method()
+
+        self.assertEqual(path, '/tmp/dumped-core')
+        self.assertIn('matching the crashing program name', warning)
+        self.assertEqual(self.gen._effective_coredump_pid, 333)
+        dump_core.assert_called_once_with(['333'], warning)
+        self.assertEqual(run_command.call_count, 5)
+
+    def test_falls_back_to_name_without_env_var_when_running_in_pid_namespace(self):
+        entries = self._entries_json(
+            self._entry(555, '/usr/libexec/WebKitWebProcess'),
+        )
+
+        with mock.patch.object(CrashLogUtils, 'in_host_pid_namespace', return_value=False), \
+             mock.patch.object(CrashLogUtils, 'allow_unreliable_fallback_to_latest_coredump', return_value=False), \
+             mock.patch.object(self.gen._executive, 'run_command', return_value=entries) as run_command, \
+             mock.patch.object(self.gen, '_coredumpctl_dump_core_for_pid', side_effect=self._dump_core_side_effect) as dump_core:
+            path, warning = self.gen._get_coredump_path_with_coredumpctl_method()
+
+        self.assertEqual(path, '/tmp/dumped-core')
+        self.assertIn('matching the crashing program name', warning)
+        self.assertEqual(self.gen._effective_coredump_pid, 555)
+        dump_core.assert_called_once_with(['555'], warning)
+        self.assertEqual(run_command.call_count, 1)
+
+    def test_falls_back_to_name_without_env_var_when_pid_is_invalid(self):
+        self.gen.pid = None
+
+        entries = self._entries_json(
+            self._entry(555, '/usr/libexec/WebKitWebProcess'),
+        )
+
+        with mock.patch.object(CrashLogUtils, 'in_host_pid_namespace', return_value=True), \
+             mock.patch.object(CrashLogUtils, 'allow_unreliable_fallback_to_latest_coredump', return_value=False), \
+             mock.patch.object(self.gen._executive, 'run_command', return_value=entries) as run_command, \
+             mock.patch.object(self.gen, '_coredumpctl_dump_core_for_pid', side_effect=self._dump_core_side_effect) as dump_core:
+            path, warning = self.gen._get_coredump_path_with_coredumpctl_method()
+
+        self.assertEqual(path, '/tmp/dumped-core')
+        self.assertIn('matching the crashing program name', warning)
+        self.assertEqual(self.gen._effective_coredump_pid, 555)
+        dump_core.assert_called_once_with(['555'], warning)
+        self.assertEqual(run_command.call_count, 1)
+
+    def test_falls_back_to_latest_only_when_unreliable_fallback_is_enabled(self):
+        entries = self._entries_json(
+            self._entry(111, '/usr/libexec/OtherProcess', time='2026-05-19T12:00:00+0000'),
+            self._entry(999, '/usr/libexec/CompletelyDifferentProcess', time='2026-05-19T12:01:00+0000'),
+        )
+
+        with mock.patch.object(CrashLogUtils, 'in_host_pid_namespace', return_value=True), \
+             mock.patch.object(CrashLogUtils, 'allow_unreliable_fallback_to_latest_coredump', return_value=True), \
+             mock.patch.object(self.gen._executive, 'run_command', return_value=entries), \
+             mock.patch.object(self.gen, '_coredumpctl_dump_core_for_pid', side_effect=self._dump_core_side_effect) as dump_core, \
+             mock.patch('time.sleep'):
+            path, warning = self.gen._get_coredump_path_with_coredumpctl_method()
+
+        self.assertEqual(path, '/tmp/dumped-core')
+        self.assertIn('high risk', warning)
+        self.assertEqual(self.gen._effective_coredump_pid, 999)
+        dump_core.assert_called_once_with(['999'], warning)

--- a/Tools/glib/dependencies/apt
+++ b/Tools/glib/dependencies/apt
@@ -101,6 +101,7 @@ PACKAGES=(
     python3-gi
     ruby-highline
     ruby-json
+    time
 
     # These are dependencies necessary for building the jhbuild.
     bison

--- a/Tools/glib/dependencies/dnf
+++ b/Tools/glib/dependencies/dnf
@@ -80,6 +80,7 @@ PACKAGES=(
     python3-psutil
     rubygem-highline
     rubygem-json
+    time
 
     # These are dependencies necessary for building the jhbuild.
     expat-devel

--- a/Tools/glib/dependencies/pacman
+++ b/Tools/glib/dependencies/pacman
@@ -59,6 +59,7 @@ PACKAGES=(
     pulseaudio
     python2-psutil
     ttf-liberation
+    time
 
     # These are dependencies necessary for building the jhbuild.
     # Note: Could not find libegl-mesa.


### PR DESCRIPTION
#### aaa99edbf8c0cfd95b8fbac26b9ddbfb6e4fef48
<pre>
[Tools] linux_get_crash_log: Revamp crash log generation for Linux layout tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=315073">https://bugs.webkit.org/show_bug.cgi?id=315073</a>

Reviewed by Nikolas Zimmermann.

Rewrite the Linux crash log tooling to be more reliable and informative.
The coredump location is now determined by reading /proc/sys/kernel/core_pattern
directly instead of relying on a hardcoded WEBKIT_CORE_DUMPS_DIRECTORY environment
variable. Both raw coredump files (abspath method) and systemd-coredump via
coredumpctl are supported, with automatic detection of which one is configured.

Coredump files are now matched to the crashing process by PID when possible,
using the %p format specifier from core_pattern. A fallback matching by program
name and timestamp is available but disabled by default since it is unreliable
when several test workers run in parallel. This can be tuned via environment
variables documented in the help message shown on missing coredumps.

A new inotify-based background thread captures thread names from /proc/&lt;pid&gt;/task
the moment the kernel creates the coredump file, before the process fully exits.
This information is included in the crash log to help identify the crashing thread.
The thread runs as a singleton across concurrent test runner instances using a
lockfile to avoid races when writing the thread name data.

GDB backtraces now use &quot;bt full&quot; to include local variables, and optionally wrap
the GDB invocation with GNU time to report memory and CPU usage. Parallel GDB
execution can be rate-limited via WEBKIT_CRASHLOG_GDB_CONCURRENT_EXECUTION_LIMIT
to avoid memory exhaustion during runs with many simultaneous crashes. Running
inside a PID namespace (e.g. containers) is detected and warned about, since it
prevents reliable coredump attribution when using the coredumpctl method.

* Tools/Scripts/webkitpy/__init__.py:
* Tools/Scripts/webkitpy/layout_tests/run_webkit_tests.py:
(run):
* Tools/Scripts/webkitpy/port/glib.py:
(GLibPort.setup_environ_for_server):
* Tools/Scripts/webkitpy/port/linux_get_crash_log.py:
(StrEnum):
(StrEnum.__str__):
(PrefixAdapter):
(PrefixAdapter.process):
(PrefixAdapter.log):
(LockFile):
(LockFile.__init__):
(LockFile.acquire):
(LockFile._try_claim):
(LockFile._acquire_single):
(LockFile._acquire_multi):
(LockFile.release):
(LockFile._log_waiter):
(LockFile.__enter__):
(LockFile.__exit__):
(CoreDumpMethod):
(CrashLogEnvVars):
(CrashLogUtils):
(CrashLogUtils.get_gdb_concurrent_execution_limit):
(CrashLogUtils._get_gdb_lock_configuration):
(CrashLogUtils.get_gdb_lock):
(CrashLogUtils.get_thread_info_file_name):
(CrashLogUtils.get_thread_data_dir):
(CrashLogUtils.get_temp_dir_for_coredumpctl_dumps):
(CrashLogUtils.get_temp_dir_for_coredumpctl_dumps.is_tmpfs):
(CrashLogUtils.get_temp_dir_for_coredumpctl_dumps.check_and_return_subdir):
(CrashLogUtils.allow_unreliable_fallback_to_latest_coredump):
(CrashLogUtils.expand_core_pattern_and_detect_variable_specifiers):
(CrashLogUtils.determine_coredump_method_and_dir):
(CrashLogUtils.core_pattern_to_regex):
(CrashLogUtils.are_coredumps_enabled):
(CrashLogUtils.are_coredumps_enabled_and_unlimited):
(CrashLogUtils.human_readable_size):
(CrashLogUtils.human_readable_size.fmt):
(CrashLogUtils.make_temp_path):
(CrashLogUtils.in_host_pid_namespace):
(CrashLogUtils.core_pattern_has_pid_format_string):
(ThreadNamesCrashLogCapturer):
(ThreadNamesCrashLogCapturer.__init__):
(ThreadNamesCrashLogCapturer._get_regex_for_core_pattern_pid_match):
(ThreadNamesCrashLogCapturer.watch_coredump_dir):
(ThreadNamesCrashLogCapturer.read_thread_info):
(ThreadNamesCrashLogCapturer.handle_coredump):
(GDBCrashLogStartupHandler):
(GDBCrashLogStartupHandler.__init__):
(GDBCrashLogStartupHandler._maybe_remove_file_if_old):
(GDBCrashLogStartupHandler._is_debuginfod_server_available):
(GDBCrashLogStartupHandler._check_debuginfod_servers):
(GDBCrashLogStartupHandler.clean_old_coredumps):
(GDBCrashLogStartupHandler.clean_old_thread_info_files):
(GDBCrashLogGenerator):
(GDBCrashLogGenerator.__init__):
(GDBCrashLogGenerator._get_gdb_output):
(GDBCrashLogGenerator._coredump_pattern_has_pid_format_string):
(GDBCrashLogGenerator._pid_is_valid):
(GDBCrashLogGenerator._build_warning_msg):
(GDBCrashLogGenerator._pick_most_recent):
(GDBCrashLogGenerator._get_coredump_path_with_core_pattern_method):
(GDBCrashLogGenerator._coredumpctl_dump_core_for_pid):
(GDBCrashLogGenerator._get_coredump_path_with_coredumpctl_method):
(GDBCrashLogGenerator._get_coredump_path):
(GDBCrashLogGenerator._get_help_message):
(GDBCrashLogGenerator._get_thread_info_for_effective_pid):
(GDBCrashLogGenerator._pid_representation):
(GDBCrashLogGenerator._filter_with_cppfilt):
(GDBCrashLogGenerator._underscore_header):
(GDBCrashLogGenerator.generate_crash_log):
(GDBCrashLogGenerator._get_trace_from_systemd): Deleted.
(GDBCrashLogGenerator.generate_crash_log.match_filename): Deleted.
* Tools/Scripts/webkitpy/port/linux_get_crash_log_unittest.py:
(_make_generator):
(AreCoredumpsEnabledTest):
(AreCoredumpsEnabledTest.test_coredumpctl_always_enabled):
(AreCoredumpsEnabledTest.test_abspath_checks_rlimit):
(CorePatternToRegexTest):
(CorePatternToRegexTest.test_literal_string_passes_through):
(CorePatternToRegexTest.test_specifier_becomes_wildcard):
(CorePatternToRegexTest.test_named_pid_capture_group):
(CorePatternToRegexTest.test_pid_capture_only_when_requested):
(CorePatternToRegexTest.test_double_percent_is_literal_percent):
(CorePatternToRegexTest.test_trailing_lone_percent_is_dropped):
(CorePatternToRegexTest.test_invalid_specifier_is_dropped):
(CorePatternToRegexTest.test_regex_metacharacters_are_escaped):
(CorePatternToRegexTest.test_full_path_with_multiple_specifiers):
(ExpandCorePatternTest):
(ExpandCorePatternTest.test_no_specifiers):
(ExpandCorePatternTest.test_fixed_specifier_uid_is_expanded):
(ExpandCorePatternTest.test_variable_specifier_pid_is_detected):
(ExpandCorePatternTest.test_double_percent_preserved_as_literal):
(ExpandCorePatternTest.test_trailing_lone_percent_is_dropped):
(HumanReadableSizeTest):
(HumanReadableSizeTest._file_of_size):
(HumanReadableSizeTest.test_small_file_reports_bytes):
(HumanReadableSizeTest.test_few_kilobyte_file_reports_kb):
(HumanReadableSizeTest.test_empty_file):
(MakeTempPathTest):
(MakeTempPathTest.test_creates_a_real_empty_file):
(MakeTempPathTest.test_respects_suffix):
(MakeTempPathTest.test_respects_dir):
(MakeTempPathTest.test_paths_are_unique):
(LockFileTest):
(LockFileTest.setUp):
(LockFileTest.test_acquire_creates_and_release_removes_lockfile):
(LockFileTest.test_context_manager):
(LockFileTest.test_release_when_not_acquired_is_noop):
(LockFileTest.test_lockfile_contains_pid):
(LockFileTest.test_single_slot_serializes_two_threads):
(LockFileTest.test_single_slot_serializes_two_threads.worker):
(LockFileTest.test_multi_slot_allows_concurrent_holders):
(LockFileTest.test_get_gdb_lock_returns_distinct_lock_instances):
(GDBCrashLogGeneratorHelpersTest):
(GDBCrashLogGeneratorHelpersTest.setUp):
(GDBCrashLogGeneratorHelpersTest.test_pid_representation_known):
(GDBCrashLogGeneratorHelpersTest.test_pid_representation_none):
(GDBCrashLogGeneratorHelpersTest.test_pid_is_valid_when_numeric):
(GDBCrashLogGeneratorHelpersTest.test_pid_is_invalid_when_none):
(GDBCrashLogGeneratorHelpersTest.test_pid_is_invalid_when_non_numeric_string):
(GDBCrashLogGeneratorHelpersTest.test_pattern_with_pid_specifier):
(GDBCrashLogGeneratorHelpersTest.test_pattern_without_pid_specifier):
(GDBCrashLogGeneratorHelpersTest.test_underscore_header_basic):
(GDBCrashLogGeneratorHelpersTest.test_underscore_header_first_omits_leading_newlines):
(BuildWarningMsgTest):
(BuildWarningMsgTest.setUp):
(BuildWarningMsgTest.test_pid_found_returns_none):
(BuildWarningMsgTest.test_name_found_mentions_program_name):
(BuildWarningMsgTest.test_last_found_warns_high_risk):
(BuildWarningMsgTest.test_nothing_found_default_path_suggests_env_var):
(BuildWarningMsgTest.test_no_flag_set_raises):
(PickMostRecentTest):
(PickMostRecentTest.setUp):
(PickMostRecentTest._touch):
(PickMostRecentTest.test_empty_candidates_returns_none):
(PickMostRecentTest.test_no_pattern_match_returns_none):
(PickMostRecentTest.test_picks_newest_and_extracts_pid):
(PickMostRecentTest.test_warning_kwargs_passed_through):
(GenerateCrashLogTest):
(GenerateCrashLogTest.test_no_coredump_emits_help_message_and_sections):
(GenerateCrashLogTest.test_stderr_section_skipped_when_no_stderr):
(DetermineCoredumpMethodAndDirTest):
(DetermineCoredumpMethodAndDirTest._run_with_core_pattern):
(DetermineCoredumpMethodAndDirTest.test_abspath_method_simple):
(DetermineCoredumpMethodAndDirTest.test_abspath_with_fixed_specifier_in_dir):
(DetermineCoredumpMethodAndDirTest.test_abspath_with_variable_specifier_in_dir):
(DetermineCoredumpMethodAndDirTest.test_systemd_pipe_with_coredumpctl_present):
(DetermineCoredumpMethodAndDirTest.test_systemd_pipe_without_coredumpctl_program):
(DetermineCoredumpMethodAndDirTest.test_pipe_to_non_systemd_program):
(DetermineCoredumpMethodAndDirTest.test_unknown_when_pattern_is_relative):
(GetTempDirForCoredumpctlDumpsTest):
(GetTempDirForCoredumpctlDumpsTest.setUp):
(GetTempDirForCoredumpctlDumpsTest._run):
(GetTempDirForCoredumpctlDumpsTest._run.fake_open):
(GetTempDirForCoredumpctlDumpsTest.test_picks_tmp_when_only_tmp_writable):
(GetTempDirForCoredumpctlDumpsTest.test_picks_var_tmp_when_only_var_tmp_writable):
(GetTempDirForCoredumpctlDumpsTest.test_picks_tmp_when_free_space_is_similar):
(GetTempDirForCoredumpctlDumpsTest.test_picks_var_tmp_when_substantially_more_free):
(GetTempDirForCoredumpctlDumpsTest.test_skips_tmpfs_mount):
(GetTempDirForCoredumpctlDumpsTest.test_falls_back_to_tmp_when_nothing_usable):
(ThreadNamesCrashLogCapturerTest):
(ThreadNamesCrashLogCapturerTest.setUp):
(ThreadNamesCrashLogCapturerTest._read_output):
(ThreadNamesCrashLogCapturerTest.test_capturer_is_disabled_when_pattern_only_contains_literal_percent_p):
(ThreadNamesCrashLogCapturerTest.test_repeated_pid_specifiers_reuse_the_same_pid_capture):
(ThreadNamesCrashLogCapturerTest.test_writes_thread_table_when_threads_present):
(ThreadNamesCrashLogCapturerTest.test_writes_error_when_process_already_gone):
(ThreadNamesCrashLogCapturerTest.test_writes_warning_when_no_threads_found):
(ThreadNamesCrashLogCapturerTest.test_full_path_through_fake_proc_task):
(ThreadNamesCrashLogCapturerTest.test_full_path_through_fake_proc_task.fake_listdir):
(ThreadNamesCrashLogCapturerTest.test_full_path_through_fake_proc_task.fake_open):
(GetCoredumpPathTest):
(GetCoredumpPathTest.setUp):
(GetCoredumpPathTest._touch):
(GetCoredumpPathTest.test_matches_by_pid_when_available):
(GetCoredumpPathTest.test_matches_by_pid_when_pattern_contains_literal_percent_p):
(GetCoredumpPathTest.test_does_not_fall_back_to_name_when_pid_match_is_possible_and_fallback_is_disabled):
(GetCoredumpPathTest.test_falls_back_to_name_when_pid_match_is_possible_and_fallback_is_enabled):
(GetCoredumpPathTest.test_falls_back_to_name_when_pid_is_invalid_and_fallback_is_disabled):
(GetCoredumpPathTest.test_falls_back_to_name_when_core_pattern_cannot_match_pid_and_fallback_is_disabled):
(GetCoredumpPathTest.test_pid_match_on_second_attempt_wins_over_existing_name_match):
(GetCoredumpPathTest.test_pid_match_on_second_attempt_wins_over_existing_name_match.create_pid_match):
(GetCoredumpPathTest.test_pattern_with_literal_percent_p_has_no_pid_specifier):
(GetCoredumpPathTest.test_pid_lookup_ignores_filename_with_extra_suffix):
(GetCoredumpPathTest.test_returns_none_without_unreliable_fallback):
(GetCoredumpPathTest.test_filters_by_newer_than):
(GetCoredumpPathWithCoredumpctlTest):
(GetCoredumpPathWithCoredumpctlTest.setUp):
(GetCoredumpPathWithCoredumpctlTest._entries_json):
(GetCoredumpPathWithCoredumpctlTest._entry):
(GetCoredumpPathWithCoredumpctlTest._dump_core_side_effect):
(GetCoredumpPathWithCoredumpctlTest.test_matches_by_pid_when_pid_is_valid_and_in_host_namespace):
(GetCoredumpPathWithCoredumpctlTest.test_does_not_fall_back_to_name_when_pid_match_is_possible_and_fallback_is_disabled):
(GetCoredumpPathWithCoredumpctlTest.test_falls_back_to_name_when_pid_match_is_possible_but_fallback_is_enabled):
(GetCoredumpPathWithCoredumpctlTest.test_falls_back_to_name_without_env_var_when_running_in_pid_namespace):
(GetCoredumpPathWithCoredumpctlTest.test_falls_back_to_name_without_env_var_when_pid_is_invalid):
(GetCoredumpPathWithCoredumpctlTest.test_falls_back_to_latest_only_when_unreliable_fallback_is_enabled):
(GDBCrashLogGeneratorTest): Deleted.
(GDBCrashLogGeneratorTest.test_generate_crash_log): Deleted.
* Tools/glib/dependencies/apt:
* Tools/glib/dependencies/dnf:
* Tools/glib/dependencies/pacman:

Canonical link: <a href="https://commits.webkit.org/313530@main">https://commits.webkit.org/313530@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9e21c38f464e81d675f854e12599588180a91f51

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163398 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/36881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/30097 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/172338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/119845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165267 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/37210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/36881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/172338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/119845 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166357 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/37210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/146891 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/172338 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/162719 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/37210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/36881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/20040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/37210 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/24614 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/174842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/26270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/174842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/162795 "Passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/36551 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/36881 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/174842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/37336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/146409 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/99292 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24866 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/37336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/23254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/36047 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/35544 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/1279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/35792 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/35692 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
<!--EWS-Status-Bubble-End-->