### PR TITLE
[Site Isolation] imported/w3c/web-platform-tests/fetch/api/redirect/redirect-keepalive.any.html fails

### DIFF
--- a/LayoutTests/platform/ios-site-isolation/TestExpectations
+++ b/LayoutTests/platform/ios-site-isolation/TestExpectations
@@ -238,7 +238,6 @@ imported/w3c/web-platform-tests/css/css-view-transitions/root-element-cv-hidden-
 imported/w3c/web-platform-tests/css/css-viewport/zoom/zoom-iframe-dynamic.html [ Failure ]
 imported/w3c/web-platform-tests/editing/crashtests/collapse-selection-into-textarea-and-createLink.html [ Failure ]
 imported/w3c/web-platform-tests/fetch/api/basic/keepalive.any.html [ Failure ]
-imported/w3c/web-platform-tests/fetch/api/redirect/redirect-keepalive.any.html [ Failure ]
 imported/w3c/web-platform-tests/fetch/api/redirect/redirect-keepalive.https.any.html [ Failure ]
 imported/w3c/web-platform-tests/fetch/metadata/generated/element-frame.sub.html [ Failure ]
 imported/w3c/web-platform-tests/FileAPI/url/url-in-tags-revoke.window.html [ Failure ]

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -244,8 +244,7 @@ imported/w3c/web-platform-tests/cookies/partitioned-cookies/partitioned-cookies.
 imported/w3c/web-platform-tests/css/css-fonts/font-display/font-display-failure-fallback.html [ Failure ]
 imported/w3c/web-platform-tests/css/css-view-transitions/navigation/reload-crash.html [ Failure ]
 imported/w3c/web-platform-tests/dom/events/scrolling/scroll-cross-origin-iframes.html [ Failure ]
-imported/w3c/web-platform-tests/fetch/api/basic/keepalive.any.html [ Failure ]
-imported/w3c/web-platform-tests/fetch/api/redirect/redirect-keepalive.any.html [ Failure ]
+imported/w3c/web-platform-tests/fetch/api/basic/keepalive.any.html
 imported/w3c/web-platform-tests/FileAPI/url/url-in-tags-revoke.window.html [ Failure ]
 imported/w3c/web-platform-tests/fullscreen/rendering/fullscreen-root-block-scroll.html [ Failure ]
 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-replace-with-cross-origin-redirect.sub.html [ Failure ]

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -181,7 +181,7 @@ ProvisionalPageProxy::~ProvisionalPageProxy()
             protect(process->processPool())->pageEndUsingWebsiteDataStore(page, *dataStore);
 
         if (process->hasConnection() && m_shouldClosePage)
-            send(Messages::WebPage::Close());
+            sendWithAsyncReply(Messages::WebPage::Close(), [] { });
         process->removeVisitedLinkStoreUser(page->visitedLinkStore(), page->identifier());
     }
 

--- a/Source/WebKit/UIProcess/RemotePageProxy.cpp
+++ b/Source/WebKit/UIProcess/RemotePageProxy.cpp
@@ -116,7 +116,7 @@ void RemotePageProxy::disconnect()
     if (RefPtr page = m_page.get())
         page->isNoLongerAssociatedWithRemotePage(*this);
     if (m_drawingArea)
-        m_process->send(Messages::WebPage::Close(), m_webPageID);
+        m_process->sendWithAsyncReply(Messages::WebPage::Close(), [] { }, m_webPageID);
     m_process->removeRemotePageProxy(*this);
 
     m_drawingArea = nullptr;

--- a/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
+++ b/Source/WebKit/UIProcess/SuspendedPageProxy.cpp
@@ -295,7 +295,7 @@ void SuspendedPageProxy::close()
 
     RELEASE_LOG(ProcessSwapping, "%p - SuspendedPageProxy::close()", this);
     m_isClosed = true;
-    send(Messages::WebPage::Close());
+    sendWithAsyncReply(Messages::WebPage::Close(), [] { });
 }
 
 void SuspendedPageProxy::pageDidFirstLayerFlush()

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -1954,9 +1954,9 @@ void WebPageProxy::close()
         });
     });
     // Delay sending close message to next runloop cycle to avoid white flash.
-    RunLoop::currentSingleton().dispatch([processesToClose = WTF::move(processesToClose)] {
-        for (auto [process, pageID, scope] : processesToClose)
-            protect(process)->send(Messages::WebPage::Close(), pageID);
+    RunLoop::currentSingleton().dispatch([processesToClose = WTF::move(processesToClose)] mutable {
+        for (auto& [process, pageID, scope] : processesToClose)
+            protect(process)->sendWithAsyncReply(Messages::WebPage::Close(), [scope = WTF::move(scope)] { }, pageID);
     });
 
     process->removeWebPage(*this, WebProcessProxy::EndsUsingDataStore::Yes);
@@ -5765,7 +5765,7 @@ void WebPageProxy::commitProvisionalPage(IPC::Connection& connection, FrameIdent
 
     // There is no way we'll be able to return to the page in the previous page so close it.
     if (!didSuspendPreviousPage && shouldClosePreviousPage(*provisionalPage))
-        send(Messages::WebPage::Close());
+        sendWithAsyncReply(Messages::WebPage::Close(), [] { });
 
 #if ENABLE(MODEL_ELEMENT_IMMERSIVE)
     if (m_immersive)

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -735,6 +735,8 @@ void WebProcessProxy::shutDown()
     RELEASE_ASSERT(isMainThreadOrCheckDisabled());
     WEBPROCESSPROXY_RELEASE_LOG(Process, "shutDown:");
 
+    m_isShuttingDown = true;
+
     if (m_isInProcessCache) {
         processPool().webProcessCache().removeProcess(*this, WebProcessCache::ShouldShutDownProcess::No);
         ASSERT(!m_isInProcessCache);
@@ -1651,7 +1653,9 @@ void WebProcessProxy::maybeShutDown()
         return;
     }
 
-    if (state() == State::Terminated || !canTerminateAuxiliaryProcess())
+    // shutDownProcess() can re-entrantly trigger maybeShutDown() when
+    // cancelAsyncReplyHandlers() releases shutdown-preventing scope tokens.
+    if (state() == State::Terminated || m_isShuttingDown || !canTerminateAuxiliaryProcess())
         return;
 
     if (canBeAddedToWebProcessCache() && protect(processPool().webProcessCache())->addProcessIfPossible(*this))

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -835,6 +835,7 @@ private:
     HashSet<WebCore::RegistrableDomain> m_sharedProcessDomains;
     std::pair<LoadedWebArchive, HashSet<WebCore::RegistrableDomain>> m_allowedFirstPartiesForCookies { LoadedWebArchive::No, { } };
     bool m_isInProcessCache { false };
+    bool m_isShuttingDown { false };
 
     IsolatedProcessType m_isolatedProcessType { IsolatedProcessType::Unspecified };
     std::optional<WebCore::Site> m_mainFrameSite;

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -2097,10 +2097,12 @@ void WebPage::exitAcceleratedCompositingMode(WebCore::Frame& frame)
     protect(drawingArea())->setRootCompositingLayer(frame, nullptr);
 }
 
-void WebPage::close()
+void WebPage::close(CompletionHandler<void()>&& completionHandler)
 {
-    if (m_isClosed)
+    if (m_isClosed) {
+        completionHandler();
         return;
+    }
 
     flushDeferredDidReceiveMouseEvent();
 
@@ -2214,6 +2216,8 @@ void WebPage::close()
 
     if (isRunningModal)
         RunLoop::mainSingleton().stop();
+
+    completionHandler();
 }
 
 void WebPage::tryClose(CompletionHandler<void(bool)>&& completionHandler)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -623,7 +623,7 @@ public:
     void reinitializeWebPage(WebPageCreationParameters&&);
     void platformReinitializeAccessibilityToken();
 
-    void close();
+    void close(CompletionHandler<void()>&&);
 
     static WebPage* fromCorePage(WebCore::Page&);
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.messages.in
@@ -306,7 +306,7 @@ messages -> WebPage WantsAsyncDispatchMessage {
     Suspend() -> (bool success)
     Resume() -> (bool success)
 
-    Close()
+    Close() -> ()
     TryClose() -> (bool shouldClose)
     DispatchCrossOriginBeforeUnloadCheckForFrame(WebCore::FrameIdentifier frameID, WebCore::SecurityOriginData navigatingFrameOrigin)
 

--- a/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
+++ b/Source/WebKit/WebProcess/glib/WebProcessGLib.cpp
@@ -112,7 +112,7 @@ void WebProcess::stopRunLoop()
     // ensure the threaded compositor is invalidated and GL resources
     // released (see https://bugs.webkit.org/show_bug.cgi?id=217655).
     for (auto& webPage : copyToVector(m_pageMap.values()))
-        webPage->close();
+        webPage->close([] { });
 
     if (auto* display = PlatformDisplay::sharedDisplayIfExists())
         display->clearGLContexts();

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewEvaluateJavaScript.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewEvaluateJavaScript.mm
@@ -83,7 +83,6 @@ TEST(WKWebView, EvaluateJavaScriptBlockCrash)
             (void)request;
             
             EXPECT_NULL(result);
-            EXPECT_NOT_NULL(error);
 
             isDone = true;
         }];


### PR DESCRIPTION
#### 2a91836e951396786de2ad74935db4ac1e43ac34
<pre>
[Site Isolation] imported/w3c/web-platform-tests/fetch/api/redirect/redirect-keepalive.any.html fails
<a href="https://bugs.webkit.org/show_bug.cgi?id=313863">https://bugs.webkit.org/show_bug.cgi?id=313863</a>
<a href="https://rdar.apple.com/176599181">rdar://176599181</a>

Reviewed by Ryosuke Niwa.

When closing a page (e.g., window.close()), the UI process sends WebPage::Close to the web process, which triggers page
teardown including firing unload events. JavaScript in unload handlers may initiate keepalive fetch requests (e.g.,
analytics beacons).

Previously, the shutdownPreventingScope was released immediately after sending Close message, allowing the web process
to terminate before it processed the message. This means unload events never fired and keepalive fetches were never
sent. This patch fixes the issue by making Close an async reply message so the shutdownPreventingScope is held until the
web process confirms it has processed Close and completed teardown.

With this change, some tests start to hit an assertion in AuxiliaryProcessProxy::shutDownProcess(). The cause is web
process is killed (some test manually kill web process to simulate crash case) after UI process sends WebPage::Close
message and before web process handles the message. In this case, WebProcess::shutDown() is reentrant with the chain:
WebProcessProxy::processDidTerminateOrFailedToLaunch =&gt; WebProcessProxy::shutDown() =&gt;
AuxiliaryProcessProxy::shutDownProcess() =&gt; Connection::invalidate() =&gt; Connection::cancelAsyncReplyHandlers() =&gt;
RefCounter&lt;ShutdownPreventingScopeType&gt;::m_valueDidChange =&gt; WebProcessProxy::maybeShutDown() =&gt;
WebProcessProxy::shutDown(). To fix the reentrancy issue, adding a new flag WebProcessProxy::m_isShuttingDown.

* LayoutTests/platform/ios-site-isolation/TestExpectations:
* LayoutTests/platform/mac-site-isolation/TestExpectations:
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::~ProvisionalPageProxy):
* Source/WebKit/UIProcess/RemotePageProxy.cpp:
(WebKit::RemotePageProxy::disconnect):
* Source/WebKit/UIProcess/SuspendedPageProxy.cpp:
(WebKit::SuspendedPageProxy::close):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::close):
(WebKit::WebPageProxy::commitProvisionalPage):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::shutDown):
(WebKit::WebProcessProxy::maybeShutDown):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::close):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/WebPage.messages.in:
* Source/WebKit/WebProcess/glib/WebProcessGLib.cpp:
(WebKit::WebProcess::stopRunLoop):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebViewEvaluateJavaScript.mm:
(TEST(WKWebView, EvaluateJavaScriptBlockCrash)): Update EvaluateJavaScriptBlockCrash test expectation: the process now
lives long enough for pending evaluateJavaScript to complete successfully instead of being cancelled with an error.

Canonical link: <a href="https://commits.webkit.org/313673@main">https://commits.webkit.org/313673@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5db8baf5664d09718d228d79ad3965021fd0277c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163606 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37090 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30309 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172546 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/120055 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/99b35b0b-1c63-45ab-8bfe-69d96628eab3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165475 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37421 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37089 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127076 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89586 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dcdfe595-f734-4d14-b0e0-786b45ed6123) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166565 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29352 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147084 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107630 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/88417b5b-807a-4641-9ae5-20f98fe98acd) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28401 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27034 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20249 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138300 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24801 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175051 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27982 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26464 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135379 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36760 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31136 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135361 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36528 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37545 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146596 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99606 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30672 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23448 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36255 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109401 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35753 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1556 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36003 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35900 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->