### PR TITLE
[Win] `OSAllocator::tryProtect` fails when memory spans multiple reserved regions

### DIFF
--- a/Source/WTF/wtf/win/OSAllocatorWin.cpp
+++ b/Source/WTF/wtf/win/OSAllocatorWin.cpp
@@ -145,7 +145,24 @@ bool OSAllocator::tryProtect(void* address, size_t bytes, bool readable, bool wr
         ASSERT(!readable && !writable);
         protection = PAGE_NOACCESS;
     }
-    return VirtualAlloc(address, bytes, MEM_COMMIT, protection);
+
+    // VirtualAlloc(MEM_COMMIT) cannot span multiple MEM_RESERVE regions, so walk
+    // the range with VirtualQuery and commit one region at a time. See 306171@main.
+    size_t totalSeen = 0;
+    char* currentPtr = static_cast<char*>(address);
+    while (totalSeen < bytes) {
+        MEMORY_BASIC_INFORMATION memInfo;
+        if (!VirtualQuery(currentPtr, &memInfo, sizeof(memInfo)))
+            return false;
+        ASSERT(memInfo.RegionSize > 0);
+        ASSERT(static_cast<char*>(memInfo.BaseAddress) == currentPtr);
+        size_t chunkSize = std::min(static_cast<size_t>(memInfo.RegionSize), bytes - totalSeen);
+        if (!VirtualAlloc(currentPtr, chunkSize, MEM_COMMIT, protection))
+            return false;
+        currentPtr += chunkSize;
+        totalSeen += chunkSize;
+    }
+    return true;
 }
 
 void OSAllocator::protect(void* address, size_t bytes, bool readable, bool writable)


### PR DESCRIPTION
#### 912cfd18d9b4aea6adf13d939cac6658c2fd9b9d
<pre>
[Win] `OSAllocator::tryProtect` fails when memory spans multiple reserved regions
<a href="https://bugs.webkit.org/show_bug.cgi?id=315080">https://bugs.webkit.org/show_bug.cgi?id=315080</a>

Reviewed by Yusuke Suzuki.

OSAllocator::tryProtect on Windows uses VirtualAlloc(MEM_COMMIT) to change
page protection. VirtualAlloc(MEM_COMMIT) cannot span multiple regions
created by separate MEM_RESERVE calls and fails with ERROR_INVALID_ADDRESS
when given such a range. libpas can return a contiguous address range that
is backed by multiple reservations, and JSC calls OSAllocator::protect on
libpas-allocated memory when growing Wasm shared memory and resizable
ArrayBuffers, which then crashes in RELEASE_ASSERT_NOT_REACHED.

Walk the range with VirtualQuery and commit one region at a time, mirroring
the vmZeroAndPurge fix in 306171@main.

* Source/WTF/wtf/win/OSAllocatorWin.cpp:
(WTF::OSAllocator::tryProtect):

Canonical link: <a href="https://commits.webkit.org/313532@main">https://commits.webkit.org/313532@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/747920fde44ea36efbab3d677a08787a138dbd22

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163222 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36703 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29920 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172161 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119669 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37031 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36704 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126738 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89340 "2 flakes 4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166181 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29015 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146738 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107306 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28061 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26689 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19862 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/155367 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137954 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24462 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174664 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/24109 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/26821 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26117 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135045 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36373 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30791 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135037 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36434 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37159 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146257 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99062 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30342 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23101 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195624 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35869 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108230 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50993 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35368 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1126 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35615 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35515 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->