### PR TITLE
[CSS Viewport] Make zoom animatable by computed value

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/animations/zoom-interpolation-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-viewport/animations/zoom-interpolation-expected.txt
@@ -1,204 +1,204 @@
 
-FAIL CSS Transitions: property <zoom> from neutral to [2] at (-0.3) should be [0.7] assert_equals: expected "0.7 " but got "2 "
-FAIL CSS Transitions: property <zoom> from neutral to [2] at (0) should be [1] assert_equals: expected "1 " but got "2 "
-FAIL CSS Transitions: property <zoom> from neutral to [2] at (0.3) should be [1.3] assert_equals: expected "1.3 " but got "2 "
-FAIL CSS Transitions: property <zoom> from neutral to [2] at (0.6) should be [1.6] assert_equals: expected "1.6 " but got "2 "
+PASS CSS Transitions: property <zoom> from neutral to [2] at (-0.3) should be [0.7]
+PASS CSS Transitions: property <zoom> from neutral to [2] at (0) should be [1]
+PASS CSS Transitions: property <zoom> from neutral to [2] at (0.3) should be [1.3]
+PASS CSS Transitions: property <zoom> from neutral to [2] at (0.6) should be [1.6]
 PASS CSS Transitions: property <zoom> from neutral to [2] at (1) should be [2]
-FAIL CSS Transitions: property <zoom> from neutral to [2] at (1.5) should be [2.5] assert_equals: expected "2.5 " but got "2 "
-FAIL CSS Transitions with transition: all: property <zoom> from neutral to [2] at (-0.3) should be [0.7] assert_equals: expected "0.7 " but got "2 "
-FAIL CSS Transitions with transition: all: property <zoom> from neutral to [2] at (0) should be [1] assert_equals: expected "1 " but got "2 "
-FAIL CSS Transitions with transition: all: property <zoom> from neutral to [2] at (0.3) should be [1.3] assert_equals: expected "1.3 " but got "2 "
-FAIL CSS Transitions with transition: all: property <zoom> from neutral to [2] at (0.6) should be [1.6] assert_equals: expected "1.6 " but got "2 "
+PASS CSS Transitions: property <zoom> from neutral to [2] at (1.5) should be [2.5]
+PASS CSS Transitions with transition: all: property <zoom> from neutral to [2] at (-0.3) should be [0.7]
+PASS CSS Transitions with transition: all: property <zoom> from neutral to [2] at (0) should be [1]
+PASS CSS Transitions with transition: all: property <zoom> from neutral to [2] at (0.3) should be [1.3]
+PASS CSS Transitions with transition: all: property <zoom> from neutral to [2] at (0.6) should be [1.6]
 PASS CSS Transitions with transition: all: property <zoom> from neutral to [2] at (1) should be [2]
-FAIL CSS Transitions with transition: all: property <zoom> from neutral to [2] at (1.5) should be [2.5] assert_equals: expected "2.5 " but got "2 "
-FAIL CSS Animations: property <zoom> from neutral to [2] at (-0.3) should be [0.7] assert_equals: expected "0.7 " but got "1 "
+PASS CSS Transitions with transition: all: property <zoom> from neutral to [2] at (1.5) should be [2.5]
+PASS CSS Animations: property <zoom> from neutral to [2] at (-0.3) should be [0.7]
 PASS CSS Animations: property <zoom> from neutral to [2] at (0) should be [1]
-FAIL CSS Animations: property <zoom> from neutral to [2] at (0.3) should be [1.3] assert_equals: expected "1.3 " but got "1 "
-FAIL CSS Animations: property <zoom> from neutral to [2] at (0.6) should be [1.6] assert_equals: expected "1.6 " but got "1 "
-FAIL CSS Animations: property <zoom> from neutral to [2] at (1) should be [2] assert_equals: expected "2 " but got "1 "
-FAIL CSS Animations: property <zoom> from neutral to [2] at (1.5) should be [2.5] assert_equals: expected "2.5 " but got "1 "
-FAIL Web Animations: property <zoom> from neutral to [2] at (-0.3) should be [0.7] assert_equals: expected "0.7 " but got "1 "
+PASS CSS Animations: property <zoom> from neutral to [2] at (0.3) should be [1.3]
+PASS CSS Animations: property <zoom> from neutral to [2] at (0.6) should be [1.6]
+PASS CSS Animations: property <zoom> from neutral to [2] at (1) should be [2]
+PASS CSS Animations: property <zoom> from neutral to [2] at (1.5) should be [2.5]
+PASS Web Animations: property <zoom> from neutral to [2] at (-0.3) should be [0.7]
 PASS Web Animations: property <zoom> from neutral to [2] at (0) should be [1]
-FAIL Web Animations: property <zoom> from neutral to [2] at (0.3) should be [1.3] assert_equals: expected "1.3 " but got "1 "
-FAIL Web Animations: property <zoom> from neutral to [2] at (0.6) should be [1.6] assert_equals: expected "1.6 " but got "1 "
-FAIL Web Animations: property <zoom> from neutral to [2] at (1) should be [2] assert_equals: expected "2 " but got "1 "
-FAIL Web Animations: property <zoom> from neutral to [2] at (1.5) should be [2.5] assert_equals: expected "2.5 " but got "1 "
-FAIL CSS Transitions: property <zoom> from [initial] to [2] at (-0.3) should be [0.7] assert_equals: expected "0.7 " but got "2 "
-FAIL CSS Transitions: property <zoom> from [initial] to [2] at (0) should be [1] assert_equals: expected "1 " but got "2 "
-FAIL CSS Transitions: property <zoom> from [initial] to [2] at (0.3) should be [1.3] assert_equals: expected "1.3 " but got "2 "
-FAIL CSS Transitions: property <zoom> from [initial] to [2] at (0.6) should be [1.6] assert_equals: expected "1.6 " but got "2 "
+PASS Web Animations: property <zoom> from neutral to [2] at (0.3) should be [1.3]
+PASS Web Animations: property <zoom> from neutral to [2] at (0.6) should be [1.6]
+PASS Web Animations: property <zoom> from neutral to [2] at (1) should be [2]
+PASS Web Animations: property <zoom> from neutral to [2] at (1.5) should be [2.5]
+PASS CSS Transitions: property <zoom> from [initial] to [2] at (-0.3) should be [0.7]
+PASS CSS Transitions: property <zoom> from [initial] to [2] at (0) should be [1]
+PASS CSS Transitions: property <zoom> from [initial] to [2] at (0.3) should be [1.3]
+PASS CSS Transitions: property <zoom> from [initial] to [2] at (0.6) should be [1.6]
 PASS CSS Transitions: property <zoom> from [initial] to [2] at (1) should be [2]
-FAIL CSS Transitions: property <zoom> from [initial] to [2] at (1.5) should be [2.5] assert_equals: expected "2.5 " but got "2 "
-FAIL CSS Transitions with transition: all: property <zoom> from [initial] to [2] at (-0.3) should be [0.7] assert_equals: expected "0.7 " but got "2 "
-FAIL CSS Transitions with transition: all: property <zoom> from [initial] to [2] at (0) should be [1] assert_equals: expected "1 " but got "2 "
-FAIL CSS Transitions with transition: all: property <zoom> from [initial] to [2] at (0.3) should be [1.3] assert_equals: expected "1.3 " but got "2 "
-FAIL CSS Transitions with transition: all: property <zoom> from [initial] to [2] at (0.6) should be [1.6] assert_equals: expected "1.6 " but got "2 "
+PASS CSS Transitions: property <zoom> from [initial] to [2] at (1.5) should be [2.5]
+PASS CSS Transitions with transition: all: property <zoom> from [initial] to [2] at (-0.3) should be [0.7]
+PASS CSS Transitions with transition: all: property <zoom> from [initial] to [2] at (0) should be [1]
+PASS CSS Transitions with transition: all: property <zoom> from [initial] to [2] at (0.3) should be [1.3]
+PASS CSS Transitions with transition: all: property <zoom> from [initial] to [2] at (0.6) should be [1.6]
 PASS CSS Transitions with transition: all: property <zoom> from [initial] to [2] at (1) should be [2]
-FAIL CSS Transitions with transition: all: property <zoom> from [initial] to [2] at (1.5) should be [2.5] assert_equals: expected "2.5 " but got "2 "
-FAIL CSS Animations: property <zoom> from [initial] to [2] at (-0.3) should be [0.7] assert_equals: expected "0.7 " but got "1 "
+PASS CSS Transitions with transition: all: property <zoom> from [initial] to [2] at (1.5) should be [2.5]
+PASS CSS Animations: property <zoom> from [initial] to [2] at (-0.3) should be [0.7]
 PASS CSS Animations: property <zoom> from [initial] to [2] at (0) should be [1]
-FAIL CSS Animations: property <zoom> from [initial] to [2] at (0.3) should be [1.3] assert_equals: expected "1.3 " but got "1 "
-FAIL CSS Animations: property <zoom> from [initial] to [2] at (0.6) should be [1.6] assert_equals: expected "1.6 " but got "1 "
-FAIL CSS Animations: property <zoom> from [initial] to [2] at (1) should be [2] assert_equals: expected "2 " but got "1 "
-FAIL CSS Animations: property <zoom> from [initial] to [2] at (1.5) should be [2.5] assert_equals: expected "2.5 " but got "1 "
-FAIL Web Animations: property <zoom> from [initial] to [2] at (-0.3) should be [0.7] assert_equals: expected "0.7 " but got "1 "
+PASS CSS Animations: property <zoom> from [initial] to [2] at (0.3) should be [1.3]
+PASS CSS Animations: property <zoom> from [initial] to [2] at (0.6) should be [1.6]
+PASS CSS Animations: property <zoom> from [initial] to [2] at (1) should be [2]
+PASS CSS Animations: property <zoom> from [initial] to [2] at (1.5) should be [2.5]
+PASS Web Animations: property <zoom> from [initial] to [2] at (-0.3) should be [0.7]
 PASS Web Animations: property <zoom> from [initial] to [2] at (0) should be [1]
-FAIL Web Animations: property <zoom> from [initial] to [2] at (0.3) should be [1.3] assert_equals: expected "1.3 " but got "1 "
-FAIL Web Animations: property <zoom> from [initial] to [2] at (0.6) should be [1.6] assert_equals: expected "1.6 " but got "1 "
-FAIL Web Animations: property <zoom> from [initial] to [2] at (1) should be [2] assert_equals: expected "2 " but got "1 "
-FAIL Web Animations: property <zoom> from [initial] to [2] at (1.5) should be [2.5] assert_equals: expected "2.5 " but got "1 "
-FAIL CSS Transitions: property <zoom> from [inherit] to [2] at (-0.3) should be [3.3] assert_equals: expected "3.3 " but got "2 "
-FAIL CSS Transitions: property <zoom> from [inherit] to [2] at (0) should be [3] assert_equals: expected "3 " but got "2 "
-FAIL CSS Transitions: property <zoom> from [inherit] to [2] at (0.3) should be [2.7] assert_equals: expected "2.7 " but got "2 "
-FAIL CSS Transitions: property <zoom> from [inherit] to [2] at (0.6) should be [2.4] assert_equals: expected "2.4 " but got "2 "
+PASS Web Animations: property <zoom> from [initial] to [2] at (0.3) should be [1.3]
+PASS Web Animations: property <zoom> from [initial] to [2] at (0.6) should be [1.6]
+PASS Web Animations: property <zoom> from [initial] to [2] at (1) should be [2]
+PASS Web Animations: property <zoom> from [initial] to [2] at (1.5) should be [2.5]
+PASS CSS Transitions: property <zoom> from [inherit] to [2] at (-0.3) should be [3.3]
+PASS CSS Transitions: property <zoom> from [inherit] to [2] at (0) should be [3]
+PASS CSS Transitions: property <zoom> from [inherit] to [2] at (0.3) should be [2.7]
+PASS CSS Transitions: property <zoom> from [inherit] to [2] at (0.6) should be [2.4]
 PASS CSS Transitions: property <zoom> from [inherit] to [2] at (1) should be [2]
-FAIL CSS Transitions: property <zoom> from [inherit] to [2] at (1.5) should be [1.5] assert_equals: expected "1.5 " but got "2 "
-FAIL CSS Transitions with transition: all: property <zoom> from [inherit] to [2] at (-0.3) should be [3.3] assert_equals: expected "3.3 " but got "2 "
-FAIL CSS Transitions with transition: all: property <zoom> from [inherit] to [2] at (0) should be [3] assert_equals: expected "3 " but got "2 "
-FAIL CSS Transitions with transition: all: property <zoom> from [inherit] to [2] at (0.3) should be [2.7] assert_equals: expected "2.7 " but got "2 "
-FAIL CSS Transitions with transition: all: property <zoom> from [inherit] to [2] at (0.6) should be [2.4] assert_equals: expected "2.4 " but got "2 "
+PASS CSS Transitions: property <zoom> from [inherit] to [2] at (1.5) should be [1.5]
+PASS CSS Transitions with transition: all: property <zoom> from [inherit] to [2] at (-0.3) should be [3.3]
+PASS CSS Transitions with transition: all: property <zoom> from [inherit] to [2] at (0) should be [3]
+PASS CSS Transitions with transition: all: property <zoom> from [inherit] to [2] at (0.3) should be [2.7]
+PASS CSS Transitions with transition: all: property <zoom> from [inherit] to [2] at (0.6) should be [2.4]
 PASS CSS Transitions with transition: all: property <zoom> from [inherit] to [2] at (1) should be [2]
-FAIL CSS Transitions with transition: all: property <zoom> from [inherit] to [2] at (1.5) should be [1.5] assert_equals: expected "1.5 " but got "2 "
-FAIL CSS Animations: property <zoom> from [inherit] to [2] at (-0.3) should be [3.3] assert_equals: expected "3.3 " but got "1 "
-FAIL CSS Animations: property <zoom> from [inherit] to [2] at (0) should be [3] assert_equals: expected "3 " but got "1 "
-FAIL CSS Animations: property <zoom> from [inherit] to [2] at (0.3) should be [2.7] assert_equals: expected "2.7 " but got "1 "
-FAIL CSS Animations: property <zoom> from [inherit] to [2] at (0.6) should be [2.4] assert_equals: expected "2.4 " but got "1 "
-FAIL CSS Animations: property <zoom> from [inherit] to [2] at (1) should be [2] assert_equals: expected "2 " but got "1 "
-FAIL CSS Animations: property <zoom> from [inherit] to [2] at (1.5) should be [1.5] assert_equals: expected "1.5 " but got "1 "
-FAIL Web Animations: property <zoom> from [inherit] to [2] at (-0.3) should be [3.3] assert_equals: expected "3.3 " but got "1 "
-FAIL Web Animations: property <zoom> from [inherit] to [2] at (0) should be [3] assert_equals: expected "3 " but got "1 "
-FAIL Web Animations: property <zoom> from [inherit] to [2] at (0.3) should be [2.7] assert_equals: expected "2.7 " but got "1 "
-FAIL Web Animations: property <zoom> from [inherit] to [2] at (0.6) should be [2.4] assert_equals: expected "2.4 " but got "1 "
-FAIL Web Animations: property <zoom> from [inherit] to [2] at (1) should be [2] assert_equals: expected "2 " but got "1 "
-FAIL Web Animations: property <zoom> from [inherit] to [2] at (1.5) should be [1.5] assert_equals: expected "1.5 " but got "1 "
-FAIL CSS Transitions: property <zoom> from [unset] to [2] at (-0.3) should be [0.7] assert_equals: expected "0.7 " but got "2 "
-FAIL CSS Transitions: property <zoom> from [unset] to [2] at (0) should be [1] assert_equals: expected "1 " but got "2 "
-FAIL CSS Transitions: property <zoom> from [unset] to [2] at (0.3) should be [1.3] assert_equals: expected "1.3 " but got "2 "
-FAIL CSS Transitions: property <zoom> from [unset] to [2] at (0.6) should be [1.6] assert_equals: expected "1.6 " but got "2 "
+PASS CSS Transitions with transition: all: property <zoom> from [inherit] to [2] at (1.5) should be [1.5]
+PASS CSS Animations: property <zoom> from [inherit] to [2] at (-0.3) should be [3.3]
+PASS CSS Animations: property <zoom> from [inherit] to [2] at (0) should be [3]
+PASS CSS Animations: property <zoom> from [inherit] to [2] at (0.3) should be [2.7]
+PASS CSS Animations: property <zoom> from [inherit] to [2] at (0.6) should be [2.4]
+PASS CSS Animations: property <zoom> from [inherit] to [2] at (1) should be [2]
+PASS CSS Animations: property <zoom> from [inherit] to [2] at (1.5) should be [1.5]
+PASS Web Animations: property <zoom> from [inherit] to [2] at (-0.3) should be [3.3]
+PASS Web Animations: property <zoom> from [inherit] to [2] at (0) should be [3]
+PASS Web Animations: property <zoom> from [inherit] to [2] at (0.3) should be [2.7]
+PASS Web Animations: property <zoom> from [inherit] to [2] at (0.6) should be [2.4]
+PASS Web Animations: property <zoom> from [inherit] to [2] at (1) should be [2]
+PASS Web Animations: property <zoom> from [inherit] to [2] at (1.5) should be [1.5]
+PASS CSS Transitions: property <zoom> from [unset] to [2] at (-0.3) should be [0.7]
+PASS CSS Transitions: property <zoom> from [unset] to [2] at (0) should be [1]
+PASS CSS Transitions: property <zoom> from [unset] to [2] at (0.3) should be [1.3]
+PASS CSS Transitions: property <zoom> from [unset] to [2] at (0.6) should be [1.6]
 PASS CSS Transitions: property <zoom> from [unset] to [2] at (1) should be [2]
-FAIL CSS Transitions: property <zoom> from [unset] to [2] at (1.5) should be [2.5] assert_equals: expected "2.5 " but got "2 "
-FAIL CSS Transitions with transition: all: property <zoom> from [unset] to [2] at (-0.3) should be [0.7] assert_equals: expected "0.7 " but got "2 "
-FAIL CSS Transitions with transition: all: property <zoom> from [unset] to [2] at (0) should be [1] assert_equals: expected "1 " but got "2 "
-FAIL CSS Transitions with transition: all: property <zoom> from [unset] to [2] at (0.3) should be [1.3] assert_equals: expected "1.3 " but got "2 "
-FAIL CSS Transitions with transition: all: property <zoom> from [unset] to [2] at (0.6) should be [1.6] assert_equals: expected "1.6 " but got "2 "
+PASS CSS Transitions: property <zoom> from [unset] to [2] at (1.5) should be [2.5]
+PASS CSS Transitions with transition: all: property <zoom> from [unset] to [2] at (-0.3) should be [0.7]
+PASS CSS Transitions with transition: all: property <zoom> from [unset] to [2] at (0) should be [1]
+PASS CSS Transitions with transition: all: property <zoom> from [unset] to [2] at (0.3) should be [1.3]
+PASS CSS Transitions with transition: all: property <zoom> from [unset] to [2] at (0.6) should be [1.6]
 PASS CSS Transitions with transition: all: property <zoom> from [unset] to [2] at (1) should be [2]
-FAIL CSS Transitions with transition: all: property <zoom> from [unset] to [2] at (1.5) should be [2.5] assert_equals: expected "2.5 " but got "2 "
-FAIL CSS Animations: property <zoom> from [unset] to [2] at (-0.3) should be [0.7] assert_equals: expected "0.7 " but got "1 "
+PASS CSS Transitions with transition: all: property <zoom> from [unset] to [2] at (1.5) should be [2.5]
+PASS CSS Animations: property <zoom> from [unset] to [2] at (-0.3) should be [0.7]
 PASS CSS Animations: property <zoom> from [unset] to [2] at (0) should be [1]
-FAIL CSS Animations: property <zoom> from [unset] to [2] at (0.3) should be [1.3] assert_equals: expected "1.3 " but got "1 "
-FAIL CSS Animations: property <zoom> from [unset] to [2] at (0.6) should be [1.6] assert_equals: expected "1.6 " but got "1 "
-FAIL CSS Animations: property <zoom> from [unset] to [2] at (1) should be [2] assert_equals: expected "2 " but got "1 "
-FAIL CSS Animations: property <zoom> from [unset] to [2] at (1.5) should be [2.5] assert_equals: expected "2.5 " but got "1 "
-FAIL Web Animations: property <zoom> from [unset] to [2] at (-0.3) should be [0.7] assert_equals: expected "0.7 " but got "1 "
+PASS CSS Animations: property <zoom> from [unset] to [2] at (0.3) should be [1.3]
+PASS CSS Animations: property <zoom> from [unset] to [2] at (0.6) should be [1.6]
+PASS CSS Animations: property <zoom> from [unset] to [2] at (1) should be [2]
+PASS CSS Animations: property <zoom> from [unset] to [2] at (1.5) should be [2.5]
+PASS Web Animations: property <zoom> from [unset] to [2] at (-0.3) should be [0.7]
 PASS Web Animations: property <zoom> from [unset] to [2] at (0) should be [1]
-FAIL Web Animations: property <zoom> from [unset] to [2] at (0.3) should be [1.3] assert_equals: expected "1.3 " but got "1 "
-FAIL Web Animations: property <zoom> from [unset] to [2] at (0.6) should be [1.6] assert_equals: expected "1.6 " but got "1 "
-FAIL Web Animations: property <zoom> from [unset] to [2] at (1) should be [2] assert_equals: expected "2 " but got "1 "
-FAIL Web Animations: property <zoom> from [unset] to [2] at (1.5) should be [2.5] assert_equals: expected "2.5 " but got "1 "
-FAIL CSS Transitions: property <zoom> from [1] to [2] at (-5) should be [1] assert_equals: expected "1 " but got "2 "
-FAIL CSS Transitions: property <zoom> from [1] to [2] at (-0.3) should be [0.7] assert_equals: expected "0.7 " but got "2 "
-FAIL CSS Transitions: property <zoom> from [1] to [2] at (0) should be [1] assert_equals: expected "1 " but got "2 "
-FAIL CSS Transitions: property <zoom> from [1] to [2] at (0.3) should be [1.3] assert_equals: expected "1.3 " but got "2 "
-FAIL CSS Transitions: property <zoom> from [1] to [2] at (0.6) should be [1.6] assert_equals: expected "1.6 " but got "2 "
+PASS Web Animations: property <zoom> from [unset] to [2] at (0.3) should be [1.3]
+PASS Web Animations: property <zoom> from [unset] to [2] at (0.6) should be [1.6]
+PASS Web Animations: property <zoom> from [unset] to [2] at (1) should be [2]
+PASS Web Animations: property <zoom> from [unset] to [2] at (1.5) should be [2.5]
+PASS CSS Transitions: property <zoom> from [1] to [2] at (-5) should be [1]
+PASS CSS Transitions: property <zoom> from [1] to [2] at (-0.3) should be [0.7]
+PASS CSS Transitions: property <zoom> from [1] to [2] at (0) should be [1]
+PASS CSS Transitions: property <zoom> from [1] to [2] at (0.3) should be [1.3]
+PASS CSS Transitions: property <zoom> from [1] to [2] at (0.6) should be [1.6]
 PASS CSS Transitions: property <zoom> from [1] to [2] at (1) should be [2]
-FAIL CSS Transitions: property <zoom> from [1] to [2] at (1.5) should be [2.5] assert_equals: expected "2.5 " but got "2 "
-FAIL CSS Transitions with transition: all: property <zoom> from [1] to [2] at (-5) should be [1] assert_equals: expected "1 " but got "2 "
-FAIL CSS Transitions with transition: all: property <zoom> from [1] to [2] at (-0.3) should be [0.7] assert_equals: expected "0.7 " but got "2 "
-FAIL CSS Transitions with transition: all: property <zoom> from [1] to [2] at (0) should be [1] assert_equals: expected "1 " but got "2 "
-FAIL CSS Transitions with transition: all: property <zoom> from [1] to [2] at (0.3) should be [1.3] assert_equals: expected "1.3 " but got "2 "
-FAIL CSS Transitions with transition: all: property <zoom> from [1] to [2] at (0.6) should be [1.6] assert_equals: expected "1.6 " but got "2 "
+PASS CSS Transitions: property <zoom> from [1] to [2] at (1.5) should be [2.5]
+PASS CSS Transitions with transition: all: property <zoom> from [1] to [2] at (-5) should be [1]
+PASS CSS Transitions with transition: all: property <zoom> from [1] to [2] at (-0.3) should be [0.7]
+PASS CSS Transitions with transition: all: property <zoom> from [1] to [2] at (0) should be [1]
+PASS CSS Transitions with transition: all: property <zoom> from [1] to [2] at (0.3) should be [1.3]
+PASS CSS Transitions with transition: all: property <zoom> from [1] to [2] at (0.6) should be [1.6]
 PASS CSS Transitions with transition: all: property <zoom> from [1] to [2] at (1) should be [2]
-FAIL CSS Transitions with transition: all: property <zoom> from [1] to [2] at (1.5) should be [2.5] assert_equals: expected "2.5 " but got "2 "
+PASS CSS Transitions with transition: all: property <zoom> from [1] to [2] at (1.5) should be [2.5]
 PASS CSS Animations: property <zoom> from [1] to [2] at (-5) should be [1]
-FAIL CSS Animations: property <zoom> from [1] to [2] at (-0.3) should be [0.7] assert_equals: expected "0.7 " but got "1 "
+PASS CSS Animations: property <zoom> from [1] to [2] at (-0.3) should be [0.7]
 PASS CSS Animations: property <zoom> from [1] to [2] at (0) should be [1]
-FAIL CSS Animations: property <zoom> from [1] to [2] at (0.3) should be [1.3] assert_equals: expected "1.3 " but got "1 "
-FAIL CSS Animations: property <zoom> from [1] to [2] at (0.6) should be [1.6] assert_equals: expected "1.6 " but got "1 "
-FAIL CSS Animations: property <zoom> from [1] to [2] at (1) should be [2] assert_equals: expected "2 " but got "1 "
-FAIL CSS Animations: property <zoom> from [1] to [2] at (1.5) should be [2.5] assert_equals: expected "2.5 " but got "1 "
+PASS CSS Animations: property <zoom> from [1] to [2] at (0.3) should be [1.3]
+PASS CSS Animations: property <zoom> from [1] to [2] at (0.6) should be [1.6]
+PASS CSS Animations: property <zoom> from [1] to [2] at (1) should be [2]
+PASS CSS Animations: property <zoom> from [1] to [2] at (1.5) should be [2.5]
 PASS Web Animations: property <zoom> from [1] to [2] at (-5) should be [1]
-FAIL Web Animations: property <zoom> from [1] to [2] at (-0.3) should be [0.7] assert_equals: expected "0.7 " but got "1 "
+PASS Web Animations: property <zoom> from [1] to [2] at (-0.3) should be [0.7]
 PASS Web Animations: property <zoom> from [1] to [2] at (0) should be [1]
-FAIL Web Animations: property <zoom> from [1] to [2] at (0.3) should be [1.3] assert_equals: expected "1.3 " but got "1 "
-FAIL Web Animations: property <zoom> from [1] to [2] at (0.6) should be [1.6] assert_equals: expected "1.6 " but got "1 "
-FAIL Web Animations: property <zoom> from [1] to [2] at (1) should be [2] assert_equals: expected "2 " but got "1 "
-FAIL Web Animations: property <zoom> from [1] to [2] at (1.5) should be [2.5] assert_equals: expected "2.5 " but got "1 "
-FAIL CSS Transitions: property <zoom> from [0.5] to [1.5] at (-5) should be [1] assert_equals: expected "1 " but got "1.5 "
-FAIL CSS Transitions: property <zoom> from [0.5] to [1.5] at (-0.3) should be [0.2] assert_equals: expected "0.2 " but got "1.5 "
-FAIL CSS Transitions: property <zoom> from [0.5] to [1.5] at (0) should be [0.5] assert_equals: expected "0.5 " but got "1.5 "
-FAIL CSS Transitions: property <zoom> from [0.5] to [1.5] at (0.5) should be [1] assert_equals: expected "1 " but got "1.5 "
+PASS Web Animations: property <zoom> from [1] to [2] at (0.3) should be [1.3]
+PASS Web Animations: property <zoom> from [1] to [2] at (0.6) should be [1.6]
+PASS Web Animations: property <zoom> from [1] to [2] at (1) should be [2]
+PASS Web Animations: property <zoom> from [1] to [2] at (1.5) should be [2.5]
+PASS CSS Transitions: property <zoom> from [0.5] to [1.5] at (-5) should be [1]
+PASS CSS Transitions: property <zoom> from [0.5] to [1.5] at (-0.3) should be [0.2]
+PASS CSS Transitions: property <zoom> from [0.5] to [1.5] at (0) should be [0.5]
+PASS CSS Transitions: property <zoom> from [0.5] to [1.5] at (0.5) should be [1]
 PASS CSS Transitions: property <zoom> from [0.5] to [1.5] at (1) should be [1.5]
-FAIL CSS Transitions: property <zoom> from [0.5] to [1.5] at (1.5) should be [2] assert_equals: expected "2 " but got "1.5 "
-FAIL CSS Transitions with transition: all: property <zoom> from [0.5] to [1.5] at (-5) should be [1] assert_equals: expected "1 " but got "1.5 "
-FAIL CSS Transitions with transition: all: property <zoom> from [0.5] to [1.5] at (-0.3) should be [0.2] assert_equals: expected "0.2 " but got "1.5 "
-FAIL CSS Transitions with transition: all: property <zoom> from [0.5] to [1.5] at (0) should be [0.5] assert_equals: expected "0.5 " but got "1.5 "
-FAIL CSS Transitions with transition: all: property <zoom> from [0.5] to [1.5] at (0.5) should be [1] assert_equals: expected "1 " but got "1.5 "
+PASS CSS Transitions: property <zoom> from [0.5] to [1.5] at (1.5) should be [2]
+PASS CSS Transitions with transition: all: property <zoom> from [0.5] to [1.5] at (-5) should be [1]
+PASS CSS Transitions with transition: all: property <zoom> from [0.5] to [1.5] at (-0.3) should be [0.2]
+PASS CSS Transitions with transition: all: property <zoom> from [0.5] to [1.5] at (0) should be [0.5]
+PASS CSS Transitions with transition: all: property <zoom> from [0.5] to [1.5] at (0.5) should be [1]
 PASS CSS Transitions with transition: all: property <zoom> from [0.5] to [1.5] at (1) should be [1.5]
-FAIL CSS Transitions with transition: all: property <zoom> from [0.5] to [1.5] at (1.5) should be [2] assert_equals: expected "2 " but got "1.5 "
+PASS CSS Transitions with transition: all: property <zoom> from [0.5] to [1.5] at (1.5) should be [2]
 PASS CSS Animations: property <zoom> from [0.5] to [1.5] at (-5) should be [1]
-FAIL CSS Animations: property <zoom> from [0.5] to [1.5] at (-0.3) should be [0.2] assert_equals: expected "0.2 " but got "1 "
-FAIL CSS Animations: property <zoom> from [0.5] to [1.5] at (0) should be [0.5] assert_equals: expected "0.5 " but got "1 "
+PASS CSS Animations: property <zoom> from [0.5] to [1.5] at (-0.3) should be [0.2]
+PASS CSS Animations: property <zoom> from [0.5] to [1.5] at (0) should be [0.5]
 PASS CSS Animations: property <zoom> from [0.5] to [1.5] at (0.5) should be [1]
-FAIL CSS Animations: property <zoom> from [0.5] to [1.5] at (1) should be [1.5] assert_equals: expected "1.5 " but got "1 "
-FAIL CSS Animations: property <zoom> from [0.5] to [1.5] at (1.5) should be [2] assert_equals: expected "2 " but got "1 "
+PASS CSS Animations: property <zoom> from [0.5] to [1.5] at (1) should be [1.5]
+PASS CSS Animations: property <zoom> from [0.5] to [1.5] at (1.5) should be [2]
 PASS Web Animations: property <zoom> from [0.5] to [1.5] at (-5) should be [1]
-FAIL Web Animations: property <zoom> from [0.5] to [1.5] at (-0.3) should be [0.2] assert_equals: expected "0.2 " but got "1 "
-FAIL Web Animations: property <zoom> from [0.5] to [1.5] at (0) should be [0.5] assert_equals: expected "0.5 " but got "1 "
+PASS Web Animations: property <zoom> from [0.5] to [1.5] at (-0.3) should be [0.2]
+PASS Web Animations: property <zoom> from [0.5] to [1.5] at (0) should be [0.5]
 PASS Web Animations: property <zoom> from [0.5] to [1.5] at (0.5) should be [1]
-FAIL Web Animations: property <zoom> from [0.5] to [1.5] at (1) should be [1.5] assert_equals: expected "1.5 " but got "1 "
-FAIL Web Animations: property <zoom> from [0.5] to [1.5] at (1.5) should be [2] assert_equals: expected "2 " but got "1 "
-FAIL CSS Transitions: property <zoom> from [normal] to [3] at (-0.5) should be [1] assert_equals: expected "1 " but got "3 "
-FAIL CSS Transitions: property <zoom> from [normal] to [3] at (0) should be [1] assert_equals: expected "1 " but got "3 "
-FAIL CSS Transitions: property <zoom> from [normal] to [3] at (0.5) should be [2] assert_equals: expected "2 " but got "3 "
+PASS Web Animations: property <zoom> from [0.5] to [1.5] at (1) should be [1.5]
+PASS Web Animations: property <zoom> from [0.5] to [1.5] at (1.5) should be [2]
+PASS CSS Transitions: property <zoom> from [normal] to [3] at (-0.5) should be [1]
+PASS CSS Transitions: property <zoom> from [normal] to [3] at (0) should be [1]
+PASS CSS Transitions: property <zoom> from [normal] to [3] at (0.5) should be [2]
 PASS CSS Transitions: property <zoom> from [normal] to [3] at (1) should be [3]
-FAIL CSS Transitions with transition: all: property <zoom> from [normal] to [3] at (-0.5) should be [1] assert_equals: expected "1 " but got "3 "
-FAIL CSS Transitions with transition: all: property <zoom> from [normal] to [3] at (0) should be [1] assert_equals: expected "1 " but got "3 "
-FAIL CSS Transitions with transition: all: property <zoom> from [normal] to [3] at (0.5) should be [2] assert_equals: expected "2 " but got "3 "
+PASS CSS Transitions with transition: all: property <zoom> from [normal] to [3] at (-0.5) should be [1]
+PASS CSS Transitions with transition: all: property <zoom> from [normal] to [3] at (0) should be [1]
+PASS CSS Transitions with transition: all: property <zoom> from [normal] to [3] at (0.5) should be [2]
 PASS CSS Transitions with transition: all: property <zoom> from [normal] to [3] at (1) should be [3]
 PASS CSS Animations: property <zoom> from [normal] to [3] at (-0.5) should be [1]
 PASS CSS Animations: property <zoom> from [normal] to [3] at (0) should be [1]
-FAIL CSS Animations: property <zoom> from [normal] to [3] at (0.5) should be [2] assert_equals: expected "2 " but got "1 "
-FAIL CSS Animations: property <zoom> from [normal] to [3] at (1) should be [3] assert_equals: expected "3 " but got "1 "
+PASS CSS Animations: property <zoom> from [normal] to [3] at (0.5) should be [2]
+PASS CSS Animations: property <zoom> from [normal] to [3] at (1) should be [3]
 PASS Web Animations: property <zoom> from [normal] to [3] at (-0.5) should be [1]
 PASS Web Animations: property <zoom> from [normal] to [3] at (0) should be [1]
-FAIL Web Animations: property <zoom> from [normal] to [3] at (0.5) should be [2] assert_equals: expected "2 " but got "1 "
-FAIL Web Animations: property <zoom> from [normal] to [3] at (1) should be [3] assert_equals: expected "3 " but got "1 "
-FAIL CSS Transitions: property <zoom> from [100%] to [300%] at (0) should be [1] assert_equals: expected "1 " but got "3 "
-FAIL CSS Transitions: property <zoom> from [100%] to [300%] at (0.5) should be [2] assert_equals: expected "2 " but got "3 "
+PASS Web Animations: property <zoom> from [normal] to [3] at (0.5) should be [2]
+PASS Web Animations: property <zoom> from [normal] to [3] at (1) should be [3]
+PASS CSS Transitions: property <zoom> from [100%] to [300%] at (0) should be [1]
+PASS CSS Transitions: property <zoom> from [100%] to [300%] at (0.5) should be [2]
 PASS CSS Transitions: property <zoom> from [100%] to [300%] at (1) should be [3]
-FAIL CSS Transitions with transition: all: property <zoom> from [100%] to [300%] at (0) should be [1] assert_equals: expected "1 " but got "3 "
-FAIL CSS Transitions with transition: all: property <zoom> from [100%] to [300%] at (0.5) should be [2] assert_equals: expected "2 " but got "3 "
+PASS CSS Transitions with transition: all: property <zoom> from [100%] to [300%] at (0) should be [1]
+PASS CSS Transitions with transition: all: property <zoom> from [100%] to [300%] at (0.5) should be [2]
 PASS CSS Transitions with transition: all: property <zoom> from [100%] to [300%] at (1) should be [3]
 PASS CSS Animations: property <zoom> from [100%] to [300%] at (0) should be [1]
-FAIL CSS Animations: property <zoom> from [100%] to [300%] at (0.5) should be [2] assert_equals: expected "2 " but got "1 "
-FAIL CSS Animations: property <zoom> from [100%] to [300%] at (1) should be [3] assert_equals: expected "3 " but got "1 "
+PASS CSS Animations: property <zoom> from [100%] to [300%] at (0.5) should be [2]
+PASS CSS Animations: property <zoom> from [100%] to [300%] at (1) should be [3]
 PASS Web Animations: property <zoom> from [100%] to [300%] at (0) should be [1]
-FAIL Web Animations: property <zoom> from [100%] to [300%] at (0.5) should be [2] assert_equals: expected "2 " but got "1 "
-FAIL Web Animations: property <zoom> from [100%] to [300%] at (1) should be [3] assert_equals: expected "3 " but got "1 "
-FAIL CSS Transitions: property <zoom> from [50%] to [2] at (0) should be [0.5] assert_equals: expected "0.5 " but got "2 "
-FAIL CSS Transitions: property <zoom> from [50%] to [2] at (0.5) should be [1.25] assert_equals: expected "1.25 " but got "2 "
+PASS Web Animations: property <zoom> from [100%] to [300%] at (0.5) should be [2]
+PASS Web Animations: property <zoom> from [100%] to [300%] at (1) should be [3]
+PASS CSS Transitions: property <zoom> from [50%] to [2] at (0) should be [0.5]
+PASS CSS Transitions: property <zoom> from [50%] to [2] at (0.5) should be [1.25]
 PASS CSS Transitions: property <zoom> from [50%] to [2] at (1) should be [2]
-FAIL CSS Transitions with transition: all: property <zoom> from [50%] to [2] at (0) should be [0.5] assert_equals: expected "0.5 " but got "2 "
-FAIL CSS Transitions with transition: all: property <zoom> from [50%] to [2] at (0.5) should be [1.25] assert_equals: expected "1.25 " but got "2 "
+PASS CSS Transitions with transition: all: property <zoom> from [50%] to [2] at (0) should be [0.5]
+PASS CSS Transitions with transition: all: property <zoom> from [50%] to [2] at (0.5) should be [1.25]
 PASS CSS Transitions with transition: all: property <zoom> from [50%] to [2] at (1) should be [2]
-FAIL CSS Animations: property <zoom> from [50%] to [2] at (0) should be [0.5] assert_equals: expected "0.5 " but got "1 "
-FAIL CSS Animations: property <zoom> from [50%] to [2] at (0.5) should be [1.25] assert_equals: expected "1.25 " but got "1 "
-FAIL CSS Animations: property <zoom> from [50%] to [2] at (1) should be [2] assert_equals: expected "2 " but got "1 "
-FAIL Web Animations: property <zoom> from [50%] to [2] at (0) should be [0.5] assert_equals: expected "0.5 " but got "1 "
-FAIL Web Animations: property <zoom> from [50%] to [2] at (0.5) should be [1.25] assert_equals: expected "1.25 " but got "1 "
-FAIL Web Animations: property <zoom> from [50%] to [2] at (1) should be [2] assert_equals: expected "2 " but got "1 "
-FAIL CSS Transitions: property <zoom> from [calc(sibling-index() * 100%)] to [2] at (0) should be [1] assert_equals: expected "1 " but got "2 "
-FAIL CSS Transitions: property <zoom> from [calc(sibling-index() * 100%)] to [2] at (0.5) should be [1.5] assert_equals: expected "1.5 " but got "2 "
+PASS CSS Animations: property <zoom> from [50%] to [2] at (0) should be [0.5]
+PASS CSS Animations: property <zoom> from [50%] to [2] at (0.5) should be [1.25]
+PASS CSS Animations: property <zoom> from [50%] to [2] at (1) should be [2]
+PASS Web Animations: property <zoom> from [50%] to [2] at (0) should be [0.5]
+PASS Web Animations: property <zoom> from [50%] to [2] at (0.5) should be [1.25]
+PASS Web Animations: property <zoom> from [50%] to [2] at (1) should be [2]
+PASS CSS Transitions: property <zoom> from [calc(sibling-index() * 100%)] to [2] at (0) should be [1]
+PASS CSS Transitions: property <zoom> from [calc(sibling-index() * 100%)] to [2] at (0.5) should be [1.5]
 PASS CSS Transitions: property <zoom> from [calc(sibling-index() * 100%)] to [2] at (1) should be [2]
-FAIL CSS Transitions with transition: all: property <zoom> from [calc(sibling-index() * 100%)] to [2] at (0) should be [1] assert_equals: expected "1 " but got "2 "
-FAIL CSS Transitions with transition: all: property <zoom> from [calc(sibling-index() * 100%)] to [2] at (0.5) should be [1.5] assert_equals: expected "1.5 " but got "2 "
+PASS CSS Transitions with transition: all: property <zoom> from [calc(sibling-index() * 100%)] to [2] at (0) should be [1]
+PASS CSS Transitions with transition: all: property <zoom> from [calc(sibling-index() * 100%)] to [2] at (0.5) should be [1.5]
 PASS CSS Transitions with transition: all: property <zoom> from [calc(sibling-index() * 100%)] to [2] at (1) should be [2]
 PASS CSS Animations: property <zoom> from [calc(sibling-index() * 100%)] to [2] at (0) should be [1]
-FAIL CSS Animations: property <zoom> from [calc(sibling-index() * 100%)] to [2] at (0.5) should be [1.5] assert_equals: expected "1.5 " but got "1 "
-FAIL CSS Animations: property <zoom> from [calc(sibling-index() * 100%)] to [2] at (1) should be [2] assert_equals: expected "2 " but got "1 "
+PASS CSS Animations: property <zoom> from [calc(sibling-index() * 100%)] to [2] at (0.5) should be [1.5]
+PASS CSS Animations: property <zoom> from [calc(sibling-index() * 100%)] to [2] at (1) should be [2]
 PASS Web Animations: property <zoom> from [calc(sibling-index() * 100%)] to [2] at (0) should be [1]
-FAIL Web Animations: property <zoom> from [calc(sibling-index() * 100%)] to [2] at (0.5) should be [1.5] assert_equals: expected "1.5 " but got "1 "
-FAIL Web Animations: property <zoom> from [calc(sibling-index() * 100%)] to [2] at (1) should be [2] assert_equals: expected "2 " but got "1 "
-FAIL Animating zoom affects layout using the interpolated value assert_approx_equals: expected 1.5 +/- 0.01 but got 1
-FAIL transition: all animates zoom changes from :hover assert_approx_equals: expected 1.5 +/- 0.01 but got 2
+PASS Web Animations: property <zoom> from [calc(sibling-index() * 100%)] to [2] at (0.5) should be [1.5]
+PASS Web Animations: property <zoom> from [calc(sibling-index() * 100%)] to [2] at (1) should be [2]
+PASS Animating zoom affects layout using the interpolated value
+PASS transition: all animates zoom changes from :hover
 

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -1667,7 +1667,7 @@
             }
         },
         "zoom": {
-            "animation-type": "not animatable",
+            "animation-type": "by computed value",
             "initial": "1",
             "values": [
                 {
@@ -1676,6 +1676,7 @@
                 }
             ],
             "codegen-properties": {
+                "animation-wrapper-requires-setter": "setZoomFromAnimation",
                 "style-builder-custom": "All",
                 "high-priority": true,
                 "computed-style-initial-constexpr": true,

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.cpp
@@ -38,6 +38,7 @@
 #include "StylePrimitiveNumericTypes+Evaluation.h"
 #include "StyleTextDecorationLine.h"
 #include "StyleTextTransform.h"
+#include "StyleZoom.h"
 #include <algorithm>
 #include <wtf/MathExtras.h>
 #include <wtf/StdLibExtras.h>
@@ -292,6 +293,21 @@ void ComputedStyleBase::setWordSpacingFromAnimation(WordSpacing&& value)
 
         synchronizeWordSpacingWithFontCascade();
     }
+}
+
+void ComputedStyleBase::setZoomFromAnimation(Zoom value)
+{
+    // Match StyleBuilderCustom::applyValueZoom: treat zoom: 0 as 1.
+    if (evaluate<float>(value) < Zoom::minEffective)
+        value = Zoom { 1.0f };
+
+    // Replay StyleBuilderCustom::resetUsedZoom: recover parent.usedZoom from (zoom, usedZoom) so setUsedZoom below ends at parent.usedZoom * specifiedZoom.
+    auto currentSpecified = evaluate<float>(m_nonInheritedData->rareData->zoom);
+    auto parentUsedZoom = currentSpecified < Zoom::minEffective ? 1.0f : usedZoom() / currentSpecified;
+    setUsedZoom(clampTo<float>(parentUsedZoom * evaluate<float>(value), Zoom::minEffective, Zoom::maxEffective));
+
+    if (value != m_nonInheritedData->rareData->zoom)
+        m_nonInheritedData.access().rareData.access().zoom = value;
 }
 
 void ComputedStyleBase::synchronizeLetterSpacingWithFontCascade()

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.h
@@ -618,6 +618,8 @@ public:
     inline float usedZoom() const;
     inline bool setUsedZoom(float);
 
+    void setZoomFromAnimation(Zoom);
+
     inline ZoomFactor usedZoomForLength() const;
 
     // MARK: - Fonts

--- a/Source/WebCore/style/computed/StyleComputedStyleProperties+SettersCustomInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleProperties+SettersCustomInlines.h
@@ -69,11 +69,7 @@ inline bool ComputedStyleProperties::setWritingMode(StyleWritingMode mode)
 
 inline bool ComputedStyleProperties::setZoom(Zoom zoom)
 {
-    // Clamp the effective zoom value to avoid overflow in derived computations.
-    // This matches other engines values for compatibility.
-    constexpr float minEffectiveZoom = 1e-6f;
-    constexpr float maxEffectiveZoom = 1e6f;
-    setUsedZoom(clampTo<float>(usedZoom() * evaluate<float>(zoom), minEffectiveZoom, maxEffectiveZoom));
+    setUsedZoom(clampTo<float>(usedZoom() * evaluate<float>(zoom), Zoom::minEffective, Zoom::maxEffective));
 
     if (compareEqual(m_nonInheritedData->rareData->zoom, zoom))
         return false;

--- a/Source/WebCore/style/values/viewport/StyleZoom.h
+++ b/Source/WebCore/style/values/viewport/StyleZoom.h
@@ -37,6 +37,11 @@ struct Zoom {
     using Number = Value::Number;
     using Percentage = Value::Percentage;
 
+    // Clamp range for the effective zoom value, used to avoid overflow in
+    // derived computations. Matches the values used by other engines.
+    static constexpr float minEffective = 1e-6f;
+    static constexpr float maxEffective = 1e6f;
+
     Value value;
 
     constexpr Zoom(Value value) : value { value } { }


### PR DESCRIPTION
#### ec9c24b678b4159b2365e99b89de6bdf84a1f1d7
<pre>
[CSS Viewport] Make zoom animatable by computed value
<a href="https://bugs.webkit.org/show_bug.cgi?id=315081">https://bugs.webkit.org/show_bug.cgi?id=315081</a>
<a href="https://rdar.apple.com/177411607">rdar://177411607</a>

Reviewed by Sam Weinig.

This patch aligns WebKit with the recent CSS Viewport Specification
resolution [1] that defines `zoom` as animatable by computed value.

WebKit previously marked `zoom` as &quot;not animatable&quot;, leading to ~150
failing subtests in the recently-added zoom-interpolation.html.

The change flips `zoom`&apos;s animation-type to &quot;by computed value&quot; so the
auto-derived tuple-like `Blending&lt;Style::Zoom&gt;` (forwarding to the
existing `Blending&lt;NumberOrPercentageResolvedToNumber&lt;...&gt;&gt;`) handles
the interpolation. The standard `StyleTypeWrapper` is then wired up via
`animation-wrapper-requires-setter`, pointing at a new
`Style::ComputedStyleBase::setZoomFromAnimation` (mirroring
`setLetterSpacingFromAnimation` / `setWordSpacingFromAnimation`).

The dedicated setter is needed to avoid a double-apply bug: `setZoom`
multiplies the new specified value into the cumulative `usedZoom`, so
the style builder calls `resetUsedZoom()` (usedZoom &lt;- parent.usedZoom)
before each `setZoom`. The animation pipeline doesn&apos;t issue that reset,
so calling `setZoom` directly would fold the destination&apos;s existing
zoom in a second time. `setZoomFromAnimation` recovers the parent&apos;s
`usedZoom` from the destination&apos;s current (specifiedZoom, usedZoom)
pair and replays the multiplication, leaving usedZoom at
`parent.usedZoom * specifiedZoom` — so layout reflects the animated
value.

It also applies the legacy `zoom: 0` -&gt; `1` fold (matching
`StyleBuilderCustom::applyValueZoom`) so that negative-progress
extrapolation that clamps near 0 doesn&apos;t leak through.

[1] <a href="https://github.com/w3c/csswg-drafts/issues/10872">https://github.com/w3c/csswg-drafts/issues/10872</a>

* Source/WebCore/css/CSSProperties.json:
Change `zoom`&apos;s animation-type from &quot;not animatable&quot; to
&quot;by computed value&quot; and route the wrapper&apos;s setter through
`setZoomFromAnimation` via `animation-wrapper-requires-setter`.

* Source/WebCore/style/computed/StyleComputedStyleBase.h:
* Source/WebCore/style/computed/StyleComputedStyleBase.cpp:
Add `setZoomFromAnimation`, which recovers parent&apos;s `usedZoom` from
the destination&apos;s existing (specifiedZoom, usedZoom) pair, replays
the `usedZoom = parent.usedZoom * specifiedZoom` accumulation under
the same clamp `setZoom` uses, and applies the `zoom: 0` -&gt; `1`
legacy fold.

* Source/WebCore/style/values/viewport/StyleZoom.h:
Hoist `minEffective` / `maxEffective` clamp bounds onto
`Style::Zoom` so `setZoom` and `setZoomFromAnimation` share one
source of truth.

* Source/WebCore/style/computed/StyleComputedStyleProperties+SettersCustomInlines.h:
Use the hoisted `Style::Zoom::minEffective` / `maxEffective`
constants.

Canonical link: <a href="https://commits.webkit.org/313735@main">https://commits.webkit.org/313735@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61704e561c3cf4519d13f01f3fc3bc39dbec0800

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163966 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37450 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30669 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172995 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165835 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37783 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37450 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127378 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121217 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166925 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29664 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147405 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107926 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b91c40b6-11cc-46ac-a7fa-33449e54de4a) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28710 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27333 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20759 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138611 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25122 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175520 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28342 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26790 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135688 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37120 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31445 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135660 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36558 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37905 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146917 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100069 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30963 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23773 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36714 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109761 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36113 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1813 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36363 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36260 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->