### PR TITLE
[JSC] ScopedArgumentsTable ScopeOffset buffer should allocate from fastMalloc

### DIFF
--- a/Source/JavaScriptCore/runtime/CachedTypes.cpp
+++ b/Source/JavaScriptCore/runtime/CachedTypes.cpp
@@ -1202,15 +1202,15 @@ class CachedScopedArgumentsTable : public CachedObject<ScopedArgumentsTable> {
 public:
     void encode(Encoder& encoder, const ScopedArgumentsTable& scopedArgumentsTable)
     {
-        m_length = scopedArgumentsTable.m_length;
-        m_arguments.encode(encoder, scopedArgumentsTable.m_arguments.get(), m_length);
+        m_length = scopedArgumentsTable.m_arguments.size();
+        m_arguments.encode(encoder, scopedArgumentsTable.m_arguments.span().data(), m_length);
     }
 
     ScopedArgumentsTable* decode(Decoder& decoder) const
     {
         ScopedArgumentsTable* scopedArgumentsTable = ScopedArgumentsTable::tryCreate(decoder.vm(), m_length);
         RELEASE_ASSERT(scopedArgumentsTable); // We crash here. This is unlikely to continue execution if we hit this condition when decoding UnlinkedCodeBlock.
-        m_arguments.decode(decoder, scopedArgumentsTable->m_arguments.get(), m_length);
+        m_arguments.decode(decoder, scopedArgumentsTable->m_arguments.mutableSpan().data(), m_length);
         return scopedArgumentsTable;
     }
 

--- a/Source/JavaScriptCore/runtime/ScopedArgumentsTable.cpp
+++ b/Source/JavaScriptCore/runtime/ScopedArgumentsTable.cpp
@@ -38,7 +38,6 @@ const ClassInfo ScopedArgumentsTable::s_info = { "ScopedArgumentsTable"_s, nullp
 
 ScopedArgumentsTable::ScopedArgumentsTable(VM& vm)
     : Base(vm, vm.scopedArgumentsTableStructure.get())
-    , m_length(0)
     , m_locked(false)
 {
 }
@@ -66,21 +65,20 @@ ScopedArgumentsTable* ScopedArgumentsTable::tryCreate(VM& vm, uint32_t length)
     ScopedArgumentsTable* result = new (NotNull, buffer) ScopedArgumentsTable(vm);
     result->finishCreation(vm);
 
-    result->m_length = length;
-    result->m_arguments = ArgumentsPtr::tryCreate(length);
-    if (!result->m_arguments) [[unlikely]]
+    if (!result->m_arguments.tryGrow(length)) [[unlikely]]
         return nullptr;
-    result->m_watchpointSets.fill(nullptr, length);
+    if (!result->m_watchpointSets.tryGrow(length)) [[unlikely]]
+        return nullptr;
+    std::ranges::fill(result->m_watchpointSets.mutableSpan(), nullptr);
     return result;
 }
 
 ScopedArgumentsTable* ScopedArgumentsTable::tryClone(VM& vm)
 {
-    ScopedArgumentsTable* result = tryCreate(vm, m_length);
+    ScopedArgumentsTable* result = tryCreate(vm, m_arguments.size());
     if (!result) [[unlikely]]
         return nullptr;
-    for (unsigned i = m_length; i--;)
-        result->at(i) = this->at(i);
+    result->m_arguments = m_arguments;
     result->m_watchpointSets = this->m_watchpointSets;
     return result;
 }
@@ -88,23 +86,21 @@ ScopedArgumentsTable* ScopedArgumentsTable::tryClone(VM& vm)
 ScopedArgumentsTable* ScopedArgumentsTable::trySetLength(VM& vm, uint32_t newLength)
 {
     if (!m_locked) [[likely]] {
-        ArgumentsPtr newArguments = ArgumentsPtr::tryCreate(newLength, newLength);
-        if (!newArguments) [[unlikely]]
+        size_t oldSize = m_watchpointSets.size();
+        if (!m_arguments.tryGrow(newLength))
             return nullptr;
-        for (unsigned i = std::min(m_length, newLength); i--;)
-            newArguments.at(i) = this->at(i);
-        m_length = newLength;
-        m_arguments = WTF::move(newArguments);
-        m_watchpointSets.resize(newLength);
+        if (!m_watchpointSets.tryGrow(newLength))
+            return nullptr;
+        if (newLength > oldSize)
+            std::ranges::fill(m_watchpointSets.mutableSpan().subspan(oldSize), nullptr);
         return this;
     }
-    
+
     ScopedArgumentsTable* result = tryCreate(vm, newLength);
     if (!result) [[unlikely]]
         return nullptr;
-    m_watchpointSets.resize(newLength);
-    for (unsigned i = std::min(m_length, newLength); i--;) {
-        result->at(i) = this->at(i);
+    for (unsigned i = std::min<uint32_t>(m_arguments.size(), newLength); i--;) {
+        result->m_arguments[i] = this->m_arguments[i];
         result->m_watchpointSets[i] = this->m_watchpointSets[i];
     }
     return result;
@@ -121,7 +117,7 @@ ScopedArgumentsTable* ScopedArgumentsTable::trySet(VM& vm, uint32_t i, ScopeOffs
             return nullptr;
     } else
         result = this;
-    result->at(i) = value;
+    result->m_arguments[i] = value;
     return result;
 }
 

--- a/Source/JavaScriptCore/runtime/ScopedArgumentsTable.h
+++ b/Source/JavaScriptCore/runtime/ScopedArgumentsTable.h
@@ -29,7 +29,7 @@
 #include <JavaScriptCore/ScopeOffset.h>
 #include <JavaScriptCore/VM.h>
 #include <wtf/Assertions.h>
-#include <wtf/CagedUniquePtr.h>
+#include <wtf/Vector.h>
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
 
@@ -67,10 +67,10 @@ public:
 
     static void destroy(JSCell*);
 
-    uint32_t length() const { return m_length; }
+    uint32_t length() const { return m_arguments.size(); }
     ScopedArgumentsTable* trySetLength(VM&, uint32_t newLength);
     
-    ScopeOffset get(uint32_t i) const { return at(i); }
+    ScopeOffset get(uint32_t i) const { return m_arguments.at(i); }
     WatchpointSet* getWatchpointSet(uint32_t i) const { return m_watchpointSets.at(i); }
     
     void lock()
@@ -86,24 +86,17 @@ public:
     
     static Structure* createStructure(VM&, JSGlobalObject*, JSValue prototype);
 
-    static constexpr ptrdiff_t offsetOfLength() { return OBJECT_OFFSETOF(ScopedArgumentsTable, m_length); }
-    static constexpr ptrdiff_t offsetOfArguments() { return OBJECT_OFFSETOF(ScopedArgumentsTable, m_arguments); }
+    using ArgumentScopeBufferType = Vector<ScopeOffset>;
 
-    typedef CagedUniquePtr<Gigacage::Primitive, ScopeOffset> ArgumentsPtr;
+    static constexpr ptrdiff_t offsetOfLength() { return OBJECT_OFFSETOF(ScopedArgumentsTable, m_arguments) + ArgumentScopeBufferType::sizeMemoryOffset(); }
+    static constexpr ptrdiff_t offsetOfArguments() { return OBJECT_OFFSETOF(ScopedArgumentsTable, m_arguments) + ArgumentScopeBufferType::bufferMemoryOffset(); }
 
 private:
     ScopedArgumentsTable* tryClone(VM&);
-
-    ScopeOffset& at(uint32_t i) const
-    {
-        ASSERT_WITH_SECURITY_IMPLICATION(i < m_length);
-        return m_arguments.get()[i];
-    }
     
-    uint32_t m_length;
-    bool m_locked; // Being locked means that there are multiple references to this object and none of them expect to see the others' modifications. This means that modifications need to make a copy first.
-    ArgumentsPtr m_arguments;
+    ArgumentScopeBufferType m_arguments;
     Vector<WatchpointSet*> m_watchpointSets;
+    bool m_locked; // Being locked means that there are multiple references to this object and none of them expect to see the others' modifications. This means that modifications need to make a copy first.
 };
 
 } // namespace JSC

--- a/Source/WTF/wtf/Vector.h
+++ b/Source/WTF/wtf/Vector.h
@@ -765,6 +765,7 @@ public:
     [[nodiscard]] size_t size() const { return m_size; }
     [[nodiscard]] size_t sizeInBytes() const { return static_cast<size_t>(m_size) * sizeof(T); }
     static constexpr ptrdiff_t sizeMemoryOffset() { return OBJECT_OFFSETOF(Vector, m_size); }
+    static constexpr ptrdiff_t bufferMemoryOffset() { return Base::bufferMemoryOffset(); }
     [[nodiscard]] size_t capacity() const { return Base::capacity(); }
     [[nodiscard]] bool isEmpty() const { return !size(); }
     [[nodiscard]] std::span<const T> span() const LIFETIME_BOUND { return { data(), size() }; }


### PR DESCRIPTION
#### 72272dcc4feb84122a18d38b2ef1af99c0bf01d1
<pre>
[JSC] ScopedArgumentsTable ScopeOffset buffer should allocate from fastMalloc
<a href="https://bugs.webkit.org/show_bug.cgi?id=315082">https://bugs.webkit.org/show_bug.cgi?id=315082</a>
<a href="https://rdar.apple.com/175937787">rdar://175937787</a>

Reviewed by Yusuke Suzuki.

ScopedArgumentsTable::m_arguments is engine metadata, not user payload, but
it was allocated from Gigacage::Primitive — making its ScopeOffsets reachable
through any Primitive-cage write primitive and usable as an unchecked index
into JSLexicalEnvironment::variables(). Replace the CagedUniquePtr with a
Vector&lt;ScopeOffset&gt;. JIT/LLInt loads through offsetOfLength() / offsetOfArguments()
are unchanged at the codegen level: m_size is unsigned (matches the prior
uint32_t m_length) and m_buffer is a raw T*.

Also, drop a stale m_watchpointSets.resize(newLength) from the m_locked
branch of trySetLength: it mutated the supposedly-locked instance. The
only caller (SymbolTable::trySetArgumentsLength) immediately swaps in the new
table, so no caller observed the resized state.

Canonical link: <a href="https://commits.webkit.org/313485@main">https://commits.webkit.org/313485@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a9a2c761754e394581a1232eaa8d9a2beb2f0796

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163227 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36708 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29925 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172166 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119674 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37036 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36709 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126745 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89345 "4 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166186 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29022 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146743 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107313 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/abe9eb8a-3de1-4b6d-8908-033bce5e982c) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28068 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26695 "Found 15 new API test failures: TestWebKitAPI.WKWebExtensionContext.CallingMissingBrowserAPIInBackground, TestWebKitAPI.WKWebExtensionAPIDevTools.PortMessagePassingFromPanelToDevToolsBackground, TestWebKitAPI.EnhancedSecurityPolicies.OpenerThenSelfNavigationWithSiteIsolation, TestWebKitAPI.WKWebExtensionContext.ReferenceErrorInBackground, TestWebKitAPI.WKWebExtensionContext.TopLevelThrowInModuleBackground, TestWebKitAPI.WKWebExtensionAPIDevTools.PanelsThemeName, TestWebKitAPI.WKWebExtensionAPIDevTools.InspectedWindowReload, TestWebKitAPI.WKWebExtensionContext.UnhandledPromiseRejectionInBackground, TestWebKitAPI.WKWebExtensionAPIDevTools.NetworkNavigatedEvent, TestWebKitAPI.WKWebExtensionAPIDevTools.MessagePassingFromPanelToDevToolsBackground ... (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19867 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/155372 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137961 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24467 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174669 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/24114 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/26826 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26122 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135054 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36378 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30797 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135046 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37164 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146262 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99071 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24843 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30349 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23106 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195629 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35874 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108235 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/50994 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35373 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1131 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35620 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35520 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->