### PR TITLE
List marker hidden when LI descendant has overflow:hidden

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -5208,11 +5208,9 @@ imported/w3c/web-platform-tests/css/css-lists/li-value-reversed-009a.html [ Imag
 imported/w3c/web-platform-tests/css/css-lists/li-value-reversed-009b.html [ ImageOnlyFailure ]
 
 # list-style
-imported/w3c/web-platform-tests/css/css-lists/list-style-type-decimal-line-height.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-lists/list-style-type-decimal-vertical-lr.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-lists/list-style-type-decimal-vertical-rl.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-lists/marker-webkit-text-fill-color.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-lists/list-marker-with-lineheight-and-overflow-hidden-001.html [ ImageOnlyFailure ]
 
 # list-style bidi support
 webkit.org/b/202849 imported/w3c/web-platform-tests/css/css-lists/list-style-type-string-005a.html [ ImageOnlyFailure ]

--- a/Source/WebCore/rendering/RenderListItem.cpp
+++ b/Source/WebCore/rendering/RenderListItem.cpp
@@ -312,7 +312,7 @@ void RenderListItem::paint(PaintInfo& paintInfo, const LayoutPoint& paintOffset)
     RenderBlockFlow::paint(paintInfo, paintOffset);
 
     if (auto* marker = markerRenderer(); marker && marker->shouldPaintInAssociatedListItemLayer())
-        marker->paintFromAssociatedListItemLayer(paintInfo, paintOffsetForMarkerFromAssociatedListItem(*marker, *this, paintOffset));
+        marker->paintFromAssociatedListItemLayer(paintInfo, paintOffsetForMarkerFromAssociatedListItem(*marker, *this, paintOffset + location()));
 }
 
 String RenderListItem::markerTextWithoutSuffix() const

--- a/Source/WebCore/rendering/RenderListMarker.cpp
+++ b/Source/WebCore/rendering/RenderListMarker.cpp
@@ -100,6 +100,8 @@ bool RenderListMarker::shouldPaintInAssociatedListItemLayer() const
     }
 
     for (auto* ancestor = parent(); ancestor && ancestor != associatedListItem; ancestor = ancestor->parent()) {
+        if (auto* box = dynamicDowncast<RenderBox>(*ancestor); box && box->hasNonVisibleOverflow())
+            return true;
         if (!ancestor->hasSelfPaintingLayer())
             continue;
         if (ancestor->isRenderFragmentedFlow())


### PR DESCRIPTION
#### a88b3739d98b15501a77a01ebcd03129be4812fe
<pre>
List marker hidden when LI descendant has overflow:hidden
<a href="https://bugs.webkit.org/show_bug.cgi?id=314626">https://bugs.webkit.org/show_bug.cgi?id=314626</a>
<a href="https://rdar.apple.com/177413973">rdar://177413973</a>

Reviewed by NOBODY (OOPS!).

WebKit was parenting outside markers inside descendants with non-
visible overflow, which clipped them.

This makes
1. shouldPaintInAssociatedListItemLayer() aware of
   hasNonVisibleOverflow() ancestors.
2. correct paintOffsetForMarkerFromAssociatedListItem&apos;s starting offset,
   so the bullet appears at the right position.

CSS Lists 3 §3.5 only permits hiding the marker when the list item&apos;s
own overflow is non-visible. Blink (since 2017, crbug 344941) and
Gecko match this; WebKit was the outlier.
<a href="https://drafts.csswg.org/css-lists-3/#marker-pseudo">https://drafts.csswg.org/css-lists-3/#marker-pseudo</a>
<a href="https://drafts.csswg.org/css-lists-3/#list-style-position-property">https://drafts.csswg.org/css-lists-3/#list-style-position-property</a>

Partial fix for bug 192980.

* LayoutTests/TestExpectations:
* Source/WebCore/rendering/RenderListItem.cpp:
(WebCore::RenderListItem::paint):
* Source/WebCore/rendering/RenderListMarker.cpp:
(WebCore::RenderListMarker::shouldPaintInAssociatedListItemLayer const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a88b3739d98b15501a77a01ebcd03129be4812fe

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163231 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36712 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29929 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172170 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119678 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d2d2b9ad-3238-47ca-ae7a-dfa049c34006) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165100 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37040 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36713 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126748 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89349 "1 flakes 5 failures") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/819d3790-f24e-438a-917a-c3009b868bef) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166190 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29023 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146747 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107315 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ee087409-03a3-47cf-bb7d-6bc8ebae88f3) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26698 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19871 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137962 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24471 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174673 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/26830 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26126 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135053 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36382 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30800 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135045 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37168 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146266 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99076 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30355 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23110 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35878 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108239 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35377 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1135 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35624 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35524 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->