### PR TITLE
[EWS] Add support to skip testing specific branches

### DIFF
--- a/Tools/CISupport/ews-build/factories.py
+++ b/Tools/CISupport/ews-build/factories.py
@@ -27,10 +27,14 @@ from buildbot.steps import trigger
 from .steps import *
 from Shared.steps import *
 
+LINUX_PLATFORMS = frozenset({'gtk', 'wpe', 'jsc-only'})
+
+
 class Factory(factory.BuildFactory):
     findModifiedLayoutTests = False
     skipBuildIfNoResult = True
     branches = None
+    excluded_branches = [r'webkitglib/\d+\.\d+']
     requiresUserValidation = False
 
     def __init__(self, platform, configuration=None, architectures=None, buildOnly=True, triggers=None, triggered_by=None, remotes=None, additionalArguments=None, checkRelevance=False, rebuild_without_change_on_builder=False, deployment_target=None, **kwargs):
@@ -38,7 +42,8 @@ class Factory(factory.BuildFactory):
         self.addStep(ConfigureBuild(platform=platform, configuration=configuration, architectures=architectures, buildOnly=buildOnly, triggers=triggers, triggered_by=triggered_by, remotes=remotes, additionalArguments=additionalArguments, rebuild_without_change_on_builder=rebuild_without_change_on_builder, deployment_target=deployment_target))
         if checkRelevance:
             self.addStep(CheckChangeRelevance())
-        self.addStep(ValidateChange(branches=self.branches))
+        excluded = [] if platform in LINUX_PLATFORMS else self.excluded_branches
+        self.addStep(ValidateChange(branches=self.branches, excluded_branches=excluded))
         self.addStep(PrintConfiguration())
         self.addStep(CleanGitRepo())
         if platform.startswith('mac'):
@@ -81,12 +86,14 @@ class StyleFactory(factory.BuildFactory):
 
 class SaferCPPStaticAnalyzerFactory(factory.BuildFactory):
     findModifiedLayoutTests = False
+    excluded_branches = [r'webkitglib/\d+\.\d+']
 
     def __init__(self, platform, configuration=None, architectures=None, buildOnly=True, triggers=None, triggered_by=None, remotes=None, additionalArguments=None, checkRelevance=False, **kwargs):
         factory.BuildFactory.__init__(self)
         self.addStep(ConfigureBuild(platform=platform, configuration=configuration, architectures=architectures, buildOnly=buildOnly, triggers=triggers, triggered_by=triggered_by, remotes=remotes, additionalArguments=additionalArguments))
         self.addStep(CheckChangeRelevance())
-        self.addStep(ValidateChange())
+        excluded = [] if platform in LINUX_PLATFORMS else self.excluded_branches
+        self.addStep(ValidateChange(excluded_branches=excluded))
         self.addStep(PrintConfiguration())
         self.addStep(CleanGitRepo())
         self.addStep(SetCredentialHelper())
@@ -112,6 +119,8 @@ class SaferCPPStaticAnalyzerFactory(factory.BuildFactory):
 
 
 class BindingsFactory(Factory):
+    excluded_branches = []
+
     def __init__(self, platform, configuration=None, architectures=None, additionalArguments=None, **kwargs):
         Factory.__init__(self, platform=platform, configuration=configuration, architectures=architectures, buildOnly=False, additionalArguments=additionalArguments, checkRelevance=True)
         self.addStep(ValidateChange(addURLs=False))
@@ -119,6 +128,8 @@ class BindingsFactory(Factory):
 
 
 class WebKitPerlFactory(Factory):
+    excluded_branches = []
+
     def __init__(self, platform, configuration=None, architectures=None, additionalArguments=None, **kwargs):
         Factory.__init__(self, platform=platform, configuration=configuration, architectures=architectures, buildOnly=False, additionalArguments=additionalArguments)
         self.addStep(ValidateChange(addURLs=False))
@@ -126,6 +137,8 @@ class WebKitPerlFactory(Factory):
 
 
 class WebKitPyFactory(Factory):
+    excluded_branches = []
+
     def __init__(self, platform, configuration=None, architectures=None, additionalArguments=None, **kwargs):
         Factory.__init__(self, platform=platform, configuration=configuration, architectures=architectures, buildOnly=False, additionalArgument=additionalArguments, checkRelevance=True)
         self.addStep(ValidateChange(addURLs=False))

--- a/Tools/CISupport/ews-build/steps.py
+++ b/Tools/CISupport/ews-build/steps.py
@@ -1846,6 +1846,7 @@ class ValidateChange(buildstep.BuildStep, BugzillaMixin, GitHubMixin):
         verifyNoDraftForMergeQueue=False,
         enableSkipEWSLabel=True,
         branches=None,
+        excluded_branches=None,
     ):
         self.verifyObsolete = verifyObsolete
         self.verifyBugClosed = verifyBugClosed
@@ -1858,6 +1859,9 @@ class ValidateChange(buildstep.BuildStep, BugzillaMixin, GitHubMixin):
 
         branches = branches or [r'.+']
         self.branches = [re.compile(branch) if isinstance(branch, str) else branch for branch in branches]
+
+        excluded_branches = excluded_branches or []
+        self.excluded_branches = [re.compile(branch) if isinstance(branch, str) else branch for branch in excluded_branches]
 
         super().__init__()
 
@@ -1890,6 +1894,10 @@ class ValidateChange(buildstep.BuildStep, BugzillaMixin, GitHubMixin):
         patch_id = self.getProperty('patch_id', '')
         pr_number = self.getProperty('github.number', self.getProperty('pr_number', ''))
         branch = self.getProperty('github.base.ref', DEFAULT_BRANCH)
+
+        if any(candidate.match(branch) for candidate in self.excluded_branches):
+            rc = yield self.skip_build(f"Skipping as {'PR ' + str(pr_number) if pr_number else 'patch'} targets '{branch}' branch")
+            return defer.returnValue(rc)
 
         if not any(candidate.match(branch) for candidate in self.branches):
             rc = yield self.skip_build(f"Changes to '{branch}' are not tested")

--- a/Tools/CISupport/ews-build/steps_unittest.py
+++ b/Tools/CISupport/ews-build/steps_unittest.py
@@ -6801,6 +6801,32 @@ class TestValidateChange(BuildStepMixinAdditions, unittest.TestCase):
         self.expect_property('fast_commit_queue', None, 'fast_commit_queue is unexpectedly set')
         return rc
 
+    def test_excluded_branch(self):
+        self.setup_step(ValidateChange(verifyBugClosed=False, excluded_branches=[r'webkitglib/\d+\.\d+']))
+        ValidateChange.get_pr_json = lambda x, pull_request, repository_url=None, retry=None: self.get_pr(pr_number=pull_request)
+        self.setProperty('github.number', '1234')
+        self.setProperty('repository', 'https://github.com/WebKit/WebKit')
+        self.setProperty('github.head.sha', '7496f8ecc4cc8011f19c8cc1bc7b18fe4a88ad5c')
+        self.setProperty('github.base.ref', 'webkitglib/2.46')
+
+        self.expect_outcome(result=FAILURE, state_string="Skipping as PR 1234 targets 'webkitglib/2.46' branch")
+        rc = self.run_step()
+        self.expect_property('fast_commit_queue', None, 'fast_commit_queue is unexpectedly set')
+        return rc
+
+    def test_allowed_branch_not_in_excluded(self):
+        self.setup_step(ValidateChange(verifyBugClosed=False, excluded_branches=[r'webkitglib/\d+\.\d+']))
+        ValidateChange.get_pr_json = lambda x, pull_request, repository_url=None, retry=None: self.get_pr(pr_number=pull_request)
+        self.setProperty('github.number', '1234')
+        self.setProperty('repository', 'https://github.com/WebKit/WebKit')
+        self.setProperty('github.head.sha', '7496f8ecc4cc8011f19c8cc1bc7b18fe4a88ad5c')
+        self.setProperty('github.base.ref', 'safari-123-branch')
+
+        self.expect_outcome(result=SUCCESS, state_string='Validated change')
+        rc = self.run_step()
+        self.expect_property('fast_commit_queue', None, 'fast_commit_queue is unexpectedly set')
+        return rc
+
 
 class TestRetrievePRDataFromLabel(BuildStepMixinAdditions, unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
#### f0e5651a9d939a3861e0d0c8e089797d69c9e411
<pre>
[EWS] Add support to skip testing specific branches
<a href="https://bugs.webkit.org/show_bug.cgi?id=315083">https://bugs.webkit.org/show_bug.cgi?id=315083</a>

Reviewed by Aakash Jain.

In the Linux ports, we have started using EWS to test that cherry-picked changes
to stable branches don&apos;t introduce regressions. This currently has the downside
of triggering every single EWS queue to process these patches, even when it is
likely that they don&apos;t even build in Mac or iOS after the divergence between
the branches and the Apple ports.

This change addresses this by adding a excluded_branches property to the
ValidateChange step, akin to the branches property. When specified, the
step will first check if the branch being tested should be skipped, in
which case it will just log &apos;Changes to branch x are not tested&apos;.

The base Factory class defaults excluded_branches to skip the webkitglib stable
branches. Factory.__init__ then passes an empty list to ValidateChange when
running on a Linux platform, and the class default otherwise. This way,
only Linux-specific factories will process these branches. Additionally,
disallow glib stable branches from safer CPP queues, and allow them in
bindings, perl, and python queues.

Add also unit tests for this.

* Tools/CISupport/ews-build/factories.py:
(Factory):
(Factory.__init__):
(SaferCPPStaticAnalyzerFactory):
(SaferCPPStaticAnalyzerFactory.__init__):
(BindingsFactory):
(WebKitPerlFactory):
(WebKitPyFactory):
* Tools/CISupport/ews-build/steps.py:
(ValidateChange.__init__):
(ValidateChange):
(ValidateChange.run):
* Tools/CISupport/ews-build/steps_unittest.py:

Canonical link: <a href="https://commits.webkit.org/313514@main">https://commits.webkit.org/313514@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/231d014406070f0c77c4febdecfcdab3d8b6a45d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163336 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36819 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/30034 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172275 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/119783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165205 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37146 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36819 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/126840 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/119783 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166295 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/29114 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/146838 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107407 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26790 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/19977 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/138055 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/24562 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174779 "Built successfully") | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/26218 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/135148 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/162733 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36488 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30889 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/135139 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37274 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/146357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99223 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24858 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30434 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/23202 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35983 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/35482 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/1227 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/35730 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35630 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->