### PR TITLE
[JSC] Update iterator built-ins to reflect the change of github:tc39/ecma262#3776

### DIFF
--- a/JSTests/stress/iterator-prototype-drop-bug315085.js
+++ b/JSTests/stress/iterator-prototype-drop-bug315085.js
@@ -1,0 +1,111 @@
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+function shouldNotThrow(fn, caseName) {
+    if (!caseName)
+        throw new Error(`must specify message`);
+
+    try {
+        fn();
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        throw new Error(`${caseName}: Expected not thrown but got ${actual}`);
+    }
+}
+
+function shouldBe(a, b, testname) {
+    if (a !== b)
+        throw new Error(`${testname}: Expected ${b} but got ${a}`);
+}
+
+class TestIterator extends Iterator {
+    value = 0;
+    isClosed = false;
+    isDone = false;
+    constructor(max = 3) {
+        super();
+        if (max < 0) {
+            throw new RangeError('max must be >= 0');
+        }
+        this.max = +max;
+    }
+    next() {
+        const value = this.value;
+        if (value > this.max) {
+            this.isDone = true;
+            return {
+                done: true,
+                value: undefined,
+            };
+        }
+
+        this.value += 1;
+        return {
+            done: false,
+            value,
+        };
+    }
+    return() {
+        this.isClosed = true;
+        return {
+            done: true,
+            value: undefined,
+        };
+    }
+}
+
+function test(target, limit) {
+    const newIter = Iterator.prototype.drop.call(target, limit);
+    return newIter;
+}
+
+{
+    const validUpperLowerBoundArgumentTestCases = [
+        [Number.POSITIVE_INFINITY, ],
+        [Number.MAX_SAFE_INTEGER, `Number.MAX_SAFE_INTEGER`],
+        [0, ],
+        [0.0, `0.0`],
+    ];
+
+    for (const [value, name] of validUpperLowerBoundArgumentTestCases) {
+        const label = name ?? String(name);
+        const iter = new TestIterator();
+
+        shouldNotThrow(() => {
+            test(iter, value);
+        }, `${label}: should be valid for the 1st argument`);
+        shouldBe(iter.isClosed, false, `${label}: the iterator should not be closed`);
+    }
+}
+
+{
+    const invalidOutOfRangeArgumentTestCases = [
+        [Number.MAX_VALUE, `Number.MAX_VALUE`],
+        [Number.MAX_SAFE_INTEGER + 1, `Number.MAX_SAFE_INTEGER + 1`],
+        [-1, ],
+        [Number.NEGATIVE_INFINITY, ],
+    ];
+
+    for (const [value, name] of invalidOutOfRangeArgumentTestCases) {
+        const label = name ?? String(name);
+        const iter = new TestIterator();
+
+        shouldThrow(`${label}: the 1st arg is out of range`, () => {
+            test(iter, value);
+        }, RangeError, `Iterator.prototype.drop argument must be non-negative safe integer or +Infinity`);
+
+        shouldBe(iter.isClosed, true, `${label}: the iterator should be closed`);
+    }
+}

--- a/JSTests/stress/iterator-prototype-take-bug315085.js
+++ b/JSTests/stress/iterator-prototype-take-bug315085.js
@@ -1,0 +1,111 @@
+function shouldThrow(caseName, fn, expectedErrorCtor, expectedErrorMessage) {
+    if (!caseName)
+        throw new Error(`must specify test case name`);
+
+    const expected = `${expectedErrorCtor.name}(${expectedErrorMessage})`;
+    try {
+        fn();
+        throw new Error(`${caseName}: Expected to throw ${expected}, but succeeded`);
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        if (!(e instanceof expectedErrorCtor) || e.message !== expectedErrorMessage)
+            throw new Error(`${caseName}: Expected ${expected} but got ${actual}`);
+    }
+}
+
+function shouldNotThrow(fn, caseName) {
+    if (!caseName)
+        throw new Error(`must specify message`);
+
+    try {
+        fn();
+    } catch (e) {
+        const actual = `${e.name}(${e.message})`;
+        throw new Error(`${caseName}: Expected not thrown but got ${actual}`);
+    }
+}
+
+function shouldBe(a, b, testname) {
+    if (a !== b)
+        throw new Error(`${testname}: Expected ${b} but got ${a}`);
+}
+
+class TestIterator extends Iterator {
+    value = 0;
+    isClosed = false;
+    isDone = false;
+    constructor(max = 3) {
+        super();
+        if (max < 0) {
+            throw new RangeError('max must be >= 0');
+        }
+        this.max = +max;
+    }
+    next() {
+        const value = this.value;
+        if (value > this.max) {
+            this.isDone = true;
+            return {
+                done: true,
+                value: undefined,
+            };
+        }
+
+        this.value += 1;
+        return {
+            done: false,
+            value,
+        };
+    }
+    return() {
+        this.isClosed = true;
+        return {
+            done: true,
+            value: undefined,
+        };
+    }
+}
+
+function test(target, limit) {
+    const newIter = Iterator.prototype.take.call(target, limit);
+    return newIter;
+}
+
+{
+    const validUpperLowerBoundArgumentTestCases = [
+        [Number.POSITIVE_INFINITY, ],
+        [Number.MAX_SAFE_INTEGER, `Number.MAX_SAFE_INTEGER`],
+        [0, ],
+        [0.0, `0.0`],
+    ];
+
+    for (const [value, name] of validUpperLowerBoundArgumentTestCases) {
+        const label = name ?? String(name);
+        const iter = new TestIterator();
+
+        shouldNotThrow(() => {
+            test(iter, value);
+        }, `${label}: should be valid for the 1st argument`);
+        shouldBe(iter.isClosed, false, `${label}: the iterator should not be closed`);
+    }
+}
+
+{
+    const invalidOutOfRangeArgumentTestCases = [
+        [Number.MAX_VALUE, `Number.MAX_VALUE`],
+        [Number.MAX_SAFE_INTEGER + 1, `Number.MAX_SAFE_INTEGER + 1`],
+        [-1, ],
+        [Number.NEGATIVE_INFINITY, ],
+    ];
+
+    for (const [value, name] of invalidOutOfRangeArgumentTestCases) {
+        const label = name ?? String(name);
+        const iter = new TestIterator();
+
+        shouldThrow(`${label}: the 1st arg is out of range`, () => {
+            test(iter, value);
+        }, RangeError, `Iterator.prototype.take argument must be non-negative safe integer or +Infinity`);
+
+        shouldBe(iter.isClosed, true, `${label}: the iterator should be closed`);
+    }
+}

--- a/Source/JavaScriptCore/builtins/JSIteratorPrototype.js
+++ b/Source/JavaScriptCore/builtins/JSIteratorPrototype.js
@@ -114,12 +114,20 @@ function take(limit)
         }
     }
 
+    if (@isFinite(numLimit) && numLimit > @MAX_SAFE_INTEGER) {
+        try {
+            @iteratorGenericClose(this);
+        } finally {
+            @throwRangeError("Iterator.prototype.take argument must be non-negative safe integer or +Infinity");
+        }
+    }
+
     var intLimit = @toIntegerOrInfinity(numLimit);
     if (intLimit < 0) {
         try {
             @iteratorGenericClose(this);
         } finally {
-            @throwRangeError("Iterator.prototype.take argument must be non-negative.");
+            @throwRangeError("Iterator.prototype.take argument must be non-negative safe integer or +Infinity");
         }
     }
 
@@ -169,12 +177,20 @@ function drop(limit)
         }
     }
 
+    if (@isFinite(numLimit) && numLimit > @MAX_SAFE_INTEGER) {
+        try {
+            @iteratorGenericClose(this);
+        } finally {
+            @throwRangeError("Iterator.prototype.drop argument must be non-negative safe integer or +Infinity");
+        }
+    }
+
     var intLimit = @toIntegerOrInfinity(numLimit);
     if (intLimit < 0) {
         try {
             @iteratorGenericClose(this);
         } finally {
-            @throwRangeError("Iterator.prototype.drop argument must be non-negative.");
+            @throwRangeError("Iterator.prototype.drop argument must be non-negative safe integer or +Infinity");
         }
     }
 


### PR DESCRIPTION
#### 8310ec8b3200942d386437fba3f7280336ca9b42
<pre>
[JSC] Update iterator built-ins to reflect the change of github:tc39/ecma262#3776
<a href="https://bugs.webkit.org/show_bug.cgi?id=315085">https://bugs.webkit.org/show_bug.cgi?id=315085</a>

Reviewed by Yusuke Suzuki.

The change of <a href="https://github.com/tc39/ecma262/pull/3776">https://github.com/tc39/ecma262/pull/3776</a> for iterator helper builtins are categorized into:

- Our implementations should be changed due to they should throw a `RangeError` corresponds to the user input value.
    - `Iterator.prototype.drop`
    - `Iterator.prototype.take`
- The semantics has been a bit changed but it&apos;s not related to our implementation actually.
    - `Iterator.prototype.filter`
    - `Iterator.prototype.find`
    - `Iterator.prototype.flatMap`
    - `Iterator.prototype.forEach`
    - `Iterator.prototype.map`
    - `Iterator.prototype.reduce`
    - `Iterator.prototype.some`

Tests: JSTests/stress/iterator-prototype-drop-bug315085.js
       JSTests/stress/iterator-prototype-take-bug315085.js

* JSTests/stress/iterator-prototype-drop-bug315085.js: Added.
    <a href="https://commits.webkit.org/284597@main">https://commits.webkit.org/284597@main</a> implements `Iterator.prototype.drop`
    but no stress tests. This change adds a minimum testcase.
* JSTests/stress/iterator-prototype-take-bug315085.js: Added.
    <a href="https://commits.webkit.org/284597@main">https://commits.webkit.org/284597@main</a> implements `Iterator.prototype.take`
    but no stress tests. This change adds a minimum testcase.
* Source/JavaScriptCore/builtins/JSIteratorPrototype.js:

Canonical link: <a href="https://commits.webkit.org/315276@main">https://commits.webkit.org/315276@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/21c29a404b34949d6857a711d0f59b6860afac73

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165907 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39397 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32978 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174950 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123162 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39823 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39401 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128943 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90827 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168866 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31313 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149058 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109470 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30290 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28970 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23094 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158064 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140258 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26757 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177483 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26800 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30389 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28463 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137283 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39466 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33117 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137212 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37570 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40154 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148552 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/102732 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32498 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25419 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/198800 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38665 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111738 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53407 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38062 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3501 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38307 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38205 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->