### PR TITLE
[GTK][WPE] Skia Compositor: do not change format when uploading pixels

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp
@@ -97,9 +97,9 @@ void SkiaBackingStore::drawDebugBorders(SkCanvas& canvas, const SkPaint& paint)
         canvas.drawRect(SkRect(tile.rect()), paint);
 }
 
-bool SkiaBackingStore::Tile::tryEnsureSurface(const IntSize& size, CoordinatedTileBuffer& buffer)
+bool SkiaBackingStore::Tile::tryEnsureSurface(const IntSize& size, CoordinatedTileBuffer& buffer, SkColorType colorType)
 {
-    if (m_surface)
+    if (m_surface && m_surface->imageInfo().colorType() == colorType)
         return true;
 
     OptionSet<BitmapTexture::Flags> flags;
@@ -119,8 +119,12 @@ bool SkiaBackingStore::Tile::tryEnsureSurface(const IntSize& size, CoordinatedTi
     auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
     auto texture = BitmapTexturePool::singleton().acquireTexture(size, flags);
     unsigned textureID = texture->id();
-    GrBackendTexture backendTexture = texture->createSkiaBackendTexture();
-    auto surface = SkSurfaces::WrapBackendTexture(grContext, backendTexture, kTopLeft_GrSurfaceOrigin, 0, kRGBA_8888_SkColorType, SkColorSpace::MakeSRGB(), nullptr, +[](void* userData) {
+    GrGLTextureInfo externalTexture;
+    externalTexture.fTarget = GL_TEXTURE_2D;
+    externalTexture.fID = textureID;
+    externalTexture.fFormat = colorType == kRGBA_8888_SkColorType ? GL_RGBA8 : GL_BGRA8_EXT;
+    auto backendTexture = GrBackendTextures::MakeGL(texture->size().width(), texture->size().height(), skgpu::Mipmapped::kNo, externalTexture);
+    auto surface = SkSurfaces::WrapBackendTexture(grContext, backendTexture, kTopLeft_GrSurfaceOrigin, 0, colorType, SkColorSpace::MakeSRGB(), nullptr, +[](void* userData) {
         static_cast<BitmapTexture*>(userData)->deref();
     }, &texture.leakRef());
     if (!surface)
@@ -170,7 +174,7 @@ void SkiaBackingStore::Tile::update(const IntRect& dirtyRect, const IntRect& til
                     static_cast<BitmapTexture*>(userData)->deref();
                 }, &texture.leakRef());
             }
-        } else if (tryEnsureSurface(tileRect.size(), buffer)) {
+        } else if (tryEnsureSurface(tileRect.size(), buffer, kRGBA_8888_SkColorType)) {
             auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
             auto image = SkImages::BorrowTextureFrom(grContext, backendTexture, kTopLeft_GrSurfaceOrigin, kRGBA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
             SkPaint paint;
@@ -178,7 +182,7 @@ void SkiaBackingStore::Tile::update(const IntRect& dirtyRect, const IntRect& til
             m_surface->getCanvas()->drawImageRect(image, SkRect::MakeWH(dirtyRect.width(), dirtyRect.height()), SkRect::Make(SkIRect(dirtyRect)),
                 SkSamplingOptions(SkFilterMode::kNearest, SkMipmapMode::kNone), &paint, SkCanvas::kFast_SrcRectConstraint);
         }
-    } else if (tryEnsureSurface(tileRect.size(), buffer)) {
+    } else if (tryEnsureSurface(tileRect.size(), buffer, kBGRA_8888_SkColorType)) {
         auto& unacceleratedBuffer = static_cast<CoordinatedUnacceleratedTileBuffer&>(buffer);
         auto imageInfo = SkImageInfo::Make(dirtyRect.width(), dirtyRect.height(), kBGRA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
         SkPixmap pixmap(imageInfo, unacceleratedBuffer.data(), unacceleratedBuffer.stride());
@@ -197,9 +201,9 @@ sk_sp<SkImage> SkiaBackingStore::Tile::image()
         GrGLTextureInfo externalTexture;
         externalTexture.fTarget = GL_TEXTURE_2D;
         externalTexture.fID = m_textureID;
-        externalTexture.fFormat = GL_RGBA8;
+        externalTexture.fFormat = m_surface->imageInfo().colorType() == kRGBA_8888_SkColorType ? GL_RGBA8 : GL_BGRA8_EXT;
         auto backendTexture = GrBackendTextures::MakeGL(m_surface->width(), m_surface->height(), skgpu::Mipmapped::kNo, externalTexture);
-        m_cachedImage = SkImages::BorrowTextureFrom(PlatformDisplay::sharedDisplay().skiaGrContext(), backendTexture, kTopLeft_GrSurfaceOrigin, kRGBA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
+        m_cachedImage = SkImages::BorrowTextureFrom(PlatformDisplay::sharedDisplay().skiaGrContext(), backendTexture, kTopLeft_GrSurfaceOrigin, m_surface->imageInfo().colorType(), kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
     }
     return m_cachedImage;
 }

--- a/Source/WebCore/platform/graphics/skia/SkiaBackingStore.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaBackingStore.h
@@ -64,7 +64,7 @@ private:
         sk_sp<SkImage> image();
 
     private:
-        bool tryEnsureSurface(const IntSize&, CoordinatedTileBuffer&);
+        bool tryEnsureSurface(const IntSize&, CoordinatedTileBuffer&, SkColorType);
 
         float m_scale { 1. };
         FloatRect m_rect;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.cpp
@@ -129,8 +129,12 @@ bool CoordinatedPlatformLayerBufferNativeImage::tryEnsureBuffer(UseSkiaForCompos
     if (useSkiaForCompositing == UseSkiaForCompositing::Yes) {
         auto& display = PlatformDisplay::sharedDisplay();
         GLContext::ScopedGLContextCurrent scopedCurrent(*display.skiaGLContext());
-        GrBackendTexture backendTexture = texture->createSkiaBackendTexture();
-        auto surface = SkSurfaces::WrapBackendTexture(display.skiaGrContext(), backendTexture, kTopLeft_GrSurfaceOrigin, 0, kRGBA_8888_SkColorType, SkColorSpace::MakeSRGB(), nullptr);
+        GrGLTextureInfo externalTexture;
+        externalTexture.fTarget = GL_TEXTURE_2D;
+        externalTexture.fID = texture->id();
+        externalTexture.fFormat = image->imageInfo().colorType() == kRGBA_8888_SkColorType ? GL_RGBA8 : GL_BGRA8_EXT;
+        auto backendTexture = GrBackendTextures::MakeGL(texture->size().width(), texture->size().height(), skgpu::Mipmapped::kNo, externalTexture);
+        auto surface = SkSurfaces::WrapBackendTexture(display.skiaGrContext(), backendTexture, kTopLeft_GrSurfaceOrigin, 0, image->imageInfo().colorType(), SkColorSpace::MakeSRGB(), nullptr);
         if (!surface)
             return false;
 


### PR DESCRIPTION
#### ccbb3ff9c6451766b02b5a1bbf55ed78d8b710d8
<pre>
[GTK][WPE] Skia Compositor: do not change format when uploading pixels
<a href="https://bugs.webkit.org/show_bug.cgi?id=315089">https://bugs.webkit.org/show_bug.cgi?id=315089</a>

Reviewed by Nikolas Zimmermann.

If the buffer is BGRA we can just create a SkImage keeping the BGRA
format and let skia handle the conversion if needed when painting the
image instead of when uploading pixels.

* Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp:
(WebCore::SkiaBackingStore::Tile::tryEnsureSurface):
(WebCore::SkiaBackingStore::Tile::update):
(WebCore::SkiaBackingStore::Tile::image):
* Source/WebCore/platform/graphics/skia/SkiaBackingStore.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.cpp:
(WebCore::CoordinatedPlatformLayerBufferNativeImage::tryEnsureBuffer):

Canonical link: <a href="https://commits.webkit.org/313473@main">https://commits.webkit.org/313473@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0ad44c12097690189d8d3ec4f129c3822116645d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163245 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36726 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29943 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172184 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119692 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165114 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37054 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36727 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126760 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/89357 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166204 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/29033 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146757 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107327 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28079 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26708 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19886 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/137972 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24481 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174687 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/26904 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26136 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135066 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36396 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30810 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135058 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37182 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146276 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99099 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24836 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30362 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23120 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35892 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108310 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35391 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1145 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35638 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35538 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->