### PR TITLE
Add DamageRectangleThreshold preference to tune the damage-rectangle merge limit

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -2215,6 +2215,21 @@ DOMTimersThrottlingEnabled:
     WebCore:
       default: true
 
+DamageRectangleThreshold:
+  type: uint32_t
+  status: unstable
+  category: dom
+  humanReadableName: "Damage Rectangle Threshold"
+  humanReadableDescription: "Maximum number of damage rectangles to track before damaged regions are unified into their bounding box"
+  condition: ENABLE(DAMAGE_TRACKING)
+  defaultValue:
+    WebKitLegacy:
+      default: 4
+    WebKit:
+      default: 4
+    WebCore:
+      default: 4
+
 DataDetectorTypes:
   type: uint32_t
   refinedType: WebCore::DataDetectorType

--- a/Source/WebCore/platform/graphics/Damage.h
+++ b/Source/WebCore/platform/graphics/Damage.h
@@ -81,6 +81,16 @@ public:
 
     static constexpr uint32_t NoMaxRectangles = 0;
 
+    // Clamp a preference-supplied rectangle threshold to a usable Damage limit.
+    // The constructor treats 0 as NoMaxRectangles (the default 256px-cell grid),
+    // which is the opposite of what a public threshold of 0 would suggest. Force
+    // the value to at least 1 so the preference behaves monotonically: 1 means
+    // "always unify into the bounding box".
+    static constexpr uint32_t clampRectangleThreshold(uint32_t threshold)
+    {
+        return std::max<uint32_t>(1, threshold);
+    }
+
     explicit Damage(const IntRect& rect, Mode mode = Mode::Rectangles, uint32_t maxRectangles = NoMaxRectangles)
         : m_mode(mode)
         , m_rect(rect)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp
@@ -1088,7 +1088,8 @@ void AcceleratedSurface::didRenderFrame()
     // For GL targets we use bounding box damage for render target damage, as its only 2 consumers so far
     // (CoordinatedBackingStore & ThreadedCompositor) only fetch bounds. Thus having damage with
     // better resolution is pointless as the bounds are the same in such case.
-    m_target->setDamage(Damage(m_swapChain.size(), usesGL() ? Damage::Mode::BoundingBox : Damage::Mode::Rectangles, 4));
+    // FIXME: If we start to consume fine-grained damage in the Skia compositor, we will need to relax the usesGL condition.
+    m_target->setDamage(Damage(m_swapChain.size(), usesGL() ? Damage::Mode::BoundingBox : Damage::Mode::Rectangles, m_frameDamageRectangleThreshold));
     if (m_frameDamage) {
         damageRects = m_frameDamage->rects();
         m_frameDamage = std::nullopt;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h
@@ -133,6 +133,7 @@ public:
 
 #if ENABLE(DAMAGE_TRACKING)
     void setFrameDamage(WebCore::Damage&&);
+    void setFrameDamageRectangleThreshold(unsigned threshold) { m_frameDamageRectangleThreshold = threshold; }
     const std::optional<WebCore::Damage>& frameDamage() const LIFETIME_BOUND { return m_frameDamage; }
     const std::optional<WebCore::Damage>& renderTargetDamage();
 #endif
@@ -418,6 +419,7 @@ private:
     std::unique_ptr<RunLoop::Timer> m_releaseUnusedBuffersTimer;
 #if ENABLE(DAMAGE_TRACKING)
     std::optional<WebCore::Damage> m_frameDamage;
+    unsigned m_frameDamageRectangleThreshold { 4 };
 #endif
 };
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -98,7 +98,7 @@ LayerTreeHost::LayerTreeHost(WebPage& webPage)
         if (settings.useDamagingInformationForCompositing())
             damagePropagationFlags->add(ThreadedCompositor::DamagePropagationFlags::UseForCompositing);
     }
-    m_compositor->setDamagePropagationFlags(damagePropagationFlags);
+    m_compositor->setDamagePropagationSettings(damagePropagationFlags, settings.damageRectangleThreshold());
 #endif
 }
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.cpp
@@ -111,7 +111,7 @@ LayerTreeHost::LayerTreeHost(WebPage& webPage, WebCore::PlatformDisplayID displa
         if (settings.useDamagingInformationForCompositing())
             damagePropagationFlags->add(ThreadedCompositor::DamagePropagationFlags::UseForCompositing);
     }
-    m_compositor->setDamagePropagationFlags(damagePropagationFlags);
+    m_compositor->setDamagePropagationSettings(damagePropagationFlags, settings.damageRectangleThreshold());
 #endif
     m_layerTreeContext.contextID = m_compositor->surfaceID();
 }

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/NonCompositedFrameRenderer.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/NonCompositedFrameRenderer.cpp
@@ -126,18 +126,22 @@ void NonCompositedFrameRenderer::resetFrameDamage()
 {
     auto scaledRect = m_webPage->bounds();
     scaledRect.scale(m_webPage->deviceScaleFactor());
+
+    const auto& settings = m_webPage->corePage()->settings();
+    auto rectangleThreshold = Damage::clampRectangleThreshold(settings.damageRectangleThreshold());
+
     if (!m_context) {
         // For CPU rendering use the damage unconditionally to reduce the amount of pixels to upload to the GPU for the UI process.
-        m_frameDamage = std::make_optional<Damage>(scaledRect, Damage::Mode::Rectangles, 4);
+        m_frameDamage = std::make_optional<Damage>(scaledRect, Damage::Mode::Rectangles, rectangleThreshold);
         return;
     }
 
-    if (!m_webPage->corePage()->settings().propagateDamagingInformation()) {
+    if (!settings.propagateDamagingInformation()) {
         m_frameDamage = std::nullopt;
         return;
     }
 
-    m_frameDamage = std::make_optional<Damage>(scaledRect, m_webPage->corePage()->settings().unifyDamagedRegions() ? Damage::Mode::BoundingBox : Damage::Mode::Rectangles, 4);
+    m_frameDamage = std::make_optional<Damage>(scaledRect, settings.unifyDamagedRegions() ? Damage::Mode::BoundingBox : Damage::Mode::Rectangles, rectangleThreshold);
 }
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
@@ -260,7 +260,7 @@ void ThreadedCompositor::setSize(const IntSize& size, float deviceScaleFactor)
 }
 
 #if ENABLE(DAMAGE_TRACKING)
-void ThreadedCompositor::setDamagePropagationFlags(std::optional<OptionSet<DamagePropagationFlags>> flags)
+void ThreadedCompositor::setDamagePropagationSettings(std::optional<OptionSet<DamagePropagationFlags>> flags, unsigned rectangleThreshold)
 {
     m_damage.flags = flags;
     if ((m_damage.visualizer || m_damage.showSkiaDamage) && m_damage.flags) {
@@ -268,6 +268,11 @@ void ThreadedCompositor::setDamagePropagationFlags(std::optional<OptionSet<Damag
         // frame is invalidated in the next paint so that previous damage rects are cleared.
         m_damage.flags->remove(DamagePropagationFlags::UseForCompositing);
     }
+
+    rectangleThreshold = Damage::clampRectangleThreshold(rectangleThreshold);
+    m_damage.rectangleThreshold = rectangleThreshold;
+    if (m_surface)
+        m_surface->setFrameDamageRectangleThreshold(rectangleThreshold);
 }
 
 void ThreadedCompositor::enableFrameDamageNotificationForTesting()

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
@@ -93,7 +93,7 @@ public:
         Unified = 1 << 0,
         UseForCompositing = 1 << 1
     };
-    void setDamagePropagationFlags(std::optional<OptionSet<DamagePropagationFlags>>);
+    void setDamagePropagationSettings(std::optional<OptionSet<DamagePropagationFlags>>, unsigned rectangleThreshold);
     void enableFrameDamageNotificationForTesting();
 #endif
 
@@ -183,6 +183,7 @@ private:
 #if ENABLE(DAMAGE_TRACKING)
     struct {
         std::optional<OptionSet<DamagePropagationFlags>> flags;
+        unsigned rectangleThreshold { 4 };
         std::unique_ptr<WebCore::TextureMapperDamageVisualizer> visualizer;
 
         bool showSkiaDamage { false };

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositorPlayStation.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositorPlayStation.cpp
@@ -209,7 +209,7 @@ void ThreadedCompositor::setSize(const IntSize& size, float deviceScaleFactor)
 }
 
 #if ENABLE(DAMAGE_TRACKING)
-void ThreadedCompositor::setDamagePropagationFlags(std::optional<OptionSet<DamagePropagationFlags>> flags)
+void ThreadedCompositor::setDamagePropagationSettings(std::optional<OptionSet<DamagePropagationFlags>> flags, unsigned /* rectangleThreshold */)
 {
     m_damage.flags = flags;
     if (m_damage.visualizer && m_damage.flags) {

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositorPlayStation.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositorPlayStation.h
@@ -95,7 +95,7 @@ public:
         Unified = 1 << 0,
         UseForCompositing = 1 << 1
     };
-    void setDamagePropagationFlags(std::optional<OptionSet<DamagePropagationFlags>>);
+    void setDamagePropagationSettings(std::optional<OptionSet<DamagePropagationFlags>>, unsigned rectangleThreshold);
     void enableFrameDamageNotificationForTesting();
 #endif
 


### PR DESCRIPTION
#### b44fdbf979afb8e3d9ccb642a2861874a44600ec
<pre>
Add DamageRectangleThreshold preference to tune the damage-rectangle merge limit
<a href="https://bugs.webkit.org/show_bug.cgi?id=315090">https://bugs.webkit.org/show_bug.cgi?id=315090</a>

Reviewed by Carlos Garcia Campos.

When damage tracking records many small dirty rectangles, the Damage
class merges them into a coarser set once a maximum is reached, to
bound bookkeeping cost. Until now that maximum was hardcoded to 4 in
every consumer.

This patch adds a DamageRectangleThreshold preference (default 4) so
the limit can be tuned at runtime. The threshold replaces the hardcoded
limit previously set in AcceleratedSurface (render-target damage)
and NonCompositedFrameRenderer (CPU-upload damage).

The layer-tree frame damage that ThreadedCompositor propagates to the
UI process is intentionally left unchanged: it uses a fixed 256px
spatial grid (the rectangle count scales with the viewport rather than
being capped), which is the right granularity for driving UI-process
repaints and should not depend on this tuning knob.

Damage interprets a maximum of 0 as &quot;no limit&quot;
(Damage::NoMaxRectangles, i.e. the default 256px grid), which is the
opposite of what a threshold of 0 should mean. The value is therefore
clamped to a minimum of 1 where it is applied. With that clamp, a
threshold of 1 collapses each frame&apos;s damage to a single bounding box,
making it equivalent to the existing UnifyDamagedRegions preference.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/platform/graphics/Damage.h:
(WebCore::Damage::clampRectangleThreshold):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.cpp:
(WebKit::AcceleratedSurface::didRenderFrame):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/AcceleratedSurface.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::LayerTreeHost):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.cpp:
(WebKit::LayerTreeHost::LayerTreeHost):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/NonCompositedFrameRenderer.cpp:
(WebKit::NonCompositedFrameRenderer::resetFrameDamage):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp:
(WebKit::ThreadedCompositor::setDamagePropagationSettings):
(WebKit::ThreadedCompositor::setDamagePropagationFlags): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositorPlayStation.cpp:
(WebKit::ThreadedCompositor::setDamagePropagationSettings):
(WebKit::ThreadedCompositor::setDamagePropagationFlags): Deleted.
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositorPlayStation.h:

Canonical link: <a href="https://commits.webkit.org/313875@main">https://commits.webkit.org/313875@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6015ca67560b04586193b5e9e7f90070d751e386

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164419 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37903 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31474 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173448 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121671 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166288 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38237 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37904 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127752 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89926 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167378 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30049 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147788 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108297 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29096 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27722 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21212 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/156570 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138998 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25504 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175974 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/25311 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28797 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27172 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136065 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37574 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31842 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136033 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38360 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147299 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100786 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25025 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31346 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24155 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/196822 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37170 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110214 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51701 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36566 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2213 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36816 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36716 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->