### PR TITLE
Testing MDCache

### DIFF
--- a/Source/WebCore/rendering/style/RenderStyle+GettersInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyle+GettersInlines.h
@@ -90,6 +90,16 @@ inline bool RenderStyle::fontCascadeEqual(const RenderStyle& other) const
     return m_computedStyle.fontCascadeEqual(other.m_computedStyle);
 }
 
+inline Style::CustomPropertyData& RenderStyle::mutableInheritedCustomProperties()
+{
+    return m_computedStyle.mutableInheritedCustomProperties();
+}
+
+inline Style::CustomPropertyData& RenderStyle::mutableNonInheritedCustomProperties()
+{
+    return m_computedStyle.mutableNonInheritedCustomProperties();
+}
+
 inline bool RenderStyle::scrollSnapDataEquivalent(const RenderStyle& other) const
 {
     return m_computedStyle.scrollSnapDataEquivalent(other.m_computedStyle);
@@ -110,6 +120,11 @@ inline bool RenderStyle::usesContainerUnits() const
 inline bool RenderStyle::useTreeCountingFunctions() const
 {
     return m_computedStyle.useTreeCountingFunctions();
+}
+
+inline bool RenderStyle::usesCustomPropertyReferences() const
+{
+    return m_computedStyle.usesCustomPropertyReferences();
 }
 
 inline InsideLink RenderStyle::insideLink() const

--- a/Source/WebCore/rendering/style/RenderStyle+SettersInlines.h
+++ b/Source/WebCore/rendering/style/RenderStyle+SettersInlines.h
@@ -92,6 +92,11 @@ inline void RenderStyle::setUsesTreeCountingFunctions()
     m_computedStyle.setUsesTreeCountingFunctions();
 }
 
+inline void RenderStyle::setUsesCustomPropertyReferences()
+{
+    m_computedStyle.setUsesCustomPropertyReferences();
+}
+
 inline void RenderStyle::setInsideLink(InsideLink insideLink)
 {
     m_computedStyle.setInsideLink(insideLink);

--- a/Source/WebCore/rendering/style/RenderStyle.h
+++ b/Source/WebCore/rendering/style/RenderStyle.h
@@ -97,6 +97,9 @@ public:
     inline bool useTreeCountingFunctions() const;
     inline void setUsesTreeCountingFunctions();
 
+    inline bool usesCustomPropertyReferences() const;
+    inline void setUsesCustomPropertyReferences();
+
     inline InsideLink insideLink() const;
     inline void setInsideLink(InsideLink);
 
@@ -485,6 +488,9 @@ public:
     inline bool affectsTransform() const;
 
     // MARK: - Underlying ComputedStyle
+
+    inline Style::CustomPropertyData& mutableInheritedCustomProperties();
+    inline Style::CustomPropertyData& mutableNonInheritedCustomProperties();
 
     Style::ComputedStyle& computedStyle() LIFETIME_BOUND { return m_computedStyle; }
     const Style::ComputedStyle& computedStyle() const LIFETIME_BOUND { return m_computedStyle; }

--- a/Source/WebCore/style/MatchedDeclarationsCache.cpp
+++ b/Source/WebCore/style/MatchedDeclarationsCache.cpp
@@ -102,8 +102,11 @@ bool MatchedDeclarationsCache::isCacheable(const Element& element, const RenderS
     if (element.hasRandomCachingKeyMap())
         return false;
 
-    // FIXME: counter-style: we might need to resolve cache like for fontSelector here (rdar://103018993).
+    if (style.usesCustomPropertyReferences() && (style.inheritedCustomProperties().hasAnimatedProperties()
+        || style.nonInheritedCustomProperties().hasAnimatedProperties()))
+        return false;
 
+    // FIXME: counter-style: we might need to resolve cache like for fontSelector here (rdar://103018993).
     return true;
 }
 
@@ -124,6 +127,9 @@ unsigned MatchedDeclarationsCache::computeHash(const MatchResult& matchResult, c
 {
     if (matchResult.isCompletelyNonCacheable)
         return 0;
+
+    if (inheritedCustomProperties.hasAnimatedProperties())
+        return AlreadyHashed::avoidDeletedValue(WTF::computeHash(matchResult));
 
     if (matchResult.userAgentDeclarations.isEmpty() && matchResult.userDeclarations.isEmpty()) {
         bool allNonCacheable = std::ranges::all_of(matchResult.authorDeclarations, [](auto& matchedProperties) {
@@ -150,7 +156,7 @@ std::optional<MatchedDeclarationsCache::Result> MatchedDeclarationsCache::find(u
         if (!matchResult.cacheablePropertiesEqual(*entry.matchResult))
             continue;
 
-        if (&entry.parentRenderStyle->inheritedCustomProperties() != &inheritedCustomProperties)
+        if (!parentStyle.inheritedCustomProperties().hasAnimatedProperties() && &entry.parentRenderStyle->inheritedCustomProperties() != &inheritedCustomProperties)
             continue;
 
         if (parentStyle.inheritedEqual(*entry.parentRenderStyle))

--- a/Source/WebCore/style/StyleBuilder.cpp
+++ b/Source/WebCore/style/StyleBuilder.cpp
@@ -571,6 +571,8 @@ Ref<CSSValue> Builder::resolveSubstitutionFunctions(CSSPropertyID propertyID, CS
     if (!value.hasSubstitutionFunctions())
         return value;
 
+    m_state->style().setUsesCustomPropertyReferences();
+
     SubstitutionResolver substitutionResolver(*this);
 
     auto variableValue = [&]() -> RefPtr<CSSValue> {

--- a/Source/WebCore/style/StyleInterpolation.cpp
+++ b/Source/WebCore/style/StyleInterpolation.cpp
@@ -191,6 +191,10 @@ static void interpolateCustomProperty(const AtomString& customProperty, RenderSt
 
     bool isInherited = client.document()->customPropertyRegistry().isInherited(customProperty);
     destination.setCustomPropertyValue(interpolatedCustomProperty(from, to, *fromValue, *toValue, context), isInherited);
+    if (isInherited)
+        destination.mutableInheritedCustomProperties().setHasAnimatedProperties();
+    else
+        destination.mutableNonInheritedCustomProperties().setHasAnimatedProperties();
 }
 
 static bool syntaxValuesRequireInterpolationForAccumulativeIteration(const CustomProperty::Value& a, const CustomProperty::Value& b, bool isList)

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+ConstructionInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+ConstructionInlines.h
@@ -79,6 +79,7 @@ inline ComputedStyleBase::ComputedStyleBase(CreateDefaultStyleTag)
     m_nonInheritedFlags.usesViewportUnits = false;
     m_nonInheritedFlags.usesContainerUnits = false;
     m_nonInheritedFlags.useTreeCountingFunctions = false;
+    m_nonInheritedFlags.usesCustomPropertyReferences = false;
     m_nonInheritedFlags.hasExplicitlyInheritedProperties = false;
     m_nonInheritedFlags.disallowsFastPathInheritance = false;
     m_nonInheritedFlags.emptyState = false;
@@ -128,6 +129,7 @@ inline void ComputedStyleBase::NonInheritedFlags::copyNonInheritedFrom(const Non
     usesViewportUnits = other.usesViewportUnits;
     usesContainerUnits = other.usesContainerUnits;
     useTreeCountingFunctions = other.useTreeCountingFunctions;
+    usesCustomPropertyReferences = other.usesCustomPropertyReferences;
     hasExplicitlyInheritedProperties = other.hasExplicitlyInheritedProperties;
     disallowsFastPathInheritance = other.disallowsFastPathInheritance;
 }

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+GettersInlines.h
@@ -114,6 +114,11 @@ inline bool ComputedStyleBase::useTreeCountingFunctions() const
     return m_nonInheritedFlags.useTreeCountingFunctions;
 }
 
+inline bool ComputedStyleBase::usesCustomPropertyReferences() const
+{
+    return m_nonInheritedFlags.usesCustomPropertyReferences;
+}
+
 inline InsideLink ComputedStyleBase::insideLink() const
 {
     return static_cast<InsideLink>(m_inheritedFlags.insideLink);
@@ -478,6 +483,16 @@ inline CursorType ComputedStyleBase::cursorType() const
 inline const PageSize& ComputedStyleBase::pageSize() const
 {
     return m_nonInheritedData->rareData->pageSize;
+}
+
+inline Style::CustomPropertyData& ComputedStyleBase::mutableInheritedCustomProperties()
+{
+    return m_inheritedRareData.access().customProperties.access();
+}
+
+inline Style::CustomPropertyData& ComputedStyleBase::mutableNonInheritedCustomProperties()
+{
+    return m_nonInheritedData.access().rareData.access().customProperties.access();
 }
 
 } // namespace Style

--- a/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase+SettersInlines.h
@@ -73,6 +73,11 @@ inline void ComputedStyleBase::setUsesTreeCountingFunctions()
     m_nonInheritedFlags.useTreeCountingFunctions = true;
 }
 
+inline void ComputedStyleBase::setUsesCustomPropertyReferences()
+{
+    m_nonInheritedFlags.usesCustomPropertyReferences = true;
+}
+
 inline void ComputedStyleBase::setInsideLink(InsideLink insideLink)
 {
     m_inheritedFlags.insideLink = static_cast<unsigned>(insideLink);

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.cpp
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.cpp
@@ -424,6 +424,7 @@ void ComputedStyleBase::NonInheritedFlags::dumpDifferences(TextStream& ts, const
     LOG_IF_DIFFERENT(usesViewportUnits);
     LOG_IF_DIFFERENT(usesContainerUnits);
     LOG_IF_DIFFERENT(useTreeCountingFunctions);
+    LOG_IF_DIFFERENT(usesCustomPropertyReferences);
 
     LOG_IF_DIFFERENT_WITH_FROM_RAW(TextDecorationLine, textDecorationLine);
 

--- a/Source/WebCore/style/computed/StyleComputedStyleBase.h
+++ b/Source/WebCore/style/computed/StyleComputedStyleBase.h
@@ -471,6 +471,9 @@ public:
     inline bool useTreeCountingFunctions() const;
     inline void setUsesTreeCountingFunctions();
 
+    inline bool usesCustomPropertyReferences() const;
+    inline void setUsesCustomPropertyReferences();
+
     inline InsideLink insideLink() const;
     inline void setInsideLink(InsideLink);
 
@@ -749,6 +752,7 @@ public:
         PREFERRED_TYPE(bool) unsigned usesViewportUnits : 1;
         PREFERRED_TYPE(bool) unsigned usesContainerUnits : 1;
         PREFERRED_TYPE(bool) unsigned useTreeCountingFunctions : 1;
+        PREFERRED_TYPE(bool) unsigned usesCustomPropertyReferences : 1;
         PREFERRED_TYPE(bool) unsigned hasExplicitlyInheritedProperties : 1; // Explicitly inherits a non-inherited property.
         PREFERRED_TYPE(bool) unsigned disallowsFastPathInheritance : 1;
 
@@ -813,6 +817,9 @@ public:
 #endif
         // Total = 63 bits (fits in 8 bytes)
     };
+
+    inline Style::CustomPropertyData& mutableInheritedCustomProperties();
+    inline Style::CustomPropertyData& mutableNonInheritedCustomProperties();
 
 protected:
     friend class Adjuster;

--- a/Source/WebCore/style/computed/data/StyleCustomPropertyData.cpp
+++ b/Source/WebCore/style/computed/data/StyleCustomPropertyData.cpp
@@ -37,6 +37,7 @@ static constexpr auto maximumAncestorCount = 4;
 CustomPropertyData::CustomPropertyData(const CustomPropertyData& other)
     : m_size(other.m_size)
     , m_mayHaveAnimatableProperties(other.m_mayHaveAnimatableProperties)
+    , m_hasAnimatedProperties(other.m_hasAnimatedProperties)
 {
     auto shouldReferenceAsParentValues = [&] {
         // Always reference the root style since it likely gets shared a lot.

--- a/Source/WebCore/style/computed/data/StyleCustomPropertyData.h
+++ b/Source/WebCore/style/computed/data/StyleCustomPropertyData.h
@@ -54,6 +54,8 @@ public:
 
     unsigned size() const { return m_size; }
     bool mayHaveAnimatableProperties() const { return m_mayHaveAnimatableProperties; }
+    bool hasAnimatedProperties() const { return m_hasAnimatedProperties; }
+    void setHasAnimatedProperties() { m_hasAnimatedProperties = true; }
 
     void forEach(NOESCAPE const Function<IterationStatus(const KeyValuePair<AtomString, Ref<const CustomProperty>>&)>&) const;
     AtomString findKeyAtIndex(unsigned) const;
@@ -69,6 +71,7 @@ private:
     unsigned m_size { 0 };
     unsigned m_ancestorCount { 0 };
     bool m_mayHaveAnimatableProperties { false };
+    bool m_hasAnimatedProperties { false };
 #if ASSERT_ENABLED
     mutable bool m_hasChildren { false };
 #endif


### PR DESCRIPTION
#### 428e95553e65577a76566a93a4e256a26d1cfbed
<pre>
Testing MDCache
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/428e95553e65577a76566a93a4e256a26d1cfbed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164409 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37893 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31464 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173438 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121661 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166278 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38227 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37894 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127745 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89919 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167368 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30045 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147776 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108290 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29092 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27713 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21202 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138994 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25492 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175964 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28787 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27160 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136057 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37564 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31833 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136025 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38350 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147287 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100774 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31339 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24143 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37160 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110204 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36556 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2201 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36806 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36706 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->