### PR TITLE
[JSC] Fix / Update iterator return function call's arguments

### DIFF
--- a/JSTests/stress/asynciterator-prototype-symbol-async-dispose-return-argument.js
+++ b/JSTests/stress/asynciterator-prototype-symbol-async-dispose-return-argument.js
@@ -5,11 +5,10 @@ function shouldBe(a, b) {
         throw new Error(`Expected ${b} but got ${a}`);
 }
 
-// %AsyncIteratorPrototype%[@@asyncDispose] step 6.a:
-//   Let result be Completion(Call(return.[[Value]], O, « undefined »)).
-// The return method must be called with exactly one argument (undefined),
-// matching for-await-of abrupt completion semantics. The sync
-// %IteratorPrototype%[@@dispose] calls return with no arguments (« »).
+// %AsyncIteratorPrototype%[@@asyncDispose] step 6.a (per tc39/proposal-explicit-resource-management#273):
+//   Let result be Completion(Call(return.[[Value]], O)).
+// The return method must be called with no arguments, matching the sync
+// %IteratorPrototype%[@@dispose], which also calls return with no arguments (« »).
 
 async function* ag() {}
 const AsyncIteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf(Object.getPrototypeOf(ag())));
@@ -24,11 +23,11 @@ const AsyncIteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf(Objec
     };
     iter[Symbol.asyncDispose]();
     drainMicrotasks();
-    shouldBe(argsLength, 1);
+    shouldBe(argsLength, 0);
     shouldBe(arg0, undefined);
 }
 
-// Sync @@dispose should still call return with no arguments
+// Sync @@dispose should also call return with no arguments
 {
     const IteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf([][Symbol.iterator]()));
     let argsLength;
@@ -51,5 +50,28 @@ const AsyncIteratorPrototype = Object.getPrototypeOf(Object.getPrototypeOf(Objec
     };
     iter[Symbol.asyncDispose]();
     drainMicrotasks();
-    shouldBe(argsLength, 1);
+    shouldBe(argsLength, 0);
+}
+
+// Async generator's own return is also called with no arguments via @@asyncDispose
+{
+    let argsLength;
+    async function* gen() {
+        try {
+            yield 1;
+        } finally {
+            // for-await-of abrupt completion would pass undefined here, but
+            // @@asyncDispose passes nothing, so the rest binding is empty.
+        }
+    }
+    const it = gen();
+    const origReturn = AsyncIteratorPrototype.return;
+    // Override return on the instance to observe the argument count.
+    it.return = function(...args) {
+        argsLength = args.length;
+        return Promise.resolve({ value: undefined, done: true });
+    };
+    it[Symbol.asyncDispose]();
+    drainMicrotasks();
+    shouldBe(argsLength, 0);
 }

--- a/JSTests/stress/iterator-prototype-flatMap-return-no-arguments.js
+++ b/JSTests/stress/iterator-prototype-flatMap-return-no-arguments.js
@@ -1,0 +1,130 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`Expected ${expected} but got ${actual}`);
+}
+
+// Iterator.prototype.flatMap installs an internal wrapper whose `return` forwards
+// to the underlying iterator's `return`. Per the spec (and matching IteratorClose
+// in ECMA-262), the underlying `return` must be invoked with NO arguments,
+// not with `undefined`. See tc39/proposal-explicit-resource-management#273
+// for the parallel async-iterator fix.
+
+// Triggered via abrupt completion (`break` inside the for-of) of the helper.
+{
+    let argsLength = -1;
+    let arg0 = "sentinel";
+    const baseIterator = {
+        count: 0,
+        next() {
+            if (this.count < 3)
+                return { done: false, value: ++this.count };
+            return { done: true };
+        },
+        return(...args) {
+            argsLength = args.length;
+            arg0 = args[0];
+            return { done: true };
+        },
+    };
+    const iter = { [Symbol.iterator]() { return baseIterator; } };
+
+    let pulled = 0;
+    for (const item of Iterator.from(iter).flatMap(x => [x])) {
+        pulled++;
+        if (pulled === 1)
+            break;
+    }
+    shouldBe(pulled, 1);
+    shouldBe(argsLength, 0);
+    shouldBe(arg0, undefined);
+}
+
+// Triggered via explicit `.return()` on the helper.
+{
+    let argsLength = -1;
+    const baseIterator = {
+        count: 0,
+        next() {
+            if (this.count < 5)
+                return { done: false, value: ++this.count };
+            return { done: true };
+        },
+        return(...args) {
+            argsLength = args.length;
+            return { done: true };
+        },
+    };
+    const iter = { [Symbol.iterator]() { return baseIterator; } };
+
+    const helper = Iterator.from(iter).flatMap(x => [x]);
+    helper.next();
+    helper.return();
+    shouldBe(argsLength, 0);
+}
+
+// Observable via `arguments` (no rest binding).
+{
+    let argsLength = -1;
+    const baseIterator = {
+        count: 0,
+        next() {
+            if (this.count < 3)
+                return { done: false, value: ++this.count };
+            return { done: true };
+        },
+        return() {
+            argsLength = arguments.length;
+            return { done: true };
+        },
+    };
+    const iter = { [Symbol.iterator]() { return baseIterator; } };
+
+    for (const item of Iterator.from(iter).flatMap(x => [x])) {
+        break;
+    }
+    shouldBe(argsLength, 0);
+}
+
+// Sanity: when no abrupt completion occurs, `return` is not invoked at all.
+{
+    let invoked = 0;
+    const baseIterator = {
+        count: 0,
+        next() {
+            if (this.count < 3)
+                return { done: false, value: ++this.count };
+            return { done: true };
+        },
+        return() {
+            invoked++;
+            return { done: true };
+        },
+    };
+    const iter = { [Symbol.iterator]() { return baseIterator; } };
+
+    let pulled = 0;
+    for (const item of Iterator.from(iter).flatMap(x => [x]))
+        pulled++;
+    shouldBe(pulled, 3);
+    shouldBe(invoked, 0);
+}
+
+// null return should be treated the same as undefined: no call, no throw.
+{
+    const iterated = Object.create(Iterator.prototype);
+    let count = 0;
+    iterated.next = function() {
+        if (count++ < 3) return { done: false, value: count };
+        return { done: true };
+    };
+    iterated.return = null;
+
+    let threw = false;
+    try {
+        for (const item of iterated.flatMap(x => [x]))
+            break;
+    } catch (e) {
+        threw = true;
+    }
+    shouldBe(threw, false);
+}

--- a/Source/JavaScriptCore/builtins/AsyncIteratorPrototype.js
+++ b/Source/JavaScriptCore/builtins/AsyncIteratorPrototype.js
@@ -34,7 +34,7 @@ function asyncDispose()
         if (@isUndefinedOrNull(returnMethod))
             return @newResolvedPromise(@undefined);
 
-        var result = returnMethod.@call(this, @undefined);
+        var result = returnMethod.@call(this);
         var resultWrapper;
         if (@isPromise(result) && result.constructor === @Promise)
             resultWrapper = result;

--- a/Source/JavaScriptCore/builtins/JSIteratorPrototype.js
+++ b/Source/JavaScriptCore/builtins/JSIteratorPrototype.js
@@ -226,8 +226,8 @@ function flatMap(mapper)
         next: function() { return iteratedNextMethod.@call(iterated); },
         return: function() {
             var iteratedReturnMethod = iterated.return;
-            if (iteratedReturnMethod !== @undefined)
-                return iteratedReturnMethod.@call(iterated, @undefined);
+            if (!@isUndefinedOrNull(iteratedReturnMethod))
+                return iteratedReturnMethod.@call(iterated);
             return { done: true };
         },
     };


### PR DESCRIPTION
#### 918d694777b91696db7a24f39f9334ae67c551ea
<pre>
[JSC] Fix / Update iterator return function call&apos;s arguments
<a href="https://bugs.webkit.org/show_bug.cgi?id=315095">https://bugs.webkit.org/show_bug.cgi?id=315095</a>
<a href="https://rdar.apple.com/177429981">rdar://177429981</a>

Reviewed by Yijia Huang.

This patch updates explicit-resource-management&apos;s return function
call[1]. Also we fix an issue in iterator flatMap&apos;s function call as well.

[1]: <a href="https://github.com/tc39/proposal-explicit-resource-management/issues/273">https://github.com/tc39/proposal-explicit-resource-management/issues/273</a>

Test: JSTests/stress/iterator-prototype-flatMap-return-no-arguments.js

* JSTests/stress/asynciterator-prototype-symbol-async-dispose-return-argument.js:
(const.AsyncIteratorPrototype.Object.getPrototypeOf.Object.getPrototypeOf.Object.getPrototypeOf.ag):
(shouldBe):
(shouldBe.async gen):
(shouldBe.it.return):
* JSTests/stress/iterator-prototype-flatMap-return-no-arguments.js: Added.
(shouldBe):
(throw.new.Error):
(shouldBe.iterated.next):
* Source/JavaScriptCore/builtins/AsyncIteratorPrototype.js:
(overriddenName.string_appeared_here.asyncDispose):
* Source/JavaScriptCore/builtins/JSIteratorPrototype.js:
(flatMap.iteratedWrapper.return):

Canonical link: <a href="https://commits.webkit.org/313556@main">https://commits.webkit.org/313556@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/616e15eab101a2d4fea9e59d36f21013ec06305e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163451 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36934 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30150 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172391 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119898 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37263 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36934 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126941 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89477 "layout-tests (failure)") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1e6c868d-6f8a-4db7-8403-71cc0b32edbe) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166410 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29213 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146939 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107499 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f8d45966-ce6f-4028-b24e-2d313bdcdffd) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28266 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26887 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20093 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/155596 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138154 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24662 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174895 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/24338 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27622 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26319 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135244 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36604 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30987 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135230 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37389 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146457 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99381 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24879 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30530 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23302 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195853 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36100 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109129 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51055 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35597 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1328 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35845 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35745 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->