### PR TITLE
moveBefore() needs to enqueue mutation records

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/mutation-observer-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/mutation-observer-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL [Connected move] MutationObserver removal + insertion is tracked by moveBefore() assert_equals: MutationObserver has emitted a single mutation list expected 1 but got 0
-FAIL [Disconnected move] MutationObserver removal + insertion is tracked by moveBefore() assert_equals: MutationObserver has emitted a single mutation list expected 1 but got 0
+PASS [Connected move] MutationObserver removal + insertion is tracked by moveBefore()
+PASS [Disconnected move] MutationObserver removal + insertion is tracked by moveBefore()
 

--- a/Source/WebCore/dom/ContainerNode.cpp
+++ b/Source/WebCore/dom/ContainerNode.cpp
@@ -1475,6 +1475,7 @@ ExceptionOr<void> ContainerNode::moveBefore(Node& node, RefPtr<Node>&& refChild)
     {
         WidgetHierarchyUpdatesSuspensionScope suspendWidgetHierarchyUpdates;
         ScriptDisallowedScope::InMainThread scriptDisallowedScope;
+        ChildListMutationScope(*oldParent).willRemoveChild(node);
 
         if (oldNextSibling) {
             oldNextSibling->setPreviousSibling(oldPreviousSibling.get());
@@ -1504,6 +1505,7 @@ ExceptionOr<void> ContainerNode::moveBefore(Node& node, RefPtr<Node>&& refChild)
 
         node.setTreeScopeRecursively(treeScope());
         node.updateAncestorConnectedSubframeCountForInsertion();
+        ChildListMutationScope(*this).childAdded(node);
     }
 
     auto newParentIsConnected = isConnected();
@@ -1524,8 +1526,6 @@ ExceptionOr<void> ContainerNode::moveBefore(Node& node, RefPtr<Node>&& refChild)
 
     oldParent->childrenChanged(removalChildChange);
     childrenChanged(makeChildChangeForInsertion(*this, node, refChild, ChildChange::Source::API, ReplacedAllChildren::No));
-
-    // FIXME(281223): Queue tree mutation records.
 
     return { };
 }


### PR DESCRIPTION
#### c943a0d1d1d07e4ac77736dcbbfa58b4442a99b8
<pre>
moveBefore() needs to enqueue mutation records
<a href="https://bugs.webkit.org/show_bug.cgi?id=315096">https://bugs.webkit.org/show_bug.cgi?id=315096</a>

Reviewed by Ryosuke Niwa.

Enqueues a removal and insertion mutation record after moveBefore()
so mutation observers can respond appropriately.

* LayoutTests/imported/w3c/web-platform-tests/dom/nodes/moveBefore/mutation-observer-expected.txt:
* Source/WebCore/dom/ContainerNode.cpp:
(WebCore::ContainerNode::moveBefore):

Canonical link: <a href="https://commits.webkit.org/313611@main">https://commits.webkit.org/313611@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d6cb838db4217a70f0b0b208807c6589ae56d46c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163567 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37051 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30270 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172507 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/120016 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165436 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37382 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37050 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127040 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89564 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166526 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29317 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147049 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107594 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28366 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26996 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20210 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138264 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24768 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175012 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27943 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26431 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135346 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36721 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31098 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135328 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36483 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37506 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146563 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99559 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30635 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23415 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36216 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109362 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35714 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1441 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35964 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35861 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->