### PR TITLE
Use logical selector order in compound traversal function names

### DIFF
--- a/Source/WebCore/css/CSSSelector.cpp
+++ b/Source/WebCore/css/CSSSelector.cpp
@@ -369,21 +369,21 @@ std::optional<CSSSelector::PseudoElement> CSSSelector::parsePseudoElementName(St
 }
 
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-const CSSSelector* CSSSelector::firstInCompound() const
+const CSSSelector* CSSSelector::rightmostInCompound() const
 {
     auto* selector = this;
-    while (!selector->isFirstInComplexSelector()) {
+    while (auto* preceding = selector->precedingInComplexSelector()) {
         if (selector->relation() != Relation::Subselector)
             break;
-        ++selector;
+        selector = preceding;
     }
     return selector;
 }
 
-const CSSSelector* CSSSelector::lastInCompound() const
+const CSSSelector* CSSSelector::leftmostInCompound() const
 {
     auto* selector = this;
-    while (!selector->isLastInComplexSelector()) {
+    while (!selector->m_isLastInComplexSelector) {
         auto* next = selector - 1;
         if (next->relation() != Relation::Subselector)
             break;
@@ -393,7 +393,7 @@ const CSSSelector* CSSSelector::lastInCompound() const
 }
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
-const CSSSelector* CSSSelector::precedingInCompound() const
+const CSSSelector* CSSSelector::followingInCompound() const
 {
     if (relation() != Relation::Subselector)
         return nullptr;
@@ -1000,7 +1000,7 @@ bool complexSelectorMatchesElementBackedPseudoElement(const CSSSelector& complex
     };
 
     auto result = false;
-    for (auto* simpleSelector = &complexSelector; simpleSelector; simpleSelector = simpleSelector->precedingInCompound()) {
+    for (auto* simpleSelector = &complexSelector; simpleSelector; simpleSelector = simpleSelector->followingInCompound()) {
         if (simpleSelector->matchesPseudoElement()) {
             if (!isElementBacked(simpleSelector->pseudoElement()))
                 return false;

--- a/Source/WebCore/css/CSSSelector.h
+++ b/Source/WebCore/css/CSSSelector.h
@@ -137,15 +137,16 @@ public:
     static const ASCIILiteral selectorTextForPseudoClass(PseudoClass);
     static const ASCIILiteral nameForUserAgentPartLegacyAlias(StringView);
 
-    // Selectors are kept in an array by CSSSelectorList.
-    // The left component of the selector is the next item in the array.
+    // Selectors are kept in an array by CSSSelectorList. Compounds are stored right-to-left
+    // (subject compound first), but simples within a compound are stored left-to-right.
+    // For example, ".a.b > div#id" is stored as [div, #id, .a, .b].
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
     const CSSSelector* precedingInComplexSelector() const { return m_isFirstInComplexSelector ? nullptr : this + 1; }
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 
-    const CSSSelector* NODELETE firstInCompound() const;
-    const CSSSelector* NODELETE lastInCompound() const;
-    const CSSSelector* NODELETE precedingInCompound() const;
+    const CSSSelector* NODELETE leftmostInCompound() const;
+    const CSSSelector* NODELETE rightmostInCompound() const;
+    const CSSSelector* NODELETE followingInCompound() const;
 
     const QualifiedName& tagQName() const LIFETIME_BOUND;
     const AtomString& tagLowercaseLocalName() const LIFETIME_BOUND;
@@ -181,8 +182,6 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     Relation relation() const { return static_cast<Relation>(m_relation); }
     Match match() const { return static_cast<Match>(m_match); }
 
-    bool isFirstInComplexSelector() const { return m_isFirstInComplexSelector; }
-    bool isLastInComplexSelector() const { return m_isLastInComplexSelector; }
     bool isForPage() const { return m_isForPage; }
 
     // Implicit means that this selector is not author/UA written.

--- a/Source/WebCore/css/CSSSelectorList.cpp
+++ b/Source/WebCore/css/CSSSelectorList.cpp
@@ -67,7 +67,7 @@ CSSSelectorList::CSSSelectorList(MutableCSSSelectorList&& selectorVector)
                 m_selectorArray[arrayIndex].m_isFirstInComplexSelector = false;
             ++arrayIndex;
         }
-        ASSERT(m_selectorArray[arrayIndex - 1].isFirstInComplexSelector());
+        ASSERT(!m_selectorArray[arrayIndex - 1].precedingInComplexSelector());
     }
     ASSERT(flattenedSize == arrayIndex);
 }
@@ -146,7 +146,9 @@ CSSSelectorList CSSSelectorList::makeJoining(const Vector<const CSSSelectorList*
 
 unsigned CSSSelectorList::size() const
 {
-    return std::ranges::count_if(m_selectorArray, [](auto& selector) { return selector.isFirstInComplexSelector(); });
+    return std::ranges::count_if(m_selectorArray, [](auto& selector) {
+        return !selector.precedingInComplexSelector();
+    });
 }
 
 String CSSSelectorList::selectorsText() const

--- a/Source/WebCore/css/CSSSelectorList.h
+++ b/Source/WebCore/css/CSSSelectorList.h
@@ -74,7 +74,7 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
         const_iterator& operator++()
         {
             // Skip subparts of compound selectors.
-            while (!m_ptr->isFirstInComplexSelector())
+            while (m_ptr->precedingInComplexSelector())
                 ++m_ptr;
             ++m_ptr;
             return *this;

--- a/Source/WebCore/css/parser/CSSParser.cpp
+++ b/Source/WebCore/css/parser/CSSParser.cpp
@@ -1502,7 +1502,7 @@ static void validateUserAgentSheetSelector(const CSSSelectorList& selectorList)
     auto validateRightmostCompound = [](const CSSSelector& complexSelector) {
         bool hasBucketedSelector = false;
         bool hasLogicalCombination = false;
-        for (auto* simpleSelector = &complexSelector; simpleSelector; simpleSelector = simpleSelector->precedingInCompound()) {
+        for (auto* simpleSelector = &complexSelector; simpleSelector; simpleSelector = simpleSelector->followingInCompound()) {
             if (simpleSelector->match() == CSSSelector::Match::Tag && simpleSelector->tagQName().localName() != starAtom())
                 hasBucketedSelector = true;
             if (simpleSelector->match() == CSSSelector::Match::Id)

--- a/Source/WebCore/css/parser/CSSSelectorParser.cpp
+++ b/Source/WebCore/css/parser/CSSSelectorParser.cpp
@@ -1367,8 +1367,8 @@ CSSSelectorList CSSSelectorParser::resolveNestingParent(const CSSSelectorList& n
 
     auto canInline = [](const CSSSelector& nestingSelector, const CSSSelectorList& list) {
         auto hasTagInCompound = [](const CSSSelector& simpleSelector) {
-            // A compound is organized so that any tag selector is always last.
-            return simpleSelector.lastInCompound()->match() == CSSSelector::Match::Tag;
+            // A compound is organized so that any tag selector is always leftmost.
+            return simpleSelector.leftmostInCompound()->match() == CSSSelector::Match::Tag;
         };
 
         if (list.size() != 1) {
@@ -1387,7 +1387,7 @@ CSSSelectorList CSSSelectorParser::resolveNestingParent(const CSSSelectorList& n
             // .foo .bar { & .baz {...} } -> .foo .bar .baz {...}
             return true;
         }
-        bool hasSingleCompound = !list.first().firstInCompound()->precedingInComplexSelector();
+        bool hasSingleCompound = !list.first().rightmostInCompound()->precedingInComplexSelector();
         if (hasSingleCompound) {
             // .foo.bar { .baz & {...} } -> .baz .foo.bar {...}
             return true;
@@ -1549,16 +1549,16 @@ struct HasCompoundContext {
 static std::optional<HasCompoundContext> collectHasCompoundContext(const CSSSelector& hasPseudoClass)
 {
     HasCompoundContext context;
-    for (auto* selector = hasPseudoClass.lastInCompound(); selector; selector = selector->precedingInCompound()) {
+    for (auto* selector = hasPseudoClass.leftmostInCompound(); selector; selector = selector->followingInCompound()) {
         if (selector != &hasPseudoClass)
             context.compoundPeers.append(selector);
     }
     if (context.compoundPeers.isEmpty())
         return { };
 
-    auto* firstInCompound = hasPseudoClass.firstInCompound();
-    context.compoundRelation = firstInCompound->relation();
-    context.leftStart = firstInCompound->precedingInComplexSelector();
+    auto* rightmostInCompound = hasPseudoClass.rightmostInCompound();
+    context.compoundRelation = rightmostInCompound->relation();
+    context.leftStart = rightmostInCompound->precedingInComplexSelector();
     return context;
 }
 
@@ -1609,7 +1609,7 @@ CSSSelectorList CSSSelectorParser::makeHasScopeSelector(const Vector<const CSSSe
 {
     ASSERT(!compoundSelectors.isEmpty());
 
-    auto* outermost = compoundSelectors.first()->firstInCompound();
+    auto* outermost = compoundSelectors.first()->rightmostInCompound();
 
     Vector<const CSSSelector*> mergedPeers;
     for (size_t i = 0; i < compoundSelectors.size(); ++i) {

--- a/Source/WebCore/cssjit/SelectorCompiler.cpp
+++ b/Source/WebCore/cssjit/SelectorCompiler.cpp
@@ -1665,7 +1665,7 @@ static FunctionType constructFragmentsInternal(const CSSSelector& rootSelector, 
         if (relation == CSSSelector::Relation::Subselector)
             continue;
 
-        if ((relation == CSSSelector::Relation::ShadowDescendant || relation == CSSSelector::Relation::ShadowPartDescendant) && !selector->isFirstInComplexSelector())
+        if ((relation == CSSSelector::Relation::ShadowDescendant || relation == CSSSelector::Relation::ShadowPartDescendant) && selector->precedingInComplexSelector())
             return FunctionType::CannotCompile;
 
         if (relation == CSSSelector::Relation::ShadowSlotted)

--- a/Source/WebCore/dom/SelectorQuery.cpp
+++ b/Source/WebCore/dom/SelectorQuery.cpp
@@ -51,17 +51,17 @@ WTF_MAKE_TZONE_ALLOCATED_IMPL(SelectorQueryCache);
 #if ASSERT_ENABLED
 static bool isSingleTagNameSelector(const CSSSelector& selector)
 {
-    return selector.isFirstInComplexSelector() && selector.match() == CSSSelector::Match::Tag;
+    return !selector.precedingInComplexSelector() && selector.match() == CSSSelector::Match::Tag;
 }
 
 static bool isSingleClassNameSelector(const CSSSelector& selector)
 {
-    return selector.isFirstInComplexSelector() && selector.match() == CSSSelector::Match::Class;
+    return !selector.precedingInComplexSelector() && selector.match() == CSSSelector::Match::Class;
 }
 
 static bool isSingleAttributeExactSelector(const CSSSelector& selector)
 {
-    return selector.isFirstInComplexSelector() && selector.match() == CSSSelector::Match::Exact;
+    return !selector.precedingInComplexSelector() && selector.match() == CSSSelector::Match::Exact;
 }
 
 #endif // ASSERT_ENABLED
@@ -131,7 +131,7 @@ SelectorDataList::SelectorDataList(const CSSSelectorList& selectorList)
 
     if (m_selectors.size() == 1) {
         const CSSSelector& selector = m_selectors.first().selector;
-        if (selector.isFirstInComplexSelector()) {
+        if (!selector.precedingInComplexSelector()) {
             switch (selector.match()) {
             case CSSSelector::Match::Tag:
                 m_matchType = TagNameMatch;
@@ -225,11 +225,9 @@ static const CSSSelector* NODELETE selectorForIdLookup(const ContainerNode& root
     if (rootNode.document().inQuirksMode())
         return nullptr;
 
-    for (const CSSSelector* selector = &firstSelector; selector; selector = selector->precedingInComplexSelector()) {
+    for (const CSSSelector* selector = &firstSelector; selector; selector = selector->followingInCompound()) {
         if (canBeUsedForIdFastPath(*selector))
             return selector;
-        if (selector->relation() != CSSSelector::Relation::Subselector)
-            break;
     }
 
     return nullptr;

--- a/Source/WebCore/style/ChildChangeInvalidation.cpp
+++ b/Source/WebCore/style/ChildChangeInvalidation.cpp
@@ -41,7 +41,7 @@ namespace WebCore::Style {
 
 static bool rightmostCompoundContainsEmpty(const CSSSelector& selector)
 {
-    for (auto* simple = &selector; simple; simple = simple->precedingInCompound()) {
+    for (auto* simple = &selector; simple; simple = simple->followingInCompound()) {
         if (simple->match() == CSSSelector::Match::PseudoClass && simple->pseudoClass() == CSSSelector::PseudoClass::Empty)
             return true;
         if (auto* selectorList = simple->selectorList()) {

--- a/Source/WebCore/style/HasSelectorFilter.cpp
+++ b/Source/WebCore/style/HasSelectorFilter.cpp
@@ -58,13 +58,11 @@ auto HasSelectorFilter::makeKey(const CSSSelector& hasSelector) -> Key
 {
     SelectorFilter::CollectedSelectorHashes hashes;
     bool hasHoverInCompound = false;
-    for (auto* simpleSelector = &hasSelector; simpleSelector; simpleSelector = simpleSelector->precedingInComplexSelector()) {
+    for (auto* simpleSelector = &hasSelector; simpleSelector; simpleSelector = simpleSelector->followingInCompound()) {
         if (simpleSelector->match() == CSSSelector::Match::PseudoClass && simpleSelector->pseudoClass() == CSSSelector::PseudoClass::Hover)
             hasHoverInCompound = true;
         SelectorFilter::collectSimpleSelectorHash(hashes, *simpleSelector);
         if (!hashes.ids.isEmpty())
-            break;
-        if (simpleSelector->relation() != CSSSelector::Relation::Subselector)
             break;
     }
 

--- a/Source/WebCore/style/RuleFeature.cpp
+++ b/Source/WebCore/style/RuleFeature.cpp
@@ -187,19 +187,10 @@ static bool isSiblingCombinator(CSSSelector::Relation relation)
 
 static bool compoundContainsHostPseudoClass(const CSSSelector& anySimpleInCompound)
 {
-    // Iterate every simple selector in this compound. WebKit stores compound members
-    // contiguously in selector storage; firstInCompound returns the subject (rightmost
-    // in source) and lastInCompound returns the leftmost. Walk from leftmost to subject.
-    auto* leftmost = anySimpleInCompound.lastInCompound();
-    auto* subject = anySimpleInCompound.firstInCompound();
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
-    for (auto* simple = leftmost; ; ++simple) {
+    for (auto* simple = anySimpleInCompound.leftmostInCompound(); simple; simple = simple->followingInCompound()) {
         if (simple->match() == CSSSelector::Match::PseudoClass && simple->isHostPseudoClass())
             return true;
-        if (simple == subject)
-            break;
     }
-WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     return false;
 }
 
@@ -336,7 +327,7 @@ void RuleFeatureSet::recursivelyCollectFeaturesFromSelector(SelectorFeatures& se
             auto compoundIsAffectedByChildMutation = [&] {
                 if (isSiblingCombinator(selector->relation()))
                     return true;
-                for (auto* simple = selector; simple; simple = simple->precedingInCompound()) {
+                for (auto* simple = selector; simple; simple = simple->followingInCompound()) {
                     if (simple->match() == CSSSelector::Match::PseudoClass && pseudoClassIsRelativeToSiblings(simple->pseudoClass()))
                         return true;
                 }
@@ -445,7 +436,7 @@ static PseudoClassInvalidationKey makePseudoClassInvalidationKey(CSSSelector::Ps
     AtomString attributeName;
     AtomString className;
     AtomString tagName;
-    for (auto* simpleSelector = selector.lastInCompound(); simpleSelector; simpleSelector = simpleSelector->precedingInComplexSelector()) {
+    for (auto* simpleSelector = selector.leftmostInCompound(); simpleSelector; simpleSelector = simpleSelector->followingInCompound()) {
         if (simpleSelector->match() == CSSSelector::Match::Id)
             return makePseudoClassInvalidationKey(pseudoClass, InvalidationKeyType::Id, simpleSelector->value());
 
@@ -457,9 +448,6 @@ static PseudoClassInvalidationKey makePseudoClassInvalidationKey(CSSSelector::Ps
 
         if (simpleSelector->isAttributeSelector() && !unlikelyToHaveSelectorForAttribute(simpleSelector->attribute().localNameLowercase()))
             attributeName = simpleSelector->attribute().localNameLowercase();
-
-        if (simpleSelector->relation() != CSSSelector::Relation::Subselector)
-            break;
     }
     if (!attributeName.isEmpty())
         return makePseudoClassInvalidationKey(pseudoClass, InvalidationKeyType::Attribute, attributeName);
@@ -607,7 +595,7 @@ void RuleFeatureSet::collectPseudoElementFeatures(const RuleData& ruleData)
     ASSERT(ruleData.canMatchPseudoElement());
 
     auto& selector = ruleData.selector();
-    for (auto* simpleSelector = &selector; simpleSelector; simpleSelector = simpleSelector->precedingInCompound()) {
+    for (auto* simpleSelector = &selector; simpleSelector; simpleSelector = simpleSelector->followingInCompound()) {
         if (simpleSelector->match() != CSSSelector::Match::PseudoElement)
             continue;
         switch (simpleSelector->pseudoElement()) {

--- a/Source/WebCore/style/RuleSet.cpp
+++ b/Source/WebCore/style/RuleSet.cpp
@@ -201,8 +201,8 @@ void RuleSet::addRuleToBucket(RuleData& ruleData)
     const CSSSelector* cuePseudoElementSelector = nullptr;
 #endif
     Vector<const CSSSelector*, 4> nestedSelectors;
-    const CSSSelector* selector = &ruleData.selector();
-    do {
+    // We only process the subject (rightmost) compound.
+    for (const CSSSelector* selector = &ruleData.selector(); selector; selector = selector->followingInCompound()) {
         nestedSelectors.append(selector);
         while (!nestedSelectors.isEmpty()) {
             const CSSSelector* current = nestedSelectors.takeLast();
@@ -304,11 +304,8 @@ void RuleSet::addRuleToBucket(RuleData& ruleData)
                 case CSSSelector::PseudoClass::Where: {
                     auto* selectorList = current->selectorList();
                     if (selectorList && selectorList->size() == 1) {
-                        for (auto* inner = &selectorList->first(); inner; inner = inner->precedingInComplexSelector()) {
+                        for (auto* inner = &selectorList->first(); inner; inner = inner->followingInCompound())
                             nestedSelectors.append(inner);
-                            if (inner->relation() != CSSSelector::Relation::Subselector)
-                                break;
-                        }
                     }
                     if (hasHostOrScopePseudoClassSubjectInSelectorList(selectorList))
                         m_hasHostOrScopePseudoClassRulesInUniversalBucket = true;
@@ -329,11 +326,7 @@ void RuleSet::addRuleToBucket(RuleData& ruleData)
                 break;
             }
         }
-        // We only process the subject (rightmost compound selector).
-        if (selector->relation() != CSSSelector::Relation::Subselector)
-            break;
-        selector = selector->precedingInComplexSelector();
-    } while (selector);
+    }
 
     if (!m_hasHostPseudoClassRulesMatchingInShadowTree)
         m_hasHostPseudoClassRulesMatchingInShadowTree = isHostSelectorMatchingInShadowTree(ruleData.selector());
@@ -478,18 +471,18 @@ void RuleSet::addRuleToBucket(RuleData& ruleData)
             return false;
 
         bool isHTMLNamespace = false;
-        auto* last = otherPseudoElementSelector->lastInCompound();
-        if (last->precedingInComplexSelector() == otherPseudoElementSelector) {
+        auto* leftmost = otherPseudoElementSelector->leftmostInCompound();
+        if (leftmost->precedingInComplexSelector() == otherPseudoElementSelector) {
             // Check that implicit * is present with the right namespace and nothing else.
-            if (last->match() != CSSSelector::Match::Tag)
+            if (leftmost->match() != CSSSelector::Match::Tag)
                 return false;
 
-            ASSERT(last->tagQName().localName() == starAtom());
-            auto& namespaceURI = last->tagQName().namespaceURI();
+            ASSERT(leftmost->tagQName().localName() == starAtom());
+            auto& namespaceURI = leftmost->tagQName().namespaceURI();
             isHTMLNamespace = namespaceURI == xhtmlNamespaceURI;
             if (!isHTMLNamespace && namespaceURI != starAtom())
                 return false;
-        } else if (last != otherPseudoElementSelector)
+        } else if (leftmost != otherPseudoElementSelector)
             return false;
 
         auto stylePseudoElement = CSSSelector::stylePseudoElementTypeFor(otherPseudoElementSelector->pseudoElement());


### PR DESCRIPTION
#### ad0609b55f82429f8f70a528f233438d5a59e4e8
<pre>
Use logical selector order in compound traversal function names
<a href="https://bugs.webkit.org/show_bug.cgi?id=315094">https://bugs.webkit.org/show_bug.cgi?id=315094</a>
<a href="https://rdar.apple.com/177431445">rdar://177431445</a>

Reviewed by Alan Baradlay.

Storage lays out compounds right-to-left (subject compound first) but
simples within a compound left-to-right. The old &quot;first / last in
compound&quot; names followed the storage walk and read backwards in source
order. Rename to source-frame names:

  firstInCompound      -&gt; rightmostInCompound
  lastInCompound       -&gt; leftmostInCompound
  precedingInCompound  -&gt; followingInCompound  (advances rightward in source)

Drop the public isFirstInComplexSelector / isLastInComplexSelector
accessors; their callers all want &quot;no preceding simple&quot;, which is just
!precedingInComplexSelector(). The bit fields stay as internal storage
for that primitive.

Convert iterate-and-break-at-compound-boundary loops to single
followingInCompound() for-loops where it fits.

Update the storage layout comment in CSSSelector.h with a concrete
example.

* Source/WebCore/css/CSSSelector.cpp:
(WebCore::CSSSelector::rightmostInCompound const):
(WebCore::CSSSelector::leftmostInCompound const):
(WebCore::CSSSelector::followingInCompound const):
(WebCore::complexSelectorMatchesElementBackedPseudoElement):
(WebCore::CSSSelector::firstInCompound const): Deleted.
(WebCore::CSSSelector::lastInCompound const): Deleted.
(WebCore::CSSSelector::precedingInCompound const): Deleted.
* Source/WebCore/css/CSSSelector.h:
(WebCore::CSSSelector::isFirstInComplexSelector const): Deleted.
(WebCore::CSSSelector::isLastInComplexSelector const): Deleted.
* Source/WebCore/css/CSSSelectorList.cpp:
(WebCore::CSSSelectorList::CSSSelectorList):
(WebCore::CSSSelectorList::size const):
* Source/WebCore/css/CSSSelectorList.h:
(WebCore::CSSSelectorList::const_iterator::operator++):
* Source/WebCore/css/parser/CSSParser.cpp:
(WebCore::validateUserAgentSheetSelector):
* Source/WebCore/css/parser/CSSSelectorParser.cpp:
(WebCore::CSSSelectorParser::resolveNestingParent):
(WebCore::collectHasCompoundContext):
(WebCore::CSSSelectorParser::makeHasScopeSelector):
* Source/WebCore/cssjit/SelectorCompiler.cpp:
(WebCore::SelectorCompiler::constructFragmentsInternal):
* Source/WebCore/dom/SelectorQuery.cpp:
(WebCore::isSingleTagNameSelector):
(WebCore::isSingleClassNameSelector):
(WebCore::isSingleAttributeExactSelector):
(WebCore::SelectorDataList::SelectorDataList):
(WebCore::selectorForIdLookup):
* Source/WebCore/style/ChildChangeInvalidation.cpp:
(WebCore::Style::rightmostCompoundContainsEmpty):
* Source/WebCore/style/HasSelectorFilter.cpp:
(WebCore::Style::HasSelectorFilter::makeKey):
* Source/WebCore/style/RuleFeature.cpp:
(WebCore::Style::RuleFeatureSet::recursivelyCollectFeaturesFromSelector):
(WebCore::Style::makePseudoClassInvalidationKey):
(WebCore::Style::RuleFeatureSet::collectPseudoElementFeatures):
* Source/WebCore/style/RuleSet.cpp:
(WebCore::Style::RuleSet::addRuleToBucket):

Canonical link: <a href="https://commits.webkit.org/313496@main">https://commits.webkit.org/313496@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5016b69995c856cfbe8fed8dd5dda80691a5c9d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163290 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36773 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29988 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172229 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/119737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/94c3aab6-9bdd-4117-b226-6f0e98d68b9c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165159 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37100 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36773 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/126799 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/119737 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/60f43947-57ec-4cfe-a495-dcedf39065af) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166249 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29069 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146792 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107366 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e3535516-bf6a-4531-b77b-dddca2941bf0) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28115 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19931 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/138009 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24516 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174733 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27221 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26171 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/135105 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36441 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30846 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135097 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36414 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37228 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146311 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99168 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30398 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/23156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35937 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108669 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35436 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1181 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35683 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35584 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->