### PR TITLE
[LBSE] Skip redundant clipToRect in RenderSVGRect::fillShape when clip-path bounds drawing

### DIFF
--- a/Source/WebCore/rendering/svg/RenderSVGRect.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGRect.cpp
@@ -120,7 +120,8 @@ void RenderSVGRect::fillShape(GraphicsContext& context) const
     }
 #endif
 
-    context.fillRect(m_fillBoundingBox);
+    context.fillRect(m_fillBoundingBox, fillRequiresClip() ? GraphicsContext::RequiresClipToRect::Yes : GraphicsContext::RequiresClipToRect::No);
+    setFillRequiresClip(true);
 }
 
 bool RenderSVGRect::canUseStrokeHitTestFastPath() const

--- a/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
@@ -33,6 +33,7 @@
 #include "ReferencedSVGResources.h"
 #include "RenderLayerInlines.h"
 #include "RenderSVGResourceClipperInlines.h"
+#include "RenderSVGShape.h"
 #include "RenderSVGText.h"
 #include "RenderStyle.h"
 #include "RenderView.h"
@@ -111,6 +112,12 @@ void RenderSVGResourceClipper::applyPathClipping(GraphicsContext& context, const
 
     const auto& clipPath = clipRenderer.computeClipPath(clipPathTransform);
     auto windRule = clipRenderer.style().clipRule();
+
+    if (auto* shape = dynamicDowncast<RenderSVGShape>(targetRenderer); shape && shape->shapeType() == RenderSVGShape::ShapeType::Rectangle) {
+        // When clipping a rect with a path, if we know the path is entirely inside the rect, we can skip a clip when filling the rect.
+        auto clipBounds = clipPathTransform.mapRect(clipPath.fastBoundingRect());
+        shape->setFillRequiresClip(!objectBoundingBox.contains(clipBounds));
+    }
 
     // The SVG specification wants us to clip everything, if clip-path doesn't have a child.
     if (clipPath.isEmpty())

--- a/Source/WebCore/rendering/svg/RenderSVGShape.h
+++ b/Source/WebCore/rendering/svg/RenderSVGShape.h
@@ -88,6 +88,9 @@ public:
 
     ShapeType shapeType() const { return m_shapeType; }
 
+    bool fillRequiresClip() const { return m_fillRequiresClip; }
+    void setFillRequiresClip(bool fillRequiresClip) const { m_fillRequiresClip = fillRequiresClip; }
+
     FloatRect objectBoundingBox() const final { return m_fillBoundingBox; }
     FloatRect strokeBoundingBox() const final;
     FloatRect approximateStrokeBoundingBox() const;
@@ -152,6 +155,7 @@ protected:
     mutable Markable<FloatRect> m_approximateStrokeBoundingBox;
 private:
     bool m_needsShapeUpdate { true };
+    mutable bool m_fillRequiresClip : 1 { true };
 protected:
     ShapeType m_shapeType : 3 { ShapeType::Empty };
 private:


### PR DESCRIPTION
#### 93c8445d72b55b01002030e544e3f935e0d9873b
<pre>
[LBSE] Skip redundant clipToRect in RenderSVGRect::fillShape when clip-path bounds drawing
<a href="https://bugs.webkit.org/show_bug.cgi?id=315093">https://bugs.webkit.org/show_bug.cgi?id=315093</a>

Reviewed by Rob Buis.

Port <a href="https://commits.webkit.org/281361@main">https://commits.webkit.org/281361@main</a> (&quot;Avoid an extra clip when
painting a rect with a clip-path&quot;) to LBSE.

RenderSVGShape gains an m_fillRequiresClip bit (default true) with
fillRequiresClip()/setFillRequiresClip() accessors. In
RenderSVGResourceClipper::applyPathClipping, the same containment check
used by LegacyRenderSVGResourceClipper::applyResource flips the bit to
false when the clip-path&apos;s bounds lie inside objectBoundingBox.
RenderSVGRect::fillShape then reads the bit and resets it to true,
matching legacy&apos;s reset-after-fillStrokeMarkers pattern.

Improves MotionMark/Suits score by ~10%.

Covered by existing tests.

* Source/WebCore/rendering/svg/RenderSVGRect.cpp:
(WebCore::RenderSVGRect::fillShape const):
* Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp:
(WebCore::RenderSVGResourceClipper::applyPathClipping):
* Source/WebCore/rendering/svg/RenderSVGShape.h:
(WebCore::RenderSVGShape::fillRequiresClip const):
(WebCore::RenderSVGShape::setFillRequiresClip const):

Canonical link: <a href="https://commits.webkit.org/313491@main">https://commits.webkit.org/313491@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1752972e56daa72f5feda44fae47af511d439ba9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163280 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36761 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29978 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172219 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119727 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165149 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37089 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36762 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126789 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/89385 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166239 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29056 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146785 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107356 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26732 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19921 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/137996 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24509 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174722 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27175 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26164 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135094 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36431 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30834 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135086 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36410 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37218 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146304 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99158 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30389 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23148 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35927 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108568 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35426 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1173 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35673 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35574 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->