### PR TITLE
REGRESSION(313455@main): [webkitpy] test_clean_and_null_build, test_timing_summary_parsing, and   test_single_test_selection are constant failures

### DIFF
--- a/Tools/Scripts/webkitpy/scripts/measure_build_time_unittest.py
+++ b/Tools/Scripts/webkitpy/scripts/measure_build_time_unittest.py
@@ -67,8 +67,8 @@ class MeasureBuildTimeTest(unittest.TestCase):
         proc, results = self._run_script('echo ok')
 
         self.assertEqual(proc.returncode, 0)
-        self.assertIn('BuildTime-Unspecified', results)
-        tests = results['BuildTime-Unspecified']['tests']
+        self.assertIn('BuildTime-Debug', results)
+        tests = results['BuildTime-Debug']['tests']
         self.assertIn('clean', tests)
         self.assertIn('null', tests)
         for name in ('clean', 'null'):
@@ -89,7 +89,7 @@ class MeasureBuildTimeTest(unittest.TestCase):
         proc, results = self._run_script(build_command, ['--tests', 'clean'])
 
         self.assertEqual(proc.returncode, 0)
-        clean = results['BuildTime-Unspecified']['tests']['clean']
+        clean = results['BuildTime-Debug']['tests']['clean']
         phases = clean['tests']['Phases']
 
         self.assertIn('CPUTime', phases['metrics'])
@@ -114,7 +114,7 @@ class MeasureBuildTimeTest(unittest.TestCase):
         proc, results = self._run_script('echo ok', ['--tests', 'null'])
 
         self.assertEqual(proc.returncode, 0)
-        tests = results['BuildTime-Unspecified']['tests']
+        tests = results['BuildTime-Debug']['tests']
         self.assertIn('null', tests)
         self.assertNotIn('clean', tests)
 
@@ -123,4 +123,4 @@ class MeasureBuildTimeTest(unittest.TestCase):
 
         self.assertEqual(proc.returncode, 0)
         self.assertIn('BuildTime-Release', results)
-        self.assertNotIn('BuildTime-Unspecified', results)
+        self.assertNotIn('BuildTime-Debug', results)


### PR DESCRIPTION
#### 79faca16c80186abdf56aae6dce97e1063398c92
<pre>
REGRESSION(313455@main): [webkitpy] test_clean_and_null_build, test_timing_summary_parsing, and   test_single_test_selection are constant failures
<a href="https://rdar.apple.com/177438385">rdar://177438385</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=315101">https://bugs.webkit.org/show_bug.cgi?id=315101</a>

Reviewed by Jonathan Bedard.

The follow-up commit 478a3cd61e64 made the metric key derive from --configuration (e.g. --configuration release -&gt;
BuildTime-Release). I&apos;ve updated the four stale BuildTime-Unspecified assertions to BuildTime-Debug (the new default).

* Tools/Scripts/webkitpy/scripts/measure_build_time_unittest.py:
(MeasureBuildTimeTest.test_clean_and_null_build):
(MeasureBuildTimeTest.test_timing_summary_parsing):
(MeasureBuildTimeTest):

Canonical link: <a href="https://commits.webkit.org/313499@main">https://commits.webkit.org/313499@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cf1ce5e8cebc3364a242c4f596e6ef75e3d937e5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163286 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36769 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29984 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172225 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119733 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165155 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37096 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36769 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126796 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/89389 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166245 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29065 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/146803 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107363 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/162607 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28111 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26758 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19927 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/138005 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24527 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174728 "Built successfully") | | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/26182 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135102 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36437 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30843 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135094 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37224 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146322 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99164 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24849 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30395 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/23167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35933 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35432 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1192 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35679 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35580 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->