### PR TITLE
Replace internals.settings.setStorageBlockingPolicy with WebKitTestRunner header in layout tests

### DIFF
--- a/LayoutTests/http/tests/cache/partitioned-cache-iframe.html
+++ b/LayoutTests/http/tests/cache/partitioned-cache-iframe.html
@@ -1,10 +1,10 @@
+<!-- webkit-test-runner [ StorageBlockingPolicy=1 ] -->
 <html>
 <head>
 <script>
 if (window.testRunner) {
     testRunner.dumpAsText();
     testRunner.waitUntilDone();
-    internals.settings.setStorageBlockingPolicy('BlockThirdParty');
 }
 
 var value = window.location.href.match(/\?value=([^&]*)/);
@@ -18,10 +18,8 @@ window.onmessage = function(event) {
             console.log("The cache is not properly partitioned");
         else
             console.log("PASS");
-        if (window.testRunner) {
+        if (window.testRunner)
             testRunner.notifyDone();
-            internals.settings.setStorageBlockingPolicy('AllowAll');
-        }
     } else
         window.location = "http://localhost:8000/cache/partitioned-cache-iframe.html?value=" + cachedValue;
 }

--- a/LayoutTests/http/tests/cache/partitioned-cache.html
+++ b/LayoutTests/http/tests/cache/partitioned-cache.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ StorageBlockingPolicy=1 ] -->
 <html>
 <head>
 <script>
@@ -5,7 +6,6 @@ if (window.testRunner) {
     testRunner.dumpAsText();
     testRunner.dumpChildFramesAsText();
     testRunner.waitUntilDone();
-    internals.settings.setStorageBlockingPolicy('BlockThirdParty');
 }
 
 document.location = "http://localhost:8000/cache/resources/partitioned-cache-loader.html";

--- a/LayoutTests/http/tests/cache/resources/partitioned-cache-loader.html
+++ b/LayoutTests/http/tests/cache/resources/partitioned-cache-loader.html
@@ -2,8 +2,6 @@
 <head>
 <script src="../../resources/js-test-pre.js"></script>
 <script>
-if (window.internals)
-    internals.settings.setStorageBlockingPolicy('BlockThirdParty');
 
 function setServerState(string)
 {
@@ -27,10 +25,8 @@ window.onload = function() {
     } else {
         console.log('Server state retrieved via a 3rd party resource (possibly a cached result, but it shouldn\'t be): "' + response + '"');
         shouldBeEqualToString('response',  document.domain);
-        if (window.testRunner) {
-            internals.settings.setStorageBlockingPolicy('AllowAll');
+        if (window.testRunner)
             testRunner.notifyDone();
-        }
     }
 }
 </script>

--- a/LayoutTests/http/tests/navigation/page-cache-pending-image-load-cache-partition.html
+++ b/LayoutTests/http/tests/navigation/page-cache-pending-image-load-cache-partition.html
@@ -1,4 +1,4 @@
-<!-- webkit-test-runner [ UsesBackForwardCache=true ] -->
+<!-- webkit-test-runner [ UsesBackForwardCache=true StorageBlockingPolicy=1 ] -->
 <!DOCTYPE html>
 <html>
 <body>
@@ -6,7 +6,6 @@
 <script>
 description('Tests that a page with a loading image goes into the page cache (with non-empty cache partition).');
 window.jsTestIsAsync = true;
-internals.settings.setStorageBlockingPolicy('BlockThirdParty');
 
 window.addEventListener("pageshow", function(event) {
     debug("pageshow - " + (event.persisted ? "" : "not ") + "from cache");

--- a/LayoutTests/http/tests/security/credentials-iframes.html
+++ b/LayoutTests/http/tests/security/credentials-iframes.html
@@ -1,8 +1,8 @@
+<!-- webkit-test-runner [ StorageBlockingPolicy=1 ] -->
 <script>
 if (window.testRunner) {
     testRunner.dumpAsText();
     testRunner.waitUntilDone();
-    internals.settings.setStorageBlockingPolicy('BlockThirdParty');
 }
 
 window.addEventListener("message", function (event) {

--- a/LayoutTests/http/tests/security/credentials-main-resource.html
+++ b/LayoutTests/http/tests/security/credentials-main-resource.html
@@ -1,8 +1,8 @@
+<!-- webkit-test-runner [ StorageBlockingPolicy=1 ] -->
 <script>
 if (window.testRunner) {
     testRunner.dumpAsText();
     testRunner.waitUntilDone();
-    internals.settings.setStorageBlockingPolicy('BlockThirdParty');
 }
 window.location = "http://testuser:testpass@127.0.0.1:8000/security/resources/credentials-main-resource.py";
 </script>

--- a/LayoutTests/http/tests/security/cross-origin-indexeddb.html
+++ b/LayoutTests/http/tests/security/cross-origin-indexeddb.html
@@ -1,24 +1,17 @@
+<!-- webkit-test-runner [ StorageBlockingPolicy=1 ] -->
 <!DOCTYPE html>
 <html>
 <head>
     <script>
-        var frames = 2;
         if (window.testRunner) {
             testRunner.dumpAsText();
             testRunner.dumpChildFramesAsText();
-            internals.settings.setStorageBlockingPolicy('BlockThirdParty');
-        }
-
-        function decrement() {
-            --frames;
-            if (!frames && window.testRunner)
-                internals.settings.setStorageBlockingPolicy('AllowAll');
         }
     </script>
 </head>
 <body>
     <p>Both frames can successfully open the database.</p>
-    <iframe src="http://localhost:8000/security/resources/cross-origin-iframe-for-indexeddb.html" onload="decrement()"></iframe>
-    <iframe src="http://127.0.0.1:8000/security/resources/cross-origin-iframe-for-indexeddb.html" onload="decrement()"></iframe>
+    <iframe src="http://localhost:8000/security/resources/cross-origin-iframe-for-indexeddb.html"></iframe>
+    <iframe src="http://127.0.0.1:8000/security/resources/cross-origin-iframe-for-indexeddb.html"></iframe>
 </body>
 </html>

--- a/LayoutTests/http/tests/security/cross-origin-local-storage-allowed.html
+++ b/LayoutTests/http/tests/security/cross-origin-local-storage-allowed.html
@@ -4,7 +4,6 @@
 if (window.testRunner) {
 	testRunner.dumpAsText();
 	testRunner.waitUntilDone();
-	internals.settings.setStorageBlockingPolicy('AllowAll');
 }
 
 function continueTest() {

--- a/LayoutTests/http/tests/security/cross-origin-session-storage-third-party-blocked.html
+++ b/LayoutTests/http/tests/security/cross-origin-session-storage-third-party-blocked.html
@@ -1,24 +1,17 @@
+<!-- webkit-test-runner [ StorageBlockingPolicy=1 ] -->
 <html>
 <head>
 <script>
-var frames = 2;
 if (window.testRunner) {
 	testRunner.dumpAsText();
 	testRunner.dumpChildFramesAsText();
-	internals.settings.setStorageBlockingPolicy('BlockThirdParty');
-}
-
-function decrement() {
-	--frames;
-	if (!frames && window.testRunner)
-		internals.settings.setStorageBlockingPolicy('AllowAll');
 }
 </script>
 </head>
 <body>
 <p>This iframe should not return any errors:</p>
-<iframe src="http://localhost:8000/security/resources/cross-origin-iframe-for-session-storage.html" onload="decrement()"></iframe>
+<iframe src="http://localhost:8000/security/resources/cross-origin-iframe-for-session-storage.html"></iframe>
 <p>This iframe should not return any errors:</p>
-<iframe src="http://127.0.0.1:8000/security/resources/cross-origin-iframe-for-session-storage.html" onload="decrement()"></iframe>
+<iframe src="http://127.0.0.1:8000/security/resources/cross-origin-iframe-for-session-storage.html"></iframe>
 </body>
 </html>

--- a/LayoutTests/http/tests/security/cross-origin-websql.html
+++ b/LayoutTests/http/tests/security/cross-origin-websql.html
@@ -1,24 +1,17 @@
+<!-- webkit-test-runner [ StorageBlockingPolicy=1 ] -->
 <html>
 <head>
 <script>
-var frames = 2;
 if (window.testRunner) {
 	testRunner.dumpAsText();
 	testRunner.dumpChildFramesAsText();
-	internals.settings.setStorageBlockingPolicy('BlockThirdParty');
-}
-
-function decrement() {
-	--frames;
-	if (!frames && window.testRunner)
-		internals.settings.setStorageBlockingPolicy('AllowAll');
 }
 </script>
 </head>
 <body>
 <p>This iframe should return a security error:</p>
-<iframe src="http://localhost:8000/security/resources/cross-origin-iframe-for-websql.html" onload="decrement()"></iframe>
+<iframe src="http://localhost:8000/security/resources/cross-origin-iframe-for-websql.html"></iframe>
 <p>This iframe should not return any errors:</p>
-<iframe src="http://127.0.0.1:8000/security/resources/cross-origin-iframe-for-websql.html" onload="decrement()"></iframe>
+<iframe src="http://127.0.0.1:8000/security/resources/cross-origin-iframe-for-websql.html"></iframe>
 </body>
 </html>

--- a/LayoutTests/http/tests/security/cross-origin-worker-indexeddb.html
+++ b/LayoutTests/http/tests/security/cross-origin-worker-indexeddb.html
@@ -1,3 +1,4 @@
+<!-- webkit-test-runner [ StorageBlockingPolicy=1 ] -->
 <!DOCTYPE html>
 <html>
 <head>
@@ -8,7 +9,6 @@ if (window.testRunner) {
     testRunner.dumpAsText();
     testRunner.dumpChildFramesAsText();
     testRunner.waitUntilDone();
-    internals.settings.setStorageBlockingPolicy('BlockThirdParty');
 }
 
 document.location = "resources/document-for-cross-origin-worker-indexeddb.html"

--- a/LayoutTests/http/tests/security/resources/document-for-cross-origin-worker-indexeddb.html
+++ b/LayoutTests/http/tests/security/resources/document-for-cross-origin-worker-indexeddb.html
@@ -6,10 +6,8 @@ var frames = 2;
 
 function decrement() {
     --frames;
-    if (!frames && window.testRunner) {
-        internals.settings.setStorageBlockingPolicy('AllowAll');
+    if (!frames && window.testRunner)
         testRunner.notifyDone();
-    }
 }
 
 window.onmessage = decrement;

--- a/LayoutTests/http/tests/security/resources/load-local-storage.html
+++ b/LayoutTests/http/tests/security/resources/load-local-storage.html
@@ -15,7 +15,6 @@ try {
 }
 
 if (window.testRunner) {
-	internals.settings.setStorageBlockingPolicy('AllowAll');
 	testRunner.notifyDone();
 }
 </script>

--- a/LayoutTests/http/tests/security/same-origin-document-domain-storage-allowed.html
+++ b/LayoutTests/http/tests/security/same-origin-document-domain-storage-allowed.html
@@ -1,24 +1,17 @@
+<!-- webkit-test-runner [ StorageBlockingPolicy=1 ] -->
 <html>
 <head>
 <script>
-var frames = 2;
 if (window.testRunner) {
 	testRunner.dumpAsText();
 	testRunner.dumpChildFramesAsText();
-	internals.settings.setStorageBlockingPolicy('BlockThirdParty');
-}
-
-function decrement() {
-	--frames;
-	if (!frames && window.testRunner)
-		internals.settings.setStorageBlockingPolicy('AllowAll');
 }
 </script>
 </head>
 <body>
 <p>This iframe should not return any errors:</p>
-<iframe src="http://127.0.0.1:8000/security/resources/cross-origin-iframe-for-local-storage.html" onload="decrement()"></iframe>
+<iframe src="http://127.0.0.1:8000/security/resources/cross-origin-iframe-for-local-storage.html"></iframe>
 <p>This iframe should not return any errors:</p>
-<iframe src="http://127.0.0.1:8000/security/resources/document-domain-iframe-for-local-storage.html" onload="decrement()"></iframe>
+<iframe src="http://127.0.0.1:8000/security/resources/document-domain-iframe-for-local-storage.html"></iframe>
 </body>
 </html>

--- a/LayoutTests/http/tests/security/same-origin-storage-blocked.html
+++ b/LayoutTests/http/tests/security/same-origin-storage-blocked.html
@@ -1,24 +1,17 @@
+<!-- webkit-test-runner [ StorageBlockingPolicy=2 ] -->
 <html>
 <head>
 <script>
-var frames = 2;
 if (window.testRunner) {
 	testRunner.dumpAsText();
 	testRunner.dumpChildFramesAsText();
-	internals.settings.setStorageBlockingPolicy('BlockAll');
-}
-
-function decrement() {
-	--frames;
-	if (!frames && window.testRunner)
-		internals.settings.setStorageBlockingPolicy('AllowAll');
 }
 </script>
 </head>
 <body>
 <p>This iframe should return a security error:</p>
-<iframe src="http://127.0.0.1:8000/security/resources/cross-origin-iframe-for-local-storage.html" onload="decrement()"></iframe>
+<iframe src="http://127.0.0.1:8000/security/resources/cross-origin-iframe-for-local-storage.html"></iframe>
 <p>This iframe should return a security error:</p>
-<iframe src="http://127.0.0.1:8000/security/resources/cross-origin-iframe-for-session-storage.html" onload="decrement()"></iframe>
+<iframe src="http://127.0.0.1:8000/security/resources/cross-origin-iframe-for-session-storage.html"></iframe>
 </body>
 </html>

--- a/LayoutTests/http/tests/security/same-origin-websql-blocked.html
+++ b/LayoutTests/http/tests/security/same-origin-websql-blocked.html
@@ -1,22 +1,15 @@
+<!-- webkit-test-runner [ StorageBlockingPolicy=2 ] -->
 <html>
 <head>
 <script>
-var frames = 1;
 if (window.testRunner) {
 	testRunner.dumpAsText();
 	testRunner.dumpChildFramesAsText();
-	internals.settings.setStorageBlockingPolicy('BlockAll');
-}
-
-function decrement() {
-	--frames;
-	if (!frames && window.testRunner)
-		internals.settings.setStorageBlockingPolicy('AllowAll');
 }
 </script>
 </head>
 <body>
 <p>This iframe should return a security error:</p>
-<iframe src="http://127.0.0.1:8000/security/resources/cross-origin-iframe-for-websql.html" onload="decrement()"></iframe>
+<iframe src="http://127.0.0.1:8000/security/resources/cross-origin-iframe-for-websql.html"></iframe>
 </body>
 </html>

--- a/LayoutTests/http/tests/security/sync-xhr-partition.html
+++ b/LayoutTests/http/tests/security/sync-xhr-partition.html
@@ -1,8 +1,8 @@
+<!-- webkit-test-runner [ StorageBlockingPolicy=1 ] -->
 <script>
 if (window.testRunner) {
     testRunner.dumpAsText();
     testRunner.waitUntilDone();
-    internals.settings.setStorageBlockingPolicy('BlockThirdParty');
 }
 var async = new XMLHttpRequest();
 async.onreadystatechange = function () {


### PR DESCRIPTION
#### 0e486e3ea438319749c102ae95e44fcc763f3795
<pre>
Replace internals.settings.setStorageBlockingPolicy with WebKitTestRunner header in layout tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=315103">https://bugs.webkit.org/show_bug.cgi?id=315103</a>
<a href="https://rdar.apple.com/177440049">rdar://177440049</a>

Reviewed by Per Arne Vollan.

internals.settings.setStorageBlockingPolicy only updates the storage blocking policy in the current web process. Under
Site Isolation, this means cross-site subframe processes and the network process do not receive the policy update,
leading to inconsistent behavior.

Replace runtime JavaScript calls with declarative &lt;!-- webkit-test-runner [ StorageBlockingPolicy=N ] --&gt; headers, which
set the policy via WebPreferences before the test begins and propagate it to all processes including the network process.

The four dynamic policy change tests (storage-blocking-loosened/strengthened-*) still use the internals API and will be
addressed separately.

* LayoutTests/http/tests/cache/partitioned-cache-iframe.html:
* LayoutTests/http/tests/cache/partitioned-cache.html:
* LayoutTests/http/tests/cache/resources/partitioned-cache-loader.html:
* LayoutTests/http/tests/navigation/page-cache-pending-image-load-cache-partition.html:
* LayoutTests/http/tests/security/credentials-iframes.html:
* LayoutTests/http/tests/security/credentials-main-resource.html:
* LayoutTests/http/tests/security/cross-origin-indexeddb.html:
* LayoutTests/http/tests/security/cross-origin-local-storage-allowed.html:
* LayoutTests/http/tests/security/cross-origin-session-storage-third-party-blocked.html:
* LayoutTests/http/tests/security/cross-origin-websql.html:
* LayoutTests/http/tests/security/cross-origin-worker-indexeddb.html:
* LayoutTests/http/tests/security/resources/document-for-cross-origin-worker-indexeddb.html:
* LayoutTests/http/tests/security/resources/load-local-storage.html:
* LayoutTests/http/tests/security/same-origin-document-domain-storage-allowed.html:
* LayoutTests/http/tests/security/same-origin-storage-blocked.html:
* LayoutTests/http/tests/security/same-origin-websql-blocked.html:
* LayoutTests/http/tests/security/sync-xhr-partition.html:

Canonical link: <a href="https://commits.webkit.org/313540@main">https://commits.webkit.org/313540@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d938b6d84473003b3350ea962f3511af25fb021

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163412 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36895 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30111 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172352 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119859 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37224 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36895 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126904 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/89453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166371 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29173 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146893 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107462 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/861a7b1b-879b-457b-86cc-08037d0adf19) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28219 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26849 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20054 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138114 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24616 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174856 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26297 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135206 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36565 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30949 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135192 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36442 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37350 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146411 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99306 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30497 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23256 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36061 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35558 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1281 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35806 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35706 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->