### PR TITLE
[WPE][GTK] Atlas textures use spec-violating glTexImage2D(internal=GL_RGBA, format=GL_BGRA), render black on strict GLES drivers

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaReplayAtlas.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaReplayAtlas.cpp
@@ -28,13 +28,14 @@
 
 #if USE(SKIA)
 
+#include "ColorSpaceSkia.h"
 #include "PlatformDisplay.h"
 #include "SkiaGPUAtlas.h"
-#include "SkiaUtilities.h"
 #include <wtf/TZoneMallocInlines.h>
 
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/gpu/ganesh/GrDirectContext.h>
+#include <skia/gpu/ganesh/SkImageGanesh.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 namespace WebCore {
@@ -61,7 +62,7 @@ std::unique_ptr<SkiaReplayAtlas> SkiaReplayAtlas::create(const SkiaGPUAtlas& gpu
     // The underlying GL texture was created on the main thread context but is
     // shareable via GL context sharing. However, the Skia SkImage wrapper is
     // context-specific and must be rewrapped for each worker's GrDirectContext.
-    auto rewrapped = SkiaUtilities::borrowBackendTextureAsImage(grContext, gpuAtlas.backendTexture());
+    auto rewrapped = SkImages::BorrowTextureFrom(grContext, gpuAtlas.backendTexture(), kTopLeft_GrSurfaceOrigin, kBGRA_8888_SkColorType, kPremul_SkAlphaType, sRGBColorSpaceSingleton());
     if (!rewrapped)
         return nullptr;
 

--- a/Source/WebCore/platform/graphics/skia/SkiaUtilities.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaUtilities.cpp
@@ -58,7 +58,8 @@ GrBackendTexture createBackendTexture(const BitmapTexture& texture)
     GrGLTextureInfo externalTexture;
     externalTexture.fTarget = GL_TEXTURE_2D;
     externalTexture.fID = texture.id();
-    externalTexture.fFormat = GL_RGBA8;
+    // EXT_texture_format_BGRA8888 (unsized form, matches BitmapTexture::textureFormat).
+    externalTexture.fFormat = texture.flags().contains(BitmapTexture::Flags::UseBGRALayout) ? GL_BGRA8_EXT : GL_RGBA8;
     return GrBackendTextures::MakeGL(texture.size().width(), texture.size().height(), skgpu::Mipmapped::kNo, externalTexture);
 }
 
@@ -76,11 +77,6 @@ sk_sp<SkImage> rewrapImageForContext(GrDirectContext* grContext, const SkImage& 
     if (!SkImages::GetBackendTextureFromImage(&image, &backendTexture, false))
         return nullptr;
     return SkImages::BorrowTextureFrom(grContext, backendTexture, kTopLeft_GrSurfaceOrigin, image.colorType(), image.alphaType(), image.refColorSpace());
-}
-
-sk_sp<SkImage> borrowBackendTextureAsImage(GrDirectContext* grContext, const GrBackendTexture& backendTexture, GrSurfaceOrigin origin)
-{
-    return SkImages::BorrowTextureFrom(grContext, backendTexture, origin, kRGBA_8888_SkColorType, kPremul_SkAlphaType, sRGBColorSpaceSingleton());
 }
 
 std::optional<unsigned> retrieveGLTextureID(const SkImage& image)

--- a/Source/WebCore/platform/graphics/skia/SkiaUtilities.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaUtilities.h
@@ -63,10 +63,6 @@ sk_sp<SkSurface> createSurface(GrDirectContext*, const BitmapTexture&, const SkS
 // original image's color type, alpha type, and color space.
 sk_sp<SkImage> rewrapImageForContext(GrDirectContext*, const SkImage&);
 
-// Wraps a GrBackendTexture as a non-owning SkImage for the given context,
-// using RGBA8, premultiplied alpha, and sRGB color space.
-sk_sp<SkImage> borrowBackendTextureAsImage(GrDirectContext*, const GrBackendTexture&, GrSurfaceOrigin = kTopLeft_GrSurfaceOrigin);
-
 // Extracts the GL texture ID from a GPU-backed SkImage, if available.
 std::optional<unsigned> retrieveGLTextureID(const SkImage&);
 

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
@@ -161,7 +161,9 @@ void BitmapTexture::createTexture()
 void BitmapTexture::allocateTexture()
 {
     createTexture();
-    glTexImage2D(m_renderTarget, 0, GL_RGBA, m_size.width(), m_size.height(), 0, textureFormat(), s_pixelDataType, nullptr);
+    // EXT_texture_format_BGRA8888 mandates internalFormat == format.
+    // https://registry.khronos.org/OpenGL/extensions/EXT/EXT_texture_format_BGRA8888.txt
+    glTexImage2D(m_renderTarget, 0, textureFormat(), m_size.width(), m_size.height(), 0, textureFormat(), s_pixelDataType, nullptr);
 }
 
 size_t BitmapTexture::sizeInBytes() const
@@ -297,7 +299,7 @@ void BitmapTexture::reset(const IntSize& size, OptionSet<Flags> flags)
 #endif
 
     glBindTexture(m_renderTarget, m_id);
-    glTexImage2D(m_renderTarget, 0, GL_RGBA, m_size.width(), m_size.height(), 0, textureFormat(), s_pixelDataType, nullptr);
+    glTexImage2D(m_renderTarget, 0, textureFormat(), m_size.width(), m_size.height(), 0, textureFormat(), s_pixelDataType, nullptr);
     glBindTexture(m_renderTarget, boundTexture);
 }
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferExternalOES.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferExternalOES.cpp
@@ -41,7 +41,7 @@
 #endif
 
 #if USE(SKIA)
-#include "SkiaUtilities.h"
+#include "ColorSpaceSkia.h"
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkColorSpace.h>
 #include <skia/core/SkImage.h>
@@ -184,7 +184,7 @@ sk_sp<SkImage> CoordinatedPlatformLayerBufferExternalOES::skiaImage()
     externalTexture.fID = m_textureID;
     externalTexture.fFormat = GL_RGBA8;
     auto backendTexture = GrBackendTextures::MakeGL(m_size.width(), m_size.height(), skgpu::Mipmapped::kNo, externalTexture);
-    return SkiaUtilities::borrowBackendTextureAsImage(grContext, backendTexture);
+    return SkImages::BorrowTextureFrom(grContext, backendTexture, kTopLeft_GrSurfaceOrigin, kRGBA_8888_SkColorType, kPremul_SkAlphaType, sRGBColorSpaceSingleton());
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.cpp
@@ -33,7 +33,7 @@
 #include "TextureMapper.h"
 
 #if USE(SKIA)
-#include "SkiaUtilities.h"
+#include "ColorSpaceSkia.h"
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkColorFilter.h>
 #include <skia/core/SkColorSpace.h>
@@ -95,7 +95,7 @@ sk_sp<SkImage> CoordinatedPlatformLayerBufferRGB::skiaImage()
     externalTexture.fFormat = GL_RGBA8;
     auto backendTexture = GrBackendTextures::MakeGL(m_size.width(), m_size.height(), skgpu::Mipmapped::kNo, externalTexture);
     auto origin = m_flags.contains(TextureMapperFlags::ShouldFlipTexture) ? kBottomLeft_GrSurfaceOrigin : kTopLeft_GrSurfaceOrigin;
-    return SkiaUtilities::borrowBackendTextureAsImage(grContext, backendTexture, origin);
+    return SkImages::BorrowTextureFrom(grContext, backendTexture, origin, kRGBA_8888_SkColorType, kPremul_SkAlphaType, sRGBColorSpaceSingleton());
 }
 #endif
 


### PR DESCRIPTION
#### 1f31db09ec641ff29a50e4ab208d9e4adf44ab36
<pre>
[WPE][GTK] Atlas textures use spec-violating glTexImage2D(internal=GL_RGBA, format=GL_BGRA), render black on strict GLES drivers
<a href="https://bugs.webkit.org/show_bug.cgi?id=314719">https://bugs.webkit.org/show_bug.cgi?id=314719</a>

Reviewed by Nikolas Zimmermann.

SkiaGPUAtlas allocates BitmapTextures with UseBGRALayout, intended to give
them GL_BGRA storage. BitmapTexture uploaded them via
glTexImage2D(internal=GL_RGBA, format=GL_BGRA), which is undefined per
EXT_texture_format_BGRA8888 — the spec mandates internalFormat == format.
Mesa accepts it (TextureMapper&apos;s shaders swizzle BGRA→RGBA at sample time);
Adreno rejects every upload with GL_INVALID_OPERATION, leaving the atlas
texture undefined and rendering solid-black photos after a scroll burst.

Pass textureFormat() for both internalFormat and format in glTexImage2D so
UseBGRALayout textures upload as format=GL_BGRA. On the Skia side,
declare fFormat=GL_BGRA8_EXT on the GrBackendTexture for UseBGRALayout textures.
Tile textures (createBuffer) don&apos;t have UseBGRALayout, so they remain
GL_RGBA — no-op.

Drop the helper borrowBackendTextureAsImage and inline SkImages::BorrowTextureFrom
at each call site with the SkColorType matching that site&apos;s backend texture.

* Source/WebCore/platform/graphics/skia/SkiaReplayAtlas.cpp:
(WebCore::SkiaReplayAtlas::create): Inline SkImages::BorrowTextureFrom with
kBGRA_8888_SkColorType (atlas has UseBGRALayout).
* Source/WebCore/platform/graphics/skia/SkiaUtilities.cpp:
(WebCore::SkiaUtilities::createBackendTexture): Declare fFormat=GL_BGRA for
UseBGRALayout textures.
(WebCore::SkiaUtilities::borrowBackendTextureAsImage): Deleted.
* Source/WebCore/platform/graphics/skia/SkiaUtilities.h: Drop
borrowBackendTextureAsImage declaration.
* Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp:
(WebCore::BitmapTexture::allocateTexture): Use textureFormat() for both internalFormat and format.
(WebCore::BitmapTexture::reset): Same.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferExternalOES.cpp:
(WebCore::CoordinatedPlatformLayerBufferExternalOES::skiaImage): Inline
SkImages::BorrowTextureFrom with kRGBA_8888_SkColorType (backend is GL_RGBA8).
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.cpp:
(WebCore::CoordinatedPlatformLayerBufferRGB::skiaImage): Inline

SkImages::BorrowTextureFrom with kRGBA_8888_SkColorType (backend is GL_RGBA8).
Canonical link: <a href="https://commits.webkit.org/313653@main">https://commits.webkit.org/313653@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9d1fbfe7441b3eefd243885b218da757a9da5953

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163294 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36777 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29992 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172233 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119741 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165163 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37104 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36777 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126803 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89395 "1 flakes 4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166253 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29071 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146793 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107370 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28117 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26747 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19935 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138011 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24517 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174737 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27250 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26172 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135109 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36445 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30849 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135101 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37232 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146312 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99174 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24921 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30401 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23157 "Too many flaky failures: http/tests/contentextensions/two-distinguishable-css-display-none-rules-on-main-resource.html, http/tests/media/clearkey/collect-webkit-media-session.html, http/tests/misc/object-image-error-with-onload.html, http/tests/navigation/redirect-to-random-url-versus-memory-cache.html, http/tests/resourceLoadStatistics/only-accept-first-party-cookies-with-third-party-cookie-blocking.html, http/tests/security/canvas-remote-read-remote-image-allowed-with-credentials.html, http/tests/security/contentSecurityPolicy/1.1/scriptnonce-allowed-by-enforced-policy-and-blocked-by-report-policy2.py, http/tests/security/contentSecurityPolicy/register-bypassing-scheme.html, http/tests/security/mixedContent/redirect-https-to-http-image-secure-cookies-UpgradeMixedContent.html, http/tests/site-isolation/frame-index.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35941 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108689 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35440 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1182 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35687 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35588 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->