### PR TITLE
[WebKit] Prefer non-SuspendedPageProxy entries during WebBackForwardCache capacity eviction

### DIFF
--- a/Source/WebKit/UIProcess/WebBackForwardCache.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardCache.cpp
@@ -65,6 +65,34 @@ void WebBackForwardCache::deref() const
 inline void WebBackForwardCache::removeOldestEntry()
 {
     ASSERT(!m_itemsWithCachedPage.isEmptyIgnoringNullReferences());
+
+    // Prefer to evict non-SuspendedPageProxy entries first. SPP-bearing entries
+    // hold a process-suspended cross-site cached page that gets consumed by
+    // takeSuspendedPage during back/forward navigation; capacity-based
+    // eviction would close the cached process and lose the cached state
+    // before the user can navigate to it. Other entries carry only frame
+    // metadata and can be safely evicted — the underlying
+    // WebCore::BackForwardCache entry lives in the WebProcess and only has
+    // its own per-process capacity limit to honor.
+    RefPtr<WebBackForwardListItem> oldestNonSuspendedEntry;
+    for (RefPtr item : m_itemsWithCachedPage) {
+        RefPtr entry = item->backForwardCacheEntry();
+        if (entry && !entry->suspendedPage()) {
+            oldestNonSuspendedEntry = item;
+            break;
+        }
+    }
+    if (oldestNonSuspendedEntry) {
+        m_itemsWithCachedPage.remove(*oldestNonSuspendedEntry);
+        oldestNonSuspendedEntry->setBackForwardCacheEntry(nullptr);
+        return;
+    }
+
+    // Fallback: every entry holds an SPP. Surface this so SPP leaks (entries
+    // whose target navigation never consumed them) become visible. Under
+    // normal navigation patterns SPPs are short-lived, so a frequent fallback
+    // is a smell worth tracing.
+    RELEASE_LOG_ERROR(BackForwardCache, "WebBackForwardCache::removeOldestEntry: evicting an SPP-bearing entry because no non-SPP entries are available; this may indicate an SPP that was never consumed");
     if (RefPtr item = m_itemsWithCachedPage.tryTakeFirst())
         item->setBackForwardCacheEntry(nullptr);
 }


### PR DESCRIPTION
#### e123859e8e807c8eab455de07abc2bce38d61e91
<pre>
[WebKit] Prefer non-SuspendedPageProxy entries during WebBackForwardCache capacity eviction
<a href="https://bugs.webkit.org/show_bug.cgi?id=315102">https://bugs.webkit.org/show_bug.cgi?id=315102</a>
<a href="https://rdar.apple.com/177439386">rdar://177439386</a>

Reviewed by NOBODY (OOPS!).

WebBackForwardCache::removeOldestEntry currently evicts the oldest entry in
m_itemsWithCachedPage regardless of whether it carries a SuspendedPageProxy. Under capacity
pressure this can close a process-suspended cross-site cached page before it has a chance to
be consumed via takeSuspendedPage on a back/forward navigation, regressing cross-site BFCache
restoration.

Change the eviction policy to prefer entries without a SuspendedPageProxy, falling back to
the oldest entry only when every entry holds an SPP. SPP-bearing entries hold per-process
cached state that is meant to be consumed at navigation time; other entries carry only frame
metadata and can be safely evicted — the underlying WebCore::BackForwardCache entry lives in
the WebProcess and only has its own per-process capacity limit to honor.

The SPP-only fallback is reported via RELEASE_LOG_ERROR. Under normal navigation patterns
SPPs are short-lived (they get consumed at the target back/forward navigation), so a frequent
fallback firing is a smell worth tracing.

Foundational change for ongoing work to broaden same-site BFCache coverage under Site
Isolation; the larger architectural changes are tracked under <a href="https://rdar.apple.com/175857874">rdar://175857874</a>.

No new tests (existing SiteIsolation BFCache coverage exercises the mixed-entry capacity
scenarios).

* Source/WebKit/UIProcess/WebBackForwardCache.cpp:
(WebKit::WebBackForwardCache::removeOldestEntry):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3b256122cb1bb294b7f2d9d6f6b8d866540ba174

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163297 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36780 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/29995 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/172236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/119744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/722f4c6a-f5e9-4531-ad4f-463e621378be) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37107 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36780 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/172236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/119744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/204d7014-587a-4cc3-80e1-5fa85c53c173) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166256 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/29075 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/146798 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/172236 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b458e4ed-127b-440c-9c12-411035ebaa86) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28121 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26752 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/19938 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/138015 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/174740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/27286 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/26177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/174740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36448 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30854 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/174740 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/37235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/146317 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99177 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/37235 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/23162 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35944 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108709 "Built successfully") | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/35443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/1187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35690 "Built successfully") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/35591 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->