### PR TITLE
[WebKit] Skip evicting sole holders of a SuspendedPageProxy during WebBackForwardCache capacity eviction

### DIFF
--- a/Source/WebKit/UIProcess/WebBackForwardCache.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardCache.cpp
@@ -36,6 +36,7 @@
 #include "WebProcessPool.h"
 #include "WebProcessProxy.h"
 #include "WebsiteDataStore.h"
+#include <wtf/HashSet.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
@@ -65,6 +66,53 @@ void WebBackForwardCache::deref() const
 inline void WebBackForwardCache::removeOldestEntry()
 {
     ASSERT(!m_itemsWithCachedPage.isEmptyIgnoringNullReferences());
+
+    // Walk the list in insertion order looking for an entry whose loss does
+    // not terminate a cached process. Two kinds of entry qualify:
+    //   - An entry without a SuspendedPageProxy: there is no cached process
+    //     to keep alive in the first place.
+    //   - A non-first holder of a SuspendedPageProxy already recorded in
+    //     oldestItems: SPPs are shared across entries in the same process
+    //     (see addEntry(item, Ref<SuspendedPageProxy>&&)), so the previously
+    //     recorded first holder shares its SPP with this entry and is safe
+    //     to evict — the SPP stays alive on this entry and the process is
+    //     not closed.
+    // Returning the first holder rather than the current item preserves the
+    // "oldest" semantic for the SPP-shared case: when we discover a duplicate
+    // at position p, the recorded first holder is at some position p' < p.
+    // Single pass with O(1) HashMap lookups, so the policy is O(N) overall.
+    HashMap<SuspendedPageProxy*, WebBackForwardListItem*> oldestItems;
+    auto findEvictableItem = [&oldestItems] (WebBackForwardListItem& item) -> WebBackForwardListItem* {
+        RefPtr entry = item.backForwardCacheEntry();
+        if (!entry)
+            return nullptr;
+
+        RefPtr suspendedPage = entry->suspendedPage();
+        if (!suspendedPage)
+            return &item;
+    
+        if (auto result = oldestItems.add(suspendedPage.get(), &item); !result.isNewEntry) {
+            ASSERT(result.iterator->value);
+            return result.iterator->value;
+        }
+
+        return nullptr;
+    };
+
+    for (auto& item : m_itemsWithCachedPage) {
+        if (RefPtr evictableItem = findEvictableItem(item)) {
+            m_itemsWithCachedPage.remove(*evictableItem);
+            evictableItem->setBackForwardCacheEntry(nullptr);
+            return;
+        }
+    }
+
+    // Fallback: every entry holds an exclusively-owned SuspendedPageProxy.
+    // Surface this so SPP leaks (entries whose target navigation never
+    // consumed them) become visible. Under normal navigation patterns SPPs
+    // are short-lived, so a frequent fallback firing is a smell worth
+    // tracing.
+    RELEASE_LOG_ERROR(BackForwardCache, "WebBackForwardCache::removeOldestEntry: every entry holds an exclusive SuspendedPageProxy; evicting the oldest, which will close a cached process. This may indicate an SPP that was never consumed.");
     if (RefPtr item = m_itemsWithCachedPage.tryTakeFirst())
         item->setBackForwardCacheEntry(nullptr);
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -9028,4 +9028,70 @@ TEST(SiteIsolation, MultiProcessBFCacheSameSiteNavAfterRestore)
     }
 }
 
+TEST(SiteIsolation, MultiProcessBFCacheSuspendedPageProxySurvivesCapacityPressure)
+{
+    // Capacity-based eviction in WebBackForwardCache should not close a
+    // process-suspended cross-site cached page (held by a SuspendedPageProxy
+    // with no other holder) when an evictable entry exists in the cache.
+    //
+    // SPPs are shared across entries in the same process, so a same-site
+    // cached page in a process that later acquires an SPP becomes
+    // "SPP-shared" — its eviction does not terminate the cached process and
+    // is therefore preferable over evicting the sole holder of an SPP for a
+    // different process.
+    //
+    // Sequence (capacity = 2 in tests):
+    //   1. Load a.com/a              entries: []
+    //   2. Load b.com/b1 cross-site  entries: [a(SPP_a)]
+    //   3. Load b.com/b2 same-site   entries: [a(SPP_a), b1]   (b1 non-SPP)
+    //   4. Load c.com/c cross-site
+    //      - SPP_b created for b's process; b1 receives SPP_b via sharing.
+    //      - addEntry pushes capacity to 3 → eviction.
+    //        ・Naive FIFO would evict a (oldest, sole holder of SPP_a)
+    //          and close a's process, losing a's BFCache state.
+    //        ・The share-aware policy walks for an entry whose loss is
+    //          non-fatal: a is sole-holder (skip), b1 shares SPP_b with b2
+    //          (evictable). b1 is evicted; a's SPP_a is preserved.
+    //
+    // Going back through c → b2 → b1 → a, the BFCache marker installed on a
+    // before any navigation must survive only if a's SuspendedPageProxy was
+    // not evicted.
+    HTTPServer server({
+        { "/a"_s, { "page a"_s } },
+        { "/b1"_s, { "page b1"_s } },
+        { "/b2"_s, { "page b2"_s } },
+        { "/c"_s, { "page c"_s } }
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    auto *configuration = server.httpsProxyConfiguration();
+    enableFeature(configuration, @"MultiProcessBackForwardCacheEnabled");
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://a.com/a"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    [webView objectByEvaluatingJavaScript:@"window.__bfcacheMarker_a = true"];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://b.com/b1"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://b.com/b2"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://c.com/c"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigation];
+    EXPECT_WK_STREQ(@"https://b.com/b2", [webView URL].absoluteString);
+
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigation];
+    EXPECT_WK_STREQ(@"https://b.com/b1", [webView URL].absoluteString);
+
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigation];
+    EXPECT_WK_STREQ(@"https://a.com/a", [webView URL].absoluteString);
+    EXPECT_TRUE([[webView objectByEvaluatingJavaScript:@"window.__bfcacheMarker_a ? true : false"] boolValue]);
+}
+
 }


### PR DESCRIPTION
#### 357639fff6390bdd37744a9d805733af82feb4ac
<pre>
[WebKit] Skip evicting sole holders of a SuspendedPageProxy during WebBackForwardCache capacity eviction
<a href="https://bugs.webkit.org/show_bug.cgi?id=315102">https://bugs.webkit.org/show_bug.cgi?id=315102</a>
<a href="https://rdar.apple.com/177439386">rdar://177439386</a>

Reviewed by NOBODY (OOPS!).

WebBackForwardCache::removeOldestEntry currently evicts the oldest entry in
m_itemsWithCachedPage with no regard for the SuspendedPageProxy graph. Under capacity
pressure this can close a process-suspended cross-site cached page before it has a chance
to be consumed via takeSuspendedPage on a back/forward navigation, regressing cross-site
BFCache restoration.

Change the eviction policy to walk for the oldest entry whose loss does not terminate a
cached process. An entry is safe to evict when it either (a) has no SuspendedPageProxy, or
(b) shares its SPP with another entry in the cache so the process stays alive after this
entry is dropped. SPPs are shared across entries in the same process (see
addEntry(item, Ref&lt;SuspendedPageProxy&gt;&amp;&amp;)), so a same-site cached page in a process that
later acquires an SPP becomes &quot;SPP-shared&quot;; both no-SPP and SPP-shared entries are
evictable without closing a cached process. Only entries that solely hold an SPP are
preserved.

The all-sole-holders fallback path is reported via RELEASE_LOG_ERROR. Under normal
navigation patterns SPPs are short-lived (they get consumed at the target back/forward
navigation), so a frequent fallback firing is a smell worth tracing.

Without this change, a four-page navigation that mixes cross-site and same-site
transitions (a.com → b.com/b1 → b.com/b2 → c.com/c at capacity 2) loses a&apos;s BFCache state
because the oldest entry — a&apos;s sole-SPP holder — is evicted to make room for c&apos;s entry,
even though b1 (whose SPP is shared with b2) is the obvious eviction candidate.

* Source/WebKit/UIProcess/WebBackForwardCache.cpp:
(WebKit::WebBackForwardCache::isEntryEvictable const):
(WebKit::WebBackForwardCache::removeOldestEntry):
* Source/WebKit/UIProcess/WebBackForwardCache.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TEST(SiteIsolation, MultiProcessBFCacheSuspendedPageProxySurvivesCapacityPressure)):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/357639fff6390bdd37744a9d805733af82feb4ac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163352 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36835 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30050 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172291 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/119799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165221 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37162 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36835 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126852 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/119799 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166311 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29122 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146845 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107419 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28168 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26800 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19993 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138063 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24569 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174795 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27396 "Found 1 new failure in UIProcess/WebBackForwardCache.cpp") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26225 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135160 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36504 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30899 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135151 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37290 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146364 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99244 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30448 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23209 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36000 "Built successfully") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108841 "Found 1 new failure in UIProcess/WebBackForwardCache.cpp") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35498 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1234 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35746 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35646 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->