### PR TITLE
Dynamic import() in srcdoc iframes fails to resolve absolute paths against document base URL

### DIFF
--- a/LayoutTests/http/tests/misc/import-from-srcdoc-iframe-absolute-path-expected.txt
+++ b/LayoutTests/http/tests/misc/import-from-srcdoc-iframe-absolute-path-expected.txt
@@ -1,0 +1,10 @@
+Dynamic import() of an absolute path from a srcdoc iframe should resolve against the document fallback base URL.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS result is "loaded"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/misc/import-from-srcdoc-iframe-absolute-path.html
+++ b/LayoutTests/http/tests/misc/import-from-srcdoc-iframe-absolute-path.html
@@ -1,0 +1,33 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<meta charset="UTF-8">
+<script src="/js-test-resources/js-test-pre.js"></script>
+</head>
+<body>
+<script>
+description('Dynamic import() of an absolute path from a srcdoc iframe should resolve against the document fallback base URL.');
+window.jsTestIsAsync = true;
+
+window.result = "";
+window.addEventListener("message", e => {
+    window.result = e.data;
+    shouldBeEqualToString("result", "loaded");
+    finishJSTest();
+});
+
+const iframe = document.createElement("iframe");
+iframe.srcdoc = `<!DOCTYPE html><html><head>
+  <script type="module">
+    try {
+      await import("/misc/resources/module-srcdoc-absolute.js");
+    } catch (e) {
+      parent.postMessage("error: " + e.message, "*");
+    }
+  <\/script>
+</head><body></body></html>`;
+document.body.appendChild(iframe);
+</script>
+<script src="/js-test-resources/js-test-post.js"></script>
+</body>
+</html>

--- a/LayoutTests/http/tests/misc/resources/module-srcdoc-absolute.js
+++ b/LayoutTests/http/tests/misc/resources/module-srcdoc-absolute.js
@@ -1,0 +1,1 @@
+parent.postMessage("loaded", "*");

--- a/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
+++ b/Source/WebCore/bindings/js/ScriptModuleLoader.cpp
@@ -102,9 +102,16 @@ static Expected<URL, String> resolveModuleSpecifier(ScriptExecutionContext& cont
 {
     // https://html.spec.whatwg.org/multipage/webappapis.html#resolve-a-module-specifier
 
-    URL result = importMap.resolve(specifier, ownerType == ScriptModuleLoader::OwnerType::Document ? downcast<Document>(context).baseURLForComplete(originalBaseURL) : originalBaseURL);
-    if (result.isNull())
+    auto* document = ownerType == ScriptModuleLoader::OwnerType::Document ? &downcast<Document>(context) : nullptr;
+    URL result = importMap.resolve(specifier, document ? document->baseURLForComplete(originalBaseURL) : originalBaseURL);
+    if (result.isNull()) {
+        if (document && originalBaseURL.isAboutSrcDoc()) {
+            result = importMap.resolve(specifier, document->fallbackBaseURL());
+            if (!result.isNull())
+                return result;
+        }
         return makeUnexpected(makeString("Module name, '"_s, specifier, "' does not resolve to a valid URL."_s));
+    }
     return result;
 }
 


### PR DESCRIPTION
#### fbe1369d2a980390c45ef0584ecb3780886ec71b
<pre>
Dynamic import() in srcdoc iframes fails to resolve absolute paths against document base URL
<a href="https://bugs.webkit.org/show_bug.cgi?id=314175">https://bugs.webkit.org/show_bug.cgi?id=314175</a>
<a href="https://rdar.apple.com/176334107">rdar://176334107</a>

Reviewed by Yusuke Suzuki.

This patch allows module specifier resolution to use the document&apos;s fallback base URL
if the original base URL is `about:srcdoc`.

Test: LayoutTests/http/tests/misc/import-from-srcdoc-iframe-absolute-path.html

* LayoutTests/http/tests/misc/import-from-srcdoc-iframe-absolute-path-expected.txt: Added.
* LayoutTests/http/tests/misc/import-from-srcdoc-iframe-absolute-path.html: Added.
* LayoutTests/http/tests/misc/resources/module-srcdoc-absolute.js: Added.
* Source/WebCore/bindings/js/ScriptModuleLoader.cpp:
(WebCore::resolveModuleSpecifier):

Canonical link: <a href="https://commits.webkit.org/314063@main">https://commits.webkit.org/314063@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1a08743e5a114f3820a2842ad1f1ea0c0075a421

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164510 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37994 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31565 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173540 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121762 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f5afdb2e-7a01-4ac2-91a1-da905a37f2ad) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166379 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38328 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37996 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127827 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89989 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/29266e80-d1f7-4116-a8cd-242247a5f839) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167469 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30129 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147866 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108372 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b68b7c94-eb4d-45bb-9ce5-74b0b358362e) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29176 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27802 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21303 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139079 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25582 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176066 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28889 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27250 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136144 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38063 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31924 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136109 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36788 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38753 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147377 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100905 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31398 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24233 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37261 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110305 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36659 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2294 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36907 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36807 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->