### PR TITLE
Use protect() instead of RefPtr { } in style code

### DIFF
--- a/Source/WebCore/style/StyleScope.cpp
+++ b/Source/WebCore/style/StyleScope.cpp
@@ -181,7 +181,7 @@ auto Scope::makeResolverSharingKey() -> ResolverSharingKey
 {
     constexpr bool isNonEmptyHashTableValue = true;
     return {
-        m_activeStyleSheets.map([&](auto& sheet) { return RefPtr { &sheet->contents() }; }),
+        m_activeStyleSheets.map([&](auto& sheet) { return protect(&sheet->contents()); }),
         isForUserAgentShadowTree(),
         isNonEmptyHashTableValue
     };

--- a/Source/WebCore/style/values/anchor-position/StylePositionTryFallback.cpp
+++ b/Source/WebCore/style/values/anchor-position/StylePositionTryFallback.cpp
@@ -151,7 +151,7 @@ auto CSSValueConversion<PositionTryFallback>::operator()(BuilderState& state, co
 
 static Ref<CSSValue> computedPositionAreaValue(const PositionTryFallback::PositionArea& value)
 {
-    RefPtr cssValue = RefPtr { value.properties }->getPropertyCSSValue(CSSPropertyPositionArea);
+    RefPtr cssValue = protect(value.properties)->getPropertyCSSValue(CSSPropertyPositionArea);
     if (auto* pair = dynamicDowncast<CSSValuePair>(*cssValue)) {
         auto dim1 = downcast<CSSKeywordValue>(pair->first()).valueID();
         auto dim2 = downcast<CSSKeywordValue>(pair->second()).valueID();
@@ -176,7 +176,7 @@ void Serialize<PositionTryFallback::PositionArea>::operator()(StringBuilder& bui
 
 TextStream& operator<<(TextStream& ts, const PositionTryFallback::PositionArea& value)
 {
-    return ts << RefPtr { value.properties }->getPropertyValue(CSSPropertyPositionArea);
+    return ts << protect(value.properties)->getPropertyValue(CSSPropertyPositionArea);
 }
 
 } // namespace Style


### PR DESCRIPTION
#### f2001e5dbc70f67dc6c12639a20769d87cd5a70f
<pre>
Use protect() instead of RefPtr { } in style code
<a href="https://bugs.webkit.org/show_bug.cgi?id=315113">https://bugs.webkit.org/show_bug.cgi?id=315113</a>
<a href="https://rdar.apple.com/177450429">rdar://177450429</a>

Reviewed by Ryosuke Niwa.

Mechanical migration from brace-initialized RefPtr temporaries to the
protect() free function in Source/WebCore/style, aligning with the
codebase-wide transition. Follow-up to PR #64895 (which converted the
Ref { } instances in the same directory).

All three sites are inline temporaries / return values, which the protect()
free function handles directly.

No new tests needed (no behavioral change, style-only refactor).

* Source/WebCore/style/StyleScope.cpp:
(WebCore::Style::Scope::makeResolverSharingKey):
* Source/WebCore/style/values/anchor-position/StylePositionTryFallback.cpp:
(WebCore::Style::computedPositionAreaValue):
(WebCore::Style::operator&lt;&lt;):

Canonical link: <a href="https://commits.webkit.org/313612@main">https://commits.webkit.org/313612@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/41b4237ce4dbf90096a8b94d361299f9f2daf265

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163314 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36797 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30012 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172253 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119761 "Built successfully") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/950ad6c8-88b6-4aa5-a34b-4057f956b1ef) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165183 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37124 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36797 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126821 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89408 "1 flakes 2 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7eecc3d8-5852-40ac-baf4-49606f14fe50) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166273 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29092 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146818 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107388 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28138 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26770 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19955 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138033 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24542 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174757 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27341 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26198 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135127 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36465 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30869 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135119 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36481 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37252 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146337 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99200 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30418 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23182 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35961 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108773 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35460 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1207 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35707 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35608 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->