### PR TITLE
[GTK][WPE] Fix crash in SkiaGLContext destructor when EGL is torn down during process exit

### DIFF
--- a/Source/WebCore/platform/graphics/egl/GLContext.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLContext.cpp
@@ -451,6 +451,9 @@ GLContext::GLContext(GLDisplay& display, EGLContext context, EGLSurface surface,
 
 GLContext::~GLContext()
 {
+    if (m_abandoned)
+        return;
+
     if (auto display = m_display.get()) {
         EGLDisplay eglDisplay = display->eglDisplay();
         if (m_context) {

--- a/Source/WebCore/platform/graphics/egl/GLContext.h
+++ b/Source/WebCore/platform/graphics/egl/GLContext.h
@@ -94,6 +94,7 @@ public:
     WEBCORE_EXPORT bool makeContextCurrent();
     bool unmakeContextCurrent();
     WEBCORE_EXPORT void swapBuffers();
+    void abandonContext() { m_abandoned = true; }
     GCGLContext platformContext() const;
 
     struct GLExtensions {
@@ -179,6 +180,7 @@ private:
     mutable unsigned m_version { 0 };
     EGLContext m_context { nullptr };
     EGLSurface m_surface { nullptr };
+    bool m_abandoned { false };
     EGLConfig m_config { nullptr };
 #if USE(WPE_RENDERER)
     struct wpe_renderer_backend_egl_offscreen_target* m_wpeTarget { nullptr };

--- a/Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp
@@ -244,7 +244,9 @@ public:
     ~SkiaGLContext()
     {
         if (m_skiaGLContext) {
-            m_skiaGLContext->makeContextCurrent();
+            if (m_skiaGrContext)
+                m_skiaGrContext->abandonContext();
+            m_skiaGLContext->abandonContext();
             m_skiaGrContext = nullptr;
             m_skiaGLContext = nullptr;
         }


### PR DESCRIPTION
#### 2050696d5cd1db7c84ef7567d28ce5d3b79d0ce1
<pre>
[GTK][WPE] Fix crash in SkiaGLContext destructor when EGL is torn down during process exit
<a href="https://bugs.webkit.org/show_bug.cgi?id=315115">https://bugs.webkit.org/show_bug.cgi?id=315115</a>

When a Web Process exits, painting worker threads may still be alive
when the main thread&apos;s exit() atexit chain reaches libEGL&apos;s cleanup
handler and begins unloading the GL/EGL driver stack via dlclose().
If a worker thread&apos;s TLS destructor fires for s_skiaGLContext at this
point, the SkiaGLContext destructor makes GL and EGL calls into a
driver that is mid-teardown, causing a SIGSEGV.

The crash manifests in two layers:
- GrGLGpu::onSubmitToGpu() in libgallium, triggered by
  GrDirectContext::~GrDirectContext() flushing pending GPU work.
- eglDestroyContext()/eglDestroySurface() in libEGL_mesa, triggered
  by GLContext::~GLContext() cleaning up EGL resources.

In both cases eglMakeCurrent() may still succeed at the start of the
destructor (the race window hasn&apos;t closed yet), so guarding on its
return value is insufficient.

Fix this by unconditionally abandoning both contexts before
destruction:

- Call GrDirectContext::abandonContext() before destroying the
  GrDirectContext. This marks all GPU resources as lost and prevents
  any GL commands from being issued during destruction.
- Add GLContext::abandonContext() which sets a flag causing
  GLContext::~GLContext() to return early, skipping all EGL cleanup
  calls that would crash against the partially-unloaded driver.

The EGL context and surface are not explicitly destroyed in the
abandoned path, but they are recovered when eglTerminate() is called
on display shutdown (normal exit) or by the OS (process exit).

* Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp:
  (WebCore::SkiaGLContext::~SkiaGLContext): Abandon GrDirectContext
  and GLContext before nulling the pointers, unconditionally.
* Source/WebCore/platform/graphics/egl/GLContext.h:
  (WebCore::GLContext::abandonContext): Added.
* Source/WebCore/platform/graphics/egl/GLContext.cpp:
  (WebCore::GLContext::~GLContext): Return early if abandoned.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2050696d5cd1db7c84ef7567d28ce5d3b79d0ce1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163320 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36803 "Hash 2050696d for PR 65203 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30018 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172259 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119767 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165189 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37130 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36803 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126827 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89410 "4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166279 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29098 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146821 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107394 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28144 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26774 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19961 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138039 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24545 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174763 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27350 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26201 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135132 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36471 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30873 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135123 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37258 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146340 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99206 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30424 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23185 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35967 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108783 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35466 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1210 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35714 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35614 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->