### PR TITLE
[WebGPU] Wrap deprecated Metal managed-storage and device-observer APIs in proper macros

### DIFF
--- a/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
+++ b/Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm
@@ -94,8 +94,10 @@ static bool platformSupportsMetal()
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)
     // Old Macs, such as MacBookPro11,4 cannot use WebGL via Metal.
     // This check can be removed once they are no longer supported.
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     if (![device supportsFamily:MTLGPUFamilyMac2])
         return false;
+    ALLOW_DEPRECATED_DECLARATIONS_END
 #endif
     return true;
 }

--- a/Source/WebGPU/WebGPU/BindGroup.mm
+++ b/Source/WebGPU/WebGPU/BindGroup.mm
@@ -485,7 +485,9 @@ Device::ExternalTextureData Device::createExternalTextureFromPixelBuffer(CVPixel
             textureDescriptor.mipmapLevelCount = 1;
             textureDescriptor.sampleCount = 1;
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)
+            ALLOW_DEPRECATED_DECLARATIONS_BEGIN
             textureDescriptor.storageMode = hasUnifiedMemory() ? MTLStorageModeShared : MTLStorageModeManaged;
+            ALLOW_DEPRECATED_DECLARATIONS_END
 #else
             textureDescriptor.storageMode = hasUnifiedMemory() ? MTLStorageModeShared : MTLStorageModePrivate;
 #endif

--- a/Source/WebGPU/WebGPU/Buffer.mm
+++ b/Source/WebGPU/WebGPU/Buffer.mm
@@ -113,10 +113,12 @@ static MTLStorageMode NODELETE storageMode(bool deviceHasUnifiedMemory, WGPUBuff
     if (deviceHasUnifiedMemory)
         return MTLStorageModeShared;
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     if (usage & (WGPUBufferUsage_MapRead | WGPUBufferUsage_MapWrite | WGPUBufferUsage_Index))
         return MTLStorageModeManaged;
     if (mappedAtCreation)
         return MTLStorageModeManaged;
+    ALLOW_DEPRECATED_DECLARATIONS_END
 #else
     UNUSED_PARAM(mappedAtCreation);
     UNUSED_PARAM(usage);
@@ -432,6 +434,7 @@ void Buffer::unmap()
     indirectBufferInvalidated();
 
 #if CPU(X86_64) && (PLATFORM(MAC) || PLATFORM(MACCATALYST))
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     if (m_buffer.storageMode == MTLStorageModeManaged) {
         if (m_mappedAtCreation)
             [m_buffer didModifyRange:NSMakeRange(0, m_buffer.length)];
@@ -440,6 +443,7 @@ void Buffer::unmap()
                 [m_buffer didModifyRange:NSMakeRange(static_cast<NSUInteger>(mappedRange.begin()), static_cast<NSUInteger>(mappedRange.end() - mappedRange.begin()))];
         }
     }
+    ALLOW_DEPRECATED_DECLARATIONS_END
 #endif
 
     setState(State::Unmapped);
@@ -532,8 +536,10 @@ void Buffer::takeSlowIndexValidationPath(CommandBuffer& commandBuffer, uint32_t 
         queue->clearBuffer(m_buffer);
         queue->finalizeBlitCommandEncoder();
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)
+        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         if (m_buffer.storageMode == MTLStorageModeManaged)
             [m_buffer didModifyRange:NSMakeRange(0, m_buffer.length)];
+        ALLOW_DEPRECATED_DECLARATIONS_END
 #endif
         commandBuffer.addPostCommitHandler([queue, priorData = WTF::move(priorData), protectedThis = protect(*this)](id<MTLCommandBuffer> mtlCommandBuffer) mutable {
             [mtlCommandBuffer waitUntilCompleted];
@@ -568,8 +574,10 @@ void Buffer::takeSlowIndirectIndexValidationPath(CommandBuffer& commandBuffer, B
         queue->clearBuffer(m_buffer, indirectOffset, sizeof(MTLDrawPrimitivesIndirectArguments));
         queue->finalizeBlitCommandEncoder();
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)
+        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         if (m_buffer.storageMode == MTLStorageModeManaged)
             [m_buffer didModifyRange:NSMakeRange(0, m_buffer.length)];
+        ALLOW_DEPRECATED_DECLARATIONS_END
 #endif
         commandBuffer.addPostCommitHandler([queue, priorData = WTF::move(priorData), protectedThis = protect(*this)](id<MTLCommandBuffer> mtlCommandBuffer) mutable {
             [mtlCommandBuffer waitUntilCompleted];
@@ -612,8 +620,10 @@ void Buffer::takeSlowIndirectValidationPath(CommandBuffer& commandBuffer, uint64
         queue->writeBuffer(m_buffer, indirectOffset, newDataSpan);
         queue->finalizeBlitCommandEncoder();
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)
+        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         if (m_buffer.storageMode == MTLStorageModeManaged)
             [m_buffer didModifyRange:NSMakeRange(0, m_buffer.length)];
+        ALLOW_DEPRECATED_DECLARATIONS_END
 #endif
         commandBuffer.addPostCommitHandler([queue, priorData = WTF::move(priorData), protectedThis = protect(*this)](id<MTLCommandBuffer> mtlCommandBuffer) mutable {
             [mtlCommandBuffer waitUntilCompleted];

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -1478,9 +1478,11 @@ void CommandEncoder::addBuffer(id<MTLBuffer> buffer)
         return;
 
 #if CPU(X86_64) && (PLATFORM(MAC) || PLATFORM(MACCATALYST))
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     if (buffer.storageMode == MTLStorageModeManaged)
         [m_managedBuffers addObject:buffer];
     else
+    ALLOW_DEPRECATED_DECLARATIONS_END
 #endif
         [m_retainedBuffers addObject:buffer];
 }
@@ -1490,9 +1492,11 @@ void CommandEncoder::addTexture(id<MTLTexture> texture)
         return;
 
 #if CPU(X86_64) && (PLATFORM(MAC) || PLATFORM(MACCATALYST))
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     if (texture.storageMode == MTLStorageModeManaged)
         [m_managedTextures addObject:texture];
     else
+    ALLOW_DEPRECATED_DECLARATIONS_END
 #endif
         [m_retainedTextures addObject:texture];
 }
@@ -2133,6 +2137,7 @@ Ref<CommandBuffer> CommandEncoder::finish(const WGPUCommandBufferDescriptor& des
     commandBuffer.label = descriptor.label.createNSString().get();
 
 #if CPU(X86_64) && (PLATFORM(MAC) || PLATFORM(MACCATALYST))
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     if (m_managedBuffers.count || m_managedTextures.count) {
         id<MTLBlitCommandEncoder> blitCommandEncoder = [commandBuffer blitCommandEncoder];
         for (id<MTLBuffer> buffer in m_managedBuffers)
@@ -2141,6 +2146,7 @@ Ref<CommandBuffer> CommandEncoder::finish(const WGPUCommandBufferDescriptor& des
             [blitCommandEncoder synchronizeResource:texture];
         [blitCommandEncoder endEncoding];
     }
+    ALLOW_DEPRECATED_DECLARATIONS_END
 #endif
 
     auto result = CommandBuffer::create(commandBuffer, m_device, m_sharedEvent, m_sharedEventSignalValue, WTF::move(m_onCommitHandlers), *this);

--- a/Source/WebGPU/WebGPU/Device.mm
+++ b/Source/WebGPU/WebGPU/Device.mm
@@ -298,6 +298,7 @@ Device::Device(id<MTLDevice> device, id<MTLCommandQueue> defaultQueue, HardwareC
     , m_maxVerticesPerDrawCall(computeMaxCountForDevice(device))
 {
 #if PLATFORM(MAC)
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     auto devices = MTLCopyAllDevicesWithObserver(&m_deviceObserver, [weakThis = ThreadSafeWeakPtr { *this }](id<MTLDevice> device, MTLDeviceNotificationName) {
         RefPtr<Device> protectedThis = weakThis.get();
         if (!protectedThis)
@@ -310,6 +311,7 @@ Device::Device(id<MTLDevice> device, id<MTLCommandQueue> defaultQueue, HardwareC
             });
         }
     });
+    ALLOW_DEPRECATED_DECLARATIONS_END
 
 #if ASSERT_ENABLED
     bool found = false;
@@ -341,7 +343,9 @@ Device::Device(id<MTLDevice> device, id<MTLCommandQueue> defaultQueue, HardwareC
     desc.pixelFormat = MTLPixelFormatBGRA8Unorm;
     desc.textureType = MTLTextureType2D;
 #if PLATFORM(MAC)
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     desc.storageMode = hasUnifiedMemory() ? MTLStorageModeShared : MTLStorageModeManaged;
+    ALLOW_DEPRECATED_DECLARATIONS_END
 #else
     desc.storageMode = MTLStorageModeShared;
 #endif
@@ -368,7 +372,9 @@ Device::Device(Adapter& adapter)
 Device::~Device()
 {
 #if PLATFORM(MAC)
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     MTLRemoveDeviceObserver(m_deviceObserver);
+    ALLOW_DEPRECATED_DECLARATIONS_END
 #endif
     if (m_deviceLostCallback) {
         m_deviceLostCallback(WGPUDeviceLostReason_Destroyed, ""_s);

--- a/Source/WebGPU/WebGPU/Instance.mm
+++ b/Source/WebGPU/WebGPU/Instance.mm
@@ -119,10 +119,12 @@ static NSArray<id<MTLDevice>> *sortedDevices(NSArray<id<MTLDevice>> *devices, WG
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)
         return [devices sortedArrayWithOptions:NSSortStable usingComparator:^NSComparisonResult (id<MTLDevice> obj1, id<MTLDevice> obj2)
         {
+            ALLOW_DEPRECATED_DECLARATIONS_BEGIN
             if (obj1.lowPower == obj2.lowPower)
                 return NSOrderedSame;
             if (obj1.lowPower)
                 return NSOrderedAscending;
+            ALLOW_DEPRECATED_DECLARATIONS_END
             return NSOrderedDescending;
         }];
 #else
@@ -132,10 +134,12 @@ static NSArray<id<MTLDevice>> *sortedDevices(NSArray<id<MTLDevice>> *devices, WG
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)
         return [devices sortedArrayWithOptions:NSSortStable usingComparator:^NSComparisonResult (id<MTLDevice> obj1, id<MTLDevice> obj2)
         {
+            ALLOW_DEPRECATED_DECLARATIONS_BEGIN
             if (obj1.lowPower == obj2.lowPower)
                 return NSOrderedSame;
             if (obj1.lowPower)
                 return NSOrderedDescending;
+            ALLOW_DEPRECATED_DECLARATIONS_END
             return NSOrderedAscending;
         }];
 #else

--- a/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
+++ b/Source/WebGPU/WebGPU/PresentationContextIOSurface.mm
@@ -265,11 +265,13 @@ void PresentationContextIOSurface::configure(Device& device, const WGPUSwapChain
     MTLTextureDescriptor *textureDescriptor = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:Texture::pixelFormat(effectiveFormat) width:width height:height mipmapped:NO];
     textureDescriptor.usage = Texture::usage(descriptor.usage, effectiveFormat);
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
 #if ENABLE(WEBGPU_BY_DEFAULT)
     textureDescriptor.storageMode = device.hasUnifiedMemory() ? MTLStorageModeShared : MTLStorageModeManaged;
 #else
     textureDescriptor.storageMode = MTLStorageModeManaged;
 #endif
+    ALLOW_DEPRECATED_DECLARATIONS_END
 #else
     textureDescriptor.storageMode = MTLStorageModeShared;
 #endif

--- a/Source/WebGPU/WebGPU/Queue.mm
+++ b/Source/WebGPU/WebGPU/Queue.mm
@@ -458,11 +458,13 @@ bool Queue::validateWriteBuffer(const Buffer& buffer, uint64_t bufferOffset, siz
 void Queue::synchronizeResourceAndWait(id<MTLBuffer> buffer)
 {
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     if (buffer.storageMode != MTLStorageModeManaged)
         return;
 
     ensureBlitCommandEncoder();
     [m_blitCommandEncoder synchronizeResource:buffer];
+    ALLOW_DEPRECATED_DECLARATIONS_END
     id<MTLCommandBuffer> commandBuffer = m_commandBuffer;
     finalizeBlitCommandEncoder();
     [commandBuffer waitUntilCompleted];
@@ -567,10 +569,12 @@ void Queue::writeBuffer(Buffer& buffer, uint64_t bufferOffset, std::span<uint8_t
             SUPPRESS_UNCOUNTED_ARG memcpySpan(borrow(buffer)->getBufferContents().subspan(bufferOffset, data.size()), data);
             return;
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)
+        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         case MTLStorageModeManaged:
             SUPPRESS_UNCOUNTED_ARG memcpySpan(borrow(buffer)->getBufferContents().subspan(bufferOffset, data.size()), data);
             [buffer.buffer() didModifyRange:NSMakeRange(bufferOffset, data.size())];
             return;
+        ALLOW_DEPRECATED_DECLARATIONS_END
 #endif
         case MTLStorageModePrivate:
             // The only way to get data into a private resource is to tell the GPU to copy it in.
@@ -1018,7 +1022,9 @@ void Queue::writeTexture(const WGPUImageCopyTexture& destination, std::span<uint
         switch (mtlTexture.storageMode) {
         case MTLStorageModeShared:
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)
+        ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         case MTLStorageModeManaged:
+        ALLOW_DEPRECATED_DECLARATIONS_END
 #endif
             {
                 switch (textureDimension) {

--- a/Source/WebGPU/WebGPU/Texture.mm
+++ b/Source/WebGPU/WebGPU/Texture.mm
@@ -2916,7 +2916,9 @@ static MTLStorageMode NODELETE storageMode(bool deviceHasUnifiedMemory, bool sup
         return MTLStorageModeShared;
 
 #if PLATFORM(MAC) || PLATFORM(MACCATALYST)
+    ALLOW_DEPRECATED_DECLARATIONS_BEGIN
     return MTLStorageModeManaged;
+    ALLOW_DEPRECATED_DECLARATIONS_END
 #else
     return MTLStorageModePrivate;
 #endif


### PR DESCRIPTION
#### 2d98e3c0b26e20d06bee8d5033b4cc53f1951e6a
<pre>
[WebGPU] Wrap deprecated Metal managed-storage and device-observer APIs in proper macros
<a href="https://bugs.webkit.org/show_bug.cgi?id=315114">https://bugs.webkit.org/show_bug.cgi?id=315114</a>
<a href="https://rdar.apple.com/177452722">rdar://177452722</a>

Reviewed by Mike Wyrzykowski.

Wrap them with ALLOW_DEPRECATED_DECLARATIONS_BEGIN/END rather than remove the Intel codepaths.

* Source/WebCore/platform/graphics/cocoa/GraphicsContextGLCocoa.mm:
(WebCore::platformSupportsMetal):
* Source/WebGPU/WebGPU/BindGroup.mm:
(WebGPU::Device::createExternalTextureFromPixelBuffer const):
* Source/WebGPU/WebGPU/Buffer.mm:
(WebGPU::storageMode):
(WebGPU::Buffer::unmap):
(WebGPU::Buffer::takeSlowIndexValidationPath):
(WebGPU::Buffer::takeSlowIndirectIndexValidationPath):
(WebGPU::Buffer::takeSlowIndirectValidationPath):
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::addBuffer):
(WebGPU::CommandEncoder::addTexture):
(WebGPU::CommandEncoder::finish):
* Source/WebGPU/WebGPU/Device.mm:
(WebGPU::Device::Device):
(WebGPU::Device::~Device):
* Source/WebGPU/WebGPU/Instance.mm:
(WebGPU::sortedDevices):
* Source/WebGPU/WebGPU/PresentationContextIOSurface.mm:
* Source/WebGPU/WebGPU/Queue.mm:
(WebGPU::Queue::synchronizeResourceAndWait):
(WebGPU::Queue::writeBuffer):
(WebGPU::Queue::writeTexture):
* Source/WebGPU/WebGPU/Texture.mm:
(WebGPU::storageMode):

Canonical link: <a href="https://commits.webkit.org/313515@main">https://commits.webkit.org/313515@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8bb5f4353b8a5ed11b1fbf4560f57fe3b6bdaac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163321 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36804 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30019 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172260 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/119768 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e95002b5-ed71-4980-b855-096e5744ba45) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165190 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37131 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36804 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126829 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/119768 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b4e3ae00-20b3-4ef0-b7d5-90e78638b52d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166280 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29096 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146822 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107396 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d72ba780-261d-412a-b30f-04829262f4cc) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19962 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138037 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24546 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174764 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27353 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26202 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135133 "Passed tests") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36472 "Hash b8bb5f43 for PR 65204 does not build (failure)") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30874 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135124 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36422 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37259 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146341 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99207 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30425 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23186 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35968 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108785 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35467 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1211 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35715 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35615 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->