### PR TITLE
Cherry-pick(s) db05eacaeb0c. rdar://176058395

### DIFF
--- a/LayoutTests/fast/text/fontface-setstatus-crash-expected.txt
+++ b/LayoutTests/fast/text/fontface-setstatus-crash-expected.txt
@@ -1,0 +1,2 @@
+This tests that FontFaceSet.load does not crash when resolving the loaded promise triggers a thenable check whose getter removes a font-face rule.
+WebKit should not crash or hit any assertions under ASAN.

--- a/LayoutTests/fast/text/fontface-setstatus-crash.html
+++ b/LayoutTests/fast/text/fontface-setstatus-crash.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style id="s">
+@font-face { font-family: x; src: url(nonexistent-font.woff); unicode-range: U+0042; }
+</style>
+</head>
+<body>
+<p>This tests that FontFaceSet.load does not crash when resolving the loaded
+promise triggers a thenable check whose getter removes a font-face rule.<br>
+WebKit should not crash or hit any assertions under ASAN.</p>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+window.onload = () => {
+    // JS-created face with a local source so it resolves synchronously.
+    let A = new FontFace('x', 'local(Helvetica)', { unicodeRange: 'U+0041' });
+    document.fonts.add(A);
+
+    // Register a DeferredPromise on A.
+    void A.loaded;
+
+    let fired = false;
+    Object.defineProperty(FontFace.prototype, 'then', {
+        configurable: true,
+        get() {
+            if (!fired && this === A) {
+                fired = true;
+                // Allocate to help ASAN detect freed memory reuse.
+                new FontFace('y', 'local(Helvetica Bold)', { unicodeRange: 'U+0041' });
+                new FontFace('z', 'local(Helvetica Italic)', { unicodeRange: 'U+0041' });
+                // Remove the CSS @font-face rule and force style recalc.
+                // This frees the CSS-backed CSSFontFace while FontFaceSet::load
+                // still holds a raw reference to it in matchingFaces.
+                document.getElementById('s').sheet.deleteRule(0);
+                document.body.offsetTop;
+            }
+            return undefined;
+        }
+    });
+
+    // Loading 'AB' needs both U+0041 (from A) and U+0042 (from the CSS rule).
+    // A resolves synchronously, firing the thenable check getter above.
+    document.fonts.load('1em x', 'AB');
+    setTimeout(() => {
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }, 0);
+};
+</script>
+</body>
+</html>

--- a/Source/WebCore/css/CSSFontFaceSet.cpp
+++ b/Source/WebCore/css/CSSFontFaceSet.cpp
@@ -407,7 +407,7 @@ static CodePointsMap codePointsFromString(StringView stringView)
     return result;
 }
 
-ExceptionOr<Vector<std::reference_wrapper<CSSFontFace>>> CSSFontFaceSet::matchingFacesExcludingPreinstalledFonts(ScriptExecutionContext& context, const String& fontShorthand, const String& string)
+ExceptionOr<Vector<Ref<CSSFontFace>>> CSSFontFaceSet::matchingFacesExcludingPreinstalledFonts(ScriptExecutionContext& context, const String& fontShorthand, const String& string)
 {
     auto font = CSSPropertyParserHelpers::parseUnresolvedFont(fontShorthand, context);
     if (!font)
@@ -453,7 +453,7 @@ ExceptionOr<Vector<std::reference_wrapper<CSSFontFace>>> CSSFontFaceSet::matchin
         }
     }
 
-    return WTF::map(resultConstituents, [](auto* constituent) -> std::reference_wrapper<CSSFontFace> {
+    return WTF::map(resultConstituents, [](auto* constituent) -> Ref<CSSFontFace> {
         return *constituent;
     });
 }

--- a/Source/WebCore/css/CSSFontFaceSet.h
+++ b/Source/WebCore/css/CSSFontFaceSet.h
@@ -89,7 +89,7 @@ public:
 
     size_t facesPartitionIndex() const { return m_facesPartitionIndex; }
 
-    ExceptionOr<Vector<std::reference_wrapper<CSSFontFace>>> matchingFacesExcludingPreinstalledFonts(ScriptExecutionContext&, const String& font, const String& text);
+    ExceptionOr<Vector<Ref<CSSFontFace>>> matchingFacesExcludingPreinstalledFonts(ScriptExecutionContext&, const String& font, const String& text);
 
     // FIXME: Should this be implemented?
     void updateStyleIfNeeded(CSSFontFace&) final { }

--- a/Source/WebCore/css/FontFaceSet.cpp
+++ b/Source/WebCore/css/FontFaceSet.cpp
@@ -166,8 +166,8 @@ void FontFaceSet::load(ScriptExecutionContext& context, const String& font, cons
         return;
     }
 
-    for (auto& face : matchingFaces)
-        face.get().load();
+    for (Ref face : matchingFaces)
+        face->load();
 
     if (CheckedPtr document = dynamicDowncast<Document>(scriptExecutionContext())) {
         if (document->quirks().shouldEnableFontLoadingAPIQuirk()) {
@@ -179,6 +179,7 @@ void FontFaceSet::load(ScriptExecutionContext& context, const String& font, cons
             //
             // See also: https://github.com/w3c/csswg-drafts/issues/7680
 
+<<<<<<< HEAD
             bool hasSource = false;
             for (auto& face : matchingFaces) {
                 if (face.get().sourceCount()) {
@@ -192,11 +193,25 @@ void FontFaceSet::load(ScriptExecutionContext& context, const String& font, cons
                 }));
                 return;
             }
+=======
+        bool hasSource = false;
+        for (Ref face : matchingFaces) {
+            if (face->sourceCount()) {
+                hasSource = true;
+                break;
+            }
+        }
+        if (!hasSource) {
+            promise.resolve(matchingFaces.map([scriptExecutionContext = scriptExecutionContext()] (const auto& matchingFace) {
+                return matchingFace->wrapper(scriptExecutionContext);
+            }));
+            return;
+>>>>>>> db05eacaeb0c (Use-after-free in CSSFontFace::setStatus and CSSFontFace::pump)
         }
     }
 
-    for (auto& face : matchingFaces) {
-        if (face.get().status() == CSSFontFace::Status::Failure) {
+    for (Ref face : matchingFaces) {
+        if (face->status() == CSSFontFace::Status::Failure) {
             promise.reject(ExceptionCode::NetworkError);
             return;
         }
@@ -205,6 +220,7 @@ void FontFaceSet::load(ScriptExecutionContext& context, const String& font, cons
     auto pendingPromise = PendingPromise::create(WTF::move(promise));
     bool waiting = false;
 
+<<<<<<< HEAD
     for (auto& face : matchingFaces) {
         pendingPromise->faces.append(face.get().wrapper(protect(scriptExecutionContext()).get()));
         if (face.get().status() == CSSFontFace::Status::Success)
@@ -212,6 +228,15 @@ void FontFaceSet::load(ScriptExecutionContext& context, const String& font, cons
         waiting = true;
         ASSERT(face.get().existingWrapper());
         m_pendingPromises.add(*face.get().existingWrapper(), Vector<Ref<PendingPromise>>()).iterator->value.append(pendingPromise.copyRef());
+=======
+    for (Ref face : matchingFaces) {
+        pendingPromise->faces.append(face.get().wrapper(protectedScriptExecutionContext().get()));
+        if (face->status() == CSSFontFace::Status::Success)
+            continue;
+        waiting = true;
+        ASSERT(face->existingWrapper());
+        m_pendingPromises.add(face->existingWrapper(), Vector<Ref<PendingPromise>>()).iterator->value.append(pendingPromise.copyRef());
+>>>>>>> db05eacaeb0c (Use-after-free in CSSFontFace::setStatus and CSSFontFace::pump)
     }
 
     if (!waiting)


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://176058395 to main. [db05eacaeb0c] caused a merge conflict. 

```Use-after-free in CSSFontFace::setStatus and CSSFontFace::pump
https://bugs.webkit.org/show_bug.cgi?id=312202
rdar://174525579

Reviewed by Simon Fraser.

Fixed the bug by using Ref instead of std::reference_wrapper in the return value of
CSSFontFaceSet::matchingFacesExcludingPreinstalledFonts and local variables in
FontFaceSet::load to keep CSSFontFace objects alive long enough.

Test: fast/text/fontface-setstatus-crash.html

* LayoutTests/fast/text/fontface-setstatus-crash-expected.txt: Added.
* LayoutTests/fast/text/fontface-setstatus-crash.html: Added.
* Source/WebCore/css/CSSFontFaceSet.cpp:
(WebCore::CSSFontFaceSet::matchingFacesExcludingPreinstalledFonts):
* Source/WebCore/css/CSSFontFaceSet.h:
* Source/WebCore/css/FontFaceSet.cpp:
(WebCore::FontFaceSet::load):

Originally-landed-as: 305413.664@safari-7624-branch (db05eacaeb0c). rdar://176058395

```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/73057a529c542d0f7eddf34f3a027cb6de1a6e49

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163330 "3 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36813 "Hash 73057a52 for PR 65206 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30028 "Hash 73057a52 for PR 65206 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172269 "Hash 73057a52 for PR 65206 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119777 "Hash 73057a52 for PR 65206 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165199 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37140 "Hash 73057a52 for PR 65206 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36813 "Hash 73057a52 for PR 65206 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/172269 "Hash 73057a52 for PR 65206 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/119777 "Hash 73057a52 for PR 65206 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166289 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/37140 "Hash 73057a52 for PR 65206 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/30028 "Hash 73057a52 for PR 65206 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/172269 "Hash 73057a52 for PR 65206 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/37140 "Hash 73057a52 for PR 65206 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/36813 "Hash 73057a52 for PR 65206 does not build (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19971 "Hash 73057a52 for PR 65206 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/37140 "Hash 73057a52 for PR 65206 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/30028 "Hash 73057a52 for PR 65206 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174773 "Hash 73057a52 for PR 65206 does not build (failure)") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27373 "Failed to build and analyze WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/30028 "Hash 73057a52 for PR 65206 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/174773 "Hash 73057a52 for PR 65206 does not build (failure)") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36482 "Hash 73057a52 for PR 65206 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/36813 "Hash 73057a52 for PR 65206 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/174773 "Hash 73057a52 for PR 65206 does not build (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37268 "Hash 73057a52 for PR 65206 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/30028 "Hash 73057a52 for PR 65206 does not build (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99217 "Hash 73057a52 for PR 65206 does not build (failure)") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/37268 "Hash 73057a52 for PR 65206 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/30028 "Hash 73057a52 for PR 65206 does not build (failure)") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35977 "Hash 73057a52 for PR 65206 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108802 "Failed to build and analyze WebKit") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35476 "Hash 73057a52 for PR 65206 does not build (failure)") | [⏳ 🧪 mac-site-isolation ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Site-Isolation-Tests-EWS "Waiting in queue, processing has not started yet") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35724 "Hash 73057a52 for PR 65206 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35624 "Hash 73057a52 for PR 65206 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->