### PR TITLE
Opening or refreshing wasitai.com is extremely slow

### DIFF
--- a/Source/WebCore/page/FrameSnapshotting.cpp
+++ b/Source/WebCore/page/FrameSnapshotting.cpp
@@ -117,6 +117,8 @@ RefPtr<ImageBuffer> snapshotFrameRectWithClip(LocalFrame& frame, const IntRect& 
         paintBehavior.add(PaintBehavior::DraggableSnapshot);
     if (options.flags.contains(SnapshotFlags::IncludeDocumentMarkers))
         paintBehavior.add(PaintBehavior::IncludeDocumentMarkers);
+    if (options.flags.contains(SnapshotFlags::FastAndLowQualityFilters))
+        paintBehavior.add(PaintBehavior::FastAndLowQualityFilters);
 
     // Other paint behaviors are set by paintContentsForSnapshot.
     frame.view()->setPaintBehavior(paintBehavior);

--- a/Source/WebCore/page/FrameSnapshotting.h
+++ b/Source/WebCore/page/FrameSnapshotting.h
@@ -60,6 +60,7 @@ enum class SnapshotFlags : uint16_t {
     FixedAndStickyLayersOnly                = 1 << 12,
     DraggableElement                        = 1 << 13,
     IncludeDocumentMarkers                  = 1 << 14,
+    FastAndLowQualityFilters                = 1 << 15,
 };
 
 struct SnapshotOptions {

--- a/Source/WebCore/page/PageColorSampler.cpp
+++ b/Source/WebCore/page/PageColorSampler.cpp
@@ -114,30 +114,43 @@ static bool isValidSampleLocation(Document& document, const IntPoint& location)
     return true;
 }
 
-static std::optional<Lab<float>> sampleColor(Document& document, IntPoint&& location)
+static RefPtr<PixelBuffer> takeRowSnapshot(Document& document, IntPoint&& topRight)
 {
     // FIXME: <https://webkit.org/b/225167> (Sampled Page Top Color: hook into painting logic instead of taking snapshots)
-
-    if (!isValidSampleLocation(document, location))
-        return std::nullopt;
-
     // FIXME: <https://webkit.org/b/225942> (Sampled Page Top Color: support sampling non-RGB values like P3)
+
+    static constexpr OptionSet snapshotFlags {
+        SnapshotFlags::ExcludeSelectionHighlighting,
+        SnapshotFlags::PaintEverythingExcludingSelection,
+        SnapshotFlags::FastAndLowQualityFilters
+    };
+
     auto colorSpace = DestinationColorSpace::SRGB();
+    auto rect = IntRect { { 0, topRight.y() }, { topRight.x() + 1, 1 } };
 
     ASSERT(document.view());
-    auto snapshot = snapshotFrameRect(protect(document.view()->frame()), IntRect(location, IntSize(1, 1)), { { SnapshotFlags::ExcludeSelectionHighlighting, SnapshotFlags::PaintEverythingExcludingSelection }, PixelFormat::BGRA8, colorSpace });
+    auto snapshot = snapshotFrameRect(protect(document.view()->frame()), rect, { snapshotFlags, PixelFormat::BGRA8, colorSpace });
     if (!snapshot)
-        return std::nullopt;
+        return nullptr;
 
     auto pixelBuffer = snapshot->getPixelBuffer({ AlphaPremultiplication::Unpremultiplied, PixelFormat::BGRA8, colorSpace }, { { }, snapshot->truncatedLogicalSize() });
     if (!pixelBuffer)
+        return nullptr;
+
+    if (pixelBuffer->bytes().size() < rect.area() * 4)
+        return nullptr;
+
+    return pixelBuffer;
+}
+
+static std::optional<Lab<float>> sampleColor(Document& document, const PixelBuffer& rowPixelBuffer, const IntPoint& location)
+{
+    if (!isValidSampleLocation(document, location))
         return std::nullopt;
 
-    if (pixelBuffer->bytes().size() < 4)
-        return std::nullopt;
-
-    auto snapshotData = pixelBuffer->bytes();
-    return convertColor<Lab<float>>(SRGBA<uint8_t> { snapshotData[2], snapshotData[1], snapshotData[0], snapshotData[3] });
+    auto pixels = rowPixelBuffer.bytes();
+    auto pixel = pixels.subspan(location.x() * 4, 4);
+    return convertColor<Lab<float>>(SRGBA<uint8_t> { pixel[2], pixel[1], pixel[0], pixel[3] });
 }
 
 static double colorDifference(const Lab<float>& lhs, const Lab<float>& rhs)
@@ -192,8 +205,7 @@ std::optional<Color> PageColorSampler::sampleTop(Page& page)
     if (!frameView->isVisuallyNonEmpty() || !frameView->hasContentfulDescendants() || !ContentfulPaintChecker::qualifiesForContentfulPaint(*frameView))
         return std::nullopt;
 
-    // Decrease the width by one pixel so that the last sample is within bounds and not off-by-one.
-    auto frameWidth = frameView->contentsWidth() - 1;
+    auto frameWidth = frameView->contentsWidth();
 
     static constexpr auto numSamples = 5;
     size_t nonMatchingColorIndex = numSamples;
@@ -210,8 +222,13 @@ std::optional<Color> PageColorSampler::sampleTop(Page& page)
         return false;
     };
 
+    RefPtr topPagePixelBuffer = takeRowSnapshot(*mainDocument, IntPoint(frameWidth - 1, 0));
+    if (!topPagePixelBuffer)
+        return Color();
+
     for (size_t i = 0; i < numSamples; ++i) {
-        auto sample = sampleColor(*mainDocument, IntPoint(frameWidth * i / (numSamples - 1), 0));
+        auto column = (i == numSamples - 1) ? frameWidth - 1 : frameWidth * i / (numSamples - 1);
+        auto sample = sampleColor(*mainDocument, *topPagePixelBuffer, IntPoint(column, 0));
         if (!sample) {
             if (shouldStopAfterFindingNonMatchingColor(i))
                 return Color();
@@ -256,17 +273,21 @@ std::optional<Color> PageColorSampler::sampleTop(Page& page)
     }
 
     // Decrease the height by one pixel so that the last sample is within bounds and not off-by-one.
-    auto minHeight = page.settings().sampledPageTopColorMinHeight() - 1;
-    if (minHeight > 0) {
+    int minY = static_cast<int>(page.settings().sampledPageTopColorMinHeight() - 1);
+    if (minY > 0) {
+        RefPtr minYPixelBuffer = takeRowSnapshot(*mainDocument, IntPoint(frameWidth - 1, minY));
+        if (!minYPixelBuffer)
+            return Color();
+
         if (nonMatchingColorIndex) {
-            if (auto leftMiddleSample = sampleColor(*mainDocument, IntPoint(0, minHeight))) {
+            if (auto leftMiddleSample = sampleColor(*mainDocument, *minYPixelBuffer, IntPoint(0, minY))) {
                 if (colorDifference(*leftMiddleSample, samples[0]) > maxDifference)
                     return Color();
             }
         }
 
         if (nonMatchingColorIndex != numSamples - 1) {
-            if (auto rightMiddleSample = sampleColor(*mainDocument, IntPoint(frameWidth, minHeight))) {
+            if (auto rightMiddleSample = sampleColor(*mainDocument, *minYPixelBuffer, IntPoint(frameWidth - 1, minY))) {
                 if (colorDifference(*rightMiddleSample, samples[numSamples - 1]) > maxDifference)
                     return Color();
             }

--- a/Source/WebCore/platform/graphics/coreimage/FEGaussianBlurCoreImageApplier.mm
+++ b/Source/WebCore/platform/graphics/coreimage/FEGaussianBlurCoreImageApplier.mm
@@ -59,7 +59,8 @@ bool FEGaussianBlurCoreImageApplier::apply(const Filter& filter, std::span<const
         return false;
 
     // FIXME: Support edge modes.
-    auto absoluteStdDeviation = filter.scaledByFilterScale(FloatSize(m_effect->stdDeviationX(), m_effect->stdDeviationY()));
+    auto stdDeviation = m_effect->effectiveStdDeviation(filter.renderingOptions());
+    auto absoluteStdDeviation = filter.scaledByFilterScale(stdDeviation);
 
     RetainPtr ciFilter = [CIFilter filterWithName:@"CIGaussianBlurXY"];
     [ciFilter setValue:inputImage.get() forKey:kCIInputImageKey];

--- a/Source/WebCore/platform/graphics/filters/FEGaussianBlur.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEGaussianBlur.cpp
@@ -87,6 +87,13 @@ bool FEGaussianBlur::setEdgeMode(EdgeModeType edgeMode)
     return true;
 }
 
+FloatSize FEGaussianBlur::effectiveStdDeviation(OptionSet<FilterRenderingOption> renderingOptions) const
+{
+    if (renderingOptions.contains(FilterRenderingOption::FastAndLowQuality))
+        return { std::min(m_stdX, 20.0f), std::min(m_stdY, 20.0f) };
+    return { m_stdX, m_stdY };
+}
+
 static inline float gaussianKernelFactor()
 {
     return 3 / 4.f * sqrtf(2 * std::numbers::pi_v<float>);
@@ -138,7 +145,8 @@ FloatRect FEGaussianBlur::calculateImageRect(const Filter& filter, std::span<con
     if (m_edgeMode != EdgeModeType::None)
         return enclosingIntRect(imageRect);
 
-    auto kernelSize = calculateUnscaledKernelSize(filter.resolvedSize({ m_stdX, m_stdY }));
+    auto stdDeviation = effectiveStdDeviation(filter.renderingOptions());
+    auto kernelSize = calculateUnscaledKernelSize(filter.resolvedSize(stdDeviation));
 
     // We take the half kernel size and multiply it with three, because we run box blur three times.
     imageRect.inflateX(3 * kernelSize.width() * 0.5f);
@@ -196,7 +204,8 @@ std::unique_ptr<FilterEffectApplier> FEGaussianBlur::createSoftwareApplier() con
 
 std::optional<GraphicsStyle> FEGaussianBlur::createGraphicsStyle(GraphicsContext&, const Filter& filter) const
 {
-    auto radius = calculateUnscaledKernelSize(filter.resolvedSize({ m_stdX, m_stdY }));
+    auto stdDeviation = effectiveStdDeviation(filter.renderingOptions());
+    auto radius = calculateUnscaledKernelSize(filter.resolvedSize(stdDeviation));
     return GraphicsGaussianBlur { radius };
 }
 

--- a/Source/WebCore/platform/graphics/filters/FEGaussianBlur.h
+++ b/Source/WebCore/platform/graphics/filters/FEGaussianBlur.h
@@ -27,6 +27,8 @@
 
 namespace WebCore {
 
+enum class FilterRenderingOption : uint8_t;
+
 class FEGaussianBlur final : public FilterEffect {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED(FEGaussianBlur);
     WTF_OVERRIDE_DELETE_FOR_CHECKED_PTR(FEGaussianBlur);
@@ -43,6 +45,8 @@ public:
 
     EdgeModeType edgeMode() const { return m_edgeMode; }
     bool NODELETE setEdgeMode(EdgeModeType);
+
+    FloatSize effectiveStdDeviation(OptionSet<FilterRenderingOption> = { }) const;
 
     static IntSize calculateKernelSize(const Filter&, FloatSize stdDeviation);
     static IntSize calculateUnscaledKernelSize(FloatSize stdDeviation);

--- a/Source/WebCore/platform/graphics/filters/Filter.h
+++ b/Source/WebCore/platform/graphics/filters/Filter.h
@@ -43,6 +43,7 @@ struct FilterGeometry {
 
 enum class FilterRenderingOption : uint8_t {
     ShowDebugOverlay    = 1 << 0,
+    FastAndLowQuality   = 1 << 1,
 };
 
 class Filter : public FilterFunction {

--- a/Source/WebCore/platform/graphics/filters/software/FEGaussianBlurSoftwareApplier.cpp
+++ b/Source/WebCore/platform/graphics/filters/software/FEGaussianBlurSoftwareApplier.cpp
@@ -30,6 +30,7 @@
 #if HAVE(ARM_NEON_INTRINSICS)
 #include "FEGaussianBlurNEON.h"
 #endif
+#include "Filter.h"
 #include "GraphicsContext.h"
 #include "ImageBuffer.h"
 #include "PixelBuffer.h"
@@ -439,10 +440,12 @@ bool FEGaussianBlurSoftwareApplier::apply(const Filter& filter, std::span<const 
 
     auto effectDrawingRect = result.absoluteImageRectRelativeTo(input);
     input->copyPixelBuffer(*destinationPixelBuffer, effectDrawingRect);
-    if (!m_effect->stdDeviationX() && !m_effect->stdDeviationY())
+
+    auto stdDeviation = m_effect->effectiveStdDeviation(filter.renderingOptions());
+    if (stdDeviation.isEmpty())
         return true;
 
-    auto kernelSize = m_effect->calculateKernelSize(filter, { m_effect->stdDeviationX(), m_effect->stdDeviationY() });
+    auto kernelSize = m_effect->calculateKernelSize(filter, stdDeviation);
 
     IntSize paintSize = result.absoluteImageRect().size();
     auto tempBuffer = destinationPixelBuffer->createScratchPixelBuffer(paintSize);

--- a/Source/WebCore/rendering/PaintPhase.h
+++ b/Source/WebCore/rendering/PaintPhase.h
@@ -81,6 +81,7 @@ enum class PaintBehavior : uint32_t {
     DrawsHDRContent                             = 1 << 22,
     DraggableSnapshot                           = 1 << 23,
     IncludeDocumentMarkers                      = 1 << 24,
+    FastAndLowQualityFilters                    = 1 << 25,
 };
 
 } // namespace WebCore

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -3640,7 +3640,7 @@ GraphicsContext* RenderLayer::setupFilters(GraphicsContext& destinationContext, 
         };
     }
 
-    GraphicsContext* filterContext = paintingFilters->beginFilterEffect(renderer(), destinationContext, enclosingIntRect(rootRelativeBounds), enclosingIntRect(paintingInfo.paintDirtyRect), enclosingIntRect(filterRepaintRect),
+    GraphicsContext* filterContext = paintingFilters->beginFilterEffect(renderer(), destinationContext, paintingInfo.paintBehavior, enclosingIntRect(rootRelativeBounds), enclosingIntRect(paintingInfo.paintDirtyRect), enclosingIntRect(filterRepaintRect),
         backgroundRect.rect(), applyAdditionalDestinationClip);
     if (!filterContext)
         return nullptr;
@@ -6769,6 +6769,7 @@ TextStream& operator<<(TextStream& ts, PaintBehavior behavior)
     case PaintBehavior::DrawsHDRContent: ts << "DrawsHDRContent"_s; break;
     case PaintBehavior::DraggableSnapshot: ts << "DraggableSnapshot"_s; break;
     case PaintBehavior::IncludeDocumentMarkers: ts << "IncludeDocumentMarkers"_s; break;
+    case PaintBehavior::FastAndLowQualityFilters: ts << "FastAndLowQualityFilters"_s; break;
     }
 
     return ts;

--- a/Source/WebCore/rendering/RenderLayerFilters.cpp
+++ b/Source/WebCore/rendering/RenderLayerFilters.cpp
@@ -156,7 +156,7 @@ IntOutsets RenderLayerFilters::calculateOutsets(RenderElement& renderer, const F
     return CSSFilterRenderer::calculateOutsets(renderer, filter, targetBoundingBox);
 }
 
-GraphicsContext* RenderLayerFilters::beginFilterEffect(RenderElement& renderer, GraphicsContext& context, const LayoutRect& filterBoxRect, const LayoutRect& dirtyRect, const LayoutRect& layerRepaintRect, const LayoutRect& clipRect, NOESCAPE const Function<void(GraphicsContext&)>& applyAdditionalDestinationClip)
+GraphicsContext* RenderLayerFilters::beginFilterEffect(RenderElement& renderer, GraphicsContext& context, OptionSet<PaintBehavior> paintBehavior, const LayoutRect& filterBoxRect, const LayoutRect& dirtyRect, const LayoutRect& layerRepaintRect, const LayoutRect& clipRect, NOESCAPE const Function<void(GraphicsContext&)>& applyAdditionalDestinationClip)
 {
     auto preferredFilterRenderingModes = renderer.page().preferredFilterRenderingModes(context);
     auto outsets = calculateOutsets(renderer, filterBoxRect);
@@ -197,8 +197,13 @@ GraphicsContext* RenderLayerFilters::beginFilterEffect(RenderElement& renderer, 
 
     bool hasUpdatedBackingStore = false;
     if (!m_filter || geometryReferenceGeometryChanged(m_filter->geometry(), geometry) || m_preferredFilterRenderingModes != preferredFilterRenderingModes) {
+        OptionSet<FilterRenderingOption> renderingOptions;
+        if (renderer.settings().showDebugBorders())
+            renderingOptions.add(FilterRenderingOption::ShowDebugOverlay);
+        if (paintBehavior.contains(PaintBehavior::FastAndLowQualityFilters))
+            renderingOptions.add(FilterRenderingOption::FastAndLowQuality);
+
         // FIXME: This rebuilds the entire effects chain even if the filter style didn't change.
-        auto renderingOptions(renderer.settings().showDebugBorders() ? std::make_optional(FilterRenderingOption::ShowDebugOverlay) : std::nullopt);
         m_filter = CSSFilterRenderer::create(renderer, renderer.style().filter(), geometry, preferredFilterRenderingModes, renderingOptions, context);
         hasUpdatedBackingStore = true;
     } else if (filterRegion != m_filter->filterRegion()) {

--- a/Source/WebCore/rendering/RenderLayerFilters.h
+++ b/Source/WebCore/rendering/RenderLayerFilters.h
@@ -76,7 +76,7 @@ public:
     // Per render
     LayoutRect repaintRect() const { return m_repaintRect; }
 
-    GraphicsContext* beginFilterEffect(RenderElement&, GraphicsContext&, const LayoutRect& filterBoxRect, const LayoutRect& dirtyRect, const LayoutRect& layerRepaintRect, const LayoutRect& clipRect, NOESCAPE const Function<void(GraphicsContext&)>& applyAdditionalDestinationClip = { });
+    GraphicsContext* beginFilterEffect(RenderElement&, GraphicsContext&, OptionSet<PaintBehavior>, const LayoutRect& filterBoxRect, const LayoutRect& dirtyRect, const LayoutRect& layerRepaintRect, const LayoutRect& clipRect, NOESCAPE const Function<void(GraphicsContext&)>& applyAdditionalDestinationClip = { });
     void applyFilterEffect(GraphicsContext& destinationContext);
 
 private:


### PR DESCRIPTION
#### f4ce4a791de718846d261525231aab23542a6526
<pre>
Opening or refreshing wasitai.com is extremely slow
<a href="https://bugs.webkit.org/show_bug.cgi?id=315118">https://bugs.webkit.org/show_bug.cgi?id=315118</a>
<a href="https://rdar.apple.com/172480480">rdar://172480480</a>

Reviewed by Simon Fraser.

On macOS, the first paint of wasitai.com may take a few seconds. But opening or
refreshing it on iOS may take about 50 seconds.

This slow performance happens because the PageColorSampler tries to get five
pixels from the first row in the page by taking five snapshots. The size of
every snapshot is { 1 x 1 }.

In general this is very inefficient because snapshotFrameRect() can&apos;t know to
precisely clip the whole frame drawing to just one pixel. Many renderers will be
traversed although their drawing does not affect the required pixel.

By what makes this scenario extremely slow is the expensive blur in this page.
On iPhone, wasitai.com draws a blur filter with stdDeviation = { 200, 200 }. This
is extremely large stdDeviation. Usually the stdDeviation does not exceed 20px.

So to fix this perf bug, the following fixes should be done:

(1) Instead of getting five snapshots from as single row, a single snapshot will
    be taken for the whole row. Then pixels in this row will examined.

(2) Second a new `FilterRenderingOption` named `FastAndLowQuality` will be
    introduced. This new option will allow clamping the blur stdDeviation to 20px
    if applied. The PageColorSampler will propagate this flag to rendering code
    in SnapshotFlags. `snapshotFrameRectWithClip()` will translate this
    SnapshotFlags to PaintBehavior. RenderLayer will send the PaintBehaviors to
    `RenderLayerFilters::beginFilterEffect()` which will examine paintBehavior.
    If it has FastAndLowQualityFilters it will send FastAndLowQuality to
    `CSSFilterRenderer::create()`. FEGaussianBlur will check for this flag and
    clamp the stdDeviation when creating the appliers or the CGStyle.

* Source/WebCore/page/FrameSnapshotting.cpp:
(WebCore::snapshotFrameRectWithClip):
* Source/WebCore/page/FrameSnapshotting.h:
* Source/WebCore/page/PageColorSampler.cpp:
(WebCore::takeRowSnapshot):
(WebCore::sampleColor):
(WebCore::PageColorSampler::sampleTop):
* Source/WebCore/platform/graphics/coreimage/FEGaussianBlurCoreImageApplier.mm:
(WebCore::FEGaussianBlurCoreImageApplier::apply const):
* Source/WebCore/platform/graphics/filters/FEGaussianBlur.cpp:
(WebCore::FEGaussianBlur::effectiveStdDeviation const):
(WebCore::FEGaussianBlur::calculateImageRect const):
(WebCore::FEGaussianBlur::createGraphicsStyle const):
* Source/WebCore/platform/graphics/filters/FEGaussianBlur.h:
* Source/WebCore/platform/graphics/filters/Filter.h:
* Source/WebCore/platform/graphics/filters/software/FEGaussianBlurSoftwareApplier.cpp:
(WebCore::FEGaussianBlurSoftwareApplier::apply const):
* Source/WebCore/rendering/PaintPhase.h:
* Source/WebCore/rendering/RenderLayer.cpp:
(WebCore::RenderLayer::setupFilters):
(WebCore::RenderLayer::calculateClipRects const):
* Source/WebCore/rendering/RenderLayerFilters.cpp:
(WebCore::RenderLayerFilters::beginFilterEffect):
* Source/WebCore/rendering/RenderLayerFilters.h:

Canonical link: <a href="https://commits.webkit.org/313563@main">https://commits.webkit.org/313563@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c89a5fe20889cad457ed8ef949200b2d7511e160

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163460 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36943 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30159 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172400 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119907 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165329 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37272 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36943 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126949 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89486 "layout-tests (failure)") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166419 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29218 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146945 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107507 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20102 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/138159 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24668 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174904 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27679 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26325 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135252 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36613 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135238 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36451 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37398 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146463 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99396 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30542 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23308 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36109 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109168 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35606 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1334 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35854 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35754 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->