### PR TITLE
[export-w3c-test-changes] Fix behaviour with an already-existing branch

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
@@ -475,7 +475,7 @@ nothing to commit, working tree clean
                 self.executable, 'checkout', '-B', re.compile(r'.+'),
                 cwd=self.path,
                 generator=lambda *args, **kwargs:
-                    mocks.ProcessCompletion(returncode=0) if self.checkout(args[3], source=args[4] if len(args) > 4 else None, create=False, force=True) else mocks.ProcessCompletion(returncode=1)
+                    mocks.ProcessCompletion(returncode=0) if self.checkout(args[3], source=args[4] if len(args) > 4 else None, create=True, force=True) else mocks.ProcessCompletion(returncode=1)
             ), mocks.Subprocess.Route(
                 self.executable, 'checkout', re.compile(r'.+'),
                 cwd=self.path,
@@ -975,9 +975,19 @@ nothing to commit, working tree clean
         if create:
             if commit:
                 if force:
-                    self.head = commit
-                    self.detached = something not in self.commits.keys()
-                    return True
+                    if source == something:
+                        # checkout -B branch (no start-point): reset to current HEAD
+                        del self.commits[something]
+                        # Fall through to create branch from current HEAD
+                    else:
+                        # checkout -B branch start-point: reset branch to start-point
+                        self.head = commit
+                        self.detached = False
+                        return True
+                else:
+                    return False
+            elif source != something:
+                # Source was explicitly provided but doesn't exist: fail
                 return False
             self.commits[something] = [Commit.from_json(Commit.Encoder().default(self.head))]
             # Copy one more to create a bridge commit

--- a/Tools/Scripts/webkitpy/w3c/test_exporter.py
+++ b/Tools/Scripts/webkitpy/w3c/test_exporter.py
@@ -32,6 +32,7 @@ import subprocess
 from webkitcorepy import string_utils, run
 from webkitbugspy import bugzilla
 from webkitscmpy import local
+from webkitscmpy.program.pull_request import PullRequest as PullRequestProgram
 
 from webkitpy.common.host import Host
 from webkitpy.common.webkit_finder import WebKitFinder
@@ -209,14 +210,9 @@ class WebPlatformTestExporter(object):
 
     def create_branch_with_patch(self, patch):
         _log.info('Applying patch to web-platform-tests branch ' + self._branch_name)
-        try:
-            self._run_wpt_git(['checkout', '-b', self._branch_name])
-        except Exception as e:
-            _log.warning(e)
-            _log.info('Retrying to create the branch')
-            if self._run_wpt_git(['show-ref', '--quiet', '--verify', f'refs/heads/{self._branch_name}']):
-                self._run_wpt_git(['branch', '-D', self._branch_name])
-            self._run_wpt_git(['checkout', '-b', self._branch_name])
+        if self._run_wpt_git(['checkout', '-B', self._branch_name]).returncode:
+            _log.error(f'Failed to create branch {self._branch_name}')
+            return False
 
         try:
             output = self._run_wpt_git(['apply', '--index', patch, '-3'], stderr=subprocess.STDOUT)
@@ -292,9 +288,18 @@ class WebPlatformTestExporter(object):
         return pr
 
     def create_wpt_pull_request(self, remote_branch_name, title, body):
-        _log.info(f"\nCreating pull-request for '{remote_branch_name}'...")
+        existing_pr = PullRequestProgram.find_existing_pull_request(self._wpt_repo, self._remote, branch=self._public_branch_name)
 
-        # FIXME: If the pull request/branch exists, we should give the option to overwrite or rebase - https://bugs.webkit.org/show_bug.cgi?id=295350
+        if existing_pr and existing_pr.opened:
+            _log.info(f"\nUpdating pull-request for '{remote_branch_name}'...")
+            pr = self._remote.pull_requests.update(pull_request=existing_pr, title=title, body=body)
+            if not pr:
+                _log.error(f"Failed to update pull-request for '{self._wpt_repo.branch}'\n")
+                return None
+            print(f"Updated '{pr}'!")
+            return pr
+
+        _log.info(f"\nCreating pull-request for '{remote_branch_name}'...")
         pr = self._remote.pull_requests.create(
             title=title,
             body=body,
@@ -303,7 +308,6 @@ class WebPlatformTestExporter(object):
         if not pr:
             _log.error(f"Failed to create pull-request for '{self._wpt_repo.branch}'\n")
             return None
-
         print(f"Created '{pr}'!")
         return pr
 
@@ -390,7 +394,6 @@ def parse_args(args):
     - As a dry run, one can start by running the script without -c. This will only create the branch on the user public GitHub repository.
     - By default, the script will create an https remote URL that will require a password-based authentication to GitHub. If you are using an SSH key, please use the --remote-url option.
     FIXME:
-    - The script is not yet able to update an existing pull request.
     - Need a way to monitor the progress of the pull request so that status of all pending pull requests can be done at import time.
     """
     parser = argparse.ArgumentParser(prog='export-w3c-test-changes ...', description=description, formatter_class=argparse.RawDescriptionHelpFormatter)

--- a/Tools/Scripts/webkitpy/w3c/test_exporter_unittest.py
+++ b/Tools/Scripts/webkitpy/w3c/test_exporter_unittest.py
@@ -141,6 +141,352 @@ class TestExporterTest(testing.PathTestCase):
                 WebPlatformTestExporter(host, options)
             self.assertIn('Unable to find associated bug', str(context.exception))
 
+    def test_export_local_branch_exists(self):
+        with OutputCapture(level=logging.INFO) as captured, bmocks.Bugzilla(self.BUGZILLA_URL.split('://')[1], issues=bmocks.ISSUES, environment=wkmocks.Environment(
+            BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+            BUGS_EXAMPLE_COM_PASSWORD='password',
+        )), mocks.remote.GitHub(remote='github.com/web-platform-tests/wpt', labels={
+            'webkit-export': dict(color='00000', description=''),
+        }) as wpt_remote, mocks.local.Git(
+            self.path,
+            remote='https://{}'.format(wpt_remote.remote)
+        ) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ) as mock_linter_class:
+            # Pre-create the local branch before export
+            git_mock.checkout('wpt-export-for-webkit-1', create=True)
+            git_mock.checkout(git_mock.default_branch)
+
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
+            host = TestExporterTest.MyMockHost()
+            host.filesystem.maybe_make_directory(self.path)
+            host.filesystem.write_binary_file(f'{self.path}/resources/testharness.js', '')
+            host.filesystem.write_binary_file(f'{self.path}/wpt', '')
+
+            host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+            exporter = WebPlatformTestExporter(host, options)
+            exporter.do_export()
+
+            issue = Tracker.from_string('{}/show_bug.cgi?id=1'.format(self.BUGZILLA_URL))
+            self.assertEqual(issue.comments[-1].content, 'Submitted web-platform-tests pull request: https://github.com/web-platform-tests/wpt/pull/1')
+            self.assertEqual(issue.related_links, ['https://github.com/web-platform-tests/wpt/pull/1'])
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            "Created 'PR 1 | WebKit export of https://bugs.example.com/show_bug.cgi?id=1'!\n",
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+        log = captured.root.log.getvalue().splitlines()
+        self.assertEqual(
+            [line for line in log if 'Mock process' not in line], [
+                f'Using the WPT repository found at `{self.path}`',
+                'Fetching web-platform-tests repository',
+                'Cleaning web-platform-tests master branch',
+                'Applying patch to web-platform-tests branch wpt-export-for-webkit-1',
+                'Pushing branch wpt-export-for-webkit-1 to username...',
+                'Branch available at https://github.com/username/wpt/tree/wpt-export-for-webkit-1',
+                '',
+                "Creating pull-request for 'username:wpt-export-for-webkit-1'...",
+                'Removing local branch wpt-export-for-webkit-1',
+                'WPT Pull Request: https://github.com/web-platform-tests/wpt/pull/1'],
+        )
+
+    def test_export_remote_branch_exists_no_pr(self):
+        with OutputCapture(level=logging.INFO) as captured, bmocks.Bugzilla(self.BUGZILLA_URL.split('://')[1], issues=bmocks.ISSUES, environment=wkmocks.Environment(
+            BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+            BUGS_EXAMPLE_COM_PASSWORD='password',
+        )), mocks.remote.GitHub(remote='github.com/web-platform-tests/wpt', labels={
+            'webkit-export': dict(color='00000', description=''),
+        }) as wpt_remote, mocks.local.Git(
+            self.path,
+            remote='https://{}'.format(wpt_remote.remote)
+        ) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ) as mock_linter_class:
+            # Pre-populate the remote branch (simulating a previous push) but no PR
+            git_mock.remotes['username/wpt-export-for-webkit-1'] = git_mock.commits[git_mock.default_branch][:]
+
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
+            host = TestExporterTest.MyMockHost()
+            host.filesystem.maybe_make_directory(self.path)
+            host.filesystem.write_binary_file(f'{self.path}/resources/testharness.js', '')
+            host.filesystem.write_binary_file(f'{self.path}/wpt', '')
+
+            host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+            exporter = WebPlatformTestExporter(host, options)
+            exporter.do_export()
+
+            issue = Tracker.from_string('{}/show_bug.cgi?id=1'.format(self.BUGZILLA_URL))
+            self.assertEqual(issue.comments[-1].content, 'Submitted web-platform-tests pull request: https://github.com/web-platform-tests/wpt/pull/1')
+            self.assertEqual(issue.related_links, ['https://github.com/web-platform-tests/wpt/pull/1'])
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            "Created 'PR 1 | WebKit export of https://bugs.example.com/show_bug.cgi?id=1'!\n",
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+        log = captured.root.log.getvalue().splitlines()
+        self.assertEqual(
+            [line for line in log if 'Mock process' not in line], [
+                f'Using the WPT repository found at `{self.path}`',
+                'Fetching web-platform-tests repository',
+                'Cleaning web-platform-tests master branch',
+                'Applying patch to web-platform-tests branch wpt-export-for-webkit-1',
+                'Pushing branch wpt-export-for-webkit-1 to username...',
+                'Branch available at https://github.com/username/wpt/tree/wpt-export-for-webkit-1',
+                '',
+                "Creating pull-request for 'username:wpt-export-for-webkit-1'...",
+                'Removing local branch wpt-export-for-webkit-1',
+                'WPT Pull Request: https://github.com/web-platform-tests/wpt/pull/1'],
+        )
+
+    def test_export_updates_existing_open_pr(self):
+        with OutputCapture(level=logging.INFO) as captured, bmocks.Bugzilla(self.BUGZILLA_URL.split('://')[1], issues=bmocks.ISSUES, environment=wkmocks.Environment(
+            BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+            BUGS_EXAMPLE_COM_PASSWORD='password',
+        )), mocks.remote.GitHub(remote='github.com/web-platform-tests/wpt', labels={
+            'webkit-export': dict(color='00000', description=''),
+        }) as wpt_remote, mocks.local.Git(
+            self.path,
+            remote='https://{}'.format(wpt_remote.remote)
+        ) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ) as mock_linter_class:
+            # Remote branch must exist for the push to be rejected as non-fast-forward
+            git_mock.remotes['username/wpt-export-for-webkit-1'] = git_mock.commits[git_mock.default_branch][:]
+            wpt_remote.pull_requests.append({
+                'number': 42,
+                'state': 'open',
+                'title': 'Old title',
+                'body': 'Old body',
+                'user': {'login': 'USER'},
+                'head': {'ref': 'wpt-export-for-webkit-1', 'sha': 'abc123', 'label': 'USER:wpt-export-for-webkit-1'},
+                'base': {'ref': 'master', 'label': 'web-platform-tests:master', 'user': {'login': 'web-platform-tests'}},
+                'draft': False,
+                '_links': {'issue': {'href': 'https://api.github.com/repos/web-platform-tests/wpt/issues/42'}},
+                'reviews': [],
+            })
+            wpt_remote.issues[42] = dict(
+                creator=wpt_remote.users.create(username='USER'),
+                timestamp=0,
+                assignee=None,
+                comments=[],
+                title='Old title',
+                opened=True,
+                description='Old body',
+            )
+
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
+            host = TestExporterTest.MyMockHost()
+            host.filesystem.maybe_make_directory(self.path)
+            host.filesystem.write_binary_file(f'{self.path}/resources/testharness.js', '')
+            host.filesystem.write_binary_file(f'{self.path}/wpt', '')
+
+            host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+            exporter = WebPlatformTestExporter(host, options)
+            exporter.do_export()
+
+            issue = Tracker.from_string('{}/show_bug.cgi?id=1'.format(self.BUGZILLA_URL))
+            self.assertEqual(issue.comments[-1].content, 'Submitted web-platform-tests pull request: https://github.com/web-platform-tests/wpt/pull/42')
+            self.assertEqual(issue.related_links, ['https://github.com/web-platform-tests/wpt/pull/42'])
+
+            # No new PR should have been created
+            self.assertEqual(len(wpt_remote.pull_requests), 1)
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            "Updated 'PR 42 | WebKit export of https://bugs.example.com/show_bug.cgi?id=1'!\n",
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+        log = captured.root.log.getvalue().splitlines()
+        self.assertEqual(
+            [line for line in log if 'Mock process' not in line], [
+                f'Using the WPT repository found at `{self.path}`',
+                'Fetching web-platform-tests repository',
+                'Cleaning web-platform-tests master branch',
+                'Applying patch to web-platform-tests branch wpt-export-for-webkit-1',
+                'Pushing branch wpt-export-for-webkit-1 to username...',
+                'Branch available at https://github.com/username/wpt/tree/wpt-export-for-webkit-1',
+                '',
+                "Updating pull-request for 'username:wpt-export-for-webkit-1'...",
+                'Removing local branch wpt-export-for-webkit-1',
+                'WPT Pull Request: https://github.com/web-platform-tests/wpt/pull/42'],
+        )
+
+    def test_export_local_and_remote_exist_with_open_pr(self):
+        with OutputCapture(level=logging.INFO) as captured, bmocks.Bugzilla(self.BUGZILLA_URL.split('://')[1], issues=bmocks.ISSUES, environment=wkmocks.Environment(
+            BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+            BUGS_EXAMPLE_COM_PASSWORD='password',
+        )), mocks.remote.GitHub(remote='github.com/web-platform-tests/wpt', labels={
+            'webkit-export': dict(color='00000', description=''),
+        }) as wpt_remote, mocks.local.Git(
+            self.path,
+            remote='https://{}'.format(wpt_remote.remote)
+        ) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ) as mock_linter_class:
+            # Pre-create the local branch
+            git_mock.checkout('wpt-export-for-webkit-1', create=True)
+            git_mock.checkout(git_mock.default_branch)
+
+            # Remote branch must exist for the push to be rejected as non-fast-forward
+            git_mock.remotes['username/wpt-export-for-webkit-1'] = git_mock.commits[git_mock.default_branch][:]
+            wpt_remote.pull_requests.append({
+                'number': 42,
+                'state': 'open',
+                'title': 'Old title',
+                'body': 'Old body',
+                'user': {'login': 'USER'},
+                'head': {'ref': 'wpt-export-for-webkit-1', 'sha': 'abc123', 'label': 'USER:wpt-export-for-webkit-1'},
+                'base': {'ref': 'master', 'label': 'web-platform-tests:master', 'user': {'login': 'web-platform-tests'}},
+                'draft': False,
+                '_links': {'issue': {'href': 'https://api.github.com/repos/web-platform-tests/wpt/issues/42'}},
+                'reviews': [],
+            })
+            wpt_remote.issues[42] = dict(
+                creator=wpt_remote.users.create(username='USER'),
+                timestamp=0,
+                assignee=None,
+                comments=[],
+                title='Old title',
+                opened=True,
+                description='Old body',
+            )
+
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
+            host = TestExporterTest.MyMockHost()
+            host.filesystem.maybe_make_directory(self.path)
+            host.filesystem.write_binary_file(f'{self.path}/resources/testharness.js', '')
+            host.filesystem.write_binary_file(f'{self.path}/wpt', '')
+
+            host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+            exporter = WebPlatformTestExporter(host, options)
+            exporter.do_export()
+
+            issue = Tracker.from_string('{}/show_bug.cgi?id=1'.format(self.BUGZILLA_URL))
+            self.assertEqual(issue.comments[-1].content, 'Submitted web-platform-tests pull request: https://github.com/web-platform-tests/wpt/pull/42')
+            self.assertEqual(issue.related_links, ['https://github.com/web-platform-tests/wpt/pull/42'])
+
+            # No new PR should have been created
+            self.assertEqual(len(wpt_remote.pull_requests), 1)
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            "Updated 'PR 42 | WebKit export of https://bugs.example.com/show_bug.cgi?id=1'!\n",
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+        log = captured.root.log.getvalue().splitlines()
+        self.assertEqual(
+            [line for line in log if 'Mock process' not in line], [
+                f'Using the WPT repository found at `{self.path}`',
+                'Fetching web-platform-tests repository',
+                'Cleaning web-platform-tests master branch',
+                'Applying patch to web-platform-tests branch wpt-export-for-webkit-1',
+                'Pushing branch wpt-export-for-webkit-1 to username...',
+                'Branch available at https://github.com/username/wpt/tree/wpt-export-for-webkit-1',
+                '',
+                "Updating pull-request for 'username:wpt-export-for-webkit-1'...",
+                'Removing local branch wpt-export-for-webkit-1',
+                'WPT Pull Request: https://github.com/web-platform-tests/wpt/pull/42'],
+        )
+
+    def test_export_creates_new_pr_when_existing_is_closed(self):
+        with OutputCapture(level=logging.INFO) as captured, bmocks.Bugzilla(self.BUGZILLA_URL.split('://')[1], issues=bmocks.ISSUES, environment=wkmocks.Environment(
+            BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+            BUGS_EXAMPLE_COM_PASSWORD='password',
+        )), mocks.remote.GitHub(remote='github.com/web-platform-tests/wpt', labels={
+            'webkit-export': dict(color='00000', description=''),
+        }) as wpt_remote, mocks.local.Git(
+            self.path,
+            remote='https://{}'.format(wpt_remote.remote)
+        ) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ) as mock_linter_class:
+            # Pre-populate a closed PR for the same branch
+            wpt_remote.pull_requests.append({
+                'number': 42,
+                'state': 'closed',
+                'title': 'Old title',
+                'body': 'Old body',
+                'user': {'login': 'USER'},
+                'head': {'ref': 'wpt-export-for-webkit-1', 'sha': 'abc123', 'label': 'USER:wpt-export-for-webkit-1'},
+                'base': {'ref': 'master', 'label': 'web-platform-tests:master', 'user': {'login': 'web-platform-tests'}},
+                'draft': False,
+                '_links': {'issue': {'href': 'https://api.github.com/repos/web-platform-tests/wpt/issues/42'}},
+                'reviews': [],
+            })
+            wpt_remote.issues[42] = dict(
+                creator=wpt_remote.users.create(username='USER'),
+                timestamp=0,
+                assignee=None,
+                comments=[],
+                title='Old title',
+                opened=False,
+                description='Old body',
+            )
+
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
+            host = TestExporterTest.MyMockHost()
+            host.filesystem.maybe_make_directory(self.path)
+            host.filesystem.write_binary_file(f'{self.path}/resources/testharness.js', '')
+            host.filesystem.write_binary_file(f'{self.path}/wpt', '')
+
+            host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+            exporter = WebPlatformTestExporter(host, options)
+            exporter.do_export()
+
+            issue = Tracker.from_string('{}/show_bug.cgi?id=1'.format(self.BUGZILLA_URL))
+            self.assertEqual(issue.comments[-1].content, 'Submitted web-platform-tests pull request: https://github.com/web-platform-tests/wpt/pull/43')
+            self.assertEqual(issue.related_links, ['https://github.com/web-platform-tests/wpt/pull/43'])
+
+            # A new PR should have been created (total: original closed + new open)
+            self.assertEqual(len(wpt_remote.pull_requests), 2)
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            "Created 'PR 43 | WebKit export of https://bugs.example.com/show_bug.cgi?id=1'!\n",
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+        log = captured.root.log.getvalue().splitlines()
+        self.assertEqual(
+            [line for line in log if 'Mock process' not in line], [
+                f'Using the WPT repository found at `{self.path}`',
+                'Fetching web-platform-tests repository',
+                'Cleaning web-platform-tests master branch',
+                'Applying patch to web-platform-tests branch wpt-export-for-webkit-1',
+                'Pushing branch wpt-export-for-webkit-1 to username...',
+                'Branch available at https://github.com/username/wpt/tree/wpt-export-for-webkit-1',
+                '',
+                "Creating pull-request for 'username:wpt-export-for-webkit-1'...",
+                'Removing local branch wpt-export-for-webkit-1',
+                'WPT Pull Request: https://github.com/web-platform-tests/wpt/pull/43'],
+        )
+
     def test_export_with_specific_branch(self):
         with OutputCapture(level=logging.INFO) as captured, bmocks.Bugzilla(self.BUGZILLA_URL.split('://')[1], issues=bmocks.ISSUES, environment=wkmocks.Environment(
             BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',


### PR DESCRIPTION
#### 7c7684b1f1f61fcb75748a2d42042f4025ea1c6d
<pre>
[export-w3c-test-changes] Fix behaviour with an already-existing branch
<a href="https://bugs.webkit.org/show_bug.cgi?id=307376">https://bugs.webkit.org/show_bug.cgi?id=307376</a>
<a href="https://rdar.apple.com/170508778">rdar://170508778</a>

Reviewed by Elliott Williams.

The old code wrapped `checkout -b` in a try/except, but
_run_wpt_git never raises on failure (no check=True), so the retry
path that deleted and recreated the branch was unreachable. Replace
with `checkout -B` which creates the branch or resets it if it already
exists.

When pushing to a fork where the remote branch already exists, look
for an existing open pull request and update it instead of creating a
duplicate.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py:
Fix `checkout -B` mock to pass create=True and correctly handle the
reset-existing-branch semantics (delete-then-recreate versus
reset-to-start-point).
* Tools/Scripts/webkitpy/w3c/test_exporter.py:
(WebPlatformTestExporter.create_branch_with_patch): Use `checkout -B`
instead of `checkout -b` with exception-based retry.
(WebPlatformTestExporter.create_wpt_pull_request): Check for an
existing open PR via find_existing_pull_request and update it rather
than creating a new one. If the existing PR is closed, create a new PR.
(parse_args): Remove stale FIXME about not supporting PR updates.
* Tools/Scripts/webkitpy/w3c/test_exporter_unittest.py:
(TestExporterTest.test_export_local_branch_exists):
(TestExporterTest.test_export_remote_branch_exists_no_pr):
(TestExporterTest.test_export_updates_existing_open_pr):
(TestExporterTest.test_export_local_and_remote_exist_with_open_pr):
(TestExporterTest.test_export_creates_new_pr_when_existing_is_closed):

Canonical link: <a href="https://commits.webkit.org/314744@main">https://commits.webkit.org/314744@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f6189a09ff74c75bbf9a0e946edfa94cdea577bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167072 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40563 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34143 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176120 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124330 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aafd78a0-2676-4358-accc-7a24a93fdbba) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168938 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40996 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40572 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129934 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91545 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/94e083c2-919c-4e0d-bb04-f46db2c45444) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170031 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32335 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150110 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110459 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/806cabfd-765b-4174-9413-0c9944f6669d) 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/166395 "Found 2 webkitpy test failures: webkitscmpy.test.land_unittest.TestLandGitHub.test_merge_queue, webkitscmpy.test.land_unittest.TestLandBitBucket.test_no_reviewer") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31310 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30016 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24859 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141312 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27807 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178658 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29514 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138303 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/166474 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40634 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34165 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138214 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41321 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149605 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104275 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25431 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33484 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26470 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39832 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39227 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4572 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39473 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39371 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->