### PR TITLE
[export-w3c-test-changes] Support --delete-existing/--no-delete-existing

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
@@ -61,6 +61,7 @@ class Git(mocks.Subprocess):
         self.remote = remote or 'git@example.org:mock/{}'.format(os.path.basename(path))
         self.detached = detached or False
         self.is_worktree = is_worktree
+        self.push_error = None
 
         self.tags = tags or {}
 
@@ -649,6 +650,14 @@ nothing to commit, working tree clean
                 self.executable, 'add', re.compile(r'.+'),
                 cwd=self.path,
                 generator=lambda *args, **kwargs: self.add(args[2]),
+            ), mocks.Subprocess.Route(
+                self.executable, 'show-ref', '--verify', '--quiet', re.compile(r'.+'),
+                cwd=self.path,
+                generator=lambda *args, **kwargs: self.show_ref_verify(args[4]),
+            ), mocks.Subprocess.Route(
+                self.executable, 'push', '--porcelain', re.compile(r'.+'), re.compile(r'.+'),
+                cwd=self.path,
+                generator=lambda *args, **kwargs: self.push_porcelain(args[3], args[4], force='-f' in args),
             ), mocks.Subprocess.Route(
                 self.executable, 'push', '-f', re.compile(r'.+'), re.compile(r'.+'),
                 cwd=self.path,
@@ -1352,6 +1361,30 @@ nothing to commit, working tree clean
             self.remotes[remote_branch] = self.commits[branch][:]
         elif remote_branch in self.remotes:
             del self.remotes[remote_branch]
+        return mocks.ProcessCompletion(returncode=0)
+
+    def show_ref_verify(self, ref):
+        branch = ref.replace('refs/heads/', '')
+        if branch in self.commits:
+            return mocks.ProcessCompletion(returncode=0)
+        return mocks.ProcessCompletion(returncode=1)
+
+    def push_porcelain(self, remote, refspec, force=False):
+        if self.push_error is not None:
+            return mocks.ProcessCompletion(returncode=self.push_error)
+
+        local_branch = refspec.split(':')[0]
+        remote_ref = refspec.split(':')[-1] if ':' in refspec else local_branch
+        remote_branch = '{}/{}'.format(remote, remote_ref)
+
+        if not force and remote_branch in self.remotes:
+            return mocks.ProcessCompletion(
+                returncode=1,
+                stdout='!\trefs/heads/{ref}:refs/heads/{ref}\t[rejected] (non-fast-forward)\n'.format(ref=remote_ref),
+            )
+
+        if local_branch in self.commits:
+            self.remotes[remote_branch] = self.commits[local_branch][:]
         return mocks.ProcessCompletion(returncode=0)
 
     def _fetch_with_refspec(self, refspecs):

--- a/Tools/Scripts/webkitpy/w3c/test_exporter.py
+++ b/Tools/Scripts/webkitpy/w3c/test_exporter.py
@@ -29,7 +29,7 @@ import logging
 import sys
 import subprocess
 
-from webkitcorepy import string_utils, run
+from webkitcorepy import arguments, string_utils, run
 from webkitbugspy import bugzilla
 from webkitscmpy import local
 from webkitscmpy.program.pull_request import PullRequest as PullRequestProgram
@@ -210,7 +210,15 @@ class WebPlatformTestExporter(object):
 
     def create_branch_with_patch(self, patch):
         _log.info('Applying patch to web-platform-tests branch ' + self._branch_name)
-        if self._run_wpt_git(['checkout', '-B', self._branch_name]).returncode:
+        branch_exists = not self._run_wpt_git(['show-ref', '--verify', '--quiet', f'refs/heads/{self._branch_name}']).returncode
+        if branch_exists:
+            if not self._options.delete_existing:
+                _log.error(f'Local branch {self._branch_name} already exists. Use --delete-existing to overwrite.')
+                return False
+            if self._run_wpt_git(['checkout', '-B', self._branch_name]).returncode:
+                _log.error(f'Failed to create branch {self._branch_name}')
+                return False
+        elif self._run_wpt_git(['checkout', '-b', self._branch_name]).returncode:
             _log.error(f'Failed to create branch {self._branch_name}')
             return False
 
@@ -256,9 +264,24 @@ class WebPlatformTestExporter(object):
 
     def push_to_wpt_fork(self):
         _log.info(f'Pushing branch {self._branch_name} to {self._wpt_fork_remote}...')
-        if self._run_wpt_git(['push', self._wpt_fork_remote, self._branch_name + ':' + self._public_branch_name, '-f']).returncode:
-            _log.error('Failed to push to WPT fork')
-            return 1
+        refspec = self._branch_name + ':' + self._public_branch_name
+        result = self._run_wpt_git(['push', '--porcelain', self._wpt_fork_remote, refspec], capture_output=True)
+        if result.returncode:
+            if result.returncode >= 128:
+                _log.error('Failed to push to WPT fork')
+                return None
+            stdout = result.stdout or b''
+            if any(line.startswith(b'!') for line in stdout.splitlines()):
+                if not self._options.delete_existing:
+                    _log.error(f'Remote branch {self._public_branch_name} already exists. Use --delete-existing to overwrite.')
+                    return None
+                retry = self._run_wpt_git(['push', '--porcelain', self._wpt_fork_remote, refspec, '-f'], capture_output=True)
+                if retry.returncode:
+                    _log.error('Failed to push to WPT fork')
+                    return None
+            else:
+                _log.error('Failed to push to WPT fork')
+                return None
         _log.info(f'Branch available at {self._wpt_fork_branch_github_url}')
         return True
 
@@ -410,6 +433,12 @@ def parse_args(args):
     parser.add_argument('--no-clean', action='store_false', dest='clean', help='Do not clean up.')
     parser.add_argument('--clean-on-failure', action='store_true', dest='clean_on_failure', help='Do not clean up on failure.')
     parser.add_argument('--dry-run', action='store_true', dest='dry_run', default=False, help='Create local branch and commit but do not push to remote.')
+    parser.add_argument(
+        '--delete-existing', '--no-delete-existing',
+        dest='delete_existing', default=False,
+        action=arguments.NoAction,
+        help='Allow overwriting an existing local branch or force-pushing to an existing remote branch.',
+    )
 
     options, args = parser.parse_known_args(args)
 

--- a/Tools/Scripts/webkitpy/w3c/test_exporter_unittest.py
+++ b/Tools/Scripts/webkitpy/w3c/test_exporter_unittest.py
@@ -168,7 +168,7 @@ class TestExporterTest(testing.PathTestCase):
             host.filesystem.write_binary_file(f'{self.path}/wpt', '')
 
             host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
-            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '--delete-existing', '-d', self.path])
             exporter = WebPlatformTestExporter(host, options)
             exporter.do_export()
 
@@ -222,7 +222,7 @@ class TestExporterTest(testing.PathTestCase):
             host.filesystem.write_binary_file(f'{self.path}/wpt', '')
 
             host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
-            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '--delete-existing', '-d', self.path])
             exporter = WebPlatformTestExporter(host, options)
             exporter.do_export()
 
@@ -297,7 +297,7 @@ class TestExporterTest(testing.PathTestCase):
             host.filesystem.write_binary_file(f'{self.path}/wpt', '')
 
             host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
-            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '--delete-existing', '-d', self.path])
             exporter = WebPlatformTestExporter(host, options)
             exporter.do_export()
 
@@ -379,7 +379,7 @@ class TestExporterTest(testing.PathTestCase):
             host.filesystem.write_binary_file(f'{self.path}/wpt', '')
 
             host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
-            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '--delete-existing', '-d', self.path])
             exporter = WebPlatformTestExporter(host, options)
             exporter.do_export()
 
@@ -465,6 +465,365 @@ class TestExporterTest(testing.PathTestCase):
             self.assertEqual(issue.related_links, ['https://github.com/web-platform-tests/wpt/pull/43'])
 
             # A new PR should have been created (total: original closed + new open)
+            self.assertEqual(len(wpt_remote.pull_requests), 2)
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            "Created 'PR 43 | WebKit export of https://bugs.example.com/show_bug.cgi?id=1'!\n",
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+        log = captured.root.log.getvalue().splitlines()
+        self.assertEqual(
+            [line for line in log if 'Mock process' not in line], [
+                f'Using the WPT repository found at `{self.path}`',
+                'Fetching web-platform-tests repository',
+                'Cleaning web-platform-tests master branch',
+                'Applying patch to web-platform-tests branch wpt-export-for-webkit-1',
+                'Pushing branch wpt-export-for-webkit-1 to username...',
+                'Branch available at https://github.com/username/wpt/tree/wpt-export-for-webkit-1',
+                '',
+                "Creating pull-request for 'username:wpt-export-for-webkit-1'...",
+                'Removing local branch wpt-export-for-webkit-1',
+                'WPT Pull Request: https://github.com/web-platform-tests/wpt/pull/43'],
+        )
+
+    def test_export_local_branch_exists_errors_without_flag(self):
+        with OutputCapture(level=logging.INFO) as captured, bmocks.Bugzilla(self.BUGZILLA_URL.split('://')[1], issues=bmocks.ISSUES, environment=wkmocks.Environment(
+            BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+            BUGS_EXAMPLE_COM_PASSWORD='password',
+        )), mocks.remote.GitHub(remote='github.com/web-platform-tests/wpt', labels={
+            'webkit-export': dict(color='00000', description=''),
+        }) as wpt_remote, mocks.local.Git(
+            self.path,
+            remote='https://{}'.format(wpt_remote.remote)
+        ) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ):
+            # Pre-create the local branch
+            git_mock.checkout('wpt-export-for-webkit-1', create=True)
+            git_mock.checkout(git_mock.default_branch)
+
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
+            host = TestExporterTest.MyMockHost()
+            host.filesystem.maybe_make_directory(self.path)
+            host.filesystem.write_binary_file(f'{self.path}/resources/testharness.js', '')
+            host.filesystem.write_binary_file(f'{self.path}/wpt', '')
+
+            host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
+            # NOTE: No --delete-existing flag
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+            exporter = WebPlatformTestExporter(host, options)
+            result = exporter.do_export()
+
+            self.assertEqual(result, 1)
+
+            # No bug comment should have been posted (only pre-existing mock comments)
+            issue = Tracker.from_string('{}/show_bug.cgi?id=1'.format(self.BUGZILLA_URL))
+            self.assertEqual(len(issue.comments), 2)
+
+        self.assertEqual(captured.stdout.getvalue(), '')
+        log = captured.root.log.getvalue()
+        self.assertIn('already exists', log)
+
+    def test_export_remote_branch_exists_errors_without_flag(self):
+        with OutputCapture(level=logging.INFO) as captured, bmocks.Bugzilla(self.BUGZILLA_URL.split('://')[1], issues=bmocks.ISSUES, environment=wkmocks.Environment(
+            BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+            BUGS_EXAMPLE_COM_PASSWORD='password',
+        )), mocks.remote.GitHub(remote='github.com/web-platform-tests/wpt', labels={
+            'webkit-export': dict(color='00000', description=''),
+        }) as wpt_remote, mocks.local.Git(
+            self.path,
+            remote='https://{}'.format(wpt_remote.remote)
+        ) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ):
+            # Pre-populate the remote branch
+            git_mock.remotes['username/wpt-export-for-webkit-1'] = git_mock.commits[git_mock.default_branch][:]
+
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
+            host = TestExporterTest.MyMockHost()
+            host.filesystem.maybe_make_directory(self.path)
+            host.filesystem.write_binary_file(f'{self.path}/resources/testharness.js', '')
+            host.filesystem.write_binary_file(f'{self.path}/wpt', '')
+
+            host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
+            # NOTE: No --delete-existing flag
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+            exporter = WebPlatformTestExporter(host, options)
+            result = exporter.do_export()
+
+            self.assertEqual(result, 1)
+
+            # No bug comment should have been posted (only pre-existing mock comments)
+            issue = Tracker.from_string('{}/show_bug.cgi?id=1'.format(self.BUGZILLA_URL))
+            self.assertEqual(len(issue.comments), 2)
+
+        self.assertEqual(captured.stdout.getvalue(), '')
+        log = captured.root.log.getvalue()
+        self.assertIn('already exists', log)
+
+    def test_export_push_fatal_error(self):
+        with OutputCapture(level=logging.INFO) as captured, bmocks.Bugzilla(self.BUGZILLA_URL.split('://')[1], issues=bmocks.ISSUES, environment=wkmocks.Environment(
+            BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+            BUGS_EXAMPLE_COM_PASSWORD='password',
+        )), mocks.remote.GitHub(remote='github.com/web-platform-tests/wpt', labels={
+            'webkit-export': dict(color='00000', description=''),
+        }) as wpt_remote, mocks.local.Git(
+            self.path,
+            remote='https://{}'.format(wpt_remote.remote)
+        ) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ):
+            git_mock.push_error = 128
+
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
+            host = TestExporterTest.MyMockHost()
+            host.filesystem.maybe_make_directory(self.path)
+            host.filesystem.write_binary_file(f'{self.path}/resources/testharness.js', '')
+            host.filesystem.write_binary_file(f'{self.path}/wpt', '')
+
+            host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+            exporter = WebPlatformTestExporter(host, options)
+            result = exporter.do_export()
+
+            self.assertEqual(result, 1)
+
+            issue = Tracker.from_string('{}/show_bug.cgi?id=1'.format(self.BUGZILLA_URL))
+            self.assertEqual(len(issue.comments), 2)
+
+        self.assertEqual(captured.stdout.getvalue(), '')
+        log = captured.root.log.getvalue()
+        self.assertIn('Failed to push to WPT fork', log)
+
+    def test_export_push_non_rejected_error(self):
+        with OutputCapture(level=logging.INFO) as captured, bmocks.Bugzilla(self.BUGZILLA_URL.split('://')[1], issues=bmocks.ISSUES, environment=wkmocks.Environment(
+            BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+            BUGS_EXAMPLE_COM_PASSWORD='password',
+        )), mocks.remote.GitHub(remote='github.com/web-platform-tests/wpt', labels={
+            'webkit-export': dict(color='00000', description=''),
+        }) as wpt_remote, mocks.local.Git(
+            self.path,
+            remote='https://{}'.format(wpt_remote.remote)
+        ) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ):
+            git_mock.push_error = 2
+
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
+            host = TestExporterTest.MyMockHost()
+            host.filesystem.maybe_make_directory(self.path)
+            host.filesystem.write_binary_file(f'{self.path}/resources/testharness.js', '')
+            host.filesystem.write_binary_file(f'{self.path}/wpt', '')
+
+            host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+            exporter = WebPlatformTestExporter(host, options)
+            result = exporter.do_export()
+
+            self.assertEqual(result, 1)
+
+            issue = Tracker.from_string('{}/show_bug.cgi?id=1'.format(self.BUGZILLA_URL))
+            self.assertEqual(len(issue.comments), 2)
+
+        self.assertEqual(captured.stdout.getvalue(), '')
+        log = captured.root.log.getvalue()
+        self.assertIn('Failed to push to WPT fork', log)
+
+    def test_export_open_pr_errors_without_flag(self):
+        with OutputCapture(level=logging.INFO) as captured, bmocks.Bugzilla(self.BUGZILLA_URL.split('://')[1], issues=bmocks.ISSUES, environment=wkmocks.Environment(
+            BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+            BUGS_EXAMPLE_COM_PASSWORD='password',
+        )), mocks.remote.GitHub(remote='github.com/web-platform-tests/wpt', labels={
+            'webkit-export': dict(color='00000', description=''),
+        }) as wpt_remote, mocks.local.Git(
+            self.path,
+            remote='https://{}'.format(wpt_remote.remote)
+        ) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ):
+            # Remote branch must exist for the push to be rejected as non-fast-forward
+            git_mock.remotes['username/wpt-export-for-webkit-1'] = git_mock.commits[git_mock.default_branch][:]
+            wpt_remote.pull_requests.append({
+                'number': 42,
+                'state': 'open',
+                'title': 'Old title',
+                'body': 'Old body',
+                'user': {'login': 'USER'},
+                'head': {'ref': 'wpt-export-for-webkit-1', 'sha': 'abc123', 'label': 'USER:wpt-export-for-webkit-1'},
+                'base': {'ref': 'master', 'label': 'web-platform-tests:master', 'user': {'login': 'web-platform-tests'}},
+                'draft': False,
+                '_links': {'issue': {'href': 'https://api.github.com/repos/web-platform-tests/wpt/issues/42'}},
+                'reviews': [],
+            })
+            wpt_remote.issues[42] = dict(
+                creator=wpt_remote.users.create(username='USER'),
+                timestamp=0,
+                assignee=None,
+                comments=[],
+                title='Old title',
+                opened=True,
+                description='Old body',
+            )
+
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
+            host = TestExporterTest.MyMockHost()
+            host.filesystem.maybe_make_directory(self.path)
+            host.filesystem.write_binary_file(f'{self.path}/resources/testharness.js', '')
+            host.filesystem.write_binary_file(f'{self.path}/wpt', '')
+
+            host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+            exporter = WebPlatformTestExporter(host, options)
+            result = exporter.do_export()
+
+            self.assertEqual(result, 1)
+
+            issue = Tracker.from_string('{}/show_bug.cgi?id=1'.format(self.BUGZILLA_URL))
+            self.assertEqual(len(issue.comments), 2)
+
+        self.assertEqual(captured.stdout.getvalue(), '')
+        log = captured.root.log.getvalue()
+        self.assertIn('already exists', log)
+
+    def test_export_local_and_open_pr_errors_without_flag(self):
+        with OutputCapture(level=logging.INFO) as captured, bmocks.Bugzilla(self.BUGZILLA_URL.split('://')[1], issues=bmocks.ISSUES, environment=wkmocks.Environment(
+            BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+            BUGS_EXAMPLE_COM_PASSWORD='password',
+        )), mocks.remote.GitHub(remote='github.com/web-platform-tests/wpt', labels={
+            'webkit-export': dict(color='00000', description=''),
+        }) as wpt_remote, mocks.local.Git(
+            self.path,
+            remote='https://{}'.format(wpt_remote.remote)
+        ) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ):
+            # Pre-create the local branch
+            git_mock.checkout('wpt-export-for-webkit-1', create=True)
+            git_mock.checkout(git_mock.default_branch)
+
+            # Remote branch must exist for the push to be rejected as non-fast-forward
+            git_mock.remotes['username/wpt-export-for-webkit-1'] = git_mock.commits[git_mock.default_branch][:]
+            wpt_remote.pull_requests.append({
+                'number': 42,
+                'state': 'open',
+                'title': 'Old title',
+                'body': 'Old body',
+                'user': {'login': 'USER'},
+                'head': {'ref': 'wpt-export-for-webkit-1', 'sha': 'abc123', 'label': 'USER:wpt-export-for-webkit-1'},
+                'base': {'ref': 'master', 'label': 'web-platform-tests:master', 'user': {'login': 'web-platform-tests'}},
+                'draft': False,
+                '_links': {'issue': {'href': 'https://api.github.com/repos/web-platform-tests/wpt/issues/42'}},
+                'reviews': [],
+            })
+            wpt_remote.issues[42] = dict(
+                creator=wpt_remote.users.create(username='USER'),
+                timestamp=0,
+                assignee=None,
+                comments=[],
+                title='Old title',
+                opened=True,
+                description='Old body',
+            )
+
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
+            host = TestExporterTest.MyMockHost()
+            host.filesystem.maybe_make_directory(self.path)
+            host.filesystem.write_binary_file(f'{self.path}/resources/testharness.js', '')
+            host.filesystem.write_binary_file(f'{self.path}/wpt', '')
+
+            host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+            exporter = WebPlatformTestExporter(host, options)
+            result = exporter.do_export()
+
+            self.assertEqual(result, 1)
+
+            issue = Tracker.from_string('{}/show_bug.cgi?id=1'.format(self.BUGZILLA_URL))
+            self.assertEqual(len(issue.comments), 2)
+
+        self.assertEqual(captured.stdout.getvalue(), '')
+        log = captured.root.log.getvalue()
+        self.assertIn('already exists', log)
+
+    def test_export_closed_pr_succeeds_without_flag(self):
+        with OutputCapture(level=logging.INFO) as captured, bmocks.Bugzilla(self.BUGZILLA_URL.split('://')[1], issues=bmocks.ISSUES, environment=wkmocks.Environment(
+            BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+            BUGS_EXAMPLE_COM_PASSWORD='password',
+        )), mocks.remote.GitHub(remote='github.com/web-platform-tests/wpt', labels={
+            'webkit-export': dict(color='00000', description=''),
+        }) as wpt_remote, mocks.local.Git(
+            self.path,
+            remote='https://{}'.format(wpt_remote.remote)
+        ) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ):
+            # Closed PR — branch may have been deleted
+            wpt_remote.pull_requests.append({
+                'number': 42,
+                'state': 'closed',
+                'title': 'Old title',
+                'body': 'Old body',
+                'user': {'login': 'USER'},
+                'head': {'ref': 'wpt-export-for-webkit-1', 'sha': 'abc123', 'label': 'USER:wpt-export-for-webkit-1'},
+                'base': {'ref': 'master', 'label': 'web-platform-tests:master', 'user': {'login': 'web-platform-tests'}},
+                'draft': False,
+                '_links': {'issue': {'href': 'https://api.github.com/repos/web-platform-tests/wpt/issues/42'}},
+                'reviews': [],
+            })
+            wpt_remote.issues[42] = dict(
+                creator=wpt_remote.users.create(username='USER'),
+                timestamp=0,
+                assignee=None,
+                comments=[],
+                title='Old title',
+                opened=False,
+                description='Old body',
+            )
+
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
+            host = TestExporterTest.MyMockHost()
+            host.filesystem.maybe_make_directory(self.path)
+            host.filesystem.write_binary_file(f'{self.path}/resources/testharness.js', '')
+            host.filesystem.write_binary_file(f'{self.path}/wpt', '')
+
+            host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+            exporter = WebPlatformTestExporter(host, options)
+            exporter.do_export()
+
+            issue = Tracker.from_string('{}/show_bug.cgi?id=1'.format(self.BUGZILLA_URL))
+            self.assertEqual(issue.comments[-1].content, 'Submitted web-platform-tests pull request: https://github.com/web-platform-tests/wpt/pull/43')
+            self.assertEqual(issue.related_links, ['https://github.com/web-platform-tests/wpt/pull/43'])
+
             self.assertEqual(len(wpt_remote.pull_requests), 2)
 
         self.assertEqual(


### PR DESCRIPTION
#### d1c5b2c0162a8e505bf55c7051e1a0412ab7eaff
<pre>
[export-w3c-test-changes] Support --delete-existing/--no-delete-existing
<a href="https://bugs.webkit.org/show_bug.cgi?id=295350">https://bugs.webkit.org/show_bug.cgi?id=295350</a>
<a href="https://rdar.apple.com/155454170">rdar://155454170</a>

Reviewed by Elliott Williams.

Add a --delete-existing/--no-delete-existing flag, similar to the one
git-webkit already supports, to control whether the exporter may
overwrite existing local branches or force-push to existing remote
branches. Unlike git-webkit, which defaults to rebasing an existing
branch, the exporter defaults to --no-delete-existing and refuses to
proceed when it finds pre-existing state.

As part of this, stop unconditionally force-pushing: push without
-f first, parse the --porcelain output to detect a non-fast-forward
rejection, and only force-push if --delete-existing was given.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py:
(Git): Add push_error property for injecting push failures in tests.
Add show-ref --verify --quiet and push --porcelain routes, along with
show_ref_verify and push_porcelain methods.
* Tools/Scripts/webkitpy/w3c/test_exporter.py:
(WebPlatformTestExporter.create_branch_with_patch): Check whether the
local branch exists with show-ref --verify --quiet; refuse to proceed
without --delete-existing. Use checkout -b when creating, -B when
overwriting.
(WebPlatformTestExporter.push_to_wpt_fork): Replace unconditional
push -f with push --porcelain; parse output to distinguish
non-fast-forward rejections from fatal errors, and only force-push on
rejection when --delete-existing is set.
(parse_args): Add --delete-existing/--no-delete-existing via
arguments.NoAction.
* Tools/Scripts/webkitpy/w3c/test_exporter_unittest.py:
(TestExporterTest.test_export_local_branch_exists): Pass
--delete-existing.
(TestExporterTest.test_export_remote_branch_exists_no_pr): Ditto.
(TestExporterTest.test_export_updates_existing_open_pr): Ditto.
(TestExporterTest.test_export_local_and_remote_exist_with_open_pr):
Ditto.
(TestExporterTest.test_export_creates_new_pr_when_existing_is_closed):
Ditto.
(TestExporterTest.test_export_local_branch_exists_errors_without_flag):
(TestExporterTest.test_export_remote_branch_exists_errors_without_flag):
(TestExporterTest.test_export_push_fatal_error):
(TestExporterTest.test_export_push_non_rejected_error):
(TestExporterTest.test_export_open_pr_errors_without_flag):
(TestExporterTest.test_export_local_and_open_pr_errors_without_flag):
(TestExporterTest.test_export_closed_pr_succeeds_without_flag):

Canonical link: <a href="https://commits.webkit.org/314747@main">https://commits.webkit.org/314747@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3dd05807ab2e560b3cecda026d9bc12461789a11

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167103 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40598 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34184 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176151 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/124364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a146ef48-94e7-4fe1-90d5-10d5a42a86f6) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168969 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41031 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40608 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/129965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/124364 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/734ed7c4-d8c8-43e2-9aa6-46b0e58857e5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170062 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/32363 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/150140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110482 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/633d8db1-4849-43e5-86d1-1ee882293880) 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/166425 "Found 2 webkitpy test failures: webkitscmpy.test.land_unittest.TestLandBitBucket.test_blocking_reviewer, webkitscmpy.test.land_unittest.TestLandGitHub.test_blocking_reviewer") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31345 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30054 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24890 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/141328 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/27829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178690 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29546 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/138337 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/166504 "Passed tests") | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/40672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/34207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138240 "Passed tests") | | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/41360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/149627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104315 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25433 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/41360 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/26502 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/39864 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/39261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/4600 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/39511 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/39405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->