### PR TITLE
Potential use after free of m_controller under ReadableStreamBYOBRequest::visitAdditionalChildren()

### DIFF
--- a/Source/WebCore/Modules/streams/ReadableByteStreamController.cpp
+++ b/Source/WebCore/Modules/streams/ReadableByteStreamController.cpp
@@ -183,13 +183,8 @@ ReadableStreamBYOBRequest* ReadableByteStreamController::getByobRequest() const
 {
     if (!m_byobRequest && !m_pendingPullIntos.isEmpty()) {
         auto& firstDescriptor = m_pendingPullIntos.first();
-        auto view = JSC::Uint8Array::create(firstDescriptor.buffer.ptr(), firstDescriptor.byteOffset + firstDescriptor.bytesFilled, firstDescriptor.byteLength - firstDescriptor.bytesFilled);
-        Ref byobRequest = ReadableStreamBYOBRequest::create();
-
-        byobRequest->setController(const_cast<ReadableByteStreamController*>(this));
-        byobRequest->setView(view.ptr());
-
-        m_byobRequest = WTF::move(byobRequest);
+        Ref view = JSC::Uint8Array::create(firstDescriptor.buffer.ptr(), firstDescriptor.byteOffset + firstDescriptor.bytesFilled, firstDescriptor.byteLength - firstDescriptor.bytesFilled);
+        m_byobRequest = ReadableStreamBYOBRequest::create(*const_cast<ReadableByteStreamController*>(this), WTF::move(view));
     }
 
     return m_byobRequest.get();
@@ -434,8 +429,8 @@ void ReadableByteStreamController::invalidateByobRequest()
     if (!byobRequest)
         return;
 
-    byobRequest->setController(nullptr);
-    byobRequest->setView(nullptr);
+    byobRequest->clearController();
+    byobRequest->clearView();
     m_byobRequest = nullptr;
 }
 

--- a/Source/WebCore/Modules/streams/ReadableStreamBYOBRequest.cpp
+++ b/Source/WebCore/Modules/streams/ReadableStreamBYOBRequest.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "ReadableStreamBYOBRequest.h"
 
+#include "JSReadableStream.h"
 #include "JSReadableStreamBYOBRequest.h"
 #include "ReadableByteStreamController.h"
 #include "ReadableStream.h"
@@ -33,12 +34,23 @@
 
 namespace WebCore {
 
-Ref<ReadableStreamBYOBRequest> ReadableStreamBYOBRequest::create()
+Ref<ReadableStreamBYOBRequest> ReadableStreamBYOBRequest::create(ReadableByteStreamController& controller, Ref<JSC::ArrayBufferView>&& view)
 {
-    return adoptRef(*new ReadableStreamBYOBRequest);
+    return adoptRef(*new ReadableStreamBYOBRequest(controller, WTF::move(view)));
 }
 
-ReadableStreamBYOBRequest::ReadableStreamBYOBRequest() = default;
+ReadableStreamBYOBRequest::ReadableStreamBYOBRequest(ReadableByteStreamController& controller, Ref<JSC::ArrayBufferView>&& view)
+    : m_controller(controller)
+    , m_view(WTF::move(view))
+{
+    Ref stream = controller.stream();
+    auto* globalObject = stream->globalObject();
+    ASSERT(globalObject);
+    if (!globalObject)
+        return;
+
+    m_streamWrapperForGC.set(*globalObject, globalObject, toJS(globalObject, globalObject, stream.get()));
+}
 
 JSC::ArrayBufferView* ReadableStreamBYOBRequest::view() const
 {
@@ -72,21 +84,21 @@ ExceptionOr<void> ReadableStreamBYOBRequest::respondWithNewView(JSDOMGlobalObjec
     return controller->respondWithNewView(globalObject, view);
 }
 
-void ReadableStreamBYOBRequest::setController(ReadableByteStreamController* controller)
+void ReadableStreamBYOBRequest::clearController()
 {
-    m_controller = controller;
+    m_controller = nullptr;
+    m_streamWrapperForGC.clear();
 }
 
-void ReadableStreamBYOBRequest::setView(JSC::ArrayBufferView* view)
+void ReadableStreamBYOBRequest::clearView()
 {
-    m_view = view;
+    m_view = nullptr;
 }
 
 template<typename Visitor>
 void ReadableStreamBYOBRequest::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    if (m_controller)
-        SUPPRESS_UNCOUNTED_ARG m_controller->stream().visitAdditionalChildrenInGCThread(visitor);
+    m_streamWrapperForGC.visitInGCThread(visitor);
 }
 
 DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(ReadableStreamBYOBRequest);

--- a/Source/WebCore/Modules/streams/ReadableStreamBYOBRequest.h
+++ b/Source/WebCore/Modules/streams/ReadableStreamBYOBRequest.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "ExceptionOr.h"
+#include "JSValueInWrappedObject.h"
 #include <wtf/RefCounted.h>
 #include <wtf/WeakPtr.h>
 
@@ -40,22 +41,23 @@ class ReadableByteStreamController;
 
 class ReadableStreamBYOBRequest : public RefCounted<ReadableStreamBYOBRequest> {
 public:
-    static Ref<ReadableStreamBYOBRequest> create();
+    static Ref<ReadableStreamBYOBRequest> create(ReadableByteStreamController&, Ref<JSC::ArrayBufferView>&&);
 
     JSC::ArrayBufferView* NODELETE view() const;
     ExceptionOr<void> respond(JSDOMGlobalObject&, size_t);
     ExceptionOr<void> respondWithNewView(JSDOMGlobalObject&, JSC::ArrayBufferView&);
 
-    void NODELETE setController(ReadableByteStreamController*);
-    void NODELETE setView(JSC::ArrayBufferView*);
+    void clearController();
+    void clearView();
 
     template<typename Visitor> void visitAdditionalChildrenInGCThread(Visitor&);
 
 private:
-    ReadableStreamBYOBRequest();
+    ReadableStreamBYOBRequest(ReadableByteStreamController&, Ref<JSC::ArrayBufferView>&&);
 
     WeakPtr<ReadableByteStreamController> m_controller;
     RefPtr<JSC::ArrayBufferView> m_view;
+    JSValueInWrappedObject m_streamWrapperForGC;
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 42ec79c1b6c50d5e0493fb3cda49d111ccc6d91d
<pre>
Potential use after free of m_controller under ReadableStreamBYOBRequest::visitAdditionalChildren()
<a href="https://rdar.apple.com/172462937">rdar://172462937</a>

Reviewed by Chris Dumez.

m_controller can be nullified while being used in GC thread.
We remove usage of m_controller in the GC thread.
Instead, request will store its stream as a JSValueInWrappedObject, and we will use this JSValueInWrappedObject in the GC thread.
We make sure to clear the JSValueInWrappedObject when the request gets invalidated.

Originally-landed-as: 305413.480@rapid/safari-7624.2.5.110-branch (5d62bc6b2841). <a href="https://rdar.apple.com/176062477">rdar://176062477</a>
Canonical link: <a href="https://commits.webkit.org/314990@main">https://commits.webkit.org/314990@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fd1070921c07d1241d13800f05cc129117fc5ffb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167652 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41149 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34744 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176709 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125333 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169518 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41584 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41162 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130443 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91689 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170611 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32863 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150642 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110960 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31845 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30545 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25442 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141832 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28337 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179249 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32290 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30055 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138847 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41221 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34702 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138732 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37380 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41909 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105073 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33995 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27008 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40413 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113659 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39810 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5109 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40061 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39955 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->