### PR TITLE
Remove ResourceRequest.m_cachePartition

### DIFF
--- a/LayoutTests/ipc/create-socket-channel-invalid-url-crash.html
+++ b/LayoutTests/ipc/create-socket-channel-invalid-url-crash.html
@@ -35,7 +35,7 @@ setTimeout(async () => {
                     m_targetAddressSpace: 0
                 }
             },
-            cachePartition: '',
+            shouldBlockThirdPartyStorage: true,
             hiddenFromInspector: true
         },
         protocol: '',

--- a/LayoutTests/ipc/invalid-url-network-data-task-crash.html
+++ b/LayoutTests/ipc/invalid-url-network-data-task-crash.html
@@ -46,7 +46,7 @@ setTimeout(async () => {
                     m_targetAddressSpace: 0
                 }
             },
-            cachePartition: '',
+            shouldBlockThirdPartyStorage: true,
             hiddenFromInspector: true
         },
         pageID: IPC.pageID,

--- a/Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp
+++ b/Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp
@@ -110,7 +110,7 @@ std::optional<ResourceRequest> ThreadableWebSocketChannel::webSocketConnectReque
     auto userAgent = document.userAgent(validatedURL->url);
     ResourceRequest request { WTF::move(validatedURL->url) };
     request.setHTTPUserAgent(userAgent);
-    request.setDomainForCachePartition(document.domainForCachePartition());
+    request.setShouldBlockThirdPartyStorage(document.shouldBlockThirdPartyStorage());
     request.setAllowCookies(validatedURL->areCookiesAllowed);
     request.setFirstPartyForCookies(document.firstPartyForCookies());
     request.setHTTPHeaderField(HTTPHeaderName::Origin, protect(document.securityOrigin())->toString());

--- a/Source/WebCore/dom/ScriptExecutionContext.cpp
+++ b/Source/WebCore/dom/ScriptExecutionContext.cpp
@@ -752,13 +752,15 @@ JSC::JSGlobalObject* ScriptExecutionContext::globalObject() const
 
 String ScriptExecutionContext::domainForCachePartition() const
 {
-    if (!m_domainForCachePartition.isNull())
-        return m_domainForCachePartition;
-
     if (m_storageBlockingPolicy != StorageBlockingPolicy::BlockThirdParty)
         return emptyString();
 
     return protect(topOrigin())->domainForCachePartition();
+}
+
+bool ScriptExecutionContext::shouldBlockThirdPartyStorage() const
+{
+    return m_storageBlockingPolicy == StorageBlockingPolicy::BlockThirdParty;
 }
 
 bool ScriptExecutionContext::allowsMediaDevices() const

--- a/Source/WebCore/dom/ScriptExecutionContext.h
+++ b/Source/WebCore/dom/ScriptExecutionContext.h
@@ -342,7 +342,6 @@ public:
     WEBCORE_EXPORT JSC::JSGlobalObject* globalObject() const;
 
     WEBCORE_EXPORT String domainForCachePartition() const;
-    void setDomainForCachePartition(String&& domain) { m_domainForCachePartition = WTF::move(domain); }
 
     bool allowsMediaDevices() const;
     ServiceWorker* activeServiceWorker() const { return m_activeServiceWorker.get(); }
@@ -367,6 +366,8 @@ public:
     void setHasLoggedAuthenticatedEncryptionWarning(bool value) { m_hasLoggedAuthenticatedEncryptionWarning = value; }
 
     void setStorageBlockingPolicy(StorageBlockingPolicy policy) { m_storageBlockingPolicy = policy; }
+    WEBCORE_EXPORT bool shouldBlockThirdPartyStorage() const;
+
     enum class ResourceType : uint8_t {
         Cookies,
         Geolocation,
@@ -464,7 +465,6 @@ private:
     RefPtr<ServiceWorker> m_activeServiceWorker;
     HashMap<ServiceWorkerIdentifier, WeakRef<ServiceWorker, WeakPtrImplWithEventTargetData>> m_serviceWorkers;
 
-    String m_domainForCachePartition;
     mutable ScriptExecutionContextIdentifier m_identifier;
 
     HashMap<NotificationCallbackIdentifier, CompletionHandler<void()>> m_notificationCallbacks;

--- a/Source/WebCore/html/DOMURL.cpp
+++ b/Source/WebCore/html/DOMURL.cpp
@@ -124,7 +124,7 @@ void DOMURL::revokeObjectURL(ScriptExecutionContext& scriptExecutionContext, con
 {
     URL url { urlString };
     ResourceRequest request(WTF::move(url));
-    request.setDomainForCachePartition(scriptExecutionContext.domainForCachePartition());
+    request.setShouldBlockThirdPartyStorage(scriptExecutionContext.shouldBlockThirdPartyStorage());
 
     MemoryCache::removeRequestFromSessionCaches(scriptExecutionContext, request);
 

--- a/Source/WebCore/inspector/InspectorResourceUtilities.cpp
+++ b/Source/WebCore/inspector/InspectorResourceUtilities.cpp
@@ -249,7 +249,7 @@ RefPtr<CachedResource> cachedResource(const LocalFrame* frame, const URL& url)
     RefPtr cachedResource = protect(frame->document())->cachedResourceLoader().cachedResource(MemoryCache::removeFragmentIdentifierIfNeeded(url));
     if (!cachedResource) {
         ResourceRequest request(URL { url });
-        request.setDomainForCachePartition(protect(frame->document())->domainForCachePartition());
+        request.setShouldBlockThirdPartyStorage(protect(frame->document())->shouldBlockThirdPartyStorage());
         cachedResource = MemoryCache::singleton().resourceForRequest(request, frame->page()->sessionID());
     }
 

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -2311,17 +2311,10 @@ void DocumentLoader::loadMainResource(ResourceRequest&& request)
     }
 
     CachedResourceRequest mainResourceRequest(WTF::move(request), mainResourceLoadOptions);
-    if (!frame->isMainFrame() && frame->document()) {
-        // If we are loading the main resource of a subframe, use the cache partition of the main document.
-        mainResourceRequest.setDomainForCachePartition(*protect(frame->document()));
-    } else {
-        if (frameLoader()->frame().settings().storageBlockingPolicy() != StorageBlockingPolicy::BlockThirdParty)
-            mainResourceRequest.setDomainForCachePartition(emptyString());
-        else {
-            auto origin = SecurityOrigin::create(mainResourceRequest.resourceRequest().url());
-            mainResourceRequest.setDomainForCachePartition(origin->domainForCachePartition());
-        }
-    }
+    if (!frame->isMainFrame() && frame->document())
+        mainResourceRequest.resourceRequest().setShouldBlockThirdPartyStorage(protect(frame->document())->shouldBlockThirdPartyStorage());
+    else
+        mainResourceRequest.resourceRequest().setShouldBlockThirdPartyStorage(frameLoader()->frame().settings().storageBlockingPolicy() == StorageBlockingPolicy::BlockThirdParty);
 
     auto mainResourceOrError = m_cachedResourceLoader->requestMainResource(WTF::move(mainResourceRequest));
 

--- a/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
+++ b/Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp
@@ -772,7 +772,10 @@ RefPtr<LegacyWebArchive> LegacyWebArchive::createInternal(const String& markupSt
                 auto resource = documentLoader->subresource(subresourceURL);
                 if (!resource) {
                     ResourceRequest request(URL { subresourceURL });
-                    request.setDomainForCachePartition(protect(frame.document())->domainForCachePartition());
+                    if (RefPtr document = frame.document()) {
+                        request.setShouldBlockThirdPartyStorage(document->shouldBlockThirdPartyStorage());
+                        request.setFirstPartyForCookies(document->firstPartyForCookies());
+                    }
                     if (RefPtr cachedResource = MemoryCache::singleton().resourceForRequest(request, frame.page()->sessionID()))
                         resource = ArchiveResource::create(cachedResource->resourceBuffer(), subresourceURL, cachedResource->response());
                 }

--- a/Source/WebCore/loader/cache/CachedImage.cpp
+++ b/Source/WebCore/loader/cache/CachedImage.cpp
@@ -87,23 +87,6 @@ CachedImage::CachedImage(Image* image, PAL::SessionID sessionID, const CookieJar
 {
 }
 
-CachedImage::CachedImage(const URL& url, Image* image, PAL::SessionID sessionID, const CookieJar* cookieJar, const String& domainForCachePartition)
-    : CachedResource(url, Type::ImageResource, sessionID, cookieJar)
-    , m_image(image)
-    , m_updateImageDataCount(0)
-    , m_isManuallyCached(true)
-    , m_shouldPaintBrokenImage(true)
-    , m_forceUpdateImageDataEnabledForTesting(false)
-{
-    m_resourceRequest.setDomainForCachePartition(domainForCachePartition);
-
-    // Use the incoming URL in the response field. This ensures that code using the response directly,
-    // such as origin checks for security, actually see something.
-    mutableResponse().setURL(URL { url });
-
-    setAllowsOrientationOverride(isCORSSameOrigin() || protect(m_image)->sourceURL().protocolIsData());
-}
-
 CachedImage::~CachedImage()
 {
     clearImage();

--- a/Source/WebCore/loader/cache/CachedImage.h
+++ b/Source/WebCore/loader/cache/CachedImage.h
@@ -48,8 +48,6 @@ class CachedImage final : public CachedResource {
 public:
     CachedImage(CachedResourceRequest&&, PAL::SessionID, const CookieJar*);
     CachedImage(Image*, PAL::SessionID, const CookieJar*);
-    // Constructor to use for manually cached images.
-    CachedImage(const URL&, Image*, PAL::SessionID, const CookieJar*, const String& domainForCachePartition);
     virtual ~CachedImage();
 
     WEBCORE_EXPORT Image* image() const; // Returns the nullImage() if the image is not available yet.

--- a/Source/WebCore/loader/cache/CachedResource.h
+++ b/Source/WebCore/loader/cache/CachedResource.h
@@ -139,7 +139,7 @@ public:
 
     const ResourceRequest& resourceRequest() const LIFETIME_BOUND { return m_resourceRequest; }
     const URL& url() const LIFETIME_BOUND { return m_resourceRequest.url(); }
-    const String& cachePartition() const LIFETIME_BOUND { return m_resourceRequest.cachePartition(); }
+    String cachePartition() const { return m_resourceRequest.cachePartition(); }
     PAL::SessionID sessionID() const { return m_sessionID; }
     const CookieJar* cookieJar() const { return m_cookieJar.get(); }
     Type type() const { return m_type; }

--- a/Source/WebCore/loader/cache/CachedResourceLoader.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceLoader.cpp
@@ -316,7 +316,7 @@ CachedResourceHandle<CachedCSSStyleSheet> CachedResourceLoader::requestUserCSSSt
 
     ASSERT(document());
     if (RefPtr document = this->document())
-        request.setDomainForCachePartition(*document);
+        request.resourceRequest().setShouldBlockThirdPartyStorage(document->shouldBlockThirdPartyStorage());
 
     Ref memoryCache = MemoryCache::singleton();
     if (request.allowsCaching()) {
@@ -1267,7 +1267,7 @@ ResourceErrorOr<Ref<CachedResource>> CachedResourceLoader::requestResource(Cache
     RefPtr<CachedResource> resource;
     CheckedPtr<ContentSecurityPolicy> contentSecurityPolicy;
     if (document) {
-        request.setDomainForCachePartition(*document);
+        request.resourceRequest().setShouldBlockThirdPartyStorage(document->shouldBlockThirdPartyStorage());
         request.resourceRequest().setFirstPartyForCookies(document->firstPartyForCookies());
         contentSecurityPolicy = document->contentSecurityPolicy();
     }

--- a/Source/WebCore/loader/cache/CachedResourceRequest.cpp
+++ b/Source/WebCore/loader/cache/CachedResourceRequest.cpp
@@ -125,16 +125,6 @@ void CachedResourceRequest::upgradeInsecureRequestIfNeeded(Document& document, C
     upgradeInsecureResourceRequestIfNeeded(m_resourceRequest, document, alwaysUpgradeRequest);
 }
 
-void CachedResourceRequest::setDomainForCachePartition(Document& document)
-{
-    m_resourceRequest.setDomainForCachePartition(document.domainForCachePartition());
-}
-
-void CachedResourceRequest::setDomainForCachePartition(const String& domain)
-{
-    m_resourceRequest.setDomainForCachePartition(domain);
-}
-
 static inline void appendAdditionalSupportedImageMIMETypes(StringBuilder& acceptHeader)
 {
     for (const auto& additionalSupportedImageMIMEType : MIMETypeRegistry::additionalSupportedImageMIMETypes()) {

--- a/Source/WebCore/loader/cache/CachedResourceRequest.h
+++ b/Source/WebCore/loader/cache/CachedResourceRequest.h
@@ -97,8 +97,6 @@ public:
 #if ENABLE(CONTENT_EXTENSIONS)
     void applyResults(ContentRuleListResults&&, Page*);
 #endif
-    void setDomainForCachePartition(Document&);
-    void setDomainForCachePartition(const String&);
     bool isLinkPreload() const { return m_isLinkPreload; }
     void setIsLinkPreload() { m_isLinkPreload = true; }
 

--- a/Source/WebCore/loader/cache/MemoryCache.cpp
+++ b/Source/WebCore/loader/cache/MemoryCache.cpp
@@ -35,7 +35,7 @@
 #include "Image.h"
 #include "LocalFrameView.h"
 #include "Logging.h"
-#include "PublicSuffixStore.h"
+#include "RegistrableDomain.h"
 #include "SharedBuffer.h"
 #include "WorkerGlobalScope.h"
 #include "WorkerLoaderProxy.h"
@@ -559,14 +559,16 @@ void MemoryCache::removeResourcesWithOrigin(const SecurityOrigin& origin, const 
 void MemoryCache::removeResourcesWithOrigin(const SecurityOrigin& origin)
 {
     RELEASE_ASSERT(isMainThread());
-    String originPartition = ResourceRequest::partitionName(origin.host());
+    RegistrableDomain domain = RegistrableDomain::uncheckedCreateFromHost(origin.host());
+    String originPartition = domain.isEmpty() ? emptyString() : domain.string();
     removeResourcesWithOrigin(origin, originPartition);
 }
 
 void MemoryCache::removeResourcesWithOrigin(const ClientOrigin& origin)
 {
     RELEASE_ASSERT(isMainThread());
-    auto cachePartition = origin.topOrigin == origin.clientOrigin ? emptyString() : ResourceRequest::partitionName(origin.topOrigin.host());
+    RegistrableDomain topDomain = RegistrableDomain::uncheckedCreateFromHost(origin.topOrigin.host());
+    auto cachePartition = origin.topOrigin == origin.clientOrigin ? emptyString() : (topDomain.isEmpty() ? emptyString() : topDomain.string());
     removeResourcesWithOrigin(origin.clientOrigin.securityOrigin(), cachePartition);
 }
 
@@ -579,8 +581,10 @@ void MemoryCache::removeResourcesWithOrigins(PAL::SessionID sessionID, const Has
 
     HashSet<String> originPartitions;
 
-    for (auto& origin : origins)
-        originPartitions.add(ResourceRequest::partitionName(origin->host()));
+    for (auto& origin : origins) {
+        RegistrableDomain domain = RegistrableDomain::uncheckedCreateFromHost(origin->host());
+        originPartitions.add(domain.isEmpty() ? emptyString() : domain.string());
+    }
 
     Vector<WeakPtr<CachedResource>> resourcesToRemove;
     for (auto& keyValuePair : *resourceMap) {

--- a/Source/WebCore/page/Page.cpp
+++ b/Source/WebCore/page/Page.cpp
@@ -5213,10 +5213,7 @@ void Page::setupForRemoteWorker(const URL& scriptURL, const SecurityOriginData& 
     if (auto* documentLoader = localMainFrame->loader().documentLoader())
         documentLoader->setAdvancedPrivacyProtections(advancedPrivacyProtections);
 
-    if (document->settings().storageBlockingPolicy() != StorageBlockingPolicy::BlockThirdParty)
-        document->setDomainForCachePartition(String { emptyString() });
-    else
-        document->setDomainForCachePartition(origin->domainForCachePartition());
+    document->setStorageBlockingPolicy(document->settings().storageBlockingPolicy());
 
     if (auto policy = parseReferrerPolicy(referrerPolicy, ReferrerPolicySource::HTTPHeader))
         document->setReferrerPolicy(*policy);

--- a/Source/WebCore/platform/network/ResourceRequestBase.cpp
+++ b/Source/WebCore/platform/network/ResourceRequestBase.cpp
@@ -30,7 +30,6 @@
 #include "HTTPStatusCodes.h"
 #include "IPAddressSpace.h"
 #include "Logging.h"
-#include "PublicSuffixStore.h"
 #include "RegistrableDomain.h"
 #include "ResourceRequest.h"
 #include "ResourceResponse.h"
@@ -73,7 +72,7 @@ void ResourceRequestBase::setAsIsolatedCopy(const ResourceRequest& other)
     setPriority(other.priority());
     setRequester(other.requester());
     setInitiatorIdentifier(other.initiatorIdentifier().isolatedCopy());
-    setCachePartition(other.cachePartition().isolatedCopy());
+    setShouldBlockThirdPartyStorage(other.shouldBlockThirdPartyStorage());
 
     if (auto inspectorInitiatorNodeIdentifier = other.inspectorInitiatorNodeIdentifier())
         setInspectorInitiatorNodeIdentifier(*inspectorInitiatorNodeIdentifier);
@@ -860,25 +859,18 @@ unsigned initializeMaximumHTTPConnectionCountPerHost()
 }
 #endif
 
-void ResourceRequestBase::setCachePartition(const String& cachePartition)
+String ResourceRequestBase::cachePartition() const
 {
 #if ENABLE(CACHE_PARTITIONING)
-    ASSERT(!cachePartition.isNull());
-    ASSERT(cachePartition == partitionName(cachePartition));
-    m_cachePartition = cachePartition;
+    if (!m_shouldBlockThirdPartyStorage)
+        return emptyString();
+    RegistrableDomain domain(firstPartyForCookies());
+    if (domain.isEmpty())
+        return emptyString();
+    return domain.string();
 #else
-    UNUSED_PARAM(cachePartition);
+    return emptyString();
 #endif
-}
-
-String ResourceRequestBase::partitionName(const String& domain)
-{
-    if (domain.isNull())
-        return emptyString();
-    auto highLevel = PublicSuffixStore::singleton().topPrivatelyControlledDomain(domain);
-    if (highLevel.isNull())
-        return emptyString();
-    return highLevel;
 }
 
 bool ResourceRequestBase::isThirdParty() const

--- a/Source/WebCore/platform/network/ResourceRequestBase.h
+++ b/Source/WebCore/platform/network/ResourceRequestBase.h
@@ -239,10 +239,9 @@ public:
     WEBCORE_EXPORT ResourceLoadPriority priority() const;
     WEBCORE_EXPORT void setPriority(ResourceLoadPriority);
 
-    WEBCORE_EXPORT static String partitionName(const String& domain);
-    const String& cachePartition() const LIFETIME_BOUND { return m_cachePartition; }
-    WEBCORE_EXPORT void setCachePartition(const String&);
-    void setDomainForCachePartition(const String& domain) { setCachePartition(partitionName(domain)); }
+    WEBCORE_EXPORT String cachePartition() const;
+    bool shouldBlockThirdPartyStorage() const { return m_shouldBlockThirdPartyStorage; }
+    void setShouldBlockThirdPartyStorage(bool value) { m_shouldBlockThirdPartyStorage = value; }
 
     WEBCORE_EXPORT bool isConditional() const;
     WEBCORE_EXPORT void makeUnconditional();
@@ -328,13 +327,13 @@ protected:
     
     RequestData m_requestData;
     String m_initiatorIdentifier;
-    String m_cachePartition { emptyString() };
     RefPtr<FormData> m_httpBody;
     std::optional<int> m_inspectorInitiatorNodeIdentifier;
     mutable bool m_resourceRequestUpdated : 1;
     mutable bool m_platformRequestUpdated : 1;
     mutable bool m_resourceRequestBodyUpdated : 1;
     mutable bool m_platformRequestBodyUpdated : 1;
+    bool m_shouldBlockThirdPartyStorage : 1 { true };
     bool m_hiddenFromInspector : 1;
 
 private:

--- a/Source/WebCore/platform/network/cf/ResourceRequest.h
+++ b/Source/WebCore/platform/network/cf/ResourceRequest.h
@@ -78,16 +78,16 @@ public:
     
     WEBCORE_EXPORT ResourceRequest(NSURLRequest *);
 
-    ResourceRequest(ResourceRequestBase&& base, String&& cachePartition, bool hiddenFromInspector)
+    ResourceRequest(ResourceRequestBase&& base, bool shouldBlockThirdPartyStorage, bool hiddenFromInspector)
         : ResourceRequestBase(WTF::move(base))
     {
-        m_cachePartition = WTF::move(cachePartition);
+        m_shouldBlockThirdPartyStorage = shouldBlockThirdPartyStorage;
         m_hiddenFromInspector = hiddenFromInspector;
     }
 
-    ResourceRequest(ResourceRequestPlatformData&&, const String& cachePartition, bool hiddenFromInspector);
+    ResourceRequest(ResourceRequestPlatformData&&, bool shouldBlockThirdPartyStorage, bool hiddenFromInspector);
 
-    WEBCORE_EXPORT static ResourceRequest fromResourceRequestData(ResourceRequestData&&, String&& cachePartition, bool hiddenFromInspector);
+    WEBCORE_EXPORT static ResourceRequest fromResourceRequestData(ResourceRequestData&&, bool shouldBlockThirdPartyStorage, bool hiddenFromInspector);
 
     WEBCORE_EXPORT void updateFromDelegatePreservingOldProperties(const ResourceRequest&);
     

--- a/Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm
+++ b/Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm
@@ -60,7 +60,7 @@ ResourceRequest::ResourceRequest(NSURLRequest *nsRequest)
 #endif
 }
 
-ResourceRequest::ResourceRequest(ResourceRequestPlatformData&& platformData, const String& cachePartition, bool hiddenFromInspector)
+ResourceRequest::ResourceRequest(ResourceRequestPlatformData&& platformData, bool shouldBlockThirdPartyStorage, bool hiddenFromInspector)
 {
     if (platformData.m_urlRequest) {
         if (platformData.m_requester)
@@ -75,7 +75,7 @@ ResourceRequest::ResourceRequest(ResourceRequestPlatformData&& platformData, con
         setWasSchemeOptimisticallyUpgraded(platformData.m_wasSchemeOptimisticallyUpgraded);
     }
 
-    setCachePartition(cachePartition);
+    setShouldBlockThirdPartyStorage(shouldBlockThirdPartyStorage);
     setHiddenFromInspector(hiddenFromInspector);
 }
 
@@ -86,11 +86,11 @@ ResourceRequestData ResourceRequest::getRequestDataToSerialize() const
     return m_requestData;
 }
 
-ResourceRequest ResourceRequest::fromResourceRequestData(ResourceRequestData&& requestData, String&& cachePartition, bool hiddenFromInspector)
+ResourceRequest ResourceRequest::fromResourceRequestData(ResourceRequestData&& requestData, bool shouldBlockThirdPartyStorage, bool hiddenFromInspector)
 {
     if (std::holds_alternative<RequestData>(requestData))
-        return ResourceRequest(WTF::move(std::get<RequestData>(requestData)), WTF::move(cachePartition), hiddenFromInspector);
-    return ResourceRequest(WTF::move(std::get<ResourceRequestPlatformData>(requestData)), WTF::move(cachePartition), hiddenFromInspector);
+        return ResourceRequest(WTF::move(std::get<RequestData>(requestData)), shouldBlockThirdPartyStorage, hiddenFromInspector);
+    return ResourceRequest(WTF::move(std::get<ResourceRequestPlatformData>(requestData)), shouldBlockThirdPartyStorage, hiddenFromInspector);
 }
 
 NSURLRequest *ResourceRequest::nsURLRequest(HTTPBodyUpdatePolicy bodyPolicy) const
@@ -204,9 +204,8 @@ void ResourceRequest::doUpdateResourceRequest()
     }
 
     if (m_nsRequest) {
-        RetainPtr<NSString> cachePartition = [NSURLProtocol propertyForKey:bridge_cast(_kCFURLCachePartitionKey) inRequest:m_nsRequest.get()];
-        if (cachePartition)
-            m_cachePartition = cachePartition.get();
+        RetainPtr cachePartition = dynamic_objc_cast<NSString>([NSURLProtocol propertyForKey:bridge_cast(_kCFURLCachePartitionKey) inRequest:m_nsRequest.get()]);
+        m_shouldBlockThirdPartyStorage = !![cachePartition length];
     }
 }
 

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -987,7 +987,7 @@ CachedResource* Internals::resourceFromMemoryCache(const String& url)
         return nullptr;
 
     ResourceRequest request(contextDocument()->encodingParseURL(url));
-    request.setDomainForCachePartition(contextDocument()->domainForCachePartition());
+    request.setShouldBlockThirdPartyStorage(contextDocument()->shouldBlockThirdPartyStorage());
 
     return MemoryCache::singleton().resourceForRequest(request, contextDocument()->page()->sessionID());
 }

--- a/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerContainer.cpp
@@ -247,7 +247,7 @@ void ServiceWorkerContainer::addRegistration(Variant<Ref<TrustedScriptURL>, Stri
     jobData.topOrigin = context->topOrigin().data();
     jobData.workerType = options.type;
     jobData.type = ServiceWorkerJobType::Register;
-    jobData.domainForCachePartition = context->domainForCachePartition();
+    jobData.shouldBlockThirdPartyStorage = context->shouldBlockThirdPartyStorage();
     jobData.registrationOptions = options;
 
     scheduleJob(ServiceWorkerJob::create(*this, WTF::move(promise), WTF::move(jobData)));
@@ -301,7 +301,7 @@ void ServiceWorkerContainer::updateRegistration(const URL& scopeURL, const URL& 
     jobData.topOrigin = context->topOrigin().data();
     jobData.workerType = workerType;
     jobData.type = ServiceWorkerJobType::Update;
-    jobData.domainForCachePartition = context->domainForCachePartition();
+    jobData.shouldBlockThirdPartyStorage = context->shouldBlockThirdPartyStorage();
     jobData.scopeURL = scopeURL;
     jobData.scriptURL = scriptURL;
 

--- a/Source/WebCore/workers/service/ServiceWorkerJobData.cpp
+++ b/Source/WebCore/workers/service/ServiceWorkerJobData.cpp
@@ -42,7 +42,7 @@ ServiceWorkerJobData::ServiceWorkerJobData(Identifier identifier, const ServiceW
 {
 }
 
-ServiceWorkerJobData::ServiceWorkerJobData(WebCore::ServiceWorkerJobDataIdentifier&& identifier, URL&& scriptURL, URL&& clientCreationURL, WebCore::SecurityOriginData&& topOrigin, URL&& scopeURL, WebCore::ServiceWorkerOrClientIdentifier&& sourceContext, WebCore::WorkerType workerType, WebCore::ServiceWorkerJobType type, String&& domainForCachePartition, bool isFromServiceWorkerPage, std::optional<WebCore::ServiceWorkerRegistrationOptions>&& registrationOptions)
+ServiceWorkerJobData::ServiceWorkerJobData(WebCore::ServiceWorkerJobDataIdentifier&& identifier, URL&& scriptURL, URL&& clientCreationURL, WebCore::SecurityOriginData&& topOrigin, URL&& scopeURL, WebCore::ServiceWorkerOrClientIdentifier&& sourceContext, WebCore::WorkerType workerType, WebCore::ServiceWorkerJobType type, bool shouldBlockThirdPartyStorage, bool isFromServiceWorkerPage, std::optional<WebCore::ServiceWorkerRegistrationOptions>&& registrationOptions)
     : scriptURL(WTF::move(scriptURL))
     , clientCreationURL(WTF::move(clientCreationURL))
     , topOrigin(WTF::move(topOrigin))
@@ -50,7 +50,7 @@ ServiceWorkerJobData::ServiceWorkerJobData(WebCore::ServiceWorkerJobDataIdentifi
     , sourceContext(WTF::move(sourceContext))
     , workerType(workerType)
     , type(type)
-    , domainForCachePartition(WTF::move(domainForCachePartition))
+    , shouldBlockThirdPartyStorage(shouldBlockThirdPartyStorage)
     , isFromServiceWorkerPage(isFromServiceWorkerPage)
     , registrationOptions(WTF::move(registrationOptions))
     , m_identifier(WTF::move(identifier))
@@ -82,7 +82,7 @@ ServiceWorkerJobData ServiceWorkerJobData::isolatedCopy() const
     result.clientCreationURL = clientCreationURL.isolatedCopy();
     result.topOrigin = topOrigin.isolatedCopy();
     result.scopeURL = scopeURL.isolatedCopy();
-    result.domainForCachePartition = domainForCachePartition.isolatedCopy();
+    result.shouldBlockThirdPartyStorage = shouldBlockThirdPartyStorage;
     if (registrationOptions) {
         ASSERT(type == ServiceWorkerJobType::Register);
         result.registrationOptions = crossThreadCopy(registrationOptions);

--- a/Source/WebCore/workers/service/ServiceWorkerJobData.h
+++ b/Source/WebCore/workers/service/ServiceWorkerJobData.h
@@ -40,7 +40,7 @@ struct ServiceWorkerJobData {
     using Identifier = ServiceWorkerJobDataIdentifier;
     ServiceWorkerJobData(SWServerConnectionIdentifier, const ServiceWorkerOrClientIdentifier& sourceContext);
     ServiceWorkerJobData(Identifier, const ServiceWorkerOrClientIdentifier& sourceContext);
-    WEBCORE_EXPORT ServiceWorkerJobData(WebCore::ServiceWorkerJobDataIdentifier&&, URL&& scriptURL, URL&& clientCreationURL, WebCore::SecurityOriginData&& topOrigin, URL&& scopeURL, WebCore::ServiceWorkerOrClientIdentifier&& sourceContext, WebCore::WorkerType, WebCore::ServiceWorkerJobType, String&& domainForCachePartition, bool isFromServiceWorkerPage, std::optional<WebCore::ServiceWorkerRegistrationOptions>&&);
+    WEBCORE_EXPORT ServiceWorkerJobData(WebCore::ServiceWorkerJobDataIdentifier&&, URL&& scriptURL, URL&& clientCreationURL, WebCore::SecurityOriginData&& topOrigin, URL&& scopeURL, WebCore::ServiceWorkerOrClientIdentifier&& sourceContext, WebCore::WorkerType, WebCore::ServiceWorkerJobType, bool shouldBlockThirdPartyStorage, bool isFromServiceWorkerPage, std::optional<WebCore::ServiceWorkerRegistrationOptions>&&);
 
     SWServerConnectionIdentifier connectionIdentifier() const { return m_identifier.connectionIdentifier; }
 
@@ -54,7 +54,7 @@ struct ServiceWorkerJobData {
     ServiceWorkerOrClientIdentifier sourceContext;
     WorkerType workerType;
     ServiceWorkerJobType type;
-    String domainForCachePartition;
+    bool shouldBlockThirdPartyStorage { true };
     bool isFromServiceWorkerPage { false };
 
     std::optional<ServiceWorkerRegistrationOptions> registrationOptions;

--- a/Source/WebCore/workers/service/server/SWServer.cpp
+++ b/Source/WebCore/workers/service/server/SWServer.cpp
@@ -723,7 +723,7 @@ ResourceRequest SWServer::createScriptRequest(const URL& url, const ServiceWorke
     auto topOrigin = jobData.topOrigin.securityOrigin();
     auto origin = SecurityOrigin::create(jobData.scriptURL);
 
-    request.setDomainForCachePartition(jobData.domainForCachePartition);
+    request.setShouldBlockThirdPartyStorage(jobData.shouldBlockThirdPartyStorage);
     request.setAllowCookies(true);
     request.setFirstPartyForCookies(topOrigin->toURL());
 

--- a/Source/WebCore/xml/XMLHttpRequest.cpp
+++ b/Source/WebCore/xml/XMLHttpRequest.cpp
@@ -676,7 +676,7 @@ ExceptionOr<void> XMLHttpRequest::createRequest()
                 return Exception { ExceptionCode::NetworkError };
         }
 
-        request.setDomainForCachePartition(context->domainForCachePartition());
+        request.setShouldBlockThirdPartyStorage(context->shouldBlockThirdPartyStorage());
         InspectorInstrumentation::willLoadXHRSynchronously(context.ptr());
         ThreadableLoader::loadResourceSynchronously(context, WTF::move(request), *this, options);
         InspectorInstrumentation::didLoadXHRSynchronously(context.ptr());

--- a/Source/WebKit/NetworkProcess/NetworkProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkProcess.cpp
@@ -88,6 +88,7 @@
 #include <WebCore/NetworkStateNotifier.h>
 #include <WebCore/NetworkStorageSession.h>
 #include <WebCore/NotificationData.h>
+#include <WebCore/RegistrableDomain.h>
 #include <WebCore/ResourceRequest.h>
 #include <WebCore/SQLiteDatabase.h>
 #include <WebCore/SWServer.h>
@@ -1973,7 +1974,8 @@ void NetworkProcess::deleteWebsiteDataForOrigin(PAL::SessionID sessionID, Option
     if (websiteDataTypes.contains(WebsiteDataType::DiskCache) && !sessionID.isEphemeral() && session) {
         if (RefPtr cache = session->cache()) {
             Vector<NetworkCache::Key> cacheKeysToDelete;
-            String cachePartition = origin.clientOrigin == origin.topOrigin ? emptyString() : ResourceRequest::partitionName(origin.topOrigin.host());
+            RegistrableDomain topDomain = RegistrableDomain::uncheckedCreateFromHost(origin.topOrigin.host());
+            String cachePartition = origin.clientOrigin == origin.topOrigin ? emptyString() : (topDomain.isEmpty() ? emptyString() : topDomain.string());
             bool shouldClearAllEntriesInPartition = origin.clientOrigin == origin.topOrigin;
             cache->traverse(cachePartition, [cache, clearTasksHandler, shouldClearAllEntriesInPartition, origin = origin.clientOrigin, cachePartition, cacheKeysToDelete = WTF::move(cacheKeysToDelete)](auto* traversalEntry) mutable {
                 if (traversalEntry) {

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -1598,7 +1598,7 @@ void NetworkResourceLoader::continueWillSendRequest(ResourceRequest&& newRequest
 
     // If there is a match in the network cache, we need to reuse the original cache policy and partition.
     newRequest.setCachePolicy(originalRequest().cachePolicy());
-    newRequest.setCachePartition(originalRequest().cachePartition());
+    newRequest.setShouldBlockThirdPartyStorage(originalRequest().shouldBlockThirdPartyStorage());
 
     if (m_isWaitingContinueWillSendRequestForCachedRedirect) {
         m_isWaitingContinueWillSendRequestForCachedRedirect = false;

--- a/Source/WebKit/NetworkProcess/cache/AsyncRevalidation.cpp
+++ b/Source/WebKit/NetworkProcess/cache/AsyncRevalidation.cpp
@@ -36,8 +36,6 @@ namespace NetworkCache {
 static inline WebCore::ResourceRequest constructRevalidationRequest(const Key& key, const WebCore::ResourceRequest& request, const Entry& entry)
 {
     WebCore::ResourceRequest revalidationRequest = request;
-    if (!key.partition().isEmpty())
-        revalidationRequest.setCachePartition(key.partition());
     ASSERT_WITH_MESSAGE(key.range().isEmpty(), "range is not supported");
 
     revalidationRequest.makeUnconditional();

--- a/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp
+++ b/Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp
@@ -90,14 +90,13 @@ static inline Key makeSubresourcesKey(const Key& resourceKey, const Salt& salt)
 static inline ResourceRequest constructRevalidationRequest(const Key& key, const SubresourceInfo& subResourceInfo, const Entry* entry)
 {
     ResourceRequest revalidationRequest(URL { key.identifier() });
+    revalidationRequest.setShouldBlockThirdPartyStorage(!key.partition().isEmpty());
     revalidationRequest.setHTTPHeaderFields(subResourceInfo.requestHeaders());
     revalidationRequest.setFirstPartyForCookies(subResourceInfo.firstPartyForCookies());
     revalidationRequest.setIsSameSite(subResourceInfo.isSameSite());
     revalidationRequest.setIsTopSite(subResourceInfo.isTopSite());
     revalidationRequest.setIsAppInitiated(subResourceInfo.isAppInitiated());
 
-    if (!key.partition().isEmpty())
-        revalidationRequest.setCachePartition(key.partition());
     ASSERT_WITH_MESSAGE(key.range().isEmpty(), "range is not supported");
     
     revalidationRequest.makeUnconditional();

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2197,7 +2197,7 @@ struct WebCore::ServiceWorkerJobData {
 
     WebCore::ServiceWorkerJobType type;
 
-    String domainForCachePartition;
+    bool shouldBlockThirdPartyStorage;
     bool isFromServiceWorkerPage;
 
     [Validator='( type == WebCore::ServiceWorkerJobType::Register && registrationOptions->has_value()) || (type != WebCore::ServiceWorkerJobType::Register && !registrationOptions->has_value() )'] std::optional<WebCore::ServiceWorkerRegistrationOptions> registrationOptions;

--- a/Source/WebKit/Shared/WebCoreArgumentCodersPlatform.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCodersPlatform.serialization.in
@@ -318,7 +318,7 @@ header: <WebCore/ResourceRequest.h>
 #if PLATFORM(COCOA)
 [CreateUsing=fromResourceRequestData] class WebCore::ResourceRequest {
     Variant<WebCore::ResourceRequest::RequestData, WebCore::ResourceRequestPlatformData> getRequestDataToSerialize();
-    String cachePartition();
+    bool shouldBlockThirdPartyStorage();
     bool hiddenFromInspector();
 };
 #endif


### PR DESCRIPTION
#### 71730beeaf06cb924a28ba92efe710393c28c740
<pre>
Remove ResourceRequest.m_cachePartition
<a href="https://bugs.webkit.org/show_bug.cgi?id=315121">https://bugs.webkit.org/show_bug.cgi?id=315121</a>
<a href="https://rdar.apple.com/177463736">rdar://177463736</a>

Reviewed by Brady Eidson.

Use the RegistrableDomain of m_firstPartyForCookies instead.  This eliminates
the possibility of inconsistent values between the two, which should always
have the same RegistrableDomain.

In order to keep existing functionality with regards to StorageBlockingPolicy::BlockThirdParty,
I needed to add a bool when I removed the duplicate string.  The bool indicates whether to
have an empty cache partition instead of a cache partition derived from firstPartyForCookies.

This also removes support for passing an NSURLRequest in to WKWebView that has a
_kCFURLCachePartitionKey property attached to it using NSURLProtocol.  There are no
internal users of _kCFURLCachePartitionKey above WebKit, and its use could only
cause the wrong cache partition to be used.  _kCFURLCachePartitionKey is stil used
as a mechanism of communication between WebKit and NSURLSession in the network process,
but we no longer extract the property from an app-supplied NSURLRequest.  Its emptiness
is checked, though, to determine whether we should block third party storage access,
which is necessary for detecting the bit in NSURLRequests we get from CFNetwork
such as redirects, as tested in http/tests/cache/disk-cache/disk-cache-redirect.html

* LayoutTests/ipc/create-socket-channel-invalid-url-crash.html:
* LayoutTests/ipc/invalid-url-network-data-task-crash.html:
* Source/WebCore/Modules/websockets/ThreadableWebSocketChannel.cpp:
(WebCore::ThreadableWebSocketChannel::webSocketConnectRequest):
* Source/WebCore/dom/ScriptExecutionContext.cpp:
(WebCore::ScriptExecutionContext::domainForCachePartition const):
(WebCore::ScriptExecutionContext::shouldBlockThirdPartyStorage const):
* Source/WebCore/dom/ScriptExecutionContext.h:
(WebCore::ScriptExecutionContext::setDomainForCachePartition): Deleted.
* Source/WebCore/html/DOMURL.cpp:
(WebCore::DOMURL::revokeObjectURL):
* Source/WebCore/inspector/InspectorResourceUtilities.cpp:
(Inspector::ResourceUtilities::cachedResource):
* Source/WebCore/loader/DocumentLoader.cpp:
(WebCore::DocumentLoader::loadMainResource):
* Source/WebCore/loader/archive/cf/LegacyWebArchive.cpp:
(WebCore::LegacyWebArchive::createInternal):
* Source/WebCore/loader/cache/CachedImage.cpp:
* Source/WebCore/loader/cache/CachedImage.h:
* Source/WebCore/loader/cache/CachedResource.h:
(WebCore::CachedResource::cachePartition const):
* Source/WebCore/loader/cache/CachedResourceLoader.cpp:
(WebCore::CachedResourceLoader::requestUserCSSStyleSheet):
(WebCore::CachedResourceLoader::requestResource):
* Source/WebCore/loader/cache/CachedResourceRequest.cpp:
(WebCore::CachedResourceRequest::setDomainForCachePartition): Deleted.
* Source/WebCore/loader/cache/CachedResourceRequest.h:
* Source/WebCore/loader/cache/MemoryCache.cpp:
(WebCore::MemoryCache::removeResourcesWithOrigin):
(WebCore::MemoryCache::removeResourcesWithOrigins):
* Source/WebCore/page/Page.cpp:
(WebCore::Page::setupForRemoteWorker):
* Source/WebCore/platform/network/ResourceRequestBase.cpp:
(WebCore::ResourceRequestBase::setAsIsolatedCopy):
(WebCore::ResourceRequestBase::cachePartition const):
(WebCore::ResourceRequestBase::setCachePartition): Deleted.
(WebCore::ResourceRequestBase::partitionName): Deleted.
* Source/WebCore/platform/network/ResourceRequestBase.h:
(WebCore::ResourceRequestBase::shouldBlockThirdPartyStorage const):
(WebCore::ResourceRequestBase::setShouldBlockThirdPartyStorage):
(WebCore::ResourceRequestBase::setDomainForCachePartition): Deleted.
* Source/WebCore/platform/network/cf/ResourceRequest.h:
(WebCore::ResourceRequest::ResourceRequest):
* Source/WebCore/platform/network/cocoa/ResourceRequestCocoa.mm:
(WebCore::ResourceRequest::ResourceRequest):
(WebCore::ResourceRequest::fromResourceRequestData):
(WebCore::ResourceRequest::doUpdateResourceRequest):
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::resourceFromMemoryCache):
* Source/WebCore/workers/service/ServiceWorkerContainer.cpp:
(WebCore::ServiceWorkerContainer::addRegistration):
(WebCore::ServiceWorkerContainer::updateRegistration):
* Source/WebCore/workers/service/ServiceWorkerJobData.cpp:
(WebCore::ServiceWorkerJobData::ServiceWorkerJobData):
(WebCore::ServiceWorkerJobData::isolatedCopy const):
* Source/WebCore/workers/service/ServiceWorkerJobData.h:
* Source/WebCore/workers/service/server/SWServer.cpp:
(WebCore::SWServer::createScriptRequest):
* Source/WebCore/xml/XMLHttpRequest.cpp:
(WebCore::XMLHttpRequest::createRequest):
* Source/WebKit/NetworkProcess/NetworkProcess.cpp:
(WebKit::NetworkProcess::deleteWebsiteDataForOrigin):
* Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
(WebKit::NetworkResourceLoader::continueWillSendRequest):
* Source/WebKit/NetworkProcess/cache/AsyncRevalidation.cpp:
(WebKit::NetworkCache::constructRevalidationRequest):
* Source/WebKit/NetworkProcess/cache/NetworkCacheSpeculativeLoadManager.cpp:
(WebKit::NetworkCache::constructRevalidationRequest):
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:
* Source/WebKit/Shared/WebCoreArgumentCodersPlatform.serialization.in:

Canonical link: <a href="https://commits.webkit.org/315967@main">https://commits.webkit.org/315967@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/036a8d5875b606ff938676a355b235c653d20cae

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170545 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44469 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37888 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179922 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128258 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9d80445f-4d39-4160-a2b7-8c2d64970fb8) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/172411 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45715 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44104 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132998 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0c3d04ac-f463-4db4-aaf8-949c85077d8c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173504 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36184 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153438 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/113495 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/854f91db-2791-4462-97ef-869348487032) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34801 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33144 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.NavigateFrameWithSiblingsBackForward (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28603 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/145262 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32832 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182506 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35303 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/37322 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/141452 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44126 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/152901 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141273 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44815 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109331 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26006 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36537 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116704 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43325 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/7920 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42730 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42971 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42861 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->