### PR TITLE
Fix duplicate -webkit-user-select declarations in imported WPT tests

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/user-select-none-in-editable.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/user-select-none-in-editable.html
@@ -8,7 +8,7 @@
 <style>
 .user-select-none {
     -webkit-user-select: none;
-    -webkit-user-select: none;
+    user-select: none;
 }
 </style>
 </head>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/user-select-none-on-input.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/user-select-none-on-input.html
@@ -8,7 +8,7 @@
     <style>
     input, textarea {
         -webkit-user-select: none;
-        -webkit-user-select: none;
+        user-select: none;
     }
     </style>
 </head>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-node-is-not-highlighted-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-node-is-not-highlighted-expected.html
@@ -4,7 +4,7 @@
 <style>
 body p, span {
     -webkit-user-select: none;
-    -webkit-user-select: none;
+    user-select: none;
 }
 
 ::backdrop {

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-node-is-not-highlighted-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-node-is-not-highlighted-ref.html
@@ -4,7 +4,7 @@
 <style>
 body p, span {
     -webkit-user-select: none;
-    -webkit-user-select: none;
+    user-select: none;
 }
 
 ::backdrop {

--- a/LayoutTests/imported/w3c/web-platform-tests/selection/drag-selection-extend-to-user-select-none.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/selection/drag-selection-extend-to-user-select-none.html
@@ -12,13 +12,13 @@
 <style>
 #container {
   -webkit-user-select: none;
-  -webkit-user-select: none;
+  user-select: none;
   width: 400px;
   height: 200px;
 }
 #container div {
   -webkit-user-select: text;
-  -webkit-user-select: text;
+  user-select: text;
   position: absolute;
 }
 </style>


### PR DESCRIPTION
#### 917f5e235abb1c1c005c76ed998538fc21968178
<pre>
Fix duplicate -webkit-user-select declarations in imported WPT tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=315116">https://bugs.webkit.org/show_bug.cgi?id=315116</a>
<a href="https://rdar.apple.com/177453605">rdar://177453605</a>

Reviewed by Sammy Gill.

* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/user-select-none-in-editable.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/user-select-none-on-input.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-node-is-not-highlighted-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/inert-node-is-not-highlighted-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/selection/drag-selection-extend-to-user-select-none.html:

Canonical link: <a href="https://commits.webkit.org/313525@main">https://commits.webkit.org/313525@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d640ab2e98dc1bdb1d85470cd138c2b80ce8ca01

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163346 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36829 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30044 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172285 "Built successfully") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119793 "Failed to checkout and rebase branch from PR 65214") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37156 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36829 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126847 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/119793 "Failed to checkout and rebase branch from PR 65214") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166305 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29117 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146840 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107414 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28163 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26795 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/19987 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/138058 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24564 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174789 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26220 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135156 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36498 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30894 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135147 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36430 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37284 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146359 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99238 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30445 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23204 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/35993 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35492 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1229 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35740 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35640 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->