### PR TITLE
REGRESSION (302333@main): The window.orientation property incorrectly returns 0 on initial load in WKWebView regardless of device orientation

### DIFF
--- a/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
+++ b/Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm
@@ -365,8 +365,6 @@ void WebPageProxy::setDeviceOrientation(IntDegrees deviceOrientation)
 
     // Update device orientation for all web processes
     forEachWebContentProcess([deviceOrientation](auto& process, auto pageID) {
-        if (!process.hasConnection())
-            return;
         process.send(Messages::WebPage::SetDeviceOrientation(deviceOrientation), pageID);
     });
 }

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -945,6 +945,7 @@
 				WebKit/WKWebView/ios/WKWebViewAutofillTests.mm,
 				WebKit/WKWebView/ios/WKWebViewOpaque.mm,
 				WebKit/WKWebView/ios/WKWebViewPausePlayingAudioTests.mm,
+				WebKit/WKWebView/ios/WindowOrientation.mm,
 				WebKit/WKWebView/mac/AcceptsFirstMouse.mm,
 				WebKit/WKWebView/mac/AttributedString.mm,
 				WebKit/WKWebView/mac/AttributedSubstringForProposedRange.mm,

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WindowOrientation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WindowOrientation.mm
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#import "config.h"
+
+#if PLATFORM(IOS_FAMILY)
+
+#import "PlatformUtilities.h"
+#import "TestWKWebView.h"
+#import <WebKit/WKWebViewPrivate.h>
+
+namespace TestWebKitAPI {
+
+static void runWindowOrientationTest(UIInterfaceOrientation orientation, NSString *expectedDegrees)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 320, 480)]);
+    [webView _setInterfaceOrientationOverride:orientation];
+
+    [webView synchronouslyLoadHTMLString:@"<html><body></body></html>"];
+
+    RetainPtr windowOrientation = [webView stringByEvaluatingJavaScript:@"window.orientation"];
+    EXPECT_WK_STREQ(expectedDegrees, windowOrientation.get());
+}
+
+TEST(WindowOrientation, ReflectsLandscapeRightOnLoad)
+{
+    runWindowOrientationTest(UIInterfaceOrientationLandscapeRight, @"90");
+}
+
+TEST(WindowOrientation, ReflectsLandscapeLeftOnLoad)
+{
+    runWindowOrientationTest(UIInterfaceOrientationLandscapeLeft, @"-90");
+}
+
+TEST(WindowOrientation, ReflectsPortraitOnLoad)
+{
+    runWindowOrientationTest(UIInterfaceOrientationPortrait, @"0");
+}
+
+TEST(WindowOrientation, ReflectsPortraitUpsideDownOnLoad)
+{
+    runWindowOrientationTest(UIInterfaceOrientationPortraitUpsideDown, @"180");
+}
+
+} // namespace TestWebKitAPI
+
+#endif // PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 57ddad105b2faa750dc3c15b4e17b872b71ab0e2
<pre>
REGRESSION (302333@main): The window.orientation property incorrectly returns 0 on initial load in WKWebView regardless of device orientation
<a href="https://bugs.webkit.org/show_bug.cgi?id=315120">https://bugs.webkit.org/show_bug.cgi?id=315120</a>
<a href="https://rdar.apple.com/175523434">rdar://175523434</a>

Reviewed by Aditya Keerthi.

Currently, if a device is in landscape mode upon loading a WKWebView,
the window orientation reports as 0, when it should be 90 or -90.

In 302333@main, there is a check for whether a process has
a connection. If so, a message is sent to SetDeviceOrientation.
If not, the code early returns.

Previously, this check was not there and Webkit sent the message
to SetDeviceOrientation unconditionally. Thus the orientation is
updated from the initial 0 to the current orientation. With the check,
this update is dropped by the early return since the process is still
launching and the connection has not been established yet.

So, reinstill the previous behavior of calling SetDeviceOrientation
unconditionally, keeping it for each process. This works because if the process
is still launching, the message to SetDeviceOrientation is stashed away
and sent once the process establishes the connection. If the process is
terminated, nothing happens.

Add a new file for window orientation tests. Test for all orientations.
Previously, there were no tests covering window orientation upon initial
load. Future window orientation related tests can be added to the file.

* Source/WebKit/UIProcess/ios/WebPageProxyIOS.mm:
(WebKit::WebPageProxy::setDeviceOrientation):
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WindowOrientation.mm: Added.
(TestWebKitAPI::runWindowOrientationTest):
(TestWebKitAPI::TEST(WindowOrientation, ReflectsLandscapeRightOnLoad)):
(TestWebKitAPI::TEST(WindowOrientation, ReflectsLandscapeLeftOnLoad)):
(TestWebKitAPI::TEST(WindowOrientation, ReflectsPortraitOnLoad)):
(TestWebKitAPI::TEST(WindowOrientation, ReflectsPortraitUpsideDownOnLoad)):

Canonical link: <a href="https://commits.webkit.org/313582@main">https://commits.webkit.org/313582@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0baa51a033dfc992e96373142d820fd0b52b7c82

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163381 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36864 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30080 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172320 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119828 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/26204c54-8735-484e-953e-aa802e51e074) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165250 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37193 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36864 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126887 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89438 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ae380996-0ee6-4ffa-b407-21ba14dcf396) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166340 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29150 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146874 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107445 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/137a7708-3336-416d-84d3-f65309da11b8) 
| [⏳ 🧪 webkitpy ](https://ews-build.webkit.org/#/builders/WebKitPy-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28196 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26822 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20022 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138091 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24598 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174824 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27442 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26254 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135189 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36534 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30922 "Found 2 new test failures: http/tests/site-isolation/page-lifecycle/pagehide.html http/tests/site-isolation/page-lifecycle/unload.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135174 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37319 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146393 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99274 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24893 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30475 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23238 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36030 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108888 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35527 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1263 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35775 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35675 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->