### PR TITLE
[Tools] Share host PID namespace with ephemeral container by default

### DIFF
--- a/Tools/Scripts/webkitpy/port/linux_container_sdk_utils.py
+++ b/Tools/Scripts/webkitpy/port/linux_container_sdk_utils.py
@@ -203,6 +203,7 @@ def _build_podman_run_args(pinned_version):
     uid = os.getuid()
     gid = os.getgid()
     xdg = _xdg_runtime_dir()
+    share_host_pid_ns = os.environ.get('WEBKIT_CONTAINER_SDK_SHARE_HOST_PID_NAMESPACE', '1') != '0'
 
     args = [
         # Ephemeral: container is removed as soon as the user command exits.
@@ -213,12 +214,9 @@ def _build_podman_run_args(pinned_version):
         # container's full lifetime -- collision-free across concurrent
         # invocations, and `--rm` frees the name when the command exits.
         '--name', '{}-{}'.format(WKDEV_CONTAINER_NAME, os.getpid()),
-        # tini-style PID 1 forwards signals and reaps zombies, so the user
-        # command does not have to play PID 1 itself. `--init` requires the
-        # `catatonit` helper on the host and only works with `crun`, not
-        # `runc`, so pin the runtime here rather than relying on the host
-        # default.
-        '--init',
+        # Pin the OCI runtime so behavior does not vary with the host default
+        # (some distros still ship `runc`). `crun` is also required by
+        # `--init` below when we run with a private PID namespace.
         '--runtime', 'crun',
         '--hostname', _container_hostname(),
         '--userns', 'keep-id',
@@ -247,6 +245,14 @@ def _build_podman_run_args(pinned_version):
         '--mount', 'type=tmpfs,destination=/run/user/{},tmpfs-mode=0700,chown=true'.format(uid),
         '--ipc', 'host',
         '--network', 'host',
+        # PID namespace: share with the host by default so coredumpctl works
+        # end-to-end. The host's systemd-coredump records crashes against the
+        # host PID, so the matching journal entries (bind-mounted in below)
+        # only resolve from inside the container when its PIDs are the host's.
+        # Same goes for gdb/lldb attach and perf against host processes. Opt
+        # out with WEBKIT_CONTAINER_SDK_SHARE_HOST_PID_NAMESPACE=0 to get an
+        # isolated PID namespace instead.
+        '--pid', 'host' if share_host_pid_ns else 'private',
         # Pull only when the tag is not already cached. .wkdev-sdk-version
         # uses immutable tags, so a registry round-trip per host-wrapper
         # invocation would be wasted work; new tags still pull on first use.
@@ -257,6 +263,13 @@ def _build_podman_run_args(pinned_version):
         '--env', 'HOST_HOME=/host/home/{}'.format(user),
         '--env', 'XDG_RUNTIME_DIR=/run/user/{}'.format(uid),
     ]
+    # tini-style PID 1 forwards signals and reaps zombies, so the user command
+    # does not have to play PID 1 itself. `--init` needs the `catatonit` helper
+    # on the host and a private PID namespace -- podman refuses to inject a new
+    # PID 1 when sharing the host's namespace (where PID 1 already exists),
+    # and in that case reparenting to host PID 1 reaps zombies for us anyway.
+    if not share_host_pid_ns:
+        args += ['--init']
     args += _bind_mount(container_home, '/home/{}'.format(user))
     args += _bind_mount(os.path.realpath(os.environ['HOME']), '/host/home/{}'.format(user))
 


### PR DESCRIPTION
#### ab85063d24ab826a2278add3b1658cc7d0c63d60
<pre>
[Tools] Share host PID namespace with ephemeral container by default
<a href="https://bugs.webkit.org/show_bug.cgi?id=315125">https://bugs.webkit.org/show_bug.cgi?id=315125</a>

Reviewed by Carlos Alberto Lopez Perez.

Add --pid host to the podman run args so coredumpctl can resolve the host
PIDs recorded by systemd-coredump (and the bind-mounted journal) from inside
the container. The same shared namespace also lets gdb/lldb attach and perf
target host processes by their PIDs from the host.

Gated on WEBKIT_CONTAINER_SDK_SHARE_HOST_PID_NAMESPACE; default on, set to 0
to fall back to a private PID namespace (desired bot configuration!).

For this to work we have to drrop --init when sharing the host PID namespace:
podman refuses to inject a new PID 1 there (the host&apos;s already exists), and
orphaned processes are reparented to host PID 1 which reaps them.

* Tools/Scripts/webkitpy/port/linux_container_sdk_utils.py:
(_build_podman_run_args):

Canonical link: <a href="https://commits.webkit.org/313529@main">https://commits.webkit.org/313529@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96449c078917668420f64e55af0ff8a55feb391b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163370 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36853 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30069 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172309 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/119817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165239 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37181 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36853 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/126870 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/119817 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166329 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/29137 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146861 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107436 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/162691 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20011 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/138078 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24585 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174813 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26241 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/135177 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36522 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30914 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135162 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36431 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37308 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146380 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99262 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30463 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23225 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36018 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35516 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1250 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35764 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35664 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->