### PR TITLE
[JSC] Add a test of WebAssembly IPInt stack check

### DIFF
--- a/JSTests/wasm/regress/309628.js
+++ b/JSTests/wasm/regress/309628.js
@@ -1,0 +1,53 @@
+"use strict";
+
+function leb(n) {
+    const out = [];
+    do {
+        let b = n & 0x7f;
+        n >>>= 7;
+        if (n) b |= 0x80;
+        out.push(b);
+    } while (n);
+    return out;
+}
+
+/*
+ * (module
+ *   (func (export "f")
+ *     (local $0 i64) ;; numLocals times
+ *     (drop (local.get 0))))
+ */
+function makeModule(numLocals) {
+    const body = [
+        0x01, ...leb(numLocals), 0x7e,
+        0x20, 0x00,
+        0x1a,
+        0x0b,
+    ];
+    const code = [0x01, ...leb(body.length), ...body];
+    return new Uint8Array([
+        0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00,
+        0x01, 0x04, 0x01, 0x60, 0x00, 0x00,
+        0x03, 0x02, 0x01, 0x00,
+        0x07, 0x05, 0x01, 0x01, 0x66, 0x00, 0x00,
+        0x0a, ...leb(code.length), ...code,
+    ]);
+}
+
+const workerSrc = `
+${leb.toString()}
+${makeModule.toString()}
+
+for (let L = 35000; L >= 8000; L -= 2000) {
+    const bytes = makeModule(L);
+    const inst = new WebAssembly.Instance(new WebAssembly.Module(bytes));
+    try {
+        inst.exports.f();
+        break;
+    } catch (e) {
+    }
+}
+`;
+
+$.agent.start(workerSrc);
+$.agent.sleep(2000);


### PR DESCRIPTION
#### 9161e71798e985c6cdeb7534f011574d963e979c
<pre>
[JSC] Add a test of WebAssembly IPInt stack check
<a href="https://bugs.webkit.org/show_bug.cgi?id=309628">https://bugs.webkit.org/show_bug.cgi?id=309628</a>
<a href="https://rdar.apple.com/172141532">rdar://172141532</a>

Reviewed by Yusuke Suzuki.

This patch adds a test of m_maxFrameSizeInV128 computation in IPIntGenerator::finalize(),
to verify that the computation is really performed in units of v128.

* JSTests/wasm/regress/309628.js: Added.

Originally-landed-as: 305413.442@rapid/safari-7624.2.5.110-branch (b5a9b035e465). <a href="https://rdar.apple.com/176067374">rdar://176067374</a>
Canonical link: <a href="https://commits.webkit.org/314420@main">https://commits.webkit.org/314420@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05ddb2653fa2f4f6a6d9975c59fe8a2c270b5fd2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166025 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39515 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33096 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175072 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123280 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39941 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39519 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129034 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90904 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168984 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31400 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149167 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109560 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30377 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29067 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23212 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158182 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140346 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177605 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26918 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28572 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137378 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39584 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33213 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137305 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37000 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40272 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148661 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102864 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32590 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25528 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38783 "Built successfully") | | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198774 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38180 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3614 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38425 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38323 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->