### PR TITLE
Fix run-minibrowser/run-swiftbrowser crash on argparse 'const' kwarg

### DIFF
--- a/Tools/Scripts/webkitpy/minibrowser/run_webkit_app.py
+++ b/Tools/Scripts/webkitpy/minibrowser/run_webkit_app.py
@@ -43,8 +43,10 @@ def main(argv):
                 default = None
                 if option.default != ("NO", "DEFAULT"):
                     default = option.default
-                option_group.add_argument(option.get_opt_string(), action=option.action, dest=option.dest,
-                                          help=option.help, const=option.const, default=default)
+                kwargs = dict(action=option.action, dest=option.dest, help=option.help, default=default)
+                if option.action in ('store_const', 'append_const'):
+                    kwargs['const'] = option.const
+                option_group.add_argument(option.get_opt_string(), **kwargs)
 
     option_parser.add_argument('url', metavar='url', type=lambda s: decode(s, 'utf8'), nargs='?',
                                help='Website URL to load')

--- a/Tools/Scripts/webkitpy/swiftbrowser/run_webkit_app.py
+++ b/Tools/Scripts/webkitpy/swiftbrowser/run_webkit_app.py
@@ -47,8 +47,10 @@ def main(argv):
                 default = None
                 if option.default != ("NO", "DEFAULT"):
                     default = option.default
-                option_group.add_argument(option.get_opt_string(), action=option.action, dest=option.dest,
-                                          help=option.help, const=option.const, default=default)
+                kwargs = dict(action=option.action, dest=option.dest, help=option.help, default=default)
+                if option.action in ('store_const', 'append_const'):
+                    kwargs['const'] = option.const
+                option_group.add_argument(option.get_opt_string(), **kwargs)
 
     option_parser.add_argument('url', metavar='url', type=lambda s: decode(s, 'utf8'), nargs='?', help='Website URL to load')
     options, _ = option_parser.parse_known_args(argv)


### PR DESCRIPTION
#### 85a8efec82daa8e4751f728967cb0736b9c27ce0
<pre>
Fix run-minibrowser/run-swiftbrowser crash on argparse &apos;const&apos; kwarg
<a href="https://bugs.webkit.org/show_bug.cgi?id=315130">https://bugs.webkit.org/show_bug.cgi?id=315130</a>
<a href="https://rdar.apple.com/177472652">rdar://177472652</a>

Reviewed by Pascoe.

run-minibrowser and run-swiftbrowser translate each optparse Option from
configuration_options() / platform_options() into an argparse add_argument()
call, and were unconditionally forwarding const=option.const. That worked
while every option used action=&apos;store&apos; or &apos;store_const&apos; (both accept const),
but 313522@main added --cmake with action=&apos;store_true&apos;. argparse&apos;s
_StoreTrueAction.__init__ does not accept a const keyword, so the loop now
raises:

    TypeError: __init__() got an unexpected keyword argument &apos;const&apos;

before the parser is even built, breaking both scripts at startup.

Only forward const= for the actions that accept it (store_const,
append_const). All other options keep their previous behavior.

* Tools/Scripts/webkitpy/minibrowser/run_webkit_app.py:
(main):
* Tools/Scripts/webkitpy/swiftbrowser/run_webkit_app.py:
(main):

Canonical link: <a href="https://commits.webkit.org/313527@main">https://commits.webkit.org/313527@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4e96b5a6a3ae198d44cc42a277109ade730c1bfc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163384 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36867 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30083 "Hash 4e96b5a6 for PR 65228 does not build (failure)") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/172323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/119831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165253 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37196 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36867 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/172323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/119831 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166343 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/29152 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/30083 "Hash 4e96b5a6 for PR 65228 does not build (failure)") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/172323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/162705 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28198 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/20026 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/138093 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/30083 "Hash 4e96b5a6 for PR 65228 does not build (failure)") | [  ~~🛠 gtk~~](https://ews-build.webkit.org/#/builders/2/builds/174828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/30083 "Hash 4e96b5a6 for PR 65228 does not build (failure)") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/2/builds/174828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36537 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30926 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/2/builds/174828 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37322 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/30083 "Hash 4e96b5a6 for PR 65228 does not build (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99278 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24864 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30477 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/30083 "Hash 4e96b5a6 for PR 65228 does not build (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36033 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35530 "Built successfully") | [⏳ 🧪 mac-site-isolation ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-Site-Isolation-Tests-EWS "Waiting in queue, processing has not started yet") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35778 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35678 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->