### PR TITLE
Identical buttons drawn differently with font: -apple-system-short-body

### DIFF
--- a/LayoutTests/fast/forms/ios/form-control-refresh/button/identical-buttons-have-same-corner-radius-expected.html
+++ b/LayoutTests/fast/forms/ios/form-control-refresh/button/identical-buttons-have-same-corner-radius-expected.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+input {
+    position: absolute;
+    width: 30px;
+    height: 20.1px;
+    font-size: 0;
+    scale: 32;
+    accent-color: black;
+}
+</style>
+</head>
+<body>
+<input type="submit" style="transform-origin: bottom right; left: 100px; top: 200px;"></input>
+<input type="submit" style="transform-origin: top right; left: 100px; bottom: 200px;"></input>
+</body>
+</html>

--- a/LayoutTests/fast/forms/ios/form-control-refresh/button/identical-buttons-have-same-corner-radius.html
+++ b/LayoutTests/fast/forms/ios/form-control-refresh/button/identical-buttons-have-same-corner-radius.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="fuzzy" content="maxDifference=73; totalPixels=114">
+<style>
+input {
+    position: absolute;
+    width: 30px;
+    height: 20.1px;
+    font-size: 0;
+    scale: 32;
+    accent-color: black;
+}
+</style>
+</head>
+<body>
+<input type="submit" style="transform-origin: bottom right; left: 100px; top: 200px;"></input>
+<input type="submit" style="transform-origin: top right; left: 100px; bottom: 200.1px; transform: translateY(-.003125px);"></input>
+</body>
+</html>

--- a/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
+++ b/Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm
@@ -1849,11 +1849,16 @@ static RoundedShape shapeForButton(const RenderElement& box, const FloatRect& re
         controlRadius = minDimension / 2;
 
         // If trying to make the button pill-shaped would make it a circle
-        // or nearly circle, use the non-pill shape instead.
-        const auto sizeRatio = rect.width() / rect.height();
-        const auto limitingRatio = 1.5f;
-        if (limitingRatio > sizeRatio && sizeRatio > 1 / limitingRatio)
-            controlRadius = radiusForLargeButton;
+        // or nearly a circle, use the non-pill shape instead. Compute the
+        // ratio from the unsnapped logical dimensions so identical buttons
+        // at different positions don't fall on different sides of the
+        // threshold due to device pixel snapping.
+        if (CheckedPtr renderBox = dynamicDowncast<RenderBox>(box)) {
+            const auto sizeRatio = (renderBox->width() / renderBox->height()).toFloat();
+            const auto limitingRatio = 1.5f;
+            if (limitingRatio > sizeRatio && sizeRatio > 1 / limitingRatio)
+                controlRadius = radiusForLargeButton;
+        }
     }
 #endif
 


### PR DESCRIPTION
#### 8bf88660a6641cf8df5f4511b85326ff28d83033
<pre>
Identical buttons drawn differently with font: -apple-system-short-body
<a href="https://bugs.webkit.org/show_bug.cgi?id=311188">https://bugs.webkit.org/show_bug.cgi?id=311188</a>
<a href="https://rdar.apple.com/173786057">rdar://173786057</a>

Reviewed by Abrar Rahman Protyasha and Aditya Keerthi.

There is some logic in RenderThemeCocoa&apos;s shapeForButton that tries to make
&quot;squareish&quot; pill buttons not draw a circle&quot;ish&quot; background (by dropping to a much
lower corner radius), by thresholding the aspect ratio of the button.

Identically sized buttons set at two different positions can fall on different
sides of that threshold due to pixel snapping. It just so happens that the font
and glyph combination in the testcase puts the button right on the boundary,
and rounding can kick it either way.

Fix this by thresholding the un-pixel-snapped aspect ratio, so that identically
sized buttons go down the same shape path regardless of where they sit.

The test has a small amount of fuzziness because of the aforementioned snapping,
but when it fails for real it fails with orders of magnitude more delta.

Test: fast/forms/ios/form-control-refresh/button/identical-buttons-have-same-corner-radius.html

* LayoutTests/fast/forms/ios/form-control-refresh/button/identical-buttons-have-same-corner-radius-expected.html: Added.
* LayoutTests/fast/forms/ios/form-control-refresh/button/identical-buttons-have-same-corner-radius.html: Added.
* Source/WebCore/rendering/cocoa/RenderThemeCocoa.mm:
(WebCore::shapeForButton):

Canonical link: <a href="https://commits.webkit.org/313535@main">https://commits.webkit.org/313535@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bb97d9e8101c526ebfce8437a29730ef0e0055ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163395 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36878 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30094 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172335 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/119842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/52928a2f-678e-4d58-9c50-ae2881157e32) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165264 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37207 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36878 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126893 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/119842 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166354 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29161 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146887 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107451 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c87950fa-e265-4d82-ac70-5072ddbaca71) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20037 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/138102 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24611 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174839 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27472 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26267 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/135197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36548 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30935 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135183 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36435 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37333 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146406 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99289 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30492 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23251 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36044 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108915 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35541 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1276 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35789 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35689 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->