### PR TITLE
[GFC] Implement skeleton code for "Increase sizes to accommodate spanning items crossing content-sized tracks"

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/TrackSizingAlgorithm.cpp
@@ -97,10 +97,11 @@ static TrackSizingGridItemConstraintList oppositeAxisConstraintList(const TrackS
 }
 
 struct ResolveIntrinsicTrackSizesContext {
-    ResolveIntrinsicTrackSizesContext(const TrackSizingItemList& trackSizingItems, const GridItemSizingFunctions& gridItemSizingFunctions, const TrackSizingFunctionsList& trackSizingFunctionsList)
+    ResolveIntrinsicTrackSizesContext(const TrackSizingItemList& trackSizingItems, const GridItemSizingFunctions& gridItemSizingFunctions, const TrackSizingFunctionsList& trackSizingFunctionsList, const AxisConstraint& axisConstraint)
         : trackSizingItems(trackSizingItems)
         , gridItemSizingFunctions(gridItemSizingFunctions)
         , trackSizingFunctionsList(trackSizingFunctionsList)
+        , axisConstraint(axisConstraint)
         , gridItemSpanList(trackSizingItems.map([](auto& gridItem) { return gridItem.spannedLines; }))
         , computedSizesList(trackSizingItems.map([](auto& gridItem) { return gridItem.computedSizes; }))
         , borderAndPaddingList(trackSizingItems.map([](auto& gridItem) { return gridItem.borderAndPadding; }))
@@ -109,6 +110,7 @@ struct ResolveIntrinsicTrackSizesContext {
     const TrackSizingItemList& trackSizingItems;
     const GridItemSizingFunctions& gridItemSizingFunctions;
     const TrackSizingFunctionsList& trackSizingFunctionsList;
+    const AxisConstraint& axisConstraint;
     const PlacedGridItemSpanList gridItemSpanList;
     const ComputedSizesList computedSizesList;
     const UsedBorderAndPaddingList borderAndPaddingList;
@@ -320,6 +322,137 @@ static void sizeTracksToFitNonSpanningItems(const ResolveIntrinsicTrackSizesCont
     }
 }
 
+static bool spansFlexibleTrack(WTF::Range<size_t> gridItemSpan, const UnsizedTracks& unsizedTracks)
+{
+    for (size_t trackIndex = gridItemSpan.begin(); trackIndex < gridItemSpan.end(); ++trackIndex) {
+        if (unsizedTracks[trackIndex].trackSizingFunction.max.isFlex())
+            return true;
+    }
+    return false;
+}
+
+static GridItemIndexes spanningItemsNotCrossingFlexibleTracksIndexes(const PlacedGridItemSpanList& gridItemSpanList, const UnsizedTracks& unsizedTracks)
+{
+    GridItemIndexes spanningItemIndexes;
+    for (auto [itemIndex, itemSpan] : WTF::indexedRange(gridItemSpanList)) {
+        if (itemSpan.distance() < 2)
+            continue;
+        if (!spansFlexibleTrack(itemSpan, unsizedTracks))
+            spanningItemIndexes.append(itemIndex);
+    }
+    return spanningItemIndexes;
+}
+
+// https://drafts.csswg.org/css-grid-1/#algo-content (step 3)
+// Items are processed in groups of increasing span size so that contributions from smaller spans
+// are resolved before larger spans that may depend on them.
+static Vector<GridItemIndexes> sortedItemsNotCrossingFlexibleTracksIndexesList(const PlacedGridItemSpanList& gridItemSpanList, const UnsizedTracks& unsizedTracks)
+{
+    auto itemIndexesSortedBySpanSize = spanningItemsNotCrossingFlexibleTracksIndexes(gridItemSpanList, unsizedTracks);
+    if (itemIndexesSortedBySpanSize.isEmpty())
+        return { };
+
+    std::ranges::sort(itemIndexesSortedBySpanSize, [&](size_t a, size_t b) {
+        return gridItemSpanList[a].distance() < gridItemSpanList[b].distance();
+    });
+
+    Vector<GridItemIndexes> itemIndexesSortedBySpanSizeList;
+    GridItemIndexes currentItemIndexesForSpanSize;
+    currentItemIndexesForSpanSize.append(itemIndexesSortedBySpanSize[0]);
+    for (auto index : std::span(itemIndexesSortedBySpanSize).subspan(1)) {
+        auto currentItemIndexesSpanSize = gridItemSpanList[currentItemIndexesForSpanSize.first()].distance();
+        auto itemSpanSize = gridItemSpanList[index].distance();
+        if (itemSpanSize == currentItemIndexesSpanSize) {
+            currentItemIndexesForSpanSize.append(index);
+            continue;
+        }
+        itemIndexesSortedBySpanSizeList.append(std::exchange(currentItemIndexesForSpanSize, { }));
+        currentItemIndexesForSpanSize.append(index);
+    }
+    itemIndexesSortedBySpanSizeList.append(WTF::move(currentItemIndexesForSpanSize));
+    return itemIndexesSortedBySpanSizeList;
+}
+
+// https://drafts.csswg.org/css-grid-1/#extra-space
+// To distribute extra space, perform the following steps, with these inputs:
+//   - affectedSizes: whether to affect base sizes or growth limits.
+//   - affectedTracks: which tracks to affect (within each item's span).
+//   - sizeContributions: parallel to `items` — the intrinsic size contribution being
+//     accommodated for each item.
+//   - items: the grid items spanning those tracks whose contributions drive the distribution.
+enum class AffectedSizeForExtraSpaceDistribution : uint8_t { BaseSizes, GrowthLimits };
+[[maybe_unused]] static void distributeExtraSpace(AffectedSizeForExtraSpaceDistribution, UnsizedTracks&,
+    const TrackIndexes& affectedTracks, const Vector<LayoutUnit>& sizeContributions,
+    const GridItemIndexes& items)
+{
+    UNUSED_PARAM(affectedTracks);
+    UNUSED_PARAM(sizeContributions);
+    UNUSED_PARAM(items);
+    notImplemented();
+}
+
+// https://drafts.csswg.org/css-grid-1/#algo-content
+static void increaseSizesToAccommodateSpanningItemsCrossingContentSizedTracks(const ResolveIntrinsicTrackSizesContext& resolveIntrinsicTrackSizesContext,
+    UnsizedTracks& unsizedTracks, const GridItemIndexes& itemsWithSameSpanSizeIndexes)
+{
+    UNUSED_PARAM(resolveIntrinsicTrackSizesContext);
+    UNUSED_PARAM(itemsWithSameSpanSizeIndexes);
+
+    // For intrinsic minimums: First distribute extra space to base sizes of tracks with an
+    // intrinsic min track sizing function, to accommodate these items' minimum contributions.
+    // If the grid container is being sized under a min- or max-content constraint, use the
+    // items' limited min-content contributions in place of their minimum contributions here.
+    auto distributeExtraSpaceForIntrinsicMinimums = [&] {
+        notImplemented();
+    };
+
+    // For content-based minimums: Next continue to distribute extra space to the base sizes
+    // of tracks with a min track sizing function of min-content or max-content, to accommodate
+    // these items' min-content contributions.
+    auto distributeExtraSpaceForContentBasedMinimums = [&] {
+        notImplemented();
+    };
+
+    // For max-content minimums: Next, if the grid container is being sized under a max-content
+    // constraint, continue to distribute extra space to the base sizes of tracks with a min
+    // track sizing function of auto or max-content, to accommodate these items' limited
+    // max-content contributions. In all cases, continue to distribute extra space to the base
+    // sizes of tracks with a min track sizing function of max-content, to accommodate these
+    // items' max-content contributions.
+    auto distributeExtraSpaceForMaxContentMinimums = [&] {
+        notImplemented();
+    };
+
+    // For intrinsic maximums: Next distribute extra space to the growth limits of tracks with
+    // intrinsic max track sizing function, to accommodate these items' min-content
+    // contributions. Mark any tracks whose growth limit changed from infinite to finite in
+    // this step as infinitely growable for the next step.
+    auto distributeExtraSpaceForIntrinsicMaximums = [&] {
+        notImplemented();
+    };
+
+    // For max-content maximums: Lastly continue to distribute extra space to the growth limits
+    // of tracks with a max track sizing function of max-content, to accommodate these items'
+    // max-content contributions.
+    auto distributeExtraSpaceForMaxContentMaximums = [&] {
+        notImplemented();
+    };
+
+    distributeExtraSpaceForIntrinsicMinimums();
+    distributeExtraSpaceForContentBasedMinimums();
+    distributeExtraSpaceForMaxContentMinimums();
+
+    // If at this point any track's growth limit is now less than its base size, increase its
+    // growth limit to match its base size.
+    for (auto& unsizedTrack : unsizedTracks) {
+        if (unsizedTrack.growthLimit < unsizedTrack.baseSize)
+            unsizedTrack.growthLimit = unsizedTrack.baseSize;
+    }
+
+    distributeExtraSpaceForIntrinsicMaximums();
+    distributeExtraSpaceForMaxContentMaximums();
+}
+
 // https://drafts.csswg.org/css-grid-1/#algo-content
 static void resolveIntrinsicTrackSizes(const ResolveIntrinsicTrackSizesContext& resolveIntrinsicTrackSizesContext,
     UnsizedTracks& unsizedTracks)
@@ -336,11 +469,11 @@ static void resolveIntrinsicTrackSizes(const ResolveIntrinsicTrackSizesContext& 
 
     // 3. Increase sizes to accommodate spanning items crossing content-sized tracks:
     // Next, consider the items with a span of 2 that do not span a track with a flexible
-    // sizing function.
-    auto increaseSizesToAccommodateSpanningItemsCrossingContentSizedTracks = [] {
-        notImplemented();
-    };
-    UNUSED_VARIABLE(increaseSizesToAccommodateSpanningItemsCrossingContentSizedTracks);
+    // sizing function. ... Repeat incrementally for items with greater spans until all items
+    // have been considered.
+    auto& gridItemSpanList = resolveIntrinsicTrackSizesContext.gridItemSpanList;
+    for (auto itemsWithSameSpanSizeIndexes : sortedItemsNotCrossingFlexibleTracksIndexesList(gridItemSpanList, unsizedTracks))
+        increaseSizesToAccommodateSpanningItemsCrossingContentSizedTracks(resolveIntrinsicTrackSizesContext, unsizedTracks, itemsWithSameSpanSizeIndexes);
 
     // 4. Increase sizes to accommodate spanning items crossing flexible tracks:
     auto increaseSizesToAccommodateSpanningItemsCrossingFlexibleTracks = [] {
@@ -748,7 +881,7 @@ TrackSizes TrackSizingAlgorithm::sizeTracks(const TrackSizingItemList& trackSizi
     auto unsizedTracks = initializeTrackSizes(trackSizingFunctions, availableGridSpace.value_or(0_lu));
 
     // 2. Resolve Intrinsic Track Sizes
-    resolveIntrinsicTrackSizes(ResolveIntrinsicTrackSizesContext(trackSizingItems, gridItemSizingFunctions, trackSizingFunctions), unsizedTracks);
+    resolveIntrinsicTrackSizes(ResolveIntrinsicTrackSizesContext(trackSizingItems, gridItemSizingFunctions, trackSizingFunctions, axisConstraint), unsizedTracks);
 
     // 3. Maximize Tracks
     maximizeTracks(unsizedTracks, axisConstraint, gapSize);


### PR DESCRIPTION
#### 3ed6644b676b607deaa73f8721ade47f73260a9a
<pre>
[GFC] Implement skeleton code for &quot;Increase sizes to accommodate spanning items crossing content-sized tracks&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=315134">https://bugs.webkit.org/show_bug.cgi?id=315134</a>
<a href="https://rdar.apple.com/problem/177473250">rdar://problem/177473250</a>

In order to properly implement this portion of the spec we need to add
some new helper functions that help us get the relevant grid items.
These new helper functions will go through the items, get all of the
ones that span content sized tracks, and then group the items into lists
by increasing span size. Since we don&apos;t want a bunch of copies of those
items in various lists the output of this helper function is basically a
list of indexes for the items with respect to the TrackSizingItemList
that was passed into the track sizing algorithm.

The function that will eventually contain the core logic of this step of
the algorithm currently contains some lambdas that will be filled in
with the logic for the various &quot;distribute extra space,&quot; portions of the
text. Also include the logic for making sure the growth limit is at
least as big as the base size since that is trivial.

distributeExtraSpace is an additional skeleton that will get filled out!

Plumb AxisConstraint into ResolveIntrinsicTrackSizesContext since we
will need it for the distribute extra space logic.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3ed6644b676b607deaa73f8721ade47f73260a9a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163390 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36873 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30089 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172330 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119837 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2f14c487-7372-46a8-a23b-8ca962382bb7) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165259 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37202 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36873 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126892 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89442 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8e57a980-d713-45a9-8356-8223e7367d70) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166349 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29156 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146881 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107450 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/22983980-3685-45d7-b9d2-0424f2d03066) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28202 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26834 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20032 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138097 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24605 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174834 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27466 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26261 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135191 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36543 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30934 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135177 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37328 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146400 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99284 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30482 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23245 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36039 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108904 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35536 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1270 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35784 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35684 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->