### PR TITLE
Fix duplicate -webkit-box-decoration-break declarations in imported WPT tests

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-box-decoration-break-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-box-decoration-break-expected.html
@@ -11,12 +11,12 @@
 
     .clone {
         -webkit-box-decoration-break: clone;
-        -webkit-box-decoration-break: clone;
+        box-decoration-break: clone;
     }
 
     .slice {
         -webkit-box-decoration-break: slice;
-        -webkit-box-decoration-break: slice;
+        box-decoration-break: slice;
     }
 </style>
 </head>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-box-decoration-break-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-box-decoration-break-ref.html
@@ -11,12 +11,12 @@
 
     .clone {
         -webkit-box-decoration-break: clone;
-        -webkit-box-decoration-break: clone;
+        box-decoration-break: clone;
     }
 
     .slice {
         -webkit-box-decoration-break: slice;
-        -webkit-box-decoration-break: slice;
+        box-decoration-break: slice;
     }
 </style>
 </head>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-box-decoration-break.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-box-decoration-break.html
@@ -21,12 +21,12 @@
 
     .clone {
         -webkit-box-decoration-break: clone;
-        -webkit-box-decoration-break: clone;
+        box-decoration-break: clone;
     }
 
     .slice {
         -webkit-box-decoration-break: slice;
-        -webkit-box-decoration-break: slice;
+        box-decoration-break: slice;
     }
 </style>
 </head>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-break/border-image-000.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-break/border-image-000.html
@@ -10,7 +10,7 @@
     color: transparent;
     border-image: radial-gradient(green 50%, transparent 50%) 27 fill / 27px;
     -webkit-box-decoration-break: clone;
-    -webkit-box-decoration-break: clone;
+    box-decoration-break: clone;
   }
 </style>
 <p>There should be two green circles below.</p>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/currentcolor-003-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/currentcolor-003-expected.html
@@ -11,7 +11,7 @@
     }
     span {
       -webkit-box-decoration-break: clone;
-      -webkit-box-decoration-break: clone;
+      box-decoration-break: clone;
       line-height: 50px;
       background-image: linear-gradient(currentcolor, currentcolor);
       background-color: currentColor;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/currentcolor-003-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/currentcolor-003-ref.html
@@ -11,7 +11,7 @@
     }
     span {
       -webkit-box-decoration-break: clone;
-      -webkit-box-decoration-break: clone;
+      box-decoration-break: clone;
       line-height: 50px;
       background-image: linear-gradient(currentcolor, currentcolor);
       background-color: currentColor;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-color/currentcolor-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-color/currentcolor-003.html
@@ -21,7 +21,7 @@
     }
     span {
       -webkit-box-decoration-break: clone;
-      -webkit-box-decoration-break: clone;
+      box-decoration-break: clone;
       line-height: 50px;
       background-image: linear-gradient(currentcolor, currentcolor);
       background-color: currentColor;

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/clone-intrinsic-size-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/clone-intrinsic-size-expected.html
@@ -25,7 +25,7 @@ span {
   margin: 0 4px 0 3px;
   background: yellow;
   -webkit-box-decoration-break: clone;
-  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
 }
 
 f { margin-right: 30px; float: left; }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/clone-intrinsic-size-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/clone-intrinsic-size-ref.html
@@ -25,7 +25,7 @@ span {
   margin: 0 4px 0 3px;
   background: yellow;
   -webkit-box-decoration-break: clone;
-  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
 }
 
 f { margin-right: 30px; float: left; }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/clone-intrinsic-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/clone-intrinsic-size.html
@@ -28,7 +28,7 @@ span {
   margin: 0 4px 0 3px;
   background: yellow;
   -webkit-box-decoration-break: clone;
-  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
 }
 
 f { margin-right: 30px; float: left; }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/clone-nowrap-intrinsic-size-bidi-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/clone-nowrap-intrinsic-size-bidi-expected.html
@@ -22,7 +22,7 @@ span {
   margin: 0 4px 0 3px;
   background: yellow;
   -webkit-box-decoration-break: clone;
-  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
 }
 
 f { margin-right: 30px; float: left; }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/clone-nowrap-intrinsic-size-bidi-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/clone-nowrap-intrinsic-size-bidi-ref.html
@@ -22,7 +22,7 @@ span {
   margin: 0 4px 0 3px;
   background: yellow;
   -webkit-box-decoration-break: clone;
-  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
 }
 
 f { margin-right: 30px; float: left; }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/clone-nowrap-intrinsic-size-bidi.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/clone-nowrap-intrinsic-size-bidi.html
@@ -29,7 +29,7 @@ span {
   margin: 0 4px 0 3px;
   background: yellow;
   -webkit-box-decoration-break: clone;
-  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
 }
 
 f { margin-right: 30px; float: left; }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/clone-nowrap-intrinsic-size-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/clone-nowrap-intrinsic-size-expected.html
@@ -22,7 +22,7 @@ span {
   margin: 0 4px 0 3px;
   background: yellow;
   -webkit-box-decoration-break: clone;
-  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
 }
 
 f { margin-right: 30px; float: left; }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/clone-nowrap-intrinsic-size-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/clone-nowrap-intrinsic-size-ref.html
@@ -22,7 +22,7 @@ span {
   margin: 0 4px 0 3px;
   background: yellow;
   -webkit-box-decoration-break: clone;
-  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
 }
 
 f { margin-right: 30px; float: left; }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/clone-nowrap-intrinsic-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/clone-nowrap-intrinsic-size.html
@@ -29,7 +29,7 @@ span {
   margin: 0 4px 0 3px;
   background: yellow;
   -webkit-box-decoration-break: clone;
-  -webkit-box-decoration-break: clone;
+  box-decoration-break: clone;
 }
 
 f { margin-right: 30px; float: left; }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/slice-intrinsic-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/slice-intrinsic-size.html
@@ -29,7 +29,7 @@ span {
   background: yellow;
   /* for clarity: */
   -webkit-box-decoration-break: slice;
-  -webkit-box-decoration-break: slice;
+  box-decoration-break: slice;
 }
 
 f { margin-right: 30px; float: left; }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/slice-nowrap-intrinsic-size.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/slice-nowrap-intrinsic-size.html
@@ -30,7 +30,7 @@ span {
   background: yellow;
   /* for clarity: */
   -webkit-box-decoration-break: slice;
-  -webkit-box-decoration-break: slice;
+  box-decoration-break: slice;
 }
 
 f { margin-right: 30px; float: left; }


### PR DESCRIPTION
#### d097970da67568babe7c1df2c4d1c79726cba406
<pre>
Fix duplicate -webkit-box-decoration-break declarations in imported WPT tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=315133">https://bugs.webkit.org/show_bug.cgi?id=315133</a>
<a href="https://rdar.apple.com/177473227">rdar://177473227</a>

Reviewed by Sammy Gill.

* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-box-decoration-break-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-box-decoration-break-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-clip/clip-border-area-box-decoration-break.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-break/border-image-000.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-color/currentcolor-003-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-color/currentcolor-003-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-color/currentcolor-003.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/clone-intrinsic-size-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/clone-intrinsic-size-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/clone-intrinsic-size.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/clone-nowrap-intrinsic-size-bidi-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/clone-nowrap-intrinsic-size-bidi-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/clone-nowrap-intrinsic-size-bidi.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/clone-nowrap-intrinsic-size-expected.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/clone-nowrap-intrinsic-size-ref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/clone-nowrap-intrinsic-size.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/slice-intrinsic-size.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-sizing/slice-nowrap-intrinsic-size.html:

Canonical link: <a href="https://commits.webkit.org/313539@main">https://commits.webkit.org/313539@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0fb6f236656ec7fb804a8851f13a9a0ba2227330

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163393 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36876 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30092 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172333 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119840 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37205 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36876 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126891 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/89443 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166352 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29165 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146884 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107449 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28211 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26832 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20035 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138106 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24608 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174837 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26264 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135195 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36546 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30932 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135181 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36440 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37331 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146403 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99287 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30490 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23248 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36042 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35539 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1273 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35787 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35687 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->