### PR TITLE
[JSC] incorrect side-effect modeling for Spread(SetObjectUse) in DFG abstract interpreter

### DIFF
--- a/JSTests/stress/spread-set-own-symbol-iterator-side-effects.js
+++ b/JSTests/stress/spread-set-own-symbol-iterator-side-effects.js
@@ -1,0 +1,39 @@
+//@ runDefault("--useConcurrentJIT=0")
+
+// Spread(SetObjectUse): the abstract interpreter must not retain structure
+// proofs across the node when the operand isn't proven to carry the original
+// Set structure, since the lowered slow path (operationSpreadSet) can invoke a
+// user-defined Symbol.iterator.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("bad value");
+}
+
+let obj;
+
+// Pre-create the {a}->Accessor transition so the warmup structure isn't a watchable leaf.
+{
+    let t = { a: 1.1 };
+    Object.defineProperty(t, "a", { get() { return 1; } });
+}
+
+let setWithOwnIterator = new Set([1]);
+setWithOwnIterator[Symbol.iterator] = function* () {
+    Object.defineProperty(obj, "a", { get() { return 1; }, configurable: true });
+    yield 1;
+};
+
+function f(set, o) {
+    let x = o.a;
+    let arr = [...set];
+    return o.a;
+}
+noInline(f);
+
+let plainSet = new Set([1]);
+for (let i = 0; i < testLoopCount; i++)
+    f(plainSet, { a: 1.1 });
+
+obj = { a: 1.1 };
+shouldBe(f(setWithOwnIterator, obj), 1);

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -3797,10 +3797,25 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
             break;
         default:
             if (!m_graph.canDoFastSpread(node, forNode(node->child1()))) {
-                // SetObjectUse has no side effects since we iterate directly over internal storage.
-                if (node->child1().useKind() == SetObjectUse)
-                    didFoldClobberWorld();
-                else
+                if (node->child1().useKind() == SetObjectUse) {
+                    // The lowering routes Sets that don't carry the original Set structure to operationSpreadSet,
+                    // which falls back to the JS iterator protocol. We can retain structure proofs across this
+                    // node only when the operand is proven to carry the original Set structure (the same condition
+                    // under which the lowering elides its runtime structure check). Such instances have no own
+                    // Symbol.iterator, and any mutation to Set.prototype[Symbol.iterator] invalidates this code
+                    // via the prototype-change watchpoints installed during compilation, so the slow path can
+                    // never reach a user-defined iterator from here.
+                    bool canFold = false;
+                    JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);
+                    if (Structure* originalSetStructure = globalObject->setStructureConcurrently()) {
+                        if (forNode(node->child1()).m_structure.isSubsetOf(RegisteredStructureSet(m_graph.registerStructure(originalSetStructure))))
+                            canFold = true;
+                    }
+                    if (canFold)
+                        didFoldClobberWorld();
+                    else
+                        clobberWorld();
+                } else
                     clobberWorld();
             } else
                 didFoldClobberWorld();


### PR DESCRIPTION
#### fb8bfead603ee6308af1dbfb0619cbaa40f79dee
<pre>
[JSC] incorrect side-effect modeling for Spread(SetObjectUse) in DFG abstract interpreter
<a href="https://bugs.webkit.org/show_bug.cgi?id=315132">https://bugs.webkit.org/show_bug.cgi?id=315132</a>
<a href="https://rdar.apple.com/177136593">rdar://177136593</a>

Reviewed by Yusuke Suzuki.

313031@main allows Set spreads to invoke user-defined `Symbol.iterator` functions.
This broke an assumption in the abstract interpreter that spreading a Set object
has no side effects, and under that assumption the AI had been keeping structure
proofs alive, even though now the call to a user-defined `Symbol.iterator` function
during the spread could change the structure. A subsequent GetByOffset, which
should&apos;ve been prevented by an OSR exit during the CheckStructure that was being
mistakenly folded, could then read a stale slot.

Test: JSTests/stress/spread-set-own-symbol-iterator-side-effects.js

* JSTests/stress/spread-set-own-symbol-iterator-side-effects.js: Added.
(shouldBe):
(set o):
(f):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):

Canonical link: <a href="https://commits.webkit.org/313614@main">https://commits.webkit.org/313614@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/843da51f013706076af667c6a7cd470cfc1bee3d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163399 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36882 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30098 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172339 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119846 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dcbcd0e5-6b2d-4924-b2b0-0298c637841f) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37211 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36882 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126896 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89444 "layout-tests (failure)") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166358 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29167 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146892 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107454 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28213 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26837 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20041 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/155544 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138108 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24615 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174843 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/24286 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27479 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26271 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135199 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36552 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30937 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135185 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36484 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37337 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146410 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/99293 "The change is no longer eligible for processing.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30486 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23255 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195801 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36048 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108926 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51040 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35545 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1280 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35793 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35693 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->