### PR TITLE
[webkitcorepy] Lazy load unittest.mock

### DIFF
--- a/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/timeout.py
+++ b/Tools/Scripts/libraries/webkitcorepy/webkitcorepy/timeout.py
@@ -27,7 +27,6 @@ import os
 import signal
 import threading
 import time
-from unittest import mock
 
 from webkitcorepy import log, string_utils
 
@@ -57,6 +56,8 @@ class Timeout(object):
 
     class DisableAlarm(object):
         def __init__(self, patch=True):
+            from unittest import mock
+
             if patch:
                 self._patch = mock.patch('time.sleep', new=ORIGINAL_SLEEP)
             else:
@@ -148,6 +149,8 @@ class Timeout(object):
         return ORIGINAL_SLEEP(seconds)
 
     def __init__(self, seconds=1, handler=None, patch=True):
+        from unittest import mock
+
         if seconds <= 0:
             raise ValueError('Timeouts must be positive')
 


### PR DESCRIPTION
#### 87e4f953833f8edea14e3d6630d147250771932c
<pre>
[webkitcorepy] Lazy load unittest.mock
<a href="https://bugs.webkit.org/show_bug.cgi?id=315142">https://bugs.webkit.org/show_bug.cgi?id=315142</a>
<a href="https://rdar.apple.com/177477244">rdar://177477244</a>

Reviewed by Sam Sneddon.

* Tools/Scripts/libraries/webkitcorepy/webkitcorepy/timeout.py:
(Timeout.DisableAlarm.__init__): Lazy import unittest.mock.
(Timeout.__init__): Ditto.

Canonical link: <a href="https://commits.webkit.org/313601@main">https://commits.webkit.org/313601@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e4bb4379b7b6a9b6aeaa3217c7641721d392eeff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163405 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36888 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30104 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172345 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119852 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165274 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37217 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36888 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126898 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89448 "layout-tests (failure)") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f9f3bc98-2987-41a2-a124-0b194ae978e2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166364 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29164 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146886 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107456 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/162726 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28210 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26845 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20047 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138105 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24610 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174849 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26266 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135201 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/162802 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36558 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30945 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135187 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37343 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146405 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99299 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24901 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30488 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23250 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36054 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35551 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1275 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35799 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35699 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->