### PR TITLE
[JSC] Fix DFG CPS validation for inlined sort comparator

### DIFF
--- a/JSTests/stress/array-sort-inline-isnan-comparator-cps.js
+++ b/JSTests/stress/array-sort-inline-isnan-comparator-cps.js
@@ -1,0 +1,22 @@
+function opt(a1) {
+    let array = [0, 2, ({valueOf: -Infinity, 0: 0, done: a1})];
+    function process(arg) {
+        function toDict(o) {
+        }
+        toDict((Array.prototype.sort.call(arg, (isNaN))));
+    }
+    process(array);
+    try {
+        Object.defineProperty((class a2 extends ("outer " + ("inner " + (WebAssembly.CompileError.prototype))) { get ['5']() { class a3 {
+            constructor() {
+                if (new.target) { class a4 {
+                };
+                }
+            }
+        };
+        } }), 'next', {set: (parseInt((function([a5 = 0x80000000, a6 = (a4.at(a1))] = []) {})))});
+    } catch (x) {}
+}
+try { opt(Infinity); } catch (y) {}
+try { opt((new Map().entries())); } catch (y) {}
+try { opt(Math.E); } catch (y) {}

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -12096,8 +12096,8 @@ auto ByteCodeParser::handleArraySort(Node* callee, Operand resultOperand, CallVa
             auto callLinkStatus = comparatorFunction ? CallLinkStatus(CallVariant(comparatorFunction)) : CallLinkStatus(CallVariant(comparatorExecutable));
             auto* callTargetNode = comparatorFunction ? jsConstant(comparatorFunction) : get(tmpComparator);
             handleCall(tmpCmpResult, Call, InlineCallFrame::ArraySortComparatorCall, osrExitIndex, callTargetNode, comparatorArgcIncludingThis, newRegisterOffset, callLinkStatus, SpecBytecodeTop, nullptr);
-            processSetLocalQueue();
             emitExitOK();
+            processSetLocalQueue();
             cmpResult = get(tmpCmpResult);
         } else {
             cmpResult = addCallWithoutSettingResult(Call, OpInfo(), get(tmpComparator), comparatorArgcIncludingThis, newRegisterOffset, OpInfo(SpecBytecodeTop));


### PR DESCRIPTION
#### 7429d22f2bfd5274ea68c3d9b3dadf74ca5646b4
<pre>
[JSC] Fix DFG CPS validation for inlined sort comparator
<a href="https://bugs.webkit.org/show_bug.cgi?id=315144">https://bugs.webkit.org/show_bug.cgi?id=315144</a>
<a href="https://rdar.apple.com/177411241">rdar://177411241</a>

Reviewed by Yusuke Suzuki.

312983@main introduced inlining of Array.p.sort, including comparators. When
side exiting, this restarts the entire sort call. There is a bug where, when
inlining the comparator, the SetLocal queue is flushed _before_ emitting an
ExitOK, which can cause a node to be hoisted above its producer, tripping the
DFG CPS validation.

This PR emits ExitOK before flushing the SetLocal queue.

Test: JSTests/stress/array-sort-inline-isnan-comparator-cps.js

* JSTests/stress/array-sort-inline-isnan-comparator-cps.js: Added.
(opt.process.toDict):
(opt):
(opt.try.):
(catch):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleArraySort):

Canonical link: <a href="https://commits.webkit.org/313579@main">https://commits.webkit.org/313579@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/60905a33c5db0e4ae8f6a28cacabc83db4ffa57c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163406 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36889 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30105 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172346 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119853 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37218 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36889 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126900 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89446 "layout-tests (failure)") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166365 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29168 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146908 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107458 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28214 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26846 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20048 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/155551 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138109 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24631 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174850 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/24293 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27494 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26287 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135202 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36559 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30946 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135188 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36463 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37344 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146426 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99300 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30489 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23271 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195808 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36055 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108935 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51042 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35552 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1296 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35800 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35700 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->