### PR TITLE
[DO NOT MERGE] Optimize DeferElementDidFocusToRenderingUpdate

### DIFF
--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -7512,6 +7512,7 @@ void WebPage::resetFocusedElementForFrame(WebFrame* frame)
     if (frame->isMainFrame() || m_focusedElement->document().frame() == frame->coreLocalFrame()) {
 #if PLATFORM(IOS_FAMILY)
         m_sendAutocorrectionContextAfterFocusingElement = false;
+        m_hasDispatchedFocusedElementInformation = false;
         send(Messages::WebPageProxy::ElementDidBlur());
 #elif PLATFORM(MAC)
         send(Messages::WebPageProxy::SetEditableElementIsFocused(false));
@@ -7528,12 +7529,30 @@ void WebPage::elementDidRefocus(Element& element, const FocusOptions& options)
         scheduleFullEditorStateUpdate();
 }
 
-bool WebPage::shouldDispatchUpdateAfterFocusingElement(const Element& element) const
+bool WebPage::shouldDispatchUpdateAfterFocusingElement(const Element& element, const FocusOptions& options) const
 {
     if (m_focusedElement == &element || m_recentlyBlurredElement == &element) {
 #if PLATFORM(IOS_FAMILY)
-        return !m_isShowingInputViewForFocusedElement;
+        if (m_isShowingInputViewForFocusedElement)
+            return false;
+        // Same-element refocus from a JS `.focus()` call (FocusTrigger::Bindings)
+        // while no input view is showing and the user is not interacting: skip
+        // the layoutIfNeeded() + ~50-field IPC if the UI process already has
+        // valid FocusedElementInformation and no tracked invalidation is
+        // pending. The trigger gate is essential — DOM-internal refocus paths
+        // (e.g. FrameSelection::setFocusedElementIfNeeded after
+        // selectPositionAtPoint, or dispatchEventsOnWindowAndFocusedElement on
+        // activity-state restoration) use FocusTrigger::Other and must keep
+        // dispatching so input-session policy callbacks fire.
+        if (m_focusedElement == &element
+            && m_hasDispatchedFocusedElementInformation
+            && !m_updateFocusedElementInformationTimer.isActive()
+            && !m_userIsInteracting
+            && options.trigger == FocusTrigger::Bindings)
+            return false;
+        return true;
 #else
+        UNUSED_PARAM(options);
         return false;
 #endif
     }
@@ -7564,7 +7583,7 @@ void WebPage::elementDidFocus(Element& element, const FocusOptions& options)
     m_updateFocusedElementInformationTimer.stop();
 #endif
 
-    if (!shouldDispatchUpdateAfterFocusingElement(element)) {
+    if (!shouldDispatchUpdateAfterFocusingElement(element, options)) {
         updateInputContextAfterBlurringAndRefocusingElementIfNeeded(element);
         m_focusedElement = element;
         m_recentlyBlurredElement = nullptr;
@@ -7605,6 +7624,7 @@ void WebPage::elementDidFocus(Element& element, const FocusOptions& options)
 
         information->preventScroll = options.preventScroll;
         send(Messages::WebPageProxy::ElementDidFocus(information.value(), m_userIsInteracting, m_recentlyBlurredElement, m_lastActivityStateChanges, UserData(WebProcess::singleton().transformObjectsToHandles(userData.get()).get())));
+        m_hasDispatchedFocusedElementInformation = true;
 #elif PLATFORM(MAC)
         // FIXME: This can be unified with the iOS code above by bringing ElementDidFocus to macOS.
         // This also doesn't take other noneditable controls into account, such as input type color.
@@ -7631,6 +7651,7 @@ void WebPage::elementDidBlur(WebCore::Element& element)
         m_hasPendingInputContextUpdateAfterBlurringAndRefocusingElement = false;
 #if PLATFORM(IOS_FAMILY)
         m_sendAutocorrectionContextAfterFocusingElement = false;
+        m_hasDispatchedFocusedElementInformation = false;
 #endif
     }
 }

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -2661,7 +2661,7 @@ private:
 
     void cancelCurrentInteractionInformationRequest();
 
-    bool NODELETE shouldDispatchUpdateAfterFocusingElement(const WebCore::Element&) const;
+    bool NODELETE shouldDispatchUpdateAfterFocusingElement(const WebCore::Element&, const WebCore::FocusOptions&) const;
 
     void updateMockAccessibilityElementAfterCommittingLoad();
 
@@ -3125,6 +3125,7 @@ private:
 
     bool m_isShowingInputViewForFocusedElement { false };
     bool m_wasShowingInputViewForFocusedElementDuringLastPotentialTap { false };
+    bool m_hasDispatchedFocusedElementInformation { false };
 
     enum class SelectionAnchor : bool { Start, End };
     SelectionAnchor m_selectionAnchor { SelectionAnchor::Start };


### PR DESCRIPTION
#### 196ca2fa036e25f94c463b00bde218ff9e8ebdd4
<pre>
[DO NOT MERGE] Optimize DeferElementDidFocusToRenderingUpdate
<a href="https://rdar.apple.com/177468274">rdar://177468274</a>

Reviewed by NOBODY (OOPS!).

Explanation of why this fixes the bug (OOPS!).

No new tests (OOPS!).

* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::resetFocusedElementForFrame):
(WebKit::WebPage::shouldDispatchUpdateAfterFocusingElement const):
(WebKit::WebPage::elementDidFocus):
(WebKit::WebPage::elementDidBlur):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/196ca2fa036e25f94c463b00bde218ff9e8ebdd4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163540 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37024 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30243 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172480 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119989 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37355 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37023 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127019 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89548 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166499 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29290 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147020 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107573 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28339 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26971 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20183 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138237 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174985 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27916 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26402 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135323 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36694 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31073 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135305 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37479 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146534 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99529 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30611 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23385 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36189 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109335 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35687 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1410 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35937 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35834 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->