### PR TITLE
(311867@main) PLT7 regressed for YouTube first page load

### DIFF
--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp
@@ -164,13 +164,6 @@ void RemoteAudioVideoRendererProxyManager::create(RemoteAudioVideoRendererIdenti
             protectedThis->m_gpuConnectionToWebProcess.get()->connection().send(Messages::AudioVideoRendererRemoteMessageReceiver::EffectiveRateChanged(protectedThis->stateFor(identifier)), identifier);
     });
 
-    context.renderer->setTimeObserver(remoteAudioVideoRendererUpdateInterval, [weakThis = WeakPtr { *this }, identifier](const MediaTime&) {
-        if (RefPtr protectedThis = weakThis.get(); protectedThis && protectedThis->m_renderers.contains(identifier)) {
-            protectedThis->maybeUpdateCachedVideoMetrics(identifier);
-            protectedThis->m_gpuConnectionToWebProcess.get()->connection().send(Messages::AudioVideoRendererRemoteMessageReceiver::StateUpdate(protectedThis->stateFor(identifier)), identifier);
-        }
-    });
-
 #if ENABLE(LINEAR_MEDIA_PLAYER)
     RetainPtr videoTarget = m_gpuConnectionToWebProcess.get()->videoReceiverEndpointManager().takeVideoTargetForMediaElementIdentifier(mediaElementIdentifier, playerIdentifier);
     context.renderer->setVideoTarget(videoTarget.get());
@@ -361,11 +354,36 @@ void RemoteAudioVideoRendererProxyManager::notifyWhenErrorOccurs(RemoteAudioVide
     });
 }
 
+void RemoteAudioVideoRendererProxyManager::installTimeObserver(RemoteAudioVideoRendererIdentifier identifier, Seconds interval)
+{
+    auto iterator = m_renderers.find(identifier);
+    if (iterator == m_renderers.end())
+        return;
+    auto& context = iterator->value;
+    context.renderer->setTimeObserver(interval, [weakThis = WeakPtr { *this }, identifier](const MediaTime&) {
+        RefPtr protectedThis = weakThis.get();
+        if (!protectedThis)
+            return;
+        auto iterator = protectedThis->m_renderers.find(identifier);
+        if (iterator == protectedThis->m_renderers.end())
+            return;
+        auto& context = iterator->value;
+        if (context.firstTickAfterPlay) {
+            context.firstTickAfterPlay = false;
+            protectedThis->installTimeObserver(identifier, remoteAudioVideoRendererUpdateInterval);
+        }
+        protectedThis->maybeUpdateCachedVideoMetrics(identifier);
+        protectedThis->m_gpuConnectionToWebProcess.get()->connection().send(Messages::AudioVideoRendererRemoteMessageReceiver::TimeObserverUpdate(protectedThis->stateFor(identifier)), identifier);
+    });
+}
+
 // SynchronizerInterface
 void RemoteAudioVideoRendererProxyManager::play(RemoteAudioVideoRendererIdentifier identifier, std::optional<MonotonicTime> hostTime, CompletionHandler<void(WebCore::MediaTimeUpdateData&&)>&& completionHandler)
 {
     if (RefPtr renderer = rendererFor(identifier)) {
         renderer->play(hostTime);
+        contextFor(identifier).firstTickAfterPlay = true;
+        installTimeObserver(identifier, remoteAudioVideoRendererFirstTickInterval);
         completionHandler(timeUpdateDataFor(*renderer));
         return;
     }

--- a/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
+++ b/Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h
@@ -174,6 +174,7 @@ private:
         WebCore::VideoRendererPreferences preferences { };
         Seconds videoPlaybackMetricsUpdateInterval { };
         MonotonicTime nextPlaybackQualityMetricsUpdateTime { };
+        bool firstTickAfterPlay { false };
         bool isGatheringVideoFrameMetadata { false };
     };
     RefPtr<WebCore::AudioVideoRenderer> createRenderer();
@@ -183,6 +184,7 @@ private:
     void rendereringModeChanged(RemoteAudioVideoRendererIdentifier);
     void updateCachedVideoMetrics(RemoteAudioVideoRendererIdentifier);
     void maybeUpdateCachedVideoMetrics(RemoteAudioVideoRendererIdentifier);
+    void installTimeObserver(RemoteAudioVideoRendererIdentifier, Seconds interval);
     using LayerHostingContextCallback = CompletionHandler<void(WebCore::HostingContext)>;
     void requestHostingContext(RemoteAudioVideoRendererIdentifier, LayerHostingContextCallback&&);
     WebCore::MediaSampleConverter& converterFor(RendererContext&, TrackIdentifier);

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp
@@ -107,12 +107,19 @@ bool AudioVideoRendererRemote::TimeProgressEstimator::timeIsProgressing() const
 void AudioVideoRendererRemote::TimeProgressEstimator::setTime(const MediaTimeUpdateData& data)
 {
     Locker locker { m_lock };
+    bool currentTimeChanged = data.currentTime != m_cachedTime;
     m_cachedTime = data.currentTime;
     m_wallTime = data.wallTime;
     m_effectiveRate = data.effectiveRate;
-    if (!data.effectiveRate)
-        m_lastReturnedTime.reset();
-    m_forceUseCachedTime = false;
+    // Release the cached-time freeze only when this anchor proves time has
+    // progressed: rate must be non-zero AND currentTime must have changed.
+    // A pause-reply (rate=0, possibly distinct currentTime) re-anchors but
+    // keeps the freeze, so the next play() still waits for forward progress.
+    if (data.effectiveRate && currentTimeChanged) {
+        if (std::exchange(m_forceUseCachedTime, false))
+            RELEASE_LOG(Media, "AudioVideoRendererRemote::TimeProgressEstimator started");
+    } else if (m_forceUseCachedTime)
+        RELEASE_LOG(Media, "AudioVideoRendererRemote::TimeProgressEstimator not starting, held off effectiveRate=%f currentTime=%f", data.effectiveRate, data.currentTime.toDouble());
 }
 
 void AudioVideoRendererRemote::TimeProgressEstimator::setRate(double rate)
@@ -134,6 +141,7 @@ void AudioVideoRendererRemote::TimeProgressEstimator::setRate(double rate)
 void AudioVideoRendererRemote::TimeProgressEstimator::pause()
 {
     Locker locker { m_lock };
+    m_forceUseCachedTime = true;
     auto rate = m_effectiveRate.load();
     if (!rate)
         return;
@@ -142,6 +150,12 @@ void AudioVideoRendererRemote::TimeProgressEstimator::pause()
     m_cachedTime += MediaTime::createWithDouble(rate * elapsed.seconds());
     m_wallTime = now;
     m_effectiveRate = 0;
+}
+
+void AudioVideoRendererRemote::TimeProgressEstimator::resetLastReturnedTime()
+{
+    Locker locker { m_lock };
+    m_lastReturnedTime.reset();
 }
 
 void AudioVideoRendererRemote::TimeProgressEstimator::setStallCap(const MediaTime& time)
@@ -505,7 +519,10 @@ void AudioVideoRendererRemote::play(std::optional<MonotonicTime> hostTime)
         Locker locker { m_lock };
         m_cachedState.paused = false;
     }
-    // The GPU will reply with the current MediaTimeUpdateData so the estimator can resume extrapolation without waiting for the 250ms periodic tick.
+    // The GPU's reply gives the estimator a chance to release the gate at
+    // IPC-round-trip latency if the synchronizer's timebase has already
+    // advanced past the cached anchor; otherwise the freeze stays engaged
+    // until the first periodic time observer tick (~100 ms later).
     ensureOnDispatcherWithConnection([hostTime](auto& renderer, auto& connection) {
         connection.sendWithAsyncReplyOnDispatcher(Messages::RemoteAudioVideoRendererProxyManager::Play(renderer.m_identifier, hostTime), queueSingleton(), [weakThis = ThreadSafeWeakPtr { renderer }](WebCore::MediaTimeUpdateData&& timeUpdateData) {
             if (RefPtr protectedThis = weakThis.get())
@@ -521,9 +538,14 @@ void AudioVideoRendererRemote::pause(std::optional<MonotonicTime> hostTime)
         m_cachedState.paused = true;
     }
     m_timeEstimator.pause();
-    // The GPU will reply with the current MediaTimeUpdateData so the estimator re-anchors against the GPU's view.
+    // The reply re-anchors m_cachedTime to the GPU's authoritative pause
+    // position (which may differ slightly from our local extrapolation due to
+    // IPC latency). The setTime gate keeps m_forceUseCachedTime engaged because
+    // effectiveRate is 0, so the next play() still requires a forward-progress
+    // anchor before interpolation can start.
     ensureOnDispatcherWithConnection([hostTime](auto& renderer, auto& connection) {
         connection.sendWithAsyncReplyOnDispatcher(Messages::RemoteAudioVideoRendererProxyManager::Pause(renderer.m_identifier, hostTime), queueSingleton(), [weakThis = ThreadSafeWeakPtr { renderer }](WebCore::MediaTimeUpdateData&& timeUpdateData) {
+            ASSERT(!timeUpdateData.effectiveRate);
             if (RefPtr protectedThis = weakThis.get())
                 protectedThis->m_timeEstimator.setTime(timeUpdateData);
         });
@@ -539,7 +561,9 @@ bool AudioVideoRendererRemote::paused() const
 void AudioVideoRendererRemote::setRate(double rate)
 {
     m_timeEstimator.setRate(rate);
-    // The GPU will reply with the current MediaTimeUpdateData that unfreezes the estimator (setTime clears m_forceUseCachedTime) with the real effective rate.
+    // The GPU's reply re-anchors m_cachedTime with the real effective rate. The estimator
+    // remains gated until the next TimeObserverUpdate IPC; this anchor only sets what
+    // currentTime() returns while still gated.
     ensureOnDispatcherWithConnection([rate](auto& renderer, auto& connection) {
         connection.sendWithAsyncReplyOnDispatcher(Messages::RemoteAudioVideoRendererProxyManager::SetRate(renderer.m_identifier, rate), queueSingleton(), [weakThis = ThreadSafeWeakPtr { renderer }](WebCore::MediaTimeUpdateData&& timeUpdateData) {
             if (RefPtr protectedThis = weakThis.get())
@@ -578,6 +602,7 @@ void AudioVideoRendererRemote::cancelPendingSeek()
 Ref<MediaTimePromise> AudioVideoRendererRemote::prepareToSeek(const MediaTime& time)
 {
     m_timeEstimator.setTime({ time, 0.0, MonotonicTime::now() });
+    m_timeEstimator.resetLastReturnedTime();
     m_seeking = true;
     m_lastSeekTime = time;
     return invokeAsync(queueSingleton(), [protectedThis = Ref { *this }, this, time] -> Ref<MediaTimePromise> {
@@ -615,6 +640,7 @@ Ref<MediaTimePromise> AudioVideoRendererRemote::prepareToSeek(const MediaTime& t
 Ref<GenericPromise> AudioVideoRendererRemote::finishSeek(const MediaTime& time)
 {
     m_timeEstimator.setTime({ time, 0.0, MonotonicTime::now() });
+    m_timeEstimator.resetLastReturnedTime();
     ASSERT(m_seeking, "Invalid seeking state, bad API usage");
     return invokeAsync(queueSingleton(), [protectedThis = Ref { *this }, this, time] -> Ref<GenericPromise> {
         cancelPendingSeek();
@@ -1249,6 +1275,12 @@ void AudioVideoRendererRemote::MessageReceiver::readyForMoreMediaData(TrackIdent
 }
 
 void AudioVideoRendererRemote::MessageReceiver::stateUpdate(RemoteAudioVideoRendererState state)
+{
+    if (RefPtr parent = m_parent.get())
+        parent->updateCacheState(state);
+}
+
+void AudioVideoRendererRemote::MessageReceiver::timeObserverUpdate(RemoteAudioVideoRendererState state)
 {
     if (RefPtr parent = m_parent.get())
         parent->updateCacheState(state);

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h
@@ -95,6 +95,7 @@ public:
         void errorOccurred(WebCore::PlatformMediaError);
         void readyForMoreMediaData(WebCore::SamplesRendererTrackIdentifier);
         void stateUpdate(RemoteAudioVideoRendererState);
+        void timeObserverUpdate(RemoteAudioVideoRendererState);
         void updatePlaybackQualityMetrics(WebCore::VideoPlaybackQualityMetrics);
 
 #if PLATFORM(COCOA)
@@ -111,16 +112,17 @@ public:
         void setTime(const WebCore::MediaTimeUpdateData&);
         void setRate(double);
         void pause();
+        void resetLastReturnedTime();
         void setStallCap(const MediaTime&);
         void clearStallCap();
 
     private:
         static constexpr Seconds kUpdateInterval = remoteAudioVideoRendererUpdateInterval;
         mutable Lock m_lock;
-        MediaTime m_cachedTime WTF_GUARDED_BY_LOCK(m_lock);
+        MediaTime m_cachedTime WTF_GUARDED_BY_LOCK(m_lock) { MediaTime::zeroTime() };
         MonotonicTime m_wallTime WTF_GUARDED_BY_LOCK(m_lock);
         std::atomic<double> m_effectiveRate { 0 };
-        bool m_forceUseCachedTime WTF_GUARDED_BY_LOCK(m_lock) { false };
+        bool m_forceUseCachedTime WTF_GUARDED_BY_LOCK(m_lock) { true };
         mutable std::optional<MediaTime> m_lastReturnedTime WTF_GUARDED_BY_LOCK(m_lock);
         std::optional<MediaTime> m_stallCap WTF_GUARDED_BY_LOCK(m_lock);
     };

--- a/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemoteMessageReceiver.messages.in
+++ b/Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemoteMessageReceiver.messages.in
@@ -42,6 +42,7 @@ messages -> AudioVideoRendererRemoteMessageReceiver {
     TaskTimeReached(MediaTime time, struct WebKit::RemoteAudioVideoRendererState state)
     ErrorOccurred(WebCore::PlatformMediaError error)
     StateUpdate(struct WebKit::RemoteAudioVideoRendererState state)
+    TimeObserverUpdate(struct WebKit::RemoteAudioVideoRendererState state)
     UpdatePlaybackQualityMetrics(struct WebCore::VideoPlaybackQualityMetrics metrics)
 
 #if PLATFORM(COCOA)

--- a/Source/WebKit/WebProcess/GPU/media/RemoteAudioVideoRendererState.h
+++ b/Source/WebKit/WebProcess/GPU/media/RemoteAudioVideoRendererState.h
@@ -32,10 +32,17 @@
 
 namespace WebKit {
 
-// Cadence of GPU-side time observer that pushes RemoteAudioVideoRendererState
-// updates to the WebContent process. The client-side TimeProgressEstimator
-// caps its between-update extrapolation to this same interval.
+// Cadence at which the GPU-side proxy throttles outgoing TimeObserverUpdate
+// IPCs to the WebContent process during steady-state playback. The
+// WebContent-side TimeProgressEstimator also caps its between-anchor
+// extrapolation to this interval.
 constexpr Seconds remoteAudioVideoRendererUpdateInterval = 250_ms;
+
+// Underlying GPU-side time observer cadence. Set shorter than the steady-state
+// interval so the first tick after each play() lands quickly to confirm that
+// playback has started; subsequent ticks are throttled by the proxy back to
+// remoteAudioVideoRendererUpdateInterval.
+constexpr Seconds remoteAudioVideoRendererFirstTickInterval = 100_ms;
 
 struct RemoteAudioVideoRendererState {
     WebCore::MediaTimeUpdateData timeUpdateData { };


### PR DESCRIPTION
#### 575b7c2a1eb358d60f58a9f255d6b44eb5add646
<pre>
(311867@main) PLT7 regressed for YouTube first page load
<a href="https://bugs.webkit.org/show_bug.cgi?id=315141">https://bugs.webkit.org/show_bug.cgi?id=315141</a>
<a href="https://rdar.apple.com/175874670">rdar://175874670</a>

Reviewed by Eric Carlson.

The TimeProgressEstimator in AudioVideoRendererRemote previously released its
cached-time freeze on the first effectiveRateChanged callback, which only
indicates that the GPU has *committed* to the requested rate change — not that
playback time has actually started moving. As a result the estimator could
begin interpolating from an anchor that was still pinned at the pre-play
currentTime, producing a phantom advance of up to remoteAudioVideoRendererUpdateInterval
seconds (250 ms at rate 1) before the GPU&apos;s first real time tick landed.

Logging on device confirmed this in practice: the GPU was observed delivering
state updates with effectiveRate=1 while currentTime was still reading as 0
for over 100ms. With the previous logic, currentTime() would then have
returned values up to 250 ms — the maximum the estimator allows itself to
extrapolate past the last anchor — even though playback in the GPU process
had not actually progressed past 0.

This change replaces that signal with a stricter one: TimeProgressEstimator
returns its last received cached time verbatim until an incoming setTime() with
a non-zero effectiveRate carries a currentTime distinct from the cached anchor.
That difference is the only proof that AVSampleBufferRenderSynchronizer&apos;s clock
has actually moved forward; without it, currentTime() short-circuits to m_cachedTime.

To minimize the window during which currentTime() is stepped after play(), the
GPU-side periodic time observer is registered at the new
remoteAudioVideoRendererFirstTickInterval (100 ms) for the first tick after
each play(), then re-registered at remoteAudioVideoRendererUpdateInterval
(250 ms, unchanged) for steady-state. So a fresh anchor proving forward
progress arrives within ~100 ms of playback actually starting, and IPC
frequency falls back to the existing cadence afterwards.
The 100ms window is the same as what the MediaPlayerPrivateRemote was using
with the MediaPlayerPrivateMediaSourceAVFObjC running in the GPU process
to start the estimator.

* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.cpp:
(WebKit::RemoteAudioVideoRendererProxyManager::create):
(WebKit::RemoteAudioVideoRendererProxyManager::installTimeObserver):
(WebKit::RemoteAudioVideoRendererProxyManager::play):
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.h:
* Source/WebKit/GPUProcess/media/RemoteAudioVideoRendererProxyManager.messages.in:
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.cpp:
(WebKit::AudioVideoRendererRemote::TimeProgressEstimator::setTime):
(WebKit::AudioVideoRendererRemote::TimeProgressEstimator::pause):
(WebKit::AudioVideoRendererRemote::play):
(WebKit::AudioVideoRendererRemote::pause):
(WebKit::AudioVideoRendererRemote::setRate):
(WebKit::AudioVideoRendererRemote::MessageReceiver::timeObserverUpdate):
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemote.h:
* Source/WebKit/WebProcess/GPU/media/AudioVideoRendererRemoteMessageReceiver.messages.in:
Add TimeObserverUpdate as a distinct IPC from StateUpdate so the receiver can
distinguish a periodic-time-observer-driven anchor from other state updates.
* Source/WebKit/WebProcess/GPU/media/RemoteAudioVideoRendererState.h:
Add remoteAudioVideoRendererFirstTickInterval (100 ms) alongside the existing
remoteAudioVideoRendererUpdateInterval (250 ms).

Canonical link: <a href="https://commits.webkit.org/313549@main">https://commits.webkit.org/313549@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5c5a7346f4745e2679eb588993a760da3651e3b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163427 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36910 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30126 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172367 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119874 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37239 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36910 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126918 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89462 "layout-tests (failure)") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166386 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29188 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146916 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107476 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4bfe4f9b-0cc2-4a8e-8232-64c0dd11e4c5) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28241 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26864 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20069 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138129 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174871 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27534 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26295 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135221 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36580 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30964 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135207 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36448 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37365 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146434 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99327 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30511 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23279 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36076 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108975 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35573 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1304 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35821 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35721 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->