### PR TITLE
Auto-pick last-built tree on Mac for scripts that use local build products, add --xcode flag

### DIFF
--- a/Tools/Scripts/webkit-build-directory
+++ b/Tools/Scripts/webkit-build-directory
@@ -37,6 +37,11 @@ use Getopt::Long;
 use lib $FindBin::Bin;
 use webkitdirs;
 
+# Opt this read-only path resolver into the last-built tiebreaker. Build
+# drivers (build-webkit, set-webkit-configuration) never call this, so they
+# keep the "Xcode wins when both trees exist" default.
+enableLastBuiltTiebreaker();
+
 my $showConfigurationDirectory = 0;
 my $showExecutablePath = 0;
 my $showHelp = 0;

--- a/Tools/Scripts/webkitdirs.pm
+++ b/Tools/Scripts/webkitdirs.pm
@@ -104,6 +104,7 @@ BEGIN {
        &determineCurrentSVNRevision
        &determineCrossTarget
        &determineXcodeSDK
+       &enableLastBuiltTiebreaker
        &executableProductDir
        &exitStatus
        &extractNonMacOSHostConfiguration
@@ -279,6 +280,7 @@ my $osXVersion;
 my $iosVersion;
 my $generateDsym;
 my $isCMakeBuild;
+my $shouldPickLastBuilt = 0;
 my $isGenerateProjectOnly;
 my $shouldBuild32Bit;
 my $isInspectorFrontend;
@@ -3111,20 +3113,61 @@ sub determineIsCMakeBuild()
     return if defined($isCMakeBuild);
     $isCMakeBuild = checkForArgumentAndRemoveFromARGV("--cmake");
     return if $isCMakeBuild;
+    if (checkForArgumentAndRemoveFromARGV("--xcode")) {
+        $isCMakeBuild = 0;
+        return;
+    }
 
-    # Auto-detect a CMake macOS build when no Xcode build is present at the
-    # expected path. The CMake macOS presets place artifacts under
-    # WebKitBuild/cmake-mac/<Configuration>; an Xcode build, if present,
-    # always wins to preserve existing workflows.
+    # Auto-detect a CMake macOS build. The CMake presets place artifacts under
+    # WebKitBuild/cmake-mac/<Configuration>; when both trees exist, Xcode wins
+    # by default unless a caller opts into the last-built tiebreaker via
+    # enableLastBuiltTiebreaker() (read-only path resolvers do; build drivers
+    # like build-webkit do not, so they are never auto-flipped).
     if (isAppleCocoaWebKit()) {
         determineBaseProductDir();
         determineConfiguration();
         my $cmakeMacBuild = File::Spec->catdir($baseProductDir, "cmake-mac", $configuration);
         my $xcodeBuild = File::Spec->catdir($baseProductDir, $configuration);
+
         if (-f File::Spec->catfile($cmakeMacBuild, "CMakeCache.txt") && !-d $xcodeBuild) {
             $isCMakeBuild = 1;
+            return;
+        }
+
+        # Heuristic: prefer whichever tree the developer built most recently,
+        # comparing each build system's own build log rather than a specific
+        # product binary. A product like WebKit.framework only relinks when
+        # WebKit itself changes, so a JSC-only (or WTF-only, tool-only) build
+        # would leave it stale and flip the choice to the wrong tree. Both build
+        # systems instead touch a log on every build of any target:
+        #   - CMake/Ninja:   cmake-mac/<Configuration>/.ninja_log
+        #   - Xcode/XCBuild: WebKitBuild/XCBuildData/build.db
+        # A missing log resolves to mtime 0, so an absent log degrades to the
+        # pre-existing "Xcode wins when both exist" default. Note build.db lives
+        # at the WebKitBuild root and is shared across Xcode configurations, so
+        # with two Xcode configs it reflects the most recent Xcode build of any
+        # of them rather than this specific configuration.
+        if ($shouldPickLastBuilt && -d $cmakeMacBuild && -d $xcodeBuild) {
+            my $cmakeMarker = File::Spec->catfile($cmakeMacBuild, ".ninja_log");
+            my $xcodeMarker = File::Spec->catfile($baseProductDir, "XCBuildData", "build.db");
+            my $cmakeMtime = -f $cmakeMarker ? stat($cmakeMarker)->mtime : 0;
+            my $xcodeMtime = -f $xcodeMarker ? stat($xcodeMarker)->mtime : 0;
+            if ($cmakeMtime > $xcodeMtime) {
+                $isCMakeBuild = 1;
+                print STDERR "Using last-built tree: cmake-mac/$configuration (CMake)\n";
+            } elsif ($xcodeMtime && $cmakeMtime) {
+                print STDERR "Using last-built tree: $configuration (Xcode)\n";
+            }
         }
     }
+}
+
+# Opt a read-only path resolver (e.g. webkit-build-directory) into the
+# last-built tiebreaker in determineIsCMakeBuild(). Must be called before the
+# first isCMakeBuild()/product-directory query, since the result is cached.
+sub enableLastBuiltTiebreaker
+{
+    $shouldPickLastBuilt = 1;
 }
 
 sub isCMakeBuild()

--- a/Tools/Scripts/webkitperl/webkitdirs_unittest/determineIsCMakeBuild.pl
+++ b/Tools/Scripts/webkitperl/webkitdirs_unittest/determineIsCMakeBuild.pl
@@ -1,0 +1,39 @@
+#!/usr/bin/env perl
+#
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Unit test for webkitdirs::determineIsCMakeBuild --cmake handling.
+# The function caches its answer in a script-global, so each scenario
+# lives in its own .pl file (test-webkitperl runs each in a fresh process).
+use strict;
+use warnings;
+use Test::More;
+use webkitdirs;
+
+plan(tests => 2);
+
+@ARGV = ("--cmake", "leftover");
+webkitdirs::determineIsCMakeBuild();
+
+is_deeply(\@ARGV, ["leftover"], "--cmake is removed from \@ARGV");
+ok(isCMakeBuild(), "--cmake sets isCMakeBuild() to true");

--- a/Tools/Scripts/webkitperl/webkitdirs_unittest/determineIsCMakeBuildLastBuiltCMake.pl
+++ b/Tools/Scripts/webkitperl/webkitdirs_unittest/determineIsCMakeBuildLastBuiltCMake.pl
@@ -1,0 +1,75 @@
+#!/usr/bin/env perl
+#
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Unit test for webkitdirs::determineIsCMakeBuild last-built tiebreaker:
+# when both trees exist and the CMake tree's Ninja build log (.ninja_log) is
+# newer than the Xcode build database (XCBuildData/build.db),
+# enableLastBuiltTiebreaker() should make it pick the CMake tree. The
+# function caches its answer in a script-global, so each scenario lives in
+# its own .pl file (test-webkitperl runs each in a fresh process).
+use strict;
+use warnings;
+use File::Path qw(make_path);
+use File::Spec;
+use File::Temp qw(tempdir);
+use Test::More;
+use webkitdirs;
+
+plan(tests => 1);
+
+# The tiebreaker is gated on isAppleCocoaWebKit(); force it on so the test
+# is platform-independent (webkitperl runs on non-Cocoa bots too).
+no warnings qw(redefine prototype);
+*webkitdirs::isAppleCocoaWebKit = sub () { 1 };
+use warnings qw(redefine prototype);
+
+my $configuration = "Debug";
+my $base = tempdir(CLEANUP => 1);
+# The tiebreaker compares each build system's own build log: .ninja_log in the
+# CMake tree vs. the shared XCBuildData/build.db for Xcode. It only runs when
+# both tree directories exist, so create the (otherwise empty) Xcode tree dir.
+my $cmakeMarker = File::Spec->catfile($base, "cmake-mac", $configuration, ".ninja_log");
+my $xcodeMarker = File::Spec->catfile($base, "XCBuildData", "build.db");
+make_path(File::Spec->catdir($base, $configuration));
+
+for my $marker ($cmakeMarker, $xcodeMarker) {
+    my ($volume, $dir, $file) = File::Spec->splitpath($marker);
+    make_path(File::Spec->catpath($volume, $dir, ""));
+    open(my $fh, ">", $marker) or die "Could not create $marker: $!";
+    close($fh);
+}
+
+# Make the CMake build log the more recently built one.
+my $now = time();
+utime($now - 100, $now - 100, $xcodeMarker);
+utime($now, $now, $cmakeMarker);
+
+setBaseProductDir($base);
+setConfiguration($configuration);
+enableLastBuiltTiebreaker();
+
+@ARGV = ();
+webkitdirs::determineIsCMakeBuild();
+
+ok(isCMakeBuild(), "last-built tiebreaker picks CMake when its Ninja log is newer");

--- a/Tools/Scripts/webkitperl/webkitdirs_unittest/determineIsCMakeBuildLastBuiltXcode.pl
+++ b/Tools/Scripts/webkitperl/webkitdirs_unittest/determineIsCMakeBuildLastBuiltXcode.pl
@@ -1,0 +1,75 @@
+#!/usr/bin/env perl
+#
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Unit test for webkitdirs::determineIsCMakeBuild last-built tiebreaker:
+# when both trees exist and the Xcode build database (XCBuildData/build.db) is
+# newer than the CMake tree's Ninja build log (.ninja_log) (or the CMake log is
+# absent), the pre-existing "Xcode wins" default should hold. The function
+# caches its answer in a script-global, so each scenario lives in its own .pl
+# file (test-webkitperl runs each in a fresh process).
+use strict;
+use warnings;
+use File::Path qw(make_path);
+use File::Spec;
+use File::Temp qw(tempdir);
+use Test::More;
+use webkitdirs;
+
+plan(tests => 1);
+
+# The tiebreaker is gated on isAppleCocoaWebKit(); force it on so the test
+# is platform-independent (webkitperl runs on non-Cocoa bots too).
+no warnings qw(redefine prototype);
+*webkitdirs::isAppleCocoaWebKit = sub () { 1 };
+use warnings qw(redefine prototype);
+
+my $configuration = "Debug";
+my $base = tempdir(CLEANUP => 1);
+# The tiebreaker compares each build system's own build log: .ninja_log in the
+# CMake tree vs. the shared XCBuildData/build.db for Xcode. It only runs when
+# both tree directories exist, so create the (otherwise empty) Xcode tree dir.
+my $cmakeMarker = File::Spec->catfile($base, "cmake-mac", $configuration, ".ninja_log");
+my $xcodeMarker = File::Spec->catfile($base, "XCBuildData", "build.db");
+make_path(File::Spec->catdir($base, $configuration));
+
+for my $marker ($cmakeMarker, $xcodeMarker) {
+    my ($volume, $dir, $file) = File::Spec->splitpath($marker);
+    make_path(File::Spec->catpath($volume, $dir, ""));
+    open(my $fh, ">", $marker) or die "Could not create $marker: $!";
+    close($fh);
+}
+
+# Make the Xcode build database the more recently built one.
+my $now = time();
+utime($now - 100, $now - 100, $cmakeMarker);
+utime($now, $now, $xcodeMarker);
+
+setBaseProductDir($base);
+setConfiguration($configuration);
+enableLastBuiltTiebreaker();
+
+@ARGV = ();
+webkitdirs::determineIsCMakeBuild();
+
+ok(!isCMakeBuild(), "last-built tiebreaker keeps Xcode when its build database is newer");

--- a/Tools/Scripts/webkitperl/webkitdirs_unittest/determineIsCMakeBuildXcode.pl
+++ b/Tools/Scripts/webkitperl/webkitdirs_unittest/determineIsCMakeBuildXcode.pl
@@ -1,0 +1,39 @@
+#!/usr/bin/env perl
+#
+# Copyright (C) 2026 Apple Inc. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+# 1.  Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+# 2.  Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#
+# THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+# WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS BE LIABLE FOR ANY
+# DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+# LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+# ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+# SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# Unit test for webkitdirs::determineIsCMakeBuild --xcode handling.
+# The function caches its answer in a script-global, so each scenario
+# lives in its own .pl file (test-webkitperl runs each in a fresh process).
+use strict;
+use warnings;
+use Test::More;
+use webkitdirs;
+
+plan(tests => 2);
+
+@ARGV = ("--xcode", "leftover");
+webkitdirs::determineIsCMakeBuild();
+
+is_deeply(\@ARGV, ["leftover"], "--xcode is removed from \@ARGV");
+ok(!isCMakeBuild(), "--xcode pins isCMakeBuild() to false");

--- a/Tools/Scripts/webkitpy/port/base.py
+++ b/Tools/Scripts/webkitpy/port/base.py
@@ -183,6 +183,7 @@ class Port(object):
             self._filesystem,
             self.port_name,
             use_cmake=bool(getattr(self._options, 'use_cmake', False)),
+            use_xcode=bool(getattr(self._options, 'use_xcode', False)),
             asan=bool(getattr(self._options, 'asan', False)),
         )
         self.pretty_patch = PrettyPatch(self._executive, self.path_from_webkit_base(), self._filesystem)

--- a/Tools/Scripts/webkitpy/port/config.py
+++ b/Tools/Scripts/webkitpy/port/config.py
@@ -58,13 +58,14 @@ class Config(object):
     # perl invocation whose result is invariant for given inputs within a run.
     _build_directories = {}
 
-    def __init__(self, executive, filesystem, port_implementation=None, use_cmake=False, asan=False):
+    def __init__(self, executive, filesystem, port_implementation=None, use_cmake=False, use_xcode=False, asan=False):
         self._executive = executive
         self._filesystem = filesystem
         self._webkit_finder = webkit_finder.WebKitFinder(self._filesystem)
         self._default_configuration = None
         self._port_implementation = port_implementation
         self._use_cmake = use_cmake
+        self._use_xcode = use_xcode
         self._asan = asan
 
     @classmethod
@@ -74,7 +75,7 @@ class Config(object):
     def build_directory(self, configuration, for_host=False):
         """Returns the path to the build directory for the configuration."""
         port_impl = self._port_implementation if not for_host else None
-        cache_key = (port_impl, configuration or "", for_host, self._use_cmake, self._asan)
+        cache_key = (port_impl, configuration or "", for_host, self._use_cmake, self._use_xcode, self._asan)
         if self._build_directories.get(cache_key):
             return self._build_directories[cache_key]
 
@@ -86,6 +87,8 @@ class Config(object):
             flags.append('--' + port_impl)
         if self._use_cmake:
             flags.append('--cmake')
+        if self._use_xcode:
+            flags.append('--xcode')
         if self._asan:
             flags.append('--asan')
 
@@ -100,7 +103,7 @@ class Config(object):
             default_configuration = parts[1][len(parts[0]):]
             if default_configuration.startswith("/"):
                 default_configuration = default_configuration[1:]
-            self._build_directories[(port_impl, default_configuration, for_host, self._use_cmake, self._asan)] = parts[1]
+            self._build_directories[(port_impl, default_configuration, for_host, self._use_cmake, self._use_xcode, self._asan)] = parts[1]
 
         return self._build_directories[cache_key]
 

--- a/Tools/Scripts/webkitpy/port/config_unittest.py
+++ b/Tools/Scripts/webkitpy/port/config_unittest.py
@@ -45,10 +45,10 @@ class ConfigTest(unittest.TestCase):
     def setUp(self):
         config.Config._clear_cache_for_testing()
 
-    def make_config(self, output='', files=None, exit_code=0, exception=None, run_command_fn=None, stderr='', port_implementation=None, use_cmake=False, asan=False):
+    def make_config(self, output='', files=None, exit_code=0, exception=None, run_command_fn=None, stderr='', port_implementation=None, use_cmake=False, use_xcode=False, asan=False):
         e = MockExecutive2(output=output, exit_code=exit_code, exception=exception, run_command_fn=run_command_fn, stderr=stderr)
         fs = MockFileSystem(files)
-        return config.Config(e, fs, port_implementation=port_implementation, use_cmake=use_cmake, asan=asan)
+        return config.Config(e, fs, port_implementation=port_implementation, use_cmake=use_cmake, use_xcode=use_xcode, asan=asan)
 
     def assert_configuration(self, contents, expected):
         # This tests that a configuration file containing
@@ -154,6 +154,18 @@ class ConfigTest(unittest.TestCase):
         c = self.make_config(run_command_fn=mock_run_command, files={'foo/ASan': 'YES'})
         self.assertTrue(c.asan)
         self.assertNotIn('--asan', seen[-1])
+        self.assertNotIn('--cmake', seen[-1])
+
+    def test_build_directory_passes_xcode_flag(self):
+        seen = []
+
+        def mock_run_command(arg_list):
+            seen.append(list(arg_list))
+            return '/WebKitBuild/Debug'
+
+        c_xcode = self.make_config(run_command_fn=mock_run_command, port_implementation='mac', use_xcode=True)
+        self.assertEqual(c_xcode.build_directory('Debug'), '/WebKitBuild/Debug')
+        self.assertIn('--xcode', seen[-1])
         self.assertNotIn('--cmake', seen[-1])
 
     def test_default_configuration__release(self):

--- a/Tools/Scripts/webkitpy/port/factory.py
+++ b/Tools/Scripts/webkitpy/port/factory.py
@@ -86,6 +86,8 @@ def configuration_options():
                              help='Set the configuration to Release'),
         optparse.make_option('--cmake', action='store_true', default=False, dest='use_cmake',
                              help='Use the CMake build tree (e.g. WebKitBuild/cmake-mac/<configuration>) instead of the default Xcode/Make tree'),
+        optparse.make_option('--xcode', action='store_true', default=False, dest='use_xcode',
+                             help='Use the Xcode build tree (e.g. WebKitBuild/<configuration>); overrides last-built auto-detection'),
         optparse.make_option('--asan', action='store_true', default=False, dest='asan',
                              help='Use the ASan (AddressSanitizer) build tree (with --cmake: WebKitBuild/cmake-mac/ASan). Does not require --debug/--release.'),
         optparse.make_option('--64-bit', action='store_const', const='x86_64', default=None, dest="architecture",


### PR DESCRIPTION
#### b3f1f7efedad5b6f50e1acd35a4a400e2393d120
<pre>
Auto-pick last-built tree on Mac for scripts that use local build products, add --xcode flag
<a href="https://bugs.webkit.org/show_bug.cgi?id=315146">https://bugs.webkit.org/show_bug.cgi?id=315146</a>
<a href="https://rdar.apple.com/177478344">rdar://177478344</a>

Reviewed by Pascoe.

When both WebKitBuild/&lt;Config&gt;/ (Xcode) and WebKitBuild/cmake-mac/&lt;Config&gt;/
(CMake) exist, webkit-build-directory now defaults to whichever tree was built
most recently instead of always preferring Xcode. The choice is logged on
STDERR (&quot;Using last-built tree: cmake-mac/Debug&quot; or &quot;Using last-built tree:
Debug&quot;).

Tools that benefit (anything that shells out to webkit-build-directory):
run-api-tests, run-webkit-tests, run-perf-tests, run-webdriver,
run-minibrowser, run-swiftbrowser, run-jsc-stress-tests, run-testmem,
dump-class-layout, install-built-product, measure-build-time,
extract-tbds-from-internal-sdk.

Build drivers (build-webkit and its wrappers, set-webkit-configuration) call
webkitdirs.pm directly without opting into the tiebreaker and keep today&apos;s
behavior, so they never auto-flip the build target.

Add --xcode as a counterpart to --cmake for explicit pinning.

The tiebreaker is opt-in via enableLastBuiltTiebreaker(), which
webkit-build-directory calls for itself before any product-directory query. It
compares each build system&apos;s own build log rather than a specific product
binary, so a partial build (e.g. a JSC-only build that never relinks
WebKit.framework) still moves the marker: the CMake/Ninja tree&apos;s
cmake-mac/&lt;Config&gt;/.ninja_log versus the Xcode/XCBuild tree&apos;s
WebKitBuild/XCBuildData/build.db, read via File::stat&apos;s -&gt;mtime. A missing log
resolves to mtime 0, so an absent log degrades to the pre-existing &quot;Xcode wins
when both exist&quot; default. build.db lives at the WebKitBuild root and is shared
across Xcode configurations, so with two Xcode configs it reflects the most
recent Xcode build of any of them rather than this specific configuration; that
only ever biases back toward the historical Xcode-wins default. Non-Cocoa ports
are gated out via the existing isAppleCocoaWebKit() guard.

* Tools/Scripts/webkit-build-directory:
* Tools/Scripts/webkitdirs.pm:
(determineIsCMakeBuild):
(enableLastBuiltTiebreaker): Added.
* Tools/Scripts/webkitperl/webkitdirs_unittest/determineIsCMakeBuild.pl:
* Tools/Scripts/webkitperl/webkitdirs_unittest/determineIsCMakeBuildXcode.pl: Added.
* Tools/Scripts/webkitperl/webkitdirs_unittest/determineIsCMakeBuildLastBuiltCMake.pl: Added.
* Tools/Scripts/webkitperl/webkitdirs_unittest/determineIsCMakeBuildLastBuiltXcode.pl: Added.
* Tools/Scripts/webkitpy/port/base.py:
(Port.__init__):
* Tools/Scripts/webkitpy/port/config.py:
(Config.__init__):
(Config.build_directory):
* Tools/Scripts/webkitpy/port/config_unittest.py:
(ConfigTest.make_config):
(ConfigTest.test_build_directory_passes_xcode_flag):
(ConfigTest.test_build_directory_passes_xcode_flag.mock_run_command):
* Tools/Scripts/webkitpy/port/factory.py:
(configuration_options):

Canonical link: <a href="https://commits.webkit.org/316853@main">https://commits.webkit.org/316853@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/610f23a72a10ed18d77c4861630b3f47c3898d4e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/173569 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/47502 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/41187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/183142 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/131437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/22439290-f75c-4b16-9b37-6382443e197f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/175434 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/48794 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/47184 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/134967 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/131437 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/176527 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/38395 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/155681 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/115444 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/46ad3f31-84ef-42d0-a813-aaf4a6479742) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/172890 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/37036 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/35397 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/31627 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/4193 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/147460 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/35176 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/185568 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/34831 "Built successfully and passed tests") | | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/39597 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/143847 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/47169 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/143704 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38777 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/47848 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/41187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/113022 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/38640 "Passed tests") | | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/210602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/46354 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/10129 "Passed tests") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/210602 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/45756 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/45987 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/45815 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->