### PR TITLE
DFG abstract interpreter misclassifies ArraySortCompact result as SpecObjectOther

### DIFF
--- a/JSTests/stress/array-sort-inline-ai-cell-butterfly-validation.js
+++ b/JSTests/stress/array-sort-inline-ai-cell-butterfly-validation.js
@@ -1,0 +1,17 @@
+//@ requireOptions("--useConcurrentJIT=0", "--jitPolicyScale=0.1", "--validateAbstractInterpreterState=1", "--validateDFGClobberize=1")
+
+// FTL ArraySortCompact returns a JSCellButterfly (SpecCellOther), not a
+// JSObject. The DFG abstract interpreter (and prediction propagation) used to
+// claim SpecObjectOther for this node, which is a disjoint, wrong type proof.
+// With --validateAbstractInterpreterState=1 the FTL probe traps deterministically.
+// This test ensures the AI/prediction match the runtime cell type so no probe fires.
+
+function sortIt(a, cmp) { return a.sort(cmp); }
+noInline(sortIt);
+
+let cmp = (x, y) => x.idx - y.idx;
+let template = [];
+for (let i = 0; i < 8; i++) template.push({ idx: i });
+
+for (let i = 0; i < testLoopCount; i++)
+    sortIt(template.slice(), cmp);

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -3871,7 +3871,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         break;
 
     case ArraySortCompact:
-        setTypeForNode(node, SpecObjectOther);
+        setTypeForNode(node, SpecCellOther);
         break;
 
     case ArraySortCommit:

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1366,7 +1366,7 @@ private:
         }
 
         case ArraySortCompact: {
-            setPrediction(SpecObjectOther);
+            setPrediction(SpecCellOther);
             break;
         }
 


### PR DESCRIPTION
#### 1aeca6948c89d2765d32bb90315ab070cd5f333d
<pre>
DFG abstract interpreter misclassifies ArraySortCompact result as SpecObjectOther
<a href="https://bugs.webkit.org/show_bug.cgi?id=315143">https://bugs.webkit.org/show_bug.cgi?id=315143</a>
<a href="https://rdar.apple.com/177361524">rdar://177361524</a>

Reviewed by Yijia Huang.

ArraySortCompact returns a JSCellButterfly but DFG abstract interpreter marks
the node as SpecObjectOther instead of SpecCellOther even though a JSCell is
not necessarily a JSObject. This patch fixes the abstract interpreter to use
SpecCellOther.

Test: JSTests/stress/array-sort-inline-ai-cell-butterfly-validation.js

* JSTests/stress/array-sort-inline-ai-cell-butterfly-validation.js: Added.
(sortIt):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:

Canonical link: <a href="https://commits.webkit.org/313587@main">https://commits.webkit.org/313587@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/50ebf9a04bf9581fb9f6d2d1ee285ad888f46a02

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163411 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36894 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30110 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172351 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119858 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37223 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36894 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126902 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89450 "layout-tests (failure)") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2aac74b6-3a85-4656-b274-7619d72b3a10) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166370 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29172 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146899 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107460 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28218 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26851 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20053 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/155556 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138113 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24622 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174855 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/24298 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27504 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26278 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135205 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36564 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30951 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135191 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36469 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37349 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146417 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/99305 "The change is no longer eligible for processing.") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30496 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23262 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195813 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36060 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108947 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51044 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35557 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1287 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35805 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35705 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->