### PR TITLE
[BFCache] Drive WebBackForwardCacheEntry lifecycle via explicit IPCs

### DIFF
--- a/Source/WebCore/history/BackForwardCache.cpp
+++ b/Source/WebCore/history/BackForwardCache.cpp
@@ -530,7 +530,7 @@ std::unique_ptr<CachedPage> BackForwardCache::trySuspendPage(Page& page, ForceSu
     return makeUnique<CachedPage>(page);
 }
 
-bool BackForwardCache::addIfCacheable(BackForwardFrameItemIdentifier identifier, Page& page)
+bool BackForwardCache::addIfCacheable(BackForwardFrameItemIdentifier identifier, Page& page, std::optional<BackForwardItemIdentifier> itemID)
 {
     if (isInBackForwardCache(identifier))
         return false;
@@ -539,6 +539,9 @@ bool BackForwardCache::addIfCacheable(BackForwardFrameItemIdentifier identifier,
     if (!cachedPage)
         return false;
 
+    if (itemID)
+        cachedPage->setItemID(*itemID);
+
     {
         ScriptDisallowedScope::InMainThread scriptDisallowedScope;
         m_cachedPageMap.set(identifier, makeUniqueRefFromNonNullUniquePtr(WTF::move(cachedPage)));
@@ -546,7 +549,10 @@ bool BackForwardCache::addIfCacheable(BackForwardFrameItemIdentifier identifier,
     }
     prune(PruningReason::ReachedMaxSize);
     RELEASE_LOG(BackForwardCache, "BackForwardCache::addIfCacheable frameItemID: %s, size: %u / %u", identifier.toString().utf8().data(), pageCount(), maxSize());
-    return true;
+    // prune() can evict the entry we just inserted (e.g. if maxSize() == 0 or
+    // the new entry is the oldest under the configured policy), so reflect the
+    // actual post-prune state.
+    return isInBackForwardCache(identifier);
 }
 
 static bool hasRemoteFrameDescendant(const Frame& frame)
@@ -573,7 +579,7 @@ bool BackForwardCache::addIfCacheable(HistoryItem& item, Page* page)
             return false;
     }
 
-    if (!addIfCacheable(item.frameItemID(), *page))
+    if (!addIfCacheable(item.frameItemID(), *page, item.itemID()))
         return false;
     item.notifyChanged();
     return true;
@@ -666,12 +672,31 @@ CachedPage* BackForwardCache::get(HistoryItem& item, Page* page)
     });
 }
 
-void BackForwardCache::remove(BackForwardFrameItemIdentifier frameItemID)
+// Notify the LocalFrameLoaderClient before tearing down so the WebKit layer
+// can mirror the eviction to UIProcess (DidEvictBackForwardItem). Only fires
+// for entries that have a bound itemID (set via the addIfCacheable itemID
+// parameter) — the same-site BFCache path. Cross-site / iframe insertions
+// don't carry an item identifier and so are not signaled.
+static void notifyClientOfEviction(CachedPage& cachedPage)
+{
+    auto itemID = cachedPage.itemID();
+    if (!itemID)
+        return;
+    RefPtr localMainFrame = cachedPage.page().localMainFrame();
+    if (!localMainFrame)
+        return;
+    localMainFrame->loader().client().didEvictBackForwardItem(*itemID);
+}
+
+void BackForwardCache::remove(BackForwardFrameItemIdentifier frameItemID, ShouldNotifyClient shouldNotifyClient)
 {
     // Safely ignore attempts to remove items not in the cache.
     auto it = m_cachedPageMap.find(frameItemID);
     if (it == m_cachedPageMap.end() || std::holds_alternative<PruningReason>(it->value))
         return;
+
+    if (shouldNotifyClient == ShouldNotifyClient::Yes)
+        notifyClientOfEviction(protect(std::get<UniqueRef<CachedPage>>(it->value).get()));
 
     m_items.remove(frameItemID);
     m_cachedPageMap.remove(it);
@@ -692,6 +717,8 @@ void BackForwardCache::prune(PruningReason pruningReason)
 
         // Take the CachedPage before calling set() so ~CachedPage doesn’t find itself in m_cachedPageMap.
         auto cachedPage = m_cachedPageMap.take(oldestItem);
+        if (auto* uniqueRef = std::get_if<UniqueRef<CachedPage>>(&cachedPage))
+            notifyClientOfEviction(protect(uniqueRef->get()));
         m_cachedPageMap.set(oldestItem, pruningReason);
         RELEASE_LOG(BackForwardCache, "BackForwardCache::prune removing item: %s, size: %u / %u", oldestItem.toString().utf8().data(), pageCount(), maxSize());
     }
@@ -703,6 +730,7 @@ void BackForwardCache::clearEntriesForOrigins(const HashSet<Ref<SecurityOrigin>>
         if (auto* cachedPage = std::get_if<UniqueRef<CachedPage>>(&pair.value)) {
             if (origins.contains(SecurityOrigin::create((*cachedPage)->page().mainFrameURL()))) {
                 RELEASE_LOG(BackForwardCache, "BackForwardCache::clearEntriesForOrigins removing item: %s, size: %u / %u", pair.key.toString().utf8().data(), pageCount() - 1, maxSize());
+                notifyClientOfEviction(protect(cachedPage->get()));
                 m_items.remove(pair.key);
                 return true;
             }

--- a/Source/WebCore/history/BackForwardCache.h
+++ b/Source/WebCore/history/BackForwardCache.h
@@ -57,8 +57,9 @@ public:
 
     WEBCORE_EXPORT std::unique_ptr<CachedPage> suspendPage(Page&);
     WEBCORE_EXPORT bool addIfCacheable(HistoryItem&, Page*); // Prunes if maxSize() is exceeded.
-    WEBCORE_EXPORT bool addIfCacheable(BackForwardFrameItemIdentifier, Page&);
-    WEBCORE_EXPORT void remove(BackForwardFrameItemIdentifier);
+    WEBCORE_EXPORT bool addIfCacheable(BackForwardFrameItemIdentifier, Page&, std::optional<BackForwardItemIdentifier> = std::nullopt);
+    enum class ShouldNotifyClient : bool { No, Yes };
+    WEBCORE_EXPORT void remove(BackForwardFrameItemIdentifier, ShouldNotifyClient = ShouldNotifyClient::Yes);
     WEBCORE_EXPORT void remove(HistoryItem&);
     CachedPage* get(HistoryItem&, Page*);
     std::unique_ptr<CachedPage> take(HistoryItem&, Page*);

--- a/Source/WebCore/history/CachedPage.h
+++ b/Source/WebCore/history/CachedPage.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <WebCore/BackForwardItemIdentifier.h>
 #include <WebCore/CachedFrame.h>
 #include <wtf/CheckedRef.h>
 #include <wtf/MonotonicTime.h>
@@ -65,12 +66,19 @@ public:
 
     void markForContentsSizeChanged() { m_needsUpdateContentsSize = true; }
 
+    // Bound by callers that go through the explicit-IPC same-site BFCache path
+    // so that eviction signals from BackForwardCache can carry a
+    // BackForwardItemIdentifier (the key UIProcess uses).
+    void setItemID(BackForwardItemIdentifier itemID) { m_itemID = itemID; }
+    std::optional<BackForwardItemIdentifier> itemID() const { return m_itemID; }
+
 private:
     void restoreNavigationAPIHistoryItems(LocalFrame&, BackForwardController*);
 
     WeakRef<Page> m_page;
     MonotonicTime m_expirationTime;
     std::unique_ptr<CachedFrame> m_cachedMainFrame;
+    std::optional<BackForwardItemIdentifier> m_itemID;
 #if ENABLE(VIDEO)
     bool m_needsCaptionPreferencesChanged { false };
 #endif

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -2403,8 +2403,20 @@ void FrameLoader::commitProvisionalLoad()
         m_documentPrefetcher->clearPrefetchedResourcesExcept(pdl->url());
 
     std::unique_ptr<CachedPage> cachedPage;
-    if (m_loadingFromCachedPage && history().provisionalItem())
-        cachedPage = BackForwardCache::singleton().take(*protect(history().provisionalItem()), protect(frame->page()).get());
+    if (m_loadingFromCachedPage && history().provisionalItem()) {
+        Ref provisionalItem = *history().provisionalItem();
+        cachedPage = BackForwardCache::singleton().take(provisionalItem->frameItemID(), protect(frame->page()).get());
+        if (cachedPage) {
+            // Fire DidTakeBackForwardItemForRestoration before any subsequent
+            // DidCacheBackForwardItem for the outgoing page, so the UIProcess
+            // WebBackForwardCache observes remove(provisional) → add(current)
+            // in the same order the WebProcess BackForwardCache did. Firing
+            // late (after the Document is swapped in) inverts that ordering
+            // and can drop a same-process sibling SPP entry as the new
+            // "oldest" entry under capacity pressure.
+            m_client->didTakeBackForwardItemForRestoration(provisionalItem->itemID());
+        }
+    }
 
     LOG(BackForwardCache, "WebCoreLoading frame %" PRIu64 ": About to commit provisional load from previous URL '%s' to new URL '%s' with cached page %p", m_frame->frameID().toUInt64(),
         frame->document() ? frame->document()->url().stringCenterEllipsizedToLength().utf8().data() : "",
@@ -2450,7 +2462,9 @@ void FrameLoader::commitProvisionalLoad()
     if (!frame->tree().parent() && history().currentItem() && (!history().provisionalItem() || history().currentItem()->itemID() != history().provisionalItem()->itemID())) {
         // Check to see if we need to cache the page we are navigating away from into the back/forward cache.
         // We are doing this here because we know for sure that a new page is about to be loaded.
-        BackForwardCache::singleton().addIfCacheable(*protect(history().currentItem()), protect(frame->page()).get());
+        Ref currentItem = *history().currentItem();
+        if (BackForwardCache::singleton().addIfCacheable(currentItem.get(), protect(frame->page()).get()))
+            m_client->didCacheBackForwardItem(currentItem->itemID(), currentItem->frameItemID());
 
         WebCore::jettisonExpensiveObjectsOnTopLevelNavigation();
     }

--- a/Source/WebCore/loader/LocalFrameLoaderClient.cpp
+++ b/Source/WebCore/loader/LocalFrameLoaderClient.cpp
@@ -56,6 +56,22 @@ void LocalFrameLoaderClient::didExceedNetworkUsageThreshold()
 }
 #endif
 
+// The three notifications below are entry points for the multi-process BFCache
+// coordination on top of WebKit's UIProcess. WebKitLegacy's WebFrameLoaderClient
+// does not run a UIProcess and tracks BFCache locally, so the base class
+// default is a silent no-op rather than an assert.
+void LocalFrameLoaderClient::didCacheBackForwardItem(BackForwardItemIdentifier, BackForwardFrameItemIdentifier)
+{
+}
+
+void LocalFrameLoaderClient::didEvictBackForwardItem(BackForwardItemIdentifier)
+{
+}
+
+void LocalFrameLoaderClient::didTakeBackForwardItemForRestoration(BackForwardItemIdentifier)
+{
+}
+
 RefPtr<Frame> LocalFrameLoaderClient::provisionalParentFrame() const
 {
     return nullptr;

--- a/Source/WebCore/loader/LocalFrameLoaderClient.h
+++ b/Source/WebCore/loader/LocalFrameLoaderClient.h
@@ -110,6 +110,9 @@ enum class IsSameDocumentNavigation : bool { No, Yes };
 enum class ShouldGoToHistoryItem : uint8_t { No, Yes, ItemUnknown };
 enum class ProcessSwapDisposition : uint8_t;
 
+struct BackForwardFrameItemIdentifierType;
+using BackForwardFrameItemIdentifier = ProcessQualified<ObjectIdentifier<BackForwardFrameItemIdentifierType>>;
+
 struct BackForwardItemIdentifierType;
 struct StringWithDirection;
 
@@ -269,6 +272,10 @@ public:
     virtual void transitionToCommittedForNewPage(InitializingIframe) = 0;
 
     virtual void didRestoreFromBackForwardCache() = 0;
+
+    virtual void didCacheBackForwardItem(BackForwardItemIdentifier, BackForwardFrameItemIdentifier);
+    virtual void didEvictBackForwardItem(BackForwardItemIdentifier);
+    virtual void didTakeBackForwardItemForRestoration(BackForwardItemIdentifier);
 
     virtual bool canCachePage() const = 0;
     virtual void convertMainResourceLoadToDownload(DocumentLoader*, const ResourceRequest&, const ResourceResponse&) = 0;

--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -820,14 +820,6 @@ void WebBackForwardList::backForwardUpdateItem(IPC::Connection& connection, Ref<
     if (RefPtr webPageProxy = m_page.get()) {
         ASSERT(webPageProxy->identifier() == item->pageID() && frameState->itemID == item->identifier());
 
-        Ref process = *downcast<WebProcessProxy>(AuxiliaryProcessProxy::fromConnection(connection));
-        if (!!item->backForwardCacheEntry() != frameState->hasCachedPage) {
-            if (frameState->hasCachedPage)
-                protect(webPageProxy->backForwardCache())->addEntry(*item, process->coreProcessIdentifier());
-            else if (!item->suspendedPage())
-                protect(webPageProxy->backForwardCache())->removeEntry(*item);
-        }
-
         auto oldFrameID = frameItem->frameID();
         frameItem->setFrameState(WTF::move(frameState));
         auto newFrameID = frameItem->frameID();

--- a/Source/WebKit/UIProcess/WebBackForwardList.swift
+++ b/Source/WebKit/UIProcess/WebBackForwardList.swift
@@ -1049,18 +1049,6 @@ final class WebBackForwardList {
         }
         // We can't use == here due to rdar://162357139
         assert(contentsMatch(webPageProxy.identifier(), item.pageID()) && contentsMatch(itemID, item.identifier()))
-        if let process = WebKit.AuxiliaryProcessProxy.fromConnection(connection) {
-            // The downcast in C++ is really just used to assert that the process is a WebProcessProxy
-            assert(WebKit.downcastToWebProcessProxy(process).__convertToBool())
-            let hasBackForwardCacheEntry = item.backForwardCacheEntry() != nil
-            if hasBackForwardCacheEntry != frameState.ptr().hasCachedPage {
-                if frameState.ptr().hasCachedPage {
-                    webPageProxy.backForwardCache().addEntry(item, process.coreProcessIdentifier())
-                } else if item.suspendedPage() == nil {
-                    webPageProxy.backForwardCache().removeEntry(item)
-                }
-            }
-        }
         let oldFrameID = frameItem.frameID()
         frameItem.setFrameState(consuming: frameState)
         let newFrameID = frameItem.frameID()

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -149,6 +149,7 @@
 #include "WebAutomationSession.h"
 #include "WebAutomationSessionProxyMessages.h"
 #include "WebBackForwardCache.h"
+#include "WebBackForwardCacheEntry.h"
 #include "WebBackForwardList.h"
 #include "WebBackForwardListCounts.h"
 #include "WebBackForwardListFrameItem.h"
@@ -18150,6 +18151,56 @@ void WebPageProxy::reportMixedContentViolation(FrameIdentifier frameID, bool blo
 void WebPageProxy::drawFrameToSnapshot(FrameIdentifier frameID, const IntRect& rect, RemoteSnapshotIdentifier snapshotIdentifier, CompletionHandler<void(bool)>&& completionHandler)
 {
     sendWithAsyncReplyToProcessContainingFrame(frameID, Messages::WebPage::DrawFrameToSnapshot(frameID, rect, snapshotIdentifier), WTF::move(completionHandler));
+}
+
+void WebPageProxy::didCacheBackForwardItem(BackForwardItemIdentifier itemID, CompletionHandler<void(bool)>&& completionHandler)
+{
+    RefPtr item = WebBackForwardListItem::itemForID(itemID);
+    if (!item) {
+        WEBPAGEPROXY_RELEASE_LOG_ERROR(ProcessSwapping, "didCacheBackForwardItem: unknown itemID %" PUBLIC_LOG_STRING, itemID.toString().utf8().data());
+        return completionHandler(false);
+    }
+
+    // Create the UI-side cache entry explicitly. Sole driver for the
+    // WebBackForwardCacheEntry lifecycle — no implicit flag-relay path remains.
+    protect(backForwardCache())->addEntry(*item, legacyMainFrameProcess().coreProcessIdentifier());
+    completionHandler(true);
+}
+
+void WebPageProxy::didEvictBackForwardItem(BackForwardItemIdentifier itemID)
+{
+    // WP-initiated eviction (capacity / expiration). Idempotent: drop our entry
+    // if any. UI→WP discard IPCs are NOT sent because the WP that informed us
+    // has already evicted on its side.
+    RefPtr item = WebBackForwardListItem::itemForID(itemID);
+    if (!item || !item->backForwardCacheEntry())
+        return;
+    protect(backForwardCache())->removeEntry(*item);
+}
+
+void WebPageProxy::didTakeBackForwardItemForRestoration(BackForwardItemIdentifier itemID)
+{
+    // Explicit restore notification from WebProcess. Fired in commitProvisionalLoad
+    // immediately after BackForwardCache::take() succeeds, ahead of any
+    // DidCacheBackForwardItem for the outgoing page in the same load. Drops
+    // the UI-side entry.
+    RefPtr item = WebBackForwardListItem::itemForID(itemID);
+    if (!item) {
+        WEBPAGEPROXY_RELEASE_LOG_ERROR(ProcessSwapping, "didTakeBackForwardItemForRestoration: unknown itemID %" PUBLIC_LOG_STRING, itemID.toString().utf8().data());
+        return;
+    }
+    if (!item->backForwardCacheEntry())
+        return;
+    if (item->suspendedPage()) {
+        // SuspendedPageProxy entries follow their own restore path (consumed
+        // via takeSuspendedPage at the policy-decision callback chain). They
+        // must never reach the same-site UI-driven restore handler with their
+        // SPP intact.
+        ASSERT_NOT_REACHED();
+        return;
+    }
+    protect(backForwardCache())->removeEntry(*item);
+    ASSERT(!item->backForwardCacheEntry());
 }
 
 void WebPageProxy::resetVisibilityAdjustmentsForTargetedElements(const Vector<Ref<API::TargetedElementInfo>>& elements, CompletionHandler<void(bool)>&& completion)

--- a/Source/WebKit/UIProcess/WebPageProxy.h
+++ b/Source/WebKit/UIProcess/WebPageProxy.h
@@ -3606,6 +3606,10 @@ private:
     void reportMixedContentViolation(WebCore::FrameIdentifier, bool blocked, const URL& target);
     void drawFrameToSnapshot(WebCore::FrameIdentifier, const WebCore::IntRect&, RemoteSnapshotIdentifier, CompletionHandler<void(bool)>&&);
 
+    void didCacheBackForwardItem(WebCore::BackForwardItemIdentifier, CompletionHandler<void(bool)>&&);
+    void didEvictBackForwardItem(WebCore::BackForwardItemIdentifier);
+    void didTakeBackForwardItemForRestoration(WebCore::BackForwardItemIdentifier);
+
     void setTextIndicatorFromFrame(WebCore::FrameIdentifier, RefPtr<WebCore::TextIndicator>&&, WebCore::TextIndicatorLifetime);
     void updateTextIndicatorFromFrame(WebCore::FrameIdentifier, RefPtr<WebCore::TextIndicator>&&);
 

--- a/Source/WebKit/UIProcess/WebPageProxy.messages.in
+++ b/Source/WebKit/UIProcess/WebPageProxy.messages.in
@@ -694,4 +694,8 @@ messages -> WebPageProxy {
 #endif
 
     UpdateRemoteIntersectionObserversInOtherWebProcesses();
+
+    DidCacheBackForwardItem(WebCore::BackForwardItemIdentifier itemID) -> (bool success)
+    DidEvictBackForwardItem(WebCore::BackForwardItemIdentifier itemID)
+    DidTakeBackForwardItemForRestoration(WebCore::BackForwardItemIdentifier itemID)
 }

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp
@@ -68,6 +68,7 @@
 #include "WebsitePoliciesData.h"
 #include <JavaScriptCore/APICast.h>
 #include <JavaScriptCore/JSObject.h>
+#include <WebCore/BackForwardCache.h>
 #include <WebCore/CachedFrame.h>
 #include <WebCore/CertificateInfo.h>
 #include <WebCore/Chrome.h>
@@ -1737,6 +1738,39 @@ void WebLocalFrameLoaderClient::transitionToCommittedForNewPage(InitializingIfra
 void WebLocalFrameLoaderClient::didRestoreFromBackForwardCache()
 {
     m_frameCameFromBackForwardCache = true;
+}
+
+void WebLocalFrameLoaderClient::didCacheBackForwardItem(BackForwardItemIdentifier itemID, BackForwardFrameItemIdentifier frameItemID)
+{
+    RefPtr webPage = m_frame->page();
+    ASSERT(webPage);
+    if (!webPage)
+        return;
+    webPage->sendWithAsyncReply(Messages::WebPageProxy::DidCacheBackForwardItem(itemID), [itemID, frameItemID](bool success) {
+        if (success)
+            return;
+        // UIProcess rejected the cache: roll back the WebProcess-side entry
+        // we just inserted. Skip the eviction notification because the
+        // UIProcess never registered an entry to remove.
+        RELEASE_LOG_ERROR(ProcessSwapping, "didCacheBackForwardItem: UIProcess rejected itemID %" PUBLIC_LOG_STRING ", evicting frameItemID %" PUBLIC_LOG_STRING, itemID.toString().utf8().data(), frameItemID.toString().utf8().data());
+        BackForwardCache::singleton().remove(frameItemID, BackForwardCache::ShouldNotifyClient::No);
+    });
+}
+
+void WebLocalFrameLoaderClient::didEvictBackForwardItem(BackForwardItemIdentifier itemID)
+{
+    RefPtr webPage = m_frame->page();
+    if (!webPage)
+        return;
+    webPage->send(Messages::WebPageProxy::DidEvictBackForwardItem(itemID));
+}
+
+void WebLocalFrameLoaderClient::didTakeBackForwardItemForRestoration(BackForwardItemIdentifier itemID)
+{
+    RefPtr webPage = m_frame->page();
+    if (!webPage)
+        return;
+    webPage->send(Messages::WebPageProxy::DidTakeBackForwardItemForRestoration(itemID));
 }
 
 bool WebLocalFrameLoaderClient::canCachePage() const

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h
@@ -218,6 +218,10 @@ private:
 
     void didRestoreFromBackForwardCache() final;
 
+    void didCacheBackForwardItem(WebCore::BackForwardItemIdentifier, WebCore::BackForwardFrameItemIdentifier) final;
+    void didEvictBackForwardItem(WebCore::BackForwardItemIdentifier) final;
+    void didTakeBackForwardItemForRestoration(WebCore::BackForwardItemIdentifier) final;
+
     bool canCachePage() const final;
     void convertMainResourceLoadToDownload(WebCore::DocumentLoader*, const WebCore::ResourceRequest&, const WebCore::ResourceResponse&) final;
 


### PR DESCRIPTION
#### b776e22550fb70e8942e2c34bfbbcb3798c72203
<pre>
[BFCache] Drive WebBackForwardCacheEntry lifecycle via explicit IPCs
<a href="https://bugs.webkit.org/show_bug.cgi?id=315104">https://bugs.webkit.org/show_bug.cgi?id=315104</a>
<a href="https://rdar.apple.com/177439386">rdar://177439386</a>

Reviewed by Sihui Liu.

Replace the implicit BackForwardUpdateItem hasCachedPage flag relay with
three explicit IPCs:
- DidCacheItem(itemID) on successful addIfCacheable
- DidEvictCachedItem(itemID) on WP-side eviction (capacity / origin clear)
- DidRestoreFromBackForwardCache(itemID) on successful take

The hasCachedPage diff branch in WebBackForwardList::backForwardUpdateItem
(C++ and Swift) is removed. FrameState::hasCachedPage becomes unused —
removal deferred to a follow-up PR.

WebCore::CachedPage carries an optional BackForwardItemIdentifier so the
WP-side BFCache (frameItemID-keyed) can resolve a top-level itemID for the
client notifications. addIfCacheable(BackForwardFrameItemIdentifier, Page&amp;)
takes itemID as an optional argument, bound at construction. Cross-site
WebPage::suspendForProcessSwap also passes itemID; the iframe SPP path
(suspendWithFrameItem) has no itemID context and omits it — those entries
are silent on eviction, matching their existing UIProcess flow through
SuspendedPageProxy.

Eviction notifications are funneled through notifyClientOfEviction, called
from remove(), prune(), and clearEntriesForOrigins(). The UI-rejection
rollback path (WebLocalFrameLoaderClient::didCacheItem failure handler)
calls remove() with ShouldNotifyClient::No to avoid bouncing
DidEvictCachedItem back to a UIProcess that never registered the entry.

Ordering note (FrameLoader.cpp): DidRestoreFromBackForwardCache fires
immediately after BackForwardCache::take() succeeds, before the
addIfCacheable / DidCacheItem block for the outgoing page in the same
commitProvisionalLoad. This matches the WebProcess BackForwardCache&apos;s
take→add order. Firing the restore IPC late inverts that order on the
UIProcess side and can drop a same-process sibling SuspendedPageProxy
entry as the new &quot;oldest&quot; entry under capacity pressure.

The new LocalFrameLoaderClient virtuals default to no-op so WebKitLegacy&apos;s
WebFrameLoaderClient — which has no UIProcess and tracks BFCache locally —
does not need to override them.

Covered by existing tests
(SiteIsolation.MultiProcessBFCacheSameSiteCaching,
MultiProcessBFCacheSameSiteWithCrossSiteIframeBlocked,
MultiProcessBFCacheSameSiteNavAfterRestore, MultiProcessBFCacheGoForward,
MultiProcessBFCacheGoForwardSimple, MultiProcessBFCacheIframeProcessSurvival,
MultiProcessBFCacheOpenerSkipsBFCache).

* Source/WebCore/history/BackForwardCache.h:
* Source/WebCore/history/BackForwardCache.cpp:
(WebCore::BackForwardCache::addIfCacheable):
(WebCore::notifyClientOfEviction):
(WebCore::BackForwardCache::remove):
(WebCore::BackForwardCache::prune):
(WebCore::BackForwardCache::clearEntriesForOrigins):
* Source/WebCore/history/CachedPage.h:
(WebCore::CachedPage::setItemID):
(WebCore::CachedPage::itemID const):
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::commitProvisionalLoad):
* Source/WebCore/loader/LocalFrameLoaderClient.h:
* Source/WebCore/loader/LocalFrameLoaderClient.cpp:
(WebCore::LocalFrameLoaderClient::didCacheItem):
(WebCore::LocalFrameLoaderClient::didEvictItem):
(WebCore::LocalFrameLoaderClient::didRestoreFromBackForwardCache):
* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::backForwardUpdateItem):
* Source/WebKit/UIProcess/WebBackForwardList.swift:
* Source/WebKit/UIProcess/WebPageProxy.h:
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didCacheItem):
(WebKit::WebPageProxy::didEvictCachedItem):
(WebKit::WebPageProxy::didRestoreFromBackForwardCache):
* Source/WebKit/UIProcess/WebPageProxy.messages.in:
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.h:
* Source/WebKit/WebProcess/WebCoreSupport/WebLocalFrameLoaderClient.cpp:
(WebKit::WebLocalFrameLoaderClient::didCacheItem):
(WebKit::WebLocalFrameLoaderClient::didEvictItem):
(WebKit::WebLocalFrameLoaderClient::didRestoreFromBackForwardCache):

Canonical link: <a href="https://commits.webkit.org/313625@main">https://commits.webkit.org/313625@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5269fcfacfe5f23a1080edec73bd654df1e17837

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163669 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37153 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30372 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172609 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/120160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9b75d42c-412d-410b-88e1-c85737086e89) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165538 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37484 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37152 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127125 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/120160 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0c1251b3-c1ca-4699-a817-937cccfe8bc8) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166628 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/29407 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/147143 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107679 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/23efcfc2-2c90-49f4-8575-f5f039de6bbe) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28455 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/27086 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20312 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/138354 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24860 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175114 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/28045 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26526 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135430 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36823 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31189 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135413 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36491 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37608 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146655 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99678 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30726 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/23508 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36319 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/109464 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35816 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1536 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36066 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35963 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->