### PR TITLE
[iOS] RTL/position fixed element can lose its contents when the document is scrolled

### DIFF
--- a/LayoutTests/fast/scrolling/ios/fixed-position-in-vertical-rl-expected.html
+++ b/LayoutTests/fast/scrolling/ios/fixed-position-in-vertical-rl-expected.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    :root {
+      scrollbar-width: none;
+    }
+    body {
+      writing-mode: vertical-rl;
+      margin: 0;
+    }
+
+    #overlay {
+      position: fixed;
+      background: red;
+      color: white;
+      width: 50%;
+      overflow: auto;
+      top: 0;
+      left: 0;
+      bottom: 0;
+      border: 1px solid black;
+      box-sizing: border-box;
+    }
+
+    .scrollable-content {
+        width: 4000px;
+        height: 100%;
+        background-color: green;
+    }
+  </style>
+</head>
+<body>
+  <div class="scrollable-content"></div>
+  <div id="overlay">
+      <div class="scrollable-content"></div>
+  </div>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/ios/fixed-position-in-vertical-rl.html
+++ b/LayoutTests/fast/scrolling/ios/fixed-position-in-vertical-rl.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    :root {
+      scrollbar-width: none;
+    }
+    body {
+      writing-mode: vertical-rl;
+      margin: 0;
+    }
+
+    #overlay {
+      position: fixed;
+      background: red;
+      color: white;
+      width: 50%;
+      overflow: auto;
+      top: 0;
+      left: 0;
+      bottom: 0;
+      border: 1px solid black;
+      box-sizing: border-box;
+    }
+
+    .scrollable-content {
+        width: 4000px;
+        height: 100%;
+        background-color: green;
+    }
+  </style>
+  <script src="../../../resources/ui-helper.js"></script>
+  <script>
+      window.addEventListener('load', async () => {
+          window.testRunner?.waitUntilDone();
+
+          await UIHelper.delayFor(0);
+          
+          const rightEdge = window.innerWidth;
+          await UIHelper.dragFromPointToPoint(rightEdge - 150, 300, rightEdge - 50, 300, 0.1);
+          await UIHelper.waitForTargetScrollAnimationToSettle(document.scrollingElement);
+
+          window.testRunner?.notifyDone();
+      }, false);
+  </script>
+</head>
+<body>
+  <div class="scrollable-content"></div>
+  <div id="overlay">
+      <div class="scrollable-content"></div>
+  </div>
+</body>
+</html>

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -1854,11 +1854,11 @@ LayoutRect LocalFrameView::computeUpdatedLayoutViewportRect(const LayoutRect& la
         // The max stable layout viewport origin really depends on the size of the layout viewport itself, so we need to adjust the location of the layout viewport one final time to make sure it does not end up out of bounds of the document.
         // Without this adjustment (and with using the non-constrained unobscuredContentRect's size as the size of the layout viewport) the layout viewport can be pushed past the bounds of the document during rubber-banding, and cannot be pushed
         // back in until the user scrolls back in the other direction.
-        layoutViewportOrigin.setX(clampTo<float>(layoutViewportOrigin.x().toFloat(), 0, documentRect.width() - layoutViewportRect.width()));
-        layoutViewportOrigin.setY(clampTo<float>(layoutViewportOrigin.y().toFloat(), 0, documentRect.height() - layoutViewportRect.height()));
+        layoutViewportOrigin.setX(clampTo<float>(layoutViewportOrigin.x().toFloat(), documentRect.x(), documentRect.maxX() - layoutViewportRect.width()));
+        layoutViewportOrigin.setY(clampTo<float>(layoutViewportOrigin.y().toFloat(), documentRect.y(), documentRect.maxY() - layoutViewportRect.height()));
     }
     layoutViewportRect.setLocation(layoutViewportOrigin);
-    
+
     return layoutViewportRect;
 }
 


### PR DESCRIPTION
#### f774c2b1c4f1e68a9b0a273b331f0551f64fdd0d
<pre>
[iOS] RTL/position fixed element can lose its contents when the document is scrolled
<a href="https://bugs.webkit.org/show_bug.cgi?id=315117">https://bugs.webkit.org/show_bug.cgi?id=315117</a>
<a href="https://rdar.apple.com/177454608">rdar://177454608</a>

Reviewed by Abrar Rahman Protyasha.

In a side-scrolling RTL page on iOS, scrolling the main frame would cause content inside
an overflow:scroll inside a fixedpos to disappear. The issue is that we&apos;d compute an incorrect
layoutViewportRect in `_createVisibleContentRectUpdate`, and this was sent to the web
process and used to compute layer coverage rects.

`_createVisibleContentRectUpdate` passes the `ConstrainedToDocumentRect` flag to
`LocalFrameView::computeUpdatedLayoutViewportRect()`, whose constraining logic was wrong
with RTL where documentBounds.x() goes negative. So use that to clamp, instead of 0.

I confirmed that the test case for b98e498a0, which added this code, still works.

Test: fast/scrolling/ios/fixed-position-in-vertical-rl.html

* LayoutTests/fast/scrolling/ios/fixed-position-in-vertical-rl-expected.html: Added.
* LayoutTests/fast/scrolling/ios/fixed-position-in-vertical-rl.html: Added.
* Source/WebCore/page/LocalFrameView.cpp:
(WebCore::LocalFrameView::computeUpdatedLayoutViewportRect):

Canonical link: <a href="https://commits.webkit.org/313573@main">https://commits.webkit.org/313573@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0836a07ddba257fe786f3af6eec1d451deb9a33c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163426 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36909 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30125 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172366 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119873 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9c98e09b-8adc-49e2-aea7-83c9303de74c) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165295 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37238 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36909 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126917 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89461 "layout-tests (failure)") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166385 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29187 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146914 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107475 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/07fcaf4c-aaa8-4851-8400-cd758112d340) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28240 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26863 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20068 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138128 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24637 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174870 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27532 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26293 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135220 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36579 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30963 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135206 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36456 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37364 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146432 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99325 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30510 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23277 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36075 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/108973 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35572 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1302 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35820 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35720 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->