### PR TITLE
[JSC] Make wasm name section parsing threadsafe

### DIFF
--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -3227,8 +3227,8 @@ void BBQJIT::emitEntryTierUpCheck()
 [[nodiscard]] ControlData BBQJIT::addTopLevel(BlockSignature&& signature)
 {
     if (Options::verboseBBQJITInstructions()) [[unlikely]] {
-        auto nameSection = m_info.nameSection;
-        std::pair<const Name*, RefPtr<NameSection>> name = nameSection->get(m_functionIndex);
+        auto& nameSection = m_info.nameSection();
+        std::pair<const Name*, RefPtr<NameSection>> name = nameSection.get(m_functionIndex);
         dataLog("BBQ\tFunction ");
         if (name.first)
             dataLog(makeString(*name.first));

--- a/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQPlan.cpp
@@ -96,7 +96,7 @@ void BBQPlan::work()
     TypeSignatureIndex typeSignatureIndex = m_moduleInformation->internalFunctionTypeSignatureIndices[m_functionIndex];
     const RTT& signature = m_moduleInformation->rtt(typeSignatureIndex);
 
-    Ref<BBQCallee> callee = BBQCallee::create(functionIndexSpace, m_moduleInformation->nameSection->get(functionIndexSpace), Ref { m_profiledCallee });
+    Ref<BBQCallee> callee = BBQCallee::create(functionIndexSpace, m_moduleInformation->nameSection().get(functionIndexSpace), Ref { m_profiledCallee });
     std::unique_ptr<InternalFunction> function = compileFunction(m_functionIndex, callee.get(), context, unlinkedWasmToWasmCalls);
 
     LinkBuffer linkBuffer(*context.wasmEntrypointJIT, callee.ptr(), LinkBuffer::Profile::WasmBBQ, JITCompilationCanFail);

--- a/Source/JavaScriptCore/wasm/WasmCallee.cpp
+++ b/Source/JavaScriptCore/wasm/WasmCallee.cpp
@@ -413,7 +413,7 @@ unsigned IPIntCallee::computeCodeHashImpl() const
 void OptimizingJITCallee::addCodeOrigin(unsigned firstInlineCSI, unsigned lastInlineCSI, const Wasm::ModuleInformation& info, uint32_t functionIndex)
 {
     if (!nameSections.size())
-        nameSections.append(info.nameSection);
+        nameSections.append(info.nameSection());
     // The inline frame list is stored in postorder. For example:
     // A { B() C() D { E() } F() } -> B C E D F A
 #if ASSERT_ENABLED
@@ -423,7 +423,7 @@ void OptimizingJITCallee::addCodeOrigin(unsigned firstInlineCSI, unsigned lastIn
     for (unsigned i = 0; i < codeOrigins.size(); ++i)
         ASSERT(codeOrigins[i].lastInlineCSI <= lastInlineCSI);
     ASSERT(nameSections.size() == 1);
-    ASSERT(nameSections[0].ptr() == info.nameSection.ptr());
+    ASSERT(nameSections[0].ptr() == &info.nameSection());
 #endif
     codeOrigins.append({ firstInlineCSI, lastInlineCSI, functionIndex, 0 });
 }

--- a/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp
@@ -109,7 +109,7 @@ void IPIntPlan::compileFunction(FunctionCodeIndex functionIndex)
     m_wasmInternalFunctions[functionIndex] = WTF::move(*parseAndCompileResult);
 
     {
-        auto callee = IPIntCallee::create(*m_wasmInternalFunctions[functionIndex], functionIndexSpace, signature, m_moduleInformation->nameSection->get(functionIndexSpace));
+        auto callee = IPIntCallee::create(*m_wasmInternalFunctions[functionIndex], functionIndexSpace, signature, m_moduleInformation->nameSection().get(functionIndexSpace));
         ASSERT(!callee->entrypoint());
         bool usesSIMD = m_moduleInformation->usesSIMD(functionIndex);
         // Immediately tier up to BBQ for SIMD, if necesary.

--- a/Source/JavaScriptCore/wasm/WasmModuleInformation.cpp
+++ b/Source/JavaScriptCore/wasm/WasmModuleInformation.cpp
@@ -39,8 +39,9 @@
 namespace JSC { namespace Wasm {
 
 ModuleInformation::ModuleInformation()
-    : nameSection(NameSection::create())
+    : m_nameSection(NameSection::create())
 {
+    m_nameSectionPtr.store(m_nameSection.ptr(), std::memory_order_relaxed);
 #if ENABLE(WEBASSEMBLY_DEBUGGER)
     if (Options::enableWasmDebugger()) [[unlikely]]
         debugInfo = WTF::makeUnique<ModuleDebugInfo>(*this);
@@ -48,6 +49,21 @@ ModuleInformation::ModuleInformation()
 }
 
 ModuleInformation::~ModuleInformation() = default;
+
+void ModuleInformation::setNameSection(Ref<NameSection>&& section)
+{
+    // The spec has the following editorial note:
+    //   The name section should appear only once in a module, [...]
+    //
+    // Since custom sections have no effect on the observable behavior, for simplicity, we ignore
+    // name sections after the first one if multiple such sections are present in a module.
+    if (m_hasCustomNameSection)
+        return;
+    m_hasCustomNameSection = true;
+    m_retiredNameSection = WTF::move(m_nameSection);
+    m_nameSection = WTF::move(section);
+    m_nameSectionPtr.store(m_nameSection.ptr(), std::memory_order_release);
+}
 
 // This is called during module creation, so at this point we have fully isolated access
 // to this ModuleInformation object.

--- a/Source/JavaScriptCore/wasm/WasmModuleInformation.h
+++ b/Source/JavaScriptCore/wasm/WasmModuleInformation.h
@@ -187,6 +187,11 @@ struct ModuleInformation final : public ThreadSafeRefCounted<ModuleInformation> 
     bool importedStringConstantsEquals(const String& expected) const { return m_importedStringConstants && m_importedStringConstants.value() == expected; }
     bool builtinSetsInclude(const String& qualifiedName) const { return m_qualifiedBuiltinSetNames.contains(qualifiedName); }
 
+    // nameSection is read from compiler threads (lock-free via atomic pointer)
+    // and written from the main thread when the custom "name" section is parsed.
+    NameSection& nameSection() const { return *m_nameSectionPtr.load(std::memory_order_acquire); }
+    void setNameSection(Ref<NameSection>&&);
+
     // FIXME: These should probably be FixedVectors.
     Vector<Import> imports;
     FixedBitVector importShouldBeHidden; // filter imports[i] from the result of Module.imports(moduleObject)
@@ -211,7 +216,6 @@ struct ModuleInformation final : public ThreadSafeRefCounted<ModuleInformation> 
     unsigned firstInternalGlobal { 0 };
     uint32_t codeSectionSize { 0 };
     Vector<CustomSection> customSections;
-    Ref<NameSection> nameSection;
     BranchHints branchHints;
     std::optional<uint32_t> numberOfDataSegments;
     using ConstantExpressionAndSourceOffset = std::pair<Vector<uint8_t>, size_t>;
@@ -235,6 +239,10 @@ private:
 
     std::optional<String> m_importedStringConstants;
     Vector<String> m_qualifiedBuiltinSetNames;
+    Ref<NameSection> m_nameSection;
+    RefPtr<NameSection> m_retiredNameSection;
+    std::atomic<NameSection*> m_nameSectionPtr { nullptr };
+    bool m_hasCustomNameSection { false };
 };
 
     

--- a/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOMGPlan.cpp
@@ -131,7 +131,7 @@ void OMGPlan::work()
     const RTT& signature = m_moduleInformation->rtt(typeSignatureIndex);
 
     Ref<IPIntCallee> profiledCallee = m_calleeGroup->ipintCalleeFromFunctionIndexSpace(functionIndexSpace);
-    Ref<OMGCallee> callee = OMGCallee::create(functionIndexSpace, m_moduleInformation->nameSection->get(functionIndexSpace), Ref { profiledCallee });
+    Ref<OMGCallee> callee = OMGCallee::create(functionIndexSpace, m_moduleInformation->nameSection().get(functionIndexSpace), Ref { profiledCallee });
 
     beginCompilerSignpost(callee.get());
     Vector<UnlinkedWasmToWasmCall> unlinkedCalls;
@@ -162,7 +162,7 @@ void OMGPlan::work()
         ScopedPrintStream out;
         dumpDisassembly(callee.get(), context, linkBuffer, signature, functionIndexSpace);
         omgEntrypoint.compilation = makeUnique<Compilation>(
-            FINALIZE_CODE_IF(context.procedure->shouldDumpIR(), linkBuffer, JITCompilationPtrTag, nullptr, "OMG functionIndexSpace:(", functionIndexSpace, "),sig:(", signature.toString().ascii().data(), "),name:(", makeString(IndexOrName(functionIndexSpace, m_moduleInformation->nameSection->get(functionIndexSpace))).ascii().data(), "),wasmSize:(", m_moduleInformation->functionWasmSizeImportSpace(functionIndexSpace), ")"),
+            FINALIZE_CODE_IF(context.procedure->shouldDumpIR(), linkBuffer, JITCompilationPtrTag, nullptr, "OMG functionIndexSpace:(", functionIndexSpace, "),sig:(", signature.toString().ascii().data(), "),name:(", makeString(IndexOrName(functionIndexSpace, m_moduleInformation->nameSection().get(functionIndexSpace))).ascii().data(), "),wasmSize:(", m_moduleInformation->functionWasmSizeImportSpace(functionIndexSpace), ")"),
             WTF::move(context.wasmEntrypointByproducts));
     }
 

--- a/Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp
@@ -106,7 +106,7 @@ void OSREntryPlan::work()
     const RTT& signature = m_moduleInformation->rtt(typeSignatureIndex);
 
     Ref<IPIntCallee> profiledCallee = m_calleeGroup->ipintCalleeFromFunctionIndexSpace(functionIndexSpace);
-    Ref<OMGOSREntryCallee> callee = OMGOSREntryCallee::create(functionIndexSpace, m_moduleInformation->nameSection->get(functionIndexSpace), Ref { profiledCallee }, m_loopIndex);
+    Ref<OMGOSREntryCallee> callee = OMGOSREntryCallee::create(functionIndexSpace, m_moduleInformation->nameSection().get(functionIndexSpace), Ref { profiledCallee }, m_loopIndex);
 
     beginCompilerSignpost(callee.get());
     Vector<UnlinkedWasmToWasmCall> unlinkedCalls;

--- a/Source/JavaScriptCore/wasm/WasmPlan.cpp
+++ b/Source/JavaScriptCore/wasm/WasmPlan.cpp
@@ -134,7 +134,7 @@ CString Plan::signpostMessage(CompilationMode compilationMode, uint32_t function
     CString signpostMessage;
     const FunctionData& function = m_moduleInformation->functions[functionIndexSpace - m_moduleInformation->importFunctionTypeSignatureIndices.size()];
     StringPrintStream stream;
-    stream.print(compilationMode, " ", makeString(IndexOrName(functionIndexSpace, m_moduleInformation->nameSection->get(functionIndexSpace))), " instructions size = ", function.data.size());
+    stream.print(compilationMode, " ", makeString(IndexOrName(functionIndexSpace, m_moduleInformation->nameSection().get(functionIndexSpace))), " instructions size = ", function.data.size());
     return stream.toCString();
 }
 

--- a/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmSectionParser.cpp
@@ -1447,7 +1447,7 @@ auto SectionParser::parseCustom() -> PartialResult
         NameSectionParser nameSectionParser(section.payload, m_info);
         auto nameSection = nameSectionParser.parse();
         if (nameSection)
-            m_info->nameSection = WTF::move(*nameSection);
+            m_info->setNameSection(WTF::move(*nameSection));
         else
             dataLogLnIf(Options::dumpWasmWarnings(), "Could not parse name section: ", nameSection.error());
     } else if (WTF::Unicode::equal("metadata.code.branch_hint"_span8, section.name.span())) {

--- a/Source/JavaScriptCore/wasm/WasmStreamingParser.cpp
+++ b/Source/JavaScriptCore/wasm/WasmStreamingParser.cpp
@@ -454,7 +454,7 @@ auto StreamingParser::finalize() -> State
 
         if (m_remaining.isEmpty()) {
             if (Options::useEagerWasmModuleHashing()) [[unlikely]]
-                m_info->nameSection->setHash(m_hasher.computeHexDigest());
+                m_info->nameSection().setHash(m_hasher.computeHexDigest());
 
             m_info->importShouldBeHidden = FixedBitVector(m_info->imports.size());
 

--- a/Source/JavaScriptCore/wasm/debugger/WasmModuleDebugInfo.cpp
+++ b/Source/JavaScriptCore/wasm/debugger/WasmModuleDebugInfo.cpp
@@ -105,7 +105,7 @@ String ModuleDebugInfo::debugName() const
             result.append(sourceURL);
     }
 
-    const auto& rawName = moduleInfo->nameSection->moduleName;
+    const auto& rawName = moduleInfo->nameSection().moduleName;
     if (!rawName.isEmpty()) {
         if (!result.isEmpty())
             result.append(':');

--- a/Source/WebCore/css/SelectorChecker.cpp
+++ b/Source/WebCore/css/SelectorChecker.cpp
@@ -103,7 +103,7 @@ struct SelectorChecker::LocalContext {
     { }
 
     const CSSSelector* selector;
-    const Element* element;
+    CheckedPtr<const Element> element;
     VisitedMatchType visitedMatchType;
     const CSSSelector* firstSelectorOfTheFragment;
     std::optional<Style::PseudoElementIdentifier> requestedPseudoElement;


### PR DESCRIPTION
#### 24362e675175d25b0f1716c0590a94e930796b18
<pre>
[JSC] Make wasm name section parsing threadsafe
<a href="https://bugs.webkit.org/show_bug.cgi?id=309538">https://bugs.webkit.org/show_bug.cgi?id=309538</a>
<a href="https://rdar.apple.com/172053974">rdar://172053974</a>

Reviewed by Yusuke Suzuki.

There is a race when parsing the wasm &quot;name&quot; custom section. Compiler threads
and the main thread may race on access of the name section.

This PR fixes the race by making the name section go through a rel/acq
accessor. Lifetime safety is upkept by holding onto the retired name section
(the initial empty one) when the parser finishes parsing a name section. For
simplicity, all name sections after the first one are ignored, as there is
no normative requirement on custom sections.

No test added as manual sleeping is required to widen the window to reproduce.

* Source/JavaScriptCore/wasm/WasmBBQJIT.cpp:
(JSC::Wasm::BBQJITImpl::BBQJIT::addTopLevel):
* Source/JavaScriptCore/wasm/WasmBBQPlan.cpp:
(JSC::Wasm::BBQPlan::work):
* Source/JavaScriptCore/wasm/WasmCallee.cpp:
(JSC::Wasm::OptimizingJITCallee::addCodeOrigin):
* Source/JavaScriptCore/wasm/WasmIPIntPlan.cpp:
(JSC::Wasm::IPIntPlan::compileFunction):
* Source/JavaScriptCore/wasm/WasmModuleInformation.cpp:
(JSC::Wasm::ModuleInformation::ModuleInformation):
(JSC::Wasm::ModuleInformation::setNameSection):
* Source/JavaScriptCore/wasm/WasmModuleInformation.h:
* Source/JavaScriptCore/wasm/WasmOMGPlan.cpp:
(JSC::Wasm::OMGPlan::work):
* Source/JavaScriptCore/wasm/WasmOSREntryPlan.cpp:
(JSC::Wasm::OSREntryPlan::work):
* Source/JavaScriptCore/wasm/WasmPlan.cpp:
(JSC::Wasm::Plan::signpostMessage const):
* Source/JavaScriptCore/wasm/WasmSectionParser.cpp:
(JSC::Wasm::SectionParser::parseCustom):
* Source/JavaScriptCore/wasm/WasmStreamingParser.cpp:
(JSC::Wasm::StreamingParser::finalize):

Originally-landed-as: 305413.432@rapid/safari-7624.2.5.110-branch (935ddf64e1d2). <a href="https://rdar.apple.com/176067717">rdar://176067717</a>
Canonical link: <a href="https://commits.webkit.org/314992@main">https://commits.webkit.org/314992@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8fa5aa37f0e25297b6a25b9835a51549a03fe748

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167694 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41191 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34786 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176751 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125375 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169560 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41626 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41204 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130473 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91700 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170653 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32908 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150683 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110990 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31890 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30581 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25484 "Built successfully") | 
| [  ~~🛠 🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/20/builds/160191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141877 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28378 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179291 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/28940 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32332 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30096 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138879 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41263 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34738 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138764 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37381 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41951 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105127 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34027 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27049 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/200371 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40455 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113701 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53829 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39852 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5152 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40103 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39997 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->