### PR TITLE
Fix duplicate -webkit-text-fill-color declarations in imported WPT tests

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-gradient-interpolation-002-expected-mismatch.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-gradient-interpolation-002-expected-mismatch.html
@@ -17,7 +17,6 @@
   -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;
-  -webkit-text-fill-color: transparent;
   width: fit-content;
   margin: 0;
 }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-gradient-interpolation-002-notref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-gradient-interpolation-002-notref.html
@@ -17,7 +17,6 @@
   -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;
-  -webkit-text-fill-color: transparent;
   width: fit-content;
   margin: 0;
 }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-gradient-interpolation-002.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-gradient-interpolation-002.html
@@ -34,7 +34,6 @@
   -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;
-  -webkit-text-fill-color: transparent;
   width: fit-content;
   margin: 0;
 }

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-gradient-interpolation-003.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-gradient-interpolation-003.html
@@ -37,7 +37,6 @@
   -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;
-  -webkit-text-fill-color: transparent;
   width: fit-content;
   margin: 0;
 }


### PR DESCRIPTION
#### 1e91c9bd0d47a0572a785a54e15f92e207aa3592
<pre>
Fix duplicate -webkit-text-fill-color declarations in imported WPT tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=315154">https://bugs.webkit.org/show_bug.cgi?id=315154</a>
<a href="https://rdar.apple.com/177488641">rdar://177488641</a>

Reviewed by Tim Nguyen.

* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-gradient-interpolation-002-expected-mismatch.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-gradient-interpolation-002-notref.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-gradient-interpolation-002.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/background-gradient-interpolation-003.html:

Canonical link: <a href="https://commits.webkit.org/313595@main">https://commits.webkit.org/313595@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/65afb963ba3f2c9cb9bdd9ba4cfe5468e751a040

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163580 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37064 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30283 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172520 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/120029 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/17cd9c0c-076e-42a6-a045-c9148fb83064) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37395 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37063 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127053 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89571 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0655cbd6-b24b-4033-a9c1-7b9512092d97) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166539 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29327 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147054 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107607 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/88121850-2f45-4242-8690-2915f32af993) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/27008 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20223 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138274 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24773 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175025 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26436 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135359 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36734 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31110 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135341 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36474 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37519 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146568 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99572 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30647 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23420 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36229 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35727 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1446 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35977 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35874 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->