### PR TITLE
[AppKit Gestures] Gesture-driven drag-and-drop does not recognize <img> elements

### DIFF
--- a/Source/WebCore/platform/PlatformScreen.h
+++ b/Source/WebCore/platform/PlatformScreen.h
@@ -75,7 +75,7 @@ double fontDPI(); // dpi to use for font scaling
 double screenDPI(PlatformDisplayID); // dpi of the display device, corrected for device scaling
 #endif
 
-FloatRect screenRect(Widget*);
+WEBCORE_EXPORT FloatRect screenRect(Widget*);
 FloatRect screenAvailableRect(Widget*);
 
 WEBCORE_EXPORT OptionSet<ContentsFormat> screenContentsFormats(Widget* = nullptr);

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm
@@ -63,6 +63,7 @@
 #import <WebCore/Model.h>
 #import <WebCore/NodeDocument.h>
 #import <WebCore/Page.h>
+#import <WebCore/PlatformScreen.h>
 #import <WebCore/Quirks.h>
 #import <WebCore/RenderBlockFlow.h>
 #import <WebCore/RenderBoxInlines.h>
@@ -201,7 +202,16 @@ static std::optional<std::pair<WebCore::RenderImage&, WebCore::Image&>> imageRen
     return { { *renderImage, *image } };
 }
 
+static WebCore::FloatSize platformBitmapSizeCap(const WebPage& page)
+{
 #if PLATFORM(IOS_FAMILY)
+    return WebCore::screenSize();
+#else
+    RefPtr localMainFrame = page.corePage()->localMainFrame();
+    return WebCore::screenRect(localMainFrame ? protect(localMainFrame->view()) : nullptr).size();
+#endif
+}
+
 static void videoPositionInformation(WebPage& page, WebCore::HTMLVideoElement& element, const InteractionInformationRequest& request, InteractionInformationAtPosition& info)
 {
     info.elementContainsImageOverlay = WebCore::ImageOverlay::hasOverlay(element);
@@ -220,7 +230,6 @@ static void videoPositionInformation(WebPage& page, WebCore::HTMLVideoElement& e
 
     info.hostImageOrVideoElementContext = page.contextForElement(element);
 }
-#endif // PLATFORM(IOS_FAMILY)
 
 static RefPtr<WebCore::HTMLVideoElement> hostVideoElementIgnoringImageOverlay(WebCore::Node& node)
 {
@@ -233,7 +242,6 @@ static RefPtr<WebCore::HTMLVideoElement> hostVideoElementIgnoringImageOverlay(We
     return dynamicDowncast<WebCore::HTMLVideoElement>(node.shadowHost());
 }
 
-#if PLATFORM(IOS_FAMILY)
 static void imagePositionInformation(WebPage& page, WebCore::Element& element, const InteractionInformationRequest& request, InteractionInformationAtPosition& info)
 {
     auto rendererAndImage = imageRendererAndImage(element);
@@ -253,11 +261,10 @@ static void imagePositionInformation(WebPage& page, WebCore::Element& element, c
 #endif
 
     if (request.includeSnapshot || request.includeImageData)
-        info.image = createShareableBitmap(renderImage, { WebCore::screenSize() * page.corePage()->deviceScaleFactor(), AllowAnimatedImages::Yes, UseSnapshotForTransparentImages::Yes });
+        info.image = createShareableBitmap(renderImage, { platformBitmapSizeCap(page) * page.corePage()->deviceScaleFactor(), AllowAnimatedImages::Yes, UseSnapshotForTransparentImages::Yes });
 
     info.hostImageOrVideoElementContext = page.contextForElement(element);
 }
-#endif // PLATFORM(IOS_FAMILY)
 
 static void boundsPositionInformation(WebCore::RenderObject& renderer, InteractionInformationAtPosition& info)
 {
@@ -314,7 +321,6 @@ static void elementPositionInformation(WebPage& page, WebCore::Element& element,
 #endif
 
     if (CheckedPtr renderer = element.renderer()) {
-#if PLATFORM(IOS_FAMILY)
         bool shouldCollectImagePositionInformation = renderer->isRenderImage();
         if (shouldCollectImagePositionInformation && info.isImageOverlayText) {
             shouldCollectImagePositionInformation = false;
@@ -323,7 +329,7 @@ static void elementPositionInformation(WebPage& page, WebCore::Element& element,
                     auto& [renderImage, image] = *rendererAndImage;
                     info.imageURL = page.applyLinkDecorationFiltering(document->encodingParseURL(protect(renderImage.cachedImage())->url().string()), WebCore::LinkDecorationFilteringTrigger::Unspecified);
                     info.imageMIMEType = image.mimeType();
-                    info.image = createShareableBitmap(renderImage, { WebCore::screenSize() * page.corePage()->deviceScaleFactor(), AllowAnimatedImages::Yes, UseSnapshotForTransparentImages::Yes });
+                    info.image = createShareableBitmap(renderImage, { platformBitmapSizeCap(page) * page.corePage()->deviceScaleFactor(), AllowAnimatedImages::Yes, UseSnapshotForTransparentImages::Yes });
                 }
             }
         }
@@ -333,7 +339,6 @@ static void elementPositionInformation(WebPage& page, WebCore::Element& element,
             else
                 imagePositionInformation(page, element, request, info);
         }
-#endif // PLATFORM(IOS_FAMILY)
         boundsPositionInformation(*renderer, info);
     }
 
@@ -668,14 +673,12 @@ InteractionInformationAtPosition positionInformationForWebPage(WebPage& page, co
         dataDetectorImageOverlayPositionInformation(*hitTestedImageOverlayHost, request, info);
 #endif // ENABLE(DATA_DETECTION) && PLATFORM(IOS_FAMILY)
 
-#if PLATFORM(IOS_FAMILY)
     if (!info.isImage && request.includeImageData && hitTestNode) {
         if (auto video = hostVideoElementIgnoringImageOverlay(*hitTestNode))
             videoPositionInformation(page, *video, request, info);
         else if (RefPtr img = dynamicDowncast<WebCore::HTMLImageElement>(hitTestNode))
             imagePositionInformation(page, *img, request, info);
     }
-#endif // PLATFORM(IOS_FAMILY)
 
     animationPositionInformation(page, request, hitTestResult, info);
     selectionPositionInformation(page, request, info);

--- a/Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptMessages.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptMessages.swift
@@ -41,6 +41,10 @@ extension JavaScriptMessages {
         // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
         public static var expression: String {
             """
+            if (elementID) {
+                return document.getElementById(elementID).getBoundingClientRect().toJSON();
+            }
+
             const range = document.createRange();
 
             if (selection.kind === "range") {
@@ -58,13 +62,18 @@ extension JavaScriptMessages {
             """
         }
 
-        private let selection: JavaScriptSelection
+        private enum Storage {
+            case selection(JavaScriptSelection)
+            case element(id: String)
+        }
+
+        private let storage: Storage
 
         /// Create a `BoundingClientRect` expression from the given selection.
         ///
         /// - Parameter selection: The selection that will be set.
         public init(_ selection: JavaScriptSelection) {
-            self.selection = selection
+            self.storage = .selection(selection)
         }
 
         /// A convenience initializer for a range selection.
@@ -73,18 +82,36 @@ extension JavaScriptMessages {
         ///   - container: The container the range is relative to.
         ///   - range: The range of the selection within the container.
         public init(in container: String, range: Range<Int>) {
-            self.selection = .range(
-                base: .init(in: container, at: range.lowerBound),
-                extent: .init(in: container, at: range.upperBound),
+            self.storage = .selection(
+                .range(
+                    base: .init(in: container, at: range.lowerBound),
+                    extent: .init(in: container, at: range.upperBound),
+                )
             )
+        }
+
+        /// Create a `BoundingClientRect` expression for the element with the given `id` attribute.
+        ///
+        /// - Parameter elementID: The `id` attribute of the target element.
+        public init(elementID: String) {
+            self.storage = .element(id: elementID)
         }
 
         // Protocol conformance.
         // swift-format-ignore: AllPublicDeclarationsHaveDocumentation
         public func encoded() -> [String: Any?] {
-            [
-                "selection": selection.encoded()
-            ]
+            switch storage {
+            case .selection(let selection):
+                [
+                    "selection": selection.encoded(),
+                    "elementID": NSNull(),
+                ]
+            case .element(let id):
+                [
+                    "selection": NSNull(),
+                    "elementID": id,
+                ]
+            }
         }
     }
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift
@@ -466,6 +466,71 @@ struct AppKitGesturesTests {
     }
 
     @Test(
+        .bug("https://webkit.org/b/315155", "Gesture-driven drag-and-drop does not recognize <img> elements")
+    )
+    func pressDragOnImageInitiatesDragAndDrop() async throws {
+        let baseURL = try #require(Bundle.testResources.resourceURL)
+        let html = """
+            <img id="img" src="400x400-green.png" style="display: block; margin: 50px;">
+            """
+        try await page.load(html: html, baseURL: baseURL).wait()
+
+        try await page.callJavaScript(
+            """
+            const img = document.getElementById("img");
+            if (img.complete && img.naturalWidth > 0) {
+                return;
+            }
+            await new Promise(resolve => img.addEventListener("load", resolve, { once: true }));
+            """
+        )
+
+        let imgViewportBounds = try await page.callJavaScript(JavaScriptMessages.BoundingClientRect(elementID: "img"))
+        let imgBounds = convertToCoreGraphicsScreenCoordinates(
+            rectInViewportCoordinates: imgViewportBounds,
+            window: window
+        )
+
+        let dragEnd = CGPoint(x: imgBounds.maxX + 50, y: imgBounds.midY)
+
+        guard NSApp.isActive else { return }
+
+        let dragInitiated = Future()
+
+        let implementation: @convention(block) (NSView, NSArray, NSGestureRecognizer, AnyObject) -> NSDraggingSession? = { _, _, _, _ in
+            dragInitiated.signal()
+            return NSDraggingSession()
+        }
+
+        try await withSwizzledObjectiveCInstanceMethod(
+            replacing: NSView.self,
+            name: #selector(NSView.beginDraggingSession(items:gesture:source:)),
+            with: implementation
+        ) {
+            await recap.play { composer in
+                composer._wk_drag(
+                    withStart: imgBounds.center,
+                    end: dragEnd,
+                    duration: .seconds(1.5),
+                    pressAndWait: .seconds(1.0)
+                )
+            }
+
+            // If a drag cannot happen, the text selection gestures take over and the
+            // gesture falls through to a range selection. Detect that early so the test
+            // fails with a diagnostic instead of timing out on `dragInitiated.wait()`.
+            await page.waitForNextPresentationUpdate()
+            let selection = try await page.callJavaScript(JavaScriptMessages.GetSelection())
+            if case .range = selection {
+                Issue.record("press-drag on <img> produced a range selection (\(selection)) instead of initiating a drag")
+                return
+            }
+
+            await dragInitiated.wait()
+        }
+    }
+
+    @Test(
         .bug("rdar://176317069", "REGRESSION(312023@main): Text cannot be selected with press + drag gesture")
     )
     func pressDragOnExistingSelectionDoesNotExtendSelection() async throws {


### PR DESCRIPTION
#### 33a1cda45d6c0058bd2ce05d6d186dc4d7392cc5
<pre>
[AppKit Gestures] Gesture-driven drag-and-drop does not recognize &lt;img&gt; elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=315155">https://bugs.webkit.org/show_bug.cgi?id=315155</a>
<a href="https://rdar.apple.com/177489462">rdar://177489462</a>

Reviewed by Richard Robinson.

In 313504@main, we taught WKAppKitGestureController to consult position
information to determine whether the gesture in question is interacting
with &quot;draggable&quot; web content. Unfortunately, the `isImage` bit was just
never computed for macOS, and so plain `&lt;img&gt;` elements were being
rejected as drag candidates.

To fix this, we undo the `#if PLATFORM(IOS_FAMILY)` guards in all of the
image and video helpers in PositionInformationForWebPage.mm. These code
paths generally do not have any iOS-specific dependencies, and the one
platform-specific call inside WebCore::screenSize(), which was used as a
size limit for the generated image bitmap, was generalized via a helper
that consults the local main frame&apos;s view to ask `screenRect(Widget*)`
for the web view&apos;s current screen on macOS, falling back to a null widget
(and therefore the primary screen) when this web process does not host
the local main frame.

That last change is mostly academic, though, because there are no macOS
codepaths that set includeSnapshot or includeImageData on the
interaction information request anyway.

Test: AppKitGesturesTests.pressDragOnImageInitiatesDragAndDrop

* Source/WebCore/platform/PlatformScreen.h:
* Source/WebKit/WebProcess/WebPage/Cocoa/PositionInformationForWebPage.mm:
(WebKit::platformBitmapSizeCap):
(WebKit::videoPositionInformation):
(WebKit::imagePositionInformation):
(WebKit::elementPositionInformation):
(WebKit::positionInformationForWebPage):
* Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptMessages.swift:
(BoundingClientRect.expression):
(Storage.encoded):
(BoundingClientRect.encoded): Deleted.
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift:
(AppKitGesturesTests.pressDragOnImageInitiatesDragAndDrop):

Canonical link: <a href="https://commits.webkit.org/313624@main">https://commits.webkit.org/313624@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3c24d1c1423b9dd0f3e1a7ca9f9b0a62db5dcd0a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163595 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37079 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30298 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172535 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/120044 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3b507334-ab76-40d2-b256-aabe463a6111) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165464 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37410 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37078 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127072 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89579 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/781f3b59-da37-47e2-8865-436ebbc17d93) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166554 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29344 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147074 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107626 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/380cb66d-2f82-4658-a85e-3922cefb5a4b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28393 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27023 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20238 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138291 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24792 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175040 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27971 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26455 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135375 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36749 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31125 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; Ignored 1 pre-existing failure based on results-db; Uploaded test results") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135357 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37534 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146587 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99592 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24909 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30664 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23439 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36244 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109390 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35742 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1465 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35992 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35889 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->