### PR TITLE
[webkitbugspy] Lazily resolve radar authentication

### DIFF
--- a/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py
+++ b/Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py
@@ -131,16 +131,29 @@ class Tracker(GenericTracker):
         self._invalid_keywords = set()
 
         self.library = self.radarclient()
-        authentication = authentication or (self.authentication() if self.library else None)
-        if authentication:
-            self.client = self.library.RadarClient(
-                authentication, self.library.ClientSystemIdentifier(library_name, str(library_version)),
+
+        self._authentication = authentication
+        self._client = None
+
+    @property
+    def client(self):
+        if self._client:
+            return self._client
+
+        if self.authentication():
+            self._client = self.library.RadarClient(
+                self.authentication(), self.library.ClientSystemIdentifier(library_name, str(library_version)),
                 retry_policy=self.radarclient().RetryPolicy(),
             )
-        else:
-            self.client = None
+        return self._client
 
     def authentication(self):
+        if self._authentication:
+            return self._authentication
+
+        if not self.library:
+            return None
+
         identity = Environment.instance().get('RADAR_IDENTITY')
         username = Environment.instance().get('RADAR_USERNAME')
         password = Environment.instance().get('RADAR_PASSWORD')
@@ -149,15 +162,16 @@ class Tracker(GenericTracker):
 
         try:
             if identity and os.path.isdir(identity):
-                return self.library.AuthenticationStrategyNarrative(identity)
-            if username and password and totp_secret and totp_id:
-                return self.library.AuthenticationStrategySystemAccountOAuth(
+                self._authentication = self.library.AuthenticationStrategyNarrative(identity)
+            elif username and password and totp_secret and totp_id:
+                self._authentication = self.library.AuthenticationStrategySystemAccountOAuth(
                     username, password, totp_secret, totp_id,
                 )
-            return self.library.AuthenticationStrategyAppleConnect()
+            else:
+                self._authentication = self.library.AuthenticationStrategyAppleConnect()
         except Exception:
             sys.stderr.write('No valid authentication session for Radar\n')
-            return None
+        return self._authentication
 
     @classmethod
     def parse_id(cls, string):


### PR DESCRIPTION
#### 94ecf4035f70d7dccf7fa5a701e5e0788fede0b5
<pre>
[webkitbugspy] Lazily resolve radar authentication
<a href="https://bugs.webkit.org/show_bug.cgi?id=315159">https://bugs.webkit.org/show_bug.cgi?id=315159</a>
<a href="https://rdar.apple.com/177492256">rdar://177492256</a>

Reviewed by Sam Sneddon.

* Tools/Scripts/libraries/webkitbugspy/webkitbugspy/radar.py:
(Tracker.__init__): Move authentication and client resolution into properties.
(Tracker.client): Only create the client when it&apos;s required.
(Tracker.authentication): Only create the authentication strategy when it&apos;s required.

Canonical link: <a href="https://commits.webkit.org/314954@main">https://commits.webkit.org/314954@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1070bd2373970b372b0f340dd19269ac05d5d33b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167059 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40550 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34130 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176107 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124317 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a6420db5-b4ab-4a2b-a50d-6411f5913900) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168925 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40983 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40559 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129922 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91526 "1 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4c72d80d-74d0-44a6-affd-cbe0e23c7cf2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170018 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32323 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150102 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110447 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/200b59dd-bbc0-4d78-a37a-12ce4ef13d6d) 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/166382 "Found 1 webkitpy test failure: webkitscmpy.test.land_unittest.TestLandGitHub.test_blocking_reviewer") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31298 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30004 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24846 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141273 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27799 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178645 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29506 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138290 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40621 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34153 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138201 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41308 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149597 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104253 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25533 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33473 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26462 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39819 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39214 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4563 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39460 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39358 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->