### PR TITLE
NetworkConnectionToWebProcess::createSocketChannel should reject requests with an invalid URL

### DIFF
--- a/LayoutTests/ipc/create-socket-channel-invalid-url-crash-expected.txt
+++ b/LayoutTests/ipc/create-socket-channel-invalid-url-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash.

--- a/LayoutTests/ipc/create-socket-channel-invalid-url-crash.html
+++ b/LayoutTests/ipc/create-socket-channel-invalid-url-crash.html
@@ -1,0 +1,60 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<p>This test passes if WebKit does not crash.</p>
+<script>
+testRunner?.dumpAsText();
+testRunner?.waitUntilDone();
+
+setTimeout(async () => {
+    if (!window.IPC)
+        return testRunner?.notifyDone();
+
+    const { CoreIPC } = await import('./coreipc.js');
+    CoreIPC.Networking.NetworkConnectionToWebProcess.CreateSocketChannel(0, {
+        request: {
+            getRequestDataToSerialize: {
+                variantType: 'WebCore::ResourceRequest::RequestData',
+                variant: {
+                    m_url: { string: 'A' },
+                    m_firstPartyForCookies: { string: '' },
+                    m_timeoutInterval: 0,
+                    m_httpMethod: 'GET',
+                    m_httpHeaderFields: { commonHeaders: [], uncommonHeaders: [] },
+                    m_responseContentDispositionEncodingFallbackArray: [],
+                    m_cachePolicy: 0,
+                    m_sameSiteDisposition: 0,
+                    m_priority: 1,
+                    m_requester: 0,
+                    m_allowCookies: true,
+                    m_isTopSite: true,
+                    m_isAppInitiated: true,
+                    m_privacyProxyFailClosedForUnreachableNonMainHosts: true,
+                    m_useAdvancedPrivacyProtections: true,
+                    m_didFilterLinkDecoration: false,
+                    m_isPrivateTokenUsageByThirdPartyAllowed: false,
+                    m_wasSchemeOptimisticallyUpgraded: false,
+                    m_targetAddressSpace: 0
+                }
+            },
+            cachePartition: '',
+            hiddenFromInspector: true
+        },
+        protocol: '',
+        identifier: 393216,
+        webPageProxyID: IPC.webPageProxyID,
+        frameID: {},
+        pageID: { optionalValue: IPC.pageID },
+        clientOrigin: {
+            topOrigin: { data: { variantType: 'WebCore::SecurityOriginData::Tuple', variant: { protocol: '', host: '', port: {} } } },
+            clientOrigin: { data: { variantType: 'WebCore::SecurityOriginData::Tuple', variant: { protocol: '', host: '', port: {} } } }
+        },
+        hadMainFrameMainResourcePrivateRelayed: false,
+        allowPrivacyProxy: false,
+        protections: 0,
+        storedCredentialsPolicy: 0
+    });
+}, 10);
+
+setTimeout(() => {
+    testRunner?.notifyDone();
+}, 2000);
+</script>

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -537,6 +537,7 @@ void NetworkConnectionToWebProcess::didReceiveInvalidMessage(IPC::Connection&, I
 
 void NetworkConnectionToWebProcess::createSocketChannel(const ResourceRequest& request, const String& protocol, WebSocketIdentifier identifier, WebPageProxyIdentifier webPageProxyID, std::optional<FrameIdentifier> frameID, std::optional<PageIdentifier> pageID, const ClientOrigin& clientOrigin, bool hadMainFrameMainResourcePrivateRelayed, bool allowPrivacyProxy, OptionSet<AdvancedPrivacyProtections> advancedPrivacyProtections, WebCore::StoredCredentialsPolicy storedCredentialsPolicy)
 {
+    MESSAGE_CHECK(request.url().isValid());
     MESSAGE_CHECK(m_networkProcess->allowsFirstPartyForCookies(m_webProcessIdentifier, request.firstPartyForCookies()) != NetworkProcess::AllowCookieAccess::Terminate);
 
     ASSERT(!m_networkSocketChannels.contains(identifier));

--- a/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
+++ b/Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm
@@ -1653,7 +1653,7 @@ RefPtr<WebSocketTask> NetworkSessionCocoa::createWebSocketTask(WebPageProxyIdent
 {
     ASSERT(!request.hasHTTPHeaderField(WebCore::HTTPHeaderName::SecWebSocketProtocol));
     RetainPtr nsRequest = request.nsURLRequest(WebCore::HTTPBodyUpdatePolicy::DoNotUpdateHTTPBody);
-    if (!nsRequest)
+    if (!nsRequest || ![nsRequest URL])
         return nullptr;
     RetainPtr<NSMutableURLRequest> mutableRequest;
 


### PR DESCRIPTION
#### 84a08d4a5ba8ac7864f2bcbd4b5ba41e387585c6
<pre>
NetworkConnectionToWebProcess::createSocketChannel should reject requests with an invalid URL
<a href="https://bugs.webkit.org/show_bug.cgi?id=315163">https://bugs.webkit.org/show_bug.cgi?id=315163</a>
<a href="https://rdar.apple.com/177347637">rdar://177347637</a>

Reviewed by Chris Dumez.

A fuzzed CreateSocketChannel IPC message carrying a ResourceRequest with
an invalid URL reaches NetworkSessionCocoa::createWebSocketTask, which
materializes an NSURLRequest with a nil URL and passes it to
-[NWURLSession webSocketTaskWithRequest:]. NWURLSession throws
NSInvalidArgumentException, which propagates uncaught and aborts the
Networking process.

A well-behaved WebContent process never sends an invalid URL on this path
(WebSocket::connect rejects it), so add a MESSAGE_CHECK at the IPC entry
point. As defense in depth, also bail out of createWebSocketTask when the
NSURLRequest has a nil URL, mirroring the existing nil-request guard.

* LayoutTests/ipc/create-socket-channel-invalid-url-crash-expected.txt: Added.
* LayoutTests/ipc/create-socket-channel-invalid-url-crash.html: Added.
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::createSocketChannel):
* Source/WebKit/NetworkProcess/cocoa/NetworkSessionCocoa.mm:
(WebKit::NetworkSessionCocoa::createWebSocketTask):

Canonical link: <a href="https://commits.webkit.org/313603@main">https://commits.webkit.org/313603@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5823663ec33dbd89fa804cddc90be679f7dbc17c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163454 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36937 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30153 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172394 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119901 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37266 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36937 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126943 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89479 "layout-tests (failure)") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6af07dc2-2984-4ce1-9834-18dcb477d76e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166413 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29214 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146941 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107501 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d018483c-6e0d-452d-ac45-279ff022a28b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28267 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26889 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20096 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138155 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24664 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174898 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27640 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26321 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135246 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36607 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/30989 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135232 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36478 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37392 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146459 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99384 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30535 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23304 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36103 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109147 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35600 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1330 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35848 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35748 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->