### PR TITLE
claude.ai: Quirk to work around chat stuck in infinite reload loop after logout

### DIFF
--- a/Source/WebCore/Modules/fetch/FetchResponse.cpp
+++ b/Source/WebCore/Modules/fetch/FetchResponse.cpp
@@ -31,12 +31,14 @@
 #include "FetchResponse.h"
 
 #include "ContextDestructionObserverInlines.h"
+#include "Document.h"
 #include "FetchRequest.h"
 #include "FetchResponseBodyLoader.h"
 #include "HTTPParsers.h"
 #include "InspectorInstrumentation.h"
 #include "JSBlob.h"
 #include "MIMETypeRegistry.h"
+#include "Quirks.h"
 #include "ReadableStreamToSharedBufferSink.h"
 #include "ResourceError.h"
 #include "ScriptExecutionContext.h"
@@ -390,6 +392,9 @@ void FetchResponse::Loader::didReceiveResponse(const ResourceResponse& resourceR
     RefPtr response = m_response.get();
     if (!response)
         return;
+
+    if (RefPtr document = dynamicDowncast<Document>(response->scriptExecutionContext()))
+        document->quirks().clearLogoutSurvivingIdentityCookiesIfNeeded(resourceResponse.url(), resourceResponse.httpStatusCode());
 
     response->setReceivedInternalResponse(resourceResponse, m_credentials);
 

--- a/Source/WebCore/page/Quirks.cpp
+++ b/Source/WebCore/page/Quirks.cpp
@@ -30,6 +30,8 @@
 #include "AccessibilityRole.h"
 #include "Attr.h"
 #include "ContainerNodeInlines.h"
+#include "Cookie.h"
+#include "CookieJar.h"
 #include "DatasetDOMStringMap.h"
 #include "DeprecatedGlobalSettings.h"
 #include "DocumentLoader.h"
@@ -2492,6 +2494,45 @@ bool Quirks::needsLimitedMatroskaSupport() const
 #endif
 }
 
+// rdar://174779259.
+// Anthropic's claude.ai SPA, after a logout, leaves some identification cookies behind.
+// On the next /chat boot those non-auth cookies are enough to push the SPA into an
+// authenticated boot path; the bootstrap call 403s with "account_session_invalid", and
+// the SPA reacts with location.href = '/logout?...', producing an indefinite /chat <->
+// /logout loop. The bug seems to be on Anthropic's side; this quirk works around it by
+// performing the cookie cleanup the server forgot, when we observe a successful fetch
+// to claude.ai/api/auth/logout.
+void Quirks::clearLogoutSurvivingIdentityCookiesIfNeeded(const URL& fetchURL, int httpStatusCode)
+{
+    if (!needsQuirks()) [[unlikely]]
+        return;
+
+    if (!m_quirksData.quirkIsEnabled(QuirksData::SiteSpecificQuirk::NeedsLogoutCookieCleanupQuirk))
+        return;
+
+    if (httpStatusCode < 200 || httpStatusCode >= 300)
+        return;
+
+    if (!equalLettersIgnoringASCIICase(fetchURL.host(), "claude.ai"_s))
+        return;
+
+    if (fetchURL.path() != "/api/auth/logout"_s)
+        return;
+
+    RefPtr document = m_document.get();
+    if (!document)
+        return;
+
+    RefPtr page = document->page();
+    if (!page)
+        return;
+
+    auto& documentURL = document->url();
+    static constexpr std::array cookiesToDelete = { "__ssid"_s, "__cf_bm"_s, "anthropic-device-id"_s, "lastActiveOrg"_s, "activitySessionId"_s };
+    for (auto& cookieName : cookiesToDelete)
+        page->cookieJar().deleteCookie(*document, documentURL, cookieName, [] { });
+}
+
 bool Quirks::needsCustomUserAgentData() const
 {
     QUIRKS_EARLY_RETURN_IF_DISABLED_WITH_VALUE(false);
@@ -3025,14 +3066,21 @@ static void handleDailyMailCoUkQuirks(QuirksData& quirksData, const URL& /* quir
     quirksData.enableQuirk(QuirksData::SiteSpecificQuirk::ShouldUnloadHeavyFrames);
 }
 
-#if PLATFORM(IOS_FAMILY)
 static void handleClaudeQuirks(QuirksData& quirksData, const URL& /* quirksURL */, const String& quirksDomainString, const URL&  /* documentURL */)
 {
     QUIRKS_EARLY_RETURN_IF_NOT_DOMAIN("claude.ai"_s);
 
+#if PLATFORM(IOS_FAMILY)
     quirksData.enableQuirk(QuirksData::SiteSpecificQuirk::NeedsClaudeSidebarViewportUnitQuirk);
-}
 #endif
+
+    // rdar://174779259.
+    // The Claude SPA's logout flow leaves some identification cookies behind.
+    // On the next /chat boot those cookies cause the SPA to enter an unauthenticated boot path
+    // that 403s and triggers a /chat -> /logout redirect loop. See
+    // Quirks::clearLogoutSurvivingIdentityCookiesIfNeeded() for the cleanup hook.
+    quirksData.enableQuirk(QuirksData::SiteSpecificQuirk::NeedsLogoutCookieCleanupQuirk);
+}
 
 #if ENABLE(TEXT_AUTOSIZING)
 static void handleYCombinatorQuirks(QuirksData& quirksData, const URL& quirksURL, const String& /* quirksDomainString */, const URL& /* documentURL */)
@@ -4026,9 +4074,7 @@ void Quirks::determineRelevantQuirks()
 #endif
         { "zoom"_s, &handleZoomQuirks },
         { "dailymail"_s, &handleDailyMailCoUkQuirks },
-#if PLATFORM(IOS_FAMILY)
         { "claude"_s, &handleClaudeQuirks },
-#endif
     });
 
     auto findResult = dispatchMap->find(quirkDomainWithoutPSL);

--- a/Source/WebCore/page/Quirks.h
+++ b/Source/WebCore/page/Quirks.h
@@ -346,6 +346,8 @@ public:
 
     bool shouldSuppressMediaSessionPauseActionOnInterruption() const;
 
+    void clearLogoutSurvivingIdentityCookiesIfNeeded(const URL& fetchURL, int httpStatusCode);
+
     void determineRelevantQuirks();
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebCore/page/QuirksData.h
+++ b/Source/WebCore/page/QuirksData.h
@@ -81,6 +81,7 @@ struct QuirksData {
         NeedsBodyScrollbarWidthNoneDisabledQuirk,
         NeedsCanPlayAfterSeekedQuirk,
         NeedsChromeMediaControlsPseudoElementQuirk,
+        NeedsLogoutCookieCleanupQuirk,
 #if PLATFORM(IOS_FAMILY)
         NeedsClaudeSidebarViewportUnitQuirk,
 #endif


### PR DESCRIPTION
#### 505ef3ab0484efaf695b77b40e7ee75accb6be0b
<pre>
claude.ai: Quirk to work around chat stuck in infinite reload loop after logout
<a href="https://bugs.webkit.org/show_bug.cgi?id=315164">https://bugs.webkit.org/show_bug.cgi?id=315164</a>
<a href="https://rdar.apple.com/174779259">rdar://174779259</a>

Reviewed by Brent Fulgham.

The Claude SPA&apos;s logout flow uses fetch(&apos;/api/auth/logout&apos;) to log the user
out. The server response clears the auth cookies, but leaves several
identification cookies (__ssid, __cf_bm, anthropic-device-id, lastActiveOrg,
activitySessionId) behind. On the next /chat boot, those non-auth cookies
are enough to push the SPA into an authenticated boot path; the bootstrap
call then 403s with &quot;account_session_invalid&quot;, and the SPA reacts with
location.href = &apos;/logout?...&apos;, producing an indefinite /chat &lt;-&gt; /logout
loop.

The bug appears to be on Anthropic&apos;s side; this quirk works around it by
deleting the surviving cookies after we observe a successful fetch to
claude.ai/api/auth/logout. The hook lives in
FetchResponse::Loader::didReceiveResponse so it fires for the SPA&apos;s logout
fetch.

* Source/WebCore/Modules/fetch/FetchResponse.cpp:
(WebCore::FetchResponse::Loader::didReceiveResponse):
* Source/WebCore/page/Quirks.cpp:
* Source/WebCore/page/Quirks.h:
* Source/WebCore/page/QuirksData.h:

Canonical link: <a href="https://commits.webkit.org/313632@main">https://commits.webkit.org/313632@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e5ee2a7a0e63f27609ae35d9dfcbe9db91dae120

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163683 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37167 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30386 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172623 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/120174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dd596135-ed6d-4d63-a221-3deb04de4b04) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165552 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37498 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37166 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/127136 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/120174 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/17b1e8eb-95a6-4002-a4ae-b9ecff6c0031) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166642 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/29422 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/147156 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107690 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7e57cdbe-fa74-4636-8ff5-9b37cc60ca9e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28470 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/27100 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20326 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/138369 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24873 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175128 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28059 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26540 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/135440 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36837 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135423 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36495 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37622 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146668 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99699 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30740 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/23521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36333 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/109478 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35830 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1550 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36080 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35977 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->