### PR TITLE
[Site Isolation] Ensure FrameInfoData.documentID is populated when posting script messages from Document

### DIFF
--- a/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
+++ b/Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp
@@ -47,8 +47,10 @@
 #include <JavaScriptCore/JSLock.h>
 #include <JavaScriptCore/JSRetainPtr.h>
 #include <WebCore/DOMWrapperWorld.h>
+#include <WebCore/Document.h>
 #include <WebCore/FrameDestructionObserverInlines.h>
 #include <WebCore/FrameLoader.h>
+#include <WebCore/JSDOMGlobalObject.h>
 #include <WebCore/LocalFrame.h>
 #include <WebCore/Page.h>
 #include <WebCore/SecurityOriginData.h>
@@ -309,6 +311,18 @@ private:
     {
     }
 
+    static FrameInfoData frameInfoWithDocumentID(WebFrame& webFrame, JSC::JSGlobalObject& globalObject)
+    {
+        auto frameInfo = webFrame.info();
+        if (!frameInfo.documentID) {
+            if (auto* domGlobalObject = dynamicDowncast<JSDOMGlobalObject>(&globalObject)) {
+                if (auto* document = dynamicDowncast<Document>(domGlobalObject->scriptExecutionContext()))
+                    frameInfo.documentID = document->identifier();
+            }
+        }
+        return frameInfo;
+    }
+
     // WebCore::UserMessageHandlerDescriptor
     void didPostMessage(WebCore::UserMessageHandler& handler, JSC::JSGlobalObject& globalObject, JSC::JSValue jsMessage, WTF::Function<void(JSC::JSValue, const String&)>&& completionHandler) const override
     {
@@ -329,7 +343,9 @@ private:
         if (!message)
             return;
 
-        protect(WebProcess::singleton().parentProcessConnection())->sendWithAsyncReply(Messages::WebProcessProxy::DidPostMessage(webPage->webPageProxyIdentifier(), m_controller->identifier(), webFrame->info(), m_identifier, *message), [completionHandler = WTF::move(completionHandler), context](Expected<WebKit::JavaScriptEvaluationResult, String>&& result) {
+        auto frameInfo = frameInfoWithDocumentID(*webFrame, globalObject);
+
+        protect(WebProcess::singleton().parentProcessConnection())->sendWithAsyncReply(Messages::WebProcessProxy::DidPostMessage(webPage->webPageProxyIdentifier(), m_controller->identifier(), WTF::move(frameInfo), m_identifier, *message), [completionHandler = WTF::move(completionHandler), context](Expected<WebKit::JavaScriptEvaluationResult, String>&& result) {
             JSC::JSLockHolder lock(toJS(context.get()));
             if (!result)
                 return completionHandler(JSC::jsUndefined(), result.error());
@@ -356,7 +372,9 @@ private:
         if (!message)
             return JSC::jsUndefined();
 
-        auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebProcessProxy::DidPostLegacySynchronousMessage(webPage->webPageProxyIdentifier(), m_controller->identifier(), webFrame->info(), m_identifier, *message), 0);
+        auto frameInfo = frameInfoWithDocumentID(*webFrame, globalObject);
+
+        auto sendResult = protect(WebProcess::singleton().parentProcessConnection())->sendSync(Messages::WebProcessProxy::DidPostLegacySynchronousMessage(webPage->webPageProxyIdentifier(), m_controller->identifier(), WTF::move(frameInfo), m_identifier, *message), 0);
         auto [result] = sendResult.takeReplyOr(makeUnexpected(String()));
         if (!result)
             return JSC::jsUndefined();

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm
@@ -9098,4 +9098,28 @@ TEST(SiteIsolation, MultiProcessBFCacheSameSiteNavAfterRestore)
     }
 }
 
+TEST(SiteIsolation, ScriptMessageHandlerDocumentIdentifierOnPageHide)
+{
+    HTTPServer server({
+        { "/main"_s, { "<iframe id='child' src='https://webkit.org/iframe'></iframe><iframe id='keeper' src='https://webkit.org/keeper'></iframe>"_s } },
+        { "/iframe"_s, { "<input type='text'>"_s } },
+        { "/keeper"_s, { "keepalive"_s } },
+        { "/next"_s, { "navigated"_s } },
+    }, HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr handler = adoptNS([TestScriptMessageHandler new]);
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    [[configuration userContentController] addScriptMessageHandler:handler.get() name:@"testHandler"];
+    auto [webView, navigationDelegate] = siteIsolatedViewAndDelegate(configuration);
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example.com/main"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+    EXPECT_NE([webView mainFrame].info._processIdentifier, [webView firstChildFrame]._processIdentifier);
+
+    [webView evaluateJavaScript:@"window.addEventListener('pagehide', () => { window.webkit.messageHandlers.testHandler.postMessage('pagehide'); })" inFrame:[webView firstChildFrame] completionHandler:nil];
+    [webView evaluateJavaScript:@"document.getElementById('child').src = 'https://example.com/next'" completionHandler:nil];
+    WKScriptMessage *message = [handler waitForMessage];
+    EXPECT_WK_STREQ(@"pagehide", message.body);
+    EXPECT_NOT_NULL(message.frameInfo._documentIdentifier);
+}
+
 }


### PR DESCRIPTION
#### 62fb864bff87d513cf2570d7f32fb453311d2457
<pre>
[Site Isolation] Ensure FrameInfoData.documentID is populated when posting script messages from Document
<a href="https://bugs.webkit.org/show_bug.cgi?id=315162">https://bugs.webkit.org/show_bug.cgi?id=315162</a>
<a href="https://rdar.apple.com/171866703">rdar://171866703</a>

Reviewed by Ryosuke Niwa.

With Site Isolation enabled, when a cross-origin iframe undergoes a process swap (e.g., navigating to a different
origin), the frame transitions from local to remote state. During this transition, WebFrame::coreLocalFrame() can return
nullptr, causing webFrame-&gt;info() to produce a FrameInfoData with a nil documentID. That means, if client posts message
in pagehide event fired on a frame, it may get a null documentIdentifier. This has caused crash in existing clients --
since the message must come from an active Document, they expect the documentIdentifier will never be null and they can
access it safely.

To fix this, now we fall back to obtain the document identifier directly from JSGlobalObject&apos;s ScriptExecutionContext
when webFrame-&gt;info() fails to populate it.

Test: SiteIsolation.ScriptMessageHandlerDocumentIdentifierOnPageHide

* Source/WebKit/WebProcess/UserContent/WebUserContentController.cpp:
(WebKit::WebUserMessageHandlerDescriptorProxy::frameInfoWithDocumentID):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SiteIsolation.mm:
(TestWebKitAPI::(SiteIsolation, ScriptMessageHandlerDocumentIdentifierOnPageHide)):

Canonical link: <a href="https://commits.webkit.org/313592@main">https://commits.webkit.org/313592@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6abf6695ad92b0023a0bae3868555f8da58b343

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163561 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37045 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30264 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172501 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/120010 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/eea0b565-a32b-47ab-ba87-abf0ac9b8791) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165430 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37376 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37044 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127035 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89559 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/92458c3a-2a9a-4d4c-ac97-1be2f3c06f5e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166520 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29309 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147042 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107589 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c766ba3e-e562-4698-9a2b-147df7ce653a) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26989 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20204 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/138256 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24761 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175006 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27937 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26424 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135339 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36715 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31091 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135321 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36471 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37500 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146556 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99553 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30632 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23408 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36210 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109356 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35708 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1434 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35958 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35855 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->