### PR TITLE
[AutoFill Debugging] `scroll` should fall back to the largest overflow scroller if the root is non-scrollable

### DIFF
--- a/LayoutTests/fast/text-extraction/text-extraction-scroll-fallback-to-large-container-expected.txt
+++ b/LayoutTests/fast/text-extraction/text-extraction-scroll-fallback-to-large-container-expected.txt
@@ -1,0 +1,14 @@
+Tests that scroll interactions on a page with an unscrollable root fall back to a large scrollable container.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS rootScrollTop is 0
+PASS noArgScrollError is ""
+PASS largeScrollerScrollTopAfterFallback is > 0
+PASS scrollByError is ""
+PASS largeScrollerScrollTopAfterScrollBy is 150
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Top of large scroller

--- a/LayoutTests/fast/text-extraction/text-extraction-scroll-fallback-to-large-container.html
+++ b/LayoutTests/fast/text-extraction/text-extraction-scroll-fallback-to-large-container.html
@@ -1,0 +1,71 @@
+<!-- webkit-test-runner [ useFlexibleViewport=true textExtractionEnabled=true AsyncOverflowScrollingEnabled=true ] -->
+<!DOCTYPE html>
+<html>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta charset="utf-8">
+<head>
+    <script src="../../resources/js-test.js"></script>
+    <script src="../../resources/ui-helper.js"></script>
+    <style>
+        html, body {
+            margin: 0;
+        }
+
+        .large-scroller {
+            position: fixed;
+            top: 0;
+            left: 0;
+            width: 100vw;
+            height: 100vh;
+            overflow: scroll;
+            scrollbar-width: none;
+        }
+
+        .large-content {
+            height: 4000px;
+        }
+    </style>
+</head>
+<body>
+    <div class="large-scroller" aria-label="Main content">
+        <div class="large-content">Top of large scroller</div>
+    </div>
+    <script>
+    jsTestIsAsync = true;
+    description("Tests that scroll interactions on a page with an unscrollable root fall back to a large scrollable container.");
+
+    addEventListener("load", async () => {
+        largeScroller = document.querySelector(".large-scroller");
+
+        if (!window.testRunner)
+            return;
+
+        document.scrollingElement.scrollTop = 1000;
+        await UIHelper.ensurePresentationUpdate();
+        rootScrollTop = document.scrollingElement.scrollTop;
+        shouldBe("rootScrollTop", "0");
+
+        noArgScrollError = await UIHelper.performTextExtractionInteraction("scroll", {});
+        await UIHelper.ensureVisibleContentRectUpdate();
+        await UIHelper.ensurePresentationUpdate();
+
+        largeScrollerScrollTopAfterFallback = largeScroller.scrollTop;
+        shouldBeEqualToString("noArgScrollError", "");
+        shouldBeGreaterThan("largeScrollerScrollTopAfterFallback", "0");
+
+        largeScroller.scrollTop = 0;
+        await UIHelper.ensurePresentationUpdate();
+
+        scrollByError = await UIHelper.performTextExtractionInteraction("scroll", { scrollDelta: { x: 0, y: 150 } });
+        await UIHelper.ensureVisibleContentRectUpdate();
+        await UIHelper.ensurePresentationUpdate();
+
+        largeScrollerScrollTopAfterScrollBy = largeScroller.scrollTop;
+        shouldBeEqualToString("scrollByError", "");
+        shouldBe("largeScrollerScrollTopAfterScrollBy", "150");
+
+        finishJSTest();
+    });
+    </script>
+</body>
+</html>

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -2027,8 +2027,103 @@ static void highlightText(LocalFrame& frame, std::optional<NodeIdentifier>&& ide
     return completion(true, { });
 }
 
+static String wrapWithDoubleQuotes(StringView text)
+{
+    return makeString(u"“", text, u"”");
+}
+
+struct ScrollableContainer {
+    RefPtr<Element> element;
+    WeakPtr<ScrollableArea> scrollableArea;
+};
+
+static ScrollableContainer findLargeScrollableContainer(LocalFrame& frame)
+{
+    RefPtr view = frame.view();
+    if (!view)
+        return { };
+
+    auto viewportArea = view->visibleSize().area<RecordOverflow>();
+    if (viewportArea.hasOverflowed() || viewportArea <= 0)
+        return { };
+
+    RefPtr document = frame.document();
+    CheckedPtr renderView = document ? document->renderView() : nullptr;
+    if (!renderView)
+        return { };
+
+    ScrollableContainer best;
+    unsigned bestArea = 0;
+
+    for (CheckedRef descendant : descendantsOfType<RenderBox>(*renderView)) {
+        if (!descendant->canBeScrolledAndHasScrollableArea())
+            continue;
+
+        RefPtr element = descendant->element();
+        if (!element || is<HTMLIFrameElement>(*element))
+            continue;
+
+        CheckedPtr layer = descendant->layer();
+        if (!layer)
+            continue;
+
+        CheckedPtr scrollableArea = layer->scrollableArea();
+        if (!scrollableArea)
+            continue;
+
+        auto maxOffset = scrollableArea->maximumScrollOffset();
+        if (!maxOffset.x() && !maxOffset.y())
+            continue;
+
+        auto area = scrollableArea->visibleSize().area<RecordOverflow>();
+        if (area.hasOverflowed())
+            continue;
+
+        if (area < viewportArea / 2)
+            continue;
+
+        if (area <= bestArea)
+            continue;
+
+        bestArea = area;
+        best.element = WTF::move(element);
+        best.scrollableArea = scrollableArea.get();
+    }
+
+    return best;
+}
+
+static std::optional<std::pair<String, ScrollableContainer>> redirectToLargeScrollableContainerIfNeeded(LocalFrame& frame, bool identifierProvided, ScrollableArea* scroller)
+{
+    if (identifierProvided)
+        return { };
+
+    if (!scroller)
+        return { };
+
+    auto maxOffset = protect(scroller)->maximumScrollOffset();
+    if (!maxOffset.isZero())
+        return { };
+
+    auto [element, scrollableArea] = findLargeScrollableContainer(frame);
+    if (!element || !scrollableArea)
+        return { };
+
+    StringBuilder description;
+    auto tagName = protect(element)->tagName().convertToASCIILowercase();
+    description.append(tagName);
+
+    if (auto label = normalizedLabelText(*protect(element)); !label.isEmpty())
+        description.append(makeString(" labeled "_s, wrapWithDoubleQuotes(WTF::move(label))));
+    else if (auto role = normalizeText(element->attributeWithoutSynchronization(HTMLNames::roleAttr)); !role.isEmpty() && role != tagName)
+        description.append(makeString(" with role "_s, wrapWithDoubleQuotes(WTF::move(role))));
+
+    return { { description.toString(), { WTF::move(element), WTF::move(scrollableArea) } } };
+}
+
 static void scrollBy(LocalFrame& frame, std::optional<NodeIdentifier>&& identifier, FloatSize scrollDelta, CompletionHandler<void(bool, String&&)>&& completion)
 {
+    bool identifierProvided = identifier.has_value();
     RefPtr foundNode = resolveNodeWithBodyAsFallback(frame, identifier);
     if (!foundNode)
         return completion(false, invalidNodeIdentifierDescription(WTF::move(identifier)));
@@ -2037,13 +2132,26 @@ static void scrollBy(LocalFrame& frame, std::optional<NodeIdentifier>&& identifi
     if (!scroller)
         return completion(false, "No scrollable area found"_s);
 
+    String fallbackDescription;
+    if (auto fallbackResult = redirectToLargeScrollableContainerIfNeeded(protect(frame), identifierProvided, protect(scroller))) {
+        fallbackDescription = WTF::move(fallbackResult->first);
+        foundNode = WTF::move(fallbackResult->second.element);
+        scroller = WTF::move(fallbackResult->second.scrollableArea);
+    }
+
     addBoxShadowIfNeeded(*foundNode, "#34c759"_s);
     scroller->scrollToOffsetWithoutAnimation(FloatPoint { scroller->scrollOffset() } + scrollDelta);
-    completion(true, { });
+
+    String summary;
+    if (!fallbackDescription.isEmpty())
+        summary = makeString("Scrolled within "_s, WTF::move(fallbackDescription), " (root frame is unscrollable)"_s);
+
+    completion(true, WTF::move(summary));
 }
 
 static void scrollToNextPage(LocalFrame& frame, std::optional<NodeIdentifier>&& identifier, CompletionHandler<void(bool, String&&)>&& completion)
 {
+    bool identifierProvided = identifier.has_value();
     RefPtr foundNode = resolveNodeWithBodyAsFallback(frame, identifier);
     if (!foundNode)
         return completion(false, invalidNodeIdentifierDescription(WTF::move(identifier)));
@@ -2051,6 +2159,13 @@ static void scrollToNextPage(LocalFrame& frame, std::optional<NodeIdentifier>&& 
     WeakPtr scroller = CheckedRef { frame.eventHandler() }->enclosingScrollableArea(foundNode.get());
     if (!scroller)
         return completion(false, "No scrollable area found"_s);
+
+    String fallbackDescription;
+    if (auto fallbackResult = redirectToLargeScrollableContainerIfNeeded(frame, identifierProvided, protect(scroller))) {
+        fallbackDescription = WTF::move(fallbackResult->first);
+        foundNode = WTF::move(fallbackResult->second.element);
+        scroller = WTF::move(fallbackResult->second.scrollableArea);
+    }
 
     addBoxShadowIfNeeded(*foundNode, "#34c759"_s);
 
@@ -2061,11 +2176,25 @@ static void scrollToNextPage(LocalFrame& frame, std::optional<NodeIdentifier>&& 
     bool isAtEnd = scrollsHorizontally ? currentOffset.x() >= maxOffset.x() : currentOffset.y() >= maxOffset.y();
     bool isRTL = scroller->shouldPlaceVerticalScrollbarOnLeft();
 
+    auto buildSummary = [&](int distance, ASCIILiteral direction, ASCIILiteral wrapNote) -> String {
+        StringBuilder builder;
+        builder.append(makeString("Scrolled "_s, distance, "px "_s, direction));
+        if (!fallbackDescription.isEmpty()) {
+            builder.append(makeString(" within "_s, fallbackDescription));
+            if (wrapNote.isNull())
+                builder.append(" (root frame is unscrollable)"_s);
+            else
+                builder.append(makeString(" (root frame is unscrollable, "_s, wrapNote, ')'));
+        } else if (!wrapNote.isNull())
+            builder.append(makeString(" ("_s, wrapNote, ')'));
+        return builder.toString();
+    };
+
     if (isAtEnd) {
         scroller->scrollToOffsetWithoutAnimation({ });
         auto direction = scrollsHorizontally ? (isRTL ? "right"_s : "left"_s) : "up"_s;
         auto distance = scrollsHorizontally ? roundToInt(currentOffset.x()) : roundToInt(currentOffset.y());
-        completion(true, makeString("Scrolled "_s, distance, "px "_s, direction, " (wrapped to start)"_s));
+        completion(true, buildSummary(distance, direction, "wrapped to start"_s));
     } else {
         auto visibleSize = scroller->visibleSize();
         auto delta = scrollsHorizontally ? FloatSize { static_cast<float>(visibleSize.width()), 0 } : FloatSize { 0, static_cast<float>(visibleSize.height()) };
@@ -2073,7 +2202,7 @@ static void scrollToNextPage(LocalFrame& frame, std::optional<NodeIdentifier>&& 
         auto newOffset = scroller->scrollOffset();
         auto direction = scrollsHorizontally ? (isRTL ? "left"_s : "right"_s) : "down"_s;
         auto distance = scrollsHorizontally ? roundToInt(newOffset.x() - currentOffset.x()) : roundToInt(newOffset.y() - currentOffset.y());
-        completion(true, makeString("Scrolled "_s, distance, "px "_s, direction));
+        completion(true, buildSummary(distance, direction, ASCIILiteral { }));
     }
 }
 
@@ -2295,11 +2424,6 @@ void handleInteraction(Interaction&& interaction, LocalFrame& frame, CompletionH
             bounds = rootViewBounds(*targetNode);
         completion(success, WTF::move(message), bounds);
     });
-}
-
-static String wrapWithDoubleQuotes(StringView text)
-{
-    return makeString(u"“", text, u"”");
 }
 
 static String textDescription(const Element& element, Vector<String>& stringsToValidate, bool isTargetElement = true)


### PR DESCRIPTION
#### 7d11c41850ce89046d0d632fcd6b31469518ce7e
<pre>
[AutoFill Debugging] `scroll` should fall back to the largest overflow scroller if the root is non-scrollable
<a href="https://bugs.webkit.org/show_bug.cgi?id=315138">https://bugs.webkit.org/show_bug.cgi?id=315138</a>
<a href="https://rdar.apple.com/177474955">rdar://177474955</a>

Reviewed by Abrar Rahman Protyasha.

In the case where a `scroll` interaction is issued on a page that is not actually scrollable, fall
back to scrolling the largest scrollable area (by area).

Test: fast/text-extraction/text-extraction-scroll-fallback-to-large-container.html

* LayoutTests/fast/text-extraction/text-extraction-scroll-fallback-to-large-container-expected.txt: Added.
* LayoutTests/fast/text-extraction/text-extraction-scroll-fallback-to-large-container.html: Added.
* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::wrapWithDoubleQuotes):
(WebCore::TextExtraction::findLargeScrollableContainer):
(WebCore::TextExtraction::redirectToLargeScrollableContainerIfNeeded):
(WebCore::TextExtraction::scrollBy):
(WebCore::TextExtraction::scrollToNextPage):

Canonical link: <a href="https://commits.webkit.org/313575@main">https://commits.webkit.org/313575@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c1e9d89415770d03f87ad4718b03c7693b4cd448

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163525 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37009 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30228 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172465 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119974 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5b40b59c-b5c4-46cd-81df-51c0f536ca86) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165394 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37340 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37008 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127007 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89535 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/db180494-edce-450f-aa16-8a93bdf85e3e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166484 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29277 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147008 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107561 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6b063780-c16e-48c6-af00-bc7d0ecadd2c) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28326 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26957 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20168 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138223 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24727 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174970 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27901 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26389 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135312 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36678 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31059 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135294 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36458 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37464 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146522 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99505 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30597 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23372 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36174 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109320 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35672 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1397 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35922 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35819 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->