### PR TITLE
SkiaCompositingLayer: backdrop filter shouldn't affect to subsequent elements of element E

### DIFF
--- a/LayoutTests/css3/filters/backdrop/backdrop-blur-and-subsequent-elements-expected.html
+++ b/LayoutTests/css3/filters/backdrop/backdrop-blur-and-subsequent-elements-expected.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<style>
+  div {
+      position: absolute;
+      top: 30px;
+      left: 30px;
+      width: 300px;
+      height: 300px;
+      border: 1px solid;
+  }
+  #b {
+      will-change: transform;
+      font-size: 100px;
+  }
+</style>
+
+You should see no blur.
+
+<div id="b">CLEAR</div>

--- a/LayoutTests/css3/filters/backdrop/backdrop-blur-and-subsequent-elements.html
+++ b/LayoutTests/css3/filters/backdrop/backdrop-blur-and-subsequent-elements.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<style>
+  div {
+      position: absolute;
+      top: 30px;
+      left: 30px;
+      width: 300px;
+      height: 300px;
+      border: 1px solid;
+  }
+  #a {
+      backdrop-filter: blur(30px);
+  }
+  #b {
+      will-change: transform;
+      font-size: 100px;
+  }
+</style>
+
+You should see no blur.
+
+<div id="a"></div>
+<div id="b">CLEAR</div>

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -595,8 +595,10 @@ void SkiaCompositingLayer::paintSelf(SkCanvas& canvas, PaintContext& context)
 
 void SkiaCompositingLayer::paintSelfAndChildren(SkCanvas& canvas, PaintContext& context)
 {
-    if (m_backdrop.filter && context.paintingBackdropForLayer == this)
+    if (m_backdrop.filter && context.paintingBackdropForLayer == this) {
+        context.skipAfterBackdrop = true;
         return;
+    }
 
     if (m_backdrop.filter && !context.paintingBackdropForLayer) {
         SkAutoCanvasRestore autoRestore(&canvas, true);
@@ -623,6 +625,7 @@ void SkiaCompositingLayer::paintSelfAndChildren(SkCanvas& canvas, PaintContext& 
             SetForScope scopedOpacity(context.opacity, 1.f);
             SetForScope scopedBlendMode(context.blendMode, std::nullopt);
             SetForScope scopedReplicaTransform(context.accumulatedReplicaTransform, TransformationMatrix());
+            SetForScope scopedSkipAfterBackdrop(context.skipAfterBackdrop, false);
             backdropRoot()->paintSelfAndChildren(canvas, context);
         });
     }
@@ -857,6 +860,8 @@ void SkiaCompositingLayer::paintSelfAndChildrenWithReplicaFilterAndMask(SkCanvas
 
 void SkiaCompositingLayer::recursivePaint(SkCanvas& canvas, PaintContext& context)
 {
+    if (context.skipAfterBackdrop)
+        return;
     if (!isVisible())
         return;
 

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h
@@ -133,6 +133,7 @@ private:
         sk_sp<SkColorFilter> colorFilter;
         TransformationMatrix accumulatedReplicaTransform;
         RefPtr<SkiaCompositingLayer> paintingBackdropForLayer;
+        bool skipAfterBackdrop { false };
         std::optional<Damage>& frameDamage;
     };
 


### PR DESCRIPTION
#### d56cbfb1f04c8b668cac67a91d147edd96b0715c
<pre>
SkiaCompositingLayer: backdrop filter shouldn&apos;t affect to subsequent elements of element E
<a href="https://bugs.webkit.org/show_bug.cgi?id=315165">https://bugs.webkit.org/show_bug.cgi?id=315165</a>

Reviewed by Carlos Garcia Campos.

As per &lt;<a href="https://drafts.csswg.org/filter-effects-2/#BackdropRoot">https://drafts.csswg.org/filter-effects-2/#BackdropRoot</a>&gt;, the Backdrop
Root Image should

&gt; Paint all content, in painting order, between (and including) the
&gt; ancestor Backdrop Root element and element E.

So, we have to skip painting all elements after element E to make the Backdrop
Root Image.

Test: css3/filters/backdrop/backdrop-blur-and-subsequent-elements.html

* LayoutTests/css3/filters/backdrop/backdrop-blur-and-subsequent-elements-expected.html: Added.
* LayoutTests/css3/filters/backdrop/backdrop-blur-and-subsequent-elements.html: Added.
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
(WebCore::SkiaCompositingLayer::paintSelfAndChildren):
(WebCore::SkiaCompositingLayer::recursivePaint):
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.h:

Canonical link: <a href="https://commits.webkit.org/313560@main">https://commits.webkit.org/313560@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d5f89b111d9ca409c1f9a4cbaf094c312fcf9196

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163464 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36947 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30163 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172404 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119911 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165333 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37276 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36947 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126951 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89489 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166423 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29224 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146953 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107509 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28277 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20106 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138165 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24676 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174908 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27719 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26333 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135254 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36617 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/30998 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135240 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37402 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146471 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99405 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24883 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30547 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23316 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36113 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109172 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35610 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1343 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35858 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35758 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->