### PR TITLE
[WTF] Align load factor policy of OrderedHashTable to HashTable

### DIFF
--- a/Source/WTF/benchmarks/HashSetVariantsBenchmark.cpp
+++ b/Source/WTF/benchmarks/HashSetVariantsBenchmark.cpp
@@ -1,0 +1,435 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+// Compile (from $WEBKIT_ROOT, after a mac-dev-release build):
+//   xcrun clang++ -o HashSetVariantsBenchmark \
+//     Source/WTF/benchmarks/HashSetVariantsBenchmark.cpp \
+//     -std=c++23 -O3 -DNDEBUG=1 -fno-exceptions -fno-rtti \
+//     -ISource/WTF \
+//     -IWebKitBuild/cmake-mac/Release \
+//     -IWebKitBuild/cmake-mac/Release/WTF/DerivedSources \
+//     -FWebKitBuild/cmake-mac/Release \
+//     -framework JavaScriptCore -framework Foundation
+//
+// Run:
+//   DYLD_FRAMEWORK_PATH=WebKitBuild/cmake-mac/Release ./HashSetVariantsBenchmark
+//
+// Optional first arg: filter substring (matches container, op, or key type).
+// Optional second arg: a multiplier for repetitions (default 1.0).
+
+#include "config.h"
+
+#include <wtf/Atomics.h>
+#include <wtf/DataLog.h>
+#include <wtf/HashSet.h>
+#include <wtf/ListHashSet.h>
+#include <wtf/MonotonicTime.h>
+#include <wtf/OrderedHashSet.h>
+#include <wtf/StdLibExtras.h>
+#include <wtf/Threading.h>
+#include <wtf/Vector.h>
+#include <wtf/text/StringHash.h>
+#include <wtf/text/WTFString.h>
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
+
+namespace {
+
+// Sizes are chosen so all three containers settle at the SAME bucket count
+// and SAME load factor (~50%) after construction. Power-of-two sizes hit
+// HashTable's post-insert expansion edge (final load 25%) and
+// OrderedHashTable's pre-insert expansion edge (final load 50%) — different
+// loads, so lookup measurements compare layouts AND probe counts. Sizes of
+// 2^k - 1 sit just below both expansion triggers, equalizing both.
+constexpr unsigned kCapacities[] = { 7, 63, 511, 4095, 32767, 262143 };
+
+const char* g_filter = nullptr;
+double g_repMultiplier = 1.0;
+
+struct Row {
+    const char* container;
+    const char* op;
+    const char* keyType;
+    unsigned n;
+    double nsPerOp;
+};
+
+WTF::Vector<Row> g_rows;
+
+bool matchesFilter(const char* container, const char* op, const char* keyType)
+{
+    if (!g_filter)
+        return true;
+    auto contains = [](const char* haystack, const char* needle) {
+        return strstr(haystack, needle) != nullptr;
+    };
+    return contains(container, g_filter) || contains(op, g_filter) || contains(keyType, g_filter);
+}
+
+unsigned scaledReps(unsigned baseReps)
+{
+    double scaled = baseReps * g_repMultiplier;
+    if (scaled < 1.0)
+        scaled = 1.0;
+    return static_cast<unsigned>(scaled);
+}
+
+// Reps tuned so each cell takes roughly 50-300ms wall time.
+unsigned repsForInsert(unsigned n)
+{
+    if (n <=     8) return scaledReps(2000000);
+    if (n <=    64) return scaledReps(300000);
+    if (n <=   512) return scaledReps(40000);
+    if (n <=  4096) return scaledReps(4000);
+    if (n <= 32768) return scaledReps(400);
+    return scaledReps(40);
+}
+
+unsigned repsForLookup(unsigned n)
+{
+    if (n <=     8) return scaledReps(8000000);
+    if (n <=    64) return scaledReps(1000000);
+    if (n <=   512) return scaledReps(100000);
+    if (n <=  4096) return scaledReps(10000);
+    if (n <= 32768) return scaledReps(1000);
+    return scaledReps(100);
+}
+
+unsigned repsForIterate(unsigned n)
+{
+    if (n <=     8) return scaledReps(8000000);
+    if (n <=    64) return scaledReps(1000000);
+    if (n <=   512) return scaledReps(100000);
+    if (n <=  4096) return scaledReps(10000);
+    if (n <= 32768) return scaledReps(1000);
+    return scaledReps(100);
+}
+
+unsigned repsForChurn(unsigned n)
+{
+    if (n <=     8) return scaledReps(2000000);
+    if (n <=    64) return scaledReps(300000);
+    if (n <=   512) return scaledReps(40000);
+    if (n <=  4096) return scaledReps(4000);
+    if (n <= 32768) return scaledReps(400);
+    return scaledReps(40);
+}
+
+template<typename T> T makeKey(unsigned i);
+
+template<> uint32_t makeKey<uint32_t>(unsigned i) { return i + 1; }
+template<> void* makeKey<void*>(unsigned i)
+{
+    // Multiply to spread bits more like real heap pointers, and avoid 0.
+    return std::bit_cast<void*>(static_cast<uintptr_t>((i + 1) * 16));
+}
+template<> WTF::String makeKey<WTF::String>(unsigned i)
+{
+    return WTF::String::number(i + 1);
+}
+
+template<typename T>
+WTF::Vector<T> makeKeys(unsigned n)
+{
+    WTF::Vector<T> v;
+    v.reserveInitialCapacity(n);
+    for (unsigned i = 0; i < n; ++i)
+        v.append(makeKey<T>(i));
+    return v;
+}
+
+// To avoid stale-pointer hazards with WTF::String, keep present strings around
+// for the lifetime of "non-present" lookups too. We don't lookup absent keys
+// here, but the scaffold supports it.
+
+template<template<typename...> class SetTemplate, typename T>
+NEVER_INLINE void benchInsert(unsigned n, const char* container, const char* keyType)
+{
+    if (!matchesFilter(container, "Insert", keyType))
+        return;
+
+    auto keys = makeKeys<T>(n);
+    unsigned reps = repsForInsert(n);
+
+    auto before = WTF::MonotonicTime::now();
+    for (unsigned r = 0; r < reps; ++r) {
+        SetTemplate<T> set;
+        for (unsigned i = 0; i < n; ++i)
+            set.add(keys[i]);
+        WTF::compilerFence();
+    }
+    auto after = WTF::MonotonicTime::now();
+
+    double totalNs = (after - before).nanoseconds();
+    g_rows.append({ container, "Insert", keyType, n, totalNs / (static_cast<double>(reps) * n) });
+}
+
+template<template<typename...> class SetTemplate, typename T>
+NEVER_INLINE void benchContainsHit(unsigned n, const char* container, const char* keyType)
+{
+    if (!matchesFilter(container, "ContainsHit", keyType))
+        return;
+
+    auto keys = makeKeys<T>(n);
+    SetTemplate<T> set;
+    for (unsigned i = 0; i < n; ++i)
+        set.add(keys[i]);
+
+    unsigned reps = repsForLookup(n);
+    unsigned hitCount = 0;
+
+    auto before = WTF::MonotonicTime::now();
+    for (unsigned r = 0; r < reps; ++r) {
+        for (unsigned i = 0; i < n; ++i) {
+            if (set.contains(keys[i]))
+                ++hitCount;
+        }
+        WTF::compilerFence();
+    }
+    auto after = WTF::MonotonicTime::now();
+
+    if (hitCount != reps * n)
+        WTF::dataLog("WARNING: hit mismatch (", container, "/", keyType, "/n=", n, ")\n");
+
+    double totalNs = (after - before).nanoseconds();
+    g_rows.append({ container, "ContainsHit", keyType, n, totalNs / (static_cast<double>(reps) * n) });
+}
+
+template<template<typename...> class SetTemplate, typename T>
+NEVER_INLINE void benchIterate(unsigned n, const char* container, const char* keyType)
+{
+    if (!matchesFilter(container, "Iterate", keyType))
+        return;
+
+    auto keys = makeKeys<T>(n);
+    SetTemplate<T> set;
+    for (unsigned i = 0; i < n; ++i)
+        set.add(keys[i]);
+
+    unsigned reps = repsForIterate(n);
+    uintptr_t sink = 0;
+
+    auto before = WTF::MonotonicTime::now();
+    for (unsigned r = 0; r < reps; ++r) {
+        for (const auto& v : set) {
+            if constexpr (std::is_same_v<T, WTF::String>)
+                sink ^= v.impl() ? v.impl()->hash() : 0u;
+            else if constexpr (std::is_same_v<T, void*>)
+                sink ^= std::bit_cast<uintptr_t>(v);
+            else
+                sink ^= static_cast<uintptr_t>(v);
+        }
+        WTF::compilerFence();
+    }
+    auto after = WTF::MonotonicTime::now();
+
+    // Prevent dead-code elimination.
+    asm volatile("" : : "r"(sink) : "memory");
+
+    double totalNs = (after - before).nanoseconds();
+    g_rows.append({ container, "Iterate", keyType, n, totalNs / (static_cast<double>(reps) * n) });
+}
+
+// Churn: remove half the keys then re-insert them, repeated.
+template<template<typename...> class SetTemplate, typename T>
+NEVER_INLINE void benchChurn(unsigned n, const char* container, const char* keyType)
+{
+    if (!matchesFilter(container, "Churn", keyType))
+        return;
+
+    auto keys = makeKeys<T>(n);
+    SetTemplate<T> set;
+    for (unsigned i = 0; i < n; ++i)
+        set.add(keys[i]);
+
+    unsigned half = n / 2;
+    if (!half)
+        half = 1;
+    unsigned reps = repsForChurn(n);
+
+    auto before = WTF::MonotonicTime::now();
+    for (unsigned r = 0; r < reps; ++r) {
+        // Remove the second half.
+        for (unsigned i = half; i < n; ++i)
+            set.remove(keys[i]);
+        // Reinsert them.
+        for (unsigned i = half; i < n; ++i)
+            set.add(keys[i]);
+        WTF::compilerFence();
+    }
+    auto after = WTF::MonotonicTime::now();
+
+    double totalNs = (after - before).nanoseconds();
+    // Each rep does (n - half) removes + (n - half) inserts. Normalize per-op.
+    double opsPerRep = 2.0 * static_cast<double>(n - half);
+    g_rows.append({ container, "Churn", keyType, n, totalNs / (static_cast<double>(reps) * opsPerRep) });
+}
+
+template<template<typename...> class SetTemplate, typename T>
+void runAllOps(const char* container, const char* keyType)
+{
+    for (unsigned n : kCapacities) {
+        benchInsert<SetTemplate, T>(n, container, keyType);
+        benchContainsHit<SetTemplate, T>(n, container, keyType);
+        benchIterate<SetTemplate, T>(n, container, keyType);
+        benchChurn<SetTemplate, T>(n, container, keyType);
+    }
+}
+
+template<typename T> using HashSetT = WTF::HashSet<T>;
+template<typename T> using UncheckedKeyHashSetT = WTF::UncheckedKeyHashSet<T>;
+template<typename T> using OrderedHashSetT = WTF::OrderedHashSet<T>;
+template<typename T> using ListHashSetT = WTF::ListHashSet<T>;
+
+void printRows()
+{
+    WTF::dataLog("\n");
+    WTF::dataLog("container         op           key       n         ns/op\n");
+    WTF::dataLog("---------         --           ---       -         -----\n");
+    for (const auto& row : g_rows) {
+        char line[256];
+        snprintf(line, sizeof(line),
+            "%-16s  %-11s  %-8s  %7u  %10.2f\n",
+            row.container, row.op, row.keyType, row.n, row.nsPerOp);
+        WTF::dataLogF("%s", line);
+    }
+}
+
+const char* prettyN(unsigned n, char* buf, size_t bufSize)
+{
+    if (n >= 1024 * 1024)
+        snprintf(buf, bufSize, "%uM", n / (1024 * 1024));
+    else if (n >= 1024)
+        snprintf(buf, bufSize, "%uK", n / 1024);
+    else
+        snprintf(buf, bufSize, "%u", n);
+    return buf;
+}
+
+const Row* findRow(const char* container, const char* op, const char* keyType, unsigned n)
+{
+    for (const auto& row : g_rows) {
+        if (row.n == n
+            && !strcmp(row.container, container)
+            && !strcmp(row.op, op)
+            && !strcmp(row.keyType, keyType))
+            return &row;
+    }
+    return nullptr;
+}
+
+void printMatrix()
+{
+    static const char* kOps[] = { "Insert", "ContainsHit", "Iterate", "Churn" };
+    static const char* kContainers[] = { "HashSet", "UncheckedHashSet", "OrderedHashSet", "ListHashSet" };
+    static const char* kKeyTypes[] = { "uint32_t", "void*", "String" };
+
+    for (const char* op : kOps) {
+        WTF::dataLog("\n=== ", op, " (ns/op) ===\n");
+
+        // Header.
+        char line[512];
+        int written = snprintf(line, sizeof(line), "%-16s  %-8s", "container", "key");
+        for (unsigned n : kCapacities) {
+            char nbuf[16];
+            written += snprintf(line + written, sizeof(line) - written, "  %8s", prettyN(n, nbuf, sizeof(nbuf)));
+        }
+        snprintf(line + written, sizeof(line) - written, "\n");
+        WTF::dataLogF("%s", line);
+
+        // Separator.
+        WTF::dataLog("----------------  --------");
+        for (unsigned i = 0; i < std::size(kCapacities); ++i)
+            WTF::dataLog("  --------");
+        WTF::dataLog("\n");
+
+        // Rows: outer loop key type, inner loop container, so that each container
+        // group is contiguous within a key type.
+        for (const char* keyType : kKeyTypes) {
+            for (const char* container : kContainers) {
+                if (!matchesFilter(container, op, keyType))
+                    continue;
+                written = snprintf(line, sizeof(line), "%-16s  %-8s", container, keyType);
+                for (unsigned n : kCapacities) {
+                    if (const Row* r = findRow(container, op, keyType, n))
+                        written += snprintf(line + written, sizeof(line) - written, "  %8.2f", r->nsPerOp);
+                    else
+                        written += snprintf(line + written, sizeof(line) - written, "  %8s", "-");
+                }
+                snprintf(line + written, sizeof(line) - written, "\n");
+                WTF::dataLogF("%s", line);
+            }
+        }
+    }
+}
+
+} // anonymous namespace
+
+int main(int argc, char** argv)
+{
+    WTF::initialize();
+
+    if (argc >= 2)
+        g_filter = argv[1];
+    if (argc >= 3)
+        g_repMultiplier = atof(argv[2]);
+
+    WTF::dataLog("HashSetVariantsBenchmark — comparing WTF::HashSet, WTF::OrderedHashSet, WTF::ListHashSet\n");
+    WTF::dataLog("Capacities: ");
+    for (unsigned n : kCapacities)
+        WTF::dataLog(n, " ");
+    WTF::dataLog("\n");
+    if (g_filter)
+        WTF::dataLog("Filter: ", g_filter, "\n");
+    if (g_repMultiplier != 1.0)
+        WTF::dataLog("Rep multiplier: ", g_repMultiplier, "\n");
+
+    auto wallStart = WTF::MonotonicTime::now();
+
+    runAllOps<HashSetT, uint32_t>("HashSet", "uint32_t");
+    runAllOps<UncheckedKeyHashSetT, uint32_t>("UncheckedHashSet", "uint32_t");
+    runAllOps<OrderedHashSetT, uint32_t>("OrderedHashSet", "uint32_t");
+    runAllOps<ListHashSetT, uint32_t>("ListHashSet", "uint32_t");
+
+    runAllOps<HashSetT, void*>("HashSet", "void*");
+    runAllOps<UncheckedKeyHashSetT, void*>("UncheckedHashSet", "void*");
+    runAllOps<OrderedHashSetT, void*>("OrderedHashSet", "void*");
+    runAllOps<ListHashSetT, void*>("ListHashSet", "void*");
+
+    runAllOps<HashSetT, WTF::String>("HashSet", "String");
+    runAllOps<UncheckedKeyHashSetT, WTF::String>("UncheckedHashSet", "String");
+    runAllOps<OrderedHashSetT, WTF::String>("OrderedHashSet", "String");
+    runAllOps<ListHashSetT, WTF::String>("ListHashSet", "String");
+
+    auto wallEnd = WTF::MonotonicTime::now();
+
+    printRows();
+    printMatrix();
+
+    WTF::dataLog("\nTotal benchmark wall time: ", (wallEnd - wallStart).seconds(), " s\n");
+    return 0;
+}
+
+WTF_ALLOW_UNSAFE_BUFFER_USAGE_END

--- a/Source/WTF/wtf/OrderedHashTable.h
+++ b/Source/WTF/wtf/OrderedHashTable.h
@@ -437,9 +437,15 @@ private:
 
     static constexpr uint32_t entriesCapacityFromBucketCount(uint32_t bucketCount)
     {
-        // Load factor 3/4: entries array is 3/4 of bucket array. Leaves room for
-        // empty slots so probing terminates quickly.
-        return (bucketCount * 3) / 4;
+        // Match WTF::HashTable's load factor policy (HashTable.h):
+        //   small tables (<= 1024 buckets): 3/4 max load
+        //   large tables (>  1024 buckets): 1/2 max load
+        // Larger tables use a lower load factor so probe sequences stay short
+        // once the bucket array exceeds the L1/L2 footprint.
+        constexpr uint32_t maxSmallTableCapacity = 1024;
+        if (bucketCount <= maxSmallTableCapacity)
+            return (bucketCount * 3) / 4;
+        return bucketCount / 2;
     }
 
     static constexpr uint32_t bucketCountForKeyCount(uint32_t keyCount)


### PR DESCRIPTION
#### 021df62bfacca0026e6ccdc66ed256ec4aa05b2d
<pre>
[WTF] Align load factor policy of OrderedHashTable to HashTable
<a href="https://bugs.webkit.org/show_bug.cgi?id=315168">https://bugs.webkit.org/show_bug.cgi?id=315168</a>
<a href="https://rdar.apple.com/177505963">rdar://177505963</a>

Reviewed by Justin Michaud.

Let&apos;s align OrderedHashTable&apos;s load factor polic to normal HashTable.
Until a particular threshold, use 75%, after that, use 50%.

* Source/WTF/benchmarks/HashSetVariantsBenchmark.cpp: Added.
(main):
* Source/WTF/wtf/OrderedHashTable.h:

Canonical link: <a href="https://commits.webkit.org/315978@main">https://commits.webkit.org/315978@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ff3dd0c4309e8101681f5330f6c3af8d9620357a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/170642 "40 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/44567 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37985 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/180019 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/128355 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/45819 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/44201 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/133074 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93867 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/173601 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/36267 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/153518 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/113571 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/34885 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/33223 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/28700 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/1927 "Passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/145345 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32911 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/182603 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/31897 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/35400 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/37400 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/141532 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/44223 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/141349 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44912 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/29897 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/109498 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/26012 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/36616 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/116801 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/203321 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/43422 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/8001 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54440 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/42827 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/43068 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42958 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->