### PR TITLE
REGRESSION(313145@main): 3 unexpected failures on MVT tests on suite hls-shaka-test

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.cpp
@@ -119,8 +119,18 @@ void MediaSampleGStreamer::updateSampleTimestamps([[maybe_unused]] const String&
     GRefPtr buffer = gst_sample_get_buffer(m_sample.get());
     RELEASE_ASSERT(buffer);
 
-    auto newPts = toGstClockTime(m_pts);
-    auto newDts = toGstClockTime(m_dts);
+    GstClockTime newPts = 0;
+    if (m_pts >= MediaTime::zeroTime())
+        newPts = toGstClockTime(m_pts);
+    else
+        GST_WARNING("New PTS is negative: %s", m_pts.toString().ascii().data());
+
+    GstClockTime newDts = 0;
+    if (m_dts >= MediaTime::zeroTime())
+        newDts = toGstClockTime(m_dts);
+    else
+        GST_WARNING("New DTS is negative: %s", m_dts.toString().ascii().data());
+
     GST_TRACE("%s, new PTS: %" GST_TIME_FORMAT " (prev: %" GST_TIME_FORMAT "), new DTS: %" GST_TIME_FORMAT " (prev: %" GST_TIME_FORMAT ")", debugMessage.ascii().data(),
         GST_TIME_ARGS(newPts), GST_TIME_ARGS(GST_BUFFER_PTS(buffer.get())),
         GST_TIME_ARGS(newDts), GST_TIME_ARGS(GST_BUFFER_DTS(buffer.get())));
@@ -148,22 +158,8 @@ void MediaSampleGStreamer::offsetTimestampsBy(const MediaTime& timestampOffset)
     if (!timestampOffset)
         return;
 
-    [[maybe_unused]] bool newPtsIsZero = false;
-    auto newPts = m_pts + timestampOffset;
-    if (newPts.isInvalid() || newPts < MediaTime::zeroTime()) {
-        newPts = MediaTime::zeroTime();
-        newPtsIsZero = true;
-    }
-
-    [[maybe_unused]] bool newDtsIsZero = false;
-    auto newDts = m_dts + timestampOffset;
-    if (newDts.isInvalid() || newDts < MediaTime::zeroTime()) {
-        newDts = MediaTime::zeroTime();
-        newDtsIsZero = true;
-    }
-
-    m_pts = newPts;
-    m_dts = newDts;
+    m_pts += timestampOffset;
+    m_dts += timestampOffset;
 
     if (!m_sample)
         return;
@@ -171,7 +167,7 @@ void MediaSampleGStreamer::offsetTimestampsBy(const MediaTime& timestampOffset)
     auto debugMessage = emptyString();
 #ifndef GST_DISABLE_GST_DEBUG
     if (gst_debug_category_get_threshold(GST_CAT_DEFAULT) >= GST_LEVEL_TRACE)
-        debugMessage = makeString("Offsetting timestamps by "_s, timestampOffset.toString(), newPtsIsZero ? " negative PTS was reset to 0..."_s : emptyString(), newDtsIsZero ? " negative DTS was reset to 0..."_s : emptyString());
+        debugMessage = makeString("Offsetting timestamps by "_s, timestampOffset.toString());
 #endif
     updateSampleTimestamps(debugMessage);
 }

--- a/Tools/Scripts/run-mvt-tests
+++ b/Tools/Scripts/run-mvt-tests
@@ -590,7 +590,7 @@ def main(argument_list):
         if mvtwebdriver_runner:
             mvtwebdriver_runner.stop_driver()
             mvtwebdriver_runner.stop_display_server()
-        return exit_code
+    return exit_code
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
#### 4a7ed8d2f72fef47172645f99031951cedf023f0
<pre>
REGRESSION(313145@main): 3 unexpected failures on MVT tests on suite hls-shaka-test
<a href="https://bugs.webkit.org/show_bug.cgi?id=315150">https://bugs.webkit.org/show_bug.cgi?id=315150</a>

Reviewed by Xabier Rodriguez-Calvar.

Restore the timestamp update logic from before 313145@main, some values will be reported as negative
but actual timestamps stored in buffers are guaranteed to be positive.

Driving-by, fix a python syntax warning in run-mvt-tests, apparently &apos;return&apos; is not allowed in
finally blocks anymore.

* Source/WebCore/platform/graphics/gstreamer/MediaSampleGStreamer.cpp:
(WebCore::MediaSampleGStreamer::updateSampleTimestamps):
(WebCore::MediaSampleGStreamer::offsetTimestampsBy):
* Tools/Scripts/run-mvt-tests:

Canonical link: <a href="https://commits.webkit.org/313657@main">https://commits.webkit.org/313657@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/79504d3d800ee773fbb9b663dfffac95eba60fe4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163737 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37221 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30440 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/172755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/120988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165606 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37552 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37220 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/172755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/120988 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166696 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29463 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147194 "Passed tests") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/172755 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28510 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/27140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/20530 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/138409 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24911 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175189 "Hash 79504d3d for PR 65267 does not build (failure)") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28113 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26579 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/175189 "Hash 79504d3d for PR 65267 does not build (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36891 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/175189 "Hash 79504d3d for PR 65267 does not build (failure)") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/36512 "The change is no longer eligible for processing.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37676 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146706 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99775 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24922 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30777 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23560 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36387 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109532 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35884 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1590 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36134 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36031 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->