### PR TITLE
Update/Fix Lock/Condition Performance Test Binaries

### DIFF
--- a/Source/WTF/benchmarks/ConditionSpeedTest.cpp
+++ b/Source/WTF/benchmarks/ConditionSpeedTest.cpp
@@ -24,7 +24,16 @@
  */
 
 // On Mac, you can build this like so:
-// xcrun clang++ -o ConditionSpeedTest Source/WTF/benchmarks/ConditionSpeedTest.cpp -O3 -W -ISource/WTF -ISource/WTF/icu -LWebKitBuild/Release -lWTF -framework Foundation -licucore -std=c++14 -fvisibility=hidden
+// INTERNAL_SDK=$(xcrun --sdk macosx.internal --show-sdk-path) && \
+// xcrun clang++ -o ConditionSpeedTest Source/WTF/benchmarks/ConditionSpeedTest.cpp \
+//     -W -ISource/WTF -ISource/WTF/icu \
+//     -I"$INTERNAL_SDK/usr/local/include" -IWebKitBuild/Release/usr/local/include \
+//     -LWebKitBuild/Release -lWTF -lbmalloc \
+//     -framework Foundation -framework Security -licucore \
+//     -std=c++2b -fvisibility=hidden -DNDEBUG -O3 -arch arm64e
+//
+// For an OSS build (no internal SDK), drop the INTERNAL_SDK line and the
+// -I"$INTERNAL_SDK/usr/local/include" flag, and use -arch arm64 instead of arm64e.
 
 #include "config.h"
 

--- a/Source/WTF/benchmarks/LockFairnessTest.cpp
+++ b/Source/WTF/benchmarks/LockFairnessTest.cpp
@@ -24,7 +24,16 @@
  */
 
 // On Mac, you can build this like so:
-// xcrun clang++ -o LockFairnessTest Source/WTF/benchmarks/LockFairnessTest.cpp -O3 -W -ISource/WTF -ISource/WTF/icu -ISource/WTF/benchmarks -LWebKitBuild/Release -lWTF -framework Foundation -licucore -std=c++14 -fvisibility=hidden
+// INTERNAL_SDK=$(xcrun --sdk macosx.internal --show-sdk-path) && \
+// xcrun clang++ -o LockFairnessTest Source/WTF/benchmarks/LockFairnessTest.cpp \
+//     -W -ISource/WTF -ISource/WTF/icu -ISource/WTF/benchmarks \
+//     -I"$INTERNAL_SDK/usr/local/include" -IWebKitBuild/Release/usr/local/include \
+//     -LWebKitBuild/Release -lWTF -lbmalloc \
+//     -framework Foundation -framework Security -licucore \
+//     -std=c++2b -fvisibility=hidden -DNDEBUG -O3 -arch arm64e
+//
+// For an OSS build (no internal SDK), drop the INTERNAL_SDK line and the
+// -I"$INTERNAL_SDK/usr/local/include" flag, and use -arch arm64 instead of arm64e.
 
 #include "config.h"
 
@@ -61,8 +70,8 @@ struct Benchmark {
     static void run(const char* name)
     {
         LockType lock;
-        std::unique_ptr<unsigned[]> counts = makeUniqueWithoutFastMallocCheck<unsigned[]>(numThreads);
-        std::unique_ptr<RefPtr<Thread>[]> threads = makeUniqueWithoutFastMallocCheck<RefPtr<Thread>[]>(numThreads);
+        Vector<unsigned> counts(numThreads);
+        Vector<RefPtr<Thread>> threads(numThreads);
     
         std::atomic<bool> keepGoing = true;
     

--- a/Source/WTF/benchmarks/LockSpeedTest.cpp
+++ b/Source/WTF/benchmarks/LockSpeedTest.cpp
@@ -24,7 +24,16 @@
  */
 
 // On Mac, you can build this like so:
-// xcrun clang++ -o LockSpeedTest Source/WTF/benchmarks/LockSpeedTest.cpp -O3 -W -ISource/WTF -ISource/WTF/icu -ISource/WTF/benchmarks -LWebKitBuild/Release -lWTF -framework Foundation -licucore -std=c++14 -fvisibility=hidden
+// INTERNAL_SDK=$(xcrun --sdk macosx.internal --show-sdk-path) && \
+// xcrun clang++ -o LockSpeedTest Source/WTF/benchmarks/LockSpeedTest.cpp \
+//     -W -ISource/WTF -ISource/WTF/icu -ISource/WTF/benchmarks \
+//     -I"$INTERNAL_SDK/usr/local/include" -IWebKitBuild/Release/usr/local/include \
+//     -LWebKitBuild/Release -lWTF -lbmalloc \
+//     -framework Foundation -framework Security -licucore \
+//     -std=c++2b -fvisibility=hidden -DNDEBUG -O3 -arch arm64e
+//
+// For an OSS build (no internal SDK), drop the INTERNAL_SDK line and the
+// -I"$INTERNAL_SDK/usr/local/include" flag, and use -arch arm64 instead of arm64e.
 
 #include "config.h"
 
@@ -74,9 +83,9 @@ struct Benchmark {
     template<typename LockType>
     static void run(const char* name)
     {
-        std::unique_ptr<WithPadding<LockType>[]> locks = makeUniqueWithoutFastMallocCheck<WithPadding<LockType>[]>(numThreadGroups);
-        std::unique_ptr<WithPadding<double>[]> words = makeUniqueWithoutFastMallocCheck<WithPadding<double>[]>(numThreadGroups);
-        std::unique_ptr<RefPtr<Thread>[]> threads = makeUniqueWithoutFastMallocCheck<RefPtr<Thread>[]>(numThreadGroups * numThreadsPerGroup);
+        Vector<WithPadding<LockType>> locks(numThreadGroups);
+        Vector<WithPadding<double>> words(numThreadGroups);
+        Vector<RefPtr<Thread>> threads(numThreadGroups * numThreadsPerGroup);
 
         std::atomic<bool> keepGoing = true;
 

--- a/Source/WTF/benchmarks/ToyLocks.h
+++ b/Source/WTF/benchmarks/ToyLocks.h
@@ -85,8 +85,13 @@ public:
 
     void lock()
     {
-        while (!m_lock.compareExchangeWeak(0, 1, std::memory_order_acquire))
+        while (!m_lock.compareExchangeWeak(0, 1, std::memory_order_acquire)) {
+#if CPU(X86_64)
             asm volatile ("pause");
+#elif CPU(ARM64)
+            asm volatile ("isb sy");
+#endif
+        }
     }
 
     void unlock()


### PR DESCRIPTION
#### b15055c7b0ed8b2e06e16eaeca89dee6dbbb75eb
<pre>
Update/Fix Lock/Condition Performance Test Binaries
<a href="https://bugs.webkit.org/show_bug.cgi?id=315171">https://bugs.webkit.org/show_bug.cgi?id=315171</a>
<a href="https://rdar.apple.com/177508888">rdar://177508888</a>

Reviewed by Yusuke Suzuki.

Update the build instructions. Fix build issues with using C arrays by
switching to a WTF::Vector.

Canonical link: <a href="https://commits.webkit.org/313561@main">https://commits.webkit.org/313561@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6bc91cd4094db03b37294b9ce92777e25b3ab6b2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163481 "1 style error") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/36964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/30180 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/172421 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/119928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/37293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/36964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/172421 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/119928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166440 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/37293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/146961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/172421 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/37293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/36964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20123 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/20/builds/155635 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/37293 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/24684 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174925 "Built successfully") | | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/24375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/27859 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/26341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135268 "Build is in progress. Recent messages:") | | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/36634 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/36964 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/135254 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37419 "Failed to checkout and rebase branch from PR 65268") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/146479 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99425 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24884 "Built successfully and passed tests") | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/37419 "Failed to checkout and rebase branch from PR 65268") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/23324 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195883 "Built successfully") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/36130 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109247 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/51062 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/35627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/1351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/35875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/35775 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | | 
<!--EWS-Status-Bubble-End-->