### PR TITLE
[JSC] Introduce private tmp mechanism to DFG ByteCodeParser

### DIFF
--- a/JSTests/stress/array-sort-inline-nested-in-comparator.js
+++ b/JSTests/stress/array-sort-inline-nested-in-comparator.js
@@ -1,0 +1,42 @@
+//@ requireOptions("--useConcurrentJIT=0")
+//
+// Nested sort: the inlined comparator itself calls Array.prototype.sort, so the
+// inner handleArraySort's private cross-block tmps must not alias the outer's.
+
+function makeIntArr(n) {
+    let a = [];
+    for (let i = 0; i < n; i++)
+        a.push((n - i) | 0);
+    return a;
+}
+
+let neighbours = [];
+for (let i = 0; i < 4096; i++)
+    neighbours.push(makeIntArr(3));
+let inner = makeIntArr(3);
+for (let i = 0; i < 4096; i++)
+    neighbours.push(makeIntArr(3));
+
+function innerCmp(a, b) { return 0; }
+
+function outerCmp(a, b) {
+    (a instanceof Object); // forces a checkpoint in outerCmp.
+    inner.sort(innerCmp);
+    return false;
+}
+
+function test(arr) { return arr.sort(outerCmp); }
+noInline(test);
+
+for (let i = 0; i < testLoopCount; i++)
+    test(makeIntArr(5));
+
+for (let i = 0; i < neighbours.length; i++) {
+    if (neighbours[i].length !== 3)
+        throw new Error("neighbour " + i + " corrupted: length = " + neighbours[i].length);
+}
+gc();
+
+let result = test(makeIntArr(5));
+if (result.length !== 5)
+    throw new Error("outer result corrupted: " + JSON.stringify(result));

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -176,6 +176,18 @@ private:
             m_graph.block(i)->ensureTmps(newNumTmps);
     }
 
+    struct PrivateTmpRange {
+        unsigned base { 0 };
+        unsigned count { 0 };
+        Operand operandAt(unsigned i) const
+        {
+            ASSERT_UNUSED(count, i < count);
+            return Operand::tmp(base + i);
+        }
+    };
+
+    static unsigned tmpOffsetForInlineeOf(InlineStackEntry* caller);
+    PrivateTmpRange allocatePrivateTmps(unsigned slotCount);
 
     // Helper for min and max.
     template<typename ChecksFunctor>
@@ -1309,6 +1321,8 @@ private:
         BasicBlock* m_continuationBlock;
         BasicBlock* m_entryBlockForRecursiveTailCall { nullptr };
 
+        unsigned m_numPrivateTmps { 0 };
+
         Operand m_returnValue;
         
         // Speculations about variable types collected from the profiled code block,
@@ -1826,7 +1840,7 @@ void ByteCodeParser::inlineCall(Node* callTargetNode, Operand result, CallVarian
         inlineCallFrameStart.toLocal() + 1 +
         CallFrame::headerSizeInRegisters + codeBlock->numCalleeLocals());
     
-    ensureTmps((m_inlineStackTop->m_inlineCallFrame ? m_inlineStackTop->m_inlineCallFrame->tmpOffset : 0) + m_inlineStackTop->m_codeBlock->numTmps() + codeBlock->numTmps());
+    ensureTmps(tmpOffsetForInlineeOf(m_inlineStackTop) + codeBlock->numTmps());
 
     size_t argumentPositionStart = m_graph.m_argumentPositions.size();
 
@@ -10586,6 +10600,24 @@ void ByteCodeParser::linkBlocks(Vector<BasicBlock*>& unlinkedBlocks, Vector<Basi
     }
 }
 
+unsigned ByteCodeParser::tmpOffsetForInlineeOf(InlineStackEntry* caller)
+{
+    unsigned callerOffset = caller->m_inlineCallFrame ? caller->m_inlineCallFrame->tmpOffset : 0;
+    return callerOffset + caller->m_codeBlock->numTmps() + caller->m_numPrivateTmps;
+}
+
+auto ByteCodeParser::allocatePrivateTmps(unsigned slotCount) -> PrivateTmpRange
+{
+    InlineStackEntry* top = m_inlineStackTop;
+    unsigned currentTmpOffset = top->m_inlineCallFrame ? top->m_inlineCallFrame->tmpOffset : 0;
+    unsigned relativeBase = top->m_codeBlock->numTmps() + top->m_numPrivateTmps;
+
+    ensureTmps(currentTmpOffset + relativeBase + slotCount);
+    top->m_numPrivateTmps += slotCount;
+
+    return { relativeBase, slotCount };
+}
+
 ByteCodeParser::InlineStackEntry::InlineStackEntry(
     ByteCodeParser* byteCodeParser,
     CodeBlock* codeBlock,
@@ -10638,7 +10670,7 @@ ByteCodeParser::InlineStackEntry::InlineStackEntry(
         // The owner is the machine code block, and we already have a barrier on that when the
         // plan finishes.
         m_inlineCallFrame->baselineCodeBlock.setWithoutWriteBarrier(codeBlock->baselineVersion());
-        m_inlineCallFrame->setTmpOffset((m_caller->m_inlineCallFrame ? m_caller->m_inlineCallFrame->tmpOffset : 0) + m_caller->m_codeBlock->numTmps());
+        m_inlineCallFrame->setTmpOffset(tmpOffsetForInlineeOf(m_caller));
         m_inlineCallFrame->setStackOffset(inlineCallFrameStart.offset() - CallFrame::headerSizeInRegisters);
         m_inlineCallFrame->argumentCountIncludingThis = argumentCountIncludingThis;
         RELEASE_ASSERT(m_inlineCallFrame->argumentCountIncludingThis == argumentCountIncludingThis);
@@ -11837,31 +11869,21 @@ auto ByteCodeParser::handleArraySort(Node* callee, Operand resultOperand, CallVa
     // local to the block where the GetArrayLength lives, avoiding a CPS validation
     // failure from cross-block ordering of the inserted Check vs. its producer.
 
-    // Allocate fresh tmps for cross-block flow. `tmpLength` caches the array length once
-    // (fetched just before entering the outer loop) so the sort loop doesn't re-fetch
-    // butterfly+length every iteration, and so Commit can check length stability against
-    // the original pre-sort length.
-    //
-    // tmpBase is *relative* to the current inline frame: set()/get() remap through
-    // tmpOffset, while ensureTmps() is keyed off the absolute m_numTmps. We place our tmps
-    // at `current_frame_numTmps + maxNumCheckpointTmps` in relative coordinates so they
-    // sit above any inlined comparator's checkpoint tmps (whose inline-call-frame claims
-    // the slot range [tmpOffset + caller_numTmps, tmpOffset + caller_numTmps + callee_numTmps),
-    // where callee_numTmps <= maxNumCheckpointTmps). Then we ensureTmps() to the absolute
-    // upper bound so the parser's bounds check (operand.value() >= m_numTmps) accepts the
-    // remapped indices.
-    unsigned tmpBase = m_inlineStackTop->m_codeBlock->numTmps() + maxNumCheckpointTmps;
-    unsigned currentTmpOffset = m_inlineStackTop->m_inlineCallFrame ? m_inlineStackTop->m_inlineCallFrame->tmpOffset : 0;
-    ensureTmps(currentTmpOffset + tmpBase + 9);
-    Operand tmpI = Operand::tmp(tmpBase + 0);
-    Operand tmpJ = Operand::tmp(tmpBase + 1);
-    Operand tmpPivot = Operand::tmp(tmpBase + 2);
-    Operand tmpArray = Operand::tmp(tmpBase + 3);
-    Operand tmpCallee = Operand::tmp(tmpBase + 4);
-    Operand tmpComparator = Operand::tmp(tmpBase + 5);
-    Operand tmpCmpResult = Operand::tmp(tmpBase + 6);
-    Operand tmpScratch = Operand::tmp(tmpBase + 7);
-    Operand tmpLength = Operand::tmp(tmpBase + 8);
+    // Cross-block tmps. tmpLength caches the original length so Commit can detect
+    // mutation. The slots must not alias the inlined comparator's tmps -- if the
+    // comparator itself contains a sort that satisfies ArraySortIntrinsic, its
+    // private range would otherwise overlap ours and corrupt the JSArray cell.
+    constexpr unsigned numArraySortTmps = 9;
+    auto sortTmps = allocatePrivateTmps(numArraySortTmps);
+    Operand tmpI = sortTmps.operandAt(0);
+    Operand tmpJ = sortTmps.operandAt(1);
+    Operand tmpPivot = sortTmps.operandAt(2);
+    Operand tmpArray = sortTmps.operandAt(3);
+    Operand tmpCallee = sortTmps.operandAt(4);
+    Operand tmpComparator = sortTmps.operandAt(5);
+    Operand tmpCmpResult = sortTmps.operandAt(6);
+    Operand tmpScratch = sortTmps.operandAt(7);
+    Operand tmpLength = sortTmps.operandAt(8);
 
     // Stash cross-block values into tmps before the Branch so successor blocks see
     // them via phi merges. Explicitly flush each tmp after the set: Flush changes


### PR DESCRIPTION
#### c415e39f485baa2a4bb6ac94458b8516d2213947
<pre>
[JSC] Introduce private tmp mechanism to DFG ByteCodeParser
<a href="https://bugs.webkit.org/show_bug.cgi?id=315173">https://bugs.webkit.org/show_bug.cgi?id=315173</a>
<a href="https://rdar.apple.com/177056483">rdar://177056483</a>

Reviewed by Yijia Huang.

Sort inlining introduces new fancy opportunities to DFG: we start having
DFG private tmps and do programming in DFG. Previously all tmp comes
from CodeBlock, but now DFG can create a new tmp for its internal programming.
However current DFG ByteCodeParser is not tracking these tmps correctly,
so inlined frame will incorrectly use the assigned tmps as we are only
counting CodeBlock&apos;s tmps. This patch adds m_numPrivateTmps to each
InlineStackEntry so that we can allocate private tmps in each inlined
frame and we can track them correctly. Also adding simple allocator mechanism,
allocatePrivateTmps, to make use of them easier.

Test: JSTests/stress/array-sort-inline-nested-in-comparator.js

* JSTests/stress/array-sort-inline-nested-in-comparator.js: Added.
(makeIntArr):
(innerCmp):
(outerCmp):
(test):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::PrivateTmpRange::operandAt const):
(JSC::DFG::ByteCodeParser::inlineCall):
(JSC::DFG::ByteCodeParser::tmpOffsetForInlineeOf):
(JSC::DFG::ByteCodeParser::allocatePrivateTmps):
(JSC::DFG::ByteCodeParser::InlineStackEntry::InlineStackEntry):
(JSC::DFG::ByteCodeParser::handleArraySort):

Canonical link: <a href="https://commits.webkit.org/313590@main">https://commits.webkit.org/313590@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8b097d5f117b142177a0e15d52fe75b64f3d307a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163487 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36970 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30190 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172427 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119936 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37299 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36970 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126973 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89503 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/735e6a2e-caf1-47e2-9960-002643ada4b4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166446 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29240 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146975 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107527 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28289 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26922 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20129 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/155638 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138186 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24694 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174931 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/24378 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27863 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26356 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135278 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36640 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31024 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135260 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37425 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146489 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99435 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24896 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30563 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23339 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195889 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36136 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109282 "Built successfully") | [❌ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51065 "Found 1 new JSC stress test failure: stress/regexp-dot-star-enclosure-contains-capturing-terms-out-of-stack.js.bytecode-cache (failure)") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35635 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1364 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35884 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35781 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->