### PR TITLE
Non-unified build fixes for May 20th, 2026

### DIFF
--- a/Source/WebCore/css/CSSScrollValue.h
+++ b/Source/WebCore/css/CSSScrollValue.h
@@ -30,6 +30,7 @@
 
 #include "CSSPrimitiveValue.h"
 #include "RenderStyleConstants.h"
+#include <wtf/Function.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/css/CSSShorthandSubstitutionValue.h
+++ b/Source/WebCore/css/CSSShorthandSubstitutionValue.h
@@ -32,6 +32,7 @@
 #include "CSSProperty.h"
 #include "CSSSubstitutionValue.h"
 #include "CSSValue.h"
+#include <wtf/Function.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/css/parser/SizesAttributeParser.cpp
+++ b/Source/WebCore/css/parser/SizesAttributeParser.cpp
@@ -34,6 +34,7 @@
 #include "CSSCalcTree+Evaluation.h"
 #include "CSSCalcTree+Parser.h"
 #include "CSSCalcTree+Simplification.h"
+#include "CSSCalcTree.h"
 #include "CSSParserTokenRange.h"
 #include "CSSPrimitiveNumericCategory.h"
 #include "CSSPrimitiveNumericRange.h"

--- a/Source/WebCore/rendering/RenderImageResource.cpp
+++ b/Source/WebCore/rendering/RenderImageResource.cpp
@@ -31,6 +31,7 @@
 #include "CachedImage.h"
 #include "NullGraphicsContext.h"
 #include "RenderElement.h"
+#include "RenderObjectDocument.h"
 #include "RenderStyle+GettersInlines.h"
 #include "StyleCachedImage.h"
 #include "StyleInvalidImage.h"

--- a/Source/WebCore/style/values/animations/StyleSingleAnimationRange.cpp
+++ b/Source/WebCore/style/values/animations/StyleSingleAnimationRange.cpp
@@ -29,6 +29,7 @@
 #include "CSSKeywordValue.h"
 #include "CSSNumericFactory.h"
 #include "StyleBuilderChecking.h"
+#include "StyleCalculationValue.h"
 #include "StyleLengthWrapper+CSSValueConversion.h"
 #include "StyleLengthWrapper+DeprecatedCSSValueConversion.h"
 #include "StylePrimitiveNumericTypes+DeprecatedCSSValueConversion.h"

--- a/Source/WebCore/style/values/fill-stroke/StyleStrokeWidth.cpp
+++ b/Source/WebCore/style/values/fill-stroke/StyleStrokeWidth.cpp
@@ -28,6 +28,7 @@
 
 #include "CSSPrimitiveValue.h"
 #include "StyleBuilderChecking.h"
+#include "StyleCalculationValue.h"
 #include "StyleLengthWrapper+CSSValueConversion.h"
 #include "StylePrimitiveNumericTypes+CSSValueConversion.h"
 

--- a/Source/WebCore/style/values/flexbox/StyleFlexBasis.cpp
+++ b/Source/WebCore/style/values/flexbox/StyleFlexBasis.cpp
@@ -25,6 +25,7 @@
 #include "config.h"
 #include "StyleFlexBasis.h"
 
+#include "StyleCalculationValue.h"
 #include "StylePreferredSize.h"
 
 namespace WebCore {

--- a/Source/WebCore/style/values/images/kinds/StyleGradientImage.cpp
+++ b/Source/WebCore/style/values/images/kinds/StyleGradientImage.cpp
@@ -34,6 +34,7 @@
 #include "NodeRenderStyle.h"
 #include "RenderElement.h"
 #include "RenderStyle+GettersInlines.h"
+#include "StyleCalculationValue.h"
 #include "StylePrimitiveNumericTypes+Conversions.h"
 
 namespace WebCore {

--- a/Source/WebCore/style/values/non-standard/StyleWebKitBoxReflect.cpp
+++ b/Source/WebCore/style/values/non-standard/StyleWebKitBoxReflect.cpp
@@ -29,6 +29,7 @@
 #include "CSSKeywordValue.h"
 #include "CSSReflectValue.h"
 #include "StyleBuilderChecking.h"
+#include "StyleCalculationValue.h"
 #include "StyleKeyword+Serialization.h"
 #include "StyleLengthWrapper+CSSValueConversion.h"
 #include "StylePrimitiveNumericTypes+CSSValueConversion.h"

--- a/Source/WebCore/style/values/scroll-animations/StyleViewTimelineInsetItem.cpp
+++ b/Source/WebCore/style/values/scroll-animations/StyleViewTimelineInsetItem.cpp
@@ -27,6 +27,7 @@
 
 #include "CSSValuePair.h"
 #include "StyleBuilderChecking.h"
+#include "StyleCalculationValue.h"
 #include "StyleLengthWrapper+CSSValueConversion.h"
 #include <wtf/NeverDestroyed.h>
 

--- a/Source/WebCore/style/values/sizing/StylePreferredSize.cpp
+++ b/Source/WebCore/style/values/sizing/StylePreferredSize.cpp
@@ -25,6 +25,7 @@
 #include "config.h"
 #include "StylePreferredSize.h"
 
+#include "StyleCalculationValue.h"
 #include "StyleFlexBasis.h"
 #include "StyleMinimumSize.h"
 

--- a/Source/WebCore/style/values/svg/StyleSVGStrokeDashoffset.cpp
+++ b/Source/WebCore/style/values/svg/StyleSVGStrokeDashoffset.cpp
@@ -27,6 +27,7 @@
 
 #include "CSSPrimitiveValue.h"
 #include "StyleBuilderChecking.h"
+#include "StyleCalculationValue.h"
 #include "StyleLengthWrapper+CSSValueConversion.h"
 #include "StylePrimitiveNumericTypes+CSSValueConversion.h"
 

--- a/Source/WebCore/style/values/text/StyleLetterSpacing.cpp
+++ b/Source/WebCore/style/values/text/StyleLetterSpacing.cpp
@@ -25,6 +25,7 @@
 #include "config.h"
 #include "StyleLetterSpacing.h"
 
+#include "StyleCalculationValue.h"
 #include "StyleLengthWrapper+CSSValueConversion.h"
 
 namespace WebCore {

--- a/Source/WebCore/style/values/text/StyleWordSpacing.cpp
+++ b/Source/WebCore/style/values/text/StyleWordSpacing.cpp
@@ -25,6 +25,7 @@
 #include "config.h"
 #include "StyleWordSpacing.h"
 
+#include "StyleCalculationValue.h"
 #include "StyleLengthWrapper+CSSValueConversion.h"
 
 namespace WebCore {


### PR DESCRIPTION
#### 192e1ec2ea917b7053448e66b0e5392805cae0bb
<pre>
Non-unified build fixes for May 20th, 2026
<a href="https://bugs.webkit.org/show_bug.cgi?id=315176">https://bugs.webkit.org/show_bug.cgi?id=315176</a>

Unreviewed build fix.

* Source/WebCore/css/CSSScrollValue.h:
* Source/WebCore/css/CSSShorthandSubstitutionValue.h:
* Source/WebCore/css/parser/SizesAttributeParser.cpp:
* Source/WebCore/rendering/RenderImageResource.cpp:
* Source/WebCore/style/values/animations/StyleSingleAnimationRange.cpp:
* Source/WebCore/style/values/fill-stroke/StyleStrokeWidth.cpp:
* Source/WebCore/style/values/flexbox/StyleFlexBasis.cpp:
* Source/WebCore/style/values/images/kinds/StyleGradientImage.cpp:
* Source/WebCore/style/values/non-standard/StyleWebKitBoxReflect.cpp:
* Source/WebCore/style/values/scroll-animations/StyleViewTimelineInsetItem.cpp:
* Source/WebCore/style/values/sizing/StylePreferredSize.cpp:
* Source/WebCore/style/values/svg/StyleSVGStrokeDashoffset.cpp:
* Source/WebCore/style/values/text/StyleLetterSpacing.cpp:
* Source/WebCore/style/values/text/StyleWordSpacing.cpp:

Canonical link: <a href="https://commits.webkit.org/313565@main">https://commits.webkit.org/313565@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5613cc642747f2b70e98a198b5bfd43fc1d67d00

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163490 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36974 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/30193 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172430 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119939 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165359 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37305 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36973 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/126976 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89505 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166449 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29245 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146978 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107530 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26925 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20133 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/138191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24697 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174935 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27866 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26359 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/135281 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36643 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31027 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135263 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37429 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146492 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99437 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24887 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30565 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/23342 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36139 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109285 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35637 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1367 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35887 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35784 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->