### PR TITLE
[GTK][WPE][Tools] container-sdk-autoenter doesn't forward DBUS_SESSION_BUS_ADDRESS when that includes a ,guid string

### DIFF
--- a/Tools/Scripts/webkitpy/port/linux_container_sdk_utils.py
+++ b/Tools/Scripts/webkitpy/port/linux_container_sdk_utils.py
@@ -126,11 +126,14 @@ def _strip_unix_path_prefix(value):
     if not value:
         return ''
     value = value.strip()
-    prefix = 'unix:path='
-    if value.startswith(prefix):
-        value = value[len(prefix):]
+    # D-Bus address: unix:path=/path,key=val,...
+    if value.startswith('unix:path='):
+        value = value[len('unix:path='):]
+        return value.split(',', 1)[0]
+    # PulseAudio: unix:/path
+    if value.startswith('unix:'):
+        return value[len('unix:'):]
     return value
-
 
 def _translate_host_path_to_container(host_path):
     # The wkdev container bind-mounts the host ${HOME} at /host/home/${USER}.

--- a/Tools/Scripts/webkitpy/port/linux_container_sdk_utils_unittest.py
+++ b/Tools/Scripts/webkitpy/port/linux_container_sdk_utils_unittest.py
@@ -1,0 +1,60 @@
+# Copyright (C) 2026 Igalia S.L.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are
+# met:
+#
+#    * Redistributions of source code must retain the above copyright
+# notice, this list of conditions and the following disclaimer.
+#    * Redistributions in binary form must reproduce the above
+# copyright notice, this list of conditions and the following disclaimer
+# in the documentation and/or other materials provided with the
+# distribution.
+#    * Neither the name of the copyright holder nor the names of its
+# contributors may be used to endorse or promote products derived from
+# this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+# A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+# OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+# SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+# LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+# DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+# THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import os
+import sys
+import unittest
+
+from webkitpy.port.linux_container_sdk_utils import _strip_unix_path_prefix
+
+
+class ContainerSDKHelpersTest(unittest.TestCase):
+
+    def test_dbus_standard_path(self):
+        path = "/run/user/1000/bus"
+        DBUS_SESSION_BUS_ADDRESS = f"unix:path={path}"
+        path_resolved = _strip_unix_path_prefix(DBUS_SESSION_BUS_ADDRESS)
+        self.assertEqual(path, path_resolved)
+
+    def test_dbus_autolaunch_path(self):
+        path = "/tmp/dbus-OxJnk3YDFt"
+        DBUS_SESSION_BUS_ADDRESS = f"unix:path={path},guid=cd2293c3498d62c28d9e98816a0d8b27"
+        path_resolved = _strip_unix_path_prefix(DBUS_SESSION_BUS_ADDRESS)
+        self.assertEqual(path, path_resolved)
+
+    def test_pulse_server_path(self):
+        path = "/run/user/1000/pulse/native"
+        PULSE_SERVER = f"unix:{path}"
+        path_resolved = _strip_unix_path_prefix(PULSE_SERVER)
+        self.assertEqual(path, path_resolved)
+
+    def test_at_spi_bus_path(self):
+        path = "/run/user/1000/at-spi/bus"
+        AT_SPI_BUS_ADDRESS = f"unix:path={path},guid=b6602b80724b3d489a0e9c9c6a0d8b2d"
+        path_resolved = _strip_unix_path_prefix(AT_SPI_BUS_ADDRESS)
+        self.assertEqual(path, path_resolved)


### PR DESCRIPTION
#### 703a0299474b6ec7303fcd26870af6201d3529e8
<pre>
[GTK][WPE][Tools] container-sdk-autoenter doesn&apos;t forward DBUS_SESSION_BUS_ADDRESS when that includes a ,guid string
<a href="https://bugs.webkit.org/show_bug.cgi?id=315178">https://bugs.webkit.org/show_bug.cgi?id=315178</a>

Reviewed by Nikolas Zimmermann.

On the bots the value of DBUS_SESSION_BUS_ADDRESS includes a &quot;,guid&quot; suffix because
it is obtained via dbus-launch.

The current function to obtain the path from the value was not handling that case.
Fix it and also add some unit tests.

* Tools/Scripts/webkitpy/port/linux_container_sdk_utils.py:
(_strip_unix_path_prefix):
* Tools/Scripts/webkitpy/port/linux_container_sdk_utils_unittest.py: Added.
(ContainerSDKHelpersTest):
(ContainerSDKHelpersTest.test_dbus_standard_path):
(ContainerSDKHelpersTest.test_dbus_autolaunch_path):
(ContainerSDKHelpersTest.test_pulse_server_path):
(ContainerSDKHelpersTest.test_at_spi_bus_path):

Canonical link: <a href="https://commits.webkit.org/313569@main">https://commits.webkit.org/313569@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/048ad5b2d57a839e448ccfec9b7f1130a0239fda

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163494 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36978 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30197 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172434 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119943 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165363 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37309 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36977 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126980 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89509 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166453 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29247 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146980 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107534 "Passed tests") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/162815 "Found 1 webkitpy test failure: webkitpy.scripts.measure_build_time_unittest.MeasureBuildTimeTest.test_clean_and_null_build") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26928 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20137 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/138193 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24699 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174939 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26361 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/135284 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36647 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31030 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135266 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37433 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146494 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99441 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24890 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30570 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23344 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36143 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35641 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1369 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35891 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35788 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->