### PR TITLE
[GStreamer][EME] Improve decryption no-key errors handling

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -2135,6 +2135,10 @@ void MediaPlayerPrivateGStreamer::handleMessage(GstMessage* message)
             GST_WARNING_OBJECT(pipeline(), "Ignoring error: %s (url=%s) (code=%d)", err->message, m_url.string().utf8().data(), err->code);
             break;
         }
+        if (g_error_matches(err.get(), GST_STREAM_ERROR, GST_STREAM_ERROR_DECRYPT_NOKEY)) {
+            GST_DEBUG_OBJECT(pipeline(), "Ignoring decryption no-key error, the MediaKeySession will emit an updated keystatuses event");
+            break;
+        }
 
         GST_ERROR_OBJECT(pipeline(), "%s (url=%s) (code=%d)", err->message, m_url.string().utf8().data(), err->code);
 
@@ -2146,7 +2150,6 @@ void MediaPlayerPrivateGStreamer::handleMessage(GstMessage* message)
         error = MediaPlayer::NetworkState::Empty;
         if (g_error_matches(err.get(), GST_STREAM_ERROR, GST_STREAM_ERROR_CODEC_NOT_FOUND)
             || g_error_matches(err.get(), GST_STREAM_ERROR, GST_STREAM_ERROR_DECRYPT)
-            || g_error_matches(err.get(), GST_STREAM_ERROR, GST_STREAM_ERROR_DECRYPT_NOKEY)
             || g_error_matches(err.get(), GST_STREAM_ERROR, GST_STREAM_ERROR_WRONG_TYPE)
             || g_error_matches(err.get(), GST_STREAM_ERROR, GST_STREAM_ERROR_FAILED)
             || g_error_matches(err.get(), GST_CORE_ERROR, GST_CORE_ERROR_MISSING_PLUGIN)

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMProxyThunder.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMProxyThunder.cpp
@@ -28,6 +28,7 @@
 
 #include "config.h"
 #include "CDMProxyThunder.h"
+#include "GStreamerEMEUtilities.h"
 
 #if ENABLE(ENCRYPTED_MEDIA) && ENABLE(THUNDER)
 
@@ -80,12 +81,12 @@ BoxPtr<OpenCDMSession> CDMProxyThunder::getDecryptionSession(DecryptionContext& 
     return keyValue;
 }
 
-bool CDMProxyThunder::decrypt(CDMProxyThunder::DecryptionContext& input, const GRefPtr<GstCaps>& inputCaps)
+DecryptionResult CDMProxyThunder::decrypt(CDMProxyThunder::DecryptionContext& input, const GRefPtr<GstCaps>& inputCaps)
 {
     BoxPtr<OpenCDMSession> session = getDecryptionSession(input);
     if (!session) {
         GST_WARNING("there is no valid session to decrypt for the provided key ID (or the operation was aborted)");
-        return false;
+        return DecryptionResult::Failure;
     }
 
     OpenCDMError errorCode;
@@ -97,12 +98,22 @@ bool CDMProxyThunder::decrypt(CDMProxyThunder::DecryptionContext& input, const G
     errorCode = opencdm_gstreamer_session_decrypt(session->get(), input.dataBuffer, input.subsamplesBuffer, input.numSubsamples,
         input.ivBuffer, input.keyIDBuffer, 0);
 #endif
-    if (errorCode) {
-        GST_ERROR("decryption failed, error code %X", errorCode);
-        return false;
-    }
 
-    return true;
+    DecryptionResult result;
+    switch (errorCode) {
+    case ERROR_NONE:
+        result = DecryptionResult::Success;
+        break;
+    case ERROR_INVALID_ACCESSOR:
+        GST_ERROR("Decryption failed, converting ERROR_INVALID_ACCESSOR to NoKey error");
+        result = DecryptionResult::NoKey;
+        break;
+    default:
+        GST_ERROR("Decryption failed, error code 0x%X", errorCode);
+        result = DecryptionResult::Failure;
+        break;
+    };
+    return result;
 }
 
 #undef GST_CAT_DEFAULT

--- a/Source/WebCore/platform/graphics/gstreamer/eme/CDMProxyThunder.h
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/CDMProxyThunder.h
@@ -55,7 +55,7 @@ public:
         WeakPtr<CDMProxyDecryptionClient> cdmProxyDecryptionClient;
     };
 
-    bool decrypt(DecryptionContext&, const GRefPtr<GstCaps>& inputCaps);
+    DecryptionResult decrypt(DecryptionContext&, const GRefPtr<GstCaps>& inputCaps);
     const String& keySystem() LIFETIME_BOUND { return m_keySystem; }
 
 private:

--- a/Source/WebCore/platform/graphics/gstreamer/eme/GStreamerEMEUtilities.h
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/GStreamerEMEUtilities.h
@@ -34,6 +34,12 @@
 
 GST_DEBUG_CATEGORY_EXTERN(webkit_media_common_encryption_decrypt_debug_category);
 
+enum DecryptionResult {
+    Success,
+    Failure,
+    NoKey
+};
+
 namespace WebCore {
 class InitData {
 public:

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp
@@ -360,13 +360,13 @@ static GstFlowReturn transformInPlace(GstBaseTransform* base, GstBuffer* buffer)
 
     GST_TRACE_OBJECT(self, "decrypting");
 
-    bool didDecryptionSucceed;
+    DecryptionResult result;
 
     // Temporarily release the lock while we don't need to access priv. The lower level API is used
     // in order to avoid creating several scopes with different Locker instances in each one.
     {
         DropLockForScope noLockScope { locker };
-        didDecryptionSucceed = klass->decrypt(self, ivBuffer, keyIDBuffer, buffer, subSampleCount, subSamplesBuffer);
+        result = klass->decrypt(self, ivBuffer, keyIDBuffer, buffer, subSampleCount, subSamplesBuffer);
     }
 
     // Accessing priv members again.
@@ -375,12 +375,20 @@ static GstFlowReturn transformInPlace(GstBaseTransform* base, GstBuffer* buffer)
         return GST_FLOW_FLUSHING;
     }
 
-    if (!didDecryptionSucceed) {
-        GST_ELEMENT_ERROR(self, STREAM, DECRYPT, ("Decryption failed"), (nullptr));
-        return GST_FLOW_NOT_SUPPORTED;
-    }
-
-    return GST_FLOW_OK;
+    GstFlowReturn flowReturn;
+    switch (result) {
+    case DecryptionResult::Success:
+        flowReturn = GST_FLOW_OK;
+        break;
+    case DecryptionResult::Failure:
+        flowReturn = GST_FLOW_NOT_SUPPORTED;
+        break;
+    case DecryptionResult::NoKey:
+        GST_ELEMENT_ERROR(GST_ELEMENT_CAST(self), STREAM, DECRYPT_NOKEY, ("No key found, decryption failed"), (nullptr));
+        flowReturn = GST_FLOW_CUSTOM_ERROR;
+        break;
+    };
+    return flowReturn;
 }
 
 static bool isCDMProxyAvailable(WebKitMediaCommonEncryptionDecrypt* self)

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.h
@@ -24,7 +24,9 @@
 
 #if ENABLE(ENCRYPTED_MEDIA) && USE(GSTREAMER)
 
-#include <CDMProxy.h>
+#include "CDMProxy.h"
+#include "GStreamerEMEUtilities.h"
+
 #include <gst/base/gstbasetransform.h>
 #include <gst/gst.h>
 #include <wtf/RefPtr.h>
@@ -59,7 +61,7 @@ struct _WebKitMediaCommonEncryptionDecryptClass {
 
     ASCIILiteral (*protectionSystemId)(WebKitMediaCommonEncryptionDecrypt*);
     bool (*cdmProxyAttached)(WebKitMediaCommonEncryptionDecrypt*, const RefPtr<WebCore::CDMProxy>&);
-    bool (*decrypt)(WebKitMediaCommonEncryptionDecrypt*, GstBuffer* ivBuffer, GstBuffer* keyIDBuffer, GstBuffer* buffer, unsigned subsamplesCount, GstBuffer* subsamplesBuffer);
+    DecryptionResult (*decrypt)(WebKitMediaCommonEncryptionDecrypt*, GstBuffer* ivBuffer, GstBuffer* keyIDBuffer, GstBuffer* buffer, unsigned subsamplesCount, GstBuffer* subsamplesBuffer);
 };
 
 G_END_DECLS

--- a/Source/WebCore/platform/graphics/gstreamer/eme/WebKitThunderDecryptorGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/eme/WebKitThunderDecryptorGStreamer.cpp
@@ -21,6 +21,7 @@
 
 #include "config.h"
 #include "WebKitThunderDecryptorGStreamer.h"
+#include "WebKitCommonEncryptionDecryptorGStreamer.h"
 
 #if ENABLE(ENCRYPTED_MEDIA) && ENABLE(THUNDER) && USE(GSTREAMER)
 
@@ -38,7 +39,7 @@ struct WebKitMediaThunderDecryptPrivate {
 
 static ASCIILiteral protectionSystemId(WebKitMediaCommonEncryptionDecrypt*);
 static bool cdmProxyAttached(WebKitMediaCommonEncryptionDecrypt*, const RefPtr<CDMProxy>&);
-static bool decrypt(WebKitMediaCommonEncryptionDecrypt*, GstBuffer* iv, GstBuffer* keyid, GstBuffer* sample, unsigned subSamplesCount,
+static DecryptionResult decrypt(WebKitMediaCommonEncryptionDecrypt*, GstBuffer* iv, GstBuffer* keyid, GstBuffer* sample, unsigned subSamplesCount,
     GstBuffer* subSamples);
 
 GST_DEBUG_CATEGORY(webkitMediaThunderDecryptDebugCategory);
@@ -147,7 +148,7 @@ static bool cdmProxyAttached(WebKitMediaCommonEncryptionDecrypt* decryptor, cons
     return self->priv->cdmProxy;
 }
 
-static bool decrypt(WebKitMediaCommonEncryptionDecrypt* decryptor, GstBuffer* ivBuffer, GstBuffer* keyIDBuffer, GstBuffer* buffer, unsigned subsampleCount,
+static DecryptionResult decrypt(WebKitMediaCommonEncryptionDecrypt* decryptor, GstBuffer* ivBuffer, GstBuffer* keyIDBuffer, GstBuffer* buffer, unsigned subsampleCount,
     GstBuffer* subsamplesBuffer)
 {
     auto* self = WEBKIT_MEDIA_THUNDER_DECRYPT(decryptor);
@@ -156,13 +157,13 @@ static bool decrypt(WebKitMediaCommonEncryptionDecrypt* decryptor, GstBuffer* iv
     if (!ivBuffer || !keyIDBuffer || !buffer) {
         GST_ERROR_OBJECT(self, "invalid decrypt() parameter");
         ASSERT_NOT_REACHED();
-        return false;
+        return DecryptionResult::Failure;
     }
 
     if (subsampleCount && !subsamplesBuffer) {
         GST_ERROR_OBJECT(self, "invalid decrypt() subsamples parameter");
         ASSERT_NOT_REACHED();
-        return false;
+        return DecryptionResult::Failure;
     }
 
     CDMProxyThunder::DecryptionContext context = { };
@@ -172,9 +173,7 @@ static bool decrypt(WebKitMediaCommonEncryptionDecrypt* decryptor, GstBuffer* iv
     context.numSubsamples = subsampleCount;
     context.subsamplesBuffer = subsampleCount ? subsamplesBuffer : nullptr;
     context.cdmProxyDecryptionClient = webKitMediaCommonEncryptionDecryptGetCDMProxyDecryptionClient(decryptor);
-    bool result = priv->cdmProxy->decrypt(context, priv->inputCaps);
-
-    return result;
+    return priv->cdmProxy->decrypt(context, priv->inputCaps);
 }
 
 #undef GST_CAT_DEFAULT

--- a/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp
@@ -594,6 +594,7 @@ static void webKitMediaSrcLoop(void* userData)
         }
 
         GRefPtr<GstBuffer> buffer = gst_sample_get_buffer(sample.get());
+        auto isBufferEncrypted = areEncryptedCaps(gst_sample_get_caps(sample.get()));
         sample.clear();
 
         bool pushingFirstBuffer = !streamingMembers->hasPushedFirstBuffer;
@@ -614,7 +615,9 @@ static void webKitMediaSrcLoop(void* userData)
             GST_TRACE_OBJECT(pad, "Buffer not pushed because pad is not-linked, ignoring");
         } else if (result != GST_FLOW_OK && result != GST_FLOW_FLUSHING) {
             gst_pad_pause_task(pad);
-            GST_ELEMENT_ERROR(stream->source, CORE, PAD, ("Failed to push buffer"), ("gst_pad_push() returned %s", gst_flow_get_name(result)));
+            // Do not propagate NoKey decryption errors downstream, the decryptor should already have emitted an appropriate error message.
+            if (!isBufferEncrypted && result != GST_FLOW_CUSTOM_ERROR)
+                GST_ELEMENT_ERROR(stream->source, CORE, PAD, ("Failed to push buffer"), ("gst_pad_push() returned %s", gst_flow_get_name(result)));
         } else if (pushingFirstBuffer) {
             GST_DEBUG_OBJECT(pad, "First buffer on this pad was pushed (ret = %s).", gst_flow_get_name(result));
             dumpPipeline("first-frame-after"_s, stream);


### PR DESCRIPTION
#### 373ff82be279368d745a8944c0d81e399e412125
<pre>
[GStreamer][EME] Improve decryption no-key errors handling
<a href="https://bugs.webkit.org/show_bug.cgi?id=315181">https://bugs.webkit.org/show_bug.cgi?id=315181</a>

Reviewed by Xabier Rodriguez-Calvar.

In the case of Widevine the underlying platform CDM is signalling an expired license during
decryption using a NoKey error code and at the same time its internal key status update mechanism
will trigger a keyupdated callback in the upper layer (Thunder/OCDM). This triggers a racy behaviour
where the pipeline will receive an error message and Thunder will in parallel trigger a JS
keystatuses event to notify the web app.

The proposed solution is to introduce a new convention in OCDM implementations where a Widevine NoKey
error would be reported as ERROR_INVALID_ACCESSOR. Then in WebKit the decryptor can detect those and
emit a GStreamer DECRYPT_NOKEY error. In order to prevent double error reporting the MSE source
element also needs to handle this. In the player we can then ignore the DECRYPT_NOKEY error because
Thunder/OCDM will trigger a keystatuses event anyway.

Manually tested, we currently don&apos;t have any Widevine support in our layout test setup.

* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::handleMessage):
* Source/WebCore/platform/graphics/gstreamer/eme/CDMProxyThunder.cpp:
(WebCore::CDMProxyThunder::decrypt):
* Source/WebCore/platform/graphics/gstreamer/eme/CDMProxyThunder.h:
* Source/WebCore/platform/graphics/gstreamer/eme/GStreamerEMEUtilities.h:
* Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.cpp:
(transformInPlace):
* Source/WebCore/platform/graphics/gstreamer/eme/WebKitCommonEncryptionDecryptorGStreamer.h:
* Source/WebCore/platform/graphics/gstreamer/eme/WebKitThunderDecryptorGStreamer.cpp:
(decrypt):
* Source/WebCore/platform/graphics/gstreamer/mse/WebKitMediaSourceGStreamer.cpp:
(webKitMediaSrcLoop):

Canonical link: <a href="https://commits.webkit.org/313658@main">https://commits.webkit.org/313658@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1002fe5e1ccc5929bedc420978ed5ec3a3831850

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163754 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37238 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30457 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172776 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165623 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37569 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37237 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/127194 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121005 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166713 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29480 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147212 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107744 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28527 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/27155 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20547 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138426 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24929 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175301 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28130 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26597 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/135500 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36908 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31260 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135476 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36516 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37693 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146724 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99806 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30794 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23578 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36404 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109549 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35901 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1608 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36151 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36048 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->