### PR TITLE
[JSC] Collect profile from Baseline JIT compiler when LLInt -> Baseline

### DIFF
--- a/Source/JavaScriptCore/jit/BaselineJITPlan.cpp
+++ b/Source/JavaScriptCore/jit/BaselineJITPlan.cpp
@@ -41,6 +41,12 @@ BaselineJITPlan::BaselineJITPlan(CodeBlock* codeBlock)
 
 auto BaselineJITPlan::compileInThreadImpl(JITCompilationEffort effort) -> CompilationPath
 {
+    {
+        ConcurrentJSLocker locker(m_codeBlock->valueProfileLock());
+        m_codeBlock->updateAllNonLazyValueProfilePredictions(locker);
+        m_codeBlock->updateAllLazyValueProfilePredictions(locker);
+    }
+
     // BaselineJITPlan can keep underlying CodeBlock alive while running.
     // So we do not need to suspend this compilation thread while running GC.
     Safepoint::Result result;

--- a/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/llint/LLIntSlowPaths.cpp
@@ -375,12 +375,6 @@ static inline bool jitCompileAndSetHeuristics(VM& vm, CodeBlock* codeBlock)
 {
     DeferGCForAWhile deferGC(vm); // My callers don't set top callframe, so we don't want to GC here at all.
     ASSERT(Options::useJIT());
-    
-    {
-        ConcurrentJSLocker locker(codeBlock->valueProfileLock());
-        codeBlock->updateAllNonLazyValueProfilePredictions(locker);
-        codeBlock->updateAllLazyValueProfilePredictions(locker);
-    }
 
     if (codeBlock->jitType() != JITType::BaselineJIT) {
         if (RefPtr<BaselineJITCode> baselineRef = codeBlock->unlinkedCodeBlock()->m_unlinkedBaselineCode) {
@@ -396,7 +390,7 @@ static inline bool jitCompileAndSetHeuristics(VM& vm, CodeBlock* codeBlock)
         dataLogLnIf(Options::verboseOSR(), "    JIT threshold should be lifted.");
         return false;
     }
-    
+
     JITWorklist::State worklistState = JITWorklist::ensureGlobalWorklist().completeAllReadyPlansForVM(vm, JITCompilationKey(codeBlock->unlinkedCodeBlock(), JITCompilationMode::Baseline));
 
     if (codeBlock->jitType() == JITType::BaselineJIT) {


### PR DESCRIPTION
#### 227528432e5f6d0500a8fc5e68e4be7943ea9167
<pre>
[JSC] Collect profile from Baseline JIT compiler when LLInt -&gt; Baseline
<a href="https://bugs.webkit.org/show_bug.cgi?id=315183">https://bugs.webkit.org/show_bug.cgi?id=315183</a>
<a href="https://rdar.apple.com/problem/177517089">rdar://problem/177517089</a>

Reviewed by Marcus Plutowski.

How long time compiler takes is depending on tiers. And our Baseline -&gt;
DFG tierup is collecting profile based on the fact that we will see
several times of querying before going to DFG, and we have good chance
of collecting profiles without hurting performance. However while the
same policy is applied to LLInt -&gt; Baseline tierup, the characteristics
is largely different. Some Baseline JIT code generation takes very long
time due to its CodeBlock size but our query frequency is high because
in general Baseline compilation finishes quickly so we would like to
tier up quicly. As a result, when Baseline code is very large, we end up
scanning value profile very frequently and collecting meaningless
information with high performance penalty.

We anyway collect profile when tiering up from Baseline to DFG. So LLInt
one is very supplemental and not so critical to DFG compilation. Let&apos;s
just offload it to Baseline JIT compiler thread itself and do it once
only when building Baseline JIT code. Still Baseline code will collect
more profiles so it is fine to DFG. And we can avoid paying huge cost of
profiling when tiering up from LLInt to Baseline, in particular when
Baseline code is huge.

* Source/JavaScriptCore/jit/BaselineJITPlan.cpp:
(JSC::BaselineJITPlan::compileInThreadImpl):
* Source/JavaScriptCore/llint/LLIntSlowPaths.cpp:
(JSC::LLInt::jitCompileAndSetHeuristics):

Canonical link: <a href="https://commits.webkit.org/313583@main">https://commits.webkit.org/313583@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/01c862701c8a2310dbe2996057ccb0080927680e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163502 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36986 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30205 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172442 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119951 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b78dbc72-610f-44f9-8bf2-542c0ebfa9cb) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37317 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36985 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/126986 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89515 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4d3af15d-b14c-4505-ad31-5ef202722c4e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166461 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29256 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/146986 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107540 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/04d91cae-2f2e-490c-a189-10de87f412d3) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28305 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26936 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20145 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/155653 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138202 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24705 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174947 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/24393 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27878 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26367 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135291 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36655 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31038 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135273 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37441 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146500 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99465 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24894 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30577 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23350 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/195904 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36151 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109297 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51070 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35649 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1375 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35899 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35796 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->