### PR TITLE
[GTK][WPE][Tools] Improve bind mount of AT-SPI socket for container-sdk-autoenter

### DIFF
--- a/Tools/Scripts/webkitpy/port/linux_container_sdk_utils.py
+++ b/Tools/Scripts/webkitpy/port/linux_container_sdk_utils.py
@@ -21,6 +21,8 @@
 # SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #
 import os
+import stat
+import re
 import shutil
 import socket
 import subprocess
@@ -134,6 +136,42 @@ def _strip_unix_path_prefix(value):
     if value.startswith('unix:'):
         return value[len('unix:'):]
     return value
+
+
+def _get_at_spi_bus_socket_or_dir_and_var(xdg):
+    """Find the AT-SPI bus socket, or the directory containing it."""
+    def _socket_or_none(addr):
+        path = _strip_unix_path_prefix(addr or '')
+        try:
+            return path if path and stat.S_ISSOCK(os.stat(path).st_mode) else None
+        except OSError:
+            return None
+
+    # 1. AT_SPI_BUS_ADDRESS env var has precedence if defined
+    path = _socket_or_none(os.environ.get('AT_SPI_BUS_ADDRESS'))
+    if path:
+        return path, 'AT_SPI_BUS_ADDRESS'
+
+    # 2. Ask the session bus
+    try:
+        out = subprocess.run(
+            ['gdbus', 'call', '--session', '--dest', 'org.a11y.Bus',
+             '--object-path', '/org/a11y/bus', '--method', 'org.a11y.Bus.GetAddress'],
+            capture_output=True, text=True, timeout=5).stdout
+        m = re.match(r"\('(.+)',\)\s*$", out.strip())
+        if m:
+            path = _socket_or_none(m.group(1))
+            if path:
+                return path, None
+    except (FileNotFoundError, subprocess.TimeoutExpired, OSError):
+        pass
+
+    # 3 Fallback to usual directory
+    xdg_dir = os.path.join(xdg, 'at-spi')
+    if os.path.isdir(xdg_dir):
+        return xdg_dir, None
+
+    return None, None
 
 def _translate_host_path_to_container(host_path):
     # The wkdev container bind-mounts the host ${HOME} at /host/home/${USER}.
@@ -317,16 +355,23 @@ def _build_podman_run_args(pinned_version):
     dbus_session = _strip_unix_path_prefix(os.environ.get('DBUS_SESSION_BUS_ADDRESS')) or os.path.join(xdg, 'bus')
     if os.path.exists(dbus_session):
         args += _bind_mount(dbus_session, dbus_session)
-        args += ['--env', 'DBUS_SESSION_BUS_ADDRESS=unix:path={}'.format(dbus_session)]
+        # If defined keep the same value, because it may contain not only the path but also ",guid" values.
+        if os.environ.get('DBUS_SESSION_BUS_ADDRESS'):
+            args += ['--env', '{}={}'.format('DBUS_SESSION_BUS_ADDRESS', os.environ['DBUS_SESSION_BUS_ADDRESS'])]
+        else:
+            args += ['--env', 'DBUS_SESSION_BUS_ADDRESS=unix:path={}'.format(dbus_session)]
 
     # DBus system
     if os.path.exists('/run/dbus/system_bus_socket'):
         args += _bind_mount('/run/dbus/system_bus_socket', '/run/dbus/system_bus_socket')
 
     # Accessibility (at-spi)
-    at_spi = _strip_unix_path_prefix(os.environ.get('AT_SPI_BUS_ADDRESS')) or os.path.join(xdg, 'at-spi')
-    if os.path.isdir(at_spi):
-        args += _bind_mount(at_spi, at_spi)
+    at_spi_path, at_spi_env_var = _get_at_spi_bus_socket_or_dir_and_var(xdg)
+    if at_spi_path:
+        args += _bind_mount(at_spi_path, at_spi_path)
+        if at_spi_env_var:
+            args += ['--env', '{}={}'.format(at_spi_env_var, os.environ[at_spi_env_var])]
+
 
     # dconf
     dconf_dir = os.path.join(_xdg_config_home(), 'dconf')

--- a/Tools/Scripts/webkitpy/port/linux_container_sdk_utils_unittest.py
+++ b/Tools/Scripts/webkitpy/port/linux_container_sdk_utils_unittest.py
@@ -27,13 +27,17 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import os
-import sys
+import shutil
+import socket
+import subprocess
+import tempfile
 import unittest
+from unittest.mock import patch, MagicMock
 
-from webkitpy.port.linux_container_sdk_utils import _strip_unix_path_prefix
+from webkitpy.port.linux_container_sdk_utils import _strip_unix_path_prefix, _get_at_spi_bus_socket_or_dir_and_var
 
 
-class ContainerSDKHelpersTest(unittest.TestCase):
+class StripUnixPathPrefixTest(unittest.TestCase):
 
     def test_dbus_standard_path(self):
         path = "/run/user/1000/bus"
@@ -58,3 +62,106 @@ class ContainerSDKHelpersTest(unittest.TestCase):
         AT_SPI_BUS_ADDRESS = f"unix:path={path},guid=b6602b80724b3d489a0e9c9c6a0d8b2d"
         path_resolved = _strip_unix_path_prefix(AT_SPI_BUS_ADDRESS)
         self.assertEqual(path, path_resolved)
+
+
+class GetAtSpiBusDirTest(unittest.TestCase):
+    def setUp(self):
+        # Short prefix: AF_UNIX paths are limited to 108 chars on Linux.
+        self.tmpdir = tempfile.mkdtemp(prefix='atspi-')
+        self.addCleanup(shutil.rmtree, self.tmpdir, ignore_errors=True)
+        self._sockets = []
+        self.addCleanup(self._close_sockets)
+        # Don't let a real AT_SPI_BUS_ADDRESS from the host leak in.
+        env_patch = patch.dict(os.environ)
+        env_patch.start()
+        self.addCleanup(env_patch.stop)
+        os.environ.pop('AT_SPI_BUS_ADDRESS', None)
+
+    def _close_sockets(self):
+        for s in self._sockets:
+            s.close()
+
+    def _make_socket(self, name):
+        path = os.path.join(self.tmpdir, name)
+        s = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        s.bind(path)
+        self._sockets.append(s)
+        return path
+
+    def _mock_gdbus(self, address=None, exc=None):
+        target = 'webkitpy.port.linux_container_sdk_utils.subprocess.run'
+        if exc is not None:
+            return patch(target, side_effect=exc)
+        result = MagicMock()
+        result.stdout = "('{}',)\n".format(address) if address else ""
+        return patch(target, return_value=result)
+
+    def test_env_var_points_to_socket(self):
+        sock = self._make_socket('bus_0')
+        os.environ['AT_SPI_BUS_ADDRESS'] = "unix:path={},guid=abc".format(sock)
+        with self._mock_gdbus() as mock_run:
+            at_spi_path, at_spi_env_var = _get_at_spi_bus_socket_or_dir_and_var(self.tmpdir)
+            self.assertEqual(at_spi_path, sock)
+            self.assertEqual(at_spi_env_var, 'AT_SPI_BUS_ADDRESS')
+            mock_run.assert_not_called()  # env var hit, gdbus must be skipped
+
+    def test_env_var_missing_socket_falls_through(self):
+        os.environ['AT_SPI_BUS_ADDRESS'] = "unix:path=/does/not/exist,guid=abc"
+        with self._mock_gdbus():
+            at_spi_path, at_spi_env_var = _get_at_spi_bus_socket_or_dir_and_var(self.tmpdir)
+            self.assertIsNone(at_spi_path)
+            self.assertIsNone(at_spi_env_var)
+
+    def test_env_var_regular_file_falls_through(self):
+        regular = os.path.join(self.tmpdir, 'plain.txt')
+        open(regular, 'w').close()
+        os.environ['AT_SPI_BUS_ADDRESS'] = "unix:path={},guid=abc".format(regular)
+        with self._mock_gdbus():
+            at_spi_path, at_spi_env_var = _get_at_spi_bus_socket_or_dir_and_var(self.tmpdir)
+            self.assertIsNone(at_spi_path)
+            self.assertIsNone(at_spi_env_var)
+
+    def test_gdbus_returns_socket(self):
+        sock = self._make_socket('bus_0')
+        with self._mock_gdbus("unix:path={},guid=abc".format(sock)):
+            at_spi_path, at_spi_env_var = _get_at_spi_bus_socket_or_dir_and_var(self.tmpdir)
+            self.assertEqual(at_spi_path, sock)
+            self.assertIsNone(at_spi_env_var)
+
+    def test_gdbus_missing_socket_falls_through(self):
+        with self._mock_gdbus("unix:path=/does/not/exist,guid=abc"):
+            at_spi_path, at_spi_env_var = _get_at_spi_bus_socket_or_dir_and_var(self.tmpdir)
+            self.assertIsNone(at_spi_path)
+            self.assertIsNone(at_spi_env_var)
+
+    def test_gdbus_not_installed_falls_through(self):
+        with self._mock_gdbus(exc=FileNotFoundError()):
+            at_spi_path, at_spi_env_var = _get_at_spi_bus_socket_or_dir_and_var(self.tmpdir)
+            self.assertIsNone(at_spi_path)
+            self.assertIsNone(at_spi_env_var)
+
+    def test_gdbus_timeout_falls_through(self):
+        with self._mock_gdbus(exc=subprocess.TimeoutExpired('gdbus', 5)):
+            at_spi_path, at_spi_env_var = _get_at_spi_bus_socket_or_dir_and_var(self.tmpdir)
+            self.assertIsNone(at_spi_path)
+            self.assertIsNone(at_spi_env_var)
+
+    def test_gdbus_malformed_output_falls_through(self):
+        with self._mock_gdbus():  # stdout is ''
+            at_spi_path, at_spi_env_var = _get_at_spi_bus_socket_or_dir_and_var(self.tmpdir)
+            self.assertIsNone(at_spi_path)
+            self.assertIsNone(at_spi_env_var)
+
+    def test_falls_back_to_xdg_dir(self):
+        xdg_dir = os.path.join(self.tmpdir, 'at-spi')
+        os.makedirs(xdg_dir)
+        with self._mock_gdbus():
+            at_spi_path, at_spi_env_var = _get_at_spi_bus_socket_or_dir_and_var(self.tmpdir)
+            self.assertEqual(at_spi_path, xdg_dir)
+            self.assertIsNone(at_spi_env_var)
+
+    def test_returns_none_when_nothing_resolves(self):
+        with self._mock_gdbus():
+            at_spi_path, at_spi_env_var = _get_at_spi_bus_socket_or_dir_and_var(self.tmpdir)
+            self.assertIsNone(at_spi_path)
+            self.assertIsNone(at_spi_env_var)


### PR DESCRIPTION
#### d0c317ee7c58dddf5d45153ebd901ab96b20f2ae
<pre>
[GTK][WPE][Tools] Improve bind mount of AT-SPI socket for container-sdk-autoenter
<a href="https://bugs.webkit.org/show_bug.cgi?id=315187">https://bugs.webkit.org/show_bug.cgi?id=315187</a>

Reviewed by Nikolas Zimmermann.

The current code on container-sdk-autoenter only checks the socket at env var
AT_SPI_BUS_ADDRESS (usually undefined) or at the usual place, but it could
also ask dbus for where this socket is.

* Tools/Scripts/webkitpy/port/linux_container_sdk_utils.py:
(_strip_unix_path_prefix):
(_get_at_spi_bus_socket_or_dir_and_var):
(_get_at_spi_bus_socket_or_dir_and_var._socket_or_none):
(_build_podman_run_args):
* Tools/Scripts/webkitpy/port/linux_container_sdk_utils_unittest.py:
(StripUnixPathPrefixTest):
(StripUnixPathPrefixTest.test_at_spi_bus_path):
(GetAtSpiBusDirTest):
(GetAtSpiBusDirTest.setUp):
(GetAtSpiBusDirTest._close_sockets):
(GetAtSpiBusDirTest._make_socket):
(GetAtSpiBusDirTest._mock_gdbus):
(GetAtSpiBusDirTest.test_env_var_points_to_socket):
(GetAtSpiBusDirTest.test_env_var_missing_socket_falls_through):
(GetAtSpiBusDirTest.test_env_var_regular_file_falls_through):
(GetAtSpiBusDirTest.test_gdbus_returns_socket):
(GetAtSpiBusDirTest.test_gdbus_missing_socket_falls_through):
(GetAtSpiBusDirTest.test_gdbus_not_installed_falls_through):
(GetAtSpiBusDirTest.test_gdbus_timeout_falls_through):
(GetAtSpiBusDirTest.test_gdbus_malformed_output_falls_through):
(GetAtSpiBusDirTest.test_falls_back_to_xdg_dir):
(GetAtSpiBusDirTest.test_returns_none_when_nothing_resolves):
(ContainerSDKHelpersTest): Deleted.
(ContainerSDKHelpersTest.test_dbus_standard_path): Deleted.
(ContainerSDKHelpersTest.test_dbus_autolaunch_path): Deleted.
(ContainerSDKHelpersTest.test_pulse_server_path): Deleted.
(ContainerSDKHelpersTest.test_at_spi_bus_path): Deleted.

Canonical link: <a href="https://commits.webkit.org/313570@main">https://commits.webkit.org/313570@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/af51554335ea3593936fea76962b5e407cd3890f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163505 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/36989 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/30208 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172445 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119954 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165374 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37320 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/36988 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/126988 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89519 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166464 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29259 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/146992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107542 "Passed tests") | 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/162826 "Found 1 webkitpy test failure: webkitpy.scripts.measure_build_time_unittest.MeasureBuildTimeTest.test_clean_and_null_build") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28308 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/26939 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20148 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/138205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/24711 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174950 "Built successfully") | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/26373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/135293 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36658 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31041 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135275 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37444 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/146506 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99469 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24891 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30578 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/23356 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36154 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35652 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/1381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35902 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35799 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->