### PR TITLE
[GTK][WPE] ThreadedCompositor can composite a half-committed set of scrolling-tree layer positions

### DIFF
--- a/Source/WebCore/page/scrolling/coordinated/ScrollingTreeCoordinated.cpp
+++ b/Source/WebCore/page/scrolling/coordinated/ScrollingTreeCoordinated.cpp
@@ -85,7 +85,13 @@ void ScrollingTreeCoordinated::applyLayerPositionsInternal()
     if (!rootScrollingNode)
         return;
 
+    auto rootContentsLayer = static_cast<ScrollingTreeFrameScrollingNodeCoordinated*>(rootScrollingNode)->rootContentsLayer();
+    if (!rootContentsLayer)
+        return;
+
+    rootContentsLayer->willSetPositionsForScrolling();
     ThreadedScrollingTree::applyLayerPositionsInternal();
+    rootContentsLayer->didSetPositionsForScrolling();
 
     if (ScrollingThread::isCurrentThread()) {
         auto rootContentsLayer = static_cast<ScrollingTreeFrameScrollingNodeCoordinated*>(rootScrollingNode)->rootContentsLayer();

--- a/Source/WebCore/page/scrolling/coordinated/ScrollingTreeFixedNodeCoordinated.cpp
+++ b/Source/WebCore/page/scrolling/coordinated/ScrollingTreeFixedNodeCoordinated.cpp
@@ -56,8 +56,11 @@ bool ScrollingTreeFixedNodeCoordinated::commitStateBeforeChildren(const Scrollin
         return false;
 
     auto& fixedStateNode = downcast<ScrollingStateFixedNode>(stateNode);
-    if (fixedStateNode.hasChangedProperty(ScrollingStateNode::Property::Layer))
+    if (fixedStateNode.hasChangedProperty(ScrollingStateNode::Property::Layer)) {
+        if (m_layer)
+            m_layer->resetScrollingTreeOwnership();
         m_layer = static_cast<CoordinatedPlatformLayer*>(fixedStateNode.layer());
+    }
 
     return ScrollingTreeFixedNode::commitStateBeforeChildren(stateNode);
 }

--- a/Source/WebCore/page/scrolling/coordinated/ScrollingTreeFrameScrollingNodeCoordinated.cpp
+++ b/Source/WebCore/page/scrolling/coordinated/ScrollingTreeFrameScrollingNodeCoordinated.cpp
@@ -40,6 +40,12 @@
 
 namespace WebCore {
 
+static void resetScrollingTreeOwnership(CoordinatedPlatformLayer* layer)
+{
+    if (layer)
+        layer->resetScrollingTreeOwnership();
+}
+
 Ref<ScrollingTreeFrameScrollingNode> ScrollingTreeFrameScrollingNodeCoordinated::create(ScrollingTree& scrollingTree, ScrollingNodeType nodeType, ScrollingNodeID nodeID)
 {
     return adoptRef(*new ScrollingTreeFrameScrollingNodeCoordinated(scrollingTree, nodeType, nodeID));
@@ -60,26 +66,47 @@ ScrollingTreeScrollingNodeDelegateCoordinated& ScrollingTreeFrameScrollingNodeCo
 
 bool ScrollingTreeFrameScrollingNodeCoordinated::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
 {
+    RefPtr<CoordinatedPlatformLayer> previousScrolledContentsLayer;
+    if (auto* frameStateNode = dynamicDowncast<ScrollingStateFrameScrollingNode>(stateNode)) {
+        if (frameStateNode->hasChangedProperty(ScrollingStateNode::Property::ScrolledContentsLayer) && scrolledContentsLayer())
+            previousScrolledContentsLayer = static_cast<CoordinatedPlatformLayer*>(scrolledContentsLayer());
+    }
+
     if (!ScrollingTreeFrameScrollingNode::commitStateBeforeChildren(stateNode))
         return false;
+
+    if (previousScrolledContentsLayer)
+        previousScrolledContentsLayer->resetScrollingTreeOwnership();
 
     if (!is<ScrollingStateFrameScrollingNode>(stateNode))
         return false;
 
     const auto& scrollingStateNode = downcast<ScrollingStateFrameScrollingNode>(stateNode);
 
-    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::RootContentsLayer))
+    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::RootContentsLayer)) {
+        resetScrollingTreeOwnership(m_rootContentsLayer.get());
         m_rootContentsLayer = static_cast<CoordinatedPlatformLayer*>(scrollingStateNode.rootContentsLayer());
-    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::CounterScrollingLayer))
+    }
+    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::CounterScrollingLayer)) {
+        resetScrollingTreeOwnership(m_counterScrollingLayer.get());
         m_counterScrollingLayer = static_cast<CoordinatedPlatformLayer*>(scrollingStateNode.counterScrollingLayer());
-    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::InsetClipLayer))
+    }
+    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::InsetClipLayer)) {
+        resetScrollingTreeOwnership(m_insetClipLayer.get());
         m_insetClipLayer = static_cast<CoordinatedPlatformLayer*>(scrollingStateNode.insetClipLayer());
-    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ContentShadowLayer))
+    }
+    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::ContentShadowLayer)) {
+        resetScrollingTreeOwnership(m_contentShadowLayer.get());
         m_contentShadowLayer = static_cast<CoordinatedPlatformLayer*>(scrollingStateNode.contentShadowLayer());
-    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::HeaderLayer))
+    }
+    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::HeaderLayer)) {
+        resetScrollingTreeOwnership(m_headerLayer.get());
         m_headerLayer = static_cast<CoordinatedPlatformLayer*>(scrollingStateNode.headerLayer());
-    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::FooterLayer))
+    }
+    if (scrollingStateNode.hasChangedProperty(ScrollingStateNode::Property::FooterLayer)) {
+        resetScrollingTreeOwnership(m_footerLayer.get());
         m_footerLayer = static_cast<CoordinatedPlatformLayer*>(scrollingStateNode.footerLayer());
+    }
 
     m_delegate->updateFromStateNode(scrollingStateNode);
     return true;

--- a/Source/WebCore/page/scrolling/coordinated/ScrollingTreePositionedNodeCoordinated.cpp
+++ b/Source/WebCore/page/scrolling/coordinated/ScrollingTreePositionedNodeCoordinated.cpp
@@ -52,8 +52,11 @@ ScrollingTreePositionedNodeCoordinated::~ScrollingTreePositionedNodeCoordinated(
 
 bool ScrollingTreePositionedNodeCoordinated::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
 {
-    if (stateNode.hasChangedProperty(ScrollingStateNode::Property::Layer))
+    if (stateNode.hasChangedProperty(ScrollingStateNode::Property::Layer)) {
+        if (m_layer)
+            m_layer->resetScrollingTreeOwnership();
         m_layer = static_cast<CoordinatedPlatformLayer*>(stateNode.layer());
+    }
 
     return ScrollingTreePositionedNode::commitStateBeforeChildren(stateNode);
 }

--- a/Source/WebCore/page/scrolling/coordinated/ScrollingTreeStickyNodeCoordinated.cpp
+++ b/Source/WebCore/page/scrolling/coordinated/ScrollingTreeStickyNodeCoordinated.cpp
@@ -54,8 +54,11 @@ ScrollingTreeStickyNodeCoordinated::ScrollingTreeStickyNodeCoordinated(Scrolling
 
 bool ScrollingTreeStickyNodeCoordinated::commitStateBeforeChildren(const ScrollingStateNode& stateNode)
 {
-    if (stateNode.hasChangedProperty(ScrollingStateNode::Property::Layer))
+    if (stateNode.hasChangedProperty(ScrollingStateNode::Property::Layer)) {
+        if (m_layer)
+            m_layer->resetScrollingTreeOwnership();
         m_layer = static_cast<CoordinatedPlatformLayer*>(stateNode.layer());
+    }
 
     return ScrollingTreeStickyNode::commitStateBeforeChildren(stateNode);
 }

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -176,6 +176,8 @@ void CoordinatedPlatformLayer::notifyCompositionRequired()
 void CoordinatedPlatformLayer::setPosition(FloatPoint&& position)
 {
     ASSERT(m_lock.isHeld());
+    if (m_ownedByScrollingTree)
+        return;
     if (m_position == position)
         return;
 
@@ -187,12 +189,19 @@ void CoordinatedPlatformLayer::setPosition(FloatPoint&& position)
 void CoordinatedPlatformLayer::setPositionForScrolling(const FloatPoint& position, ForcePositionSync forceSync)
 {
     Locker locker { m_lock };
+    m_ownedByScrollingTree = true;
     if (m_position == position && forceSync == ForcePositionSync::No)
         return;
 
     m_position = position;
     m_pendingChanges.add(Change::Position);
     notifyCompositionRequired();
+}
+
+void CoordinatedPlatformLayer::resetScrollingTreeOwnership()
+{
+    Locker locker { m_lock };
+    m_ownedByScrollingTree = false;
 }
 
 const FloatPoint& CoordinatedPlatformLayer::position() const
@@ -900,6 +909,18 @@ void CoordinatedPlatformLayer::requestComposition(CompositionReason reason)
 {
     if (m_client)
         m_client->requestComposition(reason);
+}
+
+void CoordinatedPlatformLayer::willSetPositionsForScrolling()
+{
+    if (m_client)
+        m_client->willSetPositionsForScrolling();
+}
+
+void CoordinatedPlatformLayer::didSetPositionsForScrolling()
+{
+    if (m_client)
+        m_client->didSetPositionsForScrolling();
 }
 
 RunLoop* CoordinatedPlatformLayer::compositingRunLoop() const

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -78,6 +78,8 @@ public:
         virtual bool isCompositionRequiredOrOngoing() const = 0;
         virtual void requestComposition(CompositionReason) = 0;
         virtual RunLoop* compositingRunLoop() const = 0;
+        virtual void willSetPositionsForScrolling() = 0;
+        virtual void didSetPositionsForScrolling() = 0;
         virtual int maxTextureSize() const = 0;
         virtual void willPaintTile() = 0;
         virtual void didPaintTile() = 0;
@@ -111,9 +113,12 @@ public:
     void setPosition(FloatPoint&&);
     enum class ForcePositionSync : bool { No, Yes };
     void setPositionForScrolling(const FloatPoint&, ForcePositionSync = ForcePositionSync::No);
+    void resetScrollingTreeOwnership();
     const FloatPoint& position() const;
     void setTopLeftPositionForScrolling(const FloatPoint&, ForcePositionSync = ForcePositionSync::No);
     FloatPoint topLeftPositionForScrolling();
+    void willSetPositionsForScrolling();
+    void didSetPositionsForScrolling();
     void setBoundsOrigin(const FloatPoint&);
     void setBoundsOriginForScrolling(const FloatPoint&);
     const FloatPoint& boundsOrigin() const;
@@ -287,6 +292,7 @@ private:
     Lock m_lock;
     EnumSet<Change> m_pendingChanges WTF_GUARDED_BY_LOCK(m_lock);
     FloatPoint m_position WTF_GUARDED_BY_LOCK(m_lock);
+    bool m_ownedByScrollingTree WTF_GUARDED_BY_LOCK(m_lock) { false };
     FloatPoint3D m_anchorPoint WTF_GUARDED_BY_LOCK(m_lock) { 0.5f, 0.5f, 0 };
     FloatSize m_size WTF_GUARDED_BY_LOCK(m_lock);
     FloatPoint m_boundsOrigin WTF_GUARDED_BY_LOCK(m_lock);

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.h
@@ -48,6 +48,8 @@ public:
 
     WebCore::CoordinatedPlatformLayer& rootLayer() const { return m_rootLayer.get(); }
 
+    Lock& stateLock() LIFETIME_BOUND { return m_stateLock; }
+
     void setRootLayerChildren(Vector<Ref<WebCore::CoordinatedPlatformLayer>>&&);
     void addLayer(WebCore::CoordinatedPlatformLayer&);
     void removeLayer(WebCore::CoordinatedPlatformLayer&);
@@ -74,6 +76,7 @@ private:
     const Ref<WebCore::CoordinatedPlatformLayer> m_rootLayer;
     HashSet<Ref<WebCore::CoordinatedPlatformLayer>> m_layers;
     HashSet<Ref<WebCore::CoordinatedPlatformLayer>> m_layersToRemove;
+    Lock m_stateLock;
     Lock m_pendingLayersLock;
     HashSet<Ref<WebCore::CoordinatedPlatformLayer>> m_pendingLayers WTF_GUARDED_BY_LOCK(m_pendingLayersLock);
     HashSet<Ref<WebCore::CoordinatedPlatformLayer>> m_pendingLayersToRemove WTF_GUARDED_BY_LOCK(m_pendingLayersLock);

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -366,6 +366,16 @@ RunLoop* LayerTreeHost::compositingRunLoop() const
     return m_compositor->runLoop();
 }
 
+void LayerTreeHost::willSetPositionsForScrolling()
+{
+    m_sceneState->stateLock().lock();
+}
+
+void LayerTreeHost::didSetPositionsForScrolling()
+{
+    m_sceneState->stateLock().unlock();
+}
+
 int LayerTreeHost::maxTextureSize() const
 {
     return m_compositor->maxTextureSize();

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h
@@ -96,6 +96,8 @@ private:
     bool isCompositionRequiredOrOngoing() const override;
     void requestComposition(WebCore::CompositionReason) override;
     RunLoop* compositingRunLoop() const override;
+    void willSetPositionsForScrolling() override WTF_IGNORES_THREAD_SAFETY_ANALYSIS;
+    void didSetPositionsForScrolling() override WTF_IGNORES_THREAD_SAFETY_ANALYSIS;
     int maxTextureSize() const override;
     void willPaintTile() override;
     void didPaintTile() override;

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.cpp
@@ -423,6 +423,16 @@ RunLoop* LayerTreeHost::compositingRunLoop() const
     return m_compositor->runLoop();
 }
 
+void LayerTreeHost::willSetPositionsForScrolling()
+{
+    m_sceneState->stateLock().lock();
+}
+
+void LayerTreeHost::didSetPositionsForScrolling()
+{
+    m_sceneState->stateLock().unlock();
+}
+
 int LayerTreeHost::maxTextureSize() const
 {
     return m_compositor->maxTextureSize();

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.h
@@ -153,6 +153,8 @@ private:
     bool isCompositionRequiredOrOngoing() const override;
     void requestComposition(WebCore::CompositionReason) override;
     RunLoop* compositingRunLoop() const override;
+    void willSetPositionsForScrolling() override WTF_IGNORES_THREAD_SAFETY_ANALYSIS;
+    void didSetPositionsForScrolling() override WTF_IGNORES_THREAD_SAFETY_ANALYSIS;
     int maxTextureSize() const override;
     void willPaintTile() override { };
     void didPaintTile() override { };

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
@@ -293,6 +293,7 @@ void ThreadedCompositor::flushCompositingState(const OptionSet<CompositionReason
     }
 #endif
 
+    Locker locker { m_sceneState->stateLock() };
     m_sceneState->rootLayer().flushCompositingState(reasons, m_useSkia);
     for (auto& layer : m_sceneState->committedLayers())
         layer->flushCompositingState(reasons, m_useSkia);


### PR DESCRIPTION
#### d2e8005925d80b352d9adba5edeaab8d6669da8c
<pre>
[GTK][WPE] ThreadedCompositor can composite a half-committed set of scrolling-tree layer positions
<a href="https://bugs.webkit.org/show_bug.cgi?id=315185">https://bugs.webkit.org/show_bug.cgi?id=315185</a>

Reviewed by NOBODY (OOPS!).

Fixed, sticky, positioned and frame-scrolling layer positions are corrupted by two
races during async scrolling.

The scrolling thread applies layer positions while ThreadedCompositor copies the
same layers into its TextureMapperLayer targets on the compositor thread. Nothing
serializes the whole apply pass against the whole flush, so the compositor can copy
a frame node&apos;s new position together with a fixed/sticky child&apos;s old one. Serialize
them with a per-scene CoordinatedSceneState lock, held around the apply pass via
willSetPositionsForScrolling()/didSetPositionsForScrolling() and around the
flushCompositingState() copy loop.

GraphicsLayerCoordinated::updateGeometry also writes m_position from the main thread;
during a programmatic scroll it lays out one frame ahead of the offset the scrolling
thread applied, so its setPosition() lands a stale, un-scroll-compensated position
over the scroll-adjusted one. Mark the layer as owned by the scrolling tree
(m_ownedByScrollingTree, set in setPositionForScrolling) and suppress setPosition()
while owned; resetScrollingTreeOwnership() returns it to main-thread control on
hand-off.

* Source/WebCore/page/scrolling/coordinated/ScrollingTreeCoordinated.cpp:
(WebCore::ScrollingTreeCoordinated::applyLayerPositionsInternal):
* Source/WebCore/page/scrolling/coordinated/ScrollingTreeFixedNodeCoordinated.cpp:
(WebCore::ScrollingTreeFixedNodeCoordinated::commitStateBeforeChildren):
* Source/WebCore/page/scrolling/coordinated/ScrollingTreeFrameScrollingNodeCoordinated.cpp:
(WebCore::resetScrollingTreeOwnership):
(WebCore::ScrollingTreeFrameScrollingNodeCoordinated::commitStateBeforeChildren):
* Source/WebCore/page/scrolling/coordinated/ScrollingTreePositionedNodeCoordinated.cpp:
(WebCore::ScrollingTreePositionedNodeCoordinated::commitStateBeforeChildren):
* Source/WebCore/page/scrolling/coordinated/ScrollingTreeStickyNodeCoordinated.cpp:
(WebCore::ScrollingTreeStickyNodeCoordinated::commitStateBeforeChildren):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::setPosition):
(WebCore::CoordinatedPlatformLayer::setPositionForScrolling):
(WebCore::CoordinatedPlatformLayer::resetScrollingTreeOwnership):
(WebCore::CoordinatedPlatformLayer::willSetPositionsForScrolling):
(WebCore::CoordinatedPlatformLayer::didSetPositionsForScrolling):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/CoordinatedSceneState.h:
(WebKit::CoordinatedSceneState::stateLock):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::willSetPositionsForScrolling):
(WebKit::LayerTreeHost::didSetPositionsForScrolling):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.cpp:
(WebKit::LayerTreeHost::willSetPositionsForScrolling):
(WebKit::LayerTreeHost::didSetPositionsForScrolling):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHostPlayStation.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp:
(WebKit::ThreadedCompositor::flushCompositingState):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2e8005925d80b352d9adba5edeaab8d6669da8c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167645 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41142 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34737 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176702 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125326 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169511 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41577 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41155 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130436 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91685 "1 flakes 5 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170604 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32858 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150637 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110953 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31840 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30540 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.MultiProcessBFCacheSameSiteWithCrossSiteIframe (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25435 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141827 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28332 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179242 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32283 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30050 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138840 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41214 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34697 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138725 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41902 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105064 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33985 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27003 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40406 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113652 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39803 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5104 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40054 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39948 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->