### PR TITLE
[macOS] webrtc/getUserMedia-webaudio-autoplay.html is a flaky text failure.

### DIFF
--- a/LayoutTests/fast/mediastream/MediaStream-page-muted.html
+++ b/LayoutTests/fast/mediastream/MediaStream-page-muted.html
@@ -10,6 +10,7 @@
             function nextStep()
             {
                 if (muteChangedEvent.type == "unmute") {
+                    mediaStream.getTracks().forEach(t => t.stop());
                     finishJSTest();
                     return;
                 }

--- a/LayoutTests/fast/mediastream/MediaStream-video-element-displays-buffer.html
+++ b/LayoutTests/fast/mediastream/MediaStream-video-element-displays-buffer.html
@@ -50,6 +50,10 @@
         checkPixels(x, y, currentTest ? isPixelGray : isPixelBlack, true)
 
         if (currentTest >= 1) {
+            if (videos[0].srcObject)
+                videos[0].srcObject.getTracks().forEach(t => t.stop());
+            if (videos[1].srcObject)
+                videos[1].srcObject.getTracks().forEach(t => t.stop());
             finishJSTest();
             return;
         }

--- a/LayoutTests/fast/mediastream/MediaStream-video-element-video-tracks-disabled.html
+++ b/LayoutTests/fast/mediastream/MediaStream-video-element-video-tracks-disabled.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html><!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <html>
 <head>
 <meta name="fuzzy" content="maxDifference=115;totalPixels=28000-29000" />

--- a/LayoutTests/fast/mediastream/MediaStreamTrackEvent-constructor.html
+++ b/LayoutTests/fast/mediastream/MediaStreamTrackEvent-constructor.html
@@ -60,7 +60,7 @@
                 shouldBeNonNull("mediaStream.getVideoTracks()[0]");
                 mediaStreamTrack = mediaStream.getVideoTracks()[0];
                 testMediaStreamTrackEvent();
-                mediaStreamTrack.stop();
+                mediaStream.getTracks().forEach(t => t.stop());
             }
 
             function primeTimeout(msg)

--- a/LayoutTests/fast/mediastream/RTCPeerConnection-inspect-offer-bundlePolicy-bundle-only.html
+++ b/LayoutTests/fast/mediastream/RTCPeerConnection-inspect-offer-bundlePolicy-bundle-only.html
@@ -9,13 +9,12 @@
 
             description("Inspect that the SDP offer contains the correct number of a=bundle-only lines according to the bundlePolicy value.");
 
-            if (window.testRunner)
-                testRunner.setUserMediaPermission(true);
-            else {
+            if (!window.testRunner) {
                 debug("This test can not be run without the testRunner");
                 finishJSTest();
             }
 
+            let gumStreams = [];
             function testBundlePolicySDP(bundlePolicy) {
                 var mediaDescriptionVariables = [];
                 var numberOfExtraTracksPerType = 5;
@@ -47,6 +46,7 @@
 
                 navigator.mediaDevices.getUserMedia({ "audio": true, "video": true})
                 .then(function (stream) {
+                    gumStreams.push(stream);
                     testPassed("Start promise chain for bundlePolicy: " + bundlePolicy);
                     var audioTrack = stream.getAudioTracks()[0];
                     var videoTrack = stream.getVideoTracks()[0];
@@ -61,6 +61,7 @@
                         pc.addTrack(videoTrackCloned, stream);
                         mediaDescriptionVariables.push({ "trackId": audioTrackCloned.id, "streamId": stream.id });
                         mediaDescriptionVariables.push({ "trackId": videoTrackCloned.id, "streamId": stream.id });
+                        gumStreams.push(new MediaStream([audioTrackCloned, videoTrackCloned]));
                     }
                     return pc.createOffer();
                 })
@@ -92,6 +93,7 @@
                 if (subTestsCompleted == bundlePolicies.length) {
                     testPassed("Tested the following bundlePolicy values: " + bundlePolicies.join(" "));
                     finishJSTest();
+                    gumStreams.forEach(stream => stream.getTracks().forEach(track => track.stop()));
                 } else {
                     testBundlePolicySDP(bundlePolicies[subTestsCompleted]);
                     subTestsCompleted++;

--- a/LayoutTests/fast/mediastream/RTCPeerConnection-remotely-assigned-transceiver-mid.html
+++ b/LayoutTests/fast/mediastream/RTCPeerConnection-remotely-assigned-transceiver-mid.html
@@ -15,9 +15,7 @@
 
             description("Test the case where an RTCRtpTransceiver gets a remotely assigned mid and also unmute the associated source");
 
-            if (window.testRunner)
-                testRunner.setUserMediaPermission(true);
-            else {
+            if (!window.testRunner) {
                 debug("This test can not be run without the testRunner");
                 finishJSTest();
             }
@@ -37,6 +35,7 @@
 
                 event.track.onunmute = function () {
                     testPassed("B: remote track unmute event");
+                    stream.getTracks().forEach(t => t.stop());
                     finishJSTest();
                 };
             };

--- a/LayoutTests/fast/mediastream/RTCPeerConnection-stats.html
+++ b/LayoutTests/fast/mediastream/RTCPeerConnection-stats.html
@@ -69,6 +69,7 @@
                 // Named getter: Can access results by their ID values.
                 shouldBeNonNull('status_g.namedItem(res.id)');
                 shouldBeNonNull('status_g[res.id]');
+                stream.getTracks().forEach(t => t.stop());
                 finishJSTest();
             }
 

--- a/LayoutTests/fast/mediastream/audio-unit-reconfigure.html
+++ b/LayoutTests/fast/mediastream/audio-unit-reconfigure.html
@@ -25,6 +25,7 @@ promise_test(async (test) => {
     stream.getAudioTracks()[0].stop();
 
     const stream2 = await navigator.mediaDevices.getUserMedia({ audio: { sampleRate: 44100 }});
+    test.add_cleanup(() => stream2.getTracks().forEach(track => track.stop()));
     stream2.getAudioTracks()[0].onended = () => assert_not_reached("should not end");
     await new Promise(resolve => setTimeout(resolve, 100));
 }, "Reconfigure audio sample rate");
@@ -64,6 +65,7 @@ promise_test(async (test) => {
     const stream2 = await navigator.mediaDevices.getUserMedia({ audio: musicModeAudioConstraints });
     stream2.getAudioTracks()[0].onended = () => log.innerHTML += 'track ended';
     await new Promise(resolve => setTimeout(resolve, 1000));
+    test.add_cleanup(() => stream2.getTracks().forEach(track => track.stop()));
 }, "Reconfigure audio unit when being in render-only mode");
 </script>
 </body>

--- a/LayoutTests/fast/mediastream/getUserMedia-grant-persistency3.html
+++ b/LayoutTests/fast/mediastream/getUserMedia-grant-persistency3.html
@@ -11,6 +11,7 @@ promise_test((test) => {
     if (window.testRunner)
         testRunner.setUserMediaPermission(true);
     return navigator.mediaDevices.getUserMedia({audio:false, video:true}).then((stream) => {
+        test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
         if (window.testRunner)
             testRunner.setUserMediaPermission(false);
         isPageVisible = false;
@@ -22,7 +23,8 @@ promise_test((test) => {
                 testRunner.setPageVisibility();
         }, 1000);
         return navigator.mediaDevices.getUserMedia({audio:false, video:true});
-    }).then(() => {
+    }).then((stream) => {
+        test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
         assert_true(isPageVisible, "Resolving getUserMedia promise should wait for page to be visible");
     });
 }, "Testing same page getUserMedia grant persistency with visibility");

--- a/LayoutTests/fast/mediastream/granted-denied-request-management2.html
+++ b/LayoutTests/fast/mediastream/granted-denied-request-management2.html
@@ -27,7 +27,9 @@ promise_test(async (test) => {
     });
     await promise;
 
-    return navigator.mediaDevices.getUserMedia({ audio: true });
+    return navigator.mediaDevices.getUserMedia({ audio: true }).then((stream) => {
+        stream.getTracks().forEach(t => t.stop());
+    });
 }, "Remove audio denied request upon successful audio/video request");
     </script>
 </body>

--- a/LayoutTests/fast/mediastream/media-stream-track-muted.html
+++ b/LayoutTests/fast/mediastream/media-stream-track-muted.html
@@ -26,9 +26,11 @@
         setTimeout(() => { waitForPageStateChange(--numberOfTries, originalState, resolve, reject); }, 10);
     }
 
-    function testTrack(track, title)
+    function testTrack(track, title, stream)
     {
         promise_test((test) => {
+            if (stream)
+                test.add_cleanup(() => stream.getTracks().forEach(t => t.stop()));
             return new Promise((resolve, reject) => {
                 let isVideo = track.kind == "video";
                 if (window.internals) {
@@ -70,7 +72,7 @@
         return navigator.mediaDevices.getUserMedia({ video: true, audio: true})
             .then((stream) => {
                 testTrack(stream.getVideoTracks()[0], "Mute video track only");
-                testTrack(stream.getAudioTracks()[0], "Mute audio track only");
+                testTrack(stream.getAudioTracks()[0], "Mute audio track only", stream);
             });
     }, "Create stream");
 

--- a/LayoutTests/fast/mediastream/media-stream-wrapper-collected.html
+++ b/LayoutTests/fast/mediastream/media-stream-wrapper-collected.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html><!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <html>
 <head>
     <meta charset="utf-8">

--- a/LayoutTests/fast/mediastream/mediarecorder-close.html
+++ b/LayoutTests/fast/mediastream/mediarecorder-close.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!DOCTYPE html> <!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <html>
 <body>
 <div>PASS if not crashing</div>

--- a/LayoutTests/fast/mediastream/resources/apply-constraints-utils.js
+++ b/LayoutTests/fast/mediastream/resources/apply-constraints-utils.js
@@ -52,6 +52,8 @@ ConstraintsTest = class ConstraintsTest {
 
         debug("");
         if (!this.tests.length) {
+            if (this.video && this.video.srcObject)
+                this.video.srcObject.getTracks().forEach(track => track.stop());
             finishJSTest();
             return;
         }

--- a/LayoutTests/fast/mediastream/video-mediastream-restricted-invisible-autoplay-not-allowed.html
+++ b/LayoutTests/fast/mediastream/video-mediastream-restricted-invisible-autoplay-not-allowed.html
@@ -54,7 +54,7 @@
 
             function finish()
             {
-                video.srcObject.getVideoTracks()[0].stop();
+                video.srcObject.getTracks().forEach(t => t.stop());
                 video.srcObject = null;
                 endTest();
             }

--- a/LayoutTests/http/tests/media/media-stream/get-user-media-loopback-ip.html
+++ b/LayoutTests/http/tests/media/media-stream/get-user-media-loopback-ip.html
@@ -23,7 +23,8 @@
                 }
 
                 try {
-                    await window.navigator.mediaDevices.getUserMedia({audio:true});
+                    const stream = await window.navigator.mediaDevices.getUserMedia({audio:true});
+                    stream.getTracks().forEach(t => t.stop());
                     testPassed("getUserMedia succeeded");
                 } catch(err) {
                     testFailed(`getUserMedia should have succeeded but failed with error "${err}"`);

--- a/LayoutTests/http/wpt/mediarecorder/pause-recording-2.html
+++ b/LayoutTests/http/wpt/mediarecorder/pause-recording-2.html
@@ -22,6 +22,7 @@ function waitForEvent(object, eventName, testName)
 
 promise_test(async (test) => {
     const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
 
     const recorder = new MediaRecorder(stream, { mimeType: "video/webm" });
     const dataPromise = new Promise(resolve => recorder.ondataavailable = (e) => resolve(e.data));

--- a/LayoutTests/http/wpt/mediastream/serialize-mediastreamtrack-to-worker.html
+++ b/LayoutTests/http/wpt/mediastream/serialize-mediastreamtrack-to-worker.html
@@ -39,6 +39,7 @@ promise_test(async test => {
     window.internals.setTopDocumentURLForQuirks("https://zoom.us");
 
     const stream = await navigator.mediaDevices.getUserMedia({ video: { width: 640, height: 480 } });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
 
     const worker = await createWorker(`
         self.onmessage = async (event) => {

--- a/LayoutTests/platform/ios/mediastream/audio-muted-in-background-tab-gpu-process.html
+++ b/LayoutTests/platform/ios/mediastream/audio-muted-in-background-tab-gpu-process.html
@@ -70,7 +70,8 @@
                 })
 
                 .then(() => {
-                    promise_test(async () => {
+                    promise_test(async (t) => {
+                        t.add_cleanup(() => { audioTrack.stop(); videoTrack.stop(); });
                         if (window.internals)
                             window.internals.setPageVisibility(true);
                         assert_true(audioTrack.muted, "audio track is muted");

--- a/LayoutTests/platform/ios/mediastream/audio-muted-in-background-tab.html
+++ b/LayoutTests/platform/ios/mediastream/audio-muted-in-background-tab.html
@@ -70,7 +70,8 @@
                 })
 
                 .then(() => {
-                    promise_test(async () => {
+                    promise_test(async (t) => {
+                        t.add_cleanup(() => { audioTrack.stop(); videoTrack.stop(); });
                         if (window.internals)
                             window.internals.setPageVisibility(true);
                         assert_true(audioTrack.muted, "audio track is muted");

--- a/LayoutTests/platform/ios/mediastream/getUserMedia-override-audio-session-interruption.html
+++ b/LayoutTests/platform/ios/mediastream/getUserMedia-override-audio-session-interruption.html
@@ -16,7 +16,7 @@ async function waitForVideoPlaying(video)
     return !video.paused;
 }
 
-promise_test(async () => {
+promise_test(async (test) => {
     if (window.internals)
         internals.setMediaElementRestrictions(video, "invisibleautoplaynotpermitted");
 
@@ -36,6 +36,7 @@ promise_test(async () => {
         internals.clearAudioSessionInterruptionFlag();
 
     stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     video.srcObject = stream;
     assert_true(await waitForVideoPlaying(video), "test after system interruption");
 }, "call getUserMedia, stop, interrupt and recall getUserMedia");

--- a/LayoutTests/platform/ios/mediastream/getUserMedia-single-capture-gpu-process.html
+++ b/LayoutTests/platform/ios/mediastream/getUserMedia-single-capture-gpu-process.html
@@ -46,6 +46,7 @@ promise_test((test) => {
         const newMicrophoneDeviceId = await getOtherMicrophoneDevice(audioTrack);
         return navigator.mediaDevices.getUserMedia({ audio: { deviceId : newMicrophoneDeviceId} });
     }).then(async (stream) => {
+        test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
         await waitForTrackEnded(audioTrack);
 
         assert_equals(audioTrack.readyState, "ended", "audio track is ended");
@@ -53,6 +54,7 @@ promise_test((test) => {
 
         return navigator.mediaDevices.getUserMedia({ video: { facingMode: { exact: ["environment"] } } });
     }).then(async (stream) => {
+        test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
         await waitForTrackEnded(videoTrack);
 
         assert_equals(audioTrack.readyState, "ended", "audio track is ended, second check");

--- a/LayoutTests/platform/ios/mediastream/video-muted-in-background-tab.html
+++ b/LayoutTests/platform/ios/mediastream/video-muted-in-background-tab.html
@@ -77,6 +77,7 @@
             }, "Hide and mute page, video and audio should be muted");
 
             promise_test(async (t) => {
+                t.add_cleanup(() => { audioTrack.stop(); videoTrack.stop(); });
                 if (window.internals)
                     window.internals.setPageVisibility(true);
                 assert_true(audioTrack.muted, "audio track is muted");

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2281,8 +2281,6 @@ webkit.org/b/308856 [ Debug ] http/tests/websocket/tests/hybi/handshake-ok-with-
 
 webkit.org/b/309850 [ Debug ] imported/w3c/web-platform-tests/uievents/mouse/mouse_boundary_events_after_removing_last_over_element.html [ Pass Failure ]
 
-webkit.org/b/314668 webrtc/getUserMedia-webaudio-autoplay.html [ Pass Failure ]
-
 webkit.org/b/314136 accessibility/mac/client/div-bounds.html [ Pass Failure ]
 
 webkit.org/b/314851 http/tests/site-isolation/inspector/debugger/provisional-frame-target-pausing.html [ Failure ]

--- a/LayoutTests/webrtc/addICECandidate-closed.html
+++ b/LayoutTests/webrtc/addICECandidate-closed.html
@@ -12,6 +12,7 @@ promise_test(async (test) => {
     const receiver = new RTCPeerConnection();
     try {
         const stream = await navigator.mediaDevices.getUserMedia({ audio: true, video: true });
+        test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
         const localTracks = stream.getTracks();
         [[sender, receiver], [receiver, sender]].forEach(([pc1, pc2]) => {
             pc1.onicecandidate = ({ candidate }) => {

--- a/LayoutTests/webrtc/addTransceiver-then-addTrack.html
+++ b/LayoutTests/webrtc/addTransceiver-then-addTrack.html
@@ -72,10 +72,8 @@ async function validateAudioIsEncoded(connection)
 
 var pc1, pc2;
 promise_test(async (test) => {
-    if (window.testRunner)
-        testRunner.setUserMediaPermission(true);
-
     const localStream = await navigator.mediaDevices.getUserMedia({video: true, audio: true });
+    test.add_cleanup(() => localStream.getTracks().forEach(track => track.stop()));
     const stream = await new Promise((resolve, reject) => {
         createConnections((firstConnection) => {
             pc1 = firstConnection;

--- a/LayoutTests/webrtc/audio-muted-stats.html
+++ b/LayoutTests/webrtc/audio-muted-stats.html
@@ -13,7 +13,7 @@ async function getOutboundRTPStats(connection, counter)
 {
     if (!counter)
         counter = 0;
-    const stats = await connection.getStats().then((report) => {
+        const stats = await connection.getStats().then((report) => {
         var stats;
         report.forEach((statItem) => {
             if (statItem.type === "outbound-rtp") {
@@ -50,7 +50,8 @@ promise_test((test) => {
         testRunner.setUserMediaPermission(true);
 
     return navigator.mediaDevices.getUserMedia({ audio: true}).then((stream) => {
-	track = stream.getAudioTracks()[0];
+        test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
+        track = stream.getAudioTracks()[0];
         return new Promise((resolve, reject) => {
             createConnections((connection) => {
                 firstConnection = connection;
@@ -66,9 +67,9 @@ promise_test((test) => {
         statsFirstConnection = stats;
         return checkOutboundBytesSentIncreased(firstConnection, statsFirstConnection, 0);
     }).then(() => {
-	track.enabled = false;
+        track.enabled = false;
         // Let's wait a little bit so that audio is disabled.
-	return waitFor(100);
+        return waitFor(100);
     }).then((stats) => {
         return getOutboundRTPStats(firstConnection);
     }).then((stats) => {

--- a/LayoutTests/webrtc/audio-peer-connection-g722.html
+++ b/LayoutTests/webrtc/audio-peer-connection-g722.html
@@ -8,9 +8,9 @@
     <script src ="routines.js"></script>
     <script>
 var remoteStream;
-
+var localStream;
 promise_test(async (test) => {
-    const stream = await navigator.mediaDevices.getUserMedia({audio: true});
+    const stream = localStream = await navigator.mediaDevices.getUserMedia({audio: true});
     remoteStream = await new Promise((resolve, reject) => {
         createConnections((firstConnection) => {
             firstConnection.addTrack(stream.getAudioTracks()[0], stream);
@@ -38,6 +38,7 @@ promise_test(async (test) => {
     remoteStream.getAudioTracks()[0].enabled = true;
     const result = await doHumAnalysis(remoteStream, true);
     assert_true(result, "heard hum");
+    test.add_cleanup(() => localStream.getTracks().forEach(track => track.stop()));
 }, "Unmute remote track");
     </script>
 </head>

--- a/LayoutTests/webrtc/audio-peer-connection-webaudio.html
+++ b/LayoutTests/webrtc/audio-peer-connection-webaudio.html
@@ -37,6 +37,7 @@
             testRunner.setUserMediaPermission(true);
 
         return navigator.mediaDevices.getUserMedia({audio: true}).then((stream) => {
+            test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
             return new Promise((resolve, reject) => {
                 createConnections((firstConnection) => {
                     firstConnection.addTrack(stream.getAudioTracks()[0], stream);

--- a/LayoutTests/webrtc/audio-replace-track.html
+++ b/LayoutTests/webrtc/audio-replace-track.html
@@ -11,13 +11,15 @@
     <script>
     var sender;
     var remoteStream;
+    var firstStream;
     var secondStream;
     var receivingConnection;
     promise_test((test) => {
         if (window.testRunner)
             testRunner.setUserMediaPermission(true);
 
-        return navigator.mediaDevices.getUserMedia({ audio: { sampleRate: { exact: 48000 } } }).then((firstStream) => {
+        return navigator.mediaDevices.getUserMedia({ audio: { sampleRate: { exact: 48000 } } }).then((stream) => {
+            firstStream = stream;
             return new Promise((resolve, reject) => {
                 createConnections((firstConnection) => {
                     sender = firstConnection.addTrack(firstStream.getAudioTracks()[0], firstStream);
@@ -60,7 +62,11 @@
         });
     }, "Using replaceTrack for audio");
 
-    promise_test(() => {
+    promise_test((test) => {
+        test.add_cleanup(() => {
+            firstStream.getTracks().forEach(t => t.stop());
+            secondStream.getTracks().forEach(t => t.stop());
+        });
         return doHumAnalysis(remoteStream, true).then((results) => {
             assert_true(results, "heard hum 2");
         });

--- a/LayoutTests/webrtc/audio-sframe.html
+++ b/LayoutTests/webrtc/audio-sframe.html
@@ -12,6 +12,7 @@
 promise_test(async (test) => {
     let sender, receiver;
     const localStream = await navigator.mediaDevices.getUserMedia({audio: true});
+    test.add_cleanup(() => localStream.getTracks().forEach(track => track.stop()));
     const key = await crypto.subtle.importKey("raw", new Uint8Array([143, 77, 43, 10, 72, 19, 37, 67, 236, 219, 24, 93, 26, 165, 91, 178]), "HKDF", false, ["deriveBits", "deriveKey"]);
     const stream = await new Promise((resolve, reject) => {
         createConnections((firstConnection) => {

--- a/LayoutTests/webrtc/clone-audio-track.html
+++ b/LayoutTests/webrtc/clone-audio-track.html
@@ -18,6 +18,11 @@
             var clonedTrack;
             var remoteTrack;
             var remoteStream;
+            test.add_cleanup(() => {
+                localStream.getTracks().forEach(t => t.stop());
+                if (clonedTrack)
+                    clonedTrack.stop();
+            });
             return new Promise((resolve, reject) => {
                 createConnections((firstConnection) => {
                     var track = localStream.getAudioTracks()[0];

--- a/LayoutTests/webrtc/concurrentVideoPlayback.html
+++ b/LayoutTests/webrtc/concurrentVideoPlayback.html
@@ -54,6 +54,8 @@ promise_test(async (test) => {
     assert_false(video1.paused, "video1 paused");
     assert_false(video2.paused, "video2 paused");
     assert_false(video3.paused, "video3 paused");
+
+    test.add_cleanup(() => localStream.getTracks().forEach(track => track.stop()));
 }, "Play regular video content should not pause MediaStream backed video elements");
         </script>
     </body>

--- a/LayoutTests/webrtc/concurrentVideoPlayback2.html
+++ b/LayoutTests/webrtc/concurrentVideoPlayback2.html
@@ -82,6 +82,8 @@ promise_test(async (test) => {
     assert_false(video2.paused, "video2 paused");
     assert_false(video3.paused, "video3 paused");
     assert_true(video4.paused, "video4 paused");
+
+    test.add_cleanup(() => localStream.getTracks().forEach(track => track.stop()));
 }, "Pause/play MediaStream backed video elements should not change regular video content");
         </script>
     </body>

--- a/LayoutTests/webrtc/connection-state.html
+++ b/LayoutTests/webrtc/connection-state.html
@@ -11,9 +11,6 @@
         <script src ="routines.js"></script>
         <script>
 promise_test((test) => {
-    if (window.testRunner)
-        testRunner.setUserMediaPermission(true);
-
     var firstConnection, secondConnection;
     var localConnectionStates = ["new"];
     var remoteConnectionStates = ["new"];
@@ -22,6 +19,7 @@ promise_test((test) => {
     var localGatheringStates = ["new"];
     var remoteGatheringStates = ["new"];
     return navigator.mediaDevices.getUserMedia({ video: true}).then((stream) => {
+        test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
         return new Promise((resolve, reject) => {
             createConnections((connection) => {
                 firstConnection = connection;

--- a/LayoutTests/webrtc/direction-change.html
+++ b/LayoutTests/webrtc/direction-change.html
@@ -12,9 +12,10 @@
         <script>
 var pc1, pc2;
 var remoteStream;
+var localStream;
 var trackEventCounter = 0;
 promise_test(async () => {
-    const localStream = await navigator.mediaDevices.getUserMedia({audio: true, video: true});
+    localStream = await navigator.mediaDevices.getUserMedia({audio: true, video: true});
     remoteStream = await new Promise((resolve, reject) => {
         createConnections((firstConnection) => {
             pc1 = firstConnection;
@@ -38,7 +39,8 @@ promise_test(async () => {
     return renegotiate(pc1, pc2);
 }, "Set transceiver as inactive");
 
-promise_test(async () => {
+promise_test(async (t) => {
+    t.add_cleanup(() => localStream.getTracks().forEach(track => track.stop()));
     // Setting direction to sendonly will trigger two new track events.
     pc2.ontrack = (trackEvent) => {
          test(() => {

--- a/LayoutTests/webrtc/disable-encryption.html
+++ b/LayoutTests/webrtc/disable-encryption.html
@@ -14,6 +14,7 @@ promise_test(async (test) => {
     if (window.internals)
         internals.setEnableWebRTCEncryption(false);
     const localStream = await navigator.mediaDevices.getUserMedia({video: true});
+    test.add_cleanup(() => localStream.getTracks().forEach(track => track.stop()));
 
     video.srcObject = await new Promise((resolve, reject) => {
         createConnections((localConnection) => {

--- a/LayoutTests/webrtc/dtmf-gc.html
+++ b/LayoutTests/webrtc/dtmf-gc.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html> <!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <html>
     <head>
         <meta charset="utf-8">

--- a/LayoutTests/webrtc/encoded-streams-quirks.html
+++ b/LayoutTests/webrtc/encoded-streams-quirks.html
@@ -26,6 +26,7 @@ promise_test(async (test) => {
     assert_equals(permission.state, "granted");
 
     const localStream = await navigator.mediaDevices.getUserMedia({audio: true, video: true});
+    test.add_cleanup(() => localStream.getTracks().forEach(track => track.stop()));
     const stream = await new Promise((resolve, reject) => {
         createConnections((firstConnection) => {
             const audioSender = firstConnection.addTrack(localStream.getAudioTracks()[0], localStream);

--- a/LayoutTests/webrtc/ephemeral-certificates-and-cnames.html
+++ b/LayoutTests/webrtc/ephemeral-certificates-and-cnames.html
@@ -33,12 +33,10 @@ function cnameFromSDP(sdp)
 }
 
 promise_test((test) => {
-    if (window.testRunner)
-        testRunner.setUserMediaPermission(true);
-
     var offerFingerprint, answerFingerprint;
     var offerCName;
     return navigator.mediaDevices.getUserMedia({ video: true, audio: true}).then((stream) => {
+        test.add_cleanup(() => stream.getTracks().forEach(t => t.stop()));
         return new Promise((resolve, reject) => {
             createConnections((firstConnection) => {
                 firstConnection.addTrack(stream.getVideoTracks()[0], stream);
@@ -55,6 +53,7 @@ promise_test((test) => {
     }).then(() => {
         closeConnections();
         return navigator.mediaDevices.getUserMedia({ video: true, audio: true}).then((stream) => {
+            test.add_cleanup(() => stream.getTracks().forEach(t => t.stop()));
             return new Promise((resolve, reject) => {
                 createConnections((firstConnection) => {
                     firstConnection.addTrack(stream.getVideoTracks()[0], stream);

--- a/LayoutTests/webrtc/getDisplayMedia-odd-size.html
+++ b/LayoutTests/webrtc/getDisplayMedia-odd-size.html
@@ -63,6 +63,7 @@ promise_test(async (test) => {
 }, "Testing odd width");
 
 promise_test(async (test) => {
+    test.add_cleanup(() => localStream.getTracks().forEach(track => track.stop()));
     await localStream.getVideoTracks()[0].applyConstraints({ height:479 });
 
     while (!(video.videoHeight % 2))

--- a/LayoutTests/webrtc/getDisplayMedia-pc.html
+++ b/LayoutTests/webrtc/getDisplayMedia-pc.html
@@ -46,6 +46,7 @@
          var pc1, pc2;
          promise_test(async (test) => {
              const localStream = await callGetDisplayMedia({ video: { width: 1280, height:720 } });
+             test.add_cleanup(() => localStream.getTracks().forEach(track => track.stop()));
              const stream = await new Promise((resolve, reject) => {
                  createConnections((firstConnection) => {
                      pc1 = firstConnection;

--- a/LayoutTests/webrtc/getUserMedia-webaudio-autoplay.html
+++ b/LayoutTests/webrtc/getUserMedia-webaudio-autoplay.html
@@ -47,6 +47,7 @@ promise_test((test) => {
     if (!window.internals)
         return Promise.reject("Test requires internals API");
     return navigator.mediaDevices.getUserMedia({audio: true}).then((stream) => {
+        test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
         var context = new AudioContext();
         internals.setAudioContextRestrictions(context, 'RequireUserGestureForAudioStart');
 
@@ -60,6 +61,7 @@ promise_test((test) => {
     if (!window.internals)
         return Promise.reject("Test requires internals API");
     return navigator.mediaDevices.getUserMedia({audio: true}).then((stream) => {
+        test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
         var context = new AudioContext();
         internals.setAudioContextRestrictions(context, 'RequireUserGestureForAudioStart');
 

--- a/LayoutTests/webrtc/h264-profile-tests.js
+++ b/LayoutTests/webrtc/h264-profile-tests.js
@@ -48,8 +48,10 @@ function testResolutions(resolutions)
         }, "Video resolution test: " + resolution[0] + " " + resolution[1]);
     });
 
-    resolutions.forEach(resolution => {
+    resolutions.forEach((resolution, index) => {
         promise_test(async (test) => {
+            if (index === resolutions.length - 1)
+                test.add_cleanup(() => localVideoTrack.stop());
             const parameters = pc1.getSenders()[0].getParameters();
             parameters.encodings[0].maxBitrate = 100000;
             pc1.getSenders()[0].setParameters(parameters);

--- a/LayoutTests/webrtc/h265.html
+++ b/LayoutTests/webrtc/h265.html
@@ -112,6 +112,7 @@ if (hasH265) {
     }
 
     promise_test(async (test) => {
+        test.add_cleanup(() => track.stop());
         const stats = await getOutboundRTPStats(sendingConnection);
         assert_true(!!stats, "outbound-rtp stats should not be null");
         assert_true(!stats.qpSum || Number.isInteger(stats.qpSum), "outbound qpSum should be an integer");

--- a/LayoutTests/webrtc/ice-candidate-sdpMLineIndex.html
+++ b/LayoutTests/webrtc/ice-candidate-sdpMLineIndex.html
@@ -9,10 +9,8 @@
     <body>
         <script>
 promise_test((test) => {
-    if (window.testRunner)
-        testRunner.setUserMediaPermission(true);
-
     return navigator.mediaDevices.getUserMedia({audio: true, video: true}).then((stream) => {
+        test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
         return new Promise((resolve, reject) => {
             var pc = new RTCPeerConnection();
             pc.addTrack(stream.getAudioTracks()[0], stream);

--- a/LayoutTests/webrtc/libwebrtc/descriptionGetters.html
+++ b/LayoutTests/webrtc/libwebrtc/descriptionGetters.html
@@ -19,6 +19,7 @@ promise_test((test) => {
      var remoteConnection = new RTCPeerConnection();
      var currentSDP;
      return navigator.mediaDevices.getUserMedia({ video: true}).then((stream) => {
+        test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
 
         localConnection.addTrack(stream.getVideoTracks()[0], stream);
         return localConnection.createOffer();

--- a/LayoutTests/webrtc/msection-recycling.html
+++ b/LayoutTests/webrtc/msection-recycling.html
@@ -10,6 +10,7 @@
         <script>
 promise_test(async test => {
     const stream = await navigator.mediaDevices.getUserMedia({audio: true, video: true});
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
 
     const firstConnection = new RTCPeerConnection({sdpSemantics:'unified-plan'});
     const secondConnection = new RTCPeerConnection({sdpSemantics:'unified-plan'});

--- a/LayoutTests/webrtc/msid-setCodecPreferences.html
+++ b/LayoutTests/webrtc/msid-setCodecPreferences.html
@@ -11,11 +11,9 @@
         <script>
 var track, firstConnection, secondConnection;
 promise_test(async (test) => {
-    if (window.testRunner)
-        testRunner.setUserMediaPermission(true);
-
     let pc = new RTCPeerConnection();
     let stream = await navigator.mediaDevices.getUserMedia({ video: true });
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
 	let track = stream.getVideoTracks()[0];
     pc.addTrack(track, stream);
     pc.getTransceivers()[0].setCodecPreferences([{mimeType: "video/VP8", clockRate: 90000}]);

--- a/LayoutTests/webrtc/multi-audio.html
+++ b/LayoutTests/webrtc/multi-audio.html
@@ -19,14 +19,20 @@ promise_test(async (test) => {
 
     let remoteStream1, remoteStream2;
     let counter = 0;
+    let clone;
     const localStream = await navigator.mediaDevices.getUserMedia({ audio: true, video : true });
+    test.add_cleanup(() => {
+        localStream.getTracks().forEach(t => t.stop());
+        if (clone)
+            clone.getTracks().forEach(t => t.stop());
+    });
     const stream = await new Promise((resolve, reject) => {
         createConnections((firstConnection) => {
             pc1 = firstConnection;
             firstConnection.addTrack(localStream.getAudioTracks()[0], localStream);
             firstConnection.addTrack(localStream.getVideoTracks()[0], localStream);
 
-            const clone = localStream.clone();
+            clone = localStream.clone();
             firstConnection.addTrack(clone.getAudioTracks()[0], clone);
             firstConnection.addTrack(clone.getVideoTracks()[0], clone);
         }, (secondConnection) => {

--- a/LayoutTests/webrtc/multi-video.html
+++ b/LayoutTests/webrtc/multi-video.html
@@ -49,6 +49,11 @@ promise_test((test) => {
         testRunner.setUserMediaPermission(true);
 
     return navigator.mediaDevices.getUserMedia({ video: { frameRate: 5 } }).then((stream) => {
+        const clones = [];
+        test.add_cleanup(() => {
+            stream.getTracks().forEach(t => t.stop());
+            clones.forEach(t => t.stop());
+        });
         return new Promise((resolve, reject) => {
             createConnections((firstConnection) => {
                 var track = stream.getVideoTracks()[0];
@@ -58,6 +63,7 @@ promise_test((test) => {
                 var track4 = track.clone();
                 var track5 = track.clone();
                 var track6 = track.clone();
+                clones.push(track1, track2, track3, track4, track5, track6);
                 var newStream = new MediaStream([track1, track2, track3, track4, track5, track6]);
                 firstConnection.addTrack(track1, newStream);
                 firstConnection.addTrack(track2, newStream);

--- a/LayoutTests/webrtc/negotiatedneeded-event-addStream.html
+++ b/LayoutTests/webrtc/negotiatedneeded-event-addStream.html
@@ -17,6 +17,7 @@ promise_test((test) => {
         testRunner.setUserMediaPermission(true);
 
     return navigator.mediaDevices.getUserMedia({ video: true}).then((stream) => {
+        test.add_cleanup(() => stream.getTracks().forEach(t => t.stop()));
         return new Promise((resolve, reject) => {
             var pc = new RTCPeerConnection();
             var count = 0;
@@ -34,6 +35,7 @@ promise_test((test) => {
         testRunner.setUserMediaPermission(true);
 
     return navigator.mediaDevices.getUserMedia({ video: true}).then((stream) => {
+        test.add_cleanup(() => stream.getTracks().forEach(t => t.stop()));
         return new Promise((resolve, reject) => {
             var pc = new RTCPeerConnection();
             pc.onnegotiationneeded = () => { reject(); };

--- a/LayoutTests/webrtc/peer-connection-audio-mute.html
+++ b/LayoutTests/webrtc/peer-connection-audio-mute.html
@@ -11,9 +11,6 @@
     <script>
     var context = new AudioContext();
     promise_test((test) => {
-        if (window.testRunner)
-            testRunner.setUserMediaPermission(true);
-
         var remoteStream;
         async function checkForSound(expected, message, count)
         {
@@ -32,6 +29,7 @@
 
         var localTrack;
         return navigator.mediaDevices.getUserMedia({audio: { echoCancellation : false}}).then((localStream) => {
+            test.add_cleanup(() => localStream.getTracks().forEach(track => track.stop()));
             localTrack = localStream.getAudioTracks()[0];
             return new Promise((resolve, reject) => {
                 createConnections((firstConnection) => {

--- a/LayoutTests/webrtc/peer-connection-audio-mute2.html
+++ b/LayoutTests/webrtc/peer-connection-audio-mute2.html
@@ -13,6 +13,7 @@
     promise_test((test) => {
         var localTrack;
         return navigator.mediaDevices.getUserMedia({audio: true}).then((localStream) => {
+            test.add_cleanup(() => localStream.getTracks().forEach(track => track.stop()));
             localTrack = localStream.getAudioTracks()[0];
             var remoteStream;
             return new Promise((resolve, reject) => {

--- a/LayoutTests/webrtc/peer-connection-audio-unmute.html
+++ b/LayoutTests/webrtc/peer-connection-audio-unmute.html
@@ -15,6 +15,7 @@
 
         var localTrack;
         return navigator.mediaDevices.getUserMedia({audio: true}).then((localStream) => {
+            test.add_cleanup(() => localStream.getTracks().forEach(track => track.stop()));
             localTrack = localStream.getAudioTracks()[0];
             localTrack.enabled = false;
             var remoteStream;

--- a/LayoutTests/webrtc/peer-connection-remote-audio-mute.html
+++ b/LayoutTests/webrtc/peer-connection-remote-audio-mute.html
@@ -28,10 +28,8 @@
     }
 
     promise_test((test) => {
-        if (window.testRunner)
-            testRunner.setUserMediaPermission(true);
-
         return navigator.mediaDevices.getUserMedia({audio: true}).then((localStream) => {
+            test.add_cleanup(() => localStream.getTracks().forEach(track => track.stop()));
             var remoteTrack;
             return new Promise((resolve, reject) => {
                 createConnections((firstConnection) => {

--- a/LayoutTests/webrtc/peer-connection-remote-audio-mute2.html
+++ b/LayoutTests/webrtc/peer-connection-remote-audio-mute2.html
@@ -12,6 +12,7 @@
     var context = new AudioContext();
     promise_test((test) => {
         return navigator.mediaDevices.getUserMedia({audio: true}).then((localStream) => {
+            test.add_cleanup(() => localStream.getTracks().forEach(track => track.stop()));
             var remoteTrack;
             var remoteStream;
             return new Promise((resolve, reject) => {

--- a/LayoutTests/webrtc/peer-connection-track-end.html
+++ b/LayoutTests/webrtc/peer-connection-track-end.html
@@ -14,6 +14,7 @@ promise_test((test) => {
     var remoteStream, newOffer, secondConnection;
     var testPromise;
     return navigator.mediaDevices.getUserMedia({audio: true, video: true}).then((stream) => {
+        test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
         return new Promise((resolve, reject) => {
             createConnections((firstConnection) => {
                 firstConnection.addTrack(stream.getAudioTracks()[0], stream);

--- a/LayoutTests/webrtc/peerConnection-rvfc.html
+++ b/LayoutTests/webrtc/peerConnection-rvfc.html
@@ -22,6 +22,7 @@ async function grabNextMetadata(video)
 
 promise_test(async (test) => {
     const localStream = await navigator.mediaDevices.getUserMedia({video: { width: 640, height: 480 } });
+    test.add_cleanup(() => localStream.getTracks().forEach(track => track.stop()));
     const remoteStream = await new Promise((resolve, reject) => {
         createConnections((firstConnection) => {
             pc1 = firstConnection;

--- a/LayoutTests/webrtc/receiver-track-should-stay-live-even-if-receiver-is-inactive.html
+++ b/LayoutTests/webrtc/receiver-track-should-stay-live-even-if-receiver-is-inactive.html
@@ -12,8 +12,9 @@
     <script>
     var pc1, pc2;
     var remoteStream, remoteTrack;
+    var localStream;
     promise_test(async (test) => {
-        const localStream = await navigator.mediaDevices.getUserMedia({audio: true });
+        localStream = await navigator.mediaDevices.getUserMedia({audio: true });
 
         await new Promise(resolve => {
             createConnections((firstConnection) => {
@@ -50,6 +51,7 @@
     }, "Inactivate the audio transceiver");
 
     promise_test(async (test) => {
+        test.add_cleanup(() => localStream.getTracks().forEach(t => t.stop()));
         pc1.getTransceivers()[0].direction = "sendonly";
         let offer = await pc1.createOffer();
         await pc1.setLocalDescription(offer);

--- a/LayoutTests/webrtc/release-after-getting-track.html
+++ b/LayoutTests/webrtc/release-after-getting-track.html
@@ -14,6 +14,7 @@ promise_test((test) => {
         testRunner.setUserMediaPermission(true);
 
     return navigator.mediaDevices.getUserMedia({ video: true, audio: true}).then((stream) => {
+        test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
         return new Promise((resolve, reject) => {
             createConnections((firstConnection) => {
                 firstConnection.addTrack(stream.getVideoTracks()[0], stream);

--- a/LayoutTests/webrtc/remote-track-label-quirks.html
+++ b/LayoutTests/webrtc/remote-track-label-quirks.html
@@ -15,6 +15,7 @@ promise_test(async (test) => {
     window.internals.setTopDocumentURLForQuirks("https://www.facebook.com");
 
     const localStream = await navigator.mediaDevices.getUserMedia({audio: true, video: true});
+    test.add_cleanup(() => localStream.getTracks().forEach(track => track.stop()));
     const stream = await new Promise((resolve, reject) => {
         createConnections((firstConnection) => {
             firstConnection.addTrack(localStream.getAudioTracks()[0], localStream);

--- a/LayoutTests/webrtc/remoteAudio-never-played.html
+++ b/LayoutTests/webrtc/remoteAudio-never-played.html
@@ -12,6 +12,7 @@
         <script>
 promise_test(async (test) => {
     const localStream = await navigator.mediaDevices.getUserMedia({audio: true});
+    test.add_cleanup(() => localStream.getTracks().forEach(track => track.stop()));
     const stream = await new Promise((resolve, reject) => {
         createConnections((firstConnection) => {
             firstConnection.addTrack(localStream.getAudioTracks()[0], localStream);

--- a/LayoutTests/webrtc/setRemoteDescription-track.html
+++ b/LayoutTests/webrtc/setRemoteDescription-track.html
@@ -11,6 +11,7 @@
 
 promise_test(async (test) => {
     const localStream = await navigator.mediaDevices.getUserMedia({video:true });
+    test.add_cleanup(() => localStream.getTracks().forEach(track => track.stop()));
 
     const pc1 = new RTCPeerConnection();
     const pc2 = new RTCPeerConnection();

--- a/LayoutTests/webrtc/sframe-keys.html
+++ b/LayoutTests/webrtc/sframe-keys.html
@@ -11,6 +11,7 @@
         <script>
 let sender, receiver;
 let key1, key2, key3, key4;
+let sframeLocalStream;
 
 promise_test(async (test) => {
     const key = await crypto.subtle.importKey("raw", new Uint8Array([143, 77, 43, 10, 72, 19, 37, 67, 236, 219, 24, 93, 26, 165, 91, 178]), "HKDF", false, ["deriveBits", "deriveKey"]);
@@ -35,6 +36,7 @@ promise_test(async (test) => {
     key4 = await crypto.subtle.importKey("raw", new Uint8Array([146, 77, 43, 10, 72, 19, 37, 67, 236, 219, 24, 93, 26, 165, 91, 178]), "HKDF", false, ["deriveBits", "deriveKey"]);
 
     const localStream = await navigator.mediaDevices.getUserMedia({audio: true});
+    sframeLocalStream = localStream;
     const stream = await new Promise((resolve, reject) => {
         createConnections((firstConnection) => {
             sender = firstConnection.addTrack(localStream.getAudioTracks()[0], localStream);
@@ -98,6 +100,7 @@ promise_test(async (test) => {
 }, "Add a new encryption key with key id");
 
 promise_test(async (test) => {
+   test.add_cleanup(() => sframeLocalStream.getTracks().forEach(t => t.stop()));
    sender.transform.setEncryptionKey(key4, BigInt('18446744073709551613'));
 
    if (!window.internals)

--- a/LayoutTests/webrtc/utf8-sdp.html
+++ b/LayoutTests/webrtc/utf8-sdp.html
@@ -17,6 +17,7 @@ promise_test(async (test) => {
     const unicodeString = '世界你好';
 
     const stream = await navigator.mediaDevices.getUserMedia({video: true});
+    test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
     internals.setMediaStreamTrackIdentifier(stream.getVideoTracks()[0], unicodeString);
 
     const remoteStream = await new Promise((resolve, reject) => {

--- a/LayoutTests/webrtc/video-addTrack.html
+++ b/LayoutTests/webrtc/video-addTrack.html
@@ -48,6 +48,7 @@ function testBasicVideoExchangeWithAddTrack(waitForSecondTrack)
         testRunner.setUserMediaPermission(true);
 
     return navigator.mediaDevices.getUserMedia({audio: true, video: true}).then((stream) => {
+        test.add_cleanup(() => stream.getTracks().forEach(t => t.stop()));
         return new Promise((resolve, reject) => {
             createConnections((firstConnection) => {
                 assert_equals(stream.getTracks().length, 2);

--- a/LayoutTests/webrtc/video-autoplay1.html
+++ b/LayoutTests/webrtc/video-autoplay1.html
@@ -22,6 +22,7 @@ promise_test(async (test) => {
     await video1.pause();
 
     video2.srcObject = await navigator.mediaDevices.getUserMedia({ video : true });
+    test.add_cleanup(() => video2.srcObject.getTracks().forEach(track => track.stop()));
 
     while (video2.paused)
         await new Promise(resolve => setTimeout(resolve, 50));

--- a/LayoutTests/webrtc/video-autoplay2.html
+++ b/LayoutTests/webrtc/video-autoplay2.html
@@ -28,6 +28,7 @@ promise_test(async (test) => {
     assert_true(removedVideo1.paused, "out of DOM video should get paused");
 
     video2.srcObject = await navigator.mediaDevices.getUserMedia({ video : true });
+    test.add_cleanup(() => video2.srcObject.getTracks().forEach(track => track.stop()));
 
     while (video2.paused)
         await new Promise(resolve => setTimeout(resolve, 50));

--- a/LayoutTests/webrtc/video-autoplay3.html
+++ b/LayoutTests/webrtc/video-autoplay3.html
@@ -20,6 +20,7 @@ promise_test(async (test) => {
     await video1.play();
 
     video2.srcObject = await navigator.mediaDevices.getUserMedia({ video : true });
+    test.add_cleanup(() => video2.srcObject.getTracks().forEach(track => track.stop()));
 
     while (video2.paused)
         await new Promise(resolve => setTimeout(resolve, 50));

--- a/LayoutTests/webrtc/video-autoplay4.html
+++ b/LayoutTests/webrtc/video-autoplay4.html
@@ -36,6 +36,7 @@ promise_test(async (test) => {
     removedVideo2.remove();
 
     video4.srcObject = await navigator.mediaDevices.getUserMedia({ video : true });
+    test.add_cleanup(() => video4.srcObject.getTracks().forEach(track => track.stop()));
 
     while (video4.paused)
         await new Promise(resolve => setTimeout(resolve, 50));

--- a/LayoutTests/webrtc/video-av1.html
+++ b/LayoutTests/webrtc/video-av1.html
@@ -141,6 +141,7 @@ promise_test((test) => {
 }, "Verify video element size changes");
 
 promise_test((test) => {
+    test.add_cleanup(() => track.stop());
     return testFrameDecodedIncreased(receivingConnection);
 }, "Verfiy video decoding continues");
         </script>

--- a/LayoutTests/webrtc/video-clone-track.html
+++ b/LayoutTests/webrtc/video-clone-track.html
@@ -12,6 +12,10 @@
 promise_test(async (test) => {
     const localStream = await navigator.mediaDevices.getUserMedia({video: {width:640, height:360 }});
     const localStream2 = localStream.clone();
+    test.add_cleanup(() => {
+        localStream.getTracks().forEach(t => t.stop());
+        localStream2.getTracks().forEach(t => t.stop());
+    });
     const stream = await new Promise((resolve, reject) => {
         createConnections((firstConnection) => {
             const sender = firstConnection.addTrack(localStream2.getVideoTracks()[0], localStream2);

--- a/LayoutTests/webrtc/video-disabled-black.html
+++ b/LayoutTests/webrtc/video-disabled-black.html
@@ -30,6 +30,7 @@ function testStream(stream)
 var finishTest, errorTest;
 promise_test((test) => {
     return navigator.mediaDevices.getUserMedia({ video: true}).then((stream) => {
+        test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
         return new Promise((resolve, reject) => {
             finishTest = resolve;
             errorTest = reject;

--- a/LayoutTests/webrtc/video-getParameters.html
+++ b/LayoutTests/webrtc/video-getParameters.html
@@ -31,6 +31,7 @@ promise_test((test) => {
     var sender, receiver;
     var localStream, remoteStream;
     return navigator.mediaDevices.getUserMedia({ video: true}).then((stream) => {
+        test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
         localStream = stream;
         return new Promise((resolve, reject) => {
             createConnections((connection) => {

--- a/LayoutTests/webrtc/video-h264.html
+++ b/LayoutTests/webrtc/video-h264.html
@@ -45,6 +45,7 @@ promise_test(async (test) => {
         testRunner.setUserMediaPermission(true);
 
     const localStream = await navigator.mediaDevices.getUserMedia({video: true});
+    test.add_cleanup(() => localStream.getTracks().forEach(t => t.stop()));
     const stream = await new Promise((resolve, reject) => {
         createConnections((firstConnection) => {
             firstConnection.addTrack(localStream.getVideoTracks()[0], localStream);
@@ -71,6 +72,7 @@ promise_test(async (test) => {
         testRunner.setUserMediaPermission(true);
 
     const localStream = await navigator.mediaDevices.getUserMedia({video: true});
+    test.add_cleanup(() => localStream.getTracks().forEach(t => t.stop()));
     const stream = await new Promise((resolve, reject) => {
         createConnections((firstConnection) => {
             firstConnection.addTrack(localStream.getVideoTracks()[0], localStream);

--- a/LayoutTests/webrtc/video-interruption.html
+++ b/LayoutTests/webrtc/video-interruption.html
@@ -46,6 +46,7 @@ promise_test((test) => {
 
     var stream;
     return navigator.mediaDevices.getUserMedia({video: {advanced: [{width:{min:640}}, {height:{min:480} } ]}}).then((stream) => {
+        test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
         return new Promise((resolve, reject) => {
             createConnections((firstConnection) => {
                 var track = stream.getVideoTracks()[0];

--- a/LayoutTests/webrtc/video-lowercase-media-subtype.html
+++ b/LayoutTests/webrtc/video-lowercase-media-subtype.html
@@ -12,6 +12,7 @@
         <script>
 promise_test(async (test) => {
     const localStream = await navigator.mediaDevices.getUserMedia({video:true });
+    test.add_cleanup(() => localStream.getTracks().forEach(t => t.stop()));
 
     const pc1 = new RTCPeerConnection();
     const pc2 = new RTCPeerConnection();
@@ -45,6 +46,7 @@ promise_test(async (test) => {
 
 promise_test(async (test) => {
     const localStream = await navigator.mediaDevices.getUserMedia({video:true });
+    test.add_cleanup(() => localStream.getTracks().forEach(t => t.stop()));
 
     const pc1 = new RTCPeerConnection();
     const pc2 = new RTCPeerConnection();

--- a/LayoutTests/webrtc/video-maxBitrate-vp8.html
+++ b/LayoutTests/webrtc/video-maxBitrate-vp8.html
@@ -16,6 +16,7 @@ if (window.internals)
 var pc1, pc2;
 promise_test(async (test) => {
     const localStream = await navigator.mediaDevices.getUserMedia({video:{width:640}});
+    test.add_cleanup(() => localStream.getTracks().forEach(track => track.stop()));
     const stream = await new Promise((resolve, reject) => {
         createConnections((firstConnection) => {
             pc1 = firstConnection;

--- a/LayoutTests/webrtc/video-maxBitrate.html
+++ b/LayoutTests/webrtc/video-maxBitrate.html
@@ -16,6 +16,7 @@ if (window.internals)
 var pc1, pc2;
 promise_test(async (test) => {
     const localStream = await navigator.mediaDevices.getUserMedia({video:{width:640}});
+    test.add_cleanup(() => localStream.getTracks().forEach(track => track.stop()));
     const stream = await new Promise((resolve, reject) => {
         createConnections((firstConnection) => {
             pc1 = firstConnection;

--- a/LayoutTests/webrtc/video-maxFramerate.html
+++ b/LayoutTests/webrtc/video-maxFramerate.html
@@ -14,6 +14,7 @@
 var pc1, pc2;
 promise_test(async (test) => {
     const localStream = await navigator.mediaDevices.getUserMedia({video:true});
+    test.add_cleanup(() => localStream.getTracks().forEach(track => track.stop()));
     const stream = await new Promise((resolve, reject) => {
         createConnections((firstConnection) => {
             pc1 = firstConnection;

--- a/LayoutTests/webrtc/video-mute-vp8.html
+++ b/LayoutTests/webrtc/video-mute-vp8.html
@@ -147,6 +147,7 @@ promise_test((test) => {
 }, "If disabled, black frames should still be coming");
 
 promise_test((test) => {
+    test.add_cleanup(() => track.stop());
     track.enabled = true;
     return checkVideoBlack(false, canvas2, video);
 }, "Track is enabled, video should not be black 2");

--- a/LayoutTests/webrtc/video-mute.html
+++ b/LayoutTests/webrtc/video-mute.html
@@ -99,6 +99,7 @@ promise_test((test) => {
 }, "If disabled, black frames should still be coming");
 
 promise_test((test) => {
+    test.add_cleanup(() => track.stop());
     track.enabled = true;
     return checkVideoBlack(false, canvas2, video);
 }, "Track is enabled, video should not be black 2");

--- a/LayoutTests/webrtc/video-receivers.html
+++ b/LayoutTests/webrtc/video-receivers.html
@@ -15,6 +15,7 @@ promise_test((test) => {
         testRunner.setUserMediaPermission(true);
 
     return navigator.mediaDevices.getUserMedia({ video: true}).then((stream) => {
+        test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
         return new Promise((resolve, reject) => {
             createConnections((connection) => {
                 firstConnection = connection;

--- a/LayoutTests/webrtc/video-remote-mute.html
+++ b/LayoutTests/webrtc/video-remote-mute.html
@@ -20,6 +20,7 @@ promise_test((test) => {
         testRunner.setUserMediaPermission(true);
 
     return navigator.mediaDevices.getUserMedia({ video: true}).then((localStream) => {
+        test.add_cleanup(() => localStream.getTracks().forEach(t => t.stop()));
         return new Promise((resolve, reject) => {
             createConnections((firstConnection) => {
                 firstConnection.addTrack(localStream.getVideoTracks()[0], localStream);

--- a/LayoutTests/webrtc/video-replace-muted-track.html
+++ b/LayoutTests/webrtc/video-replace-muted-track.html
@@ -18,6 +18,8 @@ promise_test((test) => {
 
     var sender;
     var firstTrack;
+    var frontStream;
+    var backStream;
     return navigator.mediaDevices.getUserMedia({ video: { facingMode: { exact: ["user"] } } }).then((stream) => {
         frontStream = stream;
         return new Promise((resolve, reject) => {
@@ -40,11 +42,15 @@ promise_test((test) => {
     }).then(() => {
         return navigator.mediaDevices.getUserMedia({ video: { facingMode: { exact: ["environment"] } } });
     }).then((stream) => {
+        backStream = stream;
         return sender.replaceTrack(stream.getVideoTracks()[0]);
     }).then(() => {
         return checkVideoBlack(false, canvas, video, "Check we receive some non black frames");
     }).then(() => {
         return checkVideoBlack(true, canvas, video, "Check we do not receive any black frame", 40).then(assert_unreached, () => { });
+    }).then(() => {
+        frontStream.getTracks().forEach(t => t.stop());
+        backStream.getTracks().forEach(t => t.stop());
     });
 }, "Switching from disabled to enabled track");
         </script>

--- a/LayoutTests/webrtc/video-replace-track-to-null.html
+++ b/LayoutTests/webrtc/video-replace-track-to-null.html
@@ -99,6 +99,7 @@ promise_test(async (test) => {
 }, "Test replaceTrack with null track");
 
 promise_test(async (test) => {
+    test.add_cleanup(() => sendingTrack.stop());
     await testFrameEncodedStopped(connection);
     assert_equals(sendingTrack.readyState, "live");
 }, "Test that frame counter no longer increases");

--- a/LayoutTests/webrtc/video-replace-track.html
+++ b/LayoutTests/webrtc/video-replace-track.html
@@ -73,6 +73,10 @@ promise_test((test) => {
     var sender;
     var frontStream;
     var backStream;
+    test.add_cleanup(() => {
+        if (frontStream) frontStream.getTracks().forEach(t => t.stop());
+        if (backStream) backStream.getTracks().forEach(t => t.stop());
+    });
     return navigator.mediaDevices.getUserMedia({ video: { facingMode: { exact: ["user"] } } }).then((stream) => {
         frontStream = stream;
         return new Promise((resolve, reject) => {
@@ -112,6 +116,10 @@ promise_test((test) => {
     var sender;
     var frontStream;
     var backStream;
+    test.add_cleanup(() => {
+        if (frontStream) frontStream.getTracks().forEach(t => t.stop());
+        if (backStream) backStream.getTracks().forEach(t => t.stop());
+    });
 
     return navigator.mediaDevices.getUserMedia({ video: { width: 640, height: 480, facingMode: { exact: ["user"] } } }).then((stream) => {
         frontStream = stream;
@@ -155,6 +163,10 @@ promise_test((test) => {
     var sender;
     var frontStream;
     var backStream;
+    test.add_cleanup(() => {
+        if (frontStream) frontStream.getTracks().forEach(t => t.stop());
+        if (backStream) backStream.getTracks().forEach(t => t.stop());
+    });
 
     return navigator.mediaDevices.getUserMedia({ video: { width: 320, height: 240, facingMode: { exact: ["user"] } } }).then((stream) => {
         frontStream = stream;
@@ -191,6 +203,7 @@ promise_test((test) => {
 
 promise_test(async (test) => {
     const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+    test.add_cleanup(() => stream.getTracks().forEach(t => t.stop()));
     const pc = new RTCPeerConnection();
     pc.addTransceiver("video", {direction: "sendonly"});
     const sender = pc.addTrack(stream.getVideoTracks()[0], stream);

--- a/LayoutTests/webrtc/video-rotation-black.html
+++ b/LayoutTests/webrtc/video-rotation-black.html
@@ -48,6 +48,7 @@ function checkVideoBlack(expected, video, canvasId)
 
 promise_test(async (test) => {
     const localStream = await navigator.mediaDevices.getUserMedia({video: {width: 640, height: 480}});
+    test.add_cleanup(() => localStream.getTracks().forEach(track => track.stop()));
     if (window.testRunner)
         testRunner.setMockCameraOrientation(90);
 

--- a/LayoutTests/webrtc/video-rotation-no-cvo.html
+++ b/LayoutTests/webrtc/video-rotation-no-cvo.html
@@ -1,4 +1,3 @@
-<!-- webkit-test-runner -->
 <!doctype html>
 <html>
     <head>
@@ -14,6 +13,7 @@
         <script>
 promise_test(async (test) => {
     const localStream = await navigator.mediaDevices.getUserMedia({ video: { width: 320, height: 240 } });
+    test.add_cleanup(() => localStream.getTracks().forEach(track => track.stop()));
     if (window.testRunner)
         window.testRunner.setMockCameraOrientation(90);
 

--- a/LayoutTests/webrtc/video-rotation.html
+++ b/LayoutTests/webrtc/video-rotation.html
@@ -128,6 +128,7 @@ promise_test(async (test) => {
 }, "Track is enabled and rotated, remote video should not be black and should change size");
 
 promise_test(async (test) => {
+    test.add_cleanup(() => track.stop());
     if (window.internals)
         window.internals.setCameraMediaStreamTrackOrientation(track, 180);
     if (window.testRunner)

--- a/LayoutTests/webrtc/video-setDirection.html
+++ b/LayoutTests/webrtc/video-setDirection.html
@@ -62,6 +62,7 @@ var pc1, pc2;
 
 promise_test(async (t) => {
     const localStream = await navigator.mediaDevices.getUserMedia({video: true});
+    t.add_cleanup(() => localStream.getTracks().forEach(track => track.stop()));
     const stream = await new Promise((resolve, reject) => {
         createConnections((firstConnection) => {
             pc1 = firstConnection;

--- a/LayoutTests/webrtc/video-sframe.html
+++ b/LayoutTests/webrtc/video-sframe.html
@@ -58,6 +58,7 @@ async function doSFrameTest(codec, shouldClose)
         pc1.close();
         pc2.close();
     }
+    localStream.getTracks().forEach(t => t.stop());
 }
 
 promise_test((test) => {

--- a/LayoutTests/webrtc/video-stats.html
+++ b/LayoutTests/webrtc/video-stats.html
@@ -162,11 +162,12 @@ function checkOutboundFramesNumberIncreased(firstConnection, statsFirstConnectio
 }
 
 var firstConnection, secondConnection;
+var localStream;
 promise_test(async (test) => {
     if (window.testRunner)
         testRunner.setUserMediaPermission(true);
 
-    const localStream = await navigator.mediaDevices.getUserMedia({ audio : true, video: true});
+    localStream = await navigator.mediaDevices.getUserMedia({ audio : true, video: true});
     const remoteStream = await new Promise((resolve, reject) => {
         createConnections((connection) => {
             firstConnection = connection;
@@ -333,6 +334,7 @@ promise_test(async (test) => {
 }, "Inbound rtp stats - rtx");
 
 promise_test(async (test) => {
+    test.add_cleanup(() => localStream.getTracks().forEach(track => track.stop()));
     const pc = new RTCPeerConnection();
     pc.close();
     return pc.getStats();

--- a/LayoutTests/webrtc/video-unmute.html
+++ b/LayoutTests/webrtc/video-unmute.html
@@ -45,6 +45,7 @@ promise_test((test) => {
 }, "Track is disabled, video should be black");
 
 promise_test((test) => {
+    test.add_cleanup(() => track.stop());
     track.enabled = true;
     return checkVideoBlack(false, canvas2, video);
 }, "Track is enabled, video should not be black");

--- a/LayoutTests/webrtc/video-with-data-channel.html
+++ b/LayoutTests/webrtc/video-with-data-channel.html
@@ -40,10 +40,8 @@ function testImage()
 }
 
 promise_test((test) => {
-    if (window.testRunner)
-        testRunner.setUserMediaPermission(true);
-
     return navigator.mediaDevices.getUserMedia({ video: true, audio: true}).then((stream) => {
+        test.add_cleanup(() => stream.getTracks().forEach(track => track.stop()));
         return new Promise((resolve, reject) => {
             var count = 0;
             var channel;

--- a/LayoutTests/webrtc/video.html
+++ b/LayoutTests/webrtc/video.html
@@ -44,11 +44,12 @@ function testImage()
 }
 
 var pc1, pc2;
+var localStream;
 promise_test(async (test) => {
     if (window.testRunner)
         testRunner.setUserMediaPermission(true);
 
-    const localStream = await navigator.mediaDevices.getUserMedia({video: {advanced: [{width:{min:640}}, {height:{min:480} } ]}});
+    localStream = await navigator.mediaDevices.getUserMedia({video: {advanced: [{width:{min:640}}, {height:{min:480} } ]}});
     const localStream2 = new MediaStream([localStream.getVideoTracks()[0]]); 
     if (window.internals)
         assert_true(internals.pageMediaState().includes('HasActiveVideoCaptureDevice'), "Unexpected HasActiveVideoCaptureDevice");
@@ -143,6 +144,7 @@ promise_test(async (test) => {
 }, "Call setParameters to reenable sending a given encoding");
 
 promise_test(async (test) => {
+    test.add_cleanup(() => localStream.getTracks().forEach(track => track.stop()));
     const sender = pc1.getSenders()[0];
     let p = sender.getParameters();
     p.encodings[0].scaleResolutionDownBy = 2;

--- a/LayoutTests/webrtc/vp8-then-h264-gpu-process-crash.html
+++ b/LayoutTests/webrtc/vp8-then-h264-gpu-process-crash.html
@@ -1,4 +1,4 @@
-<!doctype html>
+<!doctype html> <!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
 <html>
     <head>
         <meta charset="utf-8">

--- a/LayoutTests/webrtc/vp8-then-h264.html
+++ b/LayoutTests/webrtc/vp8-then-h264.html
@@ -42,7 +42,8 @@ promise_test((test) => {
     });
 }, "Setting video exchange with VP8");
 
-promise_test(async () => {
+promise_test(async (test) => {
+    test.add_cleanup(() => track.stop());
     video2.srcObject = await new Promise((resolve, reject) => {
         createConnections((firstConnection) => {
             firstConnection.addTrack(video1.srcObject.getVideoTracks()[0], video1.srcObject);

--- a/LayoutTests/webrtc/vp9-profile2.html
+++ b/LayoutTests/webrtc/vp9-profile2.html
@@ -82,6 +82,7 @@ if (vp9Profile2) {
     }, "Track is disabled, video should be black");
 
     promise_test((test) => {
+        test.add_cleanup(() => track.stop());
         track.enabled = true;
         return checkVideoBlack(false, canvas2, video);
     }, "Track is enabled, video should not be black 2");

--- a/LayoutTests/webrtc/vp9-svc.html
+++ b/LayoutTests/webrtc/vp9-svc.html
@@ -71,6 +71,8 @@ async function testVP9Decoder(useVP9SVC)
 
     assert_equals(video.videoWidth, 1280);
     assert_equals(video.videoHeight, 720);
+
+    localStream.getTracks().forEach(t => t.stop());
 }
 
 promise_test(async () => {

--- a/LayoutTests/webrtc/vp9-sw.html
+++ b/LayoutTests/webrtc/vp9-sw.html
@@ -20,6 +20,7 @@ if (window.internals)
         <script>
 promise_test(async t => {
     const localStream = await navigator.mediaDevices.getUserMedia({video: {width: 320, height: 240, facingMode: "environment"}});
+    t.add_cleanup(() => localStream.getTracks().forEach(track => track.stop()));
     const track = localStream.getVideoTracks()[0];
     let receivingConnection;
     const remoteStream =  await new Promise((resolve, reject) => {


### PR DESCRIPTION
#### 9e5ba0fc9c17332e88a2736f1f298636353bbafa
<pre>
[macOS] webrtc/getUserMedia-webaudio-autoplay.html is a flaky text failure.
<a href="https://rdar.apple.com/176917820">rdar://176917820</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=314668">https://bugs.webkit.org/show_bug.cgi?id=314668</a>

Reviewed by Eric Carlson.

We stop tracks at the end of the test to prevent the warning console message to make the test flaky.
We also update other tests in fast/mediastream, http/wpt/mediastream and webrtc accordingly.
As a fly-by fix, we remove unnecessary calls to testRunner.setUserMediaPermission(true) since WTR is resetting back to true for every test.
For some tests, we cannot really stop the tracks easily, in that case we use dumpJSConsoleLogInStdErr=true.

* LayoutTests/platform/mac-wk2/TestExpectations:
* LayoutTests/webrtc/getUserMedia-webaudio-autoplay.html:

Canonical link: <a href="https://commits.webkit.org/313714@main">https://commits.webkit.org/313714@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/95e922bf3785bba106129b1219985b3e3f75fc15

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163538 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37022 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30241 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172478 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119987 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/61a77042-ef88-4be2-8e4b-1b94823e57eb) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37353 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37021 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127018 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89546 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5e0f2826-c4b8-4a25-a37f-f8088c0dc3a3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166497 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29289 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147021 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107572 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1d749f71-68cc-4442-aef2-ccd210649ab8) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28338 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26969 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20181 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138236 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24740 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174983 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26403 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135322 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36692 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31071 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135304 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36550 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37477 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146535 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99527 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30610 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23386 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36187 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35685 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1411 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35935 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35832 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->