### PR TITLE
[GTK][WPE] Skia Compositor: use deferred display lists to paint tiles

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-bottom-left-radius-004.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-bottom-left-radius-004.xht
@@ -3,7 +3,7 @@
     <title>border-bottom-left-radius using one percentage</title>
     <link rel="match" href="border-bottom-left-radius-004-ref.xht" />
     <link rel="help" href="https://drafts.csswg.org/css-backgrounds/#border-radius" />
-    <meta name="fuzzy" content="maxDifference=1; totalPixels=0-5" />
+    <meta name="fuzzy" content="maxDifference=0-4; totalPixels=0-7" />
     <style type="text/css">
       div
       {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-bottom-left-radius-005.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-bottom-left-radius-005.xht
@@ -3,7 +3,7 @@
     <title>border-bottom-left-radius using two percentages</title>
     <link rel="match" href="border-bottom-left-radius-005-ref.xht" />
     <link rel="help" href="https://drafts.csswg.org/css-backgrounds/#border-radius" />
-    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-1" />
+    <meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-2" />
     <style type="text/css">
       div
       {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-radius-clipping-with-transform-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-radius-clipping-with-transform-001.html
@@ -6,7 +6,7 @@
 <link rel="help" href="https://drafts.csswg.org/css-backgrounds-3/#corner-clipping">
 <link rel="match" href="border-radius-clipping-with-transform-001-ref.html">
 <meta name="assert" content="The content should be clipped correctly, despite the interesting transforms.">
-<meta name="fuzzy" content="maxDifference=0-48; totalPixels=0-6783" />
+<meta name="fuzzy" content="maxDifference=0-94; totalPixels=0-6783" />
 <style>
 
 #outer {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-top-left-radius-004.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-top-left-radius-004.xht
@@ -3,7 +3,7 @@
     <title>border-top-left-radius using one percentage</title>
     <link rel="match" href="border-top-left-radius-004-ref.xht" />
     <link rel="help" href="https://drafts.csswg.org/css-backgrounds/#border-radius" />
-    <meta name="fuzzy" content="maxDifference=1; totalPixels=0-5" />
+    <meta name="fuzzy" content="maxDifference=0-4; totalPixels=0-7" />
     <style type="text/css">
       div
       {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-top-left-radius-005.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-top-left-radius-005.xht
@@ -3,7 +3,7 @@
     <title>border-top-left-radius using two percentages</title>
     <link rel="match" href="border-top-left-radius-005-ref.xht" />
     <link rel="help" href="https://drafts.csswg.org/css-backgrounds/#border-radius" />
-    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-1" />
+    <meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-2" />
     <style type="text/css">
       div
       {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-top-right-radius-004.xht
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-top-right-radius-004.xht
@@ -3,7 +3,7 @@
     <title>border-top-right-radius using one percentage</title>
     <link rel="match" href="border-top-right-radius-004-ref.xht" />
     <link rel="help" href="https://drafts.csswg.org/css-backgrounds/#border-radius" />
-    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-2" />
+    <meta name="fuzzy" content="maxDifference=0-4; totalPixels=0-7" />
     <style type="text/css">
       div
       {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-borderBox-1e.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-borderBox-1e.html
@@ -3,7 +3,7 @@
 <link rel="help" href="https://drafts.fxtf.org/css-masking-1/#the-clip-path">
 <link rel="help" href="https://drafts.csswg.org/css-shapes-1/#valdef-shape-box-border-box">
 <link rel="match" href="reference/green-circle-100x100.html">
-<meta name="fuzzy" content="maxDifference=0-126; totalPixels=0-400">
+<meta name="fuzzy" content="maxDifference=0-155; totalPixels=0-400">
 <meta name="assert" content="Check that the 'clip-path' property supports border-box with border-radius.">
 
 <style>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/outline-027.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-ui/outline-027.html
@@ -6,6 +6,7 @@
 <link rel="match" href="reference/outline-027-ref.html">
 <meta name="assert" content="Test checks that 'auto' outline works as expected in an element with different paddings and inline descendant.">
 <meta name="flags" content="ahem">
+<meta name="fuzzy" content="maxDifference=0-2; totalPixels=0-2" />
 <link rel="stylesheet" type="text/css" href="/fonts/ahem.css" />
 <style>
 .outline-container {

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-clip-rect.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-clip-rect.html
@@ -4,7 +4,7 @@
 <link rel="author" href="mailto:masonf@chromium.org">
 <link rel="help" href="https://drafts.fxtf.org/filter-effects-2/#BackdropFilterProperty">
 <link rel="match"  href="backdrop-filter-clip-rect-ref.html">
-<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-1" />
+<meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-8" />
 
 <div>
   <p>Expected: A green box, color-inverted inside the short, wide box with a<br>

--- a/LayoutTests/svg/W3C-SVG-1.2-Tiny/struct-use-recursion-01-t.svg
+++ b/LayoutTests/svg/W3C-SVG-1.2-Tiny/struct-use-recursion-01-t.svg
@@ -2,7 +2,7 @@
 <svg version="1.2" baseProfile="tiny" id="svg-root" width="100%" height="100%"
   viewBox="0 0 480 360" xmlns="http://www.w3.org/2000/svg"
   xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:xe="http://www.w3.org/2001/xml-events">
-  <meta name="fuzzy" content="maxDifference=1; totalPixels=19" />
+  <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-19" />
   <!--======================================================================-->
   <!--=  Copyright 2008 World Wide Web Consortium, (Massachusetts          =-->
   <!--=  Institute of Technology, European Research Consortium for         =-->

--- a/LayoutTests/svg/custom/href-svg-namespace-static.svg
+++ b/LayoutTests/svg/custom/href-svg-namespace-static.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg">
-    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=3800-4400" />
+    <meta name="fuzzy" content="maxDifference=0-129; totalPixels=199-4400" />
     <defs>
         <linearGradient id="gradient1">
             <stop offset="0%" stop-color="green" />

--- a/LayoutTests/svg/custom/marker-stroke-dasharray-none-zero.svg
+++ b/LayoutTests/svg/custom/marker-stroke-dasharray-none-zero.svg
@@ -1,5 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" overflow="visible">
-<meta name="fuzzy" content="maxDifference=44-255; totalPixels=2-121" />
+<meta name="fuzzy" content="maxDifference=32-255; totalPixels=2-121" />
   <defs>
     <marker id="my-marker" orient="auto" overflow="visible" markerUnits="userSpaceOnUse" >
       <path stroke="black" fill="white" d="M 0 -5 -10 0 0 5 z"></path>

--- a/Source/WebCore/platform/graphics/Pattern.h
+++ b/Source/WebCore/platform/graphics/Pattern.h
@@ -43,6 +43,7 @@ typedef cairo_pattern_t* PlatformPatternPtr;
 #elif USE(SKIA)
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkShader.h>
+#include <skia/gpu/ganesh/GrContextThreadSafeProxy.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 typedef sk_sp<SkShader> PlatformPatternPtr;
 #endif
@@ -79,7 +80,7 @@ public:
 
     // Pattern space is an abstract space that maps to the default user space by the transformation 'userSpaceTransform'
 #if USE(SKIA)
-    PlatformPatternPtr createPlatformPattern(const AffineTransform& userSpaceTransform, const SkSamplingOptions&) const;
+    PlatformPatternPtr createPlatformPattern(const SkSamplingOptions&, const sk_sp<GrContextThreadSafeProxy>&) const;
 #else
     PlatformPatternPtr createPlatformPattern(const AffineTransform& userSpaceTransform) const;
 #endif

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp
@@ -202,6 +202,31 @@ static SkSamplingOptions toSkSamplingOptions(InterpolationQuality quality)
     return SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNearest);
 }
 
+sk_sp<SkImage> GraphicsContextSkia::imageForCurrentThread(const sk_sp<SkImage>& image) const
+{
+    if (!image->isTextureBacked())
+        return image;
+
+    auto* glContext = PlatformDisplay::sharedDisplay().skiaGLContext();
+    if (!glContext || !glContext->makeContextCurrent())
+        return image;
+
+    // Use the destination context (current thread's context), not nativeImage.grContext()
+    // (source context). For cross-thread transfers, we must check validity against the
+    // destination context and rewrap the texture for use in this context.
+    auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
+    RELEASE_ASSERT(grContext);
+
+    // Check if the GPU texture is valid for the current context.
+    // If the image was created in a different thread/context, we need to rewrap it.
+    sk_sp<SkImage> imageInThisThread = image->isValid(grContext->asRecorder()) ? image : SkiaUtilities::rewrapImageForContext(grContext, *image);
+    if (renderingMode() == RenderingMode::Accelerated)
+        return imageInThisThread;
+
+    // When drawing GPU-backed image on CPU-backed canvas we need to convert image to CPU-backed one.
+    return imageInThisThread->makeRasterImage(grContext);
+}
+
 void GraphicsContextSkia::drawNativeImage(const NativeImage& nativeImage, const FloatRect& destRect, const FloatRect& srcRect, ImagePaintingOptions options)
 {
     auto image = nativeImage.platformImage();
@@ -251,51 +276,22 @@ void GraphicsContextSkia::drawNativeImage(const NativeImage& nativeImage, const 
     auto clampingConstraint = options.strictImageClamping() == StrictImageClamping::Yes ? SkCanvas::kStrict_SrcRectConstraint : SkCanvas::kFast_SrcRectConstraint;
 
     // 'imageInThisThread' is either the incoming 'image', or a wrapper around the 'image' accessible in the current thread.
-    // When you want to access the image, use 'imageInThisThread' if it's non-zero or 'image'.
-    sk_sp<SkImage> imageInThisThread;
-
-    if (image->isTextureBacked()) {
-        auto* glContext = PlatformDisplay::sharedDisplay().skiaGLContext();
-        if (glContext && glContext->makeContextCurrent()) {
-            // Use the destination context (current thread's context), not nativeImage.grContext()
-            // (source context). For cross-thread transfers, we must check validity against the
-            // destination context and rewrap the texture for use in this context.
-            auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
-            RELEASE_ASSERT(grContext);
-
-            // Check if the GPU texture is valid for the current context.
-            // If the image was created in a different thread/context, we need to rewrap it.
-            if (!image->isValid(grContext->asRecorder())) {
-                // Ensure any pending GPU operations on the source image are complete before
-                // accessing its backend texture for rewrapping.
-                if (auto fence = SkiaUtilities::flushAndSubmitImageWithFence(nativeImage.grContext(), nativeImage.platformImage()))
-                    fence->serverWait();
-
-                imageInThisThread = SkiaUtilities::rewrapImageForContext(grContext, *image);
-            }
-        }
-    }
+    auto imageInThisThread = imageForCurrentThread(image);
+    if (m_threadSafeGrContext)
+        imageInThisThread = SkiaUtilities::createPromiseImageIfNeeded(imageInThisThread, m_threadSafeGrContext);
+    else
+        trackAcceleratedRenderingFenceIfNeeded(imageInThisThread, nativeImage.grContext());
 
     // 'imageForDrawing' references the incoming image (or if it's not directly accessible in this thread the 'imageInThisThread' which is).
     // However, if we have to make a raster copy (see the hasDropShadow() case below), then imageForDrawing will point to the raster copy instead.
     // This is the image we have to pass on to m_canvas.drawImageRect(...) below.
-    SkImage* imageForDrawing = imageInThisThread ? imageInThisThread.get() : image.get();
+    auto* imageForDrawing = imageInThisThread.get();
 
-    sk_sp<SkImage> imageRasterCopy;
     if (hasDropShadow()) {
-        if (imageForDrawing->isTextureBacked()) {
-            if (renderingMode() == RenderingMode::Unaccelerated) {
-                // When drawing GPU-backed image on CPU-backed canvas with filter, we need to convert image to CPU-backed one.
-                imageRasterCopy = imageInThisThread ? imageInThisThread->makeRasterImage() : image->makeRasterImage();
-                imageForDrawing = imageRasterCopy.get();
-            } else
-                trackAcceleratedRenderingFenceIfNeeded(imageInThisThread ? imageInThisThread : image, nativeImage.grContext());
-        }
         inExtraTransparencyLayer = drawOutsetShadow(paint, [&](const SkPaint& paint) {
             m_canvas.drawImageRect(imageForDrawing, normalizedSrcRect, normalizedDestRect, toSkSamplingOptions(m_state.imageInterpolationQuality()), &paint, clampingConstraint);
         });
-    } else
-        trackAcceleratedRenderingFenceIfNeeded(imageInThisThread ? imageInThisThread : image, nativeImage.grContext());
+    }
 
     m_canvas.drawImageRect(imageForDrawing, normalizedSrcRect, normalizedDestRect, toSkSamplingOptions(m_state.imageInterpolationQuality()), &paint, clampingConstraint);
     if (inExtraTransparencyLayer)
@@ -565,9 +561,10 @@ SkPaint GraphicsContextSkia::createFillPaint() const
 void GraphicsContextSkia::setupFillSource(SkPaint& paint)
 {
     if (auto fillPattern = fillBrush().pattern()) {
-        paint.setShader(fillPattern->createPlatformPattern({ }, toSkSamplingOptions(imageInterpolationQuality())));
+        paint.setShader(fillPattern->createPlatformPattern(toSkSamplingOptions(imageInterpolationQuality()), m_threadSafeGrContext));
         paint.setAlphaf(alpha());
-        trackAcceleratedRenderingFenceIfNeeded(*fillPattern);
+        if (!m_threadSafeGrContext)
+            trackAcceleratedRenderingFenceIfNeeded(*fillPattern);
     } else if (auto fillGradient = fillBrush().gradient())
         paint.setShader(fillGradient->shader(alpha(), fillBrush().gradientSpaceTransform()));
     else
@@ -591,8 +588,9 @@ SkPaint GraphicsContextSkia::createStrokePaint() const
 void GraphicsContextSkia::setupStrokeSource(SkPaint& paint)
 {
     if (auto strokePattern = strokeBrush().pattern()) {
-        paint.setShader(strokePattern->createPlatformPattern({ }, toSkSamplingOptions(imageInterpolationQuality())));
-        trackAcceleratedRenderingFenceIfNeeded(*strokePattern);
+        paint.setShader(strokePattern->createPlatformPattern(toSkSamplingOptions(imageInterpolationQuality()), m_threadSafeGrContext));
+        if (!m_threadSafeGrContext)
+            trackAcceleratedRenderingFenceIfNeeded(*strokePattern);
     } else if (auto strokeGradient = strokeBrush().gradient())
         paint.setShader(strokeGradient->shader(alpha(), strokeBrush().gradientSpaceTransform()));
     else
@@ -696,7 +694,10 @@ void GraphicsContextSkia::clipToImageBuffer(ImageBuffer& buffer, const FloatRect
 {
     if (auto nativeImage = nativeImageForDrawing(buffer)) {
         auto image = nativeImage->platformImage();
-        trackAcceleratedRenderingFenceIfNeeded(image, nativeImage->grContext());
+        if (m_threadSafeGrContext)
+            image = SkiaUtilities::createPromiseImageIfNeeded(image, m_threadSafeGrContext);
+        else
+            trackAcceleratedRenderingFenceIfNeeded(image, nativeImage->grContext());
         auto shader = image->makeShader(SkTileMode::kDecal, SkTileMode::kDecal, { }, SkMatrix::Translate(SkFloatToScalar(destRect.x()), SkFloatToScalar(destRect.y())));
 
         recordClipIfNeeded({
@@ -1098,6 +1099,8 @@ void GraphicsContextSkia::drawPattern(const NativeImage& nativeImage, const Floa
     if (!makeGLContextCurrentIfNeeded())
         return;
 
+    image = imageForCurrentThread(image);
+
     FloatPoint phaseOffset(tileRect.location());
     phaseOffset.scale(patternTransform.a(), patternTransform.d());
     phaseOffset.moveBy(phase);
@@ -1124,8 +1127,11 @@ void GraphicsContextSkia::drawPattern(const NativeImage& nativeImage, const Floa
             repeatX = imageSampledRect.x() < 0 || std::trunc(imageSampledRect.right()) > size.width();
             repeatY = imageSampledRect.y() < 0 || std::trunc(imageSampledRect.bottom()) > size.height();
         }
+        if (m_threadSafeGrContext)
+            image = SkiaUtilities::createPromiseImageIfNeeded(image, m_threadSafeGrContext);
         paint.setShader(image->makeShader(repeatX ? SkTileMode::kRepeat : SkTileMode::kClamp, repeatY ? SkTileMode::kRepeat : SkTileMode::kClamp, samplingOptions, &shaderMatrix));
-        trackAcceleratedRenderingFenceIfNeeded(image, nativeImage.grContext());
+        if (!m_threadSafeGrContext)
+            trackAcceleratedRenderingFenceIfNeeded(image, nativeImage.grContext());
     } else {
         auto tileFloatRectWithSpacing = FloatRect(0, 0, tileRect.width() + spacing.width() / patternTransform.a(), tileRect.height() + spacing.height() / patternTransform.d());
         if (image->isTextureBacked()) {
@@ -1137,8 +1143,11 @@ void GraphicsContextSkia::drawPattern(const NativeImage& nativeImage, const Floa
                 auto* recordingContext = surface->recordingContext();
                 auto* grContext = recordingContext ? recordingContext->asDirectContext() : nullptr;
                 auto tileImage = surface->makeImageSnapshot();
+                if (m_threadSafeGrContext)
+                    tileImage = SkiaUtilities::createPromiseImageIfNeeded(tileImage, m_threadSafeGrContext);
                 paint.setShader(tileImage->makeShader(SkTileMode::kRepeat, SkTileMode::kRepeat, samplingOptions, &shaderMatrix));
-                trackAcceleratedRenderingFenceIfNeeded(tileImage, grContext);
+                if (!m_threadSafeGrContext)
+                    trackAcceleratedRenderingFenceIfNeeded(tileImage, grContext);
             }
         } else {
             auto dstRect = SkRect::MakeWH(tileRect.width(), tileRect.height());
@@ -1156,18 +1165,20 @@ void GraphicsContextSkia::drawPattern(const NativeImage& nativeImage, const Floa
     m_canvas.drawRect(destRect, paint);
 }
 
-void GraphicsContextSkia::beginRecording(RecordingMode recordingMode)
+void GraphicsContextSkia::beginRecording(RecordingMode recordingMode, const sk_sp<GrContextThreadSafeProxy>& threadSafeGrContext)
 {
     ASSERT(m_contextMode == ContextMode::PaintingMode);
     switch (recordingMode) {
     case RecordingMode::Tile:
         m_contextMode = ContextMode::TileRecordingMode;
-        if (m_renderingMode == RenderingMode::Accelerated)
+        if (m_renderingMode == RenderingMode::Accelerated) {
+            m_threadSafeGrContext = threadSafeGrContext;
             m_atlasLayoutBuilder = makeUnique<SkiaImageAtlasLayoutBuilder>();
-        else
+        } else
             ASSERT(!m_atlasLayoutBuilder);
         break;
     case RecordingMode::Canvas:
+        ASSERT(!threadSafeGrContext);
         m_contextMode = ContextMode::CanvasRecordingMode;
         if (!m_enableStateReplayTracking) {
             m_enableStateReplayTracking = true;
@@ -1191,9 +1202,11 @@ SkiaRecordingData GraphicsContextSkia::endRecording()
             imageSetFingerprint = m_atlasLayoutBuilder->imageSetFingerprint();
             m_atlasLayoutBuilder = nullptr;
         }
+        m_threadSafeGrContext = nullptr;
         return { WTF::move(m_imageToFenceMap), WTF::move(atlasLayouts), imageSetFingerprint };
     }
     case ContextMode::CanvasRecordingMode:
+        ASSERT(!m_threadSafeGrContext);
         return { };
     case ContextMode::PaintingMode:
         RELEASE_ASSERT_NOT_REACHED();
@@ -1232,6 +1245,8 @@ void GraphicsContextSkia::replayStateOnCanvas(SkCanvas& canvas) const
 
 void GraphicsContextSkia::trackAcceleratedRenderingFenceIfNeeded(const sk_sp<SkImage>& image, GrDirectContext* grContext)
 {
+    ASSERT(!m_threadSafeGrContext);
+
     if (m_contextMode != ContextMode::TileRecordingMode)
         return;
 
@@ -1244,6 +1259,8 @@ void GraphicsContextSkia::trackAcceleratedRenderingFenceIfNeeded(const sk_sp<SkI
 
 void GraphicsContextSkia::trackAcceleratedRenderingFenceIfNeeded(Pattern& pattern)
 {
+    ASSERT(!m_threadSafeGrContext);
+
     if (m_contextMode != ContextMode::TileRecordingMode)
         return;
 

--- a/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
+++ b/Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h
@@ -34,6 +34,7 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkImage.h>
 #include <skia/core/SkPath.h>
 #include <skia/effects/SkDashPathEffect.h>
+#include <skia/gpu/ganesh/GrContextThreadSafeProxy.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #include <wtf/CompletionHandler.h>
 #include <wtf/HashMap.h>
@@ -58,7 +59,7 @@ public:
     const DestinationColorSpace& colorSpace() const final;
 
     enum class RecordingMode : bool { Tile, Canvas };
-    void beginRecording(RecordingMode);
+    void beginRecording(RecordingMode, const sk_sp<GrContextThreadSafeProxy>& = nullptr);
     SkiaRecordingData endRecording();
 
     void replayStateOnCanvas(SkCanvas&) const;
@@ -133,6 +134,7 @@ private:
     bool makeGLContextCurrentIfNeeded() const;
     void trackAcceleratedRenderingFenceIfNeeded(const sk_sp<SkImage>&, GrDirectContext*);
     void trackAcceleratedRenderingFenceIfNeeded(Pattern&);
+    sk_sp<SkImage> imageForCurrentThread(const sk_sp<SkImage>&) const;
 
     void setupFillSource(SkPaint&);
     void setupStrokeSource(SkPaint&);
@@ -197,6 +199,7 @@ private:
     CompletionHandler<void()> m_destroyNotify;
     SkiaState m_skiaState;
     Vector<SkiaState, 1> m_skiaStateStack;
+    sk_sp<GrContextThreadSafeProxy> m_threadSafeGrContext;
     SkiaImageToFenceMap m_imageToFenceMap;
     bool m_enableStateReplayTracking : 1 { false };
     std::unique_ptr<SkiaImageAtlasLayoutBuilder> m_atlasLayoutBuilder;

--- a/Source/WebCore/platform/graphics/skia/PatternSkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/PatternSkia.cpp
@@ -30,17 +30,18 @@
 #include "AffineTransform.h"
 #include "ImageBuffer.h"
 #include "NativeImage.h"
-#include <skia/core/SkImage.h>
-#include <skia/core/SkSamplingOptions.h>
-#include <skia/core/SkTileMode.h>
+#include "SkiaUtilities.h"
 
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkImage.h>
 #include <skia/core/SkMatrix.h>
+#include <skia/core/SkSamplingOptions.h>
+#include <skia/core/SkTileMode.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 namespace WebCore {
 
-sk_sp<SkShader> Pattern::createPlatformPattern(const AffineTransform&, const SkSamplingOptions& samplingOptions) const
+sk_sp<SkShader> Pattern::createPlatformPattern(const SkSamplingOptions& samplingOptions, const sk_sp<GrContextThreadSafeProxy>& threadSafeGrContext) const
 {
     auto nativeImage = tileNativeImage();
     if (!nativeImage)
@@ -49,6 +50,9 @@ sk_sp<SkShader> Pattern::createPlatformPattern(const AffineTransform&, const SkS
     auto platformImage = nativeImage->platformImage();
     if (!platformImage)
         return nullptr;
+
+    if (threadSafeGrContext)
+        platformImage = SkiaUtilities::createPromiseImageIfNeeded(platformImage, threadSafeGrContext);
 
     return platformImage->makeShader(repeatX() ? SkTileMode::kRepeat : SkTileMode::kDecal, repeatY() ? SkTileMode::kRepeat : SkTileMode::kDecal, samplingOptions, patternSpaceTransform());
 }

--- a/Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp
+++ b/Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp
@@ -245,6 +245,7 @@ public:
     {
         if (m_skiaGLContext) {
             m_skiaGLContext->makeContextCurrent();
+            m_skiaGrContext->abandonContext();
             m_skiaGrContext = nullptr;
             m_skiaGLContext = nullptr;
         }

--- a/Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp
@@ -29,12 +29,14 @@
 #if USE(COORDINATED_GRAPHICS) && USE(SKIA)
 #include "BitmapTexturePool.h"
 #include "CoordinatedTileBuffer.h"
+#include "FontRenderOptions.h"
 #include "PlatformDisplay.h"
 #include "SkiaPaintingEngine.h"
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkColorSpace.h>
 #include <skia/gpu/ganesh/GrBackendSurface.h>
 #include <skia/gpu/ganesh/SkImageGanesh.h>
+#include <skia/gpu/ganesh/SkSurfaceGanesh.h>
 #include <skia/gpu/ganesh/gl/GrGLBackendSurface.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #include <wtf/SystemTracing.h>
@@ -159,17 +161,46 @@ void SkiaBackingStore::Tile::update(const IntRect& dirtyRect, const IntRect& til
         auto& acceleratedBuffer = static_cast<CoordinatedAcceleratedTileBuffer&>(buffer);
         acceleratedBuffer.serverWait();
 
-        Ref texture = acceleratedBuffer.texture();
-        if (dirtyRect.size() == tileRect.size()) {
-            // Fast path: whole tile content changed -- take ownership of the incoming texture, replacing the existing tile buffer (avoiding texture copies).
-            if (m_texture)
-                m_texture->swapTexture(texture.get());
-            else
-                m_texture = WTF::move(texture);
-            m_cachedImage = nullptr;
-        } else {
-            ensureTexture(tileRect.size(), buffer);
-            m_texture->copyFromExternalTexture(texture->id(), dirtyRect, { });
+        if (auto displayList = acceleratedBuffer.displayList()) {
+            ASSERT(!m_texture);
+            ASSERT(!m_cachedImage);
+
+            auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
+            ASSERT(grContext);
+
+            auto createSkiaSurface = [&](const IntRect& rect) -> sk_sp<SkSurface> {
+                auto imageInfo = SkImageInfo::Make(rect.width(), rect.height(), kRGBA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
+                auto properties = FontRenderOptions::singleton().createSurfaceProps();
+                return SkSurfaces::RenderTarget(grContext, skgpu::Budgeted::kYes, imageInfo, 0, kTopLeft_GrSurfaceOrigin, &properties);
+            };
+            auto surface = createSkiaSurface(dirtyRect);
+            skgpu::ganesh::DrawDDL(surface.get(), displayList);
+
+            if (dirtyRect.size() == tileRect.size())
+                m_surface = WTF::move(surface);
+            else {
+                if (!m_surface)
+                    m_surface = createSkiaSurface(tileRect);
+
+                SkPaint paint;
+                paint.setBlendMode(SkBlendMode::kSrc);
+                m_surface->getCanvas()->drawImageRect(surface->makeImageSnapshot(), SkRect::MakeWH(dirtyRect.width(), dirtyRect.height()), SkRect::Make(SkIRect(dirtyRect)),
+                    SkSamplingOptions(SkFilterMode::kNearest, SkMipmapMode::kNone), &paint, SkCanvas::kFast_SrcRectConstraint);
+            }
+        } else if (auto texture = acceleratedBuffer.texture()) {
+            ASSERT(!m_surface);
+
+            if (dirtyRect.size() == tileRect.size()) {
+                // Fast path: whole tile content changed -- take ownership of the incoming texture, replacing the existing tile buffer (avoiding texture copies).
+                if (m_texture)
+                    m_texture->swapTexture(*texture);
+                else
+                    m_texture = WTF::move(texture);
+                m_cachedImage = nullptr;
+            } else {
+                ensureTexture(tileRect.size(), buffer);
+                m_texture->copyFromExternalTexture(texture->id(), dirtyRect, { });
+            }
         }
     } else {
         auto& unacceleratedBuffer = static_cast<CoordinatedUnacceleratedTileBuffer&>(buffer);
@@ -182,6 +213,9 @@ void SkiaBackingStore::Tile::update(const IntRect& dirtyRect, const IntRect& til
 
 sk_sp<SkImage> SkiaBackingStore::Tile::image() const
 {
+    if (m_surface)
+        return m_surface->makeImageSnapshot();
+
     if (!m_cachedImage && m_texture) {
         auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
         ASSERT(grContext);

--- a/Source/WebCore/platform/graphics/skia/SkiaBackingStore.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaBackingStore.h
@@ -71,6 +71,7 @@ private:
 
         float m_scale { 1. };
         FloatRect m_rect;
+        sk_sp<SkSurface> m_surface;
         RefPtr<BitmapTexture> m_texture;
         mutable sk_sp<SkImage> m_cachedImage;
     };

--- a/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.cpp
@@ -28,6 +28,7 @@
 
 #if USE(SKIA)
 #include "BitmapTexture.h"
+#include "GLContext.h"
 #include "PlatformDisplay.h"
 #include "SkiaImageAtlasLayout.h"
 #if USE(GBM)
@@ -40,16 +41,19 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkPixmap.h>
 #include <skia/gpu/ganesh/GrDirectContext.h>
 #include <skia/gpu/ganesh/SkImageGanesh.h>
+#include <skia/private/chromium/GrPromiseImageTexture.h>
+#include <skia/private/chromium/SkImageChromium.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 namespace WebCore {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(SkiaGPUAtlas);
 
-SkiaGPUAtlas::SkiaGPUAtlas(Ref<BitmapTexture>&& atlasTexture, GrBackendTexture&& backendTexture, Ref<AtlasUploadCondition>&& uploadCondition, const SkiaImageAtlasLayout& layout, const IntSize& size)
+SkiaGPUAtlas::SkiaGPUAtlas(Ref<BitmapTexture>&& atlasTexture, GrBackendTexture&& backendTexture, Ref<AtlasUploadCondition>&& uploadCondition, const sk_sp<GrContextThreadSafeProxy>& threadSafeGrContext, const SkiaImageAtlasLayout& layout, const IntSize& size)
     : m_atlasTexture(WTF::move(atlasTexture))
     , m_backendTexture(WTF::move(backendTexture))
     , m_uploadCondition(WTF::move(uploadCondition))
+    , m_threadSafeGrContext(threadSafeGrContext)
     , m_layout(layout)
     , m_size(size)
 {
@@ -62,7 +66,7 @@ SkiaGPUAtlas::SkiaGPUAtlas(Ref<BitmapTexture>&& atlasTexture, GrBackendTexture&&
 
 SkiaGPUAtlas::~SkiaGPUAtlas() = default;
 
-RefPtr<SkiaGPUAtlas> SkiaGPUAtlas::create(const SkiaImageAtlasLayout& layout, Ref<BitmapTexture>&& atlasTexture, Ref<AtlasUploadCondition>&& uploadCondition)
+RefPtr<SkiaGPUAtlas> SkiaGPUAtlas::create(const SkiaImageAtlasLayout& layout, Ref<BitmapTexture>&& atlasTexture, Ref<AtlasUploadCondition>&& uploadCondition, const sk_sp<GrContextThreadSafeProxy>& threadSafeGrContext)
 {
     const auto& atlasSize = layout.atlasSize();
     if (atlasSize.isEmpty())
@@ -74,7 +78,7 @@ RefPtr<SkiaGPUAtlas> SkiaGPUAtlas::create(const SkiaImageAtlasLayout& layout, Re
     if (!backendTexture.isValid())
         return nullptr;
 
-    return adoptRef(*new SkiaGPUAtlas(WTF::move(atlasTexture), WTF::move(backendTexture), WTF::move(uploadCondition), layout, atlasSize));
+    return adoptRef(*new SkiaGPUAtlas(WTF::move(atlasTexture), WTF::move(backendTexture), WTF::move(uploadCondition), threadSafeGrContext, layout, atlasSize));
 }
 
 void SkiaGPUAtlas::uploadImages()
@@ -139,13 +143,31 @@ void SkiaGPUAtlas::waitForUpload() const
 
 sk_sp<SkImage> SkiaGPUAtlas::atlasImageForCurrentThread() const
 {
-    if (!m_backendTexture.isValid())
+    if (m_threadSafeGrContext) {
+        ref();
+        auto backendFormat = m_threadSafeGrContext->defaultBackendFormat(kRGBA_8888_SkColorType, GrRenderable::kYes);
+        ASSERT(backendFormat.isValid());
+        return SkImages::PromiseTextureFrom(m_threadSafeGrContext, backendFormat, SkISize::Make(m_atlasTexture->size().width(), m_atlasTexture->size().height()), skgpu::Mipmapped::kNo,
+            kTopLeft_GrSurfaceOrigin, kRGBA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB(),
+            +[](void* userData) -> sk_sp<GrPromiseImageTexture> {
+                auto& atlas = *static_cast<SkiaGPUAtlas*>(userData);
+                atlas.waitForUpload();
+                return GrPromiseImageTexture::Make(atlas.m_backendTexture);
+            },
+            +[](void* userData) {
+                static_cast<SkiaGPUAtlas*>(userData)->deref();
+            }, const_cast<SkiaGPUAtlas*>(this));
+    }
+
+    auto* glContext = PlatformDisplay::sharedDisplay().skiaGLContext();
+    if (!glContext || !glContext->makeContextCurrent())
         return nullptr;
 
     waitForUpload();
 
     auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
-    RELEASE_ASSERT(grContext);
+    ASSERT(grContext);
+    ASSERT(m_backendTexture.isValid());
     return SkImages::BorrowTextureFrom(grContext, m_backendTexture, kTopLeft_GrSurfaceOrigin, kBGRA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
 }
 

--- a/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.h
@@ -34,6 +34,7 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkImage.h>
 #include <skia/core/SkRect.h>
 #include <skia/gpu/ganesh/GrBackendSurface.h>
+#include <skia/gpu/ganesh/GrContextThreadSafeProxy.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
 #include <wtf/Condition.h>
@@ -90,7 +91,7 @@ class SkiaGPUAtlas : public ThreadSafeRefCounted<SkiaGPUAtlas, WTF::DestructionT
     WTF_MAKE_TZONE_ALLOCATED(SkiaGPUAtlas);
     WTF_MAKE_NONCOPYABLE(SkiaGPUAtlas);
 public:
-    static RefPtr<SkiaGPUAtlas> create(const SkiaImageAtlasLayout&, Ref<BitmapTexture>&&, Ref<AtlasUploadCondition>&&);
+    static RefPtr<SkiaGPUAtlas> create(const SkiaImageAtlasLayout&, Ref<BitmapTexture>&&, Ref<AtlasUploadCondition>&&, const sk_sp<GrContextThreadSafeProxy>&);
 
     // Upload images into the atlas texture. Can run from any thread for dma-buf backed textures.
     void uploadImages();
@@ -103,7 +104,7 @@ public:
     sk_sp<SkImage> atlasImageForCurrentThread() const;
 
 private:
-    SkiaGPUAtlas(Ref<BitmapTexture>&&, GrBackendTexture&&, Ref<AtlasUploadCondition>&&, const SkiaImageAtlasLayout&, const IntSize&);
+    SkiaGPUAtlas(Ref<BitmapTexture>&&, GrBackendTexture&&, Ref<AtlasUploadCondition>&&, const sk_sp<GrContextThreadSafeProxy>&, const SkiaImageAtlasLayout&, const IntSize&);
 
     void waitForUpload() const;
 
@@ -111,6 +112,7 @@ private:
     GrBackendTexture m_backendTexture;
     Ref<AtlasUploadCondition> m_uploadCondition;
     std::unique_ptr<GLFence> m_uploadFence;
+    sk_sp<GrContextThreadSafeProxy> m_threadSafeGrContext;
     ImageToRectMap m_imageToRect;
     Ref<const SkiaImageAtlasLayout> m_layout;
     IntSize m_size;

--- a/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp
@@ -31,6 +31,7 @@
 #include "CoordinatedBackingStoreProxy.h"
 #include "CoordinatedPlatformLayer.h"
 #include "CoordinatedTileBuffer.h"
+#include "FontRenderOptions.h"
 #include "GLContext.h"
 #include "GraphicsContextSkia.h"
 #include "GraphicsLayerCoordinated.h"
@@ -75,9 +76,10 @@ static bool canPerformAcceleratedRendering()
     return ProcessCapabilities::canUseAcceleratedBuffers() && PlatformDisplay::sharedDisplay().skiaGLContext();
 }
 
-SkiaPaintingEngine::SkiaPaintingEngine()
+SkiaPaintingEngine::SkiaPaintingEngine(sk_sp<GrContextThreadSafeProxy>&& threadSafeGrContext)
+    : m_threadSafeGrContext(WTF::move(threadSafeGrContext))
 {
-    if (canPerformAcceleratedRendering()) {
+    if (canPerformAcceleratedRendering() && !m_threadSafeGrContext) {
         if (auto numberOfGPUThreads = numberOfGPUPaintingThreads())
             m_paintingWorkerPool = WorkerPool::create("SkiaGPUWorker"_s, numberOfGPUThreads);
 
@@ -90,9 +92,9 @@ SkiaPaintingEngine::SkiaPaintingEngine()
 
 SkiaPaintingEngine::~SkiaPaintingEngine() = default;
 
-std::unique_ptr<SkiaPaintingEngine> SkiaPaintingEngine::create()
+std::unique_ptr<SkiaPaintingEngine> SkiaPaintingEngine::create(sk_sp<GrContextThreadSafeProxy>&& threadSafeGrContext)
 {
-    return makeUnique<SkiaPaintingEngine>();
+    return makeUnique<SkiaPaintingEngine>(WTF::move(threadSafeGrContext));
 }
 
 void SkiaPaintingEngine::paintIntoGraphicsContext(const GraphicsLayer& layer, GraphicsContext& context, const IntRect& dirtyRect, bool contentsOpaque, float contentsScale) const
@@ -117,6 +119,9 @@ void SkiaPaintingEngine::paintIntoGraphicsContext(const GraphicsLayer& layer, Gr
 Ref<CoordinatedTileBuffer> SkiaPaintingEngine::createBuffer(RenderingMode renderingMode, const IntSize& size, bool contentsOpaque) const
 {
     if (renderingMode == RenderingMode::Accelerated) {
+        if (useThreadedRendering() && m_threadSafeGrContext)
+            return CoordinatedAcceleratedTileBuffer::create(m_threadSafeGrContext, size, contentsOpaque ? CoordinatedTileBuffer::NoFlags : CoordinatedTileBuffer::SupportsAlpha);
+
         PlatformDisplay::sharedDisplay().skiaGLContext()->makeContextCurrent();
 
         OptionSet<BitmapTexture::Flags> textureFlags;
@@ -149,7 +154,7 @@ RefPtr<SkiaGPUAtlas> SkiaPaintingEngine::createAtlas(const SkiaImageAtlasLayout&
         isDMABufBackedTexture = true;
 #endif
 
-    auto atlas = SkiaGPUAtlas::create(layout, WTF::move(texture), Ref { uploadCondition });
+    auto atlas = SkiaGPUAtlas::create(layout, WTF::move(texture), Ref { uploadCondition }, m_threadSafeGrContext);
     if (!atlas)
         return nullptr;
 
@@ -221,7 +226,7 @@ Ref<SkiaRecordingResult> SkiaPaintingEngine::record(const GraphicsLayerCoordinat
     SkPictureRecorder pictureRecorder;
     auto* recordingCanvas = pictureRecorder.beginRecording(recordRect.width(), recordRect.height());
     GraphicsContextSkia recordingContext(*recordingCanvas, renderingMode, RenderingPurpose::LayerBacking);
-    recordingContext.beginRecording(GraphicsContextSkia::RecordingMode::Tile);
+    recordingContext.beginRecording(GraphicsContextSkia::RecordingMode::Tile, m_threadSafeGrContext);
     paintIntoGraphicsContext(layer, recordingContext, recordRect, contentsOpaque, contentsScale);
     auto recordingData = recordingContext.endRecording();
 
@@ -272,7 +277,7 @@ Ref<SkiaRecordingResult> SkiaPaintingEngine::record(const GraphicsLayerCoordinat
     return result;
 }
 
-Ref<CoordinatedTileBuffer> SkiaPaintingEngine::replay(const GraphicsLayerCoordinated& layer, const RefPtr<SkiaRecordingResult>& recording, const IntRect& dirtyRect)
+Ref<CoordinatedTileBuffer> SkiaPaintingEngine::replay(const GraphicsLayerCoordinated& layer, Ref<SkiaRecordingResult>&& recording, const IntRect& dirtyRect)
 {
     // ### Asynchronous rendering on worker threads ###
     ASSERT(useThreadedRendering());
@@ -284,7 +289,7 @@ Ref<CoordinatedTileBuffer> SkiaPaintingEngine::replay(const GraphicsLayerCoordin
     auto buffer = createBuffer(renderingMode, dirtyRect.size(), recording->contentsOpaque());
     buffer->beginPainting();
 
-    m_paintingWorkerPool->postTask([platformLayer = WTF::move(platformLayer), buffer = Ref { buffer }, dirtyRect, recording = RefPtr { recording }]() mutable {
+    m_paintingWorkerPool->postTask([platformLayer = WTF::move(platformLayer), buffer = Ref { buffer }, dirtyRect, recording = WTF::move(recording), threadSafeGrContext = m_threadSafeGrContext]() mutable {
         if (auto* canvas = buffer->canvas()) {
             auto replayPicture = [](const sk_sp<SkPicture>& picture, SkCanvas* canvas, const IntRect& recordRect, const IntRect& paintRect) {
                 canvas->save();
@@ -298,7 +303,7 @@ Ref<CoordinatedTileBuffer> SkiaPaintingEngine::replay(const GraphicsLayerCoordin
             WTFBeginSignpost(canvas, PaintTile, "Skia/%s threaded, dirty region %ix%i+%i+%i", buffer->isBackedByOpenGL() ? "GPU" : "CPU", dirtyRect.x(), dirtyRect.y(), dirtyRect.width(), dirtyRect.height());
             // Use SkiaReplayCanvas if there are GPU fences or GPU atlases to handle.
             if (recording->hasFences() || recording->hasGPUAtlases()) {
-                auto replayCanvas = SkiaReplayCanvas::create(dirtyRect.size(), recording);
+                auto replayCanvas = SkiaReplayCanvas::create(dirtyRect.size(), recording, threadSafeGrContext);
                 replayCanvas->addCanvas(canvas);
                 replayPicture(replayCanvas->picture(), &replayCanvas.get(), recording->recordRect(), dirtyRect);
                 replayCanvas->removeCanvas(canvas);

--- a/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h
@@ -26,6 +26,9 @@
 #pragma once
 
 #if USE(COORDINATED_GRAPHICS) && USE(SKIA)
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/gpu/ganesh/GrContextThreadSafeProxy.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #include <wtf/RefPtr.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/WorkQueue.h>
@@ -49,10 +52,10 @@ class SkiaPaintingEngine {
     WTF_MAKE_TZONE_ALLOCATED(SkiaPaintingEngine);
     WTF_MAKE_NONCOPYABLE(SkiaPaintingEngine);
 public:
-    SkiaPaintingEngine();
+    explicit SkiaPaintingEngine(sk_sp<GrContextThreadSafeProxy>&&);
     ~SkiaPaintingEngine();
 
-    static std::unique_ptr<SkiaPaintingEngine> create();
+    static std::unique_ptr<SkiaPaintingEngine> create(sk_sp<GrContextThreadSafeProxy>&&);
 
     static unsigned numberOfCPUPaintingThreads();
     static unsigned numberOfGPUPaintingThreads();
@@ -64,7 +67,7 @@ public:
 
     Ref<CoordinatedTileBuffer> paint(const GraphicsLayerCoordinated&, const IntRect& dirtyRect, bool contentsOpaque, float contentsScale);
     Ref<SkiaRecordingResult> record(const GraphicsLayerCoordinated&, const IntRect& recordRect, bool contentsOpaque, float contentsScale);
-    Ref<CoordinatedTileBuffer> replay(const GraphicsLayerCoordinated&, const RefPtr<SkiaRecordingResult>&, const IntRect& dirtyRect);
+    Ref<CoordinatedTileBuffer> replay(const GraphicsLayerCoordinated&, Ref<SkiaRecordingResult>&&, const IntRect& dirtyRect);
 
 private:
     Ref<CoordinatedTileBuffer> createBuffer(RenderingMode, const IntSize&, bool contentsOpaque) const;
@@ -72,6 +75,7 @@ private:
     RefPtr<SkiaGPUAtlas> createAtlas(const SkiaImageAtlasLayout&, AtlasUploadCondition&);
     bool tryReuseCachedAtlases(SkiaRecordingResult&, unsigned fingerprint);
 
+    sk_sp<GrContextThreadSafeProxy> m_threadSafeGrContext;
     RefPtr<WorkerPool> m_paintingWorkerPool;
     RefPtr<WorkQueue> m_uploadWorkQueue;
     unsigned m_cachedImageFingerprint { 0 };

--- a/Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.cpp
@@ -34,37 +34,32 @@
 
 namespace WebCore {
 
-SkiaReplayCanvas::SkiaReplayCanvas(const IntSize& size, const RefPtr<SkiaRecordingResult>& recording)
+SkiaReplayCanvas::SkiaReplayCanvas(const IntSize& size, const Ref<SkiaRecordingResult>& recording, const sk_sp<GrContextThreadSafeProxy>& threadSafeGrContext)
     : SkNWayCanvas(size.width(), size.height())
     , m_recording(recording)
+    , m_threadSafeGrContext(threadSafeGrContext)
 {
     // Create atlas wrappers from pre-prepared GPU atlases.
     // GPU atlases were uploaded on main thread; we just rewrap for this worker's context.
-    if (m_recording && m_recording->hasGPUAtlases()) {
-        auto* glContext = PlatformDisplay::sharedDisplay().skiaGLContext();
-        if (!glContext || !glContext->makeContextCurrent())
-            return;
-
+    if (m_recording->hasGPUAtlases()) {
         const auto& gpuAtlases = m_recording->gpuAtlases();
         m_atlases.reserveInitialCapacity(gpuAtlases.size());
 
-        for (const auto& gpuAtlas : gpuAtlases) {
-            if (auto atlas = SkiaReplayAtlas::create(gpuAtlas))
-                m_atlases.append(WTF::move(atlas));
-        }
+        for (const auto& gpuAtlas : gpuAtlases)
+            m_atlases.append(SkiaReplayAtlas::create(gpuAtlas));
     }
 }
 
 SkiaReplayCanvas::~SkiaReplayCanvas() = default;
 
-Ref<SkiaReplayCanvas> SkiaReplayCanvas::create(const IntSize& size, const RefPtr<SkiaRecordingResult>& recordingResult)
+Ref<SkiaReplayCanvas> SkiaReplayCanvas::create(const IntSize& size, const Ref<SkiaRecordingResult>& recordingResult, const sk_sp<GrContextThreadSafeProxy>& threadSafeGrContext)
 {
-    return adoptRef(*new SkiaReplayCanvas(size, recordingResult));
+    return adoptRef(*new SkiaReplayCanvas(size, recordingResult, threadSafeGrContext));
 }
 
 sk_sp<SkImage> SkiaReplayCanvas::waitForRenderingCompletionAndRewrapImageIfNeeded(const SkImage* image)
 {
-    if (!image || !image->isTextureBacked())
+    if (!image || !image->isTextureBacked() || m_threadSafeGrContext)
         return nullptr;
 
     auto* glContext = PlatformDisplay::sharedDisplay().skiaGLContext();

--- a/Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.h
@@ -29,12 +29,12 @@
 #include "IntSize.h"
 #include "SkiaRecordingResult.h"
 #include "SkiaReplayAtlas.h"
-#include <wtf/Assertions.h>
-#include <wtf/Function.h>
-
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/gpu/ganesh/GrContextThreadSafeProxy.h>
 #include <skia/utils/SkNWayCanvas.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+#include <wtf/Assertions.h>
+#include <wtf/Function.h>
 
 class SkImage;
 
@@ -43,12 +43,12 @@ namespace WebCore {
 class SkiaReplayCanvas final : public SkNWayCanvas, public RefCounted<SkiaReplayCanvas> {
 public:
     ~SkiaReplayCanvas() override;
-    static Ref<SkiaReplayCanvas> create(const IntSize&, const RefPtr<SkiaRecordingResult>&);
+    static Ref<SkiaReplayCanvas> create(const IntSize&, const Ref<SkiaRecordingResult>&, const sk_sp<GrContextThreadSafeProxy>& = nullptr);
 
     const sk_sp<SkPicture>& picture() const { return m_recording->picture(); }
 
 private:
-    SkiaReplayCanvas(const IntSize&, const RefPtr<SkiaRecordingResult>&);
+    SkiaReplayCanvas(const IntSize&, const Ref<SkiaRecordingResult>&, const sk_sp<GrContextThreadSafeProxy>&);
 
     sk_sp<SkImage> waitForRenderingCompletionAndRewrapImageIfNeeded(const SkImage*);
 
@@ -79,7 +79,8 @@ private:
     void onDrawTextBlob(const SkTextBlob*, SkScalar x, SkScalar y, const SkPaint&) override;
     void onDrawVerticesObject(const SkVertices*, SkBlendMode, const SkPaint&) override;
 
-    RefPtr<SkiaRecordingResult> m_recording;
+    Ref<SkiaRecordingResult> m_recording;
+    sk_sp<GrContextThreadSafeProxy> m_threadSafeGrContext;
     Vector<std::unique_ptr<SkiaReplayAtlas>> m_atlases;
 };
 

--- a/Source/WebCore/platform/graphics/skia/SkiaUtilities.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaUtilities.cpp
@@ -30,16 +30,21 @@
 
 #include "BitmapTexture.h"
 #include "ColorSpaceSkia.h"
+#include "GLContext.h"
 #include "GLFence.h"
 #include "GraphicsTypes.h"
 #include "NotImplemented.h"
 #include "PlatformDisplay.h"
-
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/gpu/ganesh/SkImageGanesh.h>
 #include <skia/gpu/ganesh/SkSurfaceGanesh.h>
 #include <skia/gpu/ganesh/gl/GrGLBackendSurface.h>
+#include <skia/private/chromium/GrPromiseImageTexture.h>
+#include <skia/private/chromium/SkImageChromium.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+#include <wtf/RunLoop.h>
+#include <wtf/TZoneMallocInlines.h>
+#include <wtf/ThreadSafeWeakPtr.h>
 
 #if USE(LIBEPOXY)
 #include <epoxy/gl.h>
@@ -198,6 +203,87 @@ SkBlendMode toSkiaBlendMode(BlendMode blendMode, std::optional<CompositeOperator
     }
 
     return SkBlendMode::kSrcOver;
+}
+
+class PromiseImageContext {
+    WTF_MAKE_TZONE_ALLOCATED_INLINE(PromiseImageContext);
+public:
+    static std::unique_ptr<PromiseImageContext> create(const sk_sp<SkImage>& image)
+    {
+        auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
+        ASSERT(grContext);
+
+        auto fence = flushAndSubmitImageWithFence(grContext, image);
+
+        GrBackendTexture backendTexture;
+        if (!SkImages::GetBackendTextureFromImage(image.get(), &backendTexture, false))
+            return nullptr;
+
+        return makeUnique<PromiseImageContext>(image, WTF::move(backendTexture), WTF::move(fence));
+    }
+
+    PromiseImageContext(const sk_sp<SkImage>& image, GrBackendTexture&& backendTexture, std::unique_ptr<GLFence>&& fence)
+        : m_image(image)
+        , m_backendTexture(WTF::move(backendTexture))
+        , m_fence(WTF::move(fence))
+        , m_runLoop(RunLoop::currentSingleton())
+    {
+    }
+
+    ~PromiseImageContext()
+    {
+        if (auto runLoop = m_runLoop.get()) {
+            if (runLoop.get() == &RunLoop::currentSingleton())
+                return;
+
+            runLoop->dispatch([image = WTF::move(m_image)]() mutable {
+                image = nullptr;
+            });
+        }
+
+    }
+
+    sk_sp<GrPromiseImageTexture> promiseImageTexture()
+    {
+        auto* glContext = PlatformDisplay::sharedDisplay().skiaGLContext();
+        if (!glContext || !glContext->makeContextCurrent())
+            return nullptr;
+
+        if (m_fence) {
+            m_fence->serverWait();
+            m_fence = nullptr;
+        }
+
+        return GrPromiseImageTexture::Make(m_backendTexture);
+    }
+
+private:
+    sk_sp<SkImage> m_image;
+    GrBackendTexture m_backendTexture;
+    std::unique_ptr<GLFence> m_fence;
+    ThreadSafeWeakPtr<RunLoop> m_runLoop;
+};
+
+sk_sp<SkImage> createPromiseImageIfNeeded(const sk_sp<SkImage>& image, const sk_sp<GrContextThreadSafeProxy>& threadSafeGrContext)
+{
+    if (!image->isTextureBacked())
+        return image;
+
+    auto context = PromiseImageContext::create(image);
+    if (!context)
+        return image;
+
+    auto backendFormat = threadSafeGrContext->defaultBackendFormat(kRGBA_8888_SkColorType, GrRenderable::kYes);
+    ASSERT(backendFormat.isValid());
+    return SkImages::PromiseTextureFrom(threadSafeGrContext, backendFormat, image->dimensions(), skgpu::Mipmapped::kNo,
+        kTopLeft_GrSurfaceOrigin, image->colorType(), image->alphaType(), image->refColorSpace(),
+        +[](void* userData) -> sk_sp<GrPromiseImageTexture> {
+            auto& context = *static_cast<PromiseImageContext*>(userData);
+            return context.promiseImageTexture();
+        },
+        +[](void* userData) {
+            std::unique_ptr<PromiseImageContext> context(static_cast<PromiseImageContext*>(userData));
+        }, context.release());
 }
 
 } // namespace SkiaUtilities

--- a/Source/WebCore/platform/graphics/skia/SkiaUtilities.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaUtilities.h
@@ -34,6 +34,7 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkBlendMode.h>
 #include <skia/core/SkRefCnt.h>
 #include <skia/gpu/ganesh/GrBackendSurface.h>
+#include <skia/gpu/ganesh/GrContextThreadSafeProxy.h>
 #include <skia/gpu/ganesh/GrDirectContext.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
@@ -82,6 +83,8 @@ std::unique_ptr<GLFence> flushAndSubmitImageWithFence(GrDirectContext*, const sk
 std::unique_ptr<GLFence> flushAndSubmitWithFence(GrDirectContext*);
 
 SkBlendMode toSkiaBlendMode(BlendMode, std::optional<CompositeOperator> = std::nullopt);
+
+sk_sp<SkImage> createPromiseImageIfNeeded(const sk_sp<SkImage>&, const sk_sp<GrContextThreadSafeProxy>&);
 
 } // namespace SkiaUtilities
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp
@@ -142,7 +142,7 @@ OptionSet<CoordinatedBackingStoreProxy::UpdateResult> CoordinatedBackingStorePro
                 tile.rect.x(), tile.rect.y(), tile.rect.width(), tile.rect.height(), tile.dirtyRect.x(), tile.dirtyRect.y(), tile.dirtyRect.width(), tile.dirtyRect.height());
 
 #if USE(SKIA)
-            auto buffer = recording ? layer.replay(recording, tile.dirtyRect) : layer.paint(tile.dirtyRect);
+            auto buffer = recording ? layer.replay(Ref { *recording }, tile.dirtyRect) : layer.paint(tile.dirtyRect);
 #else
             auto buffer = layer.paint(tile.dirtyRect);
 #endif

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.cpp
@@ -92,12 +92,14 @@ void CoordinatedBackingStoreTile::processPendingUpdates()
             auto& buffer = static_cast<CoordinatedAcceleratedTileBuffer&>(update.buffer.get());
             buffer.serverWait();
 
+            auto texture = buffer.texture();
+            ASSERT(texture);
             // Fast path: whole tile content changed -- take ownership of the incoming texture, replacing the existing tile buffer (avoiding texture copies).
             if (update.sourceRect.size() == update.tileRect.size()) {
                 ASSERT(update.sourceRect.location().isZero());
-                m_texture->swapTexture(buffer.texture());
+                m_texture->swapTexture(*texture);
             } else
-                m_texture->copyFromExternalTexture(buffer.texture().id(), update.sourceRect, toIntSize(update.bufferOffset));
+                m_texture->copyFromExternalTexture(texture->id(), update.sourceRect, toIntSize(update.bufferOffset));
 
             WTFEndSignpost(this, CopyTextureGPUToGPU);
             WTFEndSignpost(this, CoordinatedSwapBuffer);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp
@@ -956,15 +956,14 @@ Ref<SkiaRecordingResult> CoordinatedPlatformLayer::record(const IntRect& recordR
     return paintingEngine.record(*m_owner, recordRect, m_contentsOpaque, m_contentsScale);
 }
 
-Ref<CoordinatedTileBuffer> CoordinatedPlatformLayer::replay(const RefPtr<SkiaRecordingResult>& recording, const IntRect& dirtyRect)
+Ref<CoordinatedTileBuffer> CoordinatedPlatformLayer::replay(Ref<SkiaRecordingResult>&& recording, const IntRect& dirtyRect)
 {
     ASSERT(m_lock.isHeld());
     ASSERT(m_client);
     ASSERT(m_owner);
-    ASSERT(recording);
     auto& paintingEngine = m_client->paintingEngine();
     ASSERT(paintingEngine.useThreadedRendering());
-    return paintingEngine.replay(*m_owner, recording, dirtyRect);
+    return paintingEngine.replay(*m_owner, WTF::move(recording), dirtyRect);
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h
@@ -200,7 +200,7 @@ public:
     Ref<CoordinatedTileBuffer> paint(const IntRect&);
 #if USE(SKIA)
     Ref<SkiaRecordingResult> record(const IntRect&);
-    Ref<CoordinatedTileBuffer> replay(const RefPtr<SkiaRecordingResult>&, const IntRect&);
+    Ref<CoordinatedTileBuffer> replay(Ref<SkiaRecordingResult>&&, const IntRect&);
 #endif
     void willPaintTile();
     void didPaintTile();

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.cpp
@@ -32,7 +32,6 @@
 #if USE(COORDINATED_GRAPHICS)
 
 #if USE(SKIA)
-#include "BitmapTexture.h"
 #include "FontRenderOptions.h"
 #include "GLContext.h"
 #include "GLFence.h"
@@ -74,15 +73,6 @@ double CoordinatedTileBuffer::getMemoryUsage()
     s_maxLayersMemoryUsage = s_currentLayersMemoryUsage;
     return memoryUsage;
 }
-
-#if USE(SKIA)
-SkCanvas* CoordinatedTileBuffer::canvas()
-{
-    if (!tryEnsureSurface())
-        return nullptr;
-    return m_surface->getCanvas();
-}
-#endif
 
 void CoordinatedTileBuffer::beginPainting()
 {
@@ -141,16 +131,15 @@ CoordinatedUnacceleratedTileBuffer::~CoordinatedUnacceleratedTileBuffer()
 }
 
 #if USE(SKIA)
-bool CoordinatedUnacceleratedTileBuffer::tryEnsureSurface()
+SkCanvas* CoordinatedUnacceleratedTileBuffer::canvas()
 {
-    if (m_surface)
-        return true;
-
-    auto imageInfo = SkImageInfo::Make(m_size.width(), m_size.height(), kBGRA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
-    // FIXME: ref buffer and unref on release proc?
-    auto properties = FontRenderOptions::singleton().createSurfaceProps();
-    m_surface = SkSurfaces::WrapPixels(imageInfo, data(), imageInfo.minRowBytes64(), &properties);
-    return true;
+    if (!m_surface) {
+        auto imageInfo = SkImageInfo::Make(m_size.width(), m_size.height(), kBGRA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
+        // FIXME: ref buffer and unref on release proc?
+        auto properties = FontRenderOptions::singleton().createSurfaceProps();
+        m_surface = SkSurfaces::WrapPixels(imageInfo, data(), imageInfo.minRowBytes64(), &properties);
+    }
+    return m_surface->getCanvas();
 }
 #endif
 
@@ -167,35 +156,62 @@ CoordinatedAcceleratedTileBuffer::CoordinatedAcceleratedTileBuffer(Ref<BitmapTex
 {
 }
 
+Ref<CoordinatedTileBuffer> CoordinatedAcceleratedTileBuffer::create(const sk_sp<GrContextThreadSafeProxy>& threadSafeGrContext, const IntSize& size, Flags flags)
+{
+    auto imageInfo = SkImageInfo::Make(size.width(), size.height(), kRGBA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
+    auto backendFormat = threadSafeGrContext->defaultBackendFormat(kRGBA_8888_SkColorType, GrRenderable::kYes);
+    ASSERT(backendFormat.isValid());
+    auto properties = FontRenderOptions::singleton().createSurfaceProps();
+    auto characterization = threadSafeGrContext->createCharacterization(0, imageInfo, backendFormat, 0, kTopLeft_GrSurfaceOrigin, properties, skgpu::Mipmapped::kNo);
+    return adoptRef(*new CoordinatedAcceleratedTileBuffer(WTF::move(characterization), flags));
+}
+
+CoordinatedAcceleratedTileBuffer::CoordinatedAcceleratedTileBuffer(GrSurfaceCharacterization&& characterization, Flags flags)
+    : CoordinatedTileBuffer(flags)
+    , m_characterization(WTF::move(characterization))
+{
+}
+
 CoordinatedAcceleratedTileBuffer::~CoordinatedAcceleratedTileBuffer() = default;
 
 IntSize CoordinatedAcceleratedTileBuffer::size() const
 {
-    return m_texture->size();
+    if (m_texture)
+        return m_texture->size();
+
+    return { m_characterization.width(), m_characterization.height() };
 }
 
-bool CoordinatedAcceleratedTileBuffer::tryEnsureSurface()
+SkCanvas* CoordinatedAcceleratedTileBuffer::canvas()
 {
-    if (m_surface)
-        return true;
+    if (m_texture) {
+        if (!m_surface) {
+            if (!PlatformDisplay::sharedDisplay().skiaGLContext()->makeContextCurrent())
+                return nullptr;
 
-    if (!PlatformDisplay::sharedDisplay().skiaGLContext()->makeContextCurrent())
-        return false;
+            m_surface = m_texture->createSkiaSurface(PlatformDisplay::sharedDisplay().skiaGrContext());
+        }
+        return m_surface->getCanvas();
+    }
 
-    m_surface = m_texture->createSkiaSurface(PlatformDisplay::sharedDisplay().skiaGrContext());
-    return true;
+    if (!m_recorder)
+        m_recorder = std::make_unique<GrDeferredDisplayListRecorder>(m_characterization);
+    return m_recorder->getCanvas();
 }
 
 void CoordinatedAcceleratedTileBuffer::completePainting()
 {
-    auto* recordingContext = m_surface->recordingContext();
-    auto* grContext = recordingContext ? recordingContext->asDirectContext() : nullptr;
-    if (!grContext) {
-        CoordinatedTileBuffer::completePainting();
-        return;
-    }
+    if (m_surface) {
+        auto* recordingContext = m_surface->recordingContext();
+        auto* grContext = recordingContext ? recordingContext->asDirectContext() : nullptr;
+        if (!grContext) {
+            CoordinatedTileBuffer::completePainting();
+            return;
+        }
 
-    m_fence = SkiaUtilities::flushAndSubmitSurfaceWithFence(grContext, m_surface.get());
+        m_fence = SkiaUtilities::flushAndSubmitSurfaceWithFence(grContext, m_surface.get());
+    } else if (m_recorder)
+        m_displayList = m_recorder->detach();
 
     CoordinatedTileBuffer::completePainting();
 }

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.h
@@ -30,6 +30,7 @@
 
 #if USE(COORDINATED_GRAPHICS)
 
+#include "BitmapTexture.h"
 #include "IntSize.h"
 #include "PixelFormat.h"
 #include <wtf/Condition.h>
@@ -42,6 +43,9 @@
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkCanvas.h>
 #include <skia/core/SkSurface.h>
+#include <skia/private/chromium/GrDeferredDisplayList.h>
+#include <skia/private/chromium/GrDeferredDisplayListRecorder.h>
+#include <skia/private/chromium/GrSurfaceCharacterization.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #endif
 
@@ -70,7 +74,7 @@ public:
     void waitUntilPaintingComplete();
 
 #if USE(SKIA)
-    SkCanvas* canvas();
+    virtual SkCanvas* canvas() = 0;
 #endif
 
     static void resetMemoryUsage();
@@ -80,7 +84,6 @@ protected:
     explicit CoordinatedTileBuffer(Flags);
 
 #if USE(SKIA)
-    virtual bool tryEnsureSurface() = 0;
     sk_sp<SkSurface> m_surface;
 #endif
 
@@ -121,7 +124,7 @@ private:
     PixelFormat pixelFormat() const final { return PixelFormat::BGRA8; }
 
 #if USE(SKIA)
-    bool tryEnsureSurface() final;
+    SkCanvas* canvas() final;
 #endif
 
     MallocSpan<unsigned char> m_data;
@@ -143,23 +146,29 @@ private:
 class CoordinatedAcceleratedTileBuffer final : public CoordinatedTileBuffer {
 public:
     WEBCORE_EXPORT static Ref<CoordinatedTileBuffer> create(Ref<BitmapTexture>&&);
+    WEBCORE_EXPORT static Ref<CoordinatedTileBuffer> create(const sk_sp<GrContextThreadSafeProxy>&, const IntSize&, Flags);
     WEBCORE_EXPORT virtual ~CoordinatedAcceleratedTileBuffer();
 
-    BitmapTexture& texture() const { return m_texture.get(); }
+    RefPtr<BitmapTexture> texture() const { return m_texture; }
+    sk_sp<GrDeferredDisplayList> displayList() const { return m_displayList; }
     void serverWait();
 
 private:
     CoordinatedAcceleratedTileBuffer(Ref<BitmapTexture>&&, Flags);
+    CoordinatedAcceleratedTileBuffer(GrSurfaceCharacterization&&, Flags);
 
     bool isBackedByOpenGL() const final { return true; }
     IntSize size() const final;
     PixelFormat pixelFormat() const final { return PixelFormat::RGBA8; }
 
-    bool tryEnsureSurface() final;
+    SkCanvas* canvas() final;
     void completePainting() final;
 
-    const Ref<BitmapTexture> m_texture;
+    RefPtr<BitmapTexture> m_texture;
     std::unique_ptr<GLFence> m_fence;
+    GrSurfaceCharacterization m_characterization;
+    std::unique_ptr<GrDeferredDisplayListRecorder> m_recorder;
+    sk_sp<GrDeferredDisplayList> m_displayList;
 };
 #endif
 

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp
@@ -71,7 +71,6 @@ std::unique_ptr<LayerTreeHost> LayerTreeHost::create(WebPage& webPage)
 LayerTreeHost::LayerTreeHost(WebPage& webPage)
     : m_webPage(webPage)
     , m_sceneState(CoordinatedSceneState::create())
-    , m_skiaPaintingEngine(SkiaPaintingEngine::create())
 {
     {
         auto& rootLayer = m_sceneState->rootLayer();
@@ -88,6 +87,7 @@ LayerTreeHost::LayerTreeHost(WebPage& webPage)
     }
 
     m_compositor = ThreadedCompositor::create(webPage, *this, m_sceneState.get());
+    m_skiaPaintingEngine = SkiaPaintingEngine::create(m_compositor->threadSafeGrContext());
 #if ENABLE(DAMAGE_TRACKING)
     std::optional<OptionSet<ThreadedCompositor::DamagePropagationFlags>> damagePropagationFlags;
     const auto& settings = webPage.corePage()->settings();

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp
@@ -123,9 +123,12 @@ ThreadedCompositor::ThreadedCompositor(WebPage& webPage, LayerTreeHost& layerTre
 
         glGetIntegerv(GL_MAX_TEXTURE_SIZE, &m_maxTextureSize);
 
-        if (m_useSkia)
+        if (m_useSkia) {
             PlatformDisplay::sharedDisplay().setSkiaGLContextForCurrentThread(WTF::move(context));
-        else {
+            const auto disableDDL = CStringView::unsafeFromUTF8(getenv("WEBKIT_SKIA_DISABLE_DDL"));
+            if (!disableDDL || disableDDL == "0"_s)
+                m_threadSafeGrContext = PlatformDisplay::sharedDisplay().skiaGrContext()->threadSafeProxy();
+        } else {
             m_context = WTF::move(context);
             m_textureMapper = TextureMapper::create();
             if (!nativeSurfaceHandle)

--- a/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
+++ b/Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h
@@ -35,6 +35,10 @@
 #include <WebCore/TextureMapperDamageVisualizer.h>
 #include <atomic>
 #include <optional>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/gpu/ganesh/GrContextThreadSafeProxy.h>
+#include <skia/gpu/ganesh/GrDirectContext.h>
+WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #include <wtf/Atomics.h>
 #include <wtf/CheckedPtr.h>
 #include <wtf/Noncopyable.h>
@@ -99,6 +103,8 @@ public:
 
     void fillGLInformation(RenderProcessInfo&&, CompletionHandler<void(RenderProcessInfo&&)>&&);
 
+    sk_sp<GrContextThreadSafeProxy> threadSafeGrContext() const { return m_threadSafeGrContext; }
+
 private:
     ThreadedCompositor(WebPage&, LayerTreeHost&, CoordinatedSceneState&);
 
@@ -131,6 +137,7 @@ private:
     RefPtr<AcceleratedSurface> m_surface;
     RefPtr<CoordinatedSceneState> m_sceneState;
     std::unique_ptr<WebCore::GLContext> m_context;
+    sk_sp<GrContextThreadSafeProxy> m_threadSafeGrContext;
 
     bool m_flipY { false };
     int m_maxTextureSize { 0 };


### PR DESCRIPTION
#### 63f86c394bc80273222bd823898932ee48543472
<pre>
[GTK][WPE] Skia Compositor: use deferred display lists to paint tiles
<a href="https://bugs.webkit.org/show_bug.cgi?id=315194">https://bugs.webkit.org/show_bug.cgi?id=315194</a>

Reviewed by Nikolas Zimmermann.

This way painting worker threads don&apos;t use gl at all and we don&apos;t need
to create a GrContext on every worker thread. The tile contents are
recorded into a deferred display list that is then replayed in the
compositor thread when handling tile updates. When recording tiles
accelerated images are wrapped by a promise image instead of borowing
texture.

* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-bottom-left-radius-004.xht:
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-bottom-left-radius-005.xht:
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-radius-clipping-with-transform-001.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-top-left-radius-004.xht:
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-top-left-radius-005.xht:
* LayoutTests/imported/w3c/web-platform-tests/css/css-backgrounds/border-top-right-radius-004.xht:
* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/clip-path/clip-path-borderBox-1e.html:
* LayoutTests/imported/w3c/web-platform-tests/css/css-ui/outline-027.html:
* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/backdrop-filter-clip-rect.html:
* LayoutTests/svg/W3C-SVG-1.2-Tiny/struct-use-recursion-01-t.svg:
* LayoutTests/svg/custom/href-svg-namespace-static.svg:
* LayoutTests/svg/custom/marker-stroke-dasharray-none-zero.svg:
* Source/WebCore/platform/graphics/Pattern.h:
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.cpp:
(WebCore::GraphicsContextSkia::imageForCurrentThread const):
(WebCore::GraphicsContextSkia::drawNativeImage):
(WebCore::GraphicsContextSkia::setupFillSource):
(WebCore::GraphicsContextSkia::setupStrokeSource):
(WebCore::GraphicsContextSkia::clipToImageBuffer):
(WebCore::GraphicsContextSkia::drawPattern):
(WebCore::GraphicsContextSkia::beginRecording):
(WebCore::GraphicsContextSkia::endRecording):
(WebCore::GraphicsContextSkia::trackAcceleratedRenderingFenceIfNeeded):
* Source/WebCore/platform/graphics/skia/GraphicsContextSkia.h:
* Source/WebCore/platform/graphics/skia/PatternSkia.cpp:
(WebCore::Pattern::createPlatformPattern const):
* Source/WebCore/platform/graphics/skia/PlatformDisplaySkia.cpp:
(WebCore::SkiaGLContext::~SkiaGLContext):
* Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp:
(WebCore::SkiaBackingStore::Tile::update):
(WebCore::SkiaBackingStore::Tile::image const):
* Source/WebCore/platform/graphics/skia/SkiaBackingStore.h:
* Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.cpp:
(WebCore::SkiaGPUAtlas::SkiaGPUAtlas):
(WebCore::SkiaGPUAtlas::create):
(WebCore::SkiaGPUAtlas::atlasImageForCurrentThread const):
* Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.h:
* Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.cpp:
(WebCore::SkiaPaintingEngine::SkiaPaintingEngine):
(WebCore::SkiaPaintingEngine::create):
(WebCore::SkiaPaintingEngine::createBuffer const):
(WebCore::SkiaPaintingEngine::createAtlas):
(WebCore::SkiaPaintingEngine::record):
(WebCore::SkiaPaintingEngine::replay):
* Source/WebCore/platform/graphics/skia/SkiaPaintingEngine.h:
* Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.cpp:
(WebCore::SkiaReplayCanvas::SkiaReplayCanvas):
(WebCore::SkiaReplayCanvas::create):
(WebCore::SkiaReplayCanvas::waitForRenderingCompletionAndRewrapImageIfNeeded):
* Source/WebCore/platform/graphics/skia/SkiaReplayCanvas.h:
* Source/WebCore/platform/graphics/skia/SkiaUtilities.cpp:
(WebCore::SkiaUtilities::PromiseImageContext::create):
(WebCore::SkiaUtilities::PromiseImageContext::PromiseImageContext):
(WebCore::SkiaUtilities::PromiseImageContext::~PromiseImageContext):
(WebCore::SkiaUtilities::PromiseImageContext::promiseImageTexture):
(WebCore::SkiaUtilities::createPromiseImageIfNeeded):
* Source/WebCore/platform/graphics/skia/SkiaUtilities.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreProxy.cpp:
(WebCore::CoordinatedBackingStoreProxy::updateIfNeeded):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.cpp:
(WebCore::CoordinatedBackingStoreTile::processPendingUpdates):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.cpp:
(WebCore::CoordinatedPlatformLayer::replay):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayer.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.cpp:
(WebCore::CoordinatedUnacceleratedTileBuffer::canvas):
(WebCore::CoordinatedAcceleratedTileBuffer::create):
(WebCore::CoordinatedAcceleratedTileBuffer::CoordinatedAcceleratedTileBuffer):
(WebCore::CoordinatedAcceleratedTileBuffer::size const):
(WebCore::CoordinatedAcceleratedTileBuffer::canvas):
(WebCore::CoordinatedAcceleratedTileBuffer::completePainting):
(WebCore::CoordinatedTileBuffer::canvas): Deleted.
(WebCore::CoordinatedUnacceleratedTileBuffer::tryEnsureSurface): Deleted.
(WebCore::CoordinatedAcceleratedTileBuffer::tryEnsureSurface): Deleted.
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.h:
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/LayerTreeHost.cpp:
(WebKit::LayerTreeHost::LayerTreeHost):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.cpp:
(WebKit::m_renderTimer):
* Source/WebKit/WebProcess/WebPage/CoordinatedGraphics/ThreadedCompositor.h:
(WebKit::ThreadedCompositor::threadSafeGrContext const):

Canonical link: <a href="https://commits.webkit.org/315027@main">https://commits.webkit.org/315027@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c5dc7223a0a45f8f5091001c39fd402c03d0d0e9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167865 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41362 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34957 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176923 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/125549 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169731 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41797 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41375 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130607 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91797 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170824 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33059 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150845 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111124 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25655 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/142030 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28540 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179465 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32512 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30258 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139026 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41434 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34901 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138910 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42122 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150332 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105376 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25558 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34184 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/27212 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40626 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113878 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40023 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5314 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40274 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40168 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->