### PR TITLE
REGRESSION(312649@main): [macOS] inspector/timeline/line-column.html is a constant text failure.

### DIFF
--- a/LayoutTests/inspector/timeline/line-column-expected.txt
+++ b/LayoutTests/inspector/timeline/line-column-expected.txt
@@ -8,61 +8,17 @@ Evaluating in page...
 PASS: Capturing started.
 {
   "startTime": "<filtered>",
-  "data": {},
+  "data": {
+    "type": "click",
+    "defaultPrevented": false
+  },
   "children": [
-    {
-      "startTime": "<filtered>",
-      "data": {
-        "type": "click",
-        "defaultPrevented": false
-      },
-      "children": [
-        {
-          "startTime": "<filtered>",
-          "stackTrace": {
-            "callFrames": [
-              {
-                "functionName": "click",
-                "url": "[native code]",
-                "scriptId": "<filtered>",
-                "lineNumber": 0,
-                "columnNumber": 0
-              },
-              {
-                "functionName": "willCallFunctionTest",
-                "url": "timeline/line-column.html",
-                "scriptId": "<filtered>",
-                "lineNumber": 26,
-                "columnNumber": 44
-              },
-              {
-                "functionName": "global code",
-                "url": "",
-                "scriptId": "<filtered>",
-                "lineNumber": 1,
-                "columnNumber": 21
-              }
-            ]
-          },
-          "data": {
-            "scriptName": "timeline/line-column.html",
-            "scriptLine": 17,
-            "scriptColumn": 65
-          },
-          "children": [],
-          "endTime": "<filtered>",
-          "type": "FunctionCall"
-        }
-      ],
-      "endTime": "<filtered>",
-      "type": "EventDispatch"
-    },
     {
       "startTime": "<filtered>",
       "stackTrace": {
         "callFrames": [
           {
-            "functionName": "profile",
+            "functionName": "click",
             "url": "[native code]",
             "scriptId": "<filtered>",
             "lineNumber": 0,
@@ -72,8 +28,8 @@ PASS: Capturing started.
             "functionName": "willCallFunctionTest",
             "url": "timeline/line-column.html",
             "scriptId": "<filtered>",
-            "lineNumber": 25,
-            "columnNumber": 20
+            "lineNumber": 26,
+            "columnNumber": 44
           },
           {
             "functionName": "global code",
@@ -85,15 +41,51 @@ PASS: Capturing started.
         ]
       },
       "data": {
-        "title": ""
+        "scriptName": "timeline/line-column.html",
+        "scriptLine": 17,
+        "scriptColumn": 65
       },
       "children": [],
       "endTime": "<filtered>",
-      "type": "ConsoleProfile"
+      "type": "FunctionCall"
     }
   ],
   "endTime": "<filtered>",
-  "type": "RenderingFrame"
+  "type": "EventDispatch"
+}
+{
+  "startTime": "<filtered>",
+  "stackTrace": {
+    "callFrames": [
+      {
+        "functionName": "profile",
+        "url": "[native code]",
+        "scriptId": "<filtered>",
+        "lineNumber": 0,
+        "columnNumber": 0
+      },
+      {
+        "functionName": "willCallFunctionTest",
+        "url": "timeline/line-column.html",
+        "scriptId": "<filtered>",
+        "lineNumber": 25,
+        "columnNumber": 20
+      },
+      {
+        "functionName": "global code",
+        "url": "",
+        "scriptId": "<filtered>",
+        "lineNumber": 1,
+        "columnNumber": 21
+      }
+    ]
+  },
+  "data": {
+    "title": ""
+  },
+  "children": [],
+  "endTime": "<filtered>",
+  "type": "ConsoleProfile"
 }
 PASS: Capturing stopped.
 
@@ -102,45 +94,37 @@ Evaluating in page...
 PASS: Capturing started.
 {
   "startTime": "<filtered>",
-  "data": {},
-  "children": [
-    {
-      "startTime": "<filtered>",
-      "stackTrace": {
-        "callFrames": [
-          {
-            "functionName": "profile",
-            "url": "[native code]",
-            "scriptId": "<filtered>",
-            "lineNumber": 0,
-            "columnNumber": 0
-          },
-          {
-            "functionName": "willEvaluateScriptTest",
-            "url": "timeline/line-column.html",
-            "scriptId": "<filtered>",
-            "lineNumber": 31,
-            "columnNumber": 20
-          },
-          {
-            "functionName": "global code",
-            "url": "",
-            "scriptId": "<filtered>",
-            "lineNumber": 1,
-            "columnNumber": 23
-          }
-        ]
+  "stackTrace": {
+    "callFrames": [
+      {
+        "functionName": "profile",
+        "url": "[native code]",
+        "scriptId": "<filtered>",
+        "lineNumber": 0,
+        "columnNumber": 0
       },
-      "data": {
-        "title": ""
+      {
+        "functionName": "willEvaluateScriptTest",
+        "url": "timeline/line-column.html",
+        "scriptId": "<filtered>",
+        "lineNumber": 31,
+        "columnNumber": 20
       },
-      "children": [],
-      "endTime": "<filtered>",
-      "type": "ConsoleProfile"
-    }
-  ],
+      {
+        "functionName": "global code",
+        "url": "",
+        "scriptId": "<filtered>",
+        "lineNumber": 1,
+        "columnNumber": 23
+      }
+    ]
+  },
+  "data": {
+    "title": ""
+  },
+  "children": [],
   "endTime": "<filtered>",
-  "type": "RenderingFrame"
+  "type": "ConsoleProfile"
 }
 PASS: Capturing stopped.
 

--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2204,8 +2204,6 @@ webkit.org/b/307377 [ Tahoe Release arm64 ] compositing/webgl/update-composited-
 
 webkit.org/b/309833 fast/scrolling/mac/scrollend-event-user-scroll-basic.html [ Failure Pass ]
 
-webkit.org/b/314348 inspector/timeline/line-column.html [ Failure ]
-
 webkit.org/b/307691 [ Tahoe Release arm64 ] svg/gradients/spreadMethod.svg [ ImageOnlyFailure Pass ]
 
 webkit.org/b/309370 fast/css/vertical-text-overflow-ellipsis-text-align-center.html [ Failure Pass ]


### PR DESCRIPTION
#### f6bf3a0316972ca645d7f3244c2d64e34ade617e
<pre>
REGRESSION(312649@main): [macOS] inspector/timeline/line-column.html is a constant text failure.
<a href="https://bugs.webkit.org/show_bug.cgi?id=314348">https://bugs.webkit.org/show_bug.cgi?id=314348</a>
<a href="https://rdar.apple.com/176499241">rdar://176499241</a>

Reviewed by BJ Burg.

After 312649@main redefined timeline event nesting, EventDispatch and
ConsoleProfile no longer nest under RenderingFrame. Since RenderingFrame
records with no children are suppressed, the records are now emitted as
top-level siblings instead of nested under a RenderingFrame parent.

The line/column data the test verifies is unchanged.

* LayoutTests/inspector/timeline/line-column-expected.txt:
* LayoutTests/platform/mac-wk2/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/313720@main">https://commits.webkit.org/313720@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/674dddd21831e8420bd5d651da4f6fd1b459f70e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163532 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37016 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30235 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172472 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/119981 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0f3f0ddf-a41d-4924-8f0e-5d70514921ac) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37347 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37015 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127013 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89541 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5227e761-7e56-4623-8edc-e69356dd1609) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166491 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29284 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147015 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107567 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9f9f0000-40d4-4326-9bde-e2b264af6281) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28333 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26964 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20175 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138231 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24734 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/174977 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26396 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135318 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36685 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31066 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135300 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36553 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37471 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146529 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99518 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30605 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23379 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36181 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35679 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1405 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35929 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35826 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->