### PR TITLE
Web Inspector: [SI] add DOMEditor and InspectorHistory to FrameDOMAgent

### DIFF
--- a/LayoutTests/http/tests/site-isolation/inspector/dom/undo-redo-frame-target-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/undo-redo-frame-target-expected.txt
@@ -1,0 +1,17 @@
+Tests that FrameDOMAgent exposes undo, redo, and markUndoableState. Functional undo/redo coverage lands alongside DOM editing commands in a follow-up.
+
+
+
+== Running test suite: SiteIsolation.DOM.FrameDOMAgent.UndoRedo
+-- Running test case: Setup
+PASS: Should find a cross-origin frame target.
+
+-- Running test case: SiteIsolation.DOM.UndoRedo.UndoEmptyStack
+PASS: undo() on an empty stack should not reject.
+
+-- Running test case: SiteIsolation.DOM.UndoRedo.RedoEmptyStack
+PASS: redo() on an empty stack should not reject.
+
+-- Running test case: SiteIsolation.DOM.UndoRedo.MarkUndoableState
+PASS: markUndoableState() should not reject.
+

--- a/LayoutTests/http/tests/site-isolation/inspector/dom/undo-redo-frame-target.html
+++ b/LayoutTests/http/tests/site-isolation/inspector/dom/undo-redo-frame-target.html
@@ -1,0 +1,63 @@
+<!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<script src="../../../inspector/resources/inspector-test.js"></script>
+<script src="../debugger/resources/site-isolation-debugger-test-utilities.js"></script>
+<script>
+function test() {
+    let suite = InspectorTest.createAsyncSuite("SiteIsolation.DOM.FrameDOMAgent.UndoRedo");
+
+    let frameTarget = null;
+
+    suite.addTestCase({
+        name: "Setup",
+        description: "Find the cross-origin frame target.",
+        async test() {
+            let frameTargets = WI.targets.filter((t) => t.type === WI.TargetType.Frame);
+            let urlTargetMap = await fetchDocumentURLsForTargets(frameTargets);
+            let mainFrameTarget = urlTargetMap.get(WI.networkManager.mainFrame.url);
+            frameTarget = frameTargets.find((t) => t !== mainFrameTarget);
+
+            InspectorTest.expectNotNull(frameTarget, "Should find a cross-origin frame target.");
+
+            if (frameTarget.isProvisional) {
+                let committedEvent = await WI.targetManager.awaitEvent(WI.TargetManager.Event.DidCommitProvisionalTarget);
+                frameTarget = committedEvent.data.target;
+            }
+            await frameTarget.ensureTargetExecutionContext();
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.DOM.UndoRedo.UndoEmptyStack",
+        description: "undo on an empty history stack should succeed without error.",
+        async test() {
+            await frameTarget.DOMAgent.undo();
+            InspectorTest.pass("undo() on an empty stack should not reject.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.DOM.UndoRedo.RedoEmptyStack",
+        description: "redo on an empty history stack should succeed without error.",
+        async test() {
+            await frameTarget.DOMAgent.redo();
+            InspectorTest.pass("redo() on an empty stack should not reject.");
+        }
+    });
+
+    suite.addTestCase({
+        name: "SiteIsolation.DOM.UndoRedo.MarkUndoableState",
+        description: "markUndoableState should succeed.",
+        async test() {
+            await frameTarget.DOMAgent.markUndoableState();
+            InspectorTest.pass("markUndoableState() should not reject.");
+        }
+    });
+
+    suite.runTestCasesAndFinish();
+}
+</script>
+
+<body onload="runTest()">
+<p>Tests that FrameDOMAgent exposes undo, redo, and markUndoableState. Functional undo/redo coverage lands alongside DOM editing commands in a follow-up.</p>
+<iframe src="http://localhost:8000/site-isolation/inspector/dom/resources/dom-frame.html"></iframe>
+</body>

--- a/Source/JavaScriptCore/inspector/protocol/DOM.json
+++ b/Source/JavaScriptCore/inspector/protocol/DOM.json
@@ -774,17 +774,17 @@
         {
             "name": "undo",
             "description": "Undoes the last performed action.",
-            "targetTypes": ["page"]
+            "targetTypes": ["frame", "page"]
         },
         {
             "name": "redo",
             "description": "Re-does the last undone action.",
-            "targetTypes": ["page"]
+            "targetTypes": ["frame", "page"]
         },
         {
             "name": "markUndoableState",
             "description": "Marks last undoable state.",
-            "targetTypes": ["page"]
+            "targetTypes": ["frame", "page"]
         },
         {
             "name": "focus",

--- a/Source/WebCore/inspector/agents/frame/FrameDOMAgent.cpp
+++ b/Source/WebCore/inspector/agents/frame/FrameDOMAgent.cpp
@@ -29,6 +29,7 @@
 #include "Attr.h"
 #include "CharacterData.h"
 #include "ContainerNode.h"
+#include "DOMEditor.h"
 #include "Document.h"
 #include "DocumentInlines.h"
 #include "DocumentType.h"
@@ -45,6 +46,7 @@
 #include "HTMLStyleElement.h"
 #include "HTMLTemplateElement.h"
 #include "InspectorDOMAgent.h"
+#include "InspectorHistory.h"
 #include "InspectorNodeFinder.h"
 #include "InstrumentingAgents.h"
 #include "JSEventListener.h"
@@ -155,6 +157,9 @@ FrameDOMAgent::~FrameDOMAgent() = default;
 
 void FrameDOMAgent::didCreateFrontendAndBackend()
 {
+    m_history = makeUnique<InspectorHistory>();
+    m_domEditor = makeUnique<DOMEditor>(*m_history);
+
     Ref { m_instrumentingAgents.get() }->setPersistentFrameDOMAgent(this);
 
     RefPtr frame = m_inspectedFrame.get();
@@ -164,6 +169,9 @@ void FrameDOMAgent::didCreateFrontendAndBackend()
 
 void FrameDOMAgent::willDestroyFrontendAndBackend(Inspector::DisconnectReason)
 {
+    m_domEditor.reset();
+    m_history.reset();
+
     Ref { m_instrumentingAgents.get() }->setPersistentFrameDOMAgent(nullptr);
     m_documentRequested = false;
     reset();
@@ -486,6 +494,8 @@ void FrameDOMAgent::setDocument(Document* document)
 
 void FrameDOMAgent::reset()
 {
+    if (m_history)
+        m_history->reset();
     discardBindings();
     m_document = nullptr;
     m_searchResults.clear();
@@ -1160,6 +1170,31 @@ Ref<Inspector::Protocol::DOM::EventListener> FrameDOMAgent::buildObjectForEventL
     if (disabled)
         value->setDisabled(disabled);
     return value;
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::undo()
+{
+    auto result = m_history->undo();
+    if (result.hasException())
+        return makeUnexpected(InspectorDOMAgent::toErrorString(result.releaseException()));
+
+    return { };
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::redo()
+{
+    auto result = m_history->redo();
+    if (result.hasException())
+        return makeUnexpected(InspectorDOMAgent::toErrorString(result.releaseException()));
+
+    return { };
+}
+
+Inspector::CommandResult<void> FrameDOMAgent::markUndoableState()
+{
+    m_history->markUndoableState();
+
+    return { };
 }
 
 } // namespace WebCore

--- a/Source/WebCore/inspector/agents/frame/FrameDOMAgent.h
+++ b/Source/WebCore/inspector/agents/frame/FrameDOMAgent.h
@@ -40,10 +40,12 @@
 namespace WebCore {
 
 class CharacterData;
+class DOMEditor;
 class Document;
 class Element;
 class EventListener;
 class EventTarget;
+class InspectorHistory;
 class LocalFrame;
 class Node;
 class PseudoElement;
@@ -149,6 +151,7 @@ public:
     Node* nodeForId(Inspector::Protocol::DOM::NodeId);
     Inspector::Protocol::DOM::NodeId boundNodeId(const Node*);
     Inspector::Protocol::DOM::NodeId pushNodePathToFrontend(Node*);
+    InspectorHistory* history() LIFETIME_BOUND { return m_history.get(); }
 
 private:
     Inspector::Protocol::DOM::NodeId bind(Node&);
@@ -226,6 +229,9 @@ private:
 
     HashMap<Inspector::Protocol::DOM::EventListenerId, InspectorEventListener> m_eventListenerEntries;
     Inspector::Protocol::DOM::EventListenerId m_lastEventListenerId { 1 };
+
+    std::unique_ptr<InspectorHistory> m_history;
+    std::unique_ptr<DOMEditor> m_domEditor;
 
     bool m_suppressAttributeModifiedEvent { false };
     bool m_documentRequested { false };

--- a/Source/WebCore/inspector/agents/frame/FrameDOMAgentStubs.cpp
+++ b/Source/WebCore/inspector/agents/frame/FrameDOMAgentStubs.cpp
@@ -196,21 +196,6 @@ Inspector::CommandResult<int> FrameDOMAgent::moveTo(int, int, std::optional<int>
     return makeUnexpected("Not yet implemented for frame targets"_s);
 }
 
-Inspector::CommandResult<void> FrameDOMAgent::undo()
-{
-    return makeUnexpected("Not yet implemented for frame targets"_s);
-}
-
-Inspector::CommandResult<void> FrameDOMAgent::redo()
-{
-    return makeUnexpected("Not yet implemented for frame targets"_s);
-}
-
-Inspector::CommandResult<void> FrameDOMAgent::markUndoableState()
-{
-    return makeUnexpected("Not yet implemented for frame targets"_s);
-}
-
 Inspector::CommandResult<void> FrameDOMAgent::focus(int)
 {
     return makeUnexpected("Not supported for frame targets"_s);


### PR DESCRIPTION
#### 45415270341ee79de9a0259e2410fe28616715a8
<pre>
Web Inspector: [SI] add DOMEditor and InspectorHistory to FrameDOMAgent
<a href="https://bugs.webkit.org/show_bug.cgi?id=314899">https://bugs.webkit.org/show_bug.cgi?id=314899</a>
<a href="https://rdar.apple.com/177173163">rdar://177173163</a>

Reviewed by BJ Burg.

Setting up the editing instrumentation on FrameDOMAgent so cross-origin
iframe edits can be recorded and undone. No editing commands wired yet —
follow-up radar fills the stack.

Test: http/tests/site-isolation/inspector/dom/undo-redo-frame-target.html

* LayoutTests/http/tests/site-isolation/inspector/dom/undo-redo-frame-target-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/inspector/dom/undo-redo-frame-target.html: Added.
* Source/JavaScriptCore/inspector/protocol/DOM.json:
* Source/WebCore/inspector/agents/frame/FrameDOMAgent.cpp:
(WebCore::FrameDOMAgent::didCreateFrontendAndBackend):
(WebCore::FrameDOMAgent::willDestroyFrontendAndBackend):
(WebCore::FrameDOMAgent::reset):
(WebCore::FrameDOMAgent::undo):
(WebCore::FrameDOMAgent::redo):
(WebCore::FrameDOMAgent::markUndoableState):
* Source/WebCore/inspector/agents/frame/FrameDOMAgent.h:
* Source/WebCore/inspector/agents/frame/FrameDOMAgentStubs.cpp:
(WebCore::FrameDOMAgent::undo): Deleted.
(WebCore::FrameDOMAgent::redo): Deleted.
(WebCore::FrameDOMAgent::markUndoableState): Deleted.

Canonical link: <a href="https://commits.webkit.org/315340@main">https://commits.webkit.org/315340@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f9f2fa1caced1da8b9631db20661047d2ca8e80e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168676 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42235 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35830 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178007 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126383 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/93ce43b9-b2f7-4368-ab99-21f79a15b425) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170542 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42612 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42195 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131321 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92376 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/64b789fc-3991-4000-8208-92237ec16c43) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171635 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33770 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151589 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111825 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/abba6be6-7731-46ff-a867-7a63e42f5101) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32759 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31473 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26702 "Built successfully") | | 
| [✅ 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/218/builds/7 "Passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142749 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30989 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180608 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/29927 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33338 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35641 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139763 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42247 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151058 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139612 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37608 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42936 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27961 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106660 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34894 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114703 "Built successfully") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/201355 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41439 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6047 "Passed tests") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54064 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40836 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41090 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40981 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->