### PR TITLE
[JSC] Add DFG node for `String.fromCodePoint`

### DIFF
--- a/JSTests/microbenchmarks/string-from-code-point.js
+++ b/JSTests/microbenchmarks/string-from-code-point.js
@@ -1,0 +1,37 @@
+//@ skip if $model == "Apple Watch Series 3"
+
+function fromCodePointLatin1(start, count) {
+    let result = 0;
+    for (let i = 0; i < count; ++i)
+        result += String.fromCodePoint((start + i) & 0xFF).length;
+    return result;
+}
+noInline(fromCodePointLatin1);
+
+function fromCodePointBMP(start, count) {
+    let result = 0;
+    for (let i = 0; i < count; ++i)
+        result += String.fromCodePoint(0x3000 + ((start + i) & 0xFF)).length;
+    return result;
+}
+noInline(fromCodePointBMP);
+
+function fromCodePointMixed(start, count) {
+    let result = 0;
+    for (let i = 0; i < count; ++i) {
+        const cp = ((start + i) & 0x1) ? 0x41 : 0x1F600;
+        result += String.fromCodePoint(cp).length;
+    }
+    return result;
+}
+noInline(fromCodePointMixed);
+
+let total = 0;
+for (let i = 0; i < 5000; ++i) {
+    total += fromCodePointLatin1(i, 200);
+    total += fromCodePointBMP(i, 200);
+    total += fromCodePointMixed(i, 200);
+}
+
+if (total !== 5000 * (200 + 200 + 300))
+    throw new Error(`bad total: ${total}`);

--- a/JSTests/stress/string-from-code-point-intrinsic.js
+++ b/JSTests/stress/string-from-code-point-intrinsic.js
@@ -1,0 +1,111 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error(`bad value: ${actual} (expected ${expected})`);
+}
+
+function shouldThrow(func, errorType) {
+    let error;
+    try {
+        func();
+    } catch (e) {
+        error = e;
+    }
+    if (!error)
+        throw new Error("Expected an error to be thrown");
+    if (!(error instanceof errorType))
+        throw new Error(`Expected ${errorType.name} but got ${error.name}: ${error.message}`);
+}
+
+// Latin1 small string range.
+function fromCodePointLatin1(cp) {
+    return String.fromCodePoint(cp);
+}
+noInline(fromCodePointLatin1);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    shouldBe(fromCodePointLatin1(0), "\0");
+    shouldBe(fromCodePointLatin1(0x41), "A");
+    shouldBe(fromCodePointLatin1(0xFF), "ÿ");
+}
+
+// BMP non-Latin1 range: still single UTF-16 unit, but not a small string.
+function fromCodePointBMP(cp) {
+    return String.fromCodePoint(cp);
+}
+noInline(fromCodePointBMP);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    shouldBe(fromCodePointBMP(0x100), "Ā");
+    shouldBe(fromCodePointBMP(0x3042), "あ");
+    shouldBe(fromCodePointBMP(0xFFFF), "￿");
+}
+
+// Supplementary plane: surrogate pair.
+function fromCodePointSupplementary(cp) {
+    return String.fromCodePoint(cp);
+}
+noInline(fromCodePointSupplementary);
+
+for (let i = 0; i < testLoopCount; ++i) {
+    shouldBe(fromCodePointSupplementary(0x10000), "𐀀");
+    shouldBe(fromCodePointSupplementary(0x1F600), "😀");
+    shouldBe(fromCodePointSupplementary(0x10FFFF), "􏿿");
+}
+
+// Out-of-range RangeError after warm-up with valid Int32 inputs.
+function fromCodePointMaybeThrows(cp) {
+    return String.fromCodePoint(cp);
+}
+noInline(fromCodePointMaybeThrows);
+
+for (let i = 0; i < testLoopCount; ++i)
+    shouldBe(fromCodePointMaybeThrows(0x42), "B");
+shouldThrow(() => fromCodePointMaybeThrows(-1), RangeError);
+shouldThrow(() => fromCodePointMaybeThrows(0x110000), RangeError);
+shouldThrow(() => fromCodePointMaybeThrows(0x7FFFFFFF), RangeError);
+
+// Untyped (double) inputs after warm-up.
+function fromCodePointDouble(cp) {
+    return String.fromCodePoint(cp);
+}
+noInline(fromCodePointDouble);
+
+for (let i = 0; i < testLoopCount; ++i)
+    shouldBe(fromCodePointDouble(0x41 + 0.0), "A");
+shouldBe(fromCodePointDouble(0x10000 + 0.0), "𐀀");
+shouldThrow(() => fromCodePointDouble(0.5), RangeError);
+shouldThrow(() => fromCodePointDouble(NaN), RangeError);
+shouldThrow(() => fromCodePointDouble(Infinity), RangeError);
+shouldThrow(() => fromCodePointDouble(-1.0), RangeError);
+
+// Untyped object input that triggers valueOf side effects.
+function fromCodePointObject(cp) {
+    return String.fromCodePoint(cp);
+}
+noInline(fromCodePointObject);
+
+let valueOfCalls = 0;
+const obj = { valueOf() { ++valueOfCalls; return 0x43; } };
+for (let i = 0; i < testLoopCount; ++i)
+    shouldBe(fromCodePointObject(obj), "C");
+shouldBe(valueOfCalls, testLoopCount);
+
+// Multi-argument form must still go through the host function.
+function fromCodePointMulti(a, b, c) {
+    return String.fromCodePoint(a, b, c);
+}
+noInline(fromCodePointMulti);
+
+for (let i = 0; i < testLoopCount; ++i)
+    shouldBe(fromCodePointMulti(0x41, 0x42, 0x43), "ABC");
+
+// Result-unused call must still throw RangeError (cannot be DCE'd) even with Int32 input.
+function fromCodePointDead(cp) {
+    String.fromCodePoint(cp);
+    return cp;
+}
+noInline(fromCodePointDead);
+
+for (let i = 0; i < testLoopCount; ++i)
+    shouldBe(fromCodePointDead(0x41), 0x41);
+shouldThrow(() => fromCodePointDead(0x110000), RangeError);

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -2730,6 +2730,21 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         break;
     }
 
+    case StringFromCodePoint: {
+        if (node->child1().useKind() == Int32Use || node->child1().useKind() == KnownInt32Use) {
+            if (node->child1()->isInt32Constant() && node->child1()->asUInt32() <= maxSingleCharacterString) {
+                JSString* string = m_vm.smallStrings.singleCharacterString(static_cast<unsigned char>(node->child1()->asUInt32()));
+                setConstant(node, *m_graph.freeze(string));
+                break;
+            }
+        } else if (node->child1().useKind() == UntypedUse)
+            clobberWorld();
+        else
+            DFG_CRASH(m_graph, node, "Bad use kind");
+        setTypeForNode(node, SpecStringResolved);
+        break;
+    }
+
     case StringCharAt: {
         auto& value = forNode(node->child1());
         JSValue constant = value.value();

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -3452,6 +3452,19 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             return CallOptimizationResult::Inlined;
         }
 
+        case FromCodePointIntrinsic: {
+            if (argumentCountIncludingThis != 2)
+                return CallOptimizationResult::DidNothing;
+
+            insertChecks();
+            VirtualRegister indexOperand = virtualRegisterForArgumentIncludingThis(1, registerOffset);
+            Node* result = addToGraph(StringFromCodePoint, get(indexOperand));
+
+            setResult(result);
+
+            return CallOptimizationResult::Inlined;
+        }
+
         case GlobalIsNaNIntrinsic: {
             if (argumentCountIncludingThis < 2)
                 return CallOptimizationResult::DidNothing;

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -493,6 +493,23 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         }
         return;
 
+    case StringFromCodePoint:
+        switch (node->child1().useKind()) {
+        case Int32Use:
+        case KnownInt32Use:
+            // Can throw a RangeError for an out-of-range code point, so this is not pure.
+            read(World);
+            write(SideState);
+            def(PureValue(node));
+            return;
+        case UntypedUse:
+            clobberTop();
+            return;
+        default:
+            DFG_CRASH(graph, node, "Bad use kind");
+        }
+        return;
+
     case ArithAdd:
     case DoubleAsInt32:
     case UInt32ToNumber:

--- a/Source/JavaScriptCore/dfg/DFGCloneHelper.h
+++ b/Source/JavaScriptCore/dfg/DFGCloneHelper.h
@@ -343,6 +343,7 @@ BasicBlock* CloneHelper::cloneBlock(BasicBlock* const block, const CustomizeSucc
     CLONE_STATUS(StringCharCodeAt, Common) \
     CLONE_STATUS(StringCodePointAt, Common) \
     CLONE_STATUS(StringFromCharCode, Common) \
+    CLONE_STATUS(StringFromCodePoint, Common) \
     CLONE_STATUS(StringIndexOf, Common) \
     CLONE_STATUS(StringLastIndexOf, Common) \
     CLONE_STATUS(StringStartsWith, Common) \

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -669,6 +669,7 @@ bool doesGC(Graph& graph, Node* node)
         return true;
 
     case StringFromCharCode:
+    case StringFromCodePoint:
         if (node->child1()->isInt32Constant() && (node->child1()->asUInt32() <= maxSingleCharacterString))
             return false;
         return true;

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -1121,6 +1121,15 @@ private:
                 fixEdge<UntypedUse>(node->child1());
             break;
 
+        case StringFromCodePoint:
+            // Unlike StringFromCharCode, this can throw a RangeError even for an Int32 argument,
+            // so NodeMustGenerate is never cleared.
+            if (node->child1()->shouldSpeculateInt32())
+                fixEdge<Int32Use>(node->child1());
+            else
+                fixEdge<UntypedUse>(node->child1());
+            break;
+
         case StringAt:
         case StringCharAt:
         case StringCharCodeAt:

--- a/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp
@@ -517,7 +517,7 @@ public:
                     return false;
                 }
 
-                if (node->op() == StringFromCharCode) {
+                if (node->op() == StringFromCharCode || node->op() == StringFromCodePoint) {
                     // Not supported due to performance regression rdar://150526635
                     dataLogLnIf(Options::verboseLoopUnrolling(), "Skipping loop with header ", *data.header(), " since ", node, "<", node->op(), "> is not supported");
                     return false;

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -379,6 +379,7 @@ namespace JSC { namespace DFG {
     macro(StringCodePointAt, NodeResultInt32) \
     macro(StringCharAt, NodeResultJS) \
     macro(StringFromCharCode, NodeResultJS | NodeMustGenerate) \
+    macro(StringFromCodePoint, NodeResultJS | NodeMustGenerate) \
     \
     /* Nodes for comparison operations. */\
     macro(CompareLess, NodeResultBoolean | NodeMustGenerate) \

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -5249,6 +5249,38 @@ JSC_DEFINE_JIT_OPERATION(operationStringFromCharCodeUntyped, EncodedJSValue, (JS
     OPERATION_RETURN(scope, JSValue::encode(JSC::stringFromCharCode(globalObject, chInt)));
 }
 
+JSC_DEFINE_JIT_OPERATION(operationStringFromCodePoint, JSCell*, (JSGlobalObject* globalObject, int32_t op1))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    OPERATION_RETURN(scope, JSC::stringFromCodePoint(globalObject, op1));
+}
+
+JSC_DEFINE_JIT_OPERATION(operationStringFromCodePointUntyped, EncodedJSValue, (JSGlobalObject* globalObject, EncodedJSValue encodedValue))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+    JSValue value = JSValue::decode(encodedValue);
+    double codePointAsDouble = value.toNumber(globalObject);
+    OPERATION_RETURN_IF_EXCEPTION(scope, encodedJSValue());
+
+    uint32_t codePoint = static_cast<uint32_t>(codePointAsDouble);
+    if (codePoint != codePointAsDouble || codePoint > UCHAR_MAX_VALUE) [[unlikely]] {
+        throwRangeError(globalObject, scope, "Arguments contain a value that is out of range of code points"_s);
+        OPERATION_RETURN(scope, encodedJSValue());
+    }
+
+    if (U_IS_BMP(codePoint))
+        OPERATION_RETURN(scope, JSValue::encode(jsSingleCharacterString(vm, static_cast<char16_t>(codePoint))));
+
+    char16_t buffer[2] = { U16_LEAD(codePoint), U16_TRAIL(codePoint) };
+    OPERATION_RETURN(scope, JSValue::encode(jsNontrivialString(vm, String({ buffer, 2 }))));
+}
+
 JSC_DEFINE_JIT_OPERATION(operationNewRawObject, char*, (VM* vmPointer, Structure* structure, int32_t length, Butterfly* butterfly))
 {
     VM& vm = *vmPointer;

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -58,6 +58,8 @@ struct OSRExitBase;
 
 JSC_DECLARE_JIT_OPERATION(operationStringFromCharCode, JSCell*, (JSGlobalObject*, int32_t));
 JSC_DECLARE_JIT_OPERATION(operationStringFromCharCodeUntyped, EncodedJSValue, (JSGlobalObject*, EncodedJSValue));
+JSC_DECLARE_JIT_OPERATION(operationStringFromCodePoint, JSCell*, (JSGlobalObject*, int32_t));
+JSC_DECLARE_JIT_OPERATION(operationStringFromCodePointUntyped, EncodedJSValue, (JSGlobalObject*, EncodedJSValue));
 
 // These routines provide callbacks out to C++ implementations of operations too complex to JIT.
 JSC_DECLARE_JIT_OPERATION(operationCallObjectConstructor, JSCell*, (JSGlobalObject*, EncodedJSValue encodedTarget));

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1465,7 +1465,8 @@ private:
             break;
         }
         
-        case StringFromCharCode: {
+        case StringFromCharCode:
+        case StringFromCodePoint: {
             setPrediction(SpecString);
             m_currentNode->child1()->mergeFlags(NodeBytecodeUsesAsNumber | NodeBytecodeUsesAsInt);
             break;

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -296,6 +296,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case GetFromArguments:
     case GetArgument:
     case StringFromCharCode:
+    case StringFromCodePoint:
     case ExtractOSREntryLocal:
     case ExtractCatchLocal:
     case AssertInBounds:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -2884,8 +2884,12 @@ void SpeculativeJIT::compileGetByValOnString(Node* node, const ScopedLambda<std:
     }
 }
 
-void SpeculativeJIT::compileFromCharCode(Node* node)
+void SpeculativeJIT::compileStringFromCharCodeOrCodePoint(Node* node)
 {
+    ASSERT(node->op() == StringFromCharCode || node->op() == StringFromCodePoint);
+
+    bool isCodePoint = node->op() == StringFromCodePoint;
+
     Edge& child = node->child1();
     if (child.useKind() == UntypedUse) {
         JSValueOperand opr(this, child);
@@ -2894,8 +2898,8 @@ void SpeculativeJIT::compileFromCharCode(Node* node)
         flushRegisters();
         JSValueRegsFlushedCallResult result(this);
         JSValueRegs resultRegs = result.regs();
-        callOperation(operationStringFromCharCodeUntyped, resultRegs, LinkableConstant::globalObject(*this, node), oprRegs);
-        
+        callOperation(isCodePoint ? operationStringFromCodePointUntyped : operationStringFromCharCodeUntyped, resultRegs, LinkableConstant::globalObject(*this, node), oprRegs);
+
         jsValueResult(resultRegs, node);
         return;
     }
@@ -2913,7 +2917,7 @@ void SpeculativeJIT::compileFromCharCode(Node* node)
     loadPtr(BaseIndex(smallStringsReg, propertyReg, ScalePtr, 0), scratchReg);
 
     slowCases.append(branchTest32(Zero, scratchReg));
-    addSlowPathGenerator(slowPathCall(slowCases, this, operationStringFromCharCode, scratchReg, LinkableConstant::globalObject(*this, node), propertyReg));
+    addSlowPathGenerator(slowPathCall(slowCases, this, isCodePoint ? operationStringFromCodePoint : operationStringFromCharCode, scratchReg, LinkableConstant::globalObject(*this, node), propertyReg));
     cellResult(scratchReg, m_currentNode);
 }
 

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1534,7 +1534,7 @@ public:
 
     void compileGetCharCodeAt(Node*);
     void compileGetByValOnString(Node*, const ScopedLambda<std::tuple<JSValueRegs, DataFormat>(DataFormat preferredFormat, bool needsFlush)>& prefix);
-    void compileFromCharCode(Node*); 
+    void compileStringFromCharCodeOrCodePoint(Node*);
     void compileGetByValMegamorphic(Node*);
 
     void compileGetByValOnDirectArguments(Node*, const ScopedLambda<std::tuple<JSValueRegs, DataFormat>(DataFormat preferredFormat, bool needsFlush)>& prefix);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -2606,8 +2606,9 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
-    case StringFromCharCode: {
-        compileFromCharCode(node);
+    case StringFromCharCode:
+    case StringFromCodePoint: {
+        compileStringFromCharCodeOrCodePoint(node);
         break;
     }
 

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -3820,8 +3820,9 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
-    case StringFromCharCode: {
-        compileFromCharCode(node);
+    case StringFromCharCode:
+    case StringFromCodePoint: {
+        compileStringFromCharCodeOrCodePoint(node);
         break;
     }
 

--- a/Source/JavaScriptCore/dfg/DFGValidate.cpp
+++ b/Source/JavaScriptCore/dfg/DFGValidate.cpp
@@ -333,6 +333,7 @@ public:
                     break;
                 case CheckStructure:
                 case StringFromCharCode:
+                case StringFromCodePoint:
                     VALIDATE((node), !!node->child1());
                     break;
                 case PutStructure:

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -174,6 +174,7 @@ inline CapabilityLevel canCompile(Node* node)
     case StringCharCodeAt:
     case StringCodePointAt:
     case StringFromCharCode:
+    case StringFromCodePoint:
     case StringIndexOf:
     case StringLastIndexOf:
     case StringStartsWith:

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -1393,7 +1393,8 @@ private:
             compileStringCodePointAt();
             break;
         case StringFromCharCode:
-            compileStringFromCharCode();
+        case StringFromCodePoint:
+            compileStringFromCharCodeOrCodePoint();
             break;
         case StringLocaleCompare:
             compileStringLocaleCompare();
@@ -12107,14 +12108,18 @@ IGNORE_CLANG_WARNINGS_END
         setInt32(m_out.phi(Int32, char8Bit, char16Bit, charSurrogatePair));
     }
 
-    void compileStringFromCharCode()
+    void compileStringFromCharCodeOrCodePoint()
     {
+        ASSERT(m_node->op() == StringFromCharCode || m_node->op() == StringFromCodePoint);
+
+        bool isCodePoint = m_node->op() == StringFromCodePoint;
+
         JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
         Edge childEdge = m_node->child1();
 
         if (childEdge.useKind() == UntypedUse) {
             LValue result = vmCall(
-                Int64, operationStringFromCharCodeUntyped, weakPointer(globalObject),
+                Int64, isCodePoint ? operationStringFromCodePointUntyped : operationStringFromCharCodeUntyped, weakPointer(globalObject),
                 lowJSValue(childEdge));
             setJSValue(result);
             return;
@@ -12143,7 +12148,7 @@ IGNORE_CLANG_WARNINGS_END
         m_out.appendTo(slowCase, continuation);
 
         LValue slowResultValue = vmCall(
-            pointerType(), operationStringFromCharCode, weakPointer(globalObject), value);
+            pointerType(), isCodePoint ? operationStringFromCodePoint : operationStringFromCharCode, weakPointer(globalObject), value);
         ValueFromBlock slowResult = m_out.anchor(slowResultValue);
         m_out.jump(continuation);
 

--- a/Source/JavaScriptCore/jit/ThunkGenerators.cpp
+++ b/Source/JavaScriptCore/jit/ThunkGenerators.cpp
@@ -716,6 +716,18 @@ MacroAssemblerCodeRef<JITThunkPtrTag> fromCharCodeThunkGenerator(VM& vm)
     return jit.finalize(vm.jitStubs->ctiNativeTailCall(vm), "fromCharCode");
 }
 
+MacroAssemblerCodeRef<JITThunkPtrTag> fromCodePointThunkGenerator(VM& vm)
+{
+    SpecializedThunkJIT jit(vm, 1);
+    // For an Int32 code point in the small-string range, fromCodePoint produces the same result
+    // as fromCharCode. charToString already bails for code points > maxSingleCharacterString, so
+    // surrogate pairs and out-of-range RangeError cases all fall back to the slow path.
+    jit.loadInt32Argument(0, SpecializedThunkJIT::regT0);
+    charToString(jit, vm, SpecializedThunkJIT::regT0, SpecializedThunkJIT::regT0, SpecializedThunkJIT::regT1);
+    jit.returnJSCell(SpecializedThunkJIT::regT0);
+    return jit.finalize(vm.jitStubs->ctiNativeTailCall(vm), "fromCodePoint");
+}
+
 MacroAssemblerCodeRef<JITThunkPtrTag> stringAtThunkGenerator(VM& vm)
 {
     SpecializedThunkJIT jit(vm, 1);

--- a/Source/JavaScriptCore/jit/ThunkGenerators.h
+++ b/Source/JavaScriptCore/jit/ThunkGenerators.h
@@ -78,6 +78,7 @@ MacroAssemblerCodeRef<JITThunkPtrTag> stringAtThunkGenerator(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> stringPrototypeCodePointAtThunkGenerator(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> clz32ThunkGenerator(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> fromCharCodeThunkGenerator(VM&);
+MacroAssemblerCodeRef<JITThunkPtrTag> fromCodePointThunkGenerator(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> globalIsNaNThunkGenerator(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> numberIsNaNThunkGenerator(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> globalIsFiniteThunkGenerator(VM&);

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -94,6 +94,7 @@ namespace JSC {
     macro(DatePrototypeSetTimeIntrinsic) \
     macro(ErrorIsErrorIntrinsic) \
     macro(FromCharCodeIntrinsic) \
+    macro(FromCodePointIntrinsic) \
     macro(GlobalIsFiniteIntrinsic) \
     macro(GlobalIsNaNIntrinsic) \
     macro(PowIntrinsic) \

--- a/Source/JavaScriptCore/runtime/StringConstructor.cpp
+++ b/Source/JavaScriptCore/runtime/StringConstructor.cpp
@@ -41,7 +41,7 @@ const ClassInfo StringConstructor::s_info = { "Function"_s, &Base::s_info, &stri
 /* Source for StringConstructor.lut.h
 @begin stringConstructorTable
   fromCharCode          stringFromCharCode         DontEnum|Function 1 FromCharCodeIntrinsic
-  fromCodePoint         stringFromCodePoint        DontEnum|Function 1
+  fromCodePoint         stringFromCodePoint        DontEnum|Function 1 FromCodePointIntrinsic
   raw                   JSBuiltin                  DontEnum|Function 1
 @end
 */
@@ -143,6 +143,25 @@ JSC_DEFINE_HOST_FUNCTION(stringFromCodePoint, (JSGlobalObject* globalObject, Cal
     }
 
     RELEASE_AND_RETURN(scope, JSValue::encode(jsString(vm, builder.toString())));
+}
+
+JSString* stringFromCodePoint(JSGlobalObject* globalObject, int32_t arg)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    uint32_t codePoint = static_cast<uint32_t>(arg);
+    if (arg < 0 || codePoint > UCHAR_MAX_VALUE) [[unlikely]] {
+        throwRangeError(globalObject, scope, "Arguments contain a value that is out of range of code points"_s);
+        return nullptr;
+    }
+    scope.release();
+
+    if (U_IS_BMP(codePoint))
+        return jsSingleCharacterString(vm, static_cast<char16_t>(codePoint));
+
+    char16_t buffer[2] = { U16_LEAD(codePoint), U16_TRAIL(codePoint) };
+    return jsNontrivialString(vm, String({ buffer, 2 }));
 }
 
 JSC_DEFINE_HOST_FUNCTION(constructWithStringConstructor, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/JavaScriptCore/runtime/StringConstructor.h
+++ b/Source/JavaScriptCore/runtime/StringConstructor.h
@@ -45,6 +45,7 @@ private:
 static_assert(sizeof(StringConstructor) == sizeof(JSFunction), "Allocate StringConstructor in JSFunction IsoSubspace");
 
 JSString* stringFromCharCode(JSGlobalObject*, int32_t);
+JSString* stringFromCodePoint(JSGlobalObject*, int32_t);
 JSString* stringConstructor(JSGlobalObject*, JSValue);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -744,6 +744,8 @@ static ThunkGenerator NODELETE thunkGeneratorForIntrinsic(Intrinsic intrinsic)
         return clz32ThunkGenerator;
     case FromCharCodeIntrinsic:
         return fromCharCodeThunkGenerator;
+    case FromCodePointIntrinsic:
+        return fromCodePointThunkGenerator;
     case GlobalIsNaNIntrinsic:
         return globalIsNaNThunkGenerator;
     case NumberIsNaNIntrinsic:


### PR DESCRIPTION
#### 93a4fbeda18317d134d83ccabc3abc7abc2ae12f
<pre>
[JSC] Add DFG node for `String.fromCodePoint`
<a href="https://bugs.webkit.org/show_bug.cgi?id=315201">https://bugs.webkit.org/show_bug.cgi?id=315201</a>

Reviewed by Yusuke Suzuki.

This patch adds a new StringFromCodePoint DFG node and
FromCodePointIntrinsic for String.fromCodePoint().

When the argument is an Int32 in [0, 0xFF], the result is identical to
StringFromCharCode, so the DFG/FTL fast path is shared with it
(compileStringFromCharCodeOrCodePoint): an inline lookup of the
small-string table, falling back to a runtime call for larger code
points, surrogate pairs, and the out-of-range RangeError.

Unlike StringFromCharCode, this can throw a RangeError even for an Int32
argument, so NodeMustGenerate is never cleared in fixup, and clobberize
models it as write(SideState).

                                TipOfTree                  Patched

string-from-code-point       97.3232+-1.5882     ^     18.6356+-0.2575        ^ definitely 5.2224x faster

* JSTests/microbenchmarks/string-from-code-point.js: Added.
(fromCodePointLatin1):
(fromCodePointBMP):
(fromCodePointMixed):
* JSTests/stress/string-from-code-point-intrinsic.js: Added.
(shouldBe):
(fromCodePointBMP):
(fromCodePointSupplementary):
(fromCodePointMaybeThrows):
(fromCodePointDouble):
(fromCodePointObject):
(const.obj.valueOf):
(fromCodePointMulti):
(fromCodePointDead):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGCloneHelper.h:
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
* Source/JavaScriptCore/dfg/DFGLoopUnrollingPhase.cpp:
(JSC::DFG::LoopUnrollingPhase::isLoopBodyUnrollable):
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
(JSC::DFG::SpeculativeJIT::compileStringFromCharCodeOrCodePoint):
(JSC::DFG::SpeculativeJIT::compileFromCharCode): Deleted.
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGValidate.cpp:
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileStringFromCharCodeOrCodePoint):
(JSC::FTL::DFG::LowerDFGToB3::compileStringFromCharCode): Deleted.
* Source/JavaScriptCore/jit/ThunkGenerators.cpp:
(JSC::fromCodePointThunkGenerator):
* Source/JavaScriptCore/jit/ThunkGenerators.h:
* Source/JavaScriptCore/runtime/Intrinsic.h:
* Source/JavaScriptCore/runtime/StringConstructor.cpp:
(JSC::stringFromCodePoint):
* Source/JavaScriptCore/runtime/StringConstructor.h:
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::thunkGeneratorForIntrinsic):

Canonical link: <a href="https://commits.webkit.org/313696@main">https://commits.webkit.org/313696@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/16cdc201ec5482911dcab000f82d6765f86cdff0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163722 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37206 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30425 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172767 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/120366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37537 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37205 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127188 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/120366 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166681 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29455 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147189 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107738 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28502 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27132 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20516 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/155873 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138401 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24906 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175294 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/24613 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28098 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26574 "Found 1 new test failure: imported/w3c/web-platform-tests/fetch/api/crashtests/huge-fetch.any.sharedworker.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135498 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36876 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31237 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135474 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36541 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37661 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146701 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99758 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30770 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23555 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/196124 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36372 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109517 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51136 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35869 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1585 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36119 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36016 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->