### PR TITLE
Rerun WebGPU view rendering stopped working in 26.4 (21624.1.16.11.4) & Safari Technology Preview 243

### DIFF
--- a/LayoutTests/fast/webgpu/regression/repro_303203-expected.txt
+++ b/LayoutTests/fast/webgpu/regression/repro_303203-expected.txt
@@ -1,0 +1,6 @@
+CONSOLE MESSAGE: PASS
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x600
+  RenderBlock {HTML} at (0,0) size 800x600
+    RenderBody {BODY} at (8,8) size 784x584

--- a/LayoutTests/fast/webgpu/regression/repro_303203.html
+++ b/LayoutTests/fast/webgpu/regression/repro_303203.html
@@ -1,0 +1,55 @@
+<script>
+  globalThis.testRunner?.waitUntilDone();
+  const log = console.debug;
+
+  // Regression test for rdar://165488672 / https://bugs.webkit.org/show_bug.cgi?id=303203
+  //
+  // After 303984@main, m_commandEncoders on a tracked resource was changed from
+  // Vector<uint64_t> (allowed duplicates) to a HashSet<uint64_t> (deduplicated).
+  // However, Buffer::setCommandEncoder kept calling
+  // CommandEncoder::incrementBufferMapCount() once per call, so when the same
+  // mapped buffer was referenced N times in the same encoder, the encoder's
+  // bufferMapCount was incremented N times but only decremented once on unmap.
+  // The leftover count tripped the "bufferMapCount != 0" check at submit time,
+  // producing "Validation failure - queue1." spurious validation errors that
+  // broke applications like rerun.io's WebGPU viewer.
+  //
+  // This test references a mapped-at-creation source buffer twice from the same
+  // command encoder, unmaps it, and submits. The buggy implementation reports a
+  // validation error; the fixed implementation submits cleanly.
+
+  onload = async () => {
+    let adapter = await navigator.gpu.requestAdapter({});
+    let device = await adapter.requestDevice({});
+
+    let stagingBuffer = device.createBuffer({
+      size: 16,
+      usage: GPUBufferUsage.COPY_SRC,
+      mappedAtCreation: true,
+    });
+    new Uint32Array(stagingBuffer.getMappedRange()).set([1, 2, 3, 4]);
+
+    let dest1 = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC});
+    let dest2 = device.createBuffer({size: 16, usage: GPUBufferUsage.COPY_DST | GPUBufferUsage.COPY_SRC});
+
+    let commandEncoder = device.createCommandEncoder();
+    // Two references to the same mapped buffer in the same encoder. Each call
+    // to setCommandEncoder() previously incremented bufferMapCount, but the
+    // dedup'd HashSet only registered the encoder once.
+    commandEncoder.copyBufferToBuffer(stagingBuffer, 0, dest1, 0, 16);
+    commandEncoder.copyBufferToBuffer(stagingBuffer, 0, dest2, 0, 16);
+
+    stagingBuffer.unmap();
+
+    device.pushErrorScope('validation');
+    device.queue.submit([commandEncoder.finish()]);
+    await device.queue.onSubmittedWorkDone();
+    let error = await device.popErrorScope();
+    if (error)
+      log('FAIL: ' + error.message);
+    else
+      log('PASS');
+
+    globalThis.testRunner?.notifyDone();
+  };
+</script>

--- a/Source/WebGPU/WebGPU/Buffer.mm
+++ b/Source/WebGPU/WebGPU/Buffer.mm
@@ -231,13 +231,13 @@ void Buffer::decrementBufferMapCount()
 void Buffer::setCommandEncoder(CommandEncoder& commandEncoder, bool mayModifyBuffer) const
 {
     UNUSED_PARAM(mayModifyBuffer);
-    commandEncoder.trackEncoderForBuffer(*this, m_commandEncoders);
+    bool isNewEntry = commandEncoder.trackEncoderForBuffer(*this, m_commandEncoders);
 #if !CPU(X86_64)
     if (m_device->isShaderValidationEnabled())
 #endif
         commandEncoder.addBuffer(m_buffer);
 
-    if (m_state != State::Unmapped)
+    if (m_state != State::Unmapped && isNewEntry)
         commandEncoder.incrementBufferMapCount();
     if (isDestroyed())
         commandEncoder.makeSubmitInvalid();

--- a/Source/WebGPU/WebGPU/CommandEncoder.h
+++ b/Source/WebGPU/WebGPU/CommandEncoder.h
@@ -143,7 +143,7 @@ public:
     void generateInvalidEncoderStateError();
     bool NODELETE validateClearBuffer(const Buffer&, uint64_t offset, uint64_t size);
     void clearTracking();
-    void trackEncoderForBuffer(const Buffer&, TrackedResourceContainer&);
+    bool trackEncoderForBuffer(const Buffer&, TrackedResourceContainer&);
     void trackEncoderForTexture(const Texture&, TrackedResourceContainer&);
     void trackEncoderForTextureView(const TextureView&, TrackedResourceContainer&);
     void trackEncoderForExternalTexture(const ExternalTexture&, TrackedResourceContainer&);
@@ -173,7 +173,6 @@ private:
     NSString * _Nullable errorValidatingCopyBufferToTexture(const WGPUImageCopyBuffer&, const WGPUImageCopyTexture&, const WGPUExtent3D&) const;
     NSString * _Nullable errorValidatingCopyTextureToBuffer(const WGPUImageCopyTexture&, const WGPUImageCopyBuffer&, const WGPUExtent3D&) const;
     NSString * _Nullable errorValidatingCopyTextureToTexture(const WGPUImageCopyTexture& source, const WGPUImageCopyTexture& destination, const WGPUExtent3D& copySize) const;
-    void trackEncoder(TrackedResourceContainer&);
 
     void discardCommandBuffer();
     void retainTimestampsForOneUpdateLoop();

--- a/Source/WebGPU/WebGPU/CommandEncoder.mm
+++ b/Source/WebGPU/WebGPU/CommandEncoder.mm
@@ -2337,11 +2337,6 @@ size_t CommandEncoder::computeSize(TrackedResourceContainer& container, const De
     return container.size();
 }
 
-void CommandEncoder::trackEncoder(TrackedResourceContainer& encoderContainer)
-{
-    encoderContainer.add(uniqueId());
-}
-
 void CommandEncoder::clearTracking()
 {
     auto identifier = uniqueId();
@@ -2363,30 +2358,32 @@ void CommandEncoder::clearTracking()
     m_trackedQuerySets.clear();
 }
 
-void CommandEncoder::trackEncoderForBuffer(const Buffer& buffer, TrackedResourceContainer& encoderContainer)
+bool CommandEncoder::trackEncoderForBuffer(const Buffer& buffer, TrackedResourceContainer& encoderContainer)
 {
-    trackEncoder(encoderContainer);
-    m_trackedBuffers.append(buffer);
+    auto addResult = encoderContainer.add(uniqueId());
+    if (addResult.isNewEntry)
+        m_trackedBuffers.append(buffer);
+    return addResult.isNewEntry;
 }
 void CommandEncoder::trackEncoderForTexture(const Texture& texture, TrackedResourceContainer& encoderContainer)
 {
-    trackEncoder(encoderContainer);
-    m_trackedTextures.append(texture);
+    if (encoderContainer.add(uniqueId()).isNewEntry)
+        m_trackedTextures.append(texture);
 }
 void CommandEncoder::trackEncoderForTextureView(const TextureView& textureView, TrackedResourceContainer& encoderContainer)
 {
-    trackEncoder(encoderContainer);
-    m_trackedTextureViews.append(textureView);
+    if (encoderContainer.add(uniqueId()).isNewEntry)
+        m_trackedTextureViews.append(textureView);
 }
 void CommandEncoder::trackEncoderForExternalTexture(const ExternalTexture& externalTexture, TrackedResourceContainer& encoderContainer)
 {
-    trackEncoder(encoderContainer);
-    m_trackedExternalTextures.append(externalTexture);
+    if (encoderContainer.add(uniqueId()).isNewEntry)
+        m_trackedExternalTextures.append(externalTexture);
 }
 void CommandEncoder::trackEncoderForQuerySet(const QuerySet& querySet, TrackedResourceContainer& encoderContainer)
 {
-    trackEncoder(encoderContainer);
-    m_trackedQuerySets.append(querySet);
+    if (encoderContainer.add(uniqueId()).isNewEntry)
+        m_trackedQuerySets.append(querySet);
 }
 
 void CommandEncoder::trackEncoder(CommandEncoder& commandEncoder, HashSet<uint64_t, DefaultHash<uint64_t>, WTF::UnsignedWithZeroKeyHashTraits<uint64_t>>& encoderContainer)


### PR DESCRIPTION
#### 69f81c15d7956dd1f0583718baf1cff35911a809
<pre>
Rerun WebGPU view rendering stopped working in 26.4 (21624.1.16.11.4) &amp; Safari Technology Preview 243
<a href="https://bugs.webkit.org/show_bug.cgi?id=315186">https://bugs.webkit.org/show_bug.cgi?id=315186</a>
<a href="https://rdar.apple.com/177523442">rdar://177523442</a>

Reviewed by Dan Glastonbury.

It is wrong to increment the buffer count on a resource already in use
in the same command encoder, it will lead to validation failures.

Test: fast/webgpu/regression/repro_303203.html
* LayoutTests/fast/webgpu/regression/repro_303203-expected.txt: Added.
* LayoutTests/fast/webgpu/regression/repro_303203.html: Added.
* Source/WebGPU/WebGPU/Buffer.mm:
(WebGPU::Buffer::setCommandEncoder const):
* Source/WebGPU/WebGPU/CommandEncoder.h:
* Source/WebGPU/WebGPU/CommandEncoder.mm:
(WebGPU::CommandEncoder::trackEncoderForBuffer):
(WebGPU::CommandEncoder::trackEncoderForTexture):
(WebGPU::CommandEncoder::trackEncoderForTextureView):
(WebGPU::CommandEncoder::trackEncoderForExternalTexture):
(WebGPU::CommandEncoder::trackEncoderForQuerySet):

Canonical link: <a href="https://commits.webkit.org/313712@main">https://commits.webkit.org/313712@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ff2fa7b59aa51a128de3271d5f08f3606eb35f3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163936 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37420 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30639 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172965 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7366fee2-c4e3-4bed-8789-9d5dd0ad1634) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37752 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37420 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127354 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166895 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29635 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147376 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107902 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d50c5ff8-0eee-4671-809f-94a6d6784d58) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28681 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27301 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20729 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138581 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25093 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175490 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28312 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26761 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135666 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37090 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31413 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135638 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36548 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37875 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146888 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100030 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30932 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23744 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36675 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109731 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36083 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1781 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36333 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36230 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->