### PR TITLE
[WPE][GTK] Rationalize Vulkan types and their base wrapper templates

### DIFF
--- a/Source/WebCore/PlatformGTK.cmake
+++ b/Source/WebCore/PlatformGTK.cmake
@@ -186,7 +186,10 @@ if (USE_VULKAN)
         "${WEBCORE_DIR}/platform/graphics/vulkan"
     )
     list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
+        platform/graphics/vulkan/VulkanHandle.h
+        platform/graphics/vulkan/VulkanStructure.h
         platform/graphics/vulkan/VulkanTypes.h
         platform/graphics/vulkan/VulkanUtilities.h
+        platform/graphics/vulkan/VulkanVolk.h
     )
 endif ()

--- a/Source/WebCore/PlatformWPE.cmake
+++ b/Source/WebCore/PlatformWPE.cmake
@@ -159,8 +159,11 @@ if (USE_VULKAN)
         "${WEBCORE_DIR}/platform/graphics/vulkan"
     )
     list(APPEND WebCore_PRIVATE_FRAMEWORK_HEADERS
+        platform/graphics/vulkan/VulkanHandle.h
+        platform/graphics/vulkan/VulkanStructure.h
         platform/graphics/vulkan/VulkanTypes.h
         platform/graphics/vulkan/VulkanUtilities.h
+        platform/graphics/vulkan/VulkanVolk.h
     )
 endif ()
 

--- a/Source/WebCore/platform/graphics/vulkan/VulkanHandle.h
+++ b/Source/WebCore/platform/graphics/vulkan/VulkanHandle.h
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(VULKAN)
+#include <type_traits>
+#include <wtf/Noncopyable.h>
+
+namespace WebCore {
+namespace Vulkan {
+
+//
+// Handles "own" the wrapped object and are responsible for destroying it.
+// Therefore they can only be moved, to guarantee that destruction gets
+// done only once.
+//
+template <typename VulkanType>
+    requires std::is_pointer_v<VulkanType>
+struct Handle {
+    WTF_MAKE_NONCOPYABLE(Handle)
+
+protected:
+    using Base = Handle<VulkanType>;
+
+public:
+    Handle() = default;
+
+    Handle(VulkanType ptr)
+        : m_ptr(ptr)
+    {
+    }
+
+    Handle(Handle&& other)
+        : Handle(other.leakPtr())
+    {
+    }
+
+    void swap(Handle& other)
+    {
+        std::swap(m_ptr, other.m_ptr);
+    }
+
+    Handle& operator=(Handle&& other)
+    {
+        auto handle = WTF::move(other);
+        swap(handle);
+        return *this;
+    }
+
+    [[nodiscard]] VulkanType leakPtr()
+    {
+        return std::exchange(m_ptr, nullptr);
+    }
+
+    const VulkanType ptr() const LIFETIME_BOUND { return m_ptr; }
+    VulkanType ptr() LIFETIME_BOUND { return m_ptr; }
+
+    explicit operator bool() const { return !!m_ptr; }
+    bool operator!() const { return !m_ptr; }
+
+private:
+    VulkanType m_ptr { nullptr };
+};
+
+//
+// Borrowed handles do not "own" the object, therefore they can be copied.
+// The main goal is to provide a similar API surface to Handle<T> and to
+// allow attaching methods to them.
+//
+template <typename VulkanType>
+    requires std::is_pointer_v<VulkanType>
+struct BorrowedHandle {
+    BorrowedHandle() = default;
+
+    BorrowedHandle(const BorrowedHandle&) = default;
+    BorrowedHandle& operator=(const BorrowedHandle&) = default;
+
+    BorrowedHandle(BorrowedHandle&&) = default;
+    BorrowedHandle& operator=(BorrowedHandle&&) = default;
+
+    const VulkanType ptr() const LIFETIME_BOUND { return m_ptr; }
+    VulkanType ptr() LIFETIME_BOUND { return m_ptr; }
+
+    explicit operator bool() const { return !!m_ptr; }
+    bool operator!() const { return !m_ptr; }
+
+private:
+    VulkanType m_ptr { nullptr };
+};
+
+
+} // namespace Vulkan
+} // namespace WebCore
+
+#endif // USE(VULKAN)

--- a/Source/WebCore/platform/graphics/vulkan/VulkanStructure.h
+++ b/Source/WebCore/platform/graphics/vulkan/VulkanStructure.h
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(VULKAN)
+#include "VulkanVolk.h"
+#include <type_traits>
+
+namespace WebCore {
+namespace Vulkan {
+
+template <typename VulkanType, VkStructureType vulkanStructureType>
+    requires std::is_class_v<VulkanType> && std::is_trivially_copyable_v<VulkanType>
+struct Structure {
+    using Type = VulkanType;
+    using Base = Structure<VulkanType, vulkanStructureType>;
+
+    static constexpr VkStructureType typeCode = vulkanStructureType;
+
+    Structure()
+    {
+        zeroBytes(m_inner);
+        m_inner.sType = typeCode;
+    }
+
+    Structure(VulkanType&& value)
+        : m_inner(WTF::move(value))
+    {
+        ASSERT(m_inner.sType == typeCode);
+    }
+
+    Structure(const Structure&) = default;
+    Structure& operator=(const Structure&) = default;
+
+    Structure(Structure&&) = default;
+    Structure& operator=(Structure&&) = default;
+
+    // Create another structure, make it the "next" to this, and return it.
+    // This enables the following handy idiom to create chained Structure
+    // subtype instances:
+    //
+    //   struct A : Structure<...> { };
+    //   struct B : Structure<...> { };
+    //   struct C : Structure<...> { };
+    //
+    //   A first;
+    //   auto second = first.next<B>();
+    //   auto third = second.next<C>();
+    //
+    // Then the resulting chain of structures is: first -> second -> third.
+    //
+    template <typename OtherType, typename... Args>
+    requires std::derived_from<OtherType, Structure<typename OtherType::Type, OtherType::typeCode>>
+    [[nodiscard]] OtherType next(Args&&... params)
+    {
+        OtherType nextStructure(std::forward<Args>(params)...);
+        m_inner.pNext = nextStructure.ptr();
+        return nextStructure;
+    }
+
+    const VulkanType& value() const LIFETIME_BOUND { return m_inner; }
+    VulkanType& value() LIFETIME_BOUND { return m_inner; }
+
+    const VulkanType* ptr() const LIFETIME_BOUND { return &m_inner; }
+    VulkanType* ptr() LIFETIME_BOUND { return &m_inner; }
+
+    const VulkanType* operator->() const LIFETIME_BOUND { return ptr(); }
+    VulkanType* operator->() LIFETIME_BOUND { return ptr(); }
+
+private:
+    VulkanType m_inner;
+};
+
+} // namespace Vulkan
+} // namespace WebCore
+
+#endif // USE(VULKAN)

--- a/Source/WebCore/platform/graphics/vulkan/VulkanTypes.cpp
+++ b/Source/WebCore/platform/graphics/vulkan/VulkanTypes.cpp
@@ -61,107 +61,106 @@ namespace Vulkan {
 
 ApplicationInfo::ApplicationInfo(const char* applicationName, uint32_t apiVersion)
 {
-    m_inner.pApplicationName = applicationName;
-    m_inner.apiVersion = apiVersion;
+    value().pApplicationName = applicationName;
+    value().apiVersion = apiVersion;
 }
 
 InstanceCreateInfo::InstanceCreateInfo(const ApplicationInfo& applicationInfo, std::span<const char* const> enabledLayers, std::span<const char* const> enabledExtensions)
 {
-    m_inner.pApplicationInfo = applicationInfo.ptr();
+    value().pApplicationInfo = applicationInfo.ptr();
 
-    m_inner.enabledLayerCount = enabledLayers.size();
-    m_inner.ppEnabledLayerNames = enabledLayers.data();
+    value().enabledLayerCount = enabledLayers.size();
+    value().ppEnabledLayerNames = enabledLayers.data();
 
-    m_inner.enabledExtensionCount = enabledExtensions.size();
-    m_inner.ppEnabledExtensionNames = enabledExtensions.data();
+    value().enabledExtensionCount = enabledExtensions.size();
+    value().ppEnabledExtensionNames = enabledExtensions.data();
 }
 
 std::span<const uint8_t> PhysicalDeviceIDProperties::deviceUUID() const
 {
-    return unsafeMakeSpan(m_inner.deviceUUID, VK_UUID_SIZE);
+    return unsafeMakeSpan(value().deviceUUID, VK_UUID_SIZE);
 }
 
 std::span<const uint8_t> PhysicalDeviceIDProperties::driverUUID() const
 {
-    return unsafeMakeSpan(m_inner.driverUUID, VK_UUID_SIZE);
+    return unsafeMakeSpan(value().driverUUID, VK_UUID_SIZE);
 }
 
 void PhysicalDevice::fillProperties(PhysicalDeviceProperties& properties) const
 {
-    vkGetPhysicalDeviceProperties2(m_inner, properties.ptr());
+    vkGetPhysicalDeviceProperties2(ptr(), properties.ptr());
 }
 
 Vector<QueueFamilyProperties> PhysicalDevice::queueFamilies() const
 {
     uint32_t queueFamilyCount;
-    vkGetPhysicalDeviceQueueFamilyProperties(m_inner, &queueFamilyCount, nullptr);
+    vkGetPhysicalDeviceQueueFamilyProperties(ptr(), &queueFamilyCount, nullptr);
 
     Vector<QueueFamilyProperties> queueFamilies(queueFamilyCount);
     static_assert(sizeof(QueueFamilyProperties) == sizeof(VkQueueFamilyProperties));
     auto queueFamiliesSpan = spanReinterpretCast<VkQueueFamilyProperties>(queueFamilies.mutableSpan());
     ASSERT(queueFamiliesSpan.size() == queueFamilyCount);
-    vkGetPhysicalDeviceQueueFamilyProperties(m_inner, &queueFamilyCount, queueFamiliesSpan.data());
+    vkGetPhysicalDeviceQueueFamilyProperties(ptr(), &queueFamilyCount, queueFamiliesSpan.data());
 
     return queueFamilies;
 }
 
 DeviceQueueCreateInfo::DeviceQueueCreateInfo(uint32_t familyIndex, std::span<const float> queuePriorities)
 {
-    m_inner.queueFamilyIndex = familyIndex;
-    m_inner.queueCount = queuePriorities.size();
-    m_inner.pQueuePriorities = queuePriorities.data();
+    value().queueFamilyIndex = familyIndex;
+    value().queueCount = queuePriorities.size();
+    value().pQueuePriorities = queuePriorities.data();
 }
 
 DeviceCreateInfo::DeviceCreateInfo(const DeviceQueueCreateInfo& queueCreateInfo, std::span<const char* const> enabledExtensions)
 {
-    m_inner.queueCreateInfoCount = 1;
-    m_inner.pQueueCreateInfos = queueCreateInfo.ptr();
+    value().queueCreateInfoCount = 1;
+    value().pQueueCreateInfos = queueCreateInfo.ptr();
 
-    m_inner.enabledExtensionCount = enabledExtensions.size();
-    m_inner.ppEnabledExtensionNames = enabledExtensions.data();
+    value().enabledExtensionCount = enabledExtensions.size();
+    value().ppEnabledExtensionNames = enabledExtensions.data();
 }
 
-Device::Device(VkDevice inner)
-    : Base(WTF::move(inner))
+Device::Device(VkDevice device)
+    : Base(device)
 {
-    volkLoadDeviceTable(&m_table, m_inner);
+    if (VkDevice device = ptr())
+        volkLoadDeviceTable(&m_table, device);
 }
 
 Device::~Device()
 {
-    if (m_inner) {
+    if (VkDevice device = ptr()) {
         ASSERT(m_table.vkDestroyDevice);
-        m_table.vkDestroyDevice(m_inner, nullptr);
+        m_table.vkDestroyDevice(device, nullptr);
     }
 }
 
 Result<Device> Device::create(PhysicalDevice& deviceInfo, const DeviceCreateInfo& creationInfo)
 {
     VkDevice device;
-    if (auto result = vkCreateDevice(*deviceInfo.ptr(), creationInfo.ptr(), nullptr, &device); result != VK_SUCCESS)
+    if (auto result = vkCreateDevice(deviceInfo.ptr(), creationInfo.ptr(), nullptr, &device); result != VK_SUCCESS)
         return makeUnexpected(result);
 
     return Device(device);
 }
 
-Device Device::s_sharedDevice { StaticAllocation };
+Device Device::s_sharedDevice { nullptr };
 
 void Device::setSharedDevice(Device&& device)
 {
-    if (s_sharedDevice.m_inner)
-        RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("Attempted to reset already initialized Vulkan shared device");
+    RELEASE_ASSERT_WITH_MESSAGE(!s_sharedDevice, "Attempted to reset already initialized Vulkan shared device");
     s_sharedDevice = WTF::move(device);
 }
 
 Device* Device::sharedDeviceIfExists()
 {
-    return s_sharedDevice.m_inner ? &s_sharedDevice : nullptr;
+    return s_sharedDevice ? &s_sharedDevice : nullptr;
 }
 
 Device& Device::sharedDevice()
 {
-    if (!s_sharedDevice.m_inner) [[unlikely]]
-        RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("Attempted to use Vulkan shared device before its initialization");
+    RELEASE_ASSERT_WITH_MESSAGE(s_sharedDevice, "Attempted to use Vulkan shared device before its initialization");
     return s_sharedDevice;
 }
 
@@ -254,19 +253,19 @@ Instance Instance::s_sharedInstance { nullptr };
 
 void Instance::setSharedInstance(Instance&& instance)
 {
-    if (s_sharedInstance.m_inner)
+    if (s_sharedInstance)
         RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("Attempted to reset already initialized Vulkan shared instance");
     s_sharedInstance = WTF::move(instance);
 }
 
 Instance* Instance::sharedInstanceIfExists()
 {
-    return s_sharedInstance.m_inner ? &s_sharedInstance : nullptr;
+    return s_sharedInstance ? &s_sharedInstance : nullptr;
 }
 
 Instance& Instance::sharedInstance()
 {
-    if (!s_sharedInstance.m_inner) [[unlikely]]
+    if (!s_sharedInstance) [[unlikely]]
         RELEASE_ASSERT_NOT_REACHED_WITH_MESSAGE("Attempted to use Vulkan shared instance before its initialization");
     return s_sharedInstance;
 }
@@ -277,32 +276,39 @@ Result<Instance> Instance::create(const InstanceCreateInfo& creationInfo)
     if (auto result = vkCreateInstance(creationInfo.ptr(), nullptr, &instance); result != VK_SUCCESS)
         return makeUnexpected(result);
 
-    volkLoadInstanceOnly(instance);
     return Instance(instance);
+}
+
+Instance::Instance(VkInstance instance)
+    : Base(instance)
+{
+    if (VkInstance instance = ptr())
+        volkLoadInstanceOnly(instance);
 }
 
 Instance::~Instance()
 {
+    if (VkInstance instance = ptr()) {
 #ifdef VK_EXT_debug_utils
-    if (m_debugMessenger)
-        vkDestroyDebugUtilsMessengerEXT(m_inner, m_debugMessenger, nullptr);
+        if (m_debugMessenger)
+            vkDestroyDebugUtilsMessengerEXT(instance, m_debugMessenger, nullptr);
 #endif // VK_EXT_debug_utils
 
-    if (m_inner)
-        vkDestroyInstance(m_inner, nullptr);
+        vkDestroyInstance(instance, nullptr);
+    }
 }
 
 Result<Vector<PhysicalDevice>> Instance::availableDevices() const
 {
     uint32_t deviceCount;
-    if (auto result = vkEnumeratePhysicalDevices(m_inner, &deviceCount, nullptr); result != VK_SUCCESS)
+    if (auto result = vkEnumeratePhysicalDevices(ptr(), &deviceCount, nullptr); result != VK_SUCCESS)
         return makeUnexpected(result);
 
     Vector<PhysicalDevice> devices(deviceCount);
     static_assert(sizeof(PhysicalDevice) == sizeof(VkPhysicalDevice));
     auto devicesSpan = spanReinterpretCast<VkPhysicalDevice>(devices.mutableSpan());
     ASSERT(devicesSpan.size() == deviceCount);
-    if (auto result = vkEnumeratePhysicalDevices(m_inner, &deviceCount, devicesSpan.data()); result != VK_SUCCESS)
+    if (auto result = vkEnumeratePhysicalDevices(ptr(), &deviceCount, devicesSpan.data()); result != VK_SUCCESS)
         return makeUnexpected(result);
 
     return devices;
@@ -547,7 +553,7 @@ VkResult Instance::installDebugMessenger()
     if (LOG_CHANNEL(Vulkan).level >= WTFLogLevel::Debug)
         createInfo->messageSeverity |= VK_DEBUG_UTILS_MESSAGE_SEVERITY_VERBOSE_BIT_EXT;
 
-    return vkCreateDebugUtilsMessengerEXT(m_inner, createInfo.ptr(), nullptr, &m_debugMessenger);
+    return vkCreateDebugUtilsMessengerEXT(ptr(), createInfo.ptr(), nullptr, &m_debugMessenger);
 }
 #else
 VkResult Instance::installDebugMessenger() const

--- a/Source/WebCore/platform/graphics/vulkan/VulkanTypes.h
+++ b/Source/WebCore/platform/graphics/vulkan/VulkanTypes.h
@@ -26,14 +26,9 @@
 #pragma once
 
 #if USE(VULKAN)
-// The Volk header can leave device functions undefined to prevent accidental
-// usage. Instead, use the per-device functions table to avoid the dispatch
-// overhead (up to 7%), see https://github.com/zeux/volk#optimizing-device-calls
-#define VOLK_NO_DEVICE_PROTOTYPES
-
+#include "VulkanHandle.h"
+#include "VulkanStructure.h"
 #include <expected>
-#include <volk.h>
-#include <wtf/Noncopyable.h>
 #include <wtf/text/WTFString.h>
 
 namespace WebCore {
@@ -44,94 +39,6 @@ namespace Vulkan {
 
 template <typename Type>
 using Result = std::expected<Type, VkResult>;
-
-template <typename VulkanType>
-struct BaseStruct {
-    WTF_MAKE_NONCOPYABLE(BaseStruct)
-
-    using Base = BaseStruct<VulkanType>;
-
-    BaseStruct()
-    {
-        zeroBytes(m_inner);
-    }
-
-    BaseStruct(VulkanType&& inner)
-        : m_inner(WTF::move(inner))
-    {
-    }
-
-    ~BaseStruct() = default;
-
-    BaseStruct(BaseStruct&& other)
-        : BaseStruct()
-    {
-        std::swap(m_inner, other.m_inner);
-    }
-
-    BaseStruct& operator=(BaseStruct&& other)
-    {
-        if (this != &other) [[likely]]
-            std::swap(m_inner, other.m_inner);
-        return *this;
-    }
-
-    const VulkanType* LIFETIME_BOUND ptr() const { return &m_inner; }
-    VulkanType* LIFETIME_BOUND ptr() { return &m_inner; }
-
-protected:
-    VulkanType m_inner;
-};
-
-template <typename VulkanType, VkStructureType vulkanStructureType>
-struct Structure : BaseStruct<VulkanType> {
-    using Type = VulkanType;
-    using Base = BaseStruct<VulkanType>;
-
-    static constexpr VkStructureType typeCode = vulkanStructureType;
-
-    Structure()
-    {
-        this->m_inner.sType = typeCode;
-    }
-
-    Structure(VulkanType&& inner)
-        : Base(WTF::move(inner))
-    {
-        ASSERT(this->m_inner.sType == typeCode);
-    }
-
-    Structure(Structure&& other)
-        : Structure(WTF::move(other.m_inner))
-    {
-    }
-
-    // Create another structure, make it the "next" to this, and return it.
-    // This enables the following handy idiom to create chained Structure
-    // subtype instances:
-    //
-    //   struct A : Structure<...> { };
-    //   struct B : Structure<...> { };
-    //   struct C : Structure<...> { };
-    //
-    //   A first;
-    //   auto second = first.next<B>();
-    //   auto third = second.next<C>();
-    //
-    // Then the resulting chain of structures is: first -> second -> third.
-    //
-    template <typename OtherType, typename... Args>
-    requires std::derived_from<OtherType, Structure<typename OtherType::Type, OtherType::typeCode>>
-    [[nodiscard]] OtherType next(Args&&... params)
-    {
-        OtherType nextStructure { std::forward<Args>(params)... };
-        this->m_inner.pNext = nextStructure.ptr();
-        return nextStructure;
-    }
-
-    const VulkanType* LIFETIME_BOUND operator->() const { return this->ptr(); }
-    VulkanType* LIFETIME_BOUND operator->() { return this->ptr(); }
-};
 
 struct ApplicationInfo : Structure<VkApplicationInfo, VK_STRUCTURE_TYPE_APPLICATION_INFO> {
     ApplicationInfo(const String& applicationName, uint32_t apiVersion = VK_API_VERSION_1_3)
@@ -147,18 +54,15 @@ struct InstanceCreateInfo : Structure<VkInstanceCreateInfo, VK_STRUCTURE_TYPE_IN
     InstanceCreateInfo(const ApplicationInfo& applicationInfo LIFETIME_BOUND, std::span<const char* const> enabledLayers LIFETIME_BOUND = { }, std::span<const char* const> enabledExtensions LIFETIME_BOUND = { });
 };
 
-struct QueueFamilyProperties : BaseStruct<VkQueueFamilyProperties> {
-    const VkQueueFamilyProperties* LIFETIME_BOUND operator->() const { return &m_inner; }
-    VkQueueFamilyProperties* LIFETIME_BOUND operator->() { return &m_inner; }
-};
+using QueueFamilyProperties = VkQueueFamilyProperties;
 
 struct DeviceQueueCreateInfo : Structure<VkDeviceQueueCreateInfo, VK_STRUCTURE_TYPE_DEVICE_QUEUE_CREATE_INFO> {
     DeviceQueueCreateInfo(uint32_t familyIndex, std::span<const float> queuePriorities);
 };
 
 struct PhysicalDeviceProperties : Structure<VkPhysicalDeviceProperties2, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2> {
-    const VkPhysicalDeviceProperties* LIFETIME_BOUND operator->() const { return &m_inner.properties; }
-    VkPhysicalDeviceProperties* LIFETIME_BOUND operator->() { return &m_inner.properties; }
+    const VkPhysicalDeviceProperties* LIFETIME_BOUND operator->() const { return &ptr()->properties; }
+    VkPhysicalDeviceProperties* LIFETIME_BOUND operator->() { return &ptr()->properties; }
 };
 
 struct PhysicalDeviceDRMProperties : Structure<VkPhysicalDeviceDrmPropertiesEXT, VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DRM_PROPERTIES_EXT> {
@@ -169,40 +73,26 @@ struct PhysicalDeviceIDProperties : Structure<VkPhysicalDeviceIDProperties, VK_S
     std::span<const uint8_t> driverUUID() const;
 };
 
-struct PhysicalDevice : BaseStruct<VkPhysicalDevice> {
+struct PhysicalDevice : BorrowedHandle<VkPhysicalDevice> {
     void fillProperties(PhysicalDeviceProperties&) const;
     Vector<QueueFamilyProperties> queueFamilies() const;
-
-    PhysicalDevice() = default;
-
-    // VkPhysicalDevice instances are owned by the VkInstance and are never destroyed,
-    // which means their handles (and therefore the PhysicalDevice wrapper) can be copied.
-    PhysicalDevice(const PhysicalDevice& other)
-        : BaseStruct(const_cast<VkPhysicalDevice>(other.m_inner))
-    {
-    }
 };
 
 struct DeviceCreateInfo : Structure<VkDeviceCreateInfo, VK_STRUCTURE_TYPE_DEVICE_CREATE_INFO> {
     DeviceCreateInfo(const DeviceQueueCreateInfo&, std::span<const char* const> enabledExtensions = { });
 };
 
-struct Device : BaseStruct<VkDevice> {
+struct Device : Handle<VkDevice> {
     [[nodiscard]] static Result<Device> create(PhysicalDevice&, const DeviceCreateInfo&);
     ~Device();
 
-    Device(Device&& other)
-    {
-        *this = WTF::move(other);
-    }
+    Device(Device&& other) { swap(other); }
+    Device& operator=(Device&& other) { swap(other); return *this; }
 
-    Device& operator=(Device&& other)
+    void swap(Device& other)
     {
-        if (this != &other) {
-            std::swap(m_inner, other.m_inner);
-            std::swap(m_table, other.m_table);
-        }
-        return *this;
+        Base::swap(other);
+        std::swap(m_table, other.m_table);
     }
 
     static void setSharedDevice(Device&&);
@@ -210,21 +100,16 @@ struct Device : BaseStruct<VkDevice> {
     [[nodiscard]] static Device& sharedDevice();
 
 private:
-    Device(VkDevice);
+    using Base::Base;
 
-    // Needed to avoid calling volkLoadDeviceTable() on a null pointer.
-    enum StaticAllocationTag { StaticAllocation };
-    Device(StaticAllocationTag)
-        : Base(nullptr)
-    {
-    }
+    explicit Device(VkDevice);
 
     VolkDeviceTable m_table;
 
     static Device s_sharedDevice;
 };
 
-struct Instance : BaseStruct<VkInstance> {
+struct Instance : Handle<VkInstance> {
     [[nodiscard]] static const Vector<VkLayerProperties>& availableLayers();
     [[nodiscard]] static bool hasLayers(std::span<const char* const> layerNames);
     [[nodiscard]] static bool hasLayer(const char* const layerName);
@@ -242,32 +127,25 @@ struct Instance : BaseStruct<VkInstance> {
     [[nodiscard]] static Result<Instance> create(const InstanceCreateInfo&);
     ~Instance();
 
-    Instance(Instance&& other)
-        : Base()
-    {
-        *this = WTF::move(other);
-    }
+    Instance(Instance&& other) { swap(other); }
+    Instance& operator=(Instance&& other) { swap(other); return *this; }
 
-    Instance& operator=(Instance&& other)
-    {
-        if (this != &other) {
-            std::swap(m_inner, other.m_inner);
 #ifdef VK_EXT_debug_utils
-            std::swap(m_debugMessenger, other.m_debugMessenger);
-#endif
-        }
-        return *this;
+    void swap(Instance& other)
+    {
+        Base::swap(other);
+        std::swap(m_debugMessenger, other.m_debugMessenger);
     }
+#endif // VK_EXT_debug_utils
 
     [[nodiscard]] Result<Vector<PhysicalDevice>> availableDevices() const;
     [[nodiscard]] Result<PhysicalDevice> deviceForDisplay(PlatformDisplay&);
     [[nodiscard]] VkResult installDebugMessenger();
 
 private:
-    Instance(VkInstance inner)
-        : Base(WTF::move(inner))
-    {
-    }
+    using Base::Base;
+
+    explicit Instance(VkInstance);
 
     static Instance s_sharedInstance;
 

--- a/Source/WebCore/platform/graphics/vulkan/VulkanUtilities.cpp
+++ b/Source/WebCore/platform/graphics/vulkan/VulkanUtilities.cpp
@@ -262,7 +262,7 @@ void initializeIfNeeded()
 
     const auto queueFamilies = deviceInfo->queueFamilies();
     auto queueIndex = queueFamilies.findIf([](const auto& queueProperties) {
-        return queueProperties->queueFlags & VK_QUEUE_GRAPHICS_BIT;
+        return queueProperties.queueFlags & VK_QUEUE_GRAPHICS_BIT;
     });
     if (queueIndex == notFound) {
         RELEASE_LOG_ERROR(Vulkan, "Cannot find graphics queue family");
@@ -282,7 +282,7 @@ void initializeIfNeeded()
         return;
     }
 
-    RELEASE_LOG(Vulkan, "Instantiated device %p", *device->ptr());
+    RELEASE_LOG(Vulkan, "Instantiated device %p", device->ptr());
 
     Instance::setSharedInstance(WTF::move(*instance));
     Device::setSharedDevice(WTF::move(*device));

--- a/Source/WebCore/platform/graphics/vulkan/VulkanVolk.h
+++ b/Source/WebCore/platform/graphics/vulkan/VulkanVolk.h
@@ -26,22 +26,11 @@
 #pragma once
 
 #if USE(VULKAN)
-#include "VulkanTypes.h"
 
-namespace WebCore {
-namespace Vulkan {
-
-[[nodiscard]] const char* resultString(VkResult);
-
-template <typename Type>
-[[nodiscard]] const char* resultString(const Result<Type>& result)
-{
-    return resultString(result.error_or(VK_SUCCESS));
-}
-
-void initializeIfNeeded();
-
-} // namespace Vulkan
-} // namespace WebCore
+// The Volk header can leave device functions undefined to prevent accidental
+// usage. Instead, use the per-device functions table to avoid the dispatch
+// overhead (up to 7%), see https://github.com/zeux/volk#optimizing-device-calls
+#define VOLK_NO_DEVICE_PROTOTYPES
+#include <volk.h>
 
 #endif // USE(VULKAN)


### PR DESCRIPTION
#### f5514504e1ab2449deb29445c8b4516698469f9b
<pre>
[WPE][GTK] Rationalize Vulkan types and their base wrapper templates
<a href="https://bugs.webkit.org/show_bug.cgi?id=315200">https://bugs.webkit.org/show_bug.cgi?id=315200</a>

Reviewed by Nikolas Zimmermann.

Factor out and improve the Vulkan base wrapper templates in the
following ways:

1. Rename BaseStruct&lt;T&gt; as Handle&lt;T&gt; and split it off into its own
   header, along with a new BorrowedHandle&lt;T&gt; template. While at it, add
   convenience methods (swap, leakPtr, boolean check, etc.) to make them
   behave in a way more similar to other WebKit smart pointers.

2. Move Structure&lt;T, C&gt; into its own header, and remove its inheritance
   from BaseStruct&lt;T&gt;, because structures and handles are unrelated Vulkan
   types which are treated differently. The inheritance was intended to
   reuse code; but the advantage was negligible.

3. Make the Structure::m_inner and Handle::m_ptr members private.

4. Move the VOLK_NO_DEVICE_PROTOTYPES and volk.h inclusion into a separate
   VulkanVolk.h header, which WebKit code can use to avoid accidentally
   forgetting to define the macro.

* Source/WebCore/PlatformGTK.cmake: List added headers.
* Source/WebCore/PlatformWPE.cmake: Ditto.
* Source/WebCore/platform/graphics/vulkan/VulkanHandle.h: Added.
(WebCore::Vulkan::Handle::Handle):
(WebCore::Vulkan::Handle::swap):
(WebCore::Vulkan::Handle::operator=):
(WebCore::Vulkan::Handle::leakPtr):
(WebCore::Vulkan::Handle::operator bool const):
(WebCore::Vulkan::Handle::operator! const):
(WebCore::Vulkan::BorrowedHandle::operator bool const):
(WebCore::Vulkan::BorrowedHandle::operator! const):
* Source/WebCore/platform/graphics/vulkan/VulkanStructure.h: Added.
(WebCore::Vulkan::Structure::Structure):
(WebCore::Vulkan::Structure::next):
* Source/WebCore/platform/graphics/vulkan/VulkanTypes.cpp:
(WebCore::Vulkan::ApplicationInfo::ApplicationInfo):
(WebCore::Vulkan::InstanceCreateInfo::InstanceCreateInfo):
(WebCore::Vulkan::PhysicalDeviceIDProperties::deviceUUID const):
(WebCore::Vulkan::PhysicalDeviceIDProperties::driverUUID const):
(WebCore::Vulkan::PhysicalDevice::fillProperties const):
(WebCore::Vulkan::PhysicalDevice::queueFamilies const):
(WebCore::Vulkan::DeviceQueueCreateInfo::DeviceQueueCreateInfo):
(WebCore::Vulkan::DeviceCreateInfo::DeviceCreateInfo):
(WebCore::Vulkan::Device::Device):
(WebCore::Vulkan::Device::~Device):
(WebCore::Vulkan::Device::create):
(WebCore::Vulkan::Device::setSharedDevice):
(WebCore::Vulkan::Device::sharedDeviceIfExists):
(WebCore::Vulkan::Device::sharedDevice):
(WebCore::Vulkan::Instance::setSharedInstance):
(WebCore::Vulkan::Instance::sharedInstanceIfExists):
(WebCore::Vulkan::Instance::sharedInstance):
(WebCore::Vulkan::Instance::create):
(WebCore::Vulkan::Instance::Instance):
(WebCore::Vulkan::Instance::~Instance):
(WebCore::Vulkan::Instance::availableDevices const):
(WebCore::Vulkan::Instance::installDebugMessenger):
* Source/WebCore/platform/graphics/vulkan/VulkanTypes.h:
(WebCore::Vulkan::PhysicalDeviceProperties::operator-&gt; const):
(WebCore::Vulkan::PhysicalDeviceProperties::operator-&gt;):
(WebCore::Vulkan::Device::Device):
(WebCore::Vulkan::Device::operator=):
(WebCore::Vulkan::Device::swap):
(WebCore::Vulkan::Instance::Instance):
(WebCore::Vulkan::Instance::operator=):
(WebCore::Vulkan::Instance::swap):
(WebCore::Vulkan::BaseStruct::BaseStruct): Deleted.
(WebCore::Vulkan::BaseStruct::operator=): Deleted.
(WebCore::Vulkan::BaseStruct::ptr const): Deleted.
(WebCore::Vulkan::BaseStruct::ptr): Deleted.
(WebCore::Vulkan::Structure::Structure): Deleted.
(WebCore::Vulkan::Structure::next): Deleted.
(WebCore::Vulkan::Structure::operator-&gt; const): Deleted.
(WebCore::Vulkan::Structure::operator-&gt;): Deleted.
(WebCore::Vulkan::QueueFamilyProperties::operator-&gt; const): Deleted.
(WebCore::Vulkan::QueueFamilyProperties::operator-&gt;): Deleted.
(WebCore::Vulkan::PhysicalDevice::PhysicalDevice): Deleted.
* Source/WebCore/platform/graphics/vulkan/VulkanUtilities.cpp:
(WebCore::Vulkan::initializeIfNeeded):
* Source/WebCore/platform/graphics/vulkan/VulkanUtilities.h:
* Source/WebCore/platform/graphics/vulkan/VulkanVolk.h: Copied from Source/WebCore/platform/graphics/vulkan/VulkanUtilities.h.

Canonical link: <a href="https://commits.webkit.org/313650@main">https://commits.webkit.org/313650@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8c5cbfc9999ef8d9304587818e34d02e43ce090

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163628 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37112 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30331 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172568 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/120077 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165497 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37443 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37111 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127097 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89604 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166587 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29372 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147104 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107651 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28421 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27053 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20271 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138320 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24821 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175073 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28004 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26484 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135402 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36782 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31155 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135385 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37567 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146616 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99633 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24920 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30691 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23468 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36277 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109423 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35775 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1494 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36025 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35922 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->