### PR TITLE
Give JIT helper threads QOS_UTILITY on less powerful devices

### DIFF
--- a/Source/JavaScriptCore/jit/JITWorklistThread.cpp
+++ b/Source/JavaScriptCore/jit/JITWorklistThread.cpp
@@ -33,6 +33,11 @@
 #include "VM.h"
 #include <wtf/TZoneMallocInlines.h>
 
+#if HAVE(QOS_CLASSES)
+#include <wtf/NumberOfCores.h>
+#include <wtf/Threading.h>
+#endif
+
 namespace JSC {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(JITWorklistThread);
@@ -174,6 +179,15 @@ void JITWorklistThread::threadDidStart()
 {
     dataLogLnIf(Options::verboseCompilationQueue(), m_worklist, ": Thread started");
 
+#if HAVE(QOS_CLASSES)
+#if CPU(ARM64)
+    bool isSmall = WTF::numberOfPerformanceProcessorCores() <= static_cast<int>(Options::smallDeviceMaxPerformanceCores());
+#else
+    bool isSmall = WTF::numberOfProcessorCores() <= static_cast<int>(Options::smallDeviceMaxLogicalCores());
+#endif
+    if (isSmall)
+        Thread::setCurrentThreadIsUtility();
+#endif
 }
 
 void JITWorklistThread::threadIsStopping(const AbstractLocker&)

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -299,6 +299,8 @@ bool hasCapacityToUseLargeGigacage();
     v(Int32, priorityDeltaOfDFGCompilerThreads, computePriorityDeltaOfWorkerThreads(-1, 0), Normal, nullptr) \
     v(Int32, priorityDeltaOfFTLCompilerThreads, computePriorityDeltaOfWorkerThreads(-2, 0), Normal, nullptr) \
     v(Int32, priorityDeltaOfWasmCompilerThreads, computePriorityDeltaOfWorkerThreads(-1, 0), Normal, nullptr) \
+    v(Unsigned, smallDeviceMaxPerformanceCores, 2, Normal, nullptr) \
+    v(Unsigned, smallDeviceMaxLogicalCores, 6, Normal, nullptr) \
     \
     v(Bool, useProfiler, false, Normal, nullptr) \
     v(Bool, dumpProfilerDataAtExit, false, Normal, nullptr) \

--- a/Source/WTF/wtf/NumberOfCores.cpp
+++ b/Source/WTF/wtf/NumberOfCores.cpp
@@ -104,4 +104,20 @@ int numberOfPhysicalProcessorCores()
 }
 #endif
 
+#if CPU(ARM64) && OS(DARWIN)
+int numberOfPerformanceProcessorCores()
+{
+    static int s_pcores = 0;
+    if (s_pcores > 0)
+        return s_pcores;
+
+    int32_t count = 0;
+    size_t valueSize = sizeof(count);
+    int result = sysctlbyname("hw.perflevel0.physicalcpu", &count, &valueSize, nullptr, 0);
+    RELEASE_ASSERT(result >= 0 && count > 0);
+    s_pcores = count;
+    return s_pcores;
+}
+#endif
+
 }

--- a/Source/WTF/wtf/NumberOfCores.h
+++ b/Source/WTF/wtf/NumberOfCores.h
@@ -32,4 +32,10 @@ WTF_EXPORT_PRIVATE int numberOfProcessorCores();
 WTF_EXPORT_PRIVATE int numberOfPhysicalProcessorCores();
 #endif
 
+#if CPU(ARM64) && OS(DARWIN)
+// Returns the number of performance ("P") cores on Apple silicon, queried via
+// the "hw.perflevel0.physicalcpu" sysctl.
+WTF_EXPORT_PRIVATE int numberOfPerformanceProcessorCores();
+#endif
+
 }

--- a/Source/WTF/wtf/Threading.cpp
+++ b/Source/WTF/wtf/Threading.cpp
@@ -393,6 +393,17 @@ void Thread::setCurrentThreadIsUserInitiated(int relativePriority)
 #endif
 }
 
+void Thread::setCurrentThreadIsUtility(int relativePriority)
+{
+#if HAVE(QOS_CLASSES)
+    ASSERT(relativePriority <= 0);
+    ASSERT(relativePriority >= QOS_MIN_RELATIVE_PRIORITY);
+    pthread_set_qos_class_self_np(adjustedQOSClass(QOS_CLASS_UTILITY), relativePriority);
+#else
+    UNUSED_PARAM(relativePriority);
+#endif
+}
+
 #if HAVE(QOS_CLASSES)
 static Thread::QOS NODELETE toQOS(qos_class_t qosClass)
 {

--- a/Source/WTF/wtf/Threading.h
+++ b/Source/WTF/wtf/Threading.h
@@ -199,6 +199,7 @@ public:
     // relativePriority is a value in the range [-15, 0] where a lower value indicates a lower priority.
     WTF_EXPORT_PRIVATE static void setCurrentThreadIsUserInteractive(int relativePriority = 0);
     WTF_EXPORT_PRIVATE static void setCurrentThreadIsUserInitiated(int relativePriority = 0);
+    WTF_EXPORT_PRIVATE static void setCurrentThreadIsUtility(int relativePriority = 0);
     WTF_EXPORT_PRIVATE static QOS currentThreadQOS();
     WTF_EXPORT_PRIVATE static bool currentThreadIsRealtime();
     bool isRealtime() const { return m_isRealtime; }


### PR DESCRIPTION
#### 371f7ad0ed89cd9ca8034690e3986ba7ddcc24ca
<pre>
Give JIT helper threads QOS_UTILITY on less powerful devices
<a href="https://bugs.webkit.org/show_bug.cgi?id=315203">https://bugs.webkit.org/show_bug.cgi?id=315203</a>
<a href="https://rdar.apple.com/177532305">rdar://177532305</a>

Reviewed by Marcus Plutowski and Dan Hecht.

On devices with only 2 P-cores, JIT worklist threads run at the same
QOS as the main threads, causing P-core contention. Sustained P-cluster
load also pushes less powerful devices into thermal throttling,
causing performance losses.

This change lowers JIT worklist thread priority to QOS::Utility on
small devices, defined as &lt;=2 P-cores or &lt;=6 logical cores. JIT threads
can then run on E-cores and free the P-cluster. This causes regression
on more powerful devices so we keep existing behavior there.

There are no functional changes associated with this commit.

* Source/JavaScriptCore/jit/JITWorklistThread.cpp:
(JSC::JITWorklistThread::threadDidStart):
* Source/JavaScriptCore/runtime/OptionsList.h:
* Source/WTF/wtf/NumberOfCores.cpp:
(WTF::numberOfPerformanceProcessorCores):
* Source/WTF/wtf/NumberOfCores.h:
* Source/WTF/wtf/Threading.cpp:
(WTF::Thread::setCurrentThreadIsUtility):
* Source/WTF/wtf/Threading.h:

Canonical link: <a href="https://commits.webkit.org/313672@main">https://commits.webkit.org/313672@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b463b074aad0db1e871d3058622ed6c8554acd33

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163618 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37102 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30321 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172558 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/120067 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37433 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37101 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127091 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89600 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166577 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29365 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147100 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107645 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28414 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27045 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20261 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/155769 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138313 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24817 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175063 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/24509 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27994 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26480 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135393 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36772 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31147 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135375 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36526 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37557 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146612 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99618 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30689 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23464 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/196020 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36267 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109413 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51106 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35765 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1490 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36015 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35912 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->