### PR TITLE
Cherry-pick 90e48031ed4d. https://bugs.webkit.org/show_bug.cgi?id=312938

### DIFF
--- a/JSTests/stress/dataview-bytelength-ic-stub-stack-desync.js
+++ b/JSTests/stress/dataview-bytelength-ic-stub-stack-desync.js
@@ -1,0 +1,44 @@
+let ab = new ArrayBuffer(64, { maxByteLength: 1024 });
+let dv = new DataView(ab);
+let decoy = { byteLength: 7 };
+let decoy2 = { byteLength: 7, x: 1 };
+let decoy3 = { byteLength: 7, y: 1 };
+
+let objs = [];
+for (let i = 0; i < 64; i++) objs.push({marker: 0x1337 + i});
+
+function hot(o, a, b) {
+    let p0=b[0], p1=b[1], p2=b[2], p3=b[3], p4=b[4], p5=b[5], p6=b[6], p7=b[7],
+        p8=b[8], p9=b[9], p10=b[10], p11=b[11], p12=b[12], p13=b[13], p14=b[14], p15=b[15],
+        p16=b[16], p17=b[17], p18=b[18], p19=b[19], p20=b[20], p21=b[21], p22=b[22], p23=b[23],
+        p24=b[24], p25=b[25], p26=b[26], p27=b[27], p28=b[28], p29=b[29], p30=b[30], p31=b[31];
+    let len;
+    try {
+        len = o.byteLength;
+    } catch (e) {
+        len = -1;
+    }
+    return [len, p0.marker, p1.marker, p2.marker, p3.marker, p4.marker, p5.marker, p6.marker, p7.marker,
+            p8.marker, p9.marker, p10.marker, p11.marker, p12.marker, p13.marker, p14.marker, p15.marker,
+            p16.marker, p17.marker, p18.marker, p19.marker, p20.marker, p21.marker, p22.marker, p23.marker,
+            p24.marker, p25.marker, p26.marker, p27.marker, p28.marker, p29.marker, p30.marker, p31.marker];
+}
+noInline(hot);
+
+let A = new Int32Array(64);
+for (let i = 0; i < 64; i++) A[i] = i + 1;
+
+for (let i = 0; i < 200000; i++) {
+    hot(decoy, A, objs);
+    hot(decoy2, A, objs);
+    hot(decoy3, A, objs);
+    hot(dv, A, objs);
+}
+
+for (let i = 0; i < 100; i++) {
+    hot(dv, A, objs);
+}
+
+ab.transfer();
+
+let r = hot(dv, A, objs);

--- a/JSTests/stress/ftl-osr-exit-phantom-new-array-with-butterfly-having-a-bad-time.js
+++ b/JSTests/stress/ftl-osr-exit-phantom-new-array-with-butterfly-having-a-bad-time.js
@@ -1,0 +1,35 @@
+//@ runDefault("--jitPolicyScale=0.1")
+
+let trigger = false;
+
+function cb() {
+    if (trigger) {
+        Object.defineProperty(Array.prototype, 0, {
+            get() { return 42; }, configurable: true
+        });
+    }
+}
+noInline(cb);
+
+function collect() { gc(); }
+noInline(collect);
+
+function opt() {
+    let a = new Array(5);
+    a[0] = 1.1;
+    a[1] = 2.2;
+    a[2] = 3.3;
+    a[3] = 4.4;
+    a[4] = 5.5;
+    cb();
+    collect();
+    return a[0] + a[1] + a[2] + a[3] + a[4];
+}
+noInline(opt);
+
+for (let i = 0; i < 1000; i++)
+    opt();
+
+trigger = true;
+opt();
+gc();

--- a/JSTests/stress/regress-173924142.js
+++ b/JSTests/stress/regress-173924142.js
@@ -1,0 +1,52 @@
+//@ runDefault("--useConcurrentJIT=false", "--jitPolicyScale=0.01")
+
+function assert(holds) {
+    if (!holds)
+        throw "Assertion failed";
+}
+
+const otherGlobal = createGlobalObject();
+otherGlobal.eval(`returnMultipleValues = function(foobar) {
+    return {
+        ToBoolean: Boolean(foobar),
+        TypeOfIsUndefined: typeof foobar === "undefined",
+        TypeOfIsFunction: typeof foobar === "function",
+        TypeOf: typeof foobar,
+        CompareEq: foobar == null,
+        LogicalNot: !foobar,
+    };
+}`);
+
+function returnMultipleValues(foobar) {
+    return [
+        {
+            ToBoolean: Boolean(foobar),
+            TypeOfIsUndefined: typeof foobar === "undefined",
+            TypeOfIsFunction: typeof foobar === "function",
+            TypeOf: typeof foobar,
+            CompareEq: foobar == null,
+            LogicalNot: !foobar,
+        },
+        otherGlobal.returnMultipleValues(foobar)
+    ]
+}
+noInline(returnMultipleValues)
+
+const masquerader = makeMasquerader()
+const otherGlobalMasquerader = otherGlobal.eval("makeMasquerader()")
+
+let masqueraderBefore = returnMultipleValues(masquerader);
+let otherGlobalMasqueraderBefore = returnMultipleValues(otherGlobalMasquerader);
+
+for (var i = 0; i < 10000; i++) {
+    returnMultipleValues(() => {})
+}
+
+let masqueraderAfter = returnMultipleValues(masquerader);
+let otherGlobalMasqueraderAfter = returnMultipleValues(otherGlobalMasquerader);
+
+for (const object of [masqueraderBefore, masqueraderAfter, otherGlobalMasqueraderBefore, otherGlobalMasqueraderAfter]) {
+    for (const property of Object.getOwnPropertyNames(object[0])) {
+        assert(object[0][property] !== object[1][property]);
+    }
+}

--- a/JSTests/stress/string-at-cse-array-mode.js
+++ b/JSTests/stress/string-at-cse-array-mode.js
@@ -1,0 +1,11 @@
+//@ runDefault("--jitPolicyScale=0.1")
+
+function opt(s, i) {
+    let a = s.at(i);
+    let b = s.at(i);
+    return `${a}_${b}_end`;
+}
+noInline(opt);
+
+for (let j = 0; j < 20000; j++) opt("hello", 1);
+for (let j = 0; j < 200; j++) opt("hello", 100);

--- a/JSTests/wasm/stress/deferred-work-timer-cancel-duplicate-ticket.js
+++ b/JSTests/wasm/stress/deferred-work-timer-cancel-duplicate-ticket.js
@@ -1,0 +1,52 @@
+var N_REGISTRIES = 300;
+var N_DEFERRED_WORK1 = 400;
+var N_DEFERRED_WORK2 = 1500;
+
+var sab = new SharedArrayBuffer(8);
+var i32 = new Int32Array(sab);
+
+function setupChildGlobal() {
+    var childGlobal = createGlobalObject();
+    childGlobal.N_REGISTRIES = N_REGISTRIES;
+    childGlobal.eval(
+        'globalThis.__registries = [];' +
+        'for (var k = 0; k < this.N_REGISTRIES; k++) {' +
+        '    var fr = new FinalizationRegistry(function(h){});' +
+        '    (function(){ fr.register({}, 1); })();' +
+        '    globalThis.__registries.push(fr);' +
+        '}'
+    );
+    gc();
+    return childGlobal;
+}
+noDFG(setupChildGlobal);
+
+function run() {
+    var childGlobal = setupChildGlobal();
+    globalThis.p1 = Atomics.waitAsync(i32, 0, 0).value;
+    Atomics.notify(i32, 0);
+    childGlobal = null;
+    return 0;
+}
+noDFG(run);
+run();
+
+p1.then(function () {
+    for (var i = 0; i < N_DEFERRED_WORK1; i++)
+        setTimeout(function () { }, 10);
+});
+
+gc(); gc(); gc();
+
+var p2 = Atomics.waitAsync(i32, 0, 0).value;
+Atomics.notify(i32, 0);
+p2.then(function () {
+    for (var j = 0; j < N_DEFERRED_WORK2; j++)
+        setTimeout(function () { }, 50);
+
+    gc(); gc();
+    globalThis.__fns = [];
+    for (var k = 0; k < 10; k++) __fns.push(function () { });
+});
+
+setTimeout(function () { }, 200);

--- a/JSTests/wasm/stress/tail-call-v128-ref-stack-overlap.js
+++ b/JSTests/wasm/stress/tail-call-v128-ref-stack-overlap.js
@@ -1,0 +1,64 @@
+//@ requireOptions("--useWasmSIMD=1", "--useWasmTailCalls=1")
+//@ skip if !$isSIMDPlatform
+import { instantiate } from "../wabt-wrapper.js"
+import * as assert from "../assert.js"
+
+// rdar://174490087
+
+let wat = `
+(module
+  (func $callee
+    (param i64 i64 i64 i64 i64 i64 i64 i64)          ;; 0-7   GPR
+    (param v128 v128 v128 v128 v128 v128 v128 v128)   ;; 8-15  FPR
+    (param i64)                                        ;; 16    first stack param
+    (param v128)                                       ;; 17    v128
+    (param externref)                                  ;; 18    externref overlapping v128
+    (param i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+           i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+           i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+           i64 i64 i64 i64 i64 i64 i64 i64 i64 i64
+           i64 i64 i64 i64 i64 i64)                   ;; 19-64 padding
+    (result externref)
+    local.get 18)
+
+  (func $caller (export "caller") (param $r externref) (result externref)
+    (local $z i64)
+    ;; GPR params 0-7
+    i64.const 0 i64.const 0 i64.const 0 i64.const 0
+    i64.const 0 i64.const 0 i64.const 0 i64.const 0
+    ;; FPR params 8-15
+    v128.const i64x2 0 0  v128.const i64x2 0 0
+    v128.const i64x2 0 0  v128.const i64x2 0 0
+    v128.const i64x2 0 0  v128.const i64x2 0 0
+    v128.const i64x2 0 0  v128.const i64x2 0 0
+    ;; param 16: i64
+    i64.const 0
+    ;; param 17: v128
+    v128.const i64x2 0x1111111111111111 0x2222222222222222
+    ;; param 18: the externref
+    local.get $r
+    ;; params 19-64: padding to force spills
+    local.get $z local.get $z local.get $z local.get $z local.get $z
+    local.get $z local.get $z local.get $z local.get $z local.get $z
+    local.get $z local.get $z local.get $z local.get $z local.get $z
+    local.get $z local.get $z local.get $z local.get $z local.get $z
+    local.get $z local.get $z local.get $z local.get $z local.get $z
+    local.get $z local.get $z local.get $z local.get $z local.get $z
+    local.get $z local.get $z local.get $z local.get $z local.get $z
+    local.get $z local.get $z local.get $z local.get $z local.get $z
+    local.get $z local.get $z local.get $z local.get $z local.get $z
+    local.get $z
+    return_call $callee))
+`
+
+async function test() {
+    const instance = await instantiate(wat, {}, { simd: true, tail_call: true, exceptions: true })
+    const { caller } = instance.exports
+    const sentinel = { marker: 0x1337 }
+
+    for (let i = 0; i < wasmTestLoopCount; ++i) {
+        assert.eq(caller(sentinel), sentinel)
+    }
+}
+
+await assert.asyncTest(test())

--- a/LayoutTests/http/tests/web-locks/resources/shared-worker.js
+++ b/LayoutTests/http/tests/web-locks/resources/shared-worker.js
@@ -1,0 +1,5 @@
+self.onconnect = (event) => {
+    navigator.locks.request('abc', {mode: 'shared'}, () => {
+        event.ports[0].postMessage('PASS');
+    }).catch((error) => event.ports[0].postMessage(`FAIL - ${error}`));
+}

--- a/LayoutTests/http/tests/web-locks/web-lock-in-blob-url-expected.txt
+++ b/LayoutTests/http/tests/web-locks/web-lock-in-blob-url-expected.txt
@@ -1,0 +1,4 @@
+This tests acquiring a web lock in blob URL. You should see PASS below
+
+PASS
+

--- a/LayoutTests/http/tests/web-locks/web-lock-in-blob-url.html
+++ b/LayoutTests/http/tests/web-locks/web-lock-in-blob-url.html
@@ -1,0 +1,30 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>This tests acquiring a web lock in blob URL. You should see PASS below</p>
+<div id="result">Running</div>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+    setTimeout(() => testRunner.notifyDone(), 3000);
+}
+onmessage = (message) => {
+    result.textContent = message.data;
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+const blob = new Blob([`<!DOCTYPE html><script>
+navigator.locks.request('abc', {mode: 'shared'}, () => {
+    top.postMessage('PASS', '*');
+});
+<` + '/script>'], {type: "text/html"});
+
+const iframe = document.createElement('iframe');
+document.body.appendChild(iframe);
+iframe.src = URL.createObjectURL(blob);
+
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/web-locks/web-lock-in-data-url-expected.txt
+++ b/LayoutTests/http/tests/web-locks/web-lock-in-data-url-expected.txt
@@ -1,0 +1,4 @@
+This tests acquiring a web lock in data URL. You should see PASS below
+
+PASS
+

--- a/LayoutTests/http/tests/web-locks/web-lock-in-data-url.html
+++ b/LayoutTests/http/tests/web-locks/web-lock-in-data-url.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+    setTimeout(() => testRunner.notifyDone(), 3000);
+}
+onmessage = (message) => {
+    result.textContent = message.data;
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+</script>
+<p>This tests acquiring a web lock in data URL. You should see PASS below</p>
+<div id="result">Running</div>
+<iframe src="data:text/html,
+<!DOCTYPE html>
+<script>
+top.postMessage(navigator.locks ? 'FAIL' : 'PASS', '*');
+</script>"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/web-locks/web-lock-in-opaque-srcdoc-expected.txt
+++ b/LayoutTests/http/tests/web-locks/web-lock-in-opaque-srcdoc-expected.txt
@@ -1,0 +1,4 @@
+This tests acquiring a web lock in srcdoc with sandbox attribute. You should see PASS below
+
+PASS
+

--- a/LayoutTests/http/tests/web-locks/web-lock-in-opaque-srcdoc.html
+++ b/LayoutTests/http/tests/web-locks/web-lock-in-opaque-srcdoc.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+    setTimeout(() => testRunner.notifyDone(), 3000);
+}
+onmessage = () => {
+    result.textContent = 'PASS';
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+</script>
+<p>This tests acquiring a web lock in srcdoc with sandbox attribute. You should see PASS below</p>
+<div id="result">Running</div>
+<iframe sandbox="allow-scripts" srcdoc="
+<!DOCTYPE html>
+<script>
+navigator.locks.request('abc', {mode: 'shared'}, () => {
+    top.postMessage('FAIL - Lock acquired', '*');
+}).then(
+    () => top.postMessage('FAIL - Promise resolved', '*'),
+    () => top.postMessage('PASS', '*'))
+</script>"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/web-locks/web-lock-in-serviceworker-expected.txt
+++ b/LayoutTests/http/tests/web-locks/web-lock-in-serviceworker-expected.txt
@@ -1,0 +1,3 @@
+This tests acquiring a web lock in a service worker. You should see PASS below
+
+PASS

--- a/LayoutTests/http/tests/web-locks/web-lock-in-serviceworker-service-worker.js
+++ b/LayoutTests/http/tests/web-locks/web-lock-in-serviceworker-service-worker.js
@@ -1,0 +1,21 @@
+self.addEventListener("activate", (event) => {
+    event.waitUntil(clients.claim());
+});
+
+self.addEventListener("fetch", (event) => {
+    if (event.request.url.indexOf("test1") >= 0) {
+        event.respondWith(new Promise((resolve) => {
+            navigator.locks.request('abc', {mode: 'shared'}, () => {
+                resolve(new Response("PASS"));
+            }).catch((error) => {
+                resolve(new Response(`FAIL - ${error}`));
+            });
+        }));
+        return;
+    }
+    if (event.request.mode !== "navigate") {
+        event.respondWith(Response.error());
+        return;
+    }
+    event.respondWith(fetch(event.request.url));
+});

--- a/LayoutTests/http/tests/web-locks/web-lock-in-serviceworker.html
+++ b/LayoutTests/http/tests/web-locks/web-lock-in-serviceworker.html
@@ -1,0 +1,47 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+
+if (window.testRunner) {
+    testRunner.setUseSeparateServiceWorkerProcess(true);
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+    setTimeout(() => testRunner.notifyDone(), 3000);
+}
+
+async function register() {
+    const serviceWorkerURL = './web-lock-in-serviceworker-service-worker.js?' + Date.now();
+    const registration = await navigator.serviceWorker.register(serviceWorkerURL);
+    if (registration.active)
+        return registration;
+    return new Promise((resolve) => {
+        const worker = registration.installing;
+        worker.addEventListener("statechange", () => {
+            if (worker.state == "activated")
+                resolve(registration);
+        });
+    });
+}
+
+async function runTest() {
+    const registration = await register();
+
+    if (!navigator.serviceWorker.controller)
+        await new Promise(resolve => navigator.serviceWorker.addEventListener('controllerchange', resolve));
+
+    const response = await fetch('./test1');
+
+    result.textContent = await response.text();
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+runTest();
+
+</script>
+<p>This tests acquiring a web lock in a service worker. You should see PASS below</p>
+<div id="result">Running</div>
+</body>
+</html>

--- a/LayoutTests/http/tests/web-locks/web-lock-in-sharedworker-expected.txt
+++ b/LayoutTests/http/tests/web-locks/web-lock-in-sharedworker-expected.txt
@@ -1,0 +1,3 @@
+This tests acquiring a web lock in a shared worker. You should see PASS below
+
+PASS

--- a/LayoutTests/http/tests/web-locks/web-lock-in-sharedworker.html
+++ b/LayoutTests/http/tests/web-locks/web-lock-in-sharedworker.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+    setTimeout(() => testRunner.notifyDone(), 3000);
+}
+
+const worker = new SharedWorker('./resources/shared-worker.js');
+worker.port.onmessage = (event) => {
+    result.textContent = event.data;
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+</script>
+<p>This tests acquiring a web lock in a shared worker. You should see PASS below</p>
+<div id="result">Running</div>
+</body>
+</html>

--- a/LayoutTests/http/tests/web-locks/web-lock-in-srcdoc-expected.txt
+++ b/LayoutTests/http/tests/web-locks/web-lock-in-srcdoc-expected.txt
@@ -1,0 +1,4 @@
+This tests acquiring a web lock in srcdoc. You should see PASS below
+
+PASS
+

--- a/LayoutTests/http/tests/web-locks/web-lock-in-srcdoc.html
+++ b/LayoutTests/http/tests/web-locks/web-lock-in-srcdoc.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+<body>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+    setTimeout(() => testRunner.notifyDone(), 3000);
+}
+onmessage = () => {
+    result.textContent = 'PASS';
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+</script>
+<p>This tests acquiring a web lock in srcdoc. You should see PASS below</p>
+<div id="result">Running</div>
+<iframe srcdoc="
+<!DOCTYPE html>
+<script>
+navigator.locks.request('abc', {mode: 'shared'}, () => {
+    top.postMessage('PASS', '*');
+});
+</script>"></iframe>
+</body>
+</html>

--- a/LayoutTests/ipc/weblock-registry-origin-expected.txt
+++ b/LayoutTests/ipc/weblock-registry-origin-expected.txt
@@ -1,0 +1,2 @@
+This test passes if the WebLock isn't granted.
+PASS

--- a/LayoutTests/ipc/weblock-registry-origin.html
+++ b/LayoutTests/ipc/weblock-registry-origin.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html><!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] --> 
+<html>
+<head>
+<script>
+
+async function runTest()
+{
+    if (window.testRunner)
+        testRunner.dumpAsText();
+
+    if (!window.IPC) {
+        result.textContent = window.testRunner ? 'PASS' : 'This test requires IPC testing API';
+        return;
+    }
+
+    if (window.testRunner)
+        testRunner.waitUntilDone();
+
+
+    const { CoreIPC, IPCWireTap } = await import('./coreipc.js');
+    const uiOutgoingTap = new IPCWireTap('UI', 'Outgoing');
+
+    function waitForNextRequestLock()
+    {
+        return new Promise((resolve) => {
+            const uiOutgoingTap = new IPCWireTap('UI', 'Outgoing');
+            uiOutgoingTap.tapNext(IPC.messages.WebLockRegistryProxy_RequestLock.name, (...args) => resolve(args));
+        });
+    }
+
+    function acquireLockLegitimately()
+    {
+        return new Promise((resolve) => {
+            navigator.locks.request('abc', {mode: 'shared'}, resolve);
+        });
+    }
+
+    function waitForNextLockComplete()
+    {
+        return new Promise((resolve) => {
+            const uiIncomingTap = new IPCWireTap('UI', 'Incoming');
+            uiIncomingTap.tapNext(IPC.messages.RemoteWebLockRegistry_DidCompleteLockRequest.name, (...args) => resolve(args));
+        });
+    }
+
+    const lockRequest = waitForNextRequestLock();
+
+    await acquireLockLegitimately();
+
+    let [process, connectionID, messageName, typedArguments, msgArguments] = await lockRequest;
+
+    lockComplete = waitForNextLockComplete();
+
+    CoreIPC.UI.WebLockRegistryProxy.RequestLock(connectionID, {
+        clientOrigin: {
+            topOrigin: {
+                data: {
+                    variantType: msgArguments.clientOrigin.topOrigin.data.variantType,
+                    variant: {
+                        protocol: 'https',
+                        host: 'webkit.org',
+                        port: 80,
+                    },
+                }
+            },
+            clientOrigin: {
+                data: {
+                    variantType: msgArguments.clientOrigin.topOrigin.data.variantType,
+                    variant: {
+                        protocol: 'https',
+                        host: 'webkit.org',
+                        port: 80,
+                    },
+                }
+            },
+        },
+        identifier: {
+            processIdentifier: msgArguments.clientID.processIdentifier,
+            object: 123456789,
+        },
+        clientID: {
+            processIdentifier: msgArguments.clientID.processIdentifier,
+            object: msgArguments.clientID.object,
+        },
+        name: msgArguments.name,
+        mode: msgArguments.mode,
+        steal: false,
+        ifAvailable: msgArguments.ifAvailable,
+    });
+
+    await acquireLockLegitimately();
+
+    [process, connectionID, messageName, typedArguments, msgArguments] = await lockComplete;
+    result.textContent = msgArguments.lockIdentifier.object == 123456789 ? 'FAIL - Acquired lock' : 'PASS';
+
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+</script>
+</head>
+<body onload="runTest()">
+This test passes if the WebLock isn't granted.
+<div id="result"></div>
+</body>
+</html>
+

--- a/LayoutTests/js/regress-311234-expected.txt
+++ b/LayoutTests/js/regress-311234-expected.txt
@@ -1,0 +1,5 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x8
+  RenderBlock {HTML} at (0,0) size 800x8
+    RenderBody {BODY} at (8,8) size 784x0

--- a/LayoutTests/js/regress-311234.html
+++ b/LayoutTests/js/regress-311234.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<script>
+if (testRunner) testRunner.waitUntilDone();
+
+function gc() { GCController.collect(); }
+
+const sab = new SharedArrayBuffer(4);
+
+const worker = new Worker(URL.createObjectURL(new Blob([`
+    onmessage = e => {
+        Atomics.waitAsync(new Int32Array(e.data), 0, 0);
+        postMessage("ready");
+    };
+`])));
+
+worker.onmessage = () => {
+    const f = document.createElement("iframe");
+    document.body.appendChild(f);
+    f.contentWindow.__sab__ = sab;
+    f.contentWindow.eval("Atomics.waitAsync(new Int32Array(__sab__), 0, 0)");
+    document.body.removeChild(f);
+    worker.terminate();
+    gc();
+    testRunner?.notifyDone();
+};
+
+worker.postMessage(sab);
+</script>

--- a/LayoutTests/streams/pipeTo-removed-iframe-crash-expected.txt
+++ b/LayoutTests/streams/pipeTo-removed-iframe-crash-expected.txt
@@ -1,0 +1,4 @@
+Tests that pipeTo does not crash when the document frame is detached during error propagation.
+WebKit should not crash, and you should see PASS below.
+
+PASS

--- a/LayoutTests/streams/pipeTo-removed-iframe-crash.html
+++ b/LayoutTests/streams/pipeTo-removed-iframe-crash.html
@@ -1,0 +1,51 @@
+<!DOCTYPE html>
+<html>
+<body>
+<p>Tests that pipeTo does not crash when the document frame is detached during error propagation.<br>
+WebKit should not crash, and you should see PASS below.</p>
+<div id="result"></div>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+// The crash: StreamPipeToState::globalObject() calls
+// jsDynamicCast<JSDOMGlobalObject*>(context->globalObject()), but
+// ScriptExecutionContext::globalObject() can return null when the document
+// has no frame (e.g. after its iframe is removed). jsDynamicCast does not
+// null-check its argument, so passing null crashes with a read from 0x0.
+//
+// To reproduce, pipeTo must be called in the iframe's JS context so that
+// StreamPipeToState is associated with the iframe's ScriptExecutionContext.
+// Erroring the source stream queues a microtask. If the iframe is removed
+// before that microtask runs, context->globalObject() returns null when the
+// error-propagation callback fires.
+
+const iframe = document.createElement('iframe');
+document.body.appendChild(iframe);
+
+// Run pipeTo inside the iframe's context (CallWith=CurrentGlobalObject means
+// the StreamPipeToState gets the iframe's ScriptExecutionContext).
+iframe.contentWindow.eval(`
+    var readable = new ReadableStream({ start(c) { window._controller = c; } });
+    var writable = new WritableStream();
+    readable.pipeTo(writable).catch(() => {});
+    window._controller.error("test error");
+`);
+
+// Detach the iframe's document from its frame before the error-propagation
+// microtask runs. After this, ScriptExecutionContext::globalObject() returns
+// null for the iframe's context (document->frame() is null).
+iframe.remove();
+
+// Let microtasks and the event loop run. Without the fix, the error-propagation
+// microtask crashes in StreamPipeToState::globalObject().
+setTimeout(() => {
+    document.getElementById('result').textContent = 'PASS';
+    if (window.testRunner)
+        testRunner.notifyDone();
+}, 0);
+</script>
+</body>
+</html>

--- a/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
+++ b/Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp
@@ -4326,14 +4326,19 @@ void InlineCacheCompiler::emitIntrinsicGetter(IntrinsicGetterAccessCase& accessC
 
 #if USE(JSVALUE64)
         if (isResizableOrGrowableSharedTypedArrayIncludingDataView(accessCase.structure()->classInfoForCells())) {
+            // The null-vector guard above was emitted before the push, so route it
+            // directly to m_failAndIgnore to avoid the post-push restore path.
+            m_failAndIgnore.append(failAndIgnore);
+
             auto allocator = makeDefaultScratchAllocator(m_scratchGPR);
             GPRReg scratch2GPR = allocator.allocateScratchGPR();
 
             ScratchRegisterAllocator::PreservedState preservedState = allocator.preserveReusedRegistersByPushing(jit, ScratchRegisterAllocator::ExtraStackSpace::NoExtraSpace);
 
+            CCallHelpers::JumpList postPushFailAndIgnore;
             if (isDataView) {
                 auto [outOfBounds, doneCases] = jit.loadDataViewByteLength(baseGPR, valueGPR, m_scratchGPR, scratch2GPR, type);
-                failAndIgnore.append(outOfBounds);
+                postPushFailAndIgnore.append(outOfBounds);
                 doneCases.link(&jit);
             } else
                 jit.loadTypedArrayByteLength(baseGPR, valueGPR, m_scratchGPR, scratch2GPR, typedArrayType(accessCase.structure()->typeInfo().type()));
@@ -4345,12 +4350,12 @@ void InlineCacheCompiler::emitIntrinsicGetter(IntrinsicGetterAccessCase& accessC
             allocator.restoreReusedRegistersByPopping(jit, preservedState);
             succeed();
 
-            if (allocator.didReuseRegisters() && !failAndIgnore.empty()) {
-                failAndIgnore.link(&jit);
+            if (allocator.didReuseRegisters() && !postPushFailAndIgnore.empty()) {
+                postPushFailAndIgnore.link(&jit);
                 allocator.restoreReusedRegistersByPopping(jit, preservedState);
                 m_failAndIgnore.append(jit.jump());
             } else
-                m_failAndIgnore.append(failAndIgnore);
+                m_failAndIgnore.append(postPushFailAndIgnore);
             return;
         }
 #endif

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -2230,6 +2230,11 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
         return;
 
     case StringAt:
+        // String.prototype.at returns a string when in bounds and undefined when OOB. This is
+        // unlike charAt, which always returns a string. Include arrayMode to prevent CSE across
+        // modes.
+        def(PureValue(node, node->arrayMode().asWord()));
+        return;
     case StringCharAt:
         def(PureValue(node));
         return;

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -240,7 +240,6 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
     case SameValue:
     case IsEmpty:
     case IsEmptyStorage:
-    case TypeOfIsUndefined:
     case IsUndefinedOrNull:
     case IsBoolean:
     case IsNumber:
@@ -248,8 +247,6 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
     case NumberIsInteger:
     case IsObject:
     case IsTypedArrayView:
-    case ToBoolean:
-    case LogicalNot:
     case CheckInBounds:
     case CheckInBoundsInt52:
     case DoubleRep:
@@ -264,8 +261,16 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
     case ValueToInt32:
     case GetExecutable:
     case BottomValue:
-    case TypeOf:
         def(PureValue(node));
+        return;
+
+    // These nodes are realm-dependent when MasqueradesAsUndefined is involved.
+    // Including the globalObject in the PureValue ensures nodes from different realms are not folded by CSE.
+    case TypeOfIsUndefined:
+    case ToBoolean:
+    case LogicalNot:
+    case TypeOf:
+        def(PureValue(node, graph.globalObjectFor(node->origin.semantic)));
         return;
 
     // JSCallee for Eval can change the scope field.
@@ -659,12 +664,12 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
 
     case TypeOfIsObject:
         read(MiscFields);
-        def(HeapLocation(TypeOfIsObjectLoc, MiscFields, node->child1()), LazyNode(node));
+        def(HeapLocation(TypeOfIsObjectLoc, MiscFields, node->child1(), graph.globalObjectFor(node->origin.semantic)), LazyNode(node));
         return;
 
     case TypeOfIsFunction:
         read(MiscFields);
-        def(HeapLocation(TypeOfIsFunctionLoc, MiscFields, node->child1()), LazyNode(node));
+        def(HeapLocation(TypeOfIsFunctionLoc, MiscFields, node->child1(), graph.globalObjectFor(node->origin.semantic)), LazyNode(node));
         return;
         
     case IsCallable:
@@ -2257,6 +2262,13 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
 
         if (node->isBinaryUseKind(UntypedUse)) {
             clobberTop();
+            return;
+        }
+
+        // CompareEq is realm-dependent when MasqueradesAsUndefined is involved.
+        // Including the globalObject ensures nodes from different realms are not folded by CSE.
+        if (node->op() == CompareEq) {
+            def(PureValue(node, graph.globalObjectFor(node->origin.semantic)));
             return;
         }
 

--- a/Source/JavaScriptCore/ftl/FTLOperations.cpp
+++ b/Source/JavaScriptCore/ftl/FTLOperations.cpp
@@ -97,7 +97,10 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationPopulateObjectInOSR, void, (JSGlobalO
 
             if (value.isEmpty()) {
                 ASSERT(!hasDouble(materialization->indexingType()));
-                array->butterfly()->contiguous().atUnsafe(index).clear();
+                if (hasAnyArrayStorage(array->indexingType()))
+                    array->butterfly()->arrayStorage()->m_vector[index].clear();
+                else
+                    array->butterfly()->contiguous().atUnsafe(index).clear();
                 continue;
             }
 
@@ -286,7 +289,13 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMaterializeObjectInOSR, HeapCell*, (J
     }
 
     case PhantomNewArrayWithButterfly: {
-        Structure* structure = globalObject->arrayStructureForIndexingTypeDuringAllocation(materialization->indexingType());
+        // Rematerialized butterflies are always non-ArrayStorage. However, isHavingABadTime could
+        // have become true between the FTL compilation and the rematerialization, which would have
+        // switched arrayStructureForIndexingTypeDuringAllocation to SlowPutArrayStorage for all
+        // indexing types. To avoid a layout mismatch, the original Array structure is used to
+        // rematerialize the Array initially. If we're having a bad time, the layout is switched to
+        // SlowPutArrayStorage below.
+        Structure* structure = globalObject->originalArrayStructureForIndexingType(materialization->indexingType());
 
         Butterfly* butterfly = nullptr;
         for (unsigned i = 0; i < materialization->properties().size(); ++i) {
@@ -325,6 +334,14 @@ JSC_DEFINE_NOEXCEPT_JIT_OPERATION(operationMaterializeObjectInOSR, HeapCell*, (J
                 butterfly->contiguousDouble().atUnsafe(index) = static_cast<double>(sentinel);
             else
                 butterfly->contiguous().atUnsafe(index).setStartingValue(jsNumber(sentinel));
+        }
+
+        if (globalObject->isHavingABadTime()) [[unlikely]] {
+#if ASSERT_ENABLED
+            Structure* originalStructure = globalObject->arrayStructureForIndexingTypeDuringAllocation(materialization->indexingType());
+            ASSERT(!originalStructure || hasSlowPutArrayStorage(originalStructure->indexingType()));
+#endif
+            result->switchToSlowPutArrayStorage(vm);
         }
 
         return result;

--- a/Source/JavaScriptCore/runtime/DeferredWorkTimer.cpp
+++ b/Source/JavaScriptCore/runtime/DeferredWorkTimer.cpp
@@ -257,7 +257,6 @@ void DeferredWorkTimer::cancelPendingWorkSafe(JSGlobalObject* globalObject)
     for (Ref<TicketData> ticket : *globalObject->m_weakTickets) {
         if (!ticket->isCancelled())
             cancelPendingWork(ticket.ptr());
-        m_tasks.append(std::make_tuple(ticket.ptr(), [](DeferredWorkTimer::Ticket) { }));
     }
     if (!isScheduled() && !m_currentlyRunningTask)
         setTimeUntilFire(0_s);

--- a/Source/JavaScriptCore/runtime/DeferredWorkTimer.h
+++ b/Source/JavaScriptCore/runtime/DeferredWorkTimer.h
@@ -117,6 +117,10 @@ private:
     UncheckedKeyHashSet<Ref<TicketData>> m_pendingTickets;
 };
 
+// target() reads m_dependencies, which cancelAndClear() can free concurrently.
+// Safe only when: (1) holding m_taskLock, (2) inside a scheduleWorkSoon task lambda
+// (ticket already removed from m_pendingTickets), or (3) GC End phase is prevented from running.
+// Never call from a foreign VM's thread.
 inline JSObject* DeferredWorkTimer::TicketData::target()
 {
     ASSERT(!isCancelled() && isTargetObject());

--- a/Source/JavaScriptCore/runtime/WaiterListManager.cpp
+++ b/Source/JavaScriptCore/runtime/WaiterListManager.cpp
@@ -56,6 +56,7 @@ Waiter::Waiter(VM* vm)
 
 Waiter::Waiter(JSPromise* promise)
     : m_vm(&promise->vm())
+    , m_globalObject(promise->globalObject())
     , m_ticket(m_vm->deferredWorkTimer->addPendingWork(DeferredWorkTimer::WorkType::AtSomePoint, *m_vm, promise, { }))
     , m_isAsync(true)
 {
@@ -292,16 +293,14 @@ void WaiterListManager::unregister(JSGlobalObject* globalObject)
         Ref<WaiterList> list = entry.value;
         Locker listLocker { list->lock };
         list->removeIf(listLocker, [&](Waiter* waiter) {
-            if (waiter->isAsync()) {
-                if (auto ticket = waiter->ticket(listLocker); ticket && !ticket->isCancelled() && ticket->target()->globalObject() == globalObject) {
-                    dataLogLnIf(WaiterListsManagerInternal::verbose,
-                        "<WaiterListManager> <Thread:", Thread::currentSingleton(),
-                        "> unregister JSGlobalObject is cancelling waiter=", *waiter,
-                        " in WaiterList for ptr ", RawPointer(entry.key));
+            if (waiter->isAsync() && waiter->globalObject() == globalObject) {
+                dataLogLnIf(WaiterListsManagerInternal::verbose,
+                    "<WaiterListManager> <Thread:", Thread::currentSingleton(),
+                    "> unregister JSGlobalObject is cancelling waiter=", *waiter,
+                    " in WaiterList for ptr ", RawPointer(entry.key));
 
-                    waiter->cancelAndClear(listLocker);
-                    return true;
-                }
+                waiter->cancelAndClear(listLocker);
+                return true;
             }
             return false;
         });
@@ -374,8 +373,8 @@ void Waiter::dump(PrintStream& out) const
 
     auto ticket = this->ticket(NoLockingNecessary);
     out.print(", ticket=", RawPointer(ticket.get()));
+    out.print(", globalObject=", RawPointer(m_globalObject));
     if (ticket && !ticket->isCancelled()) {
-        out.print(", m_ticket->globalObject=", RawPointer(ticket->target()->globalObject()));
         out.print(", m_ticket->target=", RawPointer(jsCast<JSObject*>(ticket->dependencies().last())));
         out.print(", m_ticket->scriptExecutionOwner=", RawPointer(ticket->scriptExecutionOwner()));
     }

--- a/Source/JavaScriptCore/runtime/WaiterListManager.h
+++ b/Source/JavaScriptCore/runtime/WaiterListManager.h
@@ -54,6 +54,12 @@ public:
         return m_vm;
     }
 
+    JSGlobalObject* globalObject() const
+    {
+        ASSERT(m_isAsync);
+        return m_globalObject;
+    }
+
     Condition& condition()
     {
         ASSERT(!m_isAsync);
@@ -101,6 +107,11 @@ public:
 
 private:
     VM* m_vm { nullptr };
+    // Cached at construction to avoid a cross-VM race: unregister(JSGlobalObject*) runs on
+    // one VM's sweep thread; reading ticket->target()->globalObject() would race with another
+    // VM's GC End phase freeing m_dependencies via cancelAndClear(). Written before the Waiter
+    // is added to any list, so readers acquiring list->lock always see the completed write.
+    JSGlobalObject* m_globalObject { nullptr };
     ThreadSafeWeakPtr<DeferredWorkTimer::TicketData> m_ticket { nullptr };
     RefPtr<RunLoop::DispatchTimer> m_timer { nullptr };
     Condition m_condition;

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -287,6 +287,18 @@ bool Location::operator==(Location other) const
     }
 }
 
+bool Location::rangesOverlap(Location a, uint32_t aSize, Location b, uint32_t bSize)
+{
+    if (a.m_kind != b.m_kind)
+        return false;
+    if (a.isStack() || a.isStackArgument()) {
+        ASSERT(aSize);
+        ASSERT(bSize);
+        return WTF::nonEmptyRangesOverlap(a.m_offset, a.m_offset + static_cast<int32_t>(aSize), b.m_offset, b.m_offset + static_cast<int32_t>(bSize));
+    }
+    return a == b;
+}
+
 Location::Kind Location::kind() const
 {
     return Kind(m_kind);
@@ -5417,7 +5429,7 @@ void BBQJIT::emitShuffle(Vector<Value, N, OverflowHandler>& srcVector, Vector<Lo
 #if ASSERT_ENABLED
     for (size_t i = 0; i < dstVector.size(); ++i) {
         for (size_t j = i + 1; j < dstVector.size(); ++j)
-            ASSERT(dstVector[i] != dstVector[j]);
+            ASSERT(!Location::rangesOverlap(dstVector[i], srcVector[i].size(), dstVector[j], srcVector[j].size()));
     }
 
     // This algorithm assumes at most one cycle: https://xavierleroy.org/publi/parallel-move.pdf

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -123,6 +123,8 @@ public:
 
         static Location fromArgumentLocation(ArgumentLocation argLocation, TypeKind type);
 
+        static bool rangesOverlap(Location a, uint32_t aSize, Location b, uint32_t bSize);
+
         bool isNone() const;
 
         bool isGPR() const;

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.h
@@ -462,11 +462,12 @@ void BBQJIT::emitShuffleMove(Vector<Value, N, OverflowHandler>& srcVector, Vecto
     if (srcLocation == dst)
         return; // Easily eliminate redundant moves here.
 
+    uint32_t dstSize = srcVector[index].size();
     statusVector[index] = ShuffleStatus::BeingMoved;
     for (unsigned i = 0; i < srcVector.size(); i ++) {
         // This check should handle constants too - constants always have location None, and no
         // dst should ever be a constant. But we assume that's asserted in the caller.
-        if (locationOf(srcVector[i]) == dst) {
+        if (Location::rangesOverlap(locationOf(srcVector[i]), srcVector[i].size(), dst, dstSize)) {
             switch (statusVector[i]) {
             case ShuffleStatus::ToMove:
                 emitShuffleMove(srcVector, dstVector, statusVector, i);

--- a/Source/WebCore/Modules/streams/StreamPipeToUtilities.cpp
+++ b/Source/WebCore/Modules/streams/StreamPipeToUtilities.cpp
@@ -256,7 +256,12 @@ StreamPipeToState::~StreamPipeToState() = default;
 JSDOMGlobalObject* StreamPipeToState::globalObject()
 {
     RefPtr context = scriptExecutionContext();
-    return context ? JSC::jsDynamicCast<JSDOMGlobalObject*>(context->globalObject()) : nullptr;
+    if (!context)
+        return nullptr;
+    auto* jsGlobalObject = context->globalObject();
+    if (!jsGlobalObject)
+        return nullptr;
+    return JSC::jsDynamicCast<JSDOMGlobalObject*>(jsGlobalObject);
 }
 
 void StreamPipeToState::handleSignal()

--- a/Source/WebCore/bindings/js/InternalReadableStreamDefaultReader.cpp
+++ b/Source/WebCore/bindings/js/InternalReadableStreamDefaultReader.cpp
@@ -159,7 +159,9 @@ void InternalReadableStreamDefaultReader::onClosedPromiseRejection(Function<void
         return;
 
     Ref domPromise = DOMPromise::create(*globalObject, *promise);
-    domPromise->whenSettledWithResult([callback = WTF::move(callback)](auto* globalObject, bool isFulfilled, auto result) {
+    domPromise->whenSettledWithResult([domPromise, callback = WTF::move(callback)](auto* globalObject, bool isFulfilled, auto result) {
+        if (domPromise->activeDOMObjectAreStopped())
+            return;
         if (isFulfilled || !globalObject)
             return;
         callback(*globalObject, result);
@@ -189,7 +191,9 @@ void InternalReadableStreamDefaultReader::onClosedPromiseResolution(Function<voi
         return;
 
     Ref domPromise = DOMPromise::create(*globalObject, *promise);
-    domPromise->whenSettledWithResult([callback = WTF::move(callback)](auto*, bool isFulfilled, auto) {
+    domPromise->whenSettledWithResult([domPromise, callback = WTF::move(callback)](auto*, bool isFulfilled, auto) {
+        if (domPromise->activeDOMObjectAreStopped())
+            return;
         if (isFulfilled)
             callback();
     });

--- a/Source/WebCore/bindings/js/InternalWritableStreamWriter.cpp
+++ b/Source/WebCore/bindings/js/InternalWritableStreamWriter.cpp
@@ -168,7 +168,9 @@ void InternalWritableStreamWriter::onClosedPromiseRejection(Function<void(JSDOMG
         return;
 
     Ref domPromise = DOMPromise::create(*globalObject, *promise);
-    domPromise->whenSettledWithResult([callback = WTF::move(callback)](auto* globalObject, bool isFulfilled, auto result) mutable {
+    domPromise->whenSettledWithResult([domPromise, callback = WTF::move(callback)](auto* globalObject, bool isFulfilled, auto result) mutable {
+        if (domPromise->activeDOMObjectAreStopped())
+            return;
         if (isFulfilled || !globalObject)
             return;
         callback(*globalObject, result);
@@ -196,7 +198,9 @@ void InternalWritableStreamWriter::onClosedPromiseResolution(Function<void()>&& 
         return;
 
     Ref domPromise = DOMPromise::create(*globalObject, *promise);
-    domPromise->whenSettledWithResult([callback = WTF::move(callback)](auto*, bool isFulfilled, auto) mutable {
+    domPromise->whenSettledWithResult([domPromise, callback = WTF::move(callback)](auto*, bool isFulfilled, auto) mutable {
+        if (domPromise->activeDOMObjectAreStopped())
+            return;
         if (!isFulfilled)
             return;
         callback();
@@ -224,7 +228,9 @@ void InternalWritableStreamWriter::whenReady(Function<void (bool)>&& callback)
         return;
 
     Ref domPromise = DOMPromise::create(*globalObject, *promise);
-    domPromise->whenSettledWithResult([callback = WTF::move(callback)](auto*, bool isFulfilled, auto) mutable {
+    domPromise->whenSettledWithResult([domPromise, callback = WTF::move(callback)](auto*, bool isFulfilled, auto) mutable {
+        if (domPromise->activeDOMObjectAreStopped())
+            return;
         callback(isFulfilled);
     });
 }

--- a/Source/WebCore/bindings/js/JSRangeCustom.cpp
+++ b/Source/WebCore/bindings/js/JSRangeCustom.cpp
@@ -34,7 +34,7 @@ namespace WebCore {
 template<typename Visitor>
 void JSRange::visitAdditionalChildren(Visitor& visitor)
 {
-    wrapped().visitNodesConcurrently(visitor);
+    wrapped().visitNodesInGCThread(visitor);
 }
 
 DEFINE_VISIT_ADDITIONAL_CHILDREN(JSRange);

--- a/Source/WebCore/dom/Range.cpp
+++ b/Source/WebCore/dom/Range.cpp
@@ -132,9 +132,14 @@ ExceptionOr<void> Range::setStart(Ref<Node>&& container, unsigned offset)
     if (childNode.hasException())
         return childNode.releaseException();
 
-    m_start.set(WTF::move(container), offset, childNode.releaseReturnValue());
-    if (!is_lteq(treeOrder(makeBoundaryPoint(m_start), makeBoundaryPoint(m_end))))
+    {
+        Locker locker { m_boundaryPointLock };
+        m_start.set(WTF::move(container), offset, childNode.releaseReturnValue());
+    }
+    if (!is_lteq(treeOrder(makeBoundaryPoint(m_start), makeBoundaryPoint(m_end)))) {
+        Locker locker { m_boundaryPointLock };
         m_end = m_start;
+    }
     updateAssociatedSelection();
     updateDocument();
     updateAssociatedHighlight();
@@ -147,9 +152,14 @@ ExceptionOr<void> Range::setEnd(Ref<Node>&& container, unsigned offset)
     if (childNode.hasException())
         return childNode.releaseException();
 
-    m_end.set(WTF::move(container), offset, childNode.releaseReturnValue());
-    if (!is_lteq(treeOrder(makeBoundaryPoint(m_start), makeBoundaryPoint(m_end))))
+    {
+        Locker locker { m_boundaryPointLock };
+        m_end.set(WTF::move(container), offset, childNode.releaseReturnValue());
+    }
+    if (!is_lteq(treeOrder(makeBoundaryPoint(m_start), makeBoundaryPoint(m_end)))) {
+        Locker locker { m_boundaryPointLock };
         m_start = m_end;
+    }
     updateAssociatedSelection();
     updateDocument();
     updateAssociatedHighlight();
@@ -158,10 +168,13 @@ ExceptionOr<void> Range::setEnd(Ref<Node>&& container, unsigned offset)
 
 void Range::collapse(bool toStart)
 {
-    if (toStart)
-        m_end = m_start;
-    else
-        m_start = m_end;
+    {
+        Locker locker { m_boundaryPointLock };
+        if (toStart)
+            m_end = m_start;
+        else
+            m_start = m_end;
+    }
     updateAssociatedSelection();
 }
 
@@ -838,8 +851,11 @@ ExceptionOr<void> Range::selectNodeContents(Node& node)
 {
     if (node.isDocumentTypeNode())
         return Exception { ExceptionCode::InvalidNodeTypeError };
-    m_start.setToBeforeContents(node);
-    m_end.setToAfterContents(node);
+    {
+        Locker locker { m_boundaryPointLock };
+        m_start.setToBeforeContents(node);
+        m_end.setToAfterContents(node);
+    }
     updateAssociatedSelection();
     updateDocument();
     return { };
@@ -922,6 +938,7 @@ static inline void boundaryNodeChildrenChanged(RangeBoundaryPoint& boundary, Con
 void Range::nodeChildrenChanged(ContainerNode& container)
 {
     ASSERT(&container.document() == m_ownerDocument.ptr());
+    Locker locker { m_boundaryPointLock };
     boundaryNodeChildrenChanged(m_start, container);
     boundaryNodeChildrenChanged(m_end, container);
     m_didChangeForHighlight = true;
@@ -936,6 +953,7 @@ static inline void boundaryNodeChildrenWillBeRemoved(RangeBoundaryPoint& boundar
 void Range::nodeChildrenWillBeRemoved(ContainerNode& container)
 {
     ASSERT(&container.document() == m_ownerDocument.ptr());
+    Locker locker { m_boundaryPointLock };
     boundaryNodeChildrenWillBeRemoved(m_start, container);
     boundaryNodeChildrenWillBeRemoved(m_end, container);
     m_didChangeForHighlight = true;
@@ -954,6 +972,8 @@ void Range::nodeWillBeRemoved(Node& node)
     ASSERT(&node.document() == m_ownerDocument.ptr());
     ASSERT(&node != m_ownerDocument.ptr());
     ASSERT(node.parentNode());
+
+    Locker locker { m_boundaryPointLock };
     boundaryNodeWillBeRemoved(m_start, node);
     boundaryNodeWillBeRemoved(m_end, node);
     m_didChangeForHighlight = true;
@@ -984,6 +1004,7 @@ static inline void boundaryTextInserted(RangeBoundaryPoint& boundary, Node& text
 void Range::textInserted(Node& text, unsigned offset, unsigned length)
 {
     ASSERT(&text.document() == m_ownerDocument.ptr());
+    Locker locker { m_boundaryPointLock };
     boundaryTextInserted(m_start, text, offset, length);
     boundaryTextInserted(m_end, text, offset, length);
     m_didChangeForHighlight = true;
@@ -1005,6 +1026,7 @@ static inline void boundaryTextRemoved(RangeBoundaryPoint& boundary, Node& text,
 void Range::textRemoved(Node& text, unsigned offset, unsigned length)
 {
     ASSERT(&text.document() == m_ownerDocument.ptr());
+    Locker locker { m_boundaryPointLock };
     boundaryTextRemoved(m_start, text, offset, length);
     boundaryTextRemoved(m_end, text, offset, length);
     m_didChangeForHighlight = true;
@@ -1026,6 +1048,7 @@ void Range::textNodesMerged(NodeWithIndex& oldNode, unsigned offset)
     ASSERT(oldNode.node()->isTextNode());
     ASSERT(oldNode.node()->previousSibling());
     ASSERT(oldNode.node()->previousSibling()->isTextNode());
+    Locker locker { m_boundaryPointLock };
     boundaryTextNodesMerged(m_start, oldNode, offset);
     boundaryTextNodesMerged(m_end, oldNode, offset);
     m_didChangeForHighlight = true;
@@ -1059,6 +1082,7 @@ void Range::textNodeSplit(Text& oldNode)
     ASSERT(&oldNode.document() == m_ownerDocument.ptr());
     ASSERT(!oldNode.parentNode() || oldNode.nextSibling());
     ASSERT(!oldNode.parentNode() || oldNode.nextSibling()->isTextNode());
+    Locker locker { m_boundaryPointLock };
     boundaryTextNodesSplit(m_start, oldNode);
     boundaryTextNodesSplit(m_end, oldNode);
     m_didChangeForHighlight = true;
@@ -1169,8 +1193,9 @@ RefPtr<Range> createLiveRange(const std::optional<SimpleRange>& range)
     return createLiveRange(*range);
 }
 
-void Range::visitNodesConcurrently(JSC::AbstractSlotVisitor& visitor) const
+void Range::visitNodesInGCThread(JSC::AbstractSlotVisitor& visitor) const
 {
+    Locker locker { m_boundaryPointLock };
     addWebCoreOpaqueRoot(visitor, m_start.container());
     addWebCoreOpaqueRoot(visitor, m_end.container());
 }

--- a/Source/WebCore/dom/Range.cpp
+++ b/Source/WebCore/dom/Range.cpp
@@ -132,14 +132,14 @@ ExceptionOr<void> Range::setStart(Ref<Node>&& container, unsigned offset)
     if (childNode.hasException())
         return childNode.releaseException();
 
+    bool shouldAlsoSetEnd = !is_lteq(treeOrder(BoundaryPoint(container.copyRef(), offset), makeBoundaryPoint(m_end)));
     {
         Locker locker { m_boundaryPointLock };
         m_start.set(WTF::move(container), offset, childNode.releaseReturnValue());
+        if (shouldAlsoSetEnd)
+            m_end = m_start;
     }
-    if (!is_lteq(treeOrder(makeBoundaryPoint(m_start), makeBoundaryPoint(m_end)))) {
-        Locker locker { m_boundaryPointLock };
-        m_end = m_start;
-    }
+
     updateAssociatedSelection();
     updateDocument();
     updateAssociatedHighlight();
@@ -152,14 +152,14 @@ ExceptionOr<void> Range::setEnd(Ref<Node>&& container, unsigned offset)
     if (childNode.hasException())
         return childNode.releaseException();
 
+    bool shouldAlsoSetStart = !is_lteq(treeOrder(makeBoundaryPoint(m_start), BoundaryPoint(container.copyRef(), offset)));
     {
         Locker locker { m_boundaryPointLock };
         m_end.set(WTF::move(container), offset, childNode.releaseReturnValue());
+        if (shouldAlsoSetStart)
+            m_start = m_end;
     }
-    if (!is_lteq(treeOrder(makeBoundaryPoint(m_start), makeBoundaryPoint(m_end)))) {
-        Locker locker { m_boundaryPointLock };
-        m_start = m_end;
-    }
+
     updateAssociatedSelection();
     updateDocument();
     updateAssociatedHighlight();
@@ -929,7 +929,7 @@ String Range::debugDescription() const
 }
 #endif
 
-static inline void boundaryNodeChildrenChanged(RangeBoundaryPoint& boundary, ContainerNode& container)
+static inline void boundaryNodeChildrenChanged(Locker<Lock>&, RangeBoundaryPoint& boundary, ContainerNode& container)
 {
     if (boundary.childBefore() && &boundary.container() == &container)
         boundary.invalidateOffset();
@@ -939,12 +939,12 @@ void Range::nodeChildrenChanged(ContainerNode& container)
 {
     ASSERT(&container.document() == m_ownerDocument.ptr());
     Locker locker { m_boundaryPointLock };
-    boundaryNodeChildrenChanged(m_start, container);
-    boundaryNodeChildrenChanged(m_end, container);
+    boundaryNodeChildrenChanged(locker, m_start, container);
+    boundaryNodeChildrenChanged(locker, m_end, container);
     m_didChangeForHighlight = true;
 }
 
-static inline void boundaryNodeChildrenWillBeRemoved(RangeBoundaryPoint& boundary, ContainerNode& containerOfNodesToBeRemoved)
+static inline void boundaryNodeChildrenWillBeRemoved(Locker<Lock>&, RangeBoundaryPoint& boundary, ContainerNode& containerOfNodesToBeRemoved)
 {
     if (containerOfNodesToBeRemoved.contains(&boundary.container()))
         boundary.setToBeforeContents(containerOfNodesToBeRemoved);
@@ -954,12 +954,12 @@ void Range::nodeChildrenWillBeRemoved(ContainerNode& container)
 {
     ASSERT(&container.document() == m_ownerDocument.ptr());
     Locker locker { m_boundaryPointLock };
-    boundaryNodeChildrenWillBeRemoved(m_start, container);
-    boundaryNodeChildrenWillBeRemoved(m_end, container);
+    boundaryNodeChildrenWillBeRemoved(locker, m_start, container);
+    boundaryNodeChildrenWillBeRemoved(locker, m_end, container);
     m_didChangeForHighlight = true;
 }
 
-static inline void boundaryNodeWillBeRemoved(RangeBoundaryPoint& boundary, Node& nodeToBeRemoved)
+static inline void boundaryNodeWillBeRemoved(Locker<Lock>&, RangeBoundaryPoint& boundary, Node& nodeToBeRemoved)
 {
     if (boundary.childBefore() == &nodeToBeRemoved)
         boundary.childBeforeWillBeRemoved();
@@ -974,8 +974,8 @@ void Range::nodeWillBeRemoved(Node& node)
     ASSERT(node.parentNode());
 
     Locker locker { m_boundaryPointLock };
-    boundaryNodeWillBeRemoved(m_start, node);
-    boundaryNodeWillBeRemoved(m_end, node);
+    boundaryNodeWillBeRemoved(locker, m_start, node);
+    boundaryNodeWillBeRemoved(locker, m_end, node);
     m_didChangeForHighlight = true;
 }
 
@@ -991,7 +991,7 @@ void Range::updateRangeForParentlessNodeMovedToNewDocument(Node& node)
     protectedOwnerDocument()->attachRange(*this);
 }
 
-static inline void boundaryTextInserted(RangeBoundaryPoint& boundary, Node& text, unsigned offset, unsigned length)
+static inline void boundaryTextInserted(Locker<Lock>&, RangeBoundaryPoint& boundary, Node& text, unsigned offset, unsigned length)
 {
     if (&boundary.container() != &text)
         return;
@@ -1005,12 +1005,12 @@ void Range::textInserted(Node& text, unsigned offset, unsigned length)
 {
     ASSERT(&text.document() == m_ownerDocument.ptr());
     Locker locker { m_boundaryPointLock };
-    boundaryTextInserted(m_start, text, offset, length);
-    boundaryTextInserted(m_end, text, offset, length);
+    boundaryTextInserted(locker, m_start, text, offset, length);
+    boundaryTextInserted(locker, m_end, text, offset, length);
     m_didChangeForHighlight = true;
 }
 
-static inline void boundaryTextRemoved(RangeBoundaryPoint& boundary, Node& text, unsigned offset, unsigned length)
+static inline void boundaryTextRemoved(Locker<Lock>&, RangeBoundaryPoint& boundary, Node& text, unsigned offset, unsigned length)
 {
     if (&boundary.container() != &text)
         return;
@@ -1027,12 +1027,12 @@ void Range::textRemoved(Node& text, unsigned offset, unsigned length)
 {
     ASSERT(&text.document() == m_ownerDocument.ptr());
     Locker locker { m_boundaryPointLock };
-    boundaryTextRemoved(m_start, text, offset, length);
-    boundaryTextRemoved(m_end, text, offset, length);
+    boundaryTextRemoved(locker, m_start, text, offset, length);
+    boundaryTextRemoved(locker, m_end, text, offset, length);
     m_didChangeForHighlight = true;
 }
 
-static inline void boundaryTextNodesMerged(RangeBoundaryPoint& boundary, NodeWithIndex& oldNode, unsigned offset)
+static inline void boundaryTextNodesMerged(Locker<Lock>&, RangeBoundaryPoint& boundary, NodeWithIndex& oldNode, unsigned offset)
 {
     if (&boundary.container() == oldNode.node())
         boundary.set(oldNode.node()->protectedPreviousSibling().releaseNonNull(), boundary.offset() + offset, nullptr);
@@ -1049,12 +1049,12 @@ void Range::textNodesMerged(NodeWithIndex& oldNode, unsigned offset)
     ASSERT(oldNode.node()->previousSibling());
     ASSERT(oldNode.node()->previousSibling()->isTextNode());
     Locker locker { m_boundaryPointLock };
-    boundaryTextNodesMerged(m_start, oldNode, offset);
-    boundaryTextNodesMerged(m_end, oldNode, offset);
+    boundaryTextNodesMerged(locker, m_start, oldNode, offset);
+    boundaryTextNodesMerged(locker, m_end, oldNode, offset);
     m_didChangeForHighlight = true;
 }
 
-static inline void boundaryTextNodesSplit(RangeBoundaryPoint& boundary, Text& oldNode)
+static inline void boundaryTextNodesSplit(Locker<Lock>&, RangeBoundaryPoint& boundary, Text& oldNode)
 {
     RefPtr parent = oldNode.parentNode();
     if (&boundary.container() == &oldNode) {
@@ -1083,8 +1083,8 @@ void Range::textNodeSplit(Text& oldNode)
     ASSERT(!oldNode.parentNode() || oldNode.nextSibling());
     ASSERT(!oldNode.parentNode() || oldNode.nextSibling()->isTextNode());
     Locker locker { m_boundaryPointLock };
-    boundaryTextNodesSplit(m_start, oldNode);
-    boundaryTextNodesSplit(m_end, oldNode);
+    boundaryTextNodesSplit(locker, m_start, oldNode);
+    boundaryTextNodesSplit(locker, m_end, oldNode);
     m_didChangeForHighlight = true;
 }
 

--- a/Source/WebCore/dom/Range.h
+++ b/Source/WebCore/dom/Range.h
@@ -27,6 +27,8 @@
 #include <WebCore/AbstractRange.h>
 #include <WebCore/RangeBoundaryPoint.h>
 #include <wtf/CheckedRef.h>
+#include <wtf/Lock.h>
+#include <wtf/Locker.h>
 #include <wtf/WeakPtr.h>
 
 namespace WebCore {
@@ -131,7 +133,7 @@ public:
     String debugDescription() const;
 #endif
 
-    void visitNodesConcurrently(JSC::AbstractSlotVisitor&) const;
+    void visitNodesInGCThread(JSC::AbstractSlotVisitor&) const;
 
     enum ActionType : uint8_t { Delete, Extract, Clone };
 
@@ -149,6 +151,7 @@ private:
     Ref<Document> m_ownerDocument;
     RangeBoundaryPoint m_start;
     RangeBoundaryPoint m_end;
+    mutable Lock m_boundaryPointLock;
     bool m_isAssociatedWithSelection { false };
     bool m_didChangeForHighlight { false };
     bool m_isAssociatedWithHighlight { false };

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -327,6 +327,8 @@ void WebFrameProxy::didFailProvisionalLoad()
 void WebFrameProxy::didCommitLoad(const String& contentType, const WebCore::CertificateInfo& certificateInfo, bool containsPluginDocument)
 {
     m_frameLoadState.didCommitLoad();
+    if (RefPtr page = m_page.get())
+        process().didCommitLoadClientOrigin(ClientOrigin { SecurityOriginData::fromURL(page->mainFrame()->url()), SecurityOriginData::fromURL(m_frameLoadState.url()) });
 
     m_title = String();
     m_MIMEType = contentType;

--- a/Source/WebKit/UIProcess/WebLockRegistryProxy.cpp
+++ b/Source/WebKit/UIProcess/WebLockRegistryProxy.cpp
@@ -60,6 +60,7 @@ void WebLockRegistryProxy::requestLock(WebCore::ClientOrigin&& clientOrigin, Web
     MESSAGE_CHECK(lockIdentifier.processIdentifier() == m_process->coreProcessIdentifier());
     MESSAGE_CHECK(clientID.processIdentifier() == m_process->coreProcessIdentifier());
     MESSAGE_CHECK(name.length() <= WebCore::WebLock::maxNameLength);
+    MESSAGE_CHECK(m_process->hasCommittedClientOrigin(clientOrigin));
     m_hasEverRequestedLocks = true;
 
     RefPtr dataStore = m_process->websiteDataStore();
@@ -81,15 +82,20 @@ void WebLockRegistryProxy::releaseLock(WebCore::ClientOrigin&& clientOrigin, Web
 {
     MESSAGE_CHECK(lockIdentifier.processIdentifier() == m_process->coreProcessIdentifier());
     MESSAGE_CHECK(clientID.processIdentifier() == m_process->coreProcessIdentifier());
+    MESSAGE_CHECK(m_process->hasCommittedClientOrigin(clientOrigin));
     Ref process = m_process.get();
-    if (RefPtr dataStore = process->websiteDataStore())
-        dataStore->webLockRegistry().releaseLock(process->sessionID(), WTF::move(clientOrigin), lockIdentifier, clientID, WTF::move(name));
+    RefPtr dataStore = process->websiteDataStore();
+    if (!dataStore)
+        return;
+
+    dataStore->webLockRegistry().releaseLock(process->sessionID(), WTF::move(clientOrigin), lockIdentifier, clientID, WTF::move(name));
 }
 
 void WebLockRegistryProxy::abortLockRequest(WebCore::ClientOrigin&& clientOrigin, WebCore::WebLockIdentifier lockIdentifier, WebCore::ScriptExecutionContextIdentifier clientID, String&& name, CompletionHandler<void(bool)>&& completionHandler)
 {
     MESSAGE_CHECK_COMPLETION(lockIdentifier.processIdentifier() == m_process->coreProcessIdentifier(), completionHandler(false));
     MESSAGE_CHECK_COMPLETION(clientID.processIdentifier() == m_process->coreProcessIdentifier(), completionHandler(false));
+    MESSAGE_CHECK_COMPLETION(m_process->hasCommittedClientOrigin(clientOrigin), completionHandler(false));
     RefPtr dataStore = m_process->websiteDataStore();
     if (!dataStore) {
         completionHandler(false);
@@ -101,6 +107,8 @@ void WebLockRegistryProxy::abortLockRequest(WebCore::ClientOrigin&& clientOrigin
 
 void WebLockRegistryProxy::snapshot(WebCore::ClientOrigin&& clientOrigin, CompletionHandler<void(WebCore::WebLockManagerSnapshot&&)>&& completionHandler)
 {
+    MESSAGE_CHECK_COMPLETION(m_process->hasCommittedClientOrigin(clientOrigin), completionHandler(WebCore::WebLockManagerSnapshot { }));
+
     RefPtr dataStore = m_process->websiteDataStore();
     if (!dataStore) {
         completionHandler(WebCore::WebLockManagerSnapshot { });
@@ -113,6 +121,7 @@ void WebLockRegistryProxy::snapshot(WebCore::ClientOrigin&& clientOrigin, Comple
 void WebLockRegistryProxy::clientIsGoingAway(WebCore::ClientOrigin&& clientOrigin, WebCore::ScriptExecutionContextIdentifier clientID)
 {
     MESSAGE_CHECK(clientID.processIdentifier() == m_process->coreProcessIdentifier());
+    MESSAGE_CHECK(m_process->hasCommittedClientOrigin(clientOrigin));
     if (RefPtr dataStore = WebsiteDataStore::existingDataStoreForSessionID(m_process->sessionID()))
         dataStore->webLockRegistry().clientIsGoingAway(m_process->sessionID(), WTF::move(clientOrigin), clientID);
 }

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -931,6 +931,20 @@ void WebProcessProxy::removePagePendingClose(WebPageProxyIdentifier pageID)
     m_pagesPendingClose.remove(pageID);
 }
 
+bool WebProcessProxy::hasCommittedClientOrigin(const WebCore::ClientOrigin& clientOrigin) const
+{
+    if (isRunningWorkers()) {
+        ASSERT(m_site);
+        return Site { clientOrigin.topOrigin } == *m_site && Site { clientOrigin.clientOrigin } == *m_site;
+    }
+    return m_committedClientOrigins.contains(clientOrigin);
+}
+
+void WebProcessProxy::didCommitLoadClientOrigin(WebCore::ClientOrigin&& clientOrigin)
+{
+    m_committedClientOrigins.add(WTF::move(clientOrigin));
+}
+
 void WebProcessProxy::addVisitedLinkStoreUser(VisitedLinkStore& visitedLinkStore, WebPageProxyIdentifier pageID)
 {
     auto& users = m_visitedLinkStoresWithUsers.ensure(visitedLinkStore, [] {

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -305,6 +305,7 @@ Ref<WebProcessProxy> WebProcessProxy::create(WebProcessPool& processPool, Websit
 Ref<WebProcessProxy> WebProcessProxy::createForRemoteWorkers(RemoteWorkerType workerType, WebProcessPool& processPool, Site&& site, WebsiteDataStore& websiteDataStore, LockdownMode lockdownMode, EnhancedSecurity enhancedSecurity)
 {
     Ref proxy = adoptRef(*new WebProcessProxy(processPool, &websiteDataStore, IsPrewarmed::No, CrossOriginMode::Shared, lockdownMode, enhancedSecurity));
+    proxy->m_committedSites.add(site);
     proxy->m_site = WTF::move(site);
     proxy->enableRemoteWorkers(workerType, processPool.userContentControllerForRemoteWorkers());
     proxy->connect();
@@ -934,7 +935,8 @@ void WebProcessProxy::removePagePendingClose(WebPageProxyIdentifier pageID)
 bool WebProcessProxy::hasCommittedClientOrigin(const WebCore::ClientOrigin& clientOrigin) const
 {
     if (isRunningWorkers()) {
-        ASSERT(m_site);
+        if (!m_site)
+            return m_committedSites.contains(Site { clientOrigin.topOrigin }) && m_committedSites.contains(Site { clientOrigin.clientOrigin });
         return Site { clientOrigin.topOrigin } == *m_site && Site { clientOrigin.clientOrigin } == *m_site;
     }
     return m_committedClientOrigins.contains(clientOrigin);
@@ -2306,6 +2308,7 @@ void WebProcessProxy::didStartProvisionalLoadForMainFrame(const URL& url)
         ASSERT((m_site && *m_site == site) || m_site.error() == SiteState::SharedProcess);
     else {
         // Associate the process with this site.
+        m_committedSites.add(site);
         m_site = WTF::move(site);
     }
 }
@@ -2319,6 +2322,7 @@ void WebProcessProxy::didStartUsingProcessForSiteIsolation(const std::optional<W
         return;
     }
     ASSERT(m_site ? (m_site.value().isEmpty() || m_site.value() == *site) : (m_site.error() == SiteState::NotYetSpecified || m_site.error() == SiteState::MultipleSites));
+    m_committedSites.add(*site);
     m_site = *site;
 }
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -310,6 +310,9 @@ public:
 
     void didCreateWebPageInProcess(WebCore::PageIdentifier);
 
+    bool hasCommittedClientOrigin(const WebCore::ClientOrigin&) const;
+    void didCommitLoadClientOrigin(WebCore::ClientOrigin&&);
+
     void addVisitedLinkStoreUser(VisitedLinkStore&, WebPageProxyIdentifier);
     void removeVisitedLinkStoreUser(VisitedLinkStore&, WebPageProxyIdentifier);
 
@@ -803,6 +806,8 @@ private:
     HashSet<WebPageProxyIdentifier> m_pagesPendingClose;
     UserInitiatedActionMap m_userInitiatedActionMap;
     HashMap<WebCore::PageIdentifier, UserInitiatedActionByAuthorizationTokenMap> m_userInitiatedActionByAuthorizationTokenMap;
+
+    HashSet<WebCore::ClientOrigin> m_committedClientOrigins; // Only grows because WebProcess can navigate back to an old origin in a history item.
 
     WeakHashMap<VisitedLinkStore, HashSet<WebPageProxyIdentifier>> m_visitedLinkStoresWithUsers;
 

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -827,6 +827,7 @@ private:
     HashMap<String, uint64_t> m_pageURLRetainCountMap;
 
     Expected<WebCore::Site, SiteState> m_site { Unexpected<SiteState> { SiteState::NotYetSpecified } };
+    HashSet<WebCore::Site> m_committedSites;
     std::optional<WebCore::Site> m_sharedProcessMainFrameSite;
     HashSet<WebCore::RegistrableDomain> m_sharedProcessDomains;
     bool m_isInProcessCache { false };

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebLocks.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WebLocks.mm
@@ -34,8 +34,20 @@
 #import <WebKit/WKWebViewConfigurationPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>
 #import <WebKit/_WKFeature.h>
+#import <WebKit/_WKProcessPoolConfiguration.h>
+#import <wtf/text/MakeString.h>
 
 namespace TestWebKitAPI {
+
+static void enableWebLocksAPI(WKWebViewConfiguration *configuration)
+{
+    for (_WKFeature *feature in [WKPreferences _features]) {
+        if ([feature.key isEqualToString:@"WebLocksAPIEnabled"]) {
+            [[configuration preferences] _setEnabled:YES forFeature:feature];
+            return;
+        }
+    }
+}
 
 enum class ShouldUseSameProcess : bool { No, Yes };
 
@@ -46,12 +58,7 @@ static void runSnapshotAcrossPagesTest(ShouldUseSameProcess shouldUseSameProcess
     });
 
     auto configuration1 = adoptNS([[WKWebViewConfiguration alloc] init]);
-    for (_WKFeature *feature in [WKPreferences _features]) {
-        if ([feature.key isEqualToString:@"WebLocksAPIEnabled"]) {
-            [[configuration1 preferences] _setEnabled:YES forFeature:feature];
-            break;
-        }
-    }
+    enableWebLocksAPI(configuration1.get());
 
     auto webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration1.get()]);
     [webView1 synchronouslyLoadRequest:server.request()];
@@ -71,12 +78,7 @@ static void runSnapshotAcrossPagesTest(ShouldUseSameProcess shouldUseSameProcess
 
     auto configuration2 = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration2.get().processPool = [configuration1 processPool];
-    for (_WKFeature *feature in [WKPreferences _features]) {
-        if ([feature.key isEqualToString:@"WebLocksAPIEnabled"]) {
-            [[configuration2 preferences] _setEnabled:YES forFeature:feature];
-            break;
-        }
-    }
+    enableWebLocksAPI(configuration2.get());
     if (shouldUseSameProcess == ShouldUseSameProcess::Yes) {
         ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         configuration2.get()._relatedWebView = webView1.get();
@@ -142,12 +144,7 @@ static void runLockRequestWaitingOnAnotherPage(ShouldUseSameProcess shouldUseSam
     });
 
     auto configuration1 = adoptNS([[WKWebViewConfiguration alloc] init]);
-    for (_WKFeature *feature in [WKPreferences _features]) {
-        if ([feature.key isEqualToString:@"WebLocksAPIEnabled"]) {
-            [[configuration1 preferences] _setEnabled:YES forFeature:feature];
-            break;
-        }
-    }
+    enableWebLocksAPI(configuration1.get());
 
     auto webView1 = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration1.get()]);
     [webView1 synchronouslyLoadRequest:server.request()];
@@ -167,12 +164,7 @@ static void runLockRequestWaitingOnAnotherPage(ShouldUseSameProcess shouldUseSam
 
     auto configuration2 = adoptNS([[WKWebViewConfiguration alloc] init]);
     configuration2.get().processPool = [configuration1 processPool];
-    for (_WKFeature *feature in [WKPreferences _features]) {
-        if ([feature.key isEqualToString:@"WebLocksAPIEnabled"]) {
-            [[configuration2 preferences] _setEnabled:YES forFeature:feature];
-            break;
-        }
-    }
+    enableWebLocksAPI(configuration2.get());
     if (shouldUseSameProcess == ShouldUseSameProcess::Yes) {
         ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         configuration2.get()._relatedWebView = webView1.get();
@@ -242,6 +234,45 @@ TEST(WebLocks, LockRequestWaitingOnAnotherPageInOtherProcess)
 TEST(WebLocks, LockRequestWaitingOnAnotherPageInSameProcess)
 {
     runLockRequestWaitingOnAnotherPage(ShouldUseSameProcess::Yes);
+}
+
+TEST(WebLocks, ServiceWorkerLockRequestAfterCrossSiteNavigationInSameProcess)
+{
+    TestWebKitAPI::HTTPServer server1({ }, TestWebKitAPI::HTTPServer::Protocol::Http);
+    TestWebKitAPI::HTTPServer server2({ }, TestWebKitAPI::HTTPServer::Protocol::Http);
+
+    auto swScript = "self.addEventListener('message', event => { event.waitUntil(new Promise(() => {})); event.source.postMessage('processing'); function loop() { navigator.locks.request('sw-lock', () => {}).then(loop); } loop(); });"_s;
+    auto page2HTML = "<script>webkit.messageHandlers.testHandler.postMessage('LOADED');</script>"_s;
+    auto page1HTML = makeString(
+        "<script>"
+        "navigator.serviceWorker.register('/sw.js').then(() => navigator.serviceWorker.ready).then(reg => {"
+        "    navigator.serviceWorker.onmessage = () => { window.location = 'http://localhost:"_s, server2.port(), "/'; };"
+        "    reg.active.postMessage('start');"
+        "});"
+        "</script>"_s);
+
+    server1.addResponse("/sw.js"_s, { { { "Content-Type"_s, "text/javascript"_s } }, swScript });
+    server1.addResponse("/"_s, { page1HTML });
+    server2.addResponse("/"_s, { page2HTML });
+
+    auto processPoolConfiguration = adoptNS([[_WKProcessPoolConfiguration alloc] init]);
+    processPoolConfiguration.get().processSwapsOnNavigation = NO;
+    auto processPool = adoptNS([[WKProcessPool alloc] _initWithConfiguration:processPoolConfiguration.get()]);
+
+    auto configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    configuration.get().processPool = processPool.get();
+    enableWebLocksAPI(configuration.get());
+
+    auto webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+
+    __block bool done = false;
+    [webView performAfterReceivingAnyMessage:^(NSString *message) {
+        EXPECT_WK_STREQ(message, @"LOADED");
+        done = true;
+    }];
+
+    [webView synchronouslyLoadRequest:server1.request()];
+    TestWebKitAPI::Util::run(&done);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 7adb7d379d57a791e4f1ebd33691590053b432b7
<pre>
Cherry-pick 90e48031ed4d. <a href="https://bugs.webkit.org/show_bug.cgi?id=312938">https://bugs.webkit.org/show_bug.cgi?id=312938</a>

    REGRESSION(305413.674@safari-7624-branch): Crash in StreamPipeToState::globalObject
    <a href="https://bugs.webkit.org/show_bug.cgi?id=312938">https://bugs.webkit.org/show_bug.cgi?id=312938</a>
    <a href="https://rdar.apple.com/175084445">rdar://175084445</a>

    Reviewed by Chris Dumez.

    The crash was caused by StreamPipeToState::globalObject calling jsDynamicCast&lt;JSDOMGlobalObject*&gt;
    on context-&gt;globalObject() without a nullptr check. Fixed the crash by adding a nullptr check.

    The newly written test revealed a related bug that we were calling DOMPromise::status even when
    active DOM objects had been stopped. Added a bunch of early returns to functions in
    InternalReadableStreamDefaultReader and InternalWritableStreamWriter to avoid debug assertions
    in these cases, one of which is hit by the new test.

    Test: streams/pipeTo-removed-iframe-crash.html

    * LayoutTests/streams/pipeTo-removed-iframe-crash-expected.txt: Added.
    * LayoutTests/streams/pipeTo-removed-iframe-crash.html: Added.
    * Source/WebCore/Modules/streams/StreamPipeToUtilities.cpp:
    (WebCore::StreamPipeToState::globalObject):
    * Source/WebCore/bindings/js/InternalReadableStreamDefaultReader.cpp:
    (WebCore::InternalReadableStreamDefaultReader::onClosedPromiseRejection):
    (WebCore::InternalReadableStreamDefaultReader::onClosedPromiseResolution):
    * Source/WebCore/bindings/js/InternalWritableStreamWriter.cpp:
    (WebCore::InternalWritableStreamWriter::onClosedPromiseRejection):
    (WebCore::InternalWritableStreamWriter::onClosedPromiseResolution):
    (WebCore::InternalWritableStreamWriter::whenReady):

    Identifier: 305413.711@safari-7624-branch

    Canonical link: <a href="https://commits.webkit.org/305413.684@safari-7624.2.5.10-branch">https://commits.webkit.org/305413.684@safari-7624.2.5.10-branch</a>

Canonical link: <a href="https://commits.webkit.org/305877.634@webkitglib/2.52">https://commits.webkit.org/305877.634@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 302c510deea66ab78470c5bb52e777b99221b4e7
<pre>
Cherry-pick 09af279a99da. <a href="https://bugs.webkit.org/show_bug.cgi?id=312314">https://bugs.webkit.org/show_bug.cgi?id=312314</a>

    [JSC] Remove unneeded m_tasks append in DeferredWorkTimer::cancelPendingWorkSafe
    <a href="https://bugs.webkit.org/show_bug.cgi?id=312314">https://bugs.webkit.org/show_bug.cgi?id=312314</a>
    <a href="https://rdar.apple.com/174738881">rdar://174738881</a>

    Reviewed by Keith Miller.

    cancelPendingWorkSafe() was unconditionally appending a (ticket, noop) entry to
    m_tasks for every weak ticket of a dying global. This is unnecessary because
    doWork() already has a removeIf(isCancelled) pass at the end that purges cancelled
    tickets from m_pendingTickets without needing a m_tasks entry, and
    setTimeUntilFire(0_s) already ensures doWork() fires to run that cleanup.

    Test: JSTests/wasm/stress/deferred-work-timer-cancel-duplicate-ticket.js
    Identifier: 305413.677@safari-7624-branch

    Canonical link: <a href="https://commits.webkit.org/305413.676@safari-7624.2.5.10-branch">https://commits.webkit.org/305413.676@safari-7624.2.5.10-branch</a>

Canonical link: <a href="https://commits.webkit.org/305877.633@webkitglib/2.52">https://commits.webkit.org/305877.633@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### ecf7025919fc53ef635995040b033cb2d5ca72db
<pre>
Cherry-pick 4fcd36e3a363. <a href="https://bugs.webkit.org/show_bug.cgi?id=312335">https://bugs.webkit.org/show_bug.cgi?id=312335</a>

    REGRESSION(305413.548@safari-7624-branch): Crash in WebProcessProxy::hasCommittedClientOrigin
    <a href="https://bugs.webkit.org/show_bug.cgi?id=312335">https://bugs.webkit.org/show_bug.cgi?id=312335</a>
    <a href="https://rdar.apple.com/174679141">rdar://174679141</a>

    Reviewed by Chris Dumez.

    WebProcessProxy::hasCommittedClientOrigin has a code path for processes running workers (isRunningWorkers())
    that dereferences m_site as in *m_site. m_site is a WTF::Expected&lt;WebCore::Site, SiteState&gt; — when it holds
    the error value SiteState::MultipleSites, operator*() accesses the non-existent value member, throwing
    std::bad_variant_access. This propagates uncaught to the Objective-C run loop boundary, triggering std::terminate().

    The three conditions that must hold simultaneously for this crash to occur:
      1. isRunningWorkers() is true — a service worker is running inside a web content process (not a dedicated worker
         process), so m_serviceWorkerInformation is set.
      2. m_site holds MultipleSites — a cross-site navigation occurred in that same web content process (no process swap),
         so didStartProvisionalLoadForMainFrame set m_site = makeUnexpected(SiteState::MultipleSites).
      3. A RequestLock IPC from the service worker arrives after condition 2 — the service worker&apos;s termination is
         deferred (terminateRemoteWorkerContextConnectionWhenPossible instead of the old disableRemoteWorkers), so
         isRunningWorkers() remains true during a window where the worker can still send IPCs.

    Fixed the bug by adding a HashSet&lt;WebCore::Site&gt; m_committedSites to WebProcessProxy, populated whenever m_site is
    assigned a valid Site (in createForRemoteWorkers, didStartProvisionalLoadForMainFrame, and
    didStartUsingProcessForSiteIsolation). In hasCommittedClientOrigin, when isRunningWorkers() is true but m_site does
    not holds a value (it&apos;s MultipleSites), the check falls back to m_committedSites instead of dereferencing m_site
    in an error state. This correctly validates the worker&apos;s origin against the sites the process has legitimately
    committed — rather than crashing or incorrectly rejecting a legitimate lock request and killing the web process.

    Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/WebLocks.mm

    * Source/WebKit/UIProcess/WebProcessProxy.cpp:
    (WebKit::WebProcessProxy::createForRemoteWorkers):
    (WebKit::WebProcessProxy::hasCommittedClientOrigin const):
    (WebKit::WebProcessProxy::didStartProvisionalLoadForMainFrame):
    (WebKit::WebProcessProxy::didStartUsingProcessForSiteIsolation):
    * Source/WebKit/UIProcess/WebProcessProxy.h:
    * Tools/TestWebKitAPI/Tests/WebKitCocoa/WebLocks.mm:
    (TestWebKitAPI::enableWebLocksAPI):
    (TestWebKitAPI::runSnapshotAcrossPagesTest):
    (TestWebKitAPI::runLockRequestWaitingOnAnotherPage):
    (TestWebKitAPI::TEST(WebLocks, ServiceWorkerLockRequestAfterCrossSiteNavigationInSameProcess)):

    Identifier: 305413.672@safari-7624-branch

    Canonical link: <a href="https://commits.webkit.org/305413.672@safari-7624.2.5.10-branch">https://commits.webkit.org/305413.672@safari-7624.2.5.10-branch</a>

Canonical link: <a href="https://commits.webkit.org/305877.632@webkitglib/2.52">https://commits.webkit.org/305877.632@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### dce97f6125c4aa90d67224344cc3d048c040f130
<pre>
Cherry-pick 305413.548@safari-7624-branch (e509924cdce7). <a href="https://bugs.webkit.org/show_bug.cgi?id=310289">https://bugs.webkit.org/show_bug.cgi?id=310289</a>

    WebLockRegistryProxy should validate its message
    <a href="https://bugs.webkit.org/show_bug.cgi?id=310289">https://bugs.webkit.org/show_bug.cgi?id=310289</a>
    <a href="https://rdar.apple.com/172389530">rdar://172389530</a>

    Reviewed by Brady Eidson and Chris Dumez.

    Check the authenticity of origins given to WebLockRegistryProxy::requestLock by
    keeping track of every ClientOrigin that got committed in WebFrameProxy.

    Test: http/tests/web-locks/web-lock-in-blob-url.html
          http/tests/web-locks/web-lock-in-data-url.html
          http/tests/web-locks/web-lock-in-opaque-srcdoc.html
          http/tests/web-locks/web-lock-in-serviceworker.html
          http/tests/web-locks/web-lock-in-sharedworker.html
          http/tests/web-locks/web-lock-in-srcdoc.html
          ipc/weblock-registry-origin.html

    * LayoutTests/http/tests/web-locks/resources/shared-worker.js: Added.
    (self.onconnect):
    * LayoutTests/http/tests/web-locks/web-lock-in-blob-url-expected.txt: Added.
    * LayoutTests/http/tests/web-locks/web-lock-in-blob-url.html: Added.
    * LayoutTests/http/tests/web-locks/web-lock-in-data-url-expected.txt: Added.
    * LayoutTests/http/tests/web-locks/web-lock-in-data-url.html: Added.
    * LayoutTests/http/tests/web-locks/web-lock-in-opaque-srcdoc-expected.txt: Added.
    * LayoutTests/http/tests/web-locks/web-lock-in-opaque-srcdoc.html: Added.
    * LayoutTests/http/tests/web-locks/web-lock-in-serviceworker-expected.txt: Added.
    * LayoutTests/http/tests/web-locks/web-lock-in-serviceworker-service-worker.js: Added.
    (event.event.request.url.indexOf):
    * LayoutTests/http/tests/web-locks/web-lock-in-serviceworker.html: Added.
    * LayoutTests/http/tests/web-locks/web-lock-in-sharedworker-expected.txt: Added.
    * LayoutTests/http/tests/web-locks/web-lock-in-sharedworker.html: Added.
    * LayoutTests/http/tests/web-locks/web-lock-in-srcdoc-expected.txt: Added.
    * LayoutTests/http/tests/web-locks/web-lock-in-srcdoc.html: Added.
    * LayoutTests/ipc/weblock-registry-origin-expected.txt: Added.
    * LayoutTests/ipc/weblock-registry-origin.html: Added.
    * Source/WebKit/UIProcess/WebFrameProxy.cpp:
    (WebKit::WebFrameProxy::didCommitLoad):
    * Source/WebKit/UIProcess/WebLockRegistryProxy.cpp:
    (WebKit::WebLockRegistryProxy::requestLock):
    (WebKit::WebLockRegistryProxy::releaseLock):
    (WebKit::WebLockRegistryProxy::abortLockRequest):
    (WebKit::WebLockRegistryProxy::snapshot):
    (WebKit::WebLockRegistryProxy::clientIsGoingAway):
    * Source/WebKit/UIProcess/WebProcessProxy.cpp:
    (WebKit::WebProcessProxy::hasCommittedClientOrigin const):
    (WebKit::WebProcessProxy::didCommitLoadClientOrigin):
    * Source/WebKit/UIProcess/WebProcessProxy.h:

    Identifier: 305413.548@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.631@webkitglib/2.52">https://commits.webkit.org/305877.631@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 18856f29747eef91a29f2220f59439cb359753f0
<pre>
Cherry-pick 73c288dd8c72. <a href="https://bugs.webkit.org/show_bug.cgi?id=312288">https://bugs.webkit.org/show_bug.cgi?id=312288</a>

    [JSC] BBQJIT tail call shuffle should detect overlapping stack slots
    <a href="https://bugs.webkit.org/show_bug.cgi?id=312288">https://bugs.webkit.org/show_bug.cgi?id=312288</a>
    <a href="https://rdar.apple.com/174490087">rdar://174490087</a>

    Reviewed by Dan Hecht.

    Because in a tail call the caller and the callee frames overlap, BBQJIT::emitTailCall()
    uses emitShuffle() to orchestrate the copying of call arguments into their destination
    locations in such a way that if a caller temp resides in the callee argument space and is
    itself passed as an argument, it is not clobbered before it&apos;s been moved to its final
    location.

    The move hazard detection in emitShuffleMove() compares stack locations by offset only
    (via Location::operator==). The core assumption here is that source and destination values
    with different base addresses never overlap, so a write to a destination address A never
    clobbers a source value at address B.

    This assumption does not always hold. Caller temps (source values) are always 16-byte
    aligned regardless of value type. Callee arguments (destination values) are packed
    contiguously. If an i64 argument at address B is followed by a v128 argument, the v128
    argument occupies the address range [B+8, B+24). This range overlaps two temp slots with
    ranges [B, B+16) and [B+16, B+32). Because hazard detection currently only considers the
    base address, this overlap will go unnoticed and the shuffle may write the v128 argument
    before the values in the overlapping source slots have been moved.

    This patch adds Location::overlaps() method which considers actual ranges for Stack and
    StackArgument locations. The method replaces Location::operator==() for hazard detection.

    The new method is also used in destination uniqueness assertion in emitShuffle.

    Test: JSTests/wasm/stress/tail-call-v128-ref-stack-overlap.js
    Identifier: 305413.670@safari-7624-branch

    Canonical link: <a href="https://commits.webkit.org/305413.671@safari-7624.2.5.10-branch">https://commits.webkit.org/305413.671@safari-7624.2.5.10-branch</a>

Canonical link: <a href="https://commits.webkit.org/305877.630@webkitglib/2.52">https://commits.webkit.org/305877.630@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 3558568ec9c0c54a64583a4cc0f9f97b31be5c60
<pre>
Cherry-pick 68274fa2f297. <a href="https://bugs.webkit.org/show_bug.cgi?id=312218">https://bugs.webkit.org/show_bug.cgi?id=312218</a>

    [JSC] Move DataView null vector check in IC outside of register save/restore
    <a href="https://bugs.webkit.org/show_bug.cgi?id=312218">https://bugs.webkit.org/show_bug.cgi?id=312218</a>
    <a href="https://rdar.apple.com/174627873">rdar://174627873</a>

    Reviewed by Marcus Plutowski.

    In the DataView byteLength getter IC, there is a null vector check which
    executes before a preserveReusedRegistersByPushing, but jumps to a point before
    restoreReusedRegistersByPopping. In other words, causing a misbalanced push and
    pop of register state.

    This PR fixes by making the null vector check jump to after the popping of
    saved registers.

    Test: JSTests/stress/dataview-bytelength-ic-stub-stack-desync.js
    * JSTests/stress/dataview-bytelength-ic-stub-stack-desync.js: Added.
    (hot):
    * Source/JavaScriptCore/bytecode/InlineCacheCompiler.cpp:
    (JSC::InlineCacheCompiler::emitIntrinsicGetter):

    Identifier: 305413.668@safari-7624-branch

    Canonical link: <a href="https://commits.webkit.org/305413.669@safari-7624.2.5.10-branch">https://commits.webkit.org/305413.669@safari-7624.2.5.10-branch</a>

Canonical link: <a href="https://commits.webkit.org/305877.629@webkitglib/2.52">https://commits.webkit.org/305877.629@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 164dfa85049b32b11acdf16b5fb8c5d6db3eccfe
<pre>
Cherry-pick 305413.657@safari-7624-branch (882fc55c5e17). <a href="https://bugs.webkit.org/show_bug.cgi?id=311663">https://bugs.webkit.org/show_bug.cgi?id=311663</a>

    [JSC] ToBoolean/TypeOfIsUndefined/TypeOfIsFunction/TypeOf/CompareEq def value in DFGClobberize doesn&apos;t depend on node&apos;s origin.semantic
    <a href="https://bugs.webkit.org/show_bug.cgi?id=311663">https://bugs.webkit.org/show_bug.cgi?id=311663</a>
    <a href="https://rdar.apple.com/173924142">rdar://173924142</a>

    Reviewed by Marcus Plutowski.

    The semantics of operations like `typeof` are realm-dependent when the input has the
    `MasqueradesAsUndefined` flag set. This patch prevents constant folding of these
    expressions if they have different realms to preserve the semantics.

    Added regress-173924142.js to ensure that the operations behave as expected even across realms.

    * JSTests/stress/regress-173924142.js: Added.
    (assert):
    (otherGlobal.eval.returnMultipleValues):
    (returnMultipleValues):
    (i.returnMultipleValues):
    (otherGlobalMasqueraderAfter.const.property.of.Object.getOwnPropertyNames):
    * Source/JavaScriptCore/dfg/DFGClobberize.h:
    (JSC::DFG::clobberize):

    Identifier: 305413.657@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.628@webkitglib/2.52">https://commits.webkit.org/305877.628@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 628f1ee208cef2b8173aa83f7a01a76a683db2dd
<pre>
Cherry-pick 305413.642@safari-7624-branch (b2284d1674da). <a href="https://bugs.webkit.org/show_bug.cgi?id=311976">https://bugs.webkit.org/show_bug.cgi?id=311976</a>

    [JSC] StringAt should respect arrayMode in CSE
    <a href="https://bugs.webkit.org/show_bug.cgi?id=311976">https://bugs.webkit.org/show_bug.cgi?id=311976</a>
    <a href="https://rdar.apple.com/174422482">rdar://174422482</a>

    Reviewed by Yusuke Suzuki.

    String.prototype.at returns a string when the index is in-bounds and undefined
    when the index is out-of-bounds. Since these are different types, StringAts
    with different arrayModes should not be CSE&apos;d.

    Test: JSTests/stress/string-at-cse-array-mode.js
    * JSTests/stress/string-at-cse-array-mode.js: Added.
    (opt):
    * Source/JavaScriptCore/dfg/DFGClobberize.h:
    (JSC::DFG::clobberize):

    Identifier: 305413.642@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.627@webkitglib/2.52">https://commits.webkit.org/305877.627@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### fb51e57e31d1e3f31bd9c2ca855601d2bf20c1a4
<pre>
Cherry-pick 305413.641@safari-7624-branch (899331a21899). <a href="https://bugs.webkit.org/show_bug.cgi?id=311883">https://bugs.webkit.org/show_bug.cgi?id=311883</a>

    [JSC] Array rematerialization should know how to have a bad time
    <a href="https://bugs.webkit.org/show_bug.cgi?id=311883">https://bugs.webkit.org/show_bug.cgi?id=311883</a>
    <a href="https://rdar.apple.com/174420676">rdar://174420676</a>

    Reviewed by Keith Miller.

    Sunk Arrays that are rematerialized with a butterfly are always rematerialized
    with a contiguous butterfly. If, in the meantime, the VM had a bad time and
    moved all Array structures to SlowPutArrayStorage, rematerialization can end up
    treating remterialized Arrays, which are now ArrayStorage, as if they had
    contiguous butterflies.

    This PR fixes that by always rematerializing with the contiguous butterfly, but
    switching to SlowPutArrayStorage after the fact if the VM is having a bad time.

    Test: JSTests/stress/ftl-osr-exit-phantom-new-array-with-butterfly-having-a-bad-time.js

    * JSTests/stress/ftl-osr-exit-phantom-new-array-with-butterfly-having-a-bad-time.js: Added.
    (cb):
    (collect):
    (opt):
    * Source/JavaScriptCore/ftl/FTLOperations.cpp:
    (JSC::FTL::JSC_DEFINE_NOEXCEPT_JIT_OPERATION):

    Identifier: 305413.641@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.626@webkitglib/2.52">https://commits.webkit.org/305877.626@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 5fda2837c10197f7b721bf628e3136cbb2c8ea06
<pre>
Cherry-pick 305413.632@safari-7624-branch (0c74ffa4edbc). <a href="https://bugs.webkit.org/show_bug.cgi?id=311261">https://bugs.webkit.org/show_bug.cgi?id=311261</a>

    Data race in Range::visitNodesConcurrently during GC, leading to a use-after-free of RangeBoundaryPoint container nodes
    <a href="https://bugs.webkit.org/show_bug.cgi?id=311261">https://bugs.webkit.org/show_bug.cgi?id=311261</a>
    <a href="https://rdar.apple.com/174214346">rdar://174214346</a>

    Unreviewed. Addressing the review comments in the original PR.

    * Source/WebCore/dom/Range.cpp:
    (WebCore::Range::setStart):
    (WebCore::Range::setEnd):
    (WebCore::boundaryNodeChildrenChanged):
    (WebCore::Range::nodeChildrenChanged):
    (WebCore::boundaryNodeChildrenWillBeRemoved):
    (WebCore::Range::nodeChildrenWillBeRemoved):
    (WebCore::boundaryNodeWillBeRemoved):
    (WebCore::Range::nodeWillBeRemoved):
    (WebCore::boundaryTextInserted):
    (WebCore::Range::textInserted):
    (WebCore::boundaryTextRemoved):
    (WebCore::Range::textRemoved):
    (WebCore::boundaryTextNodesMerged):
    (WebCore::Range::textNodesMerged):
    (WebCore::boundaryTextNodesSplit):
    (WebCore::Range::textNodeSplit):

    Identifier: 305413.632@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.625@webkitglib/2.52">https://commits.webkit.org/305877.625@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 0a44fc26b48db01d414f0aeaa4e9459274ca2700
<pre>
Cherry-pick 305413.625@safari-7624-branch (3b7488ef5bc6). <a href="https://bugs.webkit.org/show_bug.cgi?id=311234">https://bugs.webkit.org/show_bug.cgi?id=311234</a>

    [JSC] Data race in WaiterListManager::unregister
    <a href="https://bugs.webkit.org/show_bug.cgi?id=311234">https://bugs.webkit.org/show_bug.cgi?id=311234</a>
    <a href="https://rdar.apple.com/173161138">rdar://173161138</a>

    Reviewed by Yijia Huang.

    Stores a JSGlobalObject pointer in JSC::Waiter so that it doesn&apos;t
    have to be fetched from the target.

    Test: js/regress-311234.html

    * LayoutTests/js/regress-311234-expected.txt: Added.
    * LayoutTests/js/regress-311234.html: Added.
    * Source/JavaScriptCore/runtime/DeferredWorkTimer.h:
    * Source/JavaScriptCore/runtime/WaiterListManager.cpp:
    (JSC::Waiter::Waiter):
    (JSC::WaiterListManager::unregister):
    (JSC::Waiter::dump const):
    * Source/JavaScriptCore/runtime/WaiterListManager.h:

    Identifier: 305413.625@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.624@webkitglib/2.52">https://commits.webkit.org/305877.624@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 737fdb4546461effea038f3c25ddc0702935df09
<pre>
Cherry-pick 305413.623@safari-7624-branch (2c31f99593da). <a href="https://bugs.webkit.org/show_bug.cgi?id=311261">https://bugs.webkit.org/show_bug.cgi?id=311261</a>

    Data race in Range::visitNodesConcurrently during GC, leading to a use-after-free of RangeBoundaryPoint container nodes
    <a href="https://bugs.webkit.org/show_bug.cgi?id=311261">https://bugs.webkit.org/show_bug.cgi?id=311261</a>
    <a href="https://rdar.apple.com/173502014">rdar://173502014</a>

    Reviewed by Chris Dumez.

    Add a lock for mutating m_start and m_end.

    No new tests since there is no reliable way of testing this data race.

    * Source/WebCore/bindings/js/JSRangeCustom.cpp:
    (WebCore::JSRange::visitAdditionalChildren):
    * Source/WebCore/dom/Range.cpp:
    (WebCore::Range::setStart):
    (WebCore::Range::setEnd):
    (WebCore::Range::collapse):
    (WebCore::Range::selectNodeContents):
    (WebCore::Range::nodeChildrenChanged):
    (WebCore::Range::nodeChildrenWillBeRemoved):
    (WebCore::Range::nodeWillBeRemoved):
    (WebCore::Range::textInserted):
    (WebCore::Range::textRemoved):
    (WebCore::Range::textNodesMerged):
    (WebCore::Range::textNodeSplit):
    (WebCore::Range::visitNodesInGCThread const): Renamed from visitNodesConcurrently.
    * Source/WebCore/dom/Range.h:

    Identifier: 305413.623@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.623@webkitglib/2.52">https://commits.webkit.org/305877.623@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/30ab82ca25855be3df3a3095438005a6927b982e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163647 "1 style error") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/37131 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/30350 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172587 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/120138 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165516 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/37462 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/37130 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127119 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/120138 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166606 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/37462 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/30350 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107673 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/37462 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/37130 "The change is no longer eligible for processing.") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20290 "Unable to build WebKit without PR, please check manually (failure)") | 
| [  ~~🛠 🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/20/builds/155798 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/37462 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/30350 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175092 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/24538 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/28023 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/30350 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135421 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/36801 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/37130 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135404 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/37586 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/30350 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/99653 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24918 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/37586 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/30350 "The change is no longer eligible for processing.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/196049 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/36296 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/109442 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51114 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/35794 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/30350 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/36044 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/35941 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->