### PR TITLE
[Site Isolation] BindingSecurity::shouldAllowAccessToDOMWindow doesn't verify that RemoteDOMWindows are cross-origin before logging a remote access error

### DIFF
--- a/Source/WebCore/bindings/js/JSDOMBindingSecurity.cpp
+++ b/Source/WebCore/bindings/js/JSDOMBindingSecurity.cpp
@@ -32,6 +32,7 @@
 #include "LocalFrameInlines.h"
 #include "NodeDocument.h"
 #include "RemoteDOMWindow.h"
+#include "RemoteFrame.h"
 #include "SecurityOrigin.h"
 #include <JavaScriptCore/TopExceptionScope.h>
 #include <wtf/text/MakeString.h>
@@ -149,10 +150,24 @@ bool BindingSecurity::shouldAllowAccessToDOMWindow(JSC::JSGlobalObject* lexicalG
     return target && shouldAllowAccessToDOMWindow(lexicalGlobalObject, *target, reportingOption);
 }
 
+static bool isSameOriginRemoteWindowAccess(JSC::JSGlobalObject& lexicalGlobalObject, DOMWindow& window)
+{
+    RefPtr remoteWindow = dynamicDowncast<RemoteDOMWindow>(window);
+    if (!remoteWindow)
+        return false;
+    RefPtr remoteFrame = remoteWindow->frame();
+    if (!remoteFrame)
+        return false;
+    auto& active = activeDOMWindow(lexicalGlobalObject);
+    return protect(active.document()->securityOrigin())->isSameOriginDomain(remoteFrame->frameDocumentSecurityOriginOrOpaque());
+}
+
 bool BindingSecurity::shouldAllowAccessToDOMWindow(JSC::JSGlobalObject* lexicalGlobalObject, DOMWindow* window, SecurityReportingOption reportingOption)
 {
     auto* localWindow = dynamicDowncast<LocalDOMWindow>(window);
     if (window && !localWindow) {
+        if (isSameOriginRemoteWindowAccess(*lexicalGlobalObject, *window))
+            return true;
         reportErrorAccessingRemoteFrame(lexicalGlobalObject, *window, reportingOption);
         return false;
     }
@@ -163,6 +178,8 @@ bool BindingSecurity::shouldAllowAccessToDOMWindow(JSC::JSGlobalObject& lexicalG
 {
     auto* localWindow = dynamicDowncast<LocalDOMWindow>(window);
     if (window && !localWindow) {
+        if (isSameOriginRemoteWindowAccess(lexicalGlobalObject, *window))
+            return true;
         message = remoteFrameAccessError(&lexicalGlobalObject, *window);
         return false;
     }


### PR DESCRIPTION
#### 5925cb9bfe8d788a829e51ce2a3a438b605bf2e1
<pre>
[Site Isolation] BindingSecurity::shouldAllowAccessToDOMWindow doesn&apos;t verify that RemoteDOMWindows are cross-origin before logging a remote access error
<a href="https://bugs.webkit.org/show_bug.cgi?id=315205">https://bugs.webkit.org/show_bug.cgi?id=315205</a>
<a href="https://rdar.apple.com/177533830">rdar://177533830</a>

Reviewed by NOBODY (OOPS!).

When BindingSecurity::shouldAllowAccessToDOMWindow is checking access to a DOMWindow,
if the window is a RemoteDOMWindow it assumes that the window is indeed cross-origin.

While Remote DOMWindows are meant to represent cross-origin windows, this is an implementation
detail. For security checks and error messages, we need to verify that the origins are indeed cross-origin.

There are scenarios where a RemoteDOMWindow can temporarily exist with a same-origin
during the middle of a process swap.

After <a href="https://commits.webkit.org/313507@main">https://commits.webkit.org/313507@main</a>, remoteFrameAccessError was rerouted through
crossDomainAccessErrorMessage, which has an assertion that the origins are NOT
same-origin. remoteFrameAccessError didn&apos;t have this assertion so this issue never
came up previously.

        ASSERTION FAILED: !activeOrigin-&gt;isSameOriginDomain(targetOrigin)
        /Volumes/Data/worker/macOS-Tahoe-Debug-Build-EWS/build/Source/WebCore/page/DOMWindow.cpp(967) : String WebCore::DOMWindow::crossDomainAccessErrorMessage(const LocalDOMWindow &amp;, IncludeTargetOrigin)
        1   0x307845274 WebCore::DOMWindow::crossDomainAccessErrorMessage(WebCore::LocalDOMWindow const&amp;, WebCore::IncludeTargetOrigin)

This patch explictly checks if RemoteDOMWindows are same origin, and allows
access to the window BindingSecurity::shouldAllowAccessToDOMWindow.
This also avoids the assertion in the case of a same-origin RemoteWindow
by early returning before the call to reportErrorAccessingRemoteFrame.

This patch fixes the following tests which crash at this assert:
        http/tests/site-isolation/page-lifecycle/pagehide.html
        http/tests/site-isolation/page-lifecycle/pageswap.html
        http/tests/site-isolation/page-lifecycle/unload.html

No new tests (OOPS!).
* Source/WebCore/bindings/js/JSDOMBindingSecurity.cpp:
(WebCore::isSameOriginRemoteWindowAccess):
(WebCore::BindingSecurity::shouldAllowAccessToDOMWindow):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5925cb9bfe8d788a829e51ce2a3a438b605bf2e1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163557 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37041 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30260 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172497 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/120006 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165426 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37372 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37040 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127031 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89557 "layout-tests (failure)") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166516 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29305 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147040 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107585 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28354 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26985 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20200 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138252 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24759 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175002 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27933 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26422 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135335 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36711 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31087 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135317 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37496 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146554 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99549 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30624 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23406 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36206 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109352 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35704 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1432 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35954 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35851 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->