### PR TITLE
[threaded-animations] stuttery animation on bmwusa.com configurator page with 60Hz display

### DIFF
--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.h
@@ -65,7 +65,8 @@ public:
     void applyEffectsFromMainThread(PlatformLayer*, bool backdropRootIsOpaque) const;
 
     bool isDependentOnScrollingNodeWithID(WebCore::ScrollingNodeID) const;
-    bool isTimeDependent() const;
+    bool hasTimeBasedAnimations() const { return m_hasTimeBasedAnimations; }
+    bool hasProgressBasedAnimations() const { return m_hasProgressBasedAnimations; }
 
     void clear(PlatformLayer*);
 
@@ -98,6 +99,9 @@ private:
     RetainPtr<CAPresentationModifier> m_transformPresentationModifier;
     Vector<WebCore::TypedFilterPresentationModifier> m_filterPresentationModifiers;
 #endif
+
+    bool m_hasProgressBasedAnimations { false };
+    bool m_hasTimeBasedAnimations { false };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.mm
@@ -56,7 +56,9 @@ RemoteAnimationStack::RemoteAnimationStack(RemoteAnimations&& animations, WebCor
         affectsFilter = affectsFilter || properties.containsAny({ WebCore::AcceleratedEffectProperty::Filter, WebCore::AcceleratedEffectProperty::BackdropFilter });
         affectsOpacity = affectsOpacity || properties.contains(WebCore::AcceleratedEffectProperty::Opacity);
         affectsTransform = affectsTransform || properties.containsAny(WebCore::transformRelatedAcceleratedProperties);
-        if (affectsFilter && affectsOpacity && affectsTransform)
+        m_hasProgressBasedAnimations = m_hasProgressBasedAnimations || animation->timeline().isProgressBased();
+        m_hasTimeBasedAnimations = m_hasTimeBasedAnimations || animation->timeline().isMonotonic();
+        if (affectsFilter && affectsOpacity && affectsTransform && m_hasProgressBasedAnimations && m_hasTimeBasedAnimations)
             break;
     }
 
@@ -247,13 +249,6 @@ bool RemoteAnimationStack::isDependentOnScrollingNodeWithID(WebCore::ScrollingNo
     return m_animations.containsIf([scrollingNodeID](auto& animation) {
         RefPtr progressBasedTimeline = dynamicDowncast<RemoteProgressBasedTimeline>(animation->timeline());
         return progressBasedTimeline && progressBasedTimeline->source() == scrollingNodeID;
-    });
-}
-
-bool RemoteAnimationStack::isTimeDependent() const
-{
-    return m_animations.containsIf([](auto& animation) {
-        return animation->timeline().isMonotonic();
     });
 }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm
@@ -835,7 +835,7 @@ void RemoteScrollingCoordinatorProxyIOS::updateTimeDependentAnimationStacks()
     m_monotonicTimelineRegistry->advanceCurrentTime(MonotonicTime::now());
 
     updateAnimationStacks([](auto& animationStack) {
-        return animationStack.isTimeDependent();
+        return animationStack.hasTimeBasedAnimations();
     });
 }
 

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h
@@ -114,7 +114,6 @@ public:
     void animationsWereRemovedFromNode(RemoteLayerTreeNode&);
     void updateTimelinesRegistration(WebCore::ProcessIdentifier, const WebCore::AcceleratedTimelinesUpdate&, MonotonicTime);
     RefPtr<const RemoteAnimationTimeline> timeline(const TimelineID&);
-    void updateAnimations();
     RefPtr<const RemoteAnimationStack> animationStackForNodeWithIDForTesting(WebCore::PlatformLayerIdentifier) const;
     HashSet<Ref<RemoteProgressBasedTimeline>> timelinesForScrollingNodeIDForTesting(WebCore::ScrollingNodeID);
 #endif
@@ -161,6 +160,10 @@ private:
     void didStartRubberbanding();
 
     void updateLayerPositionsAndAnimations();
+#if ENABLE(THREADED_ANIMATIONS)
+    enum class AnimationStacksToUpdate : bool { All, ProgressBasedOnly };
+    void updateAnimations(AnimationStacksToUpdate = AnimationStacksToUpdate::All);
+#endif
 
 #if ENABLE(MOMENTUM_EVENT_DISPATCHER)
     void handleSyntheticWheelEvent(WebCore::PageIdentifier, const WebWheelEvent&, WebCore::RectEdges<WebCore::RubberBandingBehavior> rubberBandableEdges);

--- a/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm
@@ -644,7 +644,10 @@ void RemoteLayerTreeEventDispatcher::renderingUpdateComplete()
     ASSERT(isMainRunLoop());
 
 #if ENABLE(THREADED_ANIMATIONS)
-    updateAnimations();
+    // We only want to update scroll-driven animations in this situation
+    // as time-based animations will always be udpated from the scrolling
+    // following a call to didRefreshDisplay().
+    updateAnimations(AnimationStacksToUpdate::ProgressBasedOnly);
 #endif
 
     Locker locker { m_scrollingTreeLock };
@@ -712,7 +715,7 @@ RefPtr<const RemoteAnimationTimeline> RemoteLayerTreeEventDispatcher::timeline(c
     return nullptr;
 }
 
-void RemoteLayerTreeEventDispatcher::updateAnimations()
+void RemoteLayerTreeEventDispatcher::updateAnimations(AnimationStacksToUpdate animationStacksToUpdate)
 {
     ASSERT(isMainRunLoop() || ScrollingThread::isCurrentThread());
     Locker lock { m_animationLock };
@@ -720,13 +723,14 @@ void RemoteLayerTreeEventDispatcher::updateAnimations()
     // FIXME: Rather than using 'now' at the point this is called, we
     // should probably be using the timestamp of the (next?) display
     // link update or vblank refresh.
-    if (m_monotonicTimelineRegistry)
+    if (m_monotonicTimelineRegistry && animationStacksToUpdate == AnimationStacksToUpdate::All)
         m_monotonicTimelineRegistry->advanceCurrentTime(MonotonicTime::now());
 
     auto animationStacks = std::exchange(m_animationStacks, { });
     for (auto [layerID, currentAnimationStack] : animationStacks) {
         Ref animationStack = currentAnimationStack;
-        animationStack->applyEffects();
+        if (animationStacksToUpdate == AnimationStacksToUpdate::All || animationStack->hasProgressBasedAnimations())
+            animationStack->applyEffects();
 
         // We can clear the effect stack if it's empty, but the previous
         // call to applyEffects() is important so that the base values


### PR DESCRIPTION
#### f34545487d2f0ae366253ef8daab7088a3e830fc
<pre>
[threaded-animations] stuttery animation on bmwusa.com configurator page with 60Hz display
<a href="https://bugs.webkit.org/show_bug.cgi?id=315209">https://bugs.webkit.org/show_bug.cgi?id=315209</a>
<a href="https://rdar.apple.com/176420489">rdar://176420489</a>

Reviewed by Simon Fraser.

On macOS, an animation update is triggered both when a display refresh occurs on the
scrolling thread, somewhere under `RemoteLayerTreeEventDispatcher::didRefreshDisplay()`,
and when a page rendering update has completed on the main thread, in
`RemoteLayerTreeEventDispatcher::renderingUpdateComplete()`.

The latter call was added in 303810@main to ensure that programmatic scrolls would
correctly update progress-based animations. However, this has the undesired effects
that when the page rendering is updated, all animations, including those contained
in animation stacks that only contain time-based animations, are updated twice.

In the case of a Pro Motion display, typically this would mean that we update animations
twice every other frame, since page rendering updates still occur near 60Hz by default.
But on a display set to refresh at 60Hz, the issue is made worse since we end up
updating animations twice on every frame.

To address this, at least for the case where only time-based animations are used (the
vast majority of cases at this currently), we no longer update animation stacks that
only contain time-based animations when `RemoteLayerTreeEventDispatcher::renderingUpdateComplete()`
is called. We do so by adding a new enum argument to `updateAnimations()` and only
advance monotonic timelines and update animation stacks containing time-based animations
if the argument indicates that all animation stacks should be updated, as opposed to those
containing at least one progress-based animation.

* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.h:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.mm:
(WebKit::RemoteAnimationStack::RemoteAnimationStack):
(WebKit::RemoteAnimationStack::isTimeDependent const): Deleted.
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteScrollingCoordinatorProxyIOS.mm:
(WebKit::RemoteScrollingCoordinatorProxyIOS::updateTimeDependentAnimationStacks):
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.h:
* Source/WebKit/UIProcess/RemoteLayerTree/mac/RemoteLayerTreeEventDispatcher.mm:
(WebKit::RemoteLayerTreeEventDispatcher::renderingUpdateComplete):
(WebKit::RemoteLayerTreeEventDispatcher::updateAnimations):

Canonical link: <a href="https://commits.webkit.org/313647@main">https://commits.webkit.org/313647@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cdbf93bd97bffc47b5b990b6a6dbd8d96c2e3341

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163565 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37049 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30268 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172505 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/120014 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5549dc5b-2f59-4bd7-b760-dbd771e2bc61) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37380 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37048 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127039 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89562 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/03562106-08d5-4771-a571-c01413bdfb8c) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166524 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29314 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147047 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107593 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6765ebcf-5afb-43b3-baa1-c1a778e23292) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28363 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26994 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20208 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138261 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175010 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27941 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26429 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135344 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36719 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31096 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135326 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37504 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146561 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99557 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24917 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30634 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23413 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36214 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109360 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35712 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1439 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35962 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35859 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->