### PR TITLE
[WebXR Layers] Enable texture array support for non-projection layers

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrCylinderLayer_textureType.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrCylinderLayer_textureType.https-expected.txt
@@ -1,0 +1,6 @@
+
+PASS createCylinderLayer with textureType 'texture-array' requires WebGL2 and keeps stereo as stereo - webgl
+PASS createCylinderLayer with textureType 'texture-array' requires WebGL2 and keeps stereo as stereo - webgl2
+PASS createCylinderLayer with the default textureType resolves stereo to a concrete stereo packing - webgl
+PASS createCylinderLayer with the default textureType resolves stereo to a concrete stereo packing - webgl2
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrCylinderLayer_textureType.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrCylinderLayer_textureType.https.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/webxr_util.js"></script>
+<script src="../resources/webxr_test_constants.js"></script>
+
+<script>
+
+  // 'texture-array' is only accepted on WebGL2, keep the resolved layout as 'stereo'.
+  function testTextureArrayCreation(session, deviceController, t, { gl }) {
+    return session.requestReferenceSpace('local').then((refSpace) => {
+      const binding = new XRWebGLBinding(session, gl);
+      const baseInit = { space: refSpace, viewPixelWidth: 32, viewPixelHeight: 32, layout: 'stereo' };
+      t.step(() => {
+        if (gl instanceof WebGL2RenderingContext) {
+          const layer = binding.createCylinderLayer({ ...baseInit, textureType: 'texture-array' });
+          assert_true(layer instanceof XRCylinderLayer, "createCylinderLayer with textureType 'texture-array' must succeed on WebGL2.");
+          assert_equals(layer.layout, 'stereo', "stereo + texture-array must preserve layer.layout as 'stereo'.");
+        } else {
+          assert_throws_dom('InvalidStateError', () => binding.createCylinderLayer({ ...baseInit, textureType: 'texture-array' }),
+            "createCylinderLayer with textureType 'texture-array' must throw InvalidStateError on WebGL.");
+        }
+      });
+    });
+  }
+
+  // Default 'texture' path: mono stays mono, stereo must be resolved by the UA into a concrete side-by-side packing.
+  function testTextureCreation(session, deviceController, t, { gl }) {
+    return session.requestReferenceSpace('local').then((refSpace) => {
+      const binding = new XRWebGLBinding(session, gl);
+      t.step(() => {
+        const monoLayer = binding.createCylinderLayer({ space: refSpace, viewPixelWidth: 32, viewPixelHeight: 32 });
+        assert_true(monoLayer instanceof XRCylinderLayer, "createCylinderLayer with the default textureType must succeed.");
+        assert_equals(monoLayer.layout, 'mono', "default layout must be 'mono'.");
+
+        const stereoLayer = binding.createCylinderLayer({ space: refSpace, viewPixelWidth: 32, viewPixelHeight: 32, layout: 'stereo' });
+        assert_in_array(stereoLayer.layout, ['stereo-left-right', 'stereo-top-bottom'],
+          "stereo + default texture type must be resolved by the UA to a concrete stereo packing.");
+      });
+    });
+  }
+
+  xr_session_promise_test("createCylinderLayer with textureType 'texture-array' requires WebGL2 and keeps stereo as stereo",
+    testTextureArrayCreation, TRACKED_IMMERSIVE_DEVICE, 'immersive-vr', { requiredFeatures: ['layers', 'local'] });
+
+  xr_session_promise_test("createCylinderLayer with the default textureType resolves stereo to a concrete stereo packing",
+    testTextureCreation, TRACKED_IMMERSIVE_DEVICE, 'immersive-vr', { requiredFeatures: ['layers', 'local'] });
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrEquirectLayer_textureType.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrEquirectLayer_textureType.https-expected.txt
@@ -1,0 +1,6 @@
+
+PASS createEquirectLayer with textureType 'texture-array' requires WebGL2 and keeps stereo as stereo - webgl
+PASS createEquirectLayer with textureType 'texture-array' requires WebGL2 and keeps stereo as stereo - webgl2
+PASS createEquirectLayer with the default textureType resolves stereo to a concrete stereo packing - webgl
+PASS createEquirectLayer with the default textureType resolves stereo to a concrete stereo packing - webgl2
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrEquirectLayer_textureType.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrEquirectLayer_textureType.https.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/webxr_util.js"></script>
+<script src="../resources/webxr_test_constants.js"></script>
+
+<script>
+
+  // 'texture-array' is only accepted on WebGL2, keep the resolved layout as 'stereo'.
+  function testTextureArrayCreation(session, deviceController, t, { gl }) {
+    return session.requestReferenceSpace('local').then((refSpace) => {
+      const binding = new XRWebGLBinding(session, gl);
+      const baseInit = { space: refSpace, viewPixelWidth: 32, viewPixelHeight: 32, layout: 'stereo' };
+      t.step(() => {
+        if (gl instanceof WebGL2RenderingContext) {
+          const layer = binding.createEquirectLayer({ ...baseInit, textureType: 'texture-array' });
+          assert_true(layer instanceof XREquirectLayer, "createEquirectLayer with textureType 'texture-array' must succeed on WebGL2.");
+          assert_equals(layer.layout, 'stereo', "stereo + texture-array must preserve layer.layout as 'stereo'.");
+        } else {
+          assert_throws_dom('InvalidStateError', () => binding.createEquirectLayer({ ...baseInit, textureType: 'texture-array' }),
+            "createEquirectLayer with textureType 'texture-array' must throw InvalidStateError on WebGL.");
+        }
+      });
+    });
+  }
+
+  // Default 'texture' path: mono stays mono, stereo must be resolved by the UA into a concrete side-by-side packing.
+  function testTextureCreation(session, deviceController, t, { gl }) {
+    return session.requestReferenceSpace('local').then((refSpace) => {
+      const binding = new XRWebGLBinding(session, gl);
+      t.step(() => {
+        const monoLayer = binding.createEquirectLayer({ space: refSpace, viewPixelWidth: 32, viewPixelHeight: 32 });
+        assert_true(monoLayer instanceof XREquirectLayer, "createEquirectLayer with the default textureType must succeed.");
+        assert_equals(monoLayer.layout, 'mono', "default layout must be 'mono'.");
+
+        const stereoLayer = binding.createEquirectLayer({ space: refSpace, viewPixelWidth: 32, viewPixelHeight: 32, layout: 'stereo' });
+        assert_in_array(stereoLayer.layout, ['stereo-left-right', 'stereo-top-bottom'],
+          "stereo + default texture type must be resolved by the UA to a concrete stereo packing.");
+      });
+    });
+  }
+
+  xr_session_promise_test("createEquirectLayer with textureType 'texture-array' requires WebGL2 and keeps stereo as stereo",
+    testTextureArrayCreation, TRACKED_IMMERSIVE_DEVICE, 'immersive-vr', { requiredFeatures: ['layers', 'local'] });
+
+  xr_session_promise_test("createEquirectLayer with the default textureType resolves stereo to a concrete stereo packing",
+    testTextureCreation, TRACKED_IMMERSIVE_DEVICE, 'immersive-vr', { requiredFeatures: ['layers', 'local'] });
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrQuadLayer_textureType.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrQuadLayer_textureType.https-expected.txt
@@ -1,0 +1,6 @@
+
+PASS createQuadLayer with textureType 'texture-array' requires WebGL2 and keeps stereo as stereo - webgl
+PASS createQuadLayer with textureType 'texture-array' requires WebGL2 and keeps stereo as stereo - webgl2
+PASS createQuadLayer with the default textureType resolves stereo to a concrete stereo packing - webgl
+PASS createQuadLayer with the default textureType resolves stereo to a concrete stereo packing - webgl2
+

--- a/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrQuadLayer_textureType.https.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrQuadLayer_textureType.https.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="../resources/webxr_util.js"></script>
+<script src="../resources/webxr_test_constants.js"></script>
+
+<script>
+
+  // 'texture-array' is only accepted on WebGL2, keep the resolved layout as 'stereo'.
+  function testTextureArrayCreation(session, deviceController, t, { gl }) {
+    return session.requestReferenceSpace('local').then((refSpace) => {
+      const binding = new XRWebGLBinding(session, gl);
+      const baseInit = { space: refSpace, viewPixelWidth: 32, viewPixelHeight: 32, layout: 'stereo' };
+      t.step(() => {
+        if (gl instanceof WebGL2RenderingContext) {
+          const layer = binding.createQuadLayer({ ...baseInit, textureType: 'texture-array' });
+          assert_true(layer instanceof XRQuadLayer, "createQuadLayer with textureType 'texture-array' must succeed on WebGL2.");
+          assert_equals(layer.layout, 'stereo', "stereo + texture-array must preserve layer.layout as 'stereo'.");
+        } else {
+          assert_throws_dom('InvalidStateError', () => binding.createQuadLayer({ ...baseInit, textureType: 'texture-array' }),
+            "createQuadLayer with textureType 'texture-array' must throw InvalidStateError on WebGL.");
+        }
+      });
+    });
+  }
+
+  // Default 'texture' path: mono stays mono, stereo must be resolved by the UA into a concrete side-by-side packing.
+  function testTextureCreation(session, deviceController, t, { gl }) {
+    return session.requestReferenceSpace('local').then((refSpace) => {
+      const binding = new XRWebGLBinding(session, gl);
+      t.step(() => {
+        const monoLayer = binding.createQuadLayer({ space: refSpace, viewPixelWidth: 32, viewPixelHeight: 32 });
+        assert_true(monoLayer instanceof XRQuadLayer, "createQuadLayer with the default textureType must succeed.");
+        assert_equals(monoLayer.layout, 'mono', "default layout must be 'mono'.");
+
+        const stereoLayer = binding.createQuadLayer({ space: refSpace, viewPixelWidth: 32, viewPixelHeight: 32, layout: 'stereo' });
+        assert_in_array(stereoLayer.layout, ['stereo-left-right', 'stereo-top-bottom'],
+          "stereo + default texture type must be resolved by the UA to a concrete stereo packing.");
+      });
+    });
+  }
+
+  xr_session_promise_test("createQuadLayer with textureType 'texture-array' requires WebGL2 and keeps stereo as stereo",
+    testTextureArrayCreation, TRACKED_IMMERSIVE_DEVICE, 'immersive-vr', { requiredFeatures: ['layers', 'local'] });
+
+  xr_session_promise_test("createQuadLayer with the default textureType resolves stereo to a concrete stereo packing",
+    testTextureCreation, TRACKED_IMMERSIVE_DEVICE, 'immersive-vr', { requiredFeatures: ['layers', 'local'] });
+
+</script>

--- a/Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.cpp
+++ b/Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.cpp
@@ -552,9 +552,8 @@ void WebXRWebGLTextureArraySwapchain::bindCompositorTexturesForDisplay(GraphicsC
             return;
     }
 
-    // Create the GL_TEXTURE_2D_ARRAY that the WebXR app will render into.
+    // Create the GL_TEXTURE_2D_ARRAY that the WebXR app will render into. Each array layer has the per-eye width.
     if (!currentSet.arrayTexture) {
-        // Each array layer has the per-eye width; the shared texture holds all layers side-by-side.
         auto sliceWidth = m_texSize.width() / static_cast<int>(m_arrayLength);
         currentSet.arrayTexture = gl.createTexture();
         gl.bindTexture(GL::TEXTURE_2D_ARRAY, currentSet.arrayTexture);
@@ -574,7 +573,7 @@ void WebXRWebGLTextureArraySwapchain::blitTextureArrayToSharedImage(GraphicsCont
         m_blitDrawFBO = gl.createFramebuffer();
 
     auto sliceWidth = m_texSize.width() / static_cast<int>(m_arrayLength);
-    auto height = m_texSize.height();
+    auto sliceHeight = m_texSize.height();
 
     gl.bindFramebuffer(GL::READ_FRAMEBUFFER, m_blitReadFBO);
     gl.bindFramebuffer(GL::DRAW_FRAMEBUFFER, m_blitDrawFBO);
@@ -583,7 +582,7 @@ void WebXRWebGLTextureArraySwapchain::blitTextureArrayToSharedImage(GraphicsCont
     for (uint32_t layer = 0; layer < m_arrayLength; ++layer) {
         gl.framebufferTextureLayer(GL::READ_FRAMEBUFFER, GL::COLOR_ATTACHMENT0, currentSet.arrayTexture, 0, static_cast<GCGLint>(layer));
         auto dstX = static_cast<GCGLint>(layer) * sliceWidth;
-        gl.blitFramebuffer(0, 0, sliceWidth, height, dstX, 0, dstX + sliceWidth, height, GL::COLOR_BUFFER_BIT, GL::NEAREST);
+        gl.blitFramebuffer(0, 0, sliceWidth, sliceHeight, dstX, 0, dstX + sliceWidth, sliceHeight, GL::COLOR_BUFFER_BIT, GL::NEAREST);
     }
 
     gl.bindFramebuffer(GL::FRAMEBUFFER, 0);

--- a/Source/WebCore/Modules/webxr/XRWebGLBinding.cpp
+++ b/Source/WebCore/Modules/webxr/XRWebGLBinding.cpp
@@ -109,7 +109,7 @@ ExceptionOr<XRLayerLayout> XRWebGLBinding::determineLayout(XRTextureType texture
             if (textureType == XRTextureType::TextureArray)
                 return layout;
         }
-        if (layout == XRLayerLayout::Default || layout == XRLayerLayout::Stereo)
+        if ((layout == XRLayerLayout::Default || layout == XRLayerLayout::Stereo) && textureType == XRTextureType::Texture)
             return XRLayerLayout::StereoLeftRight;
         return layout;
     };
@@ -249,32 +249,21 @@ ExceptionOr<Ref<XRProjectionLayer>> XRWebGLBinding::createProjectionLayer(Script
     );
 }
 
-ExceptionOr<Vector<RefPtr<WebGLOpaqueTexture>>> XRWebGLBinding::allocateColorTexturesForLayer(XRCompositionLayer& layer, XRTextureType textureType, const XRLayerInit& /*init*/)
+ExceptionOr<Vector<RefPtr<WebGLOpaqueTexture>>> XRWebGLBinding::allocateColorTexturesForLayer(XRCompositionLayer& layer)
 {
     return WTF::switchOn(m_context,
         [&](const Ref<WebGLRenderingContextBase>& baseContext) -> ExceptionOr<Vector<RefPtr<WebGLOpaqueTexture>>> {
             if (baseContext->isContextLost())
                 return Exception { ExceptionCode::InvalidStateError, "Cannot create a layer with a lost WebGL context"_s };
 
-            Vector<RefPtr<WebGLOpaqueTexture>> textures;
-            switch (layer.layout()) {
-            case XRLayerLayout::Mono:
-            case XRLayerLayout::Stereo:
-            case XRLayerLayout::StereoLeftRight:
-            case XRLayerLayout::StereoTopBottom: {
-                if (textureType == XRTextureType::TextureArray)
-                    return Exception { ExceptionCode::NotSupportedError, "Texture arrays not implemented."_s };
-                RefPtr currentColorTexture = static_cast<XRWebGLLayerBacking&>(layer.backing()).currentColorTexture();
-                if (!currentColorTexture)
-                    return Exception { ExceptionCode::InvalidStateError, "Failed to get the current color texture."_s };
-                textures.append(currentColorTexture);
-                break;
-            }
-            case XRLayerLayout::Default:
-                ASSERT_NOT_REACHED_WITH_MESSAGE("Default layout is not supported for non projection Layers");
-                return Exception { ExceptionCode::NotSupportedError, "Default layout is not supported for non projection Layers."_s };
-            };
+            ASSERT(layer.layout() != XRLayerLayout::Default);
 
+            // Layout / textureType differences (size, array length, texture target) are baked into the swapchain at construction time.
+            Vector<RefPtr<WebGLOpaqueTexture>> textures;
+            RefPtr currentColorTexture = static_cast<XRWebGLLayerBacking&>(layer.backing()).currentColorTexture();
+            if (!currentColorTexture)
+                return Exception { ExceptionCode::InvalidStateError, "Failed to get the current color texture."_s };
+            textures.append(currentColorTexture);
             return textures;
         },
         [](std::monostate) {
@@ -284,7 +273,7 @@ ExceptionOr<Vector<RefPtr<WebGLOpaqueTexture>>> XRWebGLBinding::allocateColorTex
 }
 
 // https://immersive-web.github.io/layers/#allocate-depth-textures
-ExceptionOr<Vector<RefPtr<WebGLOpaqueTexture>>> XRWebGLBinding::allocateDepthTexturesForLayer(XRCompositionLayer& layer, XRTextureType textureType, const XRLayerInit& init)
+ExceptionOr<Vector<RefPtr<WebGLOpaqueTexture>>> XRWebGLBinding::allocateDepthTexturesForLayer(XRCompositionLayer& layer, const XRLayerInit& init)
 {
     return WTF::switchOn(m_context,
         [&](const Ref<WebGLRenderingContextBase>& baseContext) -> ExceptionOr<Vector<RefPtr<WebGLOpaqueTexture>>> {
@@ -292,38 +281,16 @@ ExceptionOr<Vector<RefPtr<WebGLOpaqueTexture>>> XRWebGLBinding::allocateDepthTex
                 return Exception { ExceptionCode::InvalidStateError, "Cannot create depth textures with a lost WebGL context"_s };
 
             Vector<RefPtr<WebGLOpaqueTexture>> textures;
-            if (!init.depthFormat)
+            if (!init.depthFormat || !*init.depthFormat)
                 return textures;
 
             ASSERT(depthFormatIsSupportedForNonProjectionLayer(*init.depthFormat));
+            ASSERT(layer.layout() != XRLayerLayout::Default);
 
-            switch (layer.layout()) {
-            case XRLayerLayout::Mono: {
-                if (textureType == XRTextureType::TextureArray)
-                    return Exception { ExceptionCode::NotSupportedError, "Texture arrays not implemented."_s };
-                RefPtr currentDepthTexture = static_cast<XRWebGLLayerBacking&>(layer.backing()).currentDepthTexture();
-                if (!currentDepthTexture)
-                    return Exception { ExceptionCode::InvalidStateError, "Failed to get the current depth texture."_s };
-                textures.append(currentDepthTexture);
-                break;
-            }
-            case XRLayerLayout::Stereo: {
-                if (textureType == XRTextureType::TextureArray)
-                    return Exception { ExceptionCode::NotSupportedError, "Texture arrays not implemented."_s };
-                return Exception { ExceptionCode::NotSupportedError, "Stereo depth textures not implemented."_s };
-            }
-            case XRLayerLayout::StereoLeftRight:
-            case XRLayerLayout::StereoTopBottom: {
-                if (textureType == XRTextureType::TextureArray)
-                    return Exception { ExceptionCode::NotSupportedError, "Texture arrays not implemented."_s };
-                textures.append(static_cast<XRWebGLLayerBacking&>(layer.backing()).currentDepthTexture());
-                break;
-            }
-            case XRLayerLayout::Default:
-                ASSERT_NOT_REACHED_WITH_MESSAGE("Default layout is not supported for non projection Layers");
-                return Exception { ExceptionCode::NotSupportedError, "Default layout is not supported for non projection Layers."_s };
-            };
-
+            RefPtr currentDepthTexture = static_cast<XRWebGLLayerBacking&>(layer.backing()).currentDepthTexture();
+            if (!currentDepthTexture)
+                return Exception { ExceptionCode::InvalidStateError, "Failed to get the current depth texture."_s };
+            textures.append(currentDepthTexture);
             return textures;
         },
         [](std::monostate) {
@@ -372,7 +339,7 @@ ExceptionOr<void> XRWebGLBinding::validateCompositionLayerInitParameters(const X
     if (!colorFormatIsSupportedForNonProjectionLayer(init.colorFormat))
         return Exception { ExceptionCode::NotSupportedError, "Unsupported texture format."_s };
 
-    if (init.depthFormat && !depthFormatIsSupportedForNonProjectionLayer(*init.depthFormat))
+    if (init.depthFormat && *init.depthFormat && !depthFormatIsSupportedForNonProjectionLayer(*init.depthFormat))
         return Exception { ExceptionCode::NotSupportedError, "Unsupported texture depth format."_s };
 
     return { };
@@ -653,19 +620,22 @@ ExceptionOr<Ref<XRCylinderLayer>> XRWebGLBinding::createCylinderLayer(ScriptExec
 }
 
 // https://immersive-web.github.io/layers/#initialize-the-viewport
-Ref<WebXRViewport> XRWebGLBinding::initializeViewport(IntSize textureSize, XRLayerLayout layout, int offset, int num)
+Ref<WebXRViewport> XRWebGLBinding::initializeViewport(IntSize textureSize, XRLayerLayout layout, XRTextureType textureType, int offset, int num)
 {
     int x = 0;
     int y = 0;
     int width = textureSize.width();
     int height = textureSize.height();
 
-    if (layout == XRLayerLayout::StereoLeftRight) {
-        x = width * offset / num;
-        width /= num;
-    } else if (layout == XRLayerLayout::StereoTopBottom) {
-        y = height * offset / num;
-        height /= num;
+    // For texture arrays each array slice is a full per-view texture so the viewport covers it all.
+    if (textureType == XRTextureType::Texture) {
+        if (layout == XRLayerLayout::StereoLeftRight) {
+            x = width * offset / num;
+            width /= num;
+        } else if (layout == XRLayerLayout::StereoTopBottom) {
+            y = height * offset / num;
+            height /= num;
+        }
     }
     return WebXRViewport::create(IntRect(x, y, width, height));
 }
@@ -690,12 +660,12 @@ ExceptionOr<Ref<XRWebGLSubImage>> XRWebGLBinding::getSubImage(XRCompositionLayer
                     index = layer.isXRCubeLayer() ? 6 : 1;
             }
 
-            auto colorTexturesResult = allocateColorTexturesForLayer(layer, init.textureType, init);
+            auto colorTexturesResult = allocateColorTexturesForLayer(layer);
             if (colorTexturesResult.hasException())
                 return colorTexturesResult.releaseException();
             layer.setColorTextures(colorTexturesResult.releaseReturnValue());
 
-            auto depthTexturesResult = allocateDepthTexturesForLayer(layer, init.textureType, init);
+            auto depthTexturesResult = allocateDepthTexturesForLayer(layer, init);
             if (depthTexturesResult.hasException())
                 return depthTexturesResult.releaseException();
             layer.setDepthStencilTextures(depthTexturesResult.releaseReturnValue());
@@ -704,7 +674,7 @@ ExceptionOr<Ref<XRWebGLSubImage>> XRWebGLBinding::getSubImage(XRCompositionLayer
                 return Exception { ExceptionCode::InvalidStateError, "Validation does not PASS."_s };
 
             int viewsPerTexture = layout == XRLayerLayout::StereoLeftRight || layout == XRLayerLayout::StereoTopBottom ? 2 : 1;
-            Ref viewport = initializeViewport(IntSize(init.viewPixelWidth, init.viewPixelHeight), layout, index, viewsPerTexture);
+            Ref viewport = initializeViewport(IntSize(init.viewPixelWidth, init.viewPixelHeight), layout, init.textureType, index, viewsPerTexture);
 
             auto createSubImageResult = XRWebGLSubImage::create(WTF::move(viewport), layer);
             if (createSubImageResult.hasException())

--- a/Source/WebCore/Modules/webxr/XRWebGLBinding.h
+++ b/Source/WebCore/Modules/webxr/XRWebGLBinding.h
@@ -81,7 +81,7 @@ public:
     ExceptionOr<Ref<XREquirectLayer>> createEquirectLayer(ScriptExecutionContext&, const XREquirectLayerInit&);
     ExceptionOr<Ref<XRCubeLayer>> createCubeLayer(const XRCubeLayerInit&) { RELEASE_ASSERT_NOT_REACHED(); }
 
-    Ref<WebXRViewport> initializeViewport(IntSize, XRLayerLayout, int offset, int num);
+    Ref<WebXRViewport> initializeViewport(IntSize, XRLayerLayout, XRTextureType, int offset, int num);
 
     ExceptionOr<Ref<XRWebGLSubImage>> getSubImage(XRCompositionLayer&, const WebXRFrame&, XREye);
     ExceptionOr<Ref<XRWebGLSubImage>> getViewSubImage(XRProjectionLayer&, const WebXRView&);
@@ -98,8 +98,8 @@ private:
     ExceptionOr<void> validateCompositionLayerInitParameters(const XRLayerInit&) const;
     ExceptionOr<Vector<RefPtr<WebGLOpaqueTexture>>> allocateColorTexturesForProjectionLayer(XRProjectionLayer&, XRTextureType, GCGLenum textureFormat, double scaleFactor);
     ExceptionOr<Vector<RefPtr<WebGLOpaqueTexture>>> allocateDepthTexturesForProjectionLayer(XRProjectionLayer&, XRTextureType, GCGLenum textureFormat, double scaleFactor);
-    ExceptionOr<Vector<RefPtr<WebGLOpaqueTexture>>> allocateColorTexturesForLayer(XRCompositionLayer&, XRTextureType, const XRLayerInit&);
-    ExceptionOr<Vector<RefPtr<WebGLOpaqueTexture>>> allocateDepthTexturesForLayer(XRCompositionLayer&, XRTextureType, const XRLayerInit&);
+    ExceptionOr<Vector<RefPtr<WebGLOpaqueTexture>>> allocateColorTexturesForLayer(XRCompositionLayer&);
+    ExceptionOr<Vector<RefPtr<WebGLOpaqueTexture>>> allocateDepthTexturesForLayer(XRCompositionLayer&, const XRLayerInit&);
     bool validateXRWebGLSubImageCreation(const XRCompositionLayer&, const WebXRFrame&) const;
 
     IntRect rectForView(const XRProjectionLayer&, const XRTextureType, const WebXRView&) const;

--- a/Source/WebCore/Modules/webxr/XRWebGLLayerBacking.cpp
+++ b/Source/WebCore/Modules/webxr/XRWebGLLayerBacking.cpp
@@ -97,20 +97,26 @@ void XRWebGLLayerBacking::startFrame(PlatformXR::FrameData& data)
     ASSERT(m_colorSwapchain);
 
     auto it = data.layers.find(handle());
-    if (it == data.layers.end())
+    if (it == data.layers.end()) {
+        m_shouldSkipFrame = true;
         return;
+    }
 
     m_colorSwapchain->startFrame(it->value);
     if (m_depthSwapchain)
         m_depthSwapchain->startFrame(it->value);
+    m_shouldSkipFrame = false;
 }
 
 void XRWebGLLayerBacking::endFrame(PlatformXR::DeviceLayer& layerData)
 {
     ASSERT(m_colorSwapchain);
+    if (m_shouldSkipFrame)
+        return;
     m_colorSwapchain->endFrame(layerData);
     if (m_depthSwapchain)
         m_depthSwapchain->endFrame(layerData);
+    m_shouldSkipFrame = true;
 }
 #endif
 
@@ -164,7 +170,8 @@ ExceptionOr<XRWebGLLayerBacking::XRLayerSwapchains> XRWebGLLayerBacking::createC
 
     bool useTextureArray = init.textureType == XRTextureType::TextureArray;
     GCGLenum colorTextureType = useTextureArray ? GL::TEXTURE_2D_ARRAY : GL::TEXTURE_2D;
-    uint32_t arrayLength = computeArrayLength(useTextureArray, static_cast<uint32_t>(session.views().size()));
+    uint32_t slicesPerLayer = layerLayout == PlatformXR::LayerLayout::Mono ? 1 : 2;
+    uint32_t arrayLength = computeArrayLength(useTextureArray, slicesPerLayer);
 
     return XRWebGLLayerBacking::createColorAndDepthSwapchains(context, layerInfo->handle, init.colorFormat, init.depthFormat, layerSize, init.clearOnAccess, layerInfo->numImages, arrayLength, colorTextureType);
 }

--- a/Source/WebCore/Modules/webxr/XRWebGLLayerBacking.h
+++ b/Source/WebCore/Modules/webxr/XRWebGLLayerBacking.h
@@ -101,6 +101,7 @@ private:
     std::unique_ptr<WebXRWebGLSwapchain> m_colorSwapchain;
     std::unique_ptr<WebXRWebGLSwapchain> m_depthSwapchain;
     uint32_t m_colorTextureArrayLength { 1 };
+    bool m_shouldSkipFrame { true };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 15b4ecd31e2260916c12b6612545a2055c4173a8
<pre>
[WebXR Layers] Enable texture array support for non-projection layers
<a href="https://bugs.webkit.org/show_bug.cgi?id=315208">https://bugs.webkit.org/show_bug.cgi?id=315208</a>

Reviewed by Dan Glastonbury.

Support for texture arrays was added in d158677@main. With this commit
quad, cylinder and equirect composition layers created with
textureType=&quot;texture-array&quot; now also allocate a GL_TEXTURE_2D_ARRAY
instead of a regular texture so JS could render into them via
XRWebGLBinding.getSubImage.

Three things were needed:

1. determineLayout(): the &quot;stereo&quot; requested layout was always rewritten
   to &quot;stereo-left-right&quot;. For texture arrays the requested layout must
   be preserved, i.e., each array slice already is a full per-view
   texture, there is no side-by-side packing,

2. allocate{Color|Depth}TexturesForLayer() and initializeViewport():
   both were duplicating the layout/textureType decision tree to either
   reject &quot;texture-array&quot; or compute a per-eye half-viewport. All of
   that is already baked into the swapchain (size, target, array length)
   at construction time, so there is no need to treat each case
   separatedely as described in the specs. The backing will return the
   right object to use for rendering.

3. createCompositionLayerSwapchains(): the texture array length was
   using session.views().size(), conflating session view count with
   per-layer view count. That was valid for projection layers but it was
   causing issues with other composition layers. In particular we were
   getting invalid value errors (&quot;Offset overflows texture dimensions&quot;)
   due to not properly handling stereo layouts.

Apart from that, this change also requires adjustments in the layer
backing code as we were calling endFrame() in some swapchains without
previously calling startFrame() because the latter may early return in
those cases in which the platform code has not yet produced valid
LayerData for a layer that has been added via updateRenderState. That
was not a problem for other swapchains but it matters for the texture
array one because it performs an extra blit in endFrame() which requires
access to valid m_textureSets data.

Tests: imported/w3c/web-platform-tests/webxr/layers/xrCylinderLayer_textureType.https.html
       imported/w3c/web-platform-tests/webxr/layers/xrEquirectLayer_textureType.https.html
       imported/w3c/web-platform-tests/webxr/layers/xrQuadLayer_textureType.https.html

* LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrCylinderLayer_textureType.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrCylinderLayer_textureType.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrEquirectLayer_textureType.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrEquirectLayer_textureType.https.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrQuadLayer_textureType.https-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/webxr/layers/xrQuadLayer_textureType.https.html: Added.
* Source/WebCore/Modules/webxr/WebXRWebGLSwapchain.cpp:
(WebCore::WebXRWebGLTextureArraySwapchain::bindCompositorTexturesForDisplay):
(WebCore::WebXRWebGLTextureArraySwapchain::blitTextureArrayToSharedImage):
* Source/WebCore/Modules/webxr/XRWebGLBinding.cpp:
(WebCore::XRWebGLBinding::determineLayout):
(WebCore::XRWebGLBinding::allocateColorTexturesForLayer):
(WebCore::XRWebGLBinding::allocateDepthTexturesForLayer):
(WebCore::XRWebGLBinding::validateCompositionLayerInitParameters const):
(WebCore::XRWebGLBinding::initializeViewport):
(WebCore::XRWebGLBinding::getSubImage):
* Source/WebCore/Modules/webxr/XRWebGLBinding.h:
* Source/WebCore/Modules/webxr/XRWebGLLayerBacking.cpp:
(WebCore::XRWebGLLayerBacking::startFrame):
(WebCore::XRWebGLLayerBacking::endFrame):
(WebCore::XRWebGLLayerBacking::createCompositionLayerSwapchains):
* Source/WebCore/Modules/webxr/XRWebGLLayerBacking.h:

Canonical link: <a href="https://commits.webkit.org/313872@main">https://commits.webkit.org/313872@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9067e0ba676850e732a5e43f674d45b6d1ce252d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163566 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37050 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30269 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172506 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/120015 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165435 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37381 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37049 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127041 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89563 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166525 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29315 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147048 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107595 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28364 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/26995 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20209 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138262 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24767 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175011 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27942 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26430 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135345 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36720 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31097 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135327 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36641 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37505 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146562 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99558 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30643 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23414 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36215 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109361 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35713 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1440 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35963 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35860 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->