### PR TITLE
Align with disallowing <url> type in attr()

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-attr-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-attr-expected.txt
@@ -10,7 +10,7 @@ PASS Return attr(type(*)) from untyped function
 FAIL attr() in default parameter value assert_equals: expected "42px" but got "784px"
 PASS attr() in local variable
 FAIL Returned url() is attr-tainted assert_equals: expected "url(\"http://web-platform.test:8800/css/css-mixins/parent\")" but got "url(\"http://web-platform.test:8800/css/css-mixins/cat.png\")"
-FAIL Returned url() is attr-tainted, typed attr() assert_equals: expected "url(\"http://web-platform.test:8800/css/css-mixins/parent\")" but got "url(\"http://web-platform.test:8800/css/css-mixins/cat.png\")"
+PASS Returned url() is attr-tainted, typed attr()
 PASS Returned url() is attr-tainted, typed return
 PASS Returned url() is attr-tainted, local
 PASS Returned url() is attr-tainted, argument

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-all-types-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-all-types-expected.txt
@@ -125,8 +125,8 @@ PASS CSS Values and Units Test: attr 121
 PASS CSS Values and Units Test: attr 122
 PASS CSS Values and Units Test: attr 123
 PASS CSS Values and Units Test: attr 124
-FAIL CSS Values and Units Test: attr 125 assert_equals: Value 'attr(data-foo xx, 3px)', where 'data-foo=10' should be valid for the property 'width'. expected "3px" but got "784px"
-FAIL CSS Values and Units Test: attr 126 assert_equals: Value 'attr(data-foo xx, 3px)', where 'data-foo=10px' should be valid for the property 'width'. expected "3px" but got "784px"
+PASS CSS Values and Units Test: attr 125
+PASS CSS Values and Units Test: attr 126
 PASS CSS Values and Units Test: attr 127
 PASS CSS Values and Units Test: attr 128
 PASS CSS Values and Units Test: attr 129
@@ -171,5 +171,5 @@ PASS CSS Values and Units Test: attr 167
 PASS CSS Values and Units Test: attr 168
 PASS CSS Values and Units Test: attr 169
 PASS CSS Values and Units Test: attr 170
-FAIL CSS Values and Units Test: attr 171 assert_equals: Setting property '--x' to the value 'attr(data-foo type(<url>))', where 'data-foo=url("https://does-not-exist.test/404.png")' should not change it's value. expected "" but got "url(\"https://does-not-exist.test/404.png\")"
+PASS CSS Values and Units Test: attr 171
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-security-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-security-expected.txt
@@ -9,7 +9,7 @@ PASS 'background-image: src("https://does-not-exist.test/404.png")' with data-fo
 PASS '--x: src(string("https://does-not-exist.test" attr(data-foo)))' with data-foo="/404.png"
 PASS 'background-image: src(string("https://does-not-exist.test" attr(data-foo)))' with data-foo="/404.png"
 PASS 'background-image: src(string("https://does-not-exist.test/""404.png"))' with data-foo="/404.png"
-FAIL '--x: attr(data-foo type(<url>))' with data-foo="url(https://does-not-exist.test/404.png)" assert_equals: expected "" but got "url(\"https://does-not-exist.test/404.png\")"
+PASS '--x: attr(data-foo type(<url>))' with data-foo="url(https://does-not-exist.test/404.png)"
 PASS 'background-image: attr(data-foo type(<url>))' with data-foo="url(https://does-not-exist.test/404.png)"
 PASS 'background-image: url("https://does-not-exist.test/404.png")' with data-foo="url(https://does-not-exist.test/404.png)"
 PASS '--x: image(attr(data-foo))' with data-foo="https://does-not-exist.test/404.png"

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -404,6 +404,12 @@ bool SubstitutionResolver::substituteAttrFunction(CSSParserTokenRange argumentsR
             auto syntax = CSSCustomPropertySyntax::consumeType(range);
             if (!syntax)
                 return { };
+            // https://drafts.csswg.org/css-values-5/#typedef-attr-type
+            // "For this purpose, <url> is invalid as a <syntax-single-component>."
+            for (auto& component : syntax->definition) {
+                if (component.type == CSSCustomPropertySyntax::Type::URL)
+                    return { };
+            }
             return AttrTypeResult { AttrType::Syntax, { }, WTF::move(*syntax) };
         }
 
@@ -417,9 +423,8 @@ bool SubstitutionResolver::substituteAttrFunction(CSSParserTokenRange argumentsR
                 range.consumeIncludingWhitespace();
                 return AttrTypeResult { AttrType::Number };
             }
+            // <attr-unit> = <custom-ident>. Unknown units are accepted here; substitution triggers fallback.
             auto unit = CSSParserToken::stringToUnitType(value);
-            if (unit == CSSUnitType::CSS_UNKNOWN)
-                return { };
             range.consumeIncludingWhitespace();
             return AttrTypeResult { AttrType::Unit, unit };
         }
@@ -529,6 +534,9 @@ bool SubstitutionResolver::substituteAttrFunction(CSSParserTokenRange argumentsR
     //  or a percentage if % was given."
     case AttrType::Unit:
     case AttrType::Percentage: {
+        // "If the <attr-unit> does not match a known CSS unit, it triggers fallback."
+        if (attrType == AttrType::Unit && parsedAttrType->unitType == CSSUnitType::CSS_UNKNOWN)
+            return substituteFailure();
         CSSTokenizer tokenizer(attributeValue.string().trim(isUnicodeCompatibleASCIIWhitespace<UChar>));
         auto tokenRange = tokenizer.tokenRange();
         tokenRange.consumeWhitespace();


### PR DESCRIPTION
#### b4e7e8bd27ef15d5d513534bda2750aba6fe48e0
<pre>
Align with disallowing &lt;url&gt; type in attr()
<a href="https://bugs.webkit.org/show_bug.cgi?id=314833">https://bugs.webkit.org/show_bug.cgi?id=314833</a>
<a href="https://rdar.apple.com/problem/177540489">rdar://problem/177540489</a>

Reviewed by Anne van Kesteren.

Disallow &lt;url&gt; in attr() per <a href="https://github.com/w3c/csswg-drafts/issues/5079#issuecomment-3329306728">https://github.com/w3c/csswg-drafts/issues/5079#issuecomment-3329306728</a>
Also fix handling of unknown unit types: an &lt;attr-unit&gt; that does not
match a known CSS unit should trigger fallback rather than failing the
substitution outright.

Spec: <a href="https://drafts.csswg.org/css-values-5/#attr-notation">https://drafts.csswg.org/css-values-5/#attr-notation</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-mixins/function-attr-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-all-types-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-security-expected.txt:
* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::substituteAttrFunction):

Canonical link: <a href="https://commits.webkit.org/313593@main">https://commits.webkit.org/313593@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22b2101a8a06e5bd34a42980001bb4d932bacc91

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163589 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37073 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/30292 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172529 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/120038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/503cab15-d027-4f0a-84fc-5eb40c0b1edc) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165458 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37404 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37072 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/127060 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/120038 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/32c2ab75-51a3-44a7-9e03-b57f343ae806) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166548 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29337 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/147069 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107614 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/40175ecb-e854-43a1-b073-1a8d1054cfd6) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28386 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/27016 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20232 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/138284 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/24787 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175034 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/27965 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/26450 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/135364 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36743 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135346 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36473 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37528 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/146582 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99586 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30657 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/23434 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36238 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109384 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35736 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/1460 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35986 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35883 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->