### PR TITLE
Genericise escapeKeyHandler in CloseWatcherManager

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-synthetic-keydown-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-synthetic-keydown-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL close via synthesized Esc key must not work assert_true: expected true got false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-synthetic-keydown.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-synthetic-keydown.html
@@ -4,25 +4,24 @@
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
 <script src="/resources/testdriver-actions.js"></script>
-<script src="../resources/helpers.js"></script>
 
 <body>
+<dialog id="dialog"></dialog>
 <script>
-test(t => {
-  let events = [];
-  let watcher = createRecordingCloseWatcher(t, events);
+test(() => {
+  dialog.showModal();
 
   let keydown = new KeyboardEvent("keydown", {key: "Escape", keyCode: 27});
   document.body.dispatchEvent(keydown);
   let keyup = new KeyboardEvent("keyup", {key: "Escape", keyCode: 27});
   document.body.dispatchEvent(keyup);
 
-  assert_array_equals(events, []);
+  assert_true(dialog.open);
 
   let keyup2 = document.createEvent("Event");
   keyup2.initEvent("keyup", true);
   document.body.dispatchEvent(keyup2);
 
-  assert_array_equals(events, []);
+  assert_true(dialog.open);
 }, "close via synthesized Esc key must not work");
 </script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-synthetic-keydown-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-synthetic-keydown-expected.txt
@@ -1,0 +1,3 @@
+
+FAIL close via synthesized Esc key must not work assert_true: expected true got false
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-synthetic-keydown.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-synthetic-keydown.html
@@ -4,25 +4,24 @@
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
 <script src="/resources/testdriver-actions.js"></script>
-<script src="../resources/helpers.js"></script>
 
 <body>
+<div popover id="popover"></div>
 <script>
-test(t => {
-  let events = [];
-  let watcher = createRecordingCloseWatcher(t, events);
+test(() => {
+  popover.showPopover();
 
   let keydown = new KeyboardEvent("keydown", {key: "Escape", keyCode: 27});
   document.body.dispatchEvent(keydown);
   let keyup = new KeyboardEvent("keyup", {key: "Escape", keyCode: 27});
   document.body.dispatchEvent(keyup);
 
-  assert_array_equals(events, []);
+  assert_true(popover.matches(':popover-open'));
 
   let keyup2 = document.createEvent("Event");
   keyup2.initEvent("keyup", true);
   document.body.dispatchEvent(keyup2);
 
-  assert_array_equals(events, []);
+  assert_true(popover.matches(':popover-open'));
 }, "close via synthesized Esc key must not work");
 </script>

--- a/Source/WebCore/html/closewatcher/CloseWatcherManager.cpp
+++ b/Source/WebCore/html/closewatcher/CloseWatcherManager.cpp
@@ -74,9 +74,9 @@ bool CloseWatcherManager::canPreventClose()
     return m_groups.size() < m_allowedNumberOfGroups;
 }
 
-void CloseWatcherManager::escapeKeyHandler(KeyboardEvent& event)
+void CloseWatcherManager::processCloseWatchers()
 {
-    if (!m_groups.isEmpty() && !event.defaultHandled() && event.isTrusted() && event.key() == "Escape"_s) {
+    if (!m_groups.isEmpty()) {
         auto& group = m_groups.last();
         Vector<Ref<CloseWatcher>> groupCopy(group);
         for (Ref watcher : groupCopy | std::views::reverse) {

--- a/Source/WebCore/html/closewatcher/CloseWatcherManager.h
+++ b/Source/WebCore/html/closewatcher/CloseWatcherManager.h
@@ -39,7 +39,7 @@ public:
     void NODELETE notifyAboutUserActivation();
     bool NODELETE canPreventClose();
 
-    void escapeKeyHandler(KeyboardEvent&);
+    void processCloseWatchers();
 private:
     Vector<Vector<Ref<CloseWatcher>>> m_groups;
     uint32_t m_allowedNumberOfGroups { 1 };

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -4549,8 +4549,10 @@ void EventHandler::defaultKeyboardEventHandler(KeyboardEvent& event)
             return;
 
         if (event.key() == "Escape"_s) {
-            if (frame->settings().closeWatcherEnabled())
-                frame->document()->window()->closeWatcherManager().escapeKeyHandler(event);
+            if (frame->settings().closeWatcherEnabled()) {
+                if (event.isTrusted())
+                    frame->document()->window()->closeWatcherManager().processCloseWatchers();
+            }
             if (frame->settings().closedbyAttributeEnabled()) {
                 if (RefPtr activeCloseableDialog = frame->document()->activeCloseableDialog())
                     activeCloseableDialog->requestClose(nullString(), nullptr);


### PR DESCRIPTION
#### a36c2bb72d42d5b1fc800fbac095be534af8a1f9
<pre>
Genericise escapeKeyHandler in CloseWatcherManager
<a href="https://bugs.webkit.org/show_bug.cgi?id=315206">https://bugs.webkit.org/show_bug.cgi?id=315206</a>

Reviewed by Anne van Kesteren.

Replaces escapeKeyHandler with a more generic processCloseWatchers function. This
will be useful to support new types of close signal in future.

Close Watchers are behind the testableCloseWatcherEnabled flag.

Also adds tests regarding untrusted escape keydown events.

The existing close watcher synthetic event test didn&apos;t actually test
what it intended to as it targeted the window instead of document.body.
As it&apos;s a test that nothing happened this meant it would always pass,
even if WebKit didn&apos;t check for the trusted flag.
So this test has also been updated to fix that.

Tests: imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-synthetic-keydown.html
       imported/w3c/web-platform-tests/html/semantics/popovers/popover-synthetic-keydown.html

* LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/synthetic-keyboard-event.html:
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-synthetic-keydown-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-synthetic-keydown.html: Copied from LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/synthetic-keyboard-event.html.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-synthetic-keydown-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/popovers/popover-synthetic-keydown.html: Copied from LayoutTests/imported/w3c/web-platform-tests/close-watcher/esc-key/synthetic-keyboard-event.html.
* Source/WebCore/html/closewatcher/CloseWatcherManager.cpp:
(WebCore::CloseWatcherManager::processCloseWatchers):
(WebCore::CloseWatcherManager::escapeKeyHandler): Deleted.
* Source/WebCore/html/closewatcher/CloseWatcherManager.h:
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::defaultKeyboardEventHandler):

Canonical link: <a href="https://commits.webkit.org/313671@main">https://commits.webkit.org/313671@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45eac75bda96573c32d76d9ebee903cc70f61fdc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163756 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37240 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30459 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172778 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165625 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37571 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37239 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127195 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121007 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166715 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29482 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147217 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107745 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28529 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27159 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20549 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138428 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24934 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175303 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28132 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26602 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135502 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36910 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31265 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135478 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36525 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37695 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146729 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99814 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30797 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23583 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36406 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109551 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35903 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1649 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36153 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36050 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->