### PR TITLE
Align model appearance

### DIFF
--- a/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.cpp
@@ -174,6 +174,7 @@ HTMLModelElement::~HTMLModelElement()
 
     m_loadModelTimer = nullptr;
 
+    deletePendingModelPlayer();
     deleteModelPlayer();
 }
 
@@ -274,7 +275,13 @@ void HTMLModelElement::setSourceURL(const URL& url)
     if (RefPtr resource = std::exchange(m_resource, nullptr))
         resource->removeClient(*this);
 
+#if ENABLE(GPU_PROCESS_MODEL)
+    deletePendingModelPlayer();
+    if (url.isEmpty())
+        deleteModelPlayer();
+#else
     deleteModelPlayer();
+#endif
 
 #if ENABLE(MODEL_ELEMENT_ENTITY_TRANSFORM)
     m_entityTransform = DOMMatrixReadOnly::create(TransformationMatrix::identity, DOMMatrixReadOnly::Is2D::No);
@@ -397,7 +404,32 @@ void HTMLModelElement::notifyFinished(CachedResource& resource, const NetworkLoa
 
 void HTMLModelElement::didFinishLoading(ModelPlayer& modelPlayer)
 {
+#if ENABLE(GPU_PROCESS_MODEL)
+    if (&modelPlayer == m_pendingModelPlayer) {
+        // The pending player has finished loading. Promote it to live and
+        // tear down the previous one. Re-run configureGraphicsLayer with the
+        // new player BEFORE destroying the old one so the layer's contents
+        // are atomically re-pointed to the new model surface.
+        RefPtr oldPlayer = m_modelPlayer;
+        m_modelPlayer = std::exchange(m_pendingModelPlayer, nullptr);
+
+        if (CheckedPtr renderer = this->renderer())
+            renderer->updateFromElement();
+
+        if (oldPlayer) {
+            if (RefPtr provider = m_modelPlayerProvider.get())
+                provider->deleteModelPlayer(*oldPlayer);
+        }
+
+        reportExtraMemoryCost();
+        if (!m_readyPromise->isFulfilled())
+            m_readyPromise->resolve(*this);
+        triggerModelPlayerCreationCallbacksIfNeeded(RefPtr<ModelPlayer> { m_modelPlayer });
+        return;
+    }
+#else
     ASSERT_UNUSED(modelPlayer, &modelPlayer == m_modelPlayer);
+#endif
 
     reportExtraMemoryCost();
 
@@ -409,7 +441,20 @@ void HTMLModelElement::didFinishLoading(ModelPlayer& modelPlayer)
 
 void HTMLModelElement::didFailLoading(ModelPlayer& modelPlayer, const ResourceError&)
 {
+#if ENABLE(GPU_PROCESS_MODEL)
+    if (&modelPlayer == m_pendingModelPlayer) {
+        // The pending reload failed. Tear down only the pending player and
+        // keep the existing live player on screen.
+        deletePendingModelPlayer();
+        if (!m_readyPromise->isFulfilled())
+            m_readyPromise->reject(Exception { ExceptionCode::AbortError });
+        reportExtraMemoryCost();
+        return;
+    }
+#else
     ASSERT_UNUSED(modelPlayer, &modelPlayer == m_modelPlayer);
+#endif
+
     if (!m_readyPromise->isFulfilled())
         m_readyPromise->reject(Exception { ExceptionCode::AbortError });
 
@@ -423,7 +468,12 @@ void HTMLModelElement::didFailLoading(ModelPlayer& modelPlayer, const ResourceEr
 
 void HTMLModelElement::didConvertModelData(ModelPlayer& modelPlayer, Ref<SharedBuffer>&& convertedData, const String& convertedMIMEType)
 {
+#if ENABLE(GPU_PROCESS_MODEL)
+    if (&modelPlayer != m_modelPlayer && &modelPlayer != m_pendingModelPlayer)
+        return;
+#else
     ASSERT_UNUSED(modelPlayer, &modelPlayer == m_modelPlayer);
+#endif
     ASSERT(m_dataComplete);
 
     RELEASE_LOG(ModelElement, "%p - HTMLModelElement::didConvertModelData: Received converted model data, size=%zu mimeType=%s", this, convertedData->size(), convertedMIMEType.utf8().data());
@@ -468,7 +518,14 @@ void HTMLModelElement::didUnload(ModelPlayer& modelPlayer)
 
 void HTMLModelElement::didUpdate(ModelPlayer& modelPlayer)
 {
+#if ENABLE(GPU_PROCESS_MODEL)
+    // Pending-player updates do not yet contribute to the rendered layer;
+    // ignore them until the swap in didFinishLoading().
+    if (&modelPlayer != m_modelPlayer)
+        return;
+#else
     ASSERT_UNUSED(modelPlayer, &modelPlayer == m_modelPlayer);
+#endif
 
     if (CheckedPtr renderer = this->renderer())
         renderer->updateFromElement();
@@ -521,7 +578,12 @@ bool HTMLModelElement::isVisible() const
 
 void HTMLModelElement::logWarning(ModelPlayer& modelPlayer, const String& warningMessage)
 {
+#if ENABLE(GPU_PROCESS_MODEL)
+    if (&modelPlayer != m_modelPlayer && &modelPlayer != m_pendingModelPlayer)
+        return;
+#else
     ASSERT_UNUSED(modelPlayer, &modelPlayer == m_modelPlayer);
+#endif
 
     protect(document())->addConsoleMessage(MessageSource::Other, MessageLevel::Warning, warningMessage);
 }
@@ -561,9 +623,19 @@ void HTMLModelElement::createModelPlayer()
     if (modelContainerSizeIsEmpty())
         return triggerModelPlayerCreationCallbacksIfNeeded(Exception { ExceptionCode::AbortError, "Model container size is empty"_s });
 
+#if ENABLE(GPU_PROCESS_MODEL)
+    // If a live player is already showing content, route the new player into
+    // m_pendingModelPlayer so the existing compositing layer keeps rendering
+    // until the new player has finished loading. The swap happens in
+    // didFinishLoading().
+    bool routingToPending = !!m_modelPlayer;
+    if (routingToPending)
+        deletePendingModelPlayer();
+#else
     RefPtr modelPlayer = m_modelPlayer;
     if (modelPlayer)
         deleteModelPlayer();
+#endif
 
     ASSERT(document().page());
 
@@ -578,9 +650,20 @@ void HTMLModelElement::createModelPlayer()
 
     if (!m_modelPlayerProvider)
         m_modelPlayerProvider = document().page()->modelPlayerProvider();
+
+#if ENABLE(GPU_PROCESS_MODEL)
+    RefPtr<ModelPlayer> modelPlayer;
+#endif
     if (RefPtr modelPlayerProvider = m_modelPlayerProvider.get()) {
         modelPlayer = modelPlayerProvider->createModelPlayer(*this);
+#if ENABLE(GPU_PROCESS_MODEL)
+        if (routingToPending)
+            m_pendingModelPlayer = modelPlayer.copyRef();
+        else
+            m_modelPlayer = modelPlayer.copyRef();
+#else
         m_modelPlayer = modelPlayer.copyRef();
+#endif
     }
     if (!modelPlayer) {
         if (!m_readyPromise->isFulfilled())
@@ -618,7 +701,12 @@ void HTMLModelElement::createModelPlayer()
         environmentMapRequestResource();
 #endif
 
+#if ENABLE(GPU_PROCESS_MODEL)
+    if (!routingToPending)
+        triggerModelPlayerCreationCallbacksIfNeeded(WTF::move(modelPlayer));
+#else
     triggerModelPlayerCreationCallbacksIfNeeded(WTF::move(modelPlayer));
+#endif
 }
 
 void HTMLModelElement::deleteModelPlayer()
@@ -638,6 +726,17 @@ void HTMLModelElement::deleteModelPlayer()
         return documentImmersive->exitRemovedImmersiveElementIfNeeded(this, WTF::move(deleteModelPlayerBlock));
 #endif
     deleteModelPlayerBlock();
+}
+
+void HTMLModelElement::deletePendingModelPlayer()
+{
+#if ENABLE(GPU_PROCESS_MODEL)
+    RefPtr pendingPlayer = std::exchange(m_pendingModelPlayer, nullptr);
+    if (!pendingPlayer)
+        return;
+    if (RefPtr provider = m_modelPlayerProvider.get())
+        provider->deleteModelPlayer(*pendingPlayer);
+#endif
 }
 
 void HTMLModelElement::unloadModelPlayer(bool onSuspend)
@@ -1675,7 +1774,13 @@ bool HTMLModelElement::virtualHasPendingActivity() const
 {
     // We need to ensure the JS wrapper is kept alive if a load is in progress and we may yet dispatch
     // "load" or "error" events, ie. as long as we have a resource, meaning we are in the process of loading.
+#if ENABLE(GPU_PROCESS_MODEL)
+    // Also keep alive while a pending model player is loading: the network resource may have completed
+    // but the player can still resolve or reject the ready promise / fire its first frame.
+    return m_resource || m_pendingModelPlayer;
+#else
     return m_resource;
+#endif
 }
 
 void HTMLModelElement::stop()
@@ -1688,6 +1793,7 @@ void HTMLModelElement::stop()
 
     // Once an active DOM object has been stopped it cannot be restarted,
     // so we can delete the model player now.
+    deletePendingModelPlayer();
     deleteModelPlayer();
 }
 
@@ -1773,6 +1879,7 @@ void HTMLModelElement::removingSteps(RemovalType removalType, ContainerNode& old
 
         m_loadModelTimer = nullptr;
 
+        deletePendingModelPlayer();
         deleteModelPlayer();
     }
 }

--- a/Source/WebCore/Modules/model-element/HTMLModelElement.h
+++ b/Source/WebCore/Modules/model-element/HTMLModelElement.h
@@ -211,6 +211,7 @@ private:
     void modelDidChange();
     void createModelPlayer();
     void deleteModelPlayer();
+    void deletePendingModelPlayer();
     void unloadModelPlayer(bool onSuspend);
     void reloadModelPlayer();
     void startLoadModelTimer();
@@ -344,6 +345,7 @@ private:
 #endif
 
     RefPtr<ModelPlayer> m_modelPlayer;
+    RefPtr<ModelPlayer> m_pendingModelPlayer;
     EventLoopTimerHandle m_loadModelTimer;
 
 #if ENABLE(MODEL_ELEMENT_ENTITY_TRANSFORM)

--- a/Source/WebCore/css/html.css
+++ b/Source/WebCore/css/html.css
@@ -159,12 +159,6 @@ video {
     content: normal !important;
 }
 
-#if defined(ENABLE_GPU_PROCESS_MODEL) && ENABLE_GPU_PROCESS_MODEL
-model {
-    background-color: black;
-}
-#endif
-
 audio {
     width: 200px;
     height: 25px;

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1456,7 +1456,7 @@ public:
     void addDisplayChangedObserver(const DisplayChangedObserver&);
 
     using ScreenPropertiesChangedObserver = WTF::Observer<void(PlatformDisplayID)>;
-    void addScreenPropertiesChangedObserver(const ScreenPropertiesChangedObserver&);
+    WEBCORE_EXPORT void addScreenPropertiesChangedObserver(const ScreenPropertiesChangedObserver&);
 
 #if HAVE(SPATIAL_TRACKING_LABEL)
     String defaultSpatialTrackingLabel() const;

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -1341,17 +1341,9 @@ bool RenderLayerBacking::updateConfiguration(const RenderLayer* compositingAnces
     }
 #if ENABLE(MODEL_ELEMENT)
     else if (is<RenderModel>(renderer())) {
-#if ENABLE(GPU_PROCESS_MODEL)
-        auto modelBackgroundColor = rendererBackgroundColor();
-        modelBackgroundColor = modelBackgroundColor.isValid() ? modelBackgroundColor.opaqueColor() : Color::black;
-        m_graphicsLayer->setBackgroundColor(modelBackgroundColor);
-#else
-        auto modelBackgroundColor = rendererBackgroundColor();
-#endif
-
         RefPtr element = downcast<HTMLModelElement>(renderer().element());
 
-        element->configureGraphicsLayer(*m_graphicsLayer, modelBackgroundColor);
+        element->configureGraphicsLayer(*m_graphicsLayer, rendererBackgroundColor());
         element->sizeMayHaveChanged();
 
         layerConfigChanged = true;

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift
@@ -71,7 +71,7 @@ class Renderer {
             configuration: .init(
                 output: .init(colorPixelFormat: colorPixelFormat),
                 rasterSampleCount: rasterSampleCount,
-                enableTonemap: true,
+                enableTonemap: false,
                 enableColorMatch: colorSpace != nil,
                 alphaPremultiply: false
             ),
@@ -145,7 +145,7 @@ class Renderer {
     }
 
     func setBackgroundColor(_ color: simd_float3) {
-        clearColor = MTLClearColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.0)
+        clearColor = MTLClearColor(red: Double(color.x), green: Double(color.y), blue: Double(color.z), alpha: 1.0)
     }
 
     func setCameraTransformForModelTransform(_ modelTransform: simd_float4x4) {

--- a/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
@@ -915,7 +915,7 @@ extension WKBridgeReceiver {
                 let (mtlTextureEquirectangular, _) = makeMTLTextureFromImageAsset(
                     imageAsset,
                     device: device,
-                    generateMips: false,
+                    generateMips: true,
                     memoryOwner: self.memoryOwner,
                     layout: textureData.layout
                 )

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.h
@@ -35,8 +35,10 @@
 #include <WebCore/ModelPlayerAnimationState.h>
 #include <WebCore/ModelPlayerClient.h>
 #include <WebCore/PlatformDynamicRangeLimit.h>
+#include <WebCore/PlatformScreen.h>
 #include <WebCore/StageModeOperations.h>
 #include <wtf/Forward.h>
+#include <wtf/Observer.h>
 #include <wtf/RetainPtr.h>
 #include <wtf/URL.h>
 
@@ -132,6 +134,7 @@ private:
     std::optional<double> getEffectiveDynamicRangeLimitValue() const final;
     float computeContentsHeadroom();
     void updateContentsHeadroom();
+    void updateScreenHeadroom(float currentEDRHeadroom, bool suppressEDR);
 #endif
 
     WeakPtr<WebCore::ModelPlayerClient> m_client;
@@ -171,6 +174,8 @@ private:
     bool m_needsEntityTransformNotification { false };
 
 #if HAVE(SUPPORT_HDR_DISPLAY) && ENABLE(PIXEL_FORMAT_RGBA16F)
+    using ScreenPropertiesChangedObserver = Observer<void(WebCore::PlatformDisplayID)>;
+    RefPtr<ScreenPropertiesChangedObserver> m_screenPropertiesChangedObserver;
     float m_currentEDRHeadroom { 1.f };
     bool m_suppressEDR { false };
     WebCore::PlatformDynamicRangeLimit m_dynamicRangeLimit { WebCore::PlatformDynamicRangeLimit::initialValue() };

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
@@ -141,6 +141,19 @@ WebModelPlayer::WebModelPlayer(WebCore::Page& page, WebCore::ModelPlayerClient& 
 , m_id { WebCore::ModelPlayerIdentifier::generate() }
 , m_page(page)
 {
+#if HAVE(SUPPORT_HDR_DISPLAY) && ENABLE(PIXEL_FORMAT_RGBA16F)
+    if (RefPtr document = page.localTopDocument()) {
+        m_screenPropertiesChangedObserver = ScreenPropertiesChangedObserver::create([weakThis = ThreadSafeWeakPtr { *this }](WebCore::PlatformDisplayID displayID) {
+            RefPtr protectedThis = weakThis.get();
+            if (!protectedThis)
+                return;
+            if (auto* screenData = WebCore::screenData(displayID))
+                protectedThis->updateScreenHeadroom(screenData->currentEDRHeadroom, screenData->suppressEDR);
+        });
+
+        document->addScreenPropertiesChangedObserver(*m_screenPropertiesChangedObserver);
+    }
+#endif
 }
 
 WebModelPlayer::~WebModelPlayer() = default;
@@ -196,8 +209,10 @@ void WebModelPlayer::load(WebCore::Model& modelSource, WebCore::LayoutSize size)
     WEBMODEL_WEB_MODEL_PLAYER_DECLARE_DIFFUSE_AND_SPECULAR_TEXTURES
 
     m_currentModel = static_cast<RemoteGPUProxy&>(gpu->backing()).createModelBacking(m_currentPixelSize.width(), m_currentPixelSize.height(), diffuseTexture, specularTexture, [protectedThis = protect(*this)] (Vector<MachSendRight>&& surfaceHandles) {
-        if (surfaceHandles.size())
+        if (surfaceHandles.size()) {
             protectedThis->m_displayBuffers = WTF::move(surfaceHandles);
+            protectedThis->updateContentsHeadroom();
+        }
     });
     if (!m_currentModel)
         return;
@@ -267,10 +282,10 @@ void WebModelPlayer::load(WebCore::Model& modelSource, WebCore::LayoutSize size)
     }];
 
     m_retainedData = modelSource.data()->createNSData();
-    if (![m_modelLoader loadModel:m_retainedData.get()]) {
-        if (RefPtr client = m_client.get())
-            client->didFailLoading(protectedThis.get(), { });
-    }
+    if ([m_modelLoader loadModel:m_retainedData.get()])
+        startUpdateLoopIfNeeded();
+    else if (RefPtr client = m_client.get())
+        client->didFailLoading(protectedThis.get(), { });
 }
 
 void WebModelPlayer::notifyEntityTransformUpdated()
@@ -699,12 +714,18 @@ void WebModelPlayer::setEnvironmentMap(Ref<WebCore::SharedBuffer>&& data)
         client->didFinishEnvironmentMapLoading(*this, success);
 }
 
+static bool disableReloading()
+{
+    static bool disableReloading = [[NSUserDefaults standardUserDefaults] boolForKey:@"WebKitDisableModelPlayerReloading"];
+    return disableReloading;
+}
+
 void WebModelPlayer::visibilityStateDidChange()
 {
     // When the model becomes invisible, release memory-intensive resources.
     // When it becomes visible again, HTMLModelElement will trigger a reload through startLoadModelTimer().
     RefPtr client = m_client.get();
-    if (!client)
+    if (!client || disableReloading())
         return;
 
     if (!client->isVisible()) {
@@ -722,11 +743,15 @@ void WebModelPlayer::visibilityStateDidChange()
         m_isUpdateLoopRunning = false;
         m_isUpdateScheduled = false;
         m_isUpdating = false;
+        m_displayTextureIndex = 0;
     }
 }
 
 void WebModelPlayer::reload(WebCore::Model& modelSource, WebCore::LayoutSize size, WebCore::ModelPlayerAnimationState& animationState, std::unique_ptr<WebCore::ModelPlayerTransformState>&& transformState)
 {
+    if (disableReloading())
+        return;
+
     load(modelSource, size);
     if (transformState) {
         if (auto entityTransform = transformState->entityTransform())
@@ -811,9 +836,20 @@ float WebModelPlayer::computeContentsHeadroom()
 
 void WebModelPlayer::updateContentsHeadroom()
 {
+    constexpr auto visionProHeadroom = 2.f;
     auto headroom = computeContentsHeadroom();
     if (RefPtr model = m_currentModel)
-        model->updateContentsHeadroom(headroom);
+        model->updateContentsHeadroom(std::min(visionProHeadroom, headroom));
+}
+
+void WebModelPlayer::updateScreenHeadroom(float currentEDRHeadroom, bool suppressEDR)
+{
+    if (m_suppressEDR == suppressEDR && m_currentEDRHeadroom == currentEDRHeadroom)
+        return;
+
+    m_currentEDRHeadroom = currentEDRHeadroom;
+    m_suppressEDR = suppressEDR;
+    updateContentsHeadroom();
 }
 
 void WebModelPlayer::setDynamicRangeLimit(WebCore::PlatformDynamicRangeLimit dynamicRangeLimit, float currentEDRHeadroom, bool suppressEDR)


### PR DESCRIPTION
#### 3191f12a180984b9c9b5e9dbac68ab3341912e4a
<pre>
Align model appearance
<a href="https://bugs.webkit.org/show_bug.cgi?id=315210">https://bugs.webkit.org/show_bug.cgi?id=315210</a>
<a href="https://rdar.apple.com/177195829">rdar://177195829</a>

Reviewed by Cameron McCormack.

More closely align to visionOS appearance via the following:

* Limit high range to 2.0 which matches EDR headroom on visionPro
* Restore background color by disabling RE&apos;s tonemapping but limiting excessive EDR values
* Fix flash on model reload
* generate mip levels in all environment maps if they are not otherwise present in the USD
* correctly observe display headroom change events in WebModelPlayer.mm
* update headroom from the display upon IOSurface creation

* Source/WebCore/Modules/model-element/HTMLModelElement.cpp:
(WebCore::HTMLModelElement::~HTMLModelElement):
(WebCore::HTMLModelElement::setSourceURL):
(WebCore::HTMLModelElement::didFinishLoading):
(WebCore::HTMLModelElement::didFailLoading):
(WebCore::HTMLModelElement::didConvertModelData):
(WebCore::HTMLModelElement::didUpdate):
(WebCore::HTMLModelElement::logWarning):
(WebCore::HTMLModelElement::createModelPlayer):
(WebCore::HTMLModelElement::deletePendingModelPlayer):
(WebCore::HTMLModelElement::virtualHasPendingActivity const):
(WebCore::HTMLModelElement::stop):
(WebCore::HTMLModelElement::removingSteps):
* Source/WebCore/Modules/model-element/HTMLModelElement.h:
* Source/WebCore/css/html.css:
(#if defined(ENABLE_GPU_PROCESS_MODEL) &amp;&amp; ENABLE_GPU_PROCESS_MODEL): Deleted.
* Source/WebCore/dom/Document.h:
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateConfiguration):
* Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift:
(Renderer.createMaterialCompiler(_:rasterSampleCount:colorSpace:)):
(Renderer.setBackgroundColor(_:)):
* Source/WebKit/GPUProcess/graphics/Model/USDModel.swift:
(setEnvironmentMap(_:)):
* Source/WebKit/WebProcess/Model/WebModelPlayer.h:
* Source/WebKit/WebProcess/Model/WebModelPlayer.mm:
(WebKit::m_screenPropertiesChangedObserver):
(WebKit::WebModelPlayer::load):
(WebKit::disableReloading):
(WebKit::WebModelPlayer::visibilityStateDidChange):
(WebKit::WebModelPlayer::reload):
(WebKit::WebModelPlayer::updateContentsHeadroom):
(WebKit::WebModelPlayer::updateScreenHeadroom):
(WebKit::m_page): Deleted.

Canonical link: <a href="https://commits.webkit.org/313703@main">https://commits.webkit.org/313703@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90e3ef3da638fdd6f7082e230d5e3e8d34819d78

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163925 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37409 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30628 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172954 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165794 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37741 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37409 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127345 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121176 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166884 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29629 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147370 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107893 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28675 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27294 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20718 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138575 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25087 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175478 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28301 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26755 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135656 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37079 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31406 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135628 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36544 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37864 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146882 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100019 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30929 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23738 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36646 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109720 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36072 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1775 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36322 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36219 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->