### PR TITLE
[AutoFill Debugging] Fix an occasional web content process crash under `searchForClickTarget`

### DIFF
--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -2590,6 +2590,9 @@ static String textDescription(LocalFrame& frame, std::optional<NodeIdentifier> i
         return { };
 
     RefPtr target = resolveNodeWithBodyAsFallback(frame, identifier);
+    if (!target)
+        return { };
+
     auto searchTextPrefix = emptyString();
     if (!searchText.isEmpty()) {
         auto range = action == Action::Click ? searchForClickTarget(*target, searchText) : searchForText(*target, searchText);
@@ -2597,14 +2600,13 @@ static String textDescription(LocalFrame& frame, std::optional<NodeIdentifier> i
             return { };
 
         target = commonInclusiveAncestor<ComposedTree>(*range);
+        if (!target)
+            return { };
 
         auto escapedSearchText = normalizeText(searchText);
         stringsToValidate.append(escapedSearchText);
         searchTextPrefix = makeString(wrapWithDoubleQuotes(escapedSearchText), " in "_s);
     }
-
-    if (!target)
-        return { };
 
     return makeString(WTF::move(searchTextPrefix), textDescription(target.get(), stringsToValidate));
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm
@@ -365,6 +365,22 @@ TEST(TextExtractionTests, InteractionDebugDescription)
     }
 }
 
+TEST(TextExtractionTests, InteractionDebugDescriptionWithStaleNodeIdentifier)
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [[configuration preferences] _setTextExtractionEnabled:YES];
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 800, 600) configuration:configuration.get()]);
+    [webView synchronouslyLoadTestPageNamed:@"debug-text-extraction"];
+
+    NSError *error = nil;
+    RetainPtr interaction = adoptNS([[_WKTextExtractionInteraction alloc] initWithAction:_WKTextExtractionActionClick]);
+    [interaction setNodeIdentifier:@"999999999_999999999"];
+    [interaction setText:@"Test"];
+
+    EXPECT_NOT_NULL([interaction debugDescriptionInWebView:webView error:&error]);
+}
+
 TEST(TextExtractionTests, InteractionResultSummary)
 {
     RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);


### PR DESCRIPTION
#### e558364e9e21703e65cb15048c4ab262299478ad
<pre>
[AutoFill Debugging] Fix an occasional web content process crash under `searchForClickTarget`
<a href="https://bugs.webkit.org/show_bug.cgi?id=315217">https://bugs.webkit.org/show_bug.cgi?id=315217</a>
<a href="https://rdar.apple.com/177450427">rdar://177450427</a>

Reviewed by Abrar Rahman Protyasha.

Add a missing null check to guard against the case where both search text and an invalid node
identifier was present.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::textDescription):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/TextExtractionTests.mm:
(TestWebKitAPI::TEST(TextExtractionTests, InteractionDebugDescriptionWithStaleNodeIdentifier)):

Canonical link: <a href="https://commits.webkit.org/313604@main">https://commits.webkit.org/313604@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a07738cfd7e6379365f861caf15a5a7c66dbe8ad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163592 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37076 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30295 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172532 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/120041 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e97af170-9ee4-458d-8df9-611c05d2f639) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165461 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37407 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37075 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127063 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89578 "layout-tests (failure)") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e92fae5a-b4dd-428d-a065-bf8fd8bd3cbe) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166551 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29338 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147078 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107617 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/127ad709-e5fd-47fa-9bf0-9e2a535f458e) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28387 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27020 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20235 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138285 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24796 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175037 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27968 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26459 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135368 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36746 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31122 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135350 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36479 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37531 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146591 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99589 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30658 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23443 "Too many flaky failures: http/tests/contentextensions/text-track-blocked.html, http/tests/media/hls/hls-audio-tracks-language.html, http/tests/misc/object-image-error-with-onload.html, http/tests/navigation/parsed-iframe-dynamic-form-back-entry.html, http/tests/resourceLoadStatistics/log-cross-site-load-with-link-decoration.html, http/tests/security/canvas-remote-read-remote-image-allowed-with-credentials.html, http/tests/security/contentSecurityPolicy/1.1/stylehash-multiple-policies.html, http/tests/security/contentSecurityPolicy/object-redirect-allowed.html, http/tests/security/mixedContent/secure-page-navigates-to-basic-auth-secure-page-via-insecure-redirect.https.html, http/tests/site-isolation/iframe-and-window-open.html (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36241 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109387 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35739 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1469 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35989 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35886 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->