### PR TITLE
Fix css/css-values/html-attr-case-insensitivity.html

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -4459,7 +4459,6 @@ imported/w3c/web-platform-tests/css/css-values/calc-size/calc-size-flex-009.html
 imported/w3c/web-platform-tests/css/css-values/viewport-units-scrollbars-dynamic-001.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-values/viewport-units-scrollbars-scroll-vw-002.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-values/attr-pseudo-element-placeholder.html [ ImageOnlyFailure ]
-imported/w3c/web-platform-tests/css/css-values/html-attr-case-insensitivity.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-values/urls/cross-origin/url-import-cross-origin-anonymous.sub.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-values/urls/cross-origin/url-import-cross-origin-use-credentials.sub.html [ ImageOnlyFailure ]
 imported/w3c/web-platform-tests/css/css-values/urls/cross-origin/url-svg-filter-cross-origin-anonymous.sub.html [ ImageOnlyFailure ]

--- a/LayoutTests/imported/w3c/resources/resource-files.json
+++ b/LayoutTests/imported/w3c/resources/resource-files.json
@@ -9450,6 +9450,7 @@
         "web-platform-tests/css/css-values/calc-width-table-fixed-1-ref.html",
         "web-platform-tests/css/css-values/ex-calc-expression-001-ref.html",
         "web-platform-tests/css/css-values/html-attr-case-insensitivity-ref.html",
+        "web-platform-tests/css/css-values/svg-attr-case-sensitivity-ref.html",
         "web-platform-tests/css/css-values/inline-cache-base-uri-cssom-ref.html",
         "web-platform-tests/css/css-values/inline-cache-base-uri-ref.html",
         "web-platform-tests/css/css-values/inline-cache-base-uri/inner.html",

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/svg-attr-case-sensitivity-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/svg-attr-case-sensitivity-expected.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Reference</title>
+<p>Test passes if there are two green squares and no red.</p>
+<svg width="100" height="100"><rect width="100" height="100" fill="green"/></svg>
+<svg width="100" height="100"><rect width="100" height="100" fill="green"/></svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/svg-attr-case-sensitivity-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/svg-attr-case-sensitivity-ref.html
@@ -1,0 +1,6 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>Reference</title>
+<p>Test passes if there are two green squares and no red.</p>
+<svg width="100" height="100"><rect width="100" height="100" fill="green"/></svg>
+<svg width="100" height="100"><rect width="100" height="100" fill="green"/></svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/svg-attr-case-sensitivity.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/svg-attr-case-sensitivity.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+
+<title>attr() name is case-sensitive on non-HTML elements in HTML documents</title>
+
+<link rel="help" href="https://drafts.csswg.org/css-values-5/#typedef-attr-name">
+<link rel="match" href="svg-attr-case-sensitivity-ref.html"/>
+
+<style>
+.exact rect {
+  fill: attr(myAttr type(<color>), red);
+}
+.lower rect {
+  fill: attr(myattr type(<color>), green);
+}
+</style>
+
+<p>Test passes if there are two green squares and no red.</p>
+
+<svg class="exact" width="100" height="100">
+  <rect width="100" height="100"/>
+</svg>
+
+<svg class="lower" width="100" height="100">
+  <rect width="100" height="100"/>
+</svg>
+
+<script>
+  // setAttribute preserves case on SVG elements (unlike the HTML parser, which
+  // ASCII-lowercases attribute names during tokenization).
+  for (const rect of document.querySelectorAll(".exact rect, .lower rect"))
+    rect.setAttribute("myAttr", rect.closest(".exact") ? "green" : "red");
+</script>

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -45,6 +45,7 @@
 #include "CustomFunctionRegistry.h"
 #include "Document.h"
 #include "Element.h"
+#include "ElementInlines.h"
 #include "HTMLSelectElement.h"
 #include "MatchResult.h"
 #include "MutableStyleProperties.h"
@@ -387,7 +388,13 @@ bool SubstitutionResolver::substituteAttrFunction(CSSParserTokenRange argumentsR
         return false;
     range.consumeWhitespace();
 
-    auto attributeName = parsedName->name;
+    CheckedPtr element = m_styleBuilder.state().element();
+    if (!element)
+        return false;
+
+    // https://drafts.csswg.org/css-values-5/#typedef-attr-name
+    // "As with attribute selectors, the case-sensitivity of <attr-name> depends on the document language."
+    auto attributeName = shouldIgnoreAttributeCase(*element) ? parsedName->name.convertToASCIILowercase() : parsedName->name;
 
     // Consume optional <attr-type>.
     // https://drafts.csswg.org/css-values-5/#typedef-attr-type
@@ -449,10 +456,6 @@ bool SubstitutionResolver::substituteAttrFunction(CSSParserTokenRange argumentsR
 
     m_styleBuilder.state().registerSubstitutionAttribute(attributeName);
     protect(m_styleBuilder.state().style())->setHasAttrContent();
-
-    CheckedPtr element = m_styleBuilder.state().element();
-    if (!element)
-        return false;
 
     // Resolve namespace prefix to URI.
     auto namespaceURI = [&] -> AtomString {


### PR DESCRIPTION
#### 4e12206ac706f71f5106d13960d3324abb340a37
<pre>
Fix css/css-values/html-attr-case-insensitivity.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=315219">https://bugs.webkit.org/show_bug.cgi?id=315219</a>
<a href="https://rdar.apple.com/177547701">rdar://177547701</a>

Reviewed by Anne van Kesteren.

ASCII-lowercase the attr() name only for HTML elements in HTML documents,
to match how HTML attributes are stored. Foreign content (SVG, MathML)
inside an HTML document remains case-sensitive. Without this, attr() on
an HTML element fails to find a mixed-case attribute name in the rule.

Adds a SVG-side WPT to verify case-sensitivity is preserved for
non-HTML elements.

Spec: <a href="https://drafts.csswg.org/css-values-5/#typedef-attr-name">https://drafts.csswg.org/css-values-5/#typedef-attr-name</a>

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/resources/resource-files.json:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/svg-attr-case-sensitivity-expected.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/svg-attr-case-sensitivity-ref.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/svg-attr-case-sensitivity.html: Added.
* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::substituteAttrFunction):

Canonical link: <a href="https://commits.webkit.org/313654@main">https://commits.webkit.org/313654@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fae436a1f6ff30043beac53a782288a8c728a3c8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163728 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37212 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30431 "Built successfully") | [  ~~🛠 wpe~~](https://ews-build.webkit.org/#/builders/5/builds/172672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/120373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165597 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37543 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37211 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/5/builds/172672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/120373 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166687 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29456 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/147195 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/5/builds/172672 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28503 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/27135 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/20521 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/138402 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24912 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175173 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28104 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/26580 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/135482 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36882 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/135458 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36509 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37667 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146707 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99766 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30773 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23561 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36378 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109523 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35875 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1591 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36125 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36022 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->