### PR TITLE
[webkitscmpy] Git.fetch() should update remote tracking refs

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py
@@ -1365,7 +1365,7 @@ class Git(Scm):
             prune = True
         elif prune is None and self.config()['webkitscmpy.auto-prune'] == 'only-source':
             prune = remote in self.source_remotes()
-        command = [self.executable(), 'fetch', remote, '{}:{}'.format(branch, branch)]
+        command = [self.executable(), 'fetch', remote, '{}:{}'.format(branch, branch), '+refs/heads/{}:refs/remotes/{}/{}'.format(branch, remote, branch)]
         if prune:
             command.append('--prune')
         return run(command, cwd=self.root_path).returncode

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
@@ -640,7 +640,7 @@ nothing to commit, working tree clean
             ), mocks.Subprocess.Route(
                 self.executable, 'fetch', 'origin', re.compile(r'.+:.+'),
                 cwd=self.path,
-                generator=lambda *args, **kwargs: self._fetch_with_refspec(args[3]),
+                generator=lambda *args, **kwargs: self._fetch_with_refspec(args[3:]),
             ), mocks.Subprocess.Route(
                 self.executable, 'rebase', '--onto', re.compile(r'.+'), re.compile(r'.+'), re.compile(r'.+'),
                 cwd=self.path,
@@ -1317,18 +1317,40 @@ nothing to commit, working tree clean
             del self.remotes[remote_branch]
         return mocks.ProcessCompletion(returncode=0)
 
-    def _fetch_with_refspec(self, refspec):
-        """Handle fetch with refspec like 'main:main'.
+    def _fetch_with_refspec(self, refspecs):
+        """Handle fetch with one or more refspecs like 'main:main'.
 
         Simulates git's behavior of refusing to fetch into a branch
-        that is checked out in any worktree.
+        that is checked out in any worktree, and updates local refs
+        from the remote.
         """
-        branch = refspec.split(':')[0]
-        if self.is_worktree:
-            return mocks.ProcessCompletion(
-                returncode=1,
-                stderr="fatal: refusing to fetch into branch 'refs/heads/{}' checked out at '/other/worktree'\n".format(branch),
-            )
+        for refspec in refspecs:
+            if refspec == '--prune':
+                continue
+            if refspec.startswith('-'):
+                raise ValueError('Negative refspecs are not supported by this mock: {}'.format(refspec))
+            src, dst = refspec.lstrip('+').split(':', 1)
+            if dst.startswith('refs/heads/'):
+                branch = dst[len('refs/heads/'):]
+            elif '/' not in dst:
+                branch = dst
+            else:
+                continue
+
+            if self.is_worktree:
+                return mocks.ProcessCompletion(
+                    returncode=1,
+                    stderr="fatal: refusing to fetch into branch 'refs/heads/{}' checked out at '/other/worktree'\n".format(branch),
+                )
+
+            remote_key = 'origin/{}'.format(src if '/' not in src else src.split('/')[-1])
+            if remote_key not in self.remotes:
+                return mocks.ProcessCompletion(
+                    returncode=128,
+                    stderr="fatal: couldn't find remote ref {}\n".format(src),
+                )
+            self.commits[branch] = self.remotes[remote_key][:]
+
         return mocks.ProcessCompletion(returncode=0)
 
     def dcommit(self, remote='origin', branch=None):

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py
@@ -591,6 +591,65 @@ CommitDate: {time_c}
             result = repo.fetch(branch='main', remote='origin')
             self.assertNotEqual(result, 0)
 
+    def test_fetch_succeeds_in_normal_repo(self):
+        with mocks.local.Git(self.path) as mock_git, OutputCapture():
+            repo = local.Git(self.path)
+            default_branch = mock_git.default_branch
+
+            original_commits = mock_git.commits[default_branch][:]
+            mock_git.commits[default_branch] = original_commits[:-1]
+            mock_git.head = mock_git.commits[default_branch][-1]
+
+            self.assertNotEqual(mock_git.commits[default_branch], mock_git.remotes['origin/{}'.format(default_branch)])
+
+            result = repo.fetch(branch=default_branch, remote='origin')
+            self.assertEqual(result, 0)
+            self.assertEqual(mock_git.commits[default_branch], mock_git.remotes['origin/{}'.format(default_branch)])
+
+    def test_fetch_with_prune(self):
+        with mocks.local.Git(self.path) as mock_git, OutputCapture():
+            repo = local.Git(self.path)
+            default_branch = mock_git.default_branch
+
+            original_commits = mock_git.commits[default_branch][:]
+            mock_git.commits[default_branch] = original_commits[:-1]
+            mock_git.head = mock_git.commits[default_branch][-1]
+
+            result = repo.fetch(branch=default_branch, remote='origin', prune=True)
+            self.assertEqual(result, 0)
+            self.assertEqual(mock_git.commits[default_branch], mock_git.remotes['origin/{}'.format(default_branch)])
+
+    def test_fetch_default_remote(self):
+        with mocks.local.Git(self.path) as mock_git, OutputCapture():
+            repo = local.Git(self.path)
+            default_branch = mock_git.default_branch
+
+            original_commits = mock_git.commits[default_branch][:]
+            mock_git.commits[default_branch] = original_commits[:-1]
+            mock_git.head = mock_git.commits[default_branch][-1]
+
+            result = repo.fetch(branch=default_branch)
+            self.assertEqual(result, 0)
+            self.assertEqual(mock_git.commits[default_branch], mock_git.remotes['origin/{}'.format(default_branch)])
+
+    def test_fetch_nonexistent_remote_branch(self):
+        with mocks.local.Git(self.path) as mock_git, OutputCapture():
+            repo = local.Git(self.path)
+            self.assertIn('main', mock_git.commits)
+            self.assertNotIn('origin/nonexistent', mock_git.remotes)
+            result = repo.fetch(branch='nonexistent', remote='origin')
+            self.assertNotEqual(result, 0)
+
+    def test_fetch_creates_local_branch(self):
+        with mocks.local.Git(self.path) as mock_git, OutputCapture():
+            repo = local.Git(self.path)
+            self.assertIn('origin/branch-a', mock_git.remotes)
+            del mock_git.commits['branch-a']
+            self.assertNotIn('branch-a', mock_git.commits)
+            result = repo.fetch(branch='branch-a', remote='origin')
+            self.assertEqual(result, 0)
+            self.assertEqual(mock_git.commits['branch-a'], mock_git.remotes['origin/branch-a'])
+
     def test_pull_rebase_with_branch(self):
         """Test that pull(rebase=True, branch=X) works in a normal repository.
 


### PR DESCRIPTION
#### 8b9b74668e91bcace4530d2b9656de3d6e851d09
<pre>
[webkitscmpy] Git.fetch() should update remote tracking refs
<a href="https://bugs.webkit.org/show_bug.cgi?id=315204">https://bugs.webkit.org/show_bug.cgi?id=315204</a>
<a href="https://rdar.apple.com/177532662">rdar://177532662</a>

Reviewed by Jonathan Bedard.

Git.fetch(branch) was only passing a single refspec (branch:branch) which
updates refs/heads/branch but not refs/remotes/origin/branch. This left
the remote tracking ref stale, breaking --tip-of-tree in import-w3c-tests.

Add a second refspec (+refs/heads/branch:refs/remotes/remote/branch) to
update the remote tracking ref as well.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/local/git.py:
(Git.fetch):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py:
(Git._fetch_with_refspec):
* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/test/git_unittest.py:
(test_fetch_succeeds_in_normal_repo):
(test_fetch_with_prune):
(test_fetch_default_remote):
(test_fetch_nonexistent_remote_branch):
(test_fetch_creates_local_branch):

Canonical link: <a href="https://commits.webkit.org/313618@main">https://commits.webkit.org/313618@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b52cb5f7378a741d7ee03f9d87542afb4e23943a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163598 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37082 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30301 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172538 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/120047 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/57643567-3b0f-4f5f-b1ea-2d87f1310a2b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165467 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37413 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37081 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127069 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89582 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4992165f-88d9-41f4-b481-c09754b89e62) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166557 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29345 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147082 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107623 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2e20b9d9-8d5b-4887-916c-742d85dc6174) 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/162919 "Found 1 webkitpy test failure: webkitpy.scripts.measure_build_time_unittest.MeasureBuildTimeTest.test_clean_and_null_build") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28394 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27026 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20241 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138292 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24799 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175043 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26462 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135374 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/162995 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36752 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31128 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135356 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36487 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37537 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146594 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99598 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30665 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23446 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36247 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35745 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1472 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/35995 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35892 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->