### PR TITLE
Fix crashes in RealtimeIncoming*Source destructors by ensuring sink removal before member destruction

### DIFF
--- a/Source/WebCore/platform/mediastream/RealtimeIncomingAudioSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeIncomingAudioSource.cpp
@@ -49,7 +49,10 @@ RealtimeIncomingAudioSource::RealtimeIncomingAudioSource(Ref<webrtc::AudioTrackI
 
 RealtimeIncomingAudioSource::~RealtimeIncomingAudioSource()
 {
-    stop();
+    // Subclasses must call stop() in their destructors to ensure the audio
+    // track sink is removed BEFORE derived members are destroyed. Otherwise,
+    // the OnData callback may access destroyed members on the audio thread.
+    ASSERT(!isProducingData());
     m_audioTrack->UnregisterObserver(this);
 }
 

--- a/Source/WebCore/platform/mediastream/RealtimeIncomingVideoSource.cpp
+++ b/Source/WebCore/platform/mediastream/RealtimeIncomingVideoSource.cpp
@@ -73,7 +73,10 @@ RealtimeIncomingVideoSource::RealtimeIncomingVideoSource(Ref<webrtc::VideoTrackI
 
 RealtimeIncomingVideoSource::~RealtimeIncomingVideoSource()
 {
-    stop();
+    // Subclasses must call stop() in their destructors to ensure the video
+    // track sink is removed BEFORE derived members are destroyed. Otherwise,
+    // the OnFrame callback may access destroyed members on the video thread.
+    ASSERT(!isProducingData());
     m_videoTrack->UnregisterObserver(this);
 }
 

--- a/Source/WebCore/platform/mediastream/cocoa/RealtimeIncomingAudioSourceCocoa.cpp
+++ b/Source/WebCore/platform/mediastream/cocoa/RealtimeIncomingAudioSourceCocoa.cpp
@@ -72,6 +72,11 @@ RealtimeIncomingAudioSourceCocoa::RealtimeIncomingAudioSourceCocoa(Ref<webrtc::A
 {
 }
 
+RealtimeIncomingAudioSourceCocoa::~RealtimeIncomingAudioSourceCocoa()
+{
+    stop();
+}
+
 void RealtimeIncomingAudioSourceCocoa::startProducingData()
 {
     RealtimeIncomingAudioSource::startProducingData();

--- a/Source/WebCore/platform/mediastream/cocoa/RealtimeIncomingAudioSourceCocoa.h
+++ b/Source/WebCore/platform/mediastream/cocoa/RealtimeIncomingAudioSourceCocoa.h
@@ -42,6 +42,7 @@ namespace WebCore {
 class RealtimeIncomingAudioSourceCocoa final : public RealtimeIncomingAudioSource {
 public:
     static Ref<RealtimeIncomingAudioSourceCocoa> create(Ref<webrtc::AudioTrackInterface>&&, String&&);
+    ~RealtimeIncomingAudioSourceCocoa();
 
 private:
     RealtimeIncomingAudioSourceCocoa(Ref<webrtc::AudioTrackInterface>&&, String&&);

--- a/Source/WebCore/platform/mediastream/cocoa/RealtimeIncomingVideoSourceCocoa.h
+++ b/Source/WebCore/platform/mediastream/cocoa/RealtimeIncomingVideoSourceCocoa.h
@@ -45,6 +45,7 @@ enum class VideoFrameRotation : uint16_t;
 class RealtimeIncomingVideoSourceCocoa final : public RealtimeIncomingVideoSource {
 public:
     static Ref<RealtimeIncomingVideoSourceCocoa> create(Ref<webrtc::VideoTrackInterface>&&, String&&);
+    ~RealtimeIncomingVideoSourceCocoa();
 
 private:
     RealtimeIncomingVideoSourceCocoa(Ref<webrtc::VideoTrackInterface>&&, String&&);

--- a/Source/WebCore/platform/mediastream/cocoa/RealtimeIncomingVideoSourceCocoa.mm
+++ b/Source/WebCore/platform/mediastream/cocoa/RealtimeIncomingVideoSourceCocoa.mm
@@ -63,6 +63,11 @@ RealtimeIncomingVideoSourceCocoa::RealtimeIncomingVideoSourceCocoa(Ref<webrtc::V
 {
 }
 
+RealtimeIncomingVideoSourceCocoa::~RealtimeIncomingVideoSourceCocoa()
+{
+    stop();
+}
+
 CVPixelBufferPoolRef RealtimeIncomingVideoSourceCocoa::pixelBufferPool(size_t width, size_t height, webrtc::BufferType bufferType) WTF_IGNORES_THREAD_SAFETY_ANALYSIS
 {
     if (!m_pixelBufferPool || m_pixelBufferPoolWidth != width || m_pixelBufferPoolHeight != height || m_pixelBufferPoolBufferType != bufferType) {

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingAudioSourceLibWebRTC.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingAudioSourceLibWebRTC.cpp
@@ -61,6 +61,11 @@ RealtimeIncomingAudioSourceLibWebRTC::RealtimeIncomingAudioSourceLibWebRTC(Ref<w
     GST_DEBUG("Created incoming audio source with ID: %s", persistentID().utf8().data());
 }
 
+RealtimeIncomingAudioSourceLibWebRTC::~RealtimeIncomingAudioSourceLibWebRTC()
+{
+    stop();
+}
+
 void RealtimeIncomingAudioSourceLibWebRTC::OnData(const void* audioData, int, int sampleRate, size_t numberOfChannels, size_t numberOfFrames)
 {
 #if GST_CHECK_VERSION(1, 22, 0)

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingAudioSourceLibWebRTC.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingAudioSourceLibWebRTC.h
@@ -38,6 +38,7 @@ namespace WebCore {
 class RealtimeIncomingAudioSourceLibWebRTC final : public RealtimeIncomingAudioSource {
 public:
     static Ref<RealtimeIncomingAudioSourceLibWebRTC> create(Ref<webrtc::AudioTrackInterface>&&, String&&);
+    ~RealtimeIncomingAudioSourceLibWebRTC();
 
 private:
     RealtimeIncomingAudioSourceLibWebRTC(Ref<webrtc::AudioTrackInterface>&&, String&&);

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingVideoSourceLibWebRTC.cpp
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingVideoSourceLibWebRTC.cpp
@@ -62,6 +62,11 @@ RealtimeIncomingVideoSourceLibWebRTC::RealtimeIncomingVideoSourceLibWebRTC(Ref<w
     GST_DEBUG("Created incoming video source with ID: %s", persistentID().utf8().data());
 }
 
+RealtimeIncomingVideoSourceLibWebRTC::~RealtimeIncomingVideoSourceLibWebRTC()
+{
+    stop();
+}
+
 void RealtimeIncomingVideoSourceLibWebRTC::OnFrame(const webrtc::VideoFrame& frame)
 {
     if (!isProducingData())

--- a/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingVideoSourceLibWebRTC.h
+++ b/Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingVideoSourceLibWebRTC.h
@@ -41,7 +41,7 @@ public:
 
 private:
     RealtimeIncomingVideoSourceLibWebRTC(Ref<webrtc::VideoTrackInterface>&&, String&&);
-    ~RealtimeIncomingVideoSourceLibWebRTC() { }
+    ~RealtimeIncomingVideoSourceLibWebRTC();
 
     // rtc::VideoSinkInterface
     void OnFrame(const webrtc::VideoFrame&) final;


### PR DESCRIPTION
#### 02e76c68f62d4eb9afd58210d91e07c85e5ad4b9
<pre>
Fix crashes in RealtimeIncoming*Source destructors by ensuring sink removal before member destruction
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=308636">https://bugs.webkit.org/show_bug.cgi?id=308636</a>&gt;
&lt;<a href="https://rdar.apple.com/162084447">rdar://162084447</a>&gt;

Reviewed by Jean-Yves Avenard and Youenn Fablet.

Crashes occurred when WebRTC audio/video callbacks accessed destroyed
member variables during object destruction.  The root cause is due to
C++ destruction-order behavior:  the compiler-generated destructors in
derived classes (e.g. RealtimeIncomingAudioSourceCocoa) destroy derived
members before calling the base class destructor, but the base class
destructor&apos;s stop() call is what removes the audio/video track sink.

While RTCPeerConnection::doClose() normally stops sources via
requestToEnd(), there are code paths where the source can reach
destruction while still producing data -- for example,
requestToEnd() is blocked if any RealtimeMediaSourceObserver returns
true from preventSourceFromEnding().  If the source is still producing
data when destruction begins, the base class destructor&apos;s stop() does
call RemoveSink() (which properly synchronizes with in-progress OnData
callbacks via sink_lock_ in RemoteAudioSource), but by that point
derived members like m_audioBufferList are already destroyed.

The fix ensures derived destructors call stop() to remove sinks before
any member destruction occurs.  The base class destructors now contain
ASSERT(!isProducingData()) to verify subclasses follow this pattern.

* Source/WebCore/platform/mediastream/RealtimeIncomingAudioSource.cpp:
(WebCore::RealtimeIncomingAudioSource::~RealtimeIncomingAudioSource):
* Source/WebCore/platform/mediastream/RealtimeIncomingVideoSource.cpp:
(WebCore::RealtimeIncomingVideoSource::~RealtimeIncomingVideoSource):
* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingAudioSourceLibWebRTC.cpp:
(WebCore::RealtimeIncomingAudioSourceLibWebRTC::~RealtimeIncomingAudioSourceLibWebRTC): Add.
* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingAudioSourceLibWebRTC.h:
* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingVideoSourceLibWebRTC.cpp:
(WebCore::RealtimeIncomingVideoSourceLibWebRTC::~RealtimeIncomingVideoSourceLibWebRTC): Add.
* Source/WebCore/platform/mediastream/libwebrtc/gstreamer/RealtimeIncomingVideoSourceLibWebRTC.h:
* Source/WebCore/platform/mediastream/mac/RealtimeIncomingAudioSourceCocoa.cpp:
(WebCore::RealtimeIncomingAudioSourceCocoa::~RealtimeIncomingAudioSourceCocoa): Add.
* Source/WebCore/platform/mediastream/mac/RealtimeIncomingAudioSourceCocoa.h:
* Source/WebCore/platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.h:
* Source/WebCore/platform/mediastream/mac/RealtimeIncomingVideoSourceCocoa.mm:
(WebCore::RealtimeIncomingVideoSourceCocoa::~RealtimeIncomingVideoSourceCocoa): Add.

Originally-landed-as: 305413.429@rapid/safari-7624.2.5.110-branch (6d6607033ebc). <a href="https://rdar.apple.com/176067300">rdar://176067300</a>
Canonical link: <a href="https://commits.webkit.org/313616@main">https://commits.webkit.org/313616@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a1326708a3945f4287bcd6e04cd70c818f702438

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163607 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37091 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30310 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172547 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/120056 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165476 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37422 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37090 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127077 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89587 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166566 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29353 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147083 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107631 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28402 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27032 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20250 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138301 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24800 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175052 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27983 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26463 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135380 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36761 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31134 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135362 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36485 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37546 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146595 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99607 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30673 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23447 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36256 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109402 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35754 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1473 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36004 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35901 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->