### PR TITLE
[JSC] Improve rope-string comparison

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -7790,42 +7790,95 @@ void SpeculativeJIT::compilePeepHoleNotDoubleNeitherDoubleNorHeapBigIntNorString
 void SpeculativeJIT::compileStringEquality(
     Node* node, GPRReg leftGPR, GPRReg rightGPR, GPRReg lengthGPR, GPRReg leftTempGPR,
     GPRReg rightTempGPR, GPRReg leftTemp2GPR, GPRReg rightTemp2GPR,
-    const JumpList& fastTrue, const JumpList& fastFalse)
+    const JumpList& fastTrue, const JumpList& fastFalse,
+    Edge leftEdge, Edge rightEdge)
 {
+    String leftConst = leftEdge ? leftEdge->tryGetString(m_graph) : String();
+    String rightConst = rightEdge ? rightEdge->tryGetString(m_graph) : String();
+    bool leftAtom = !leftConst.isNull() && leftConst.impl()->isAtom();
+    bool rightAtom = !rightConst.isNull() && rightConst.impl()->isAtom();
+
     JumpList trueCase;
     JumpList falseCase;
     JumpList slowCase;
-    
+
     trueCase.append(fastTrue);
     falseCase.append(fastFalse);
 
-    loadPtr(Address(leftGPR, JSString::offsetOfValue()), leftTempGPR);
-    loadPtr(Address(rightGPR, JSString::offsetOfValue()), rightTempGPR);
+    auto loadImplAndCheckRope = [&](bool atom, GPRReg jsStringGPR, GPRReg implGPR) {
+        if (atom)
+            return;
+        loadPtr(Address(jsStringGPR, JSString::offsetOfValue()), implGPR);
+        slowCase.append(branchIfRopeStringImpl(implGPR));
+    };
 
-    slowCase.append(branchIfRopeStringImpl(leftTempGPR));
-    slowCase.append(branchIfRopeStringImpl(rightTempGPR));
+    auto resolveDataPtr = [&](bool atom, const String& constStr, GPRReg implGPR) {
+        if (atom) {
+            const void* data = constStr.is8Bit()
+                ? static_cast<const void*>(constStr.span8().data())
+                : static_cast<const void*>(constStr.span16().data());
+            move(TrustedImmPtr(data), implGPR);
+            return;
+        }
+        loadPtr(Address(implGPR, StringImpl::dataOffset()), implGPR);
+    };
 
-    load32(Address(leftTempGPR, StringImpl::lengthMemoryOffset()), lengthGPR);
-    
-    falseCase.append(branch32(
-        NotEqual,
-        Address(rightTempGPR, StringImpl::lengthMemoryOffset()),
-        lengthGPR));
-    
-    trueCase.append(branchTest32(Zero, lengthGPR));
-    
-    // leftTemp2GPR/rightTemp2GPR may alias leftGPR/rightGPR (Reuse), so we must not clobber
-    // them before the last slowCase branch is emitted.
-    Jump leftIs8Bit = branchTest32(NonZero, Address(leftTempGPR, StringImpl::flagsOffset()), TrustedImm32(StringImpl::flagIs8Bit()));
-    slowCase.append(branchTest32(NonZero, Address(rightTempGPR, StringImpl::flagsOffset()), TrustedImm32(StringImpl::flagIs8Bit())));
-    lshift32(TrustedImm32(1), lengthGPR);
-    Jump widthDone = jump();
-    leftIs8Bit.link(this);
-    slowCase.append(branchTest32(Zero, Address(rightTempGPR, StringImpl::flagsOffset()), TrustedImm32(StringImpl::flagIs8Bit())));
-    widthDone.link(this);
+    auto branchSlowIfWidthMismatch = [&](GPRReg dynImplGPR, bool constIs8Bit) {
+        slowCase.append(branchTest32(
+            constIs8Bit ? Zero : NonZero,
+            Address(dynImplGPR, StringImpl::flagsOffset()),
+            TrustedImm32(StringImpl::flagIs8Bit())));
+    };
 
-    loadPtr(Address(leftTempGPR, StringImpl::dataOffset()), leftTempGPR);
-    loadPtr(Address(rightTempGPR, StringImpl::dataOffset()), rightTempGPR);
+    auto applyByteWidthForChars = [&](bool is8Bit) {
+        if (!is8Bit)
+            lshift32(TrustedImm32(1), lengthGPR);
+    };
+
+    loadImplAndCheckRope(leftAtom, leftGPR, leftTempGPR);
+    loadImplAndCheckRope(rightAtom, rightGPR, rightTempGPR);
+
+    if (leftAtom || rightAtom) {
+        const String& constStr = leftAtom ? leftConst : rightConst;
+        if (leftAtom && rightAtom) {
+            if (leftConst.length() != rightConst.length())
+                falseCase.append(jump());
+        } else {
+            GPRReg dynImplGPR = leftAtom ? rightTempGPR : leftTempGPR;
+            falseCase.append(branch32(NotEqual, Address(dynImplGPR, StringImpl::lengthMemoryOffset()), TrustedImm32(constStr.length())));
+        }
+        move(TrustedImm32(constStr.length()), lengthGPR);
+
+        unsigned constLength = leftAtom ? leftConst.length() : rightConst.length();
+        if (!constLength)
+            trueCase.append(jump());
+
+        bool constIs8Bit = leftAtom ? leftConst.is8Bit() : rightConst.is8Bit();
+        if (leftAtom && rightAtom) {
+            if (leftConst.is8Bit() != rightConst.is8Bit())
+                slowCase.append(jump());
+        } else {
+            GPRReg dynImplGPR = leftAtom ? rightTempGPR : leftTempGPR;
+            branchSlowIfWidthMismatch(dynImplGPR, constIs8Bit);
+        }
+        applyByteWidthForChars(constIs8Bit);
+    } else {
+        load32(Address(leftTempGPR, StringImpl::lengthMemoryOffset()), lengthGPR);
+        falseCase.append(branch32(NotEqual, Address(rightTempGPR, StringImpl::lengthMemoryOffset()), lengthGPR));
+
+        trueCase.append(branchTest32(Zero, lengthGPR));
+
+        Jump leftIs8Bit = branchTest32(NonZero, Address(leftTempGPR, StringImpl::flagsOffset()), TrustedImm32(StringImpl::flagIs8Bit()));
+        slowCase.append(branchTest32(NonZero, Address(rightTempGPR, StringImpl::flagsOffset()), TrustedImm32(StringImpl::flagIs8Bit())));
+        lshift32(TrustedImm32(1), lengthGPR);
+        Jump widthDone = jump();
+        leftIs8Bit.link(this);
+        slowCase.append(branchTest32(Zero, Address(rightTempGPR, StringImpl::flagsOffset()), TrustedImm32(StringImpl::flagIs8Bit())));
+        widthDone.link(this);
+    }
+
+    resolveDataPtr(leftAtom, leftConst, leftTempGPR);
+    resolveDataPtr(rightAtom, rightConst, rightTempGPR);
 
     constexpr unsigned wordSize = sizeof(void*);
 
@@ -7858,17 +7911,32 @@ void SpeculativeJIT::compileStringEquality(
 
     trueCase.link(this);
     moveTrueTo(leftTempGPR);
-    
+
     Jump done = jump();
 
     falseCase.link(this);
     moveFalseTo(leftTempGPR);
-    
+
     done.link(this);
-    addSlowPathGenerator(
-        slowPathCall(
-            slowCase, this, operationCompareStringEq, leftTempGPR, LinkableConstant::globalObject(*this, node), leftGPR, rightGPR));
-    
+
+    Vector<SilentRegisterSavePlan> savePlans;
+    silentSpillAllRegistersImpl(false, savePlans, leftTempGPR);
+    Label doneOperationCall = label();
+    addSlowPathGeneratorLambda([=, this, savePlans = WTF::move(savePlans), slowCase = WTF::move(slowCase)]() mutable {
+        slowCase.link(this);
+        silentSpill(savePlans);
+        setupArguments<decltype(operationCompareStringEq)>(LinkableConstant::globalObject(*this, node), leftGPR, rightGPR);
+        prepareForExternalCall();
+        emitStoreCodeOrigin(node->origin.semantic);
+        nearCallThunk(CodeLocationLabel<JITThunkPtrTag>(vm().getCTIStub(stringEqualThunkGenerator).code()));
+        auto exceptionReg = tryHandleOrGetExceptionUnderSilentSpill<decltype(operationCompareStringEq)>(savePlans, leftTempGPR);
+        setupResults(leftTempGPR);
+        silentFill(savePlans);
+        if (exceptionReg)
+            exceptionCheck(*exceptionReg);
+        jump().linkTo(doneOperationCall, this);
+    });
+
     blessedBooleanResult(leftTempGPR, node);
 }
 
@@ -7900,7 +7968,7 @@ void SpeculativeJIT::compileStringEquality(Node* node)
     
     compileStringEquality(
         node, leftGPR, rightGPR, lengthGPR, leftTempGPR, rightTempGPR, leftTemp2GPR,
-        rightTemp2GPR, fastTrue, Jump());
+        rightTemp2GPR, fastTrue, Jump(), node->child1(), node->child2());
 }
 
 void SpeculativeJIT::compileStringToUntypedEquality(Node* node, Edge stringEdge, Edge untypedEdge)
@@ -7937,7 +8005,7 @@ void SpeculativeJIT::compileStringToUntypedEquality(Node* node, Edge stringEdge,
     
     compileStringEquality(
         node, leftGPR, rightRegs.payloadGPR(), lengthGPR, leftTempGPR, rightTempGPR, leftTemp2GPR,
-        rightTemp2GPR, fastTrue, fastFalse);
+        rightTemp2GPR, fastTrue, fastFalse, stringEdge, Edge());
 }
 
 void SpeculativeJIT::compileStringIdentEquality(Node* node)

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1389,7 +1389,8 @@ public:
         Node*, GPRReg leftGPR, GPRReg rightGPR, GPRReg lengthGPR,
         GPRReg leftTempGPR, GPRReg rightTempGPR, GPRReg leftTemp2GPR,
         GPRReg rightTemp2GPR, const JITCompiler::JumpList& fastTrue,
-        const JITCompiler::JumpList& fastSlow);
+        const JITCompiler::JumpList& fastFalse,
+        Edge leftEdge, Edge rightEdge);
     void compileStringEquality(Node*);
     void compileStringIdentEquality(Node*);
     void compileStringToUntypedEquality(Node*, Edge stringEdge, Edge untypedEdge);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -413,7 +413,7 @@ void SpeculativeJIT::compileNeitherDoubleNorHeapBigIntToNotDoubleStrictEquality(
     if (needsTypeCheck(rightNotDoubleChild, SpecString))
         falseCase.append(branchIfNotString(rightRegs.payloadGPR()));
 
-    compileStringEquality(node, leftRegs.payloadGPR(), rightRegs.payloadGPR(), tempGPR, leftTempGPR, rightTempGPR, leftTemp2GPR, rightTemp2GPR, trueCase, falseCase);
+    compileStringEquality(node, leftRegs.payloadGPR(), rightRegs.payloadGPR(), tempGPR, leftTempGPR, rightTempGPR, leftTemp2GPR, rightTemp2GPR, trueCase, falseCase, Edge(), Edge());
 }
 
 void SpeculativeJIT::nonSpeculativePeepholeStrictEq(Node* node, Node* branchNode, bool invert)

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -21861,6 +21861,12 @@ IGNORE_CLANG_WARNINGS_END
     LValue stringsEqual(LValue leftJSString, LValue rightJSString, Edge leftJSStringEdge = Edge(), Edge rightJSStringEdge = Edge())
     {
         JSGlobalObject* globalObject = m_graph.globalObjectFor(m_origin.semantic);
+
+        String leftConst = leftJSStringEdge ? leftJSStringEdge->tryGetString(m_graph) : String();
+        String rightConst = rightJSStringEdge ? rightJSStringEdge->tryGetString(m_graph) : String();
+        bool leftAtom = !leftConst.isNull() && leftConst.impl()->isAtom();
+        bool rightAtom = !rightConst.isNull() && rightConst.impl()->isAtom();
+
         LBasicBlock notTriviallyUnequalCase = m_out.newBlock();
         LBasicBlock notEmptyCase = m_out.newBlock();
         LBasicBlock leftReadyCase = m_out.newBlock();
@@ -21880,30 +21886,46 @@ IGNORE_CLANG_WARNINGS_END
         LBasicBlock slowCase = m_out.newBlock();
         LBasicBlock continuation = m_out.newBlock();
 
-        m_out.branch(isRopeString(leftJSString, leftJSStringEdge), rarely(slowCase), usually(leftReadyCase));
+        if (leftAtom)
+            m_out.jump(leftReadyCase);
+        else
+            m_out.branch(isRopeString(leftJSString, leftJSStringEdge), rarely(slowCase), usually(leftReadyCase));
 
         LBasicBlock lastNext = m_out.appendTo(leftReadyCase, rightReadyCase);
-        m_out.branch(isRopeString(rightJSString, rightJSStringEdge), rarely(slowCase), usually(rightReadyCase));
+        if (rightAtom)
+            m_out.jump(rightReadyCase);
+        else
+            m_out.branch(isRopeString(rightJSString, rightJSStringEdge), rarely(slowCase), usually(rightReadyCase));
 
         m_out.appendTo(rightReadyCase, notTriviallyUnequalCase);
-        LValue left = m_out.loadPtr(leftJSString, m_heaps.JSString_value);
-        LValue right = m_out.loadPtr(rightJSString, m_heaps.JSString_value);
-        LValue length = m_out.load32(left, m_heaps.StringImpl_length);
+        LValue left = leftAtom ? nullptr : m_out.loadPtr(leftJSString, m_heaps.JSString_value);
+        LValue right = rightAtom ? nullptr : m_out.loadPtr(rightJSString, m_heaps.JSString_value);
+        LValue leftLength = leftAtom
+            ? m_out.constInt32(leftConst.length())
+            : m_out.load32(left, m_heaps.StringImpl_length);
+        LValue rightLength = rightAtom
+            ? m_out.constInt32(rightConst.length())
+            : m_out.load32(right, m_heaps.StringImpl_length);
         m_out.branch(
-            m_out.notEqual(length, m_out.load32(right, m_heaps.StringImpl_length)),
+            m_out.notEqual(leftLength, rightLength),
             unsure(falseCase), unsure(notTriviallyUnequalCase));
 
         m_out.appendTo(notTriviallyUnequalCase, notEmptyCase);
+        LValue length = leftLength;
         m_out.branch(m_out.isZero32(length), unsure(trueCase), unsure(notEmptyCase));
 
         // Mixed-width pairs bail to the slow path; the runtime helper handles cross-width equality.
         m_out.appendTo(notEmptyCase, widthMatchedCase);
-        LValue leftIs8Bit = m_out.bitAnd(
-            m_out.load32(left, m_heaps.StringImpl_hashAndFlags),
-            m_out.constInt32(StringImpl::flagIs8Bit()));
-        LValue rightIs8Bit = m_out.bitAnd(
-            m_out.load32(right, m_heaps.StringImpl_hashAndFlags),
-            m_out.constInt32(StringImpl::flagIs8Bit()));
+        LValue leftIs8Bit = leftAtom
+            ? m_out.constInt32(leftConst.is8Bit() ? StringImpl::flagIs8Bit() : 0)
+            : m_out.bitAnd(
+                m_out.load32(left, m_heaps.StringImpl_hashAndFlags),
+                m_out.constInt32(StringImpl::flagIs8Bit()));
+        LValue rightIs8Bit = rightAtom
+            ? m_out.constInt32(rightConst.is8Bit() ? StringImpl::flagIs8Bit() : 0)
+            : m_out.bitAnd(
+                m_out.load32(right, m_heaps.StringImpl_hashAndFlags),
+                m_out.constInt32(StringImpl::flagIs8Bit()));
         m_out.branch(m_out.notEqual(leftIs8Bit, rightIs8Bit), rarely(slowCase), usually(widthMatchedCase));
 
         // 8-bit is the common case: fall through with byteLength == length. 16-bit converts char-count
@@ -21919,8 +21941,18 @@ IGNORE_CLANG_WARNINGS_END
         m_out.appendTo(byteLengthReady, byteLoop);
         LValue byteLength = m_out.phi(Int32, byteLengthIf8Bit, byteLengthIf16Bit);
 
-        LValue leftData = m_out.loadPtr(left, m_heaps.StringImpl_data);
-        LValue rightData = m_out.loadPtr(right, m_heaps.StringImpl_data);
+        auto materializeAtomDataPtr = [&](const String& s) {
+            const void* data = s.is8Bit()
+                ? static_cast<const void*>(s.span8().data())
+                : static_cast<const void*>(s.span16().data());
+            return m_out.constIntPtr(data);
+        };
+        LValue leftData = leftAtom
+            ? materializeAtomDataPtr(leftConst)
+            : m_out.loadPtr(left, m_heaps.StringImpl_data);
+        LValue rightData = rightAtom
+            ? materializeAtomDataPtr(rightConst)
+            : m_out.loadPtr(right, m_heaps.StringImpl_data);
 
         constexpr unsigned wordSize = 8;
         ValueFromBlock byteIndexAtStart = m_out.anchor(byteLength);
@@ -21981,10 +22013,26 @@ IGNORE_CLANG_WARNINGS_END
 
         m_out.appendTo(slowCase, continuation);
 
-        LValue slowResultValue = vmCall(
-            Int64, operationCompareStringEq, weakPointer(globalObject),
-            leftJSString, rightJSString);
-        ValueFromBlock slowResult = m_out.anchor(unboxBoolean(slowResultValue));
+        VM* vmPtr = &vm();
+        callPreflight();
+        auto global = weakPointer(globalObject);
+        PatchpointValue* thunkCall = m_out.patchpoint(toOperationType(Int64));
+        thunkCall->append(global, ValueRep::reg(GPRInfo::argumentGPR0));
+        thunkCall->append(leftJSString, ValueRep::reg(GPRInfo::argumentGPR1));
+        thunkCall->append(rightJSString, ValueRep::reg(GPRInfo::argumentGPR2));
+        thunkCall->resultConstraints = {
+            ValueRep::reg(GPRInfo::returnValueGPR),
+            ValueRep::reg(GPRInfo::returnValueGPR2),
+        };
+        thunkCall->clobber(RegisterSet::registersToSaveForCCall(RegisterSet::allScalarRegisters()));
+        thunkCall->effects = Effects::forCall();
+        thunkCall->setGenerator(
+            [=] (CCallHelpers& jit, const StackmapGenerationParams&) {
+                AllowMacroScratchRegisterUsage allowScratch(jit);
+                jit.nearCallThunk(CodeLocationLabel<JITThunkPtrTag>(vmPtr->getCTIStub(stringEqualThunkGenerator).code()));
+            });
+        LValue result = operationExceptionCheckAndExtractResultIfNeeded<ExceptionOperationResult<EncodedJSValue>>(thunkCall);
+        ValueFromBlock slowResult = m_out.anchor(unboxBoolean(result));
         m_out.jump(continuation);
 
         m_out.appendTo(continuation, lastNext);

--- a/Source/JavaScriptCore/jit/ThunkGenerators.cpp
+++ b/Source/JavaScriptCore/jit/ThunkGenerators.cpp
@@ -642,6 +642,150 @@ MacroAssemblerCodeRef<JITThunkPtrTag> stringGetByValGenerator(VM& vm)
     return FINALIZE_THUNK(patchBuffer, JITThunkPtrTag, "string_get_by_val"_s, "String get_by_val stub");
 }
 
+#if USE(JSVALUE64)
+MacroAssemblerCodeRef<JITThunkPtrTag> stringEqualThunkGenerator(VM& vm)
+{
+    // Inputs (operationCompareStringEq calling convention so the slow path can tail-call it
+    // with no register shuffling):
+    //   argumentGPR0 = JSGlobalObject*
+    //   argumentGPR1 = left  JSString*
+    //   argumentGPR2 = right JSString*
+    // Output:
+    //   returnValueGPR = JSValue::encode(jsBoolean(result))
+
+    JSInterfaceJIT jit(&vm);
+    jit.tagReturnAddress();
+
+    using JIT = JSInterfaceJIT;
+    constexpr GPRReg globalObjectGPR  = GPRInfo::argumentGPR0;
+    constexpr GPRReg jsLeftGPR        = GPRInfo::argumentGPR1; // regT1
+    constexpr GPRReg jsRightGPR       = GPRInfo::argumentGPR2; // regT2
+    constexpr GPRReg leftDataGPR      = GPRInfo::regT3;
+    constexpr GPRReg leftFlagsGPR     = GPRInfo::regT4;
+    constexpr GPRReg leftLengthGPR    = GPRInfo::regT5;
+    constexpr GPRReg rightDataGPR     = GPRInfo::regT6;
+    constexpr GPRReg rightFlagsGPR    = GPRInfo::regT7;
+    constexpr GPRReg rightLengthGPR   = GPRInfo::regT0;
+
+    jit.pushPair(globalObjectGPR, globalObjectGPR);
+
+    JIT::JumpList trueCase;
+    JIT::JumpList falseCase;
+    JIT::JumpList slowCase;
+
+    trueCase.append(jit.branchPtr(JIT::Equal, jsLeftGPR, jsRightGPR));
+
+    // Decode a JSString into (dataGPR = data pointer, flagsGPR = is8Bit flag bit,
+    // lengthGPR = char count). dataGPR's slot starts as the fiber temp and ends holding the
+    // data pointer; for substring ropes lengthGPR's slot is used as a transient offset scratch
+    // before the actual length is loaded last (avoids needing a 9th register across the two
+    // sides of the comparison). Non-rope and substring-rope inputs are handled inline; concat
+    // ropes branch to slowCase.
+    auto decodeString = [&](GPRReg jsStringGPR, GPRReg dataGPR, GPRReg flagsGPR, GPRReg lengthGPR) {
+        jit.loadPtr(JIT::Address(jsStringGPR, JSString::offsetOfValue()), dataGPR);
+        auto isRope = jit.branchIfRopeStringImpl(dataGPR);
+
+        // Non-rope: dataGPR holds the StringImpl pointer.
+        jit.load32(JIT::Address(dataGPR, StringImpl::lengthMemoryOffset()), lengthGPR);
+        jit.load32(JIT::Address(dataGPR, StringImpl::flagsOffset()), flagsGPR);
+        jit.and32(JIT::TrustedImm32(StringImpl::flagIs8Bit()), flagsGPR);
+        jit.loadPtr(JIT::Address(dataGPR, StringImpl::dataOffset()), dataGPR);
+        auto done = jit.jump();
+
+        // Rope: must be substring rope (concat ropes go to slowCase).
+        isRope.link(&jit);
+        slowCase.append(jit.branchTest64(JIT::Zero, dataGPR, JIT::TrustedImm64(JSRopeString::isSubstringInPointer)));
+
+        // Load substring base raw (low 48 bits of fiber1) and mask. and64(TrustedImm64) is one
+        // instruction on ARM64 (addressMask is a valid logical immediate) and uses the
+        // macro-assembler's reserved scratch (r11) on x86_64, so we don't burn a regT slot on
+        // the mask.
+        jit.load64(JIT::Address(jsStringGPR, JSRopeString::offsetOfFiber1Lower()), dataGPR);
+        jit.and64(JIT::TrustedImm64(JSRopeString::CompactFibers::addressMask), dataGPR);
+
+        // Substring base is non-rope by construction, so its m_value is the StringImpl pointer.
+        jit.loadPtr(JIT::Address(dataGPR, JSString::offsetOfValue()), dataGPR);
+        jit.load32(JIT::Address(dataGPR, StringImpl::flagsOffset()), flagsGPR);
+        jit.and32(JIT::TrustedImm32(StringImpl::flagIs8Bit()), flagsGPR);
+        jit.loadPtr(JIT::Address(dataGPR, StringImpl::dataOffset()), dataGPR);
+
+        jit.load32(JIT::Address(jsStringGPR, JSRopeString::offsetOfFiber2Lower()), lengthGPR);
+        auto is8Bit = jit.branchTest32(JIT::NonZero, flagsGPR);
+        jit.lshiftPtr(JIT::TrustedImm32(1), lengthGPR);
+        is8Bit.link(&jit);
+        jit.addPtr(lengthGPR, dataGPR);
+        jit.load32(JIT::Address(jsStringGPR, JSRopeString::offsetOfLength()), lengthGPR);
+
+        done.link(&jit);
+    };
+
+    decodeString(jsLeftGPR, leftDataGPR, leftFlagsGPR, leftLengthGPR);
+    decodeString(jsRightGPR, rightDataGPR, rightFlagsGPR, rightLengthGPR);
+
+    // Compare lengths, widths, then walk the bytes.
+    falseCase.append(jit.branch32(JIT::NotEqual, leftLengthGPR, rightLengthGPR));
+    trueCase.append(jit.branchTest32(JIT::Zero, leftLengthGPR));
+    slowCase.append(jit.branch32(JIT::NotEqual, leftFlagsGPR, rightFlagsGPR));
+
+    // Convert char-count to byte-count when 16-bit (flags == 0).
+    auto is8Bit = jit.branchTest32(JIT::NonZero, leftFlagsGPR);
+    jit.lshiftPtr(JIT::TrustedImm32(1), leftLengthGPR);
+    is8Bit.link(&jit);
+
+    // Compare data backwards.
+    constexpr unsigned wordSize = sizeof(void*);
+    auto longString = jit.branchPtr(JIT::AboveOrEqual, leftLengthGPR, JIT::TrustedImmPtr(std::bit_cast<void*>(static_cast<uintptr_t>(wordSize))));
+
+    // byteLength in [1, wordSize): byte-at-a-time loop.
+    auto byteLoopTop = jit.label();
+    jit.subPtr(JIT::TrustedImm32(1), leftLengthGPR);
+    jit.load8(JIT::BaseIndex(leftDataGPR, leftLengthGPR, JIT::TimesOne), rightFlagsGPR);
+    jit.load8(JIT::BaseIndex(rightDataGPR, leftLengthGPR, JIT::TimesOne), rightLengthGPR);
+    falseCase.append(jit.branch32(JIT::NotEqual, rightFlagsGPR, rightLengthGPR));
+    jit.branchTestPtr(JIT::NonZero, leftLengthGPR).linkTo(byteLoopTop, &jit);
+    trueCase.append(jit.jump());
+
+    // byteLength >= wordSize: word-at-a-time loop, walking backwards.
+    longString.link(&jit);
+    auto wordLoopTop = jit.label();
+    jit.subPtr(JIT::TrustedImm32(wordSize), leftLengthGPR);
+    jit.load64(JIT::BaseIndex(leftDataGPR, leftLengthGPR, JIT::TimesOne), rightFlagsGPR);
+    jit.load64(JIT::BaseIndex(rightDataGPR, leftLengthGPR, JIT::TimesOne), rightLengthGPR);
+    falseCase.append(jit.branch64(JIT::NotEqual, rightFlagsGPR, rightLengthGPR));
+    jit.branchPtr(JIT::AboveOrEqual, leftLengthGPR, JIT::TrustedImmPtr(std::bit_cast<void*>(static_cast<uintptr_t>(wordSize)))).linkTo(wordLoopTop, &jit);
+
+    // 0 <= leftLengthGPR < wordSize bytes remain at the head. Since the original byteLength
+    // was >= wordSize, an overlapping word load at offset 0 safely covers the remainder.
+    trueCase.append(jit.branchTestPtr(JIT::Zero, leftLengthGPR));
+    jit.load64(JIT::Address(leftDataGPR), rightFlagsGPR);
+    jit.load64(JIT::Address(rightDataGPR), rightLengthGPR);
+    falseCase.append(jit.branch64(JIT::NotEqual, rightFlagsGPR, rightLengthGPR));
+    // Fall through to trueCase.
+
+    trueCase.link(&jit);
+    jit.addPtr(JIT::TrustedImm32(16), JIT::stackPointerRegister);
+    jit.move(JIT::TrustedImm64(JSValue::encode(jsBoolean(true))), GPRInfo::returnValueGPR);
+    jit.move(JIT::TrustedImmPtr(nullptr), GPRInfo::returnValueGPR2);
+    jit.ret();
+
+    falseCase.link(&jit);
+    jit.addPtr(JIT::TrustedImm32(16), JIT::stackPointerRegister);
+    jit.move(JIT::TrustedImm64(JSValue::encode(jsBoolean(false))), GPRInfo::returnValueGPR);
+    jit.move(JIT::TrustedImmPtr(nullptr), GPRInfo::returnValueGPR2);
+    jit.ret();
+
+    slowCase.link(&jit);
+    jit.popPair(GPRInfo::argumentGPR0, /* padding */ GPRInfo::nonArgGPR0);
+    jit.untagReturnAddress();
+    jit.move(JIT::TrustedImmPtr(tagCFunction<OperationPtrTag>(operationCompareStringEq)), GPRInfo::nonArgGPR0);
+    emitPointerValidation(jit, GPRInfo::nonArgGPR0, OperationPtrTag);
+    jit.farJump(GPRInfo::nonArgGPR0, OperationPtrTag);
+
+    LinkBuffer patchBuffer(jit, GLOBAL_THUNK_ID, LinkBuffer::Profile::Thunk);
+    return FINALIZE_THUNK(patchBuffer, JITThunkPtrTag, "StringEqual"_s, "String equal stub");
+}
+#endif
+
 enum class RelativeNegativeIndex : bool { No, Yes };
 template <RelativeNegativeIndex relativeNegativeIndex>
 static void stringCharLoad(SpecializedThunkJIT& jit)

--- a/Source/JavaScriptCore/jit/ThunkGenerators.h
+++ b/Source/JavaScriptCore/jit/ThunkGenerators.h
@@ -71,6 +71,9 @@ MacroAssemblerCodeRef<JITThunkPtrTag> internalFunctionConstructGenerator(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> arityFixupGenerator(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> unreachableGenerator(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> stringGetByValGenerator(VM&);
+#if USE(JSVALUE64)
+MacroAssemblerCodeRef<JITThunkPtrTag> stringEqualThunkGenerator(VM&);
+#endif
 
 MacroAssemblerCodeRef<JITThunkPtrTag> charCodeAtThunkGenerator(VM&);
 MacroAssemblerCodeRef<JITThunkPtrTag> charAtThunkGenerator(VM&);

--- a/Source/JavaScriptCore/runtime/JSString.h
+++ b/Source/JavaScriptCore/runtime/JSString.h
@@ -392,6 +392,8 @@ public:
         static constexpr ptrdiff_t offsetOfLength() { return OBJECT_OFFSETOF(CompactFibers, m_length); }
         static constexpr ptrdiff_t offsetOfFiber1() { return OBJECT_OFFSETOF(CompactFibers, m_length); }
         static constexpr ptrdiff_t offsetOfFiber2() { return OBJECT_OFFSETOF(CompactFibers, m_fiber1Upper); }
+        static constexpr ptrdiff_t offsetOfFiber1Lower() { return OBJECT_OFFSETOF(CompactFibers, m_fiber1Lower); }
+        static constexpr ptrdiff_t offsetOfFiber2Lower() { return OBJECT_OFFSETOF(CompactFibers, m_fiber2Lower); }
 
     private:
         friend class LLIntOffsetsExtractor;
@@ -613,6 +615,10 @@ public:
     static constexpr ptrdiff_t offsetOfFiber0() { return offsetOfValue(); }
     static constexpr ptrdiff_t offsetOfFiber1() { return OBJECT_OFFSETOF(JSRopeString, m_compactFibers) + CompactFibers::offsetOfFiber1(); }
     static constexpr ptrdiff_t offsetOfFiber2() { return OBJECT_OFFSETOF(JSRopeString, m_compactFibers) + CompactFibers::offsetOfFiber2(); }
+#if CPU(ADDRESS64)
+    static constexpr ptrdiff_t offsetOfFiber1Lower() { return OBJECT_OFFSETOF(JSRopeString, m_compactFibers) + CompactFibers::offsetOfFiber1Lower(); }
+    static constexpr ptrdiff_t offsetOfFiber2Lower() { return OBJECT_OFFSETOF(JSRopeString, m_compactFibers) + CompactFibers::offsetOfFiber2Lower(); }
+#endif
 
     static constexpr unsigned s_maxInternalRopeLength = 3;
 


### PR DESCRIPTION
#### e8eb62b221930f4da595eb5995661b99ee02c05d
<pre>
[JSC] Improve rope-string comparison
<a href="https://bugs.webkit.org/show_bug.cgi?id=315229">https://bugs.webkit.org/show_bug.cgi?id=315229</a>
<a href="https://rdar.apple.com/177558328">rdar://177558328</a>

Reviewed by Yijia Huang.

This patch adds StringEqual thunk, which even extracts ropes from
JSString and do string matching. We do not inline this in DFG and FTL
since it makes code too much bloated. And we use this thunk from DFG /
FTL so that we can handle common cases more efficiently.
Also we add some constant folding for string inputs to extract length
(or even data pointer) at compile time if possible to reduce code
generation size.

* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compileNeitherDoubleNorHeapBigIntToNotDoubleStrictEquality):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileCompareStrictEq):
* Source/JavaScriptCore/jit/ThunkGenerators.cpp:
(JSC::stringEqualThunkGenerator):
* Source/JavaScriptCore/jit/ThunkGenerators.h:
* Source/JavaScriptCore/runtime/JSString.h:

Canonical link: <a href="https://commits.webkit.org/313752@main">https://commits.webkit.org/313752@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a2867221c98b91bd68d2091defd3d4f3e03cb5c5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163954 "4 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37438 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30657 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172983 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cf1218d9-e95e-409e-857d-1375f299e276) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37770 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37438 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127371 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121205 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/999c595d-4724-464a-93b4-3d0f5812fd5b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166913 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29654 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147399 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107919 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/08a6df13-1e17-4872-a0b5-53c98513137d) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28700 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27321 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20747 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/156105 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138601 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25116 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175508 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/24846 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28330 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26784 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135681 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37108 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31433 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135653 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37893 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146911 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100056 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24964 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30953 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23767 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/196357 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36702 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109749 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51289 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36101 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1807 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36351 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36248 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->