### PR TITLE
Assert that non-worker MessagePortChannelProviders run in main thread

### DIFF
--- a/Source/WebCore/dom/messageports/MessagePortChannelProviderImpl.cpp
+++ b/Source/WebCore/dom/messageports/MessagePortChannelProviderImpl.cpp
@@ -28,7 +28,6 @@
 
 #include "MessagePort.h"
 #include <wtf/MainThread.h>
-#include <wtf/RunLoop.h>
 
 namespace WebCore {
 
@@ -46,59 +45,40 @@ MessagePortChannelProviderImpl::~MessagePortChannelProviderImpl()
 
 void MessagePortChannelProviderImpl::createNewMessagePortChannel(const MessagePortIdentifier& local, const MessagePortIdentifier& remote)
 {
-    ensureOnMainThread([weakRegistry = WeakPtr { m_registry }, local, remote] {
-        if (CheckedPtr registry = weakRegistry.get())
-            registry->didCreateMessagePortChannel(local, remote);
-    });
+    ASSERT(isMainThread());
+    m_registry.didCreateMessagePortChannel(local, remote);
 }
 
 void MessagePortChannelProviderImpl::entangleLocalPortInThisProcessToRemote(const MessagePortIdentifier& local, const MessagePortIdentifier& remote)
 {
-    ensureOnMainThread([weakRegistry = WeakPtr { m_registry }, local, remote] {
-        if (CheckedPtr registry = weakRegistry.get())
-            registry->didEntangleLocalToRemote(local, remote, Process::identifier());
-    });
+    ASSERT(isMainThread());
+    m_registry.didEntangleLocalToRemote(local, remote, Process::identifier());
 }
 
 void MessagePortChannelProviderImpl::messagePortDisentangled(const MessagePortIdentifier& local)
 {
-    ensureOnMainThread([weakRegistry = WeakPtr { m_registry }, local] {
-        if (CheckedPtr registry = weakRegistry.get())
-            registry->didDisentangleMessagePort(local);
-    });
+    ASSERT(isMainThread());
+    m_registry.didDisentangleMessagePort(local);
 }
 
 void MessagePortChannelProviderImpl::messagePortClosed(const MessagePortIdentifier& local)
 {
-    ensureOnMainThread([weakRegistry = WeakPtr { m_registry }, local] {
-        if (CheckedPtr registry = weakRegistry.get())
-            registry->didCloseMessagePort(local);
-    });
+    ASSERT(isMainThread());
+    m_registry.didCloseMessagePort(local);
 }
 
 void MessagePortChannelProviderImpl::postMessageToRemote(MessageWithMessagePorts&& message, const MessagePortIdentifier& remoteTarget)
 {
-    ensureOnMainThread([weakRegistry = WeakPtr { m_registry }, message = WTF::move(message), remoteTarget]() mutable {
-        CheckedPtr registry = weakRegistry.get();
-        if (!registry)
-            return;
-        if (registry->didPostMessageToRemote(WTF::move(message), remoteTarget))
-            MessagePort::notifyMessageAvailable(remoteTarget);
-    });
+    ASSERT(isMainThread());
+    if (m_registry.didPostMessageToRemote(WTF::move(message), remoteTarget))
+        MessagePort::notifyMessageAvailable(remoteTarget);
 }
 
-void MessagePortChannelProviderImpl::takeAllMessagesForPort(const MessagePortIdentifier& port, CompletionHandler<void(Vector<MessageWithMessagePorts>&&, CompletionHandler<void()>&&)>&& outerCallback)
+void MessagePortChannelProviderImpl::takeAllMessagesForPort(const MessagePortIdentifier& port, CompletionHandler<void(Vector<MessageWithMessagePorts>&&, CompletionHandler<void()>&&)>&& callback)
 {
-    // It is the responsibility of outerCallback to get itself to the appropriate thread (e.g. WebWorker thread)
-    auto callback = [outerCallback = WTF::move(outerCallback)](Vector<MessageWithMessagePorts>&& messages, CompletionHandler<void()>&& messageDeliveryCallback) mutable {
-        ASSERT(isMainThread());
-        outerCallback(WTF::move(messages), WTF::move(messageDeliveryCallback));
-    };
-
-    ensureOnMainThread([weakRegistry = WeakPtr { m_registry }, port, callback = WTF::move(callback)]() mutable {
-        if (CheckedPtr registry = weakRegistry.get())
-            registry->takeAllMessagesForPort(port, WTF::move(callback));
-    });
+    ASSERT(isMainThread());
+    // It is the responsibility of callback to get itself to the appropriate thread (e.g. WebWorker thread)
+    m_registry.takeAllMessagesForPort(port, WTF::move(callback));
 }
 
 } // namespace WebCore

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebMessagePortChannelProvider.cpp
@@ -60,6 +60,7 @@ static inline IPC::Connection& networkProcessConnection()
 
 void WebMessagePortChannelProvider::createNewMessagePortChannel(const MessagePortIdentifier& port1, const MessagePortIdentifier& port2)
 {
+    ASSERT(isMainRunLoop());
     ASSERT(!m_inProcessPortMessages.contains(port1));
     ASSERT(!m_inProcessPortMessages.contains(port2));
     m_inProcessPortMessages.add(port1, Vector<MessageWithMessagePorts> { });
@@ -70,6 +71,7 @@ void WebMessagePortChannelProvider::createNewMessagePortChannel(const MessagePor
 
 void WebMessagePortChannelProvider::entangleLocalPortInThisProcessToRemote(const MessagePortIdentifier& local, const MessagePortIdentifier& remote)
 {
+    ASSERT(isMainRunLoop());
     m_inProcessPortMessages.add(local, Vector<MessageWithMessagePorts> { });
 
     protect(networkProcessConnection())->send(Messages::NetworkConnectionToWebProcess::EntangleLocalPortInThisProcessToRemote { local, remote }, 0);
@@ -77,11 +79,13 @@ void WebMessagePortChannelProvider::entangleLocalPortInThisProcessToRemote(const
 
 void WebMessagePortChannelProvider::messagePortDisentangled(const MessagePortIdentifier& port)
 {
+    ASSERT(isMainRunLoop());
     protect(networkProcessConnection())->send(Messages::NetworkConnectionToWebProcess::MessagePortDisentangled { port }, 0);
 }
 
 void WebMessagePortChannelProvider::messagePortSentToRemote(const WebCore::MessagePortIdentifier& port)
 {
+    ASSERT(isMainRunLoop());
     auto inProcessPortMessages = m_inProcessPortMessages.take(port);
     for (auto& message : inProcessPortMessages)
         postMessageToRemote(WTF::move(message), port);
@@ -89,17 +93,20 @@ void WebMessagePortChannelProvider::messagePortSentToRemote(const WebCore::Messa
 
 void WebMessagePortChannelProvider::dropNonSerializableInProcessCache(WebCore::NonSerializedDataIdentifier identifier)
 {
+    ASSERT(isMainRunLoop());
     m_nonSerializedDataRegistry.remove(identifier);
 }
 
 void WebMessagePortChannelProvider::messagePortClosed(const MessagePortIdentifier& port)
 {
+    ASSERT(isMainRunLoop());
     m_inProcessPortMessages.remove(port);
     protect(networkProcessConnection())->send(Messages::NetworkConnectionToWebProcess::MessagePortClosed { port }, 0);
 }
 
 void WebMessagePortChannelProvider::takeAllMessagesForPort(const MessagePortIdentifier& port, CompletionHandler<void(Vector<MessageWithMessagePorts>&&, CompletionHandler<void()>&&)>&& completionHandler)
 {
+    ASSERT(isMainRunLoop());
     protect(networkProcessConnection())->sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::TakeAllMessagesForPort { port }, [completionHandler = WTF::move(completionHandler), port](Vector<WebCore::MessageWithMessagePorts>&& messages, std::optional<MessageBatchIdentifier> messageBatchIdentifier) mutable {
         if (!messageBatchIdentifier)
             return completionHandler({ }, [] { }); // IPC failure.
@@ -131,6 +138,7 @@ void WebMessagePortChannelProvider::takeAllMessagesForPort(const MessagePortIden
 
 void WebMessagePortChannelProvider::postMessageToRemote(MessageWithMessagePorts&& message, const MessagePortIdentifier& remoteTarget)
 {
+    ASSERT(isMainRunLoop());
     auto iterator = m_inProcessPortMessages.find(remoteTarget);
     if (iterator != m_inProcessPortMessages.end()) {
         iterator->value.append(WTF::move(message));


### PR DESCRIPTION
#### cd8802f4b729778d84943ec1d9077f03925146ef
<pre>
Assert that non-worker MessagePortChannelProviders run in main thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=315227">https://bugs.webkit.org/show_bug.cgi?id=315227</a>
<a href="https://rdar.apple.com/177555615">rdar://177555615</a>

Reviewed by NOBODY (OOPS!).

MessagePortChannelProviderImpl and WebMessagePortChannelProvider are
only called from the main thread already. This is needed to avoid
concurrent accesses to member variables, so enforcing it with asserts
is appropriate.

The assert is a stronger guarantee than ensureOnMainThread(), so the
latter is being removed from MessagePortChannelProviderImpl.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cd8802f4b729778d84943ec1d9077f03925146ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163611 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37095 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30314 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172551 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/120060 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8ebd391b-3052-425d-b543-2987a0b2cf58) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165480 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37426 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37094 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127080 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89590 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/845f6334-cc02-41f5-8774-fa1503e3bd28) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166570 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29362 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147094 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107634 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1d39b3b4-87f4-49b5-bf57-6e9444496b6f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28411 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27036 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20254 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138310 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24811 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175056 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/27987 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26485 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135384 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36765 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31138 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135366 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37550 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146606 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99611 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30679 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23458 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36260 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109406 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35758 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1495 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36008 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35905 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->