### PR TITLE
[JSC] Add test for MultiGetByOffset interaction with ValueRepReduction

### DIFF
--- a/JSTests/stress/ftl-multigetbyoffset-constant-numberuse.js
+++ b/JSTests/stress/ftl-multigetbyoffset-constant-numberuse.js
@@ -1,0 +1,33 @@
+let proto = { prop: function() {} };
+let obj1 = Object.create(proto); // Structure A: Property is Constant:Function
+let obj2 = Object.create(proto);
+obj2.prop = NaN;                 // Structure B: Property is Load:0
+
+function trigger(arr) {
+    let res = 0;
+    for (let i = 0; i < arr.length; i++) {
+        let val = arr[i].prop;
+        // Math.min forces a DoubleRepUse edge
+        res += Math.min(val, 1.0);
+    }
+    return res;
+}
+
+// 1. Warm up Baseline JIT with Structure B only.
+// This sets up the ValueProfile to predict DoublePureNaN.
+let arr_warmup = new Array(100).fill(obj2);
+for (let i = 0; i < 5; i++) trigger(arr_warmup);
+
+// 2. Populate the IC with Structure A EXACTLY ONCE.
+// We put it at the beginning of the array, followed by Structure B.
+// By the time the basic block finishes and ValueProfile is flushed,
+// the bucket contains NaN from obj2!
+let arr_once = [obj1, obj2, obj2, obj2, obj2];
+trigger(arr_once);
+
+// 3. Trigger DFG/FTL compilation.
+// The DFG will see the IC has both structures, but the ValueProfile ONLY predicts Number.
+// This generates a MultiGetByOffset with a Constant:Function, but predicting Number.
+// DFGValueRepReductionPhase will try to convert the Constant:Function to a double.
+let arr_dfg = new Array(1000).fill(obj2);
+for (let i = 0; i < 1000; i++) trigger(arr_dfg);


### PR DESCRIPTION
#### 267af1c47c7a03add486c081387efe146af4459c
<pre>
[JSC] Add test for MultiGetByOffset interaction with ValueRepReduction
<a href="https://bugs.webkit.org/show_bug.cgi?id=309517">https://bugs.webkit.org/show_bug.cgi?id=309517</a>
<a href="https://rdar.apple.com/171948690">rdar://171948690</a>

Reviewed by Keith Miller.

Add a test for the fix from 305413.251@safari-7624-branch, which escapes
MultiGetByOffset constant values which aren&apos;t convertible to double.

* JSTests/stress/ftl-multigetbyoffset-constant-numberuse.js: Added.

Originally-landed-as: 305413.420@rapid/safari-7624.2.5.110-branch (532faf3ef13a). <a href="https://rdar.apple.com/176067532">rdar://176067532</a>
Canonical link: <a href="https://commits.webkit.org/313626@main">https://commits.webkit.org/313626@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/06d43c990d4f510fb5721427f5b720c165a510f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163615 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37099 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30318 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172555 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/120064 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37430 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37098 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127085 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89594 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166574 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29357 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147098 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107639 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28406 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27044 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20258 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/155766 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138305 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175060 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/24506 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26488 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135387 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36769 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31146 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135369 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36492 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37554 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146610 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99615 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30685 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23462 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/196017 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36264 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51105 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35762 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1488 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36012 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35909 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->