### PR TITLE
Haptic feedback for <input type=checkbox switch> can be triggered with a programmatic click on an associated label

### DIFF
--- a/LayoutTests/fast/forms/label/label-click-event-dispatch-untrusted-expected.txt
+++ b/LayoutTests/fast/forms/label/label-click-event-dispatch-untrusted-expected.txt
@@ -1,0 +1,10 @@
+Tests that clicking a label dispatches an untrusted click event on the associated form control.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS event.isTrusted is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/label/label-click-event-dispatch-untrusted.html
+++ b/LayoutTests/fast/forms/label/label-click-event-dispatch-untrusted.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../../resources/js-test.js"></script>
+</head>
+<body>
+
+<input id="input" type="checkbox">
+<label id="label" for="input"></label>
+
+<script>
+
+description("Tests that clicking a label dispatches an untrusted click event on the associated form control.");
+
+input.addEventListener("click", (event) => {
+    shouldBeFalse("event.isTrusted");
+});
+
+label.click();
+
+</script>
+
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-label-element/label-forwarded-click-pointer-properties-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-label-element/label-forwarded-click-pointer-properties-expected.txt
@@ -2,5 +2,5 @@ click me
 
 
 FAIL Click forwarded from label to control preserves pointer metadata assert_equals: forwarded click should preserve pointerType expected "mouse" but got ""
-FAIL Click forwarded from label.click() is not trusted assert_false: forwarded click from label.click() should not be trusted expected false got true
+PASS Click forwarded from label.click() is not trusted
 

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -640,7 +640,14 @@ bool Element::dispatchKeyEvent(const PlatformKeyboardEvent& platformEvent)
 
 bool Element::dispatchSimulatedClick(Event* underlyingEvent, SimulatedClickMouseEventOptions eventOptions, SimulatedClickVisualOptions visualOptions)
 {
-    return simulateClick(*this, underlyingEvent, eventOptions, visualOptions, SimulatedClickSource::UserAgent);
+    auto simulatedClickSource = [&] {
+        if (!underlyingEvent)
+            return SimulatedClickSource::UserAgent;
+
+        return underlyingEvent->isTrusted() ? SimulatedClickSource::UserAgent : SimulatedClickSource::Bindings;
+    }();
+
+    return simulateClick(*this, underlyingEvent, eventOptions, visualOptions, simulatedClickSource);
 }
 
 Ref<Node> Element::cloneNodeInternal(Document& document, CloningOperation type, CustomElementRegistry* fallbackRegistry) const

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SwitchInputTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SwitchInputTests.mm
@@ -27,6 +27,7 @@
 
 #if PLATFORM(COCOA)
 
+#import "IOSMouseEventTestHarness.h"
 #import "InstanceMethodSwizzler.h"
 #import "Helpers/PlatformUtilities.h"
 #import "Helpers/Test.h"
@@ -63,9 +64,38 @@ TEST(SwitchInputTests, HapticFeedbackOnDrag)
 
 #endif // PLATFORM(MAC)
 
+#if HAVE(UI_IMPACT_FEEDBACK_GENERATOR)
+
+TEST(SwitchInputTests, HapticFeedbackOnClick)
+{
+    __block bool done = false;
+
+    InstanceMethodSwizzler swizzler {
+        UIImpactFeedbackGenerator.class,
+        @selector(impactOccurred),
+        imp_implementationWithBlock(^{
+            done = true;
+        })
+    };
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 300)]);
+    [webView synchronouslyLoadHTMLString:@"<meta name='viewport' content='width=device-width,initial-scale=1'><label><input type='checkbox' switch></label>"];
+
+    TestWebKitAPI::MouseEventTestHarness testHarness { webView.get() };
+    testHarness.mouseMove(15, 10);
+    testHarness.mouseDown();
+    testHarness.mouseUp();
+    [webView waitForPendingMouseEvents];
+    [webView waitForNextPresentationUpdate];
+
+    TestWebKitAPI::Util::run(&done);
+}
+
+#endif // HAVE(UI_IMPACT_FEEDBACK_GENERATOR)
+
 #if HAVE(UI_IMPACT_FEEDBACK_GENERATOR) || PLATFORM(MAC)
 
-TEST(SwitchInputTests, HapticFeedbackRequiresUserGesture)
+TEST(SwitchInputTests, HapticFeedbackRequiresUserGestureAndTrustedEvent)
 {
     InstanceMethodSwizzler swizzler {
 #if PLATFORM(MAC)
@@ -81,9 +111,18 @@ TEST(SwitchInputTests, HapticFeedbackRequiresUserGesture)
     };
 
     RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 300)]);
-    [webView synchronouslyLoadHTMLString:@"<label><input type='checkbox' switch></label>"];
+    [webView synchronouslyLoadHTMLString:@"<meta name='viewport' content='width=device-width,initial-scale=1'><div style='width: 100px; height: 100px; background: red;' onclick=\"document.querySelector('label').click()\"></div><label><input type='checkbox' switch></label>"];
 
-    [webView stringByEvaluatingJavaScript:@"document.querySelector('label').click()"];
+#if PLATFORM(MAC)
+    [webView sendClickAtPoint:NSMakePoint(15, 290)];
+#else
+    TestWebKitAPI::MouseEventTestHarness testHarness { webView.get() };
+    testHarness.mouseMove(15, 10);
+    testHarness.mouseDown();
+    testHarness.mouseUp();
+#endif
+
+    [webView waitForPendingMouseEvents];
     [webView waitForNextPresentationUpdate];
 }
 


### PR DESCRIPTION
#### fc1ef83eae10068fe468587d959e868041ddfe03
<pre>
Haptic feedback for &lt;input type=checkbox switch&gt; can be triggered with a programmatic click on an associated label
<a href="https://bugs.webkit.org/show_bug.cgi?id=309082">https://bugs.webkit.org/show_bug.cgi?id=309082</a>
<a href="https://rdar.apple.com/171635705">rdar://171635705</a>

Reviewed by Lily Spiniolas, Wenson Hsieh, and Abrar Rahman Protyasha.

288403@main ensured that haptic feedback for &lt;input type=checkbox switch&gt; required
user activation. However, it is also desired that haptics are only triggered for
trusted events. This goal can currently be bypassed by calling `click()` on a label
associated with the input. The result is that calling `click()` on the label,
immediately following a user gesture, can allow for haptics to be programmatically
triggered.

The underlying issue is that untrusted click events on label elements become
trusted click events on the associated control. This is because
`Element::dispatchSimulatedClick` unconditionally sets `SimulatedClickSource::UserAgent`.
While this is desirable for accessibility use cases, it is incorrect when the
underlying event is untrusted.

Fix by specifying `SimulatedClickSource::Bindings` if there is an underlying
event and it is untrusted.

Tests: fast/forms/label/label-click-event-dispatch-untrusted.html
       Tools/TestWebKitAPI/Tests/WebKitCocoa/SwitchInputTests.mm

* LayoutTests/fast/forms/label/label-click-event-dispatch-untrusted-expected.txt: Added.
* LayoutTests/fast/forms/label/label-click-event-dispatch-untrusted.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/html/semantics/forms/the-label-element/label-forwarded-click-pointer-properties-expected.txt:
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::dispatchSimulatedClick):

If there is an underlying event, the simulated click should be marked as from
&quot;bindings&quot;, making it untrusted. This change is not made to `simulateClick` itself
since that is used by `Element::click()`, which has no underlying event and is
always untrusted.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SwitchInputTests.mm:
(TEST(SwitchInputTests, HapticFeedbackOnClick)):
(TEST(SwitchInputTests, HapticFeedbackRequiresUserGestureAndTrustedEvent)):
(TEST(SwitchInputTests, HapticFeedbackRequiresUserGesture)): Deleted.

Originally-landed-as: 305413.395@safari-7624-branch (2c99c891b64c). <a href="https://rdar.apple.com/176067574">rdar://176067574</a>
Canonical link: <a href="https://commits.webkit.org/313638@main">https://commits.webkit.org/313638@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a77847c9450dadea544a07bd22856b0811a8e1d2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163641 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37125 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30344 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172581 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/120125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165510 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37456 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37124 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127105 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/120125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166600 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29383 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147109 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107659 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28432 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27064 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20284 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138331 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24826 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175086 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28017 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26491 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135411 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36795 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31166 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135394 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36498 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37580 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146621 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99647 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30703 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23473 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36290 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109436 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35788 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1500 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36038 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35935 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->