### PR TITLE
REGRESSION(306058@main): Images on OpenTable search appear but they disappear quickly

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/css-filters-animation-opacity.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/css-filters-animation-opacity.html
@@ -10,6 +10,7 @@
     <link rel="help" href="http://www.w3.org/TR/css3-animations/#animations">
     <link rel="match" href="css-filters-animation-opacity-ref.html">
     <meta name="assert" content="The black square should be gray">
+    <meta name="fuzzy" content="maxDifference=0-1; totalPixels=0-10000">
     <style type="text/css">
         @keyframes animate {
             0% {

--- a/Source/WebCore/platform/graphics/TransparencyLayerContextSwitcher.cpp
+++ b/Source/WebCore/platform/graphics/TransparencyLayerContextSwitcher.cpp
@@ -44,14 +44,14 @@ TransparencyLayerContextSwitcher::TransparencyLayerContextSwitcher(GraphicsConte
 
 void TransparencyLayerContextSwitcher::beginClipAndDrawSourceImage(GraphicsContext& destinationContext, const FloatRect&, const FloatRect& clipRect, NOESCAPE const Function<void(GraphicsContext&)>& applyAdditionalDestinationClip)
 {
+    destinationContext.save();
+
     // Workaround for a CG accelerated-drawing bug rdar://177036180: CGStyle filters fail if there's a
     // non-rectangular clip, so apply the rounded clip in its own wrapping transparency layer.
-    if (applyAdditionalDestinationClip) {
-        destinationContext.save();
+    if (applyAdditionalDestinationClip)
         applyAdditionalDestinationClip(destinationContext);
-        destinationContext.beginTransparencyLayer(1);
-        m_beganOuterClipLayer = true;
-    }
+
+    destinationContext.beginTransparencyLayer(1);
 
     for (auto& filterStyle : m_filterStyles) {
         destinationContext.save();
@@ -63,10 +63,8 @@ void TransparencyLayerContextSwitcher::beginClipAndDrawSourceImage(GraphicsConte
 
 void TransparencyLayerContextSwitcher::beginDrawSourceImage(GraphicsContext& destinationContext, float opacity)
 {
-    if (opacity != 1) {
-        destinationContext.beginTransparencyLayer(opacity);
-        m_beganOpacityLayer = true;
-    }
+    destinationContext.save();
+    destinationContext.beginTransparencyLayer(opacity);
 
     for (auto& filterStyle : m_filterStyles) {
         destinationContext.save();
@@ -83,16 +81,8 @@ void TransparencyLayerContextSwitcher::endDrawSourceImage(GraphicsContext& desti
         destinationContext.restore();
     }
 
-    if (m_beganOuterClipLayer) {
-        destinationContext.endTransparencyLayer();
-        destinationContext.restore();
-        m_beganOuterClipLayer = false;
-    }
-
-    if (m_beganOpacityLayer) {
-        destinationContext.endTransparencyLayer();
-        m_beganOpacityLayer = false;
-    }
+    destinationContext.endTransparencyLayer();
+    destinationContext.restore();
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/TransparencyLayerContextSwitcher.h
+++ b/Source/WebCore/platform/graphics/TransparencyLayerContextSwitcher.h
@@ -44,8 +44,6 @@ private:
     void endDrawSourceImage(GraphicsContext& destinationContext, const DestinationColorSpace&) override;
 
     FilterStyleVector m_filterStyles;
-    bool m_beganOpacityLayer { false };
-    bool m_beganOuterClipLayer { false };
 };
 
 } // namespace WebCore


### PR DESCRIPTION
#### 1f2316e748332b8b9236272f886b494f62cb0f3a
<pre>
REGRESSION(306058@main): Images on OpenTable search appear but they disappear quickly
<a href="https://bugs.webkit.org/show_bug.cgi?id=315233">https://bugs.webkit.org/show_bug.cgi?id=315233</a>
<a href="https://rdar.apple.com/176275269">rdar://176275269</a>

Reviewed by Simon Fraser and Vitor Roriz.

Manually revert 306058@main since it caused images to disappear if CoreGraphics
filters are applied.

* LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/css-filters-animation-opacity.html:
* Source/WebCore/platform/graphics/TransparencyLayerContextSwitcher.cpp:
(WebCore::TransparencyLayerContextSwitcher::beginClipAndDrawSourceImage):
(WebCore::TransparencyLayerContextSwitcher::beginDrawSourceImage):
(WebCore::TransparencyLayerContextSwitcher::endDrawSourceImage):
* Source/WebCore/platform/graphics/TransparencyLayerContextSwitcher.h:

Canonical link: <a href="https://commits.webkit.org/313656@main">https://commits.webkit.org/313656@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/76db5a5d3bb0dc1346a87bbfbf7fdf8d3535996b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163696 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37180 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30399 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172636 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/120187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165565 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37511 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37179 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127147 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/120187 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166655 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29442 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147168 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107701 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28489 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/27112 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20339 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138388 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24885 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175141 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28072 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26553 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135453 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36850 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31217 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135436 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36514 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37635 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146680 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99721 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30750 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23534 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36346 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109491 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35843 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1564 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36093 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35990 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->