### PR TITLE
Block third-party cookies for requests from about:blank popups

### DIFF
--- a/LayoutTests/http/tests/resourceLoadStatistics/third-party-cookie-blocking-about-blank-popup-expected.txt
+++ b/LayoutTests/http/tests/resourceLoadStatistics/third-party-cookie-blocking-about-blank-popup-expected.txt
@@ -1,0 +1,10 @@
+Tests that third-party cookies are blocked for requests made from an about:blank popup.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS about:blank popup: third-party cookie was correctly blocked.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/resourceLoadStatistics/third-party-cookie-blocking-about-blank-popup.html
+++ b/LayoutTests/http/tests/resourceLoadStatistics/third-party-cookie-blocking-about-blank-popup.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <script src="/js-test-resources/js-test.js"></script>
+    <script src="resources/util.js"></script>
+</head>
+<body>
+<script>
+    description("Tests that third-party cookies are blocked for requests made from an about:blank popup.");
+    jsTestIsAsync = true;
+
+    const firstPartyOrigin = "http://127.0.0.1:8000";
+    const thirdPartyOrigin = "https://localhost:8443";
+    const resourcePath = "/resourceLoadStatistics/resources";
+    const thirdPartyBaseUrl = thirdPartyOrigin + resourcePath;
+    const cookieName = "aboutBlankTestCookie";
+    const subPathToSetCookie = "/set-cookie.py?name=" + cookieName + "&value=value";
+    const returnUrl = firstPartyOrigin + "/resourceLoadStatistics/third-party-cookie-blocking-about-blank-popup.html";
+    const subPathToGetCookies = "/get-cookies.py?name1=" + cookieName;
+
+    function runTest() {
+        switch (document.location.hash) {
+            case "#step1":
+                document.location.href = thirdPartyBaseUrl + subPathToSetCookie + "#" + returnUrl + "#step2";
+                break;
+            case "#step2":
+                var popup = window.open("about:blank");
+                if (!popup) {
+                    testFailed("Could not open about:blank popup.");
+                    finishTest();
+                    return;
+                }
+
+                popup.eval(
+                    "fetch('" + thirdPartyOrigin + "/cookies/resources/echo-cookies.py', { credentials: 'include' })" +
+                    ".then(function(r) { return r.text(); })" +
+                    ".then(function(text) {" +
+                    "    window.opener.postMessage({ type: 'fetch-done', result: text }, '*');" +
+                    "})" +
+                    ".catch(function(err) {" +
+                    "    window.opener.postMessage({ type: 'fetch-done', result: 'ERROR: ' + err.message }, '*');" +
+                    "});"
+                );
+
+                window.addEventListener("message", function handler(event) {
+                    if (event.data && event.data.type === "fetch-done") {
+                        window.removeEventListener("message", handler);
+                        var result = event.data.result;
+                        if (result.indexOf(cookieName) === -1) {
+                            testPassed("about:blank popup: third-party cookie was correctly blocked.");
+                        } else {
+                            testFailed("about:blank popup: third-party cookie was sent. Result: " + result);
+                        }
+                        popup.close();
+                        finishTest();
+                    }
+                });
+                break;
+        }
+    }
+
+    function finishTest() {
+        testRunner.setStatisticsShouldBlockThirdPartyCookies(false, function() {
+            setEnableFeature(false, finishJSTest);
+        });
+    }
+
+    if (document.location.hash === "") {
+        setEnableFeature(true, function () {
+            document.location.hash = "step1";
+            testRunner.setStatisticsShouldBlockThirdPartyCookies(true, runTest);
+        });
+    } else {
+        runTest();
+    }
+</script>
+</body>
+</html>

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1240,8 +1240,19 @@ void FrameLoader::resetMultipleFormSubmissionProtection()
 
 void FrameLoader::updateFirstPartyForCookies()
 {
-    if (RefPtr page = m_frame->page())
-        setFirstPartyForCookies(page->mainFrameURL());
+    RefPtr page = m_frame->page();
+    if (!page)
+        return;
+
+    auto firstPartyForCookies = page->mainFrameURL();
+    if (SecurityPolicy::shouldInheritSecurityOriginFromOwner(firstPartyForCookies)) {
+        if (RefPtr opener = dynamicDowncast<LocalFrame>(page->mainFrame().opener())) {
+            if (RefPtr openerDocument = opener->document())
+                firstPartyForCookies = openerDocument->firstPartyForCookies();
+        }
+    }
+
+    setFirstPartyForCookies(firstPartyForCookies);
 }
 
 void FrameLoader::setFirstPartyForCookies(const URL& url)


### PR DESCRIPTION
#### d6c7e00d0a91122f69e1d759ee338a9c40e7299a
<pre>
Block third-party cookies for requests from about:blank popups
<a href="https://bugs.webkit.org/show_bug.cgi?id=308445">https://bugs.webkit.org/show_bug.cgi?id=308445</a>
<a href="https://rdar.apple.com/168927271">rdar://168927271</a>

Reviewed by Matthew Finkel.

When an about:blank popup made cross-origin requests, its firstPartyForCookies was set to about:blank,
which has an empty registrable domain. thirdPartyCookieBlockingDecisionForRequest() returns
ThirdPartyCookieBlockingDecision::None for empty domains, bypassing third-party cookie blocking.

FrameLoader::updateFirstPartyForCookies() should inherit the opener&apos;s firstPartyForCookies when the main
frame URL is an about:blank or other owner-inherited document.

* LayoutTests/http/tests/resourceLoadStatistics/third-party-cookie-blocking-about-blank-popup-expected.txt: Added.
* LayoutTests/http/tests/resourceLoadStatistics/third-party-cookie-blocking-about-blank-popup.html: Added.
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::updateFirstPartyForCookies):

Originally-landed-as: 305413.366@rapid/safari-7624.2.5.110-branch (8acf8433e6be). <a href="https://rdar.apple.com/176067216">rdar://176067216</a>
Canonical link: <a href="https://commits.webkit.org/313637@main">https://commits.webkit.org/313637@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb31978165c18fad98786459a89d010e53722085

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163632 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37116 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30335 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172572 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/120081 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165501 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37447 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37115 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127099 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89606 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166591 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29376 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147120 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107653 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28425 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27057 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20275 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138324 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24837 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175077 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28008 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26502 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135403 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36786 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31159 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135386 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36501 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37571 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146632 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99637 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30694 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23484 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36281 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109427 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35779 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1511 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36029 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35926 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->