### PR TITLE
REGRESSION (301011@main): Crash in MediaPlayerPrivateMediaSourceAVFObjC::setNetworkState during destruction

### DIFF
--- a/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm
@@ -130,6 +130,13 @@ MediaPlayerPrivateMediaSourceAVFObjC::~MediaPlayerPrivateMediaSourceAVFObjC()
 {
     ALWAYS_LOG(LOGIDENTIFIER);
 
+    // Prevent re-entrant callbacks during member destruction. Without this,
+    // KVO notifications fired during m_mediaSourcePrivate's destruction can
+    // call back into this partially-destroyed object via WeakPtr-guarded
+    // callbacks (such as the error callback calling setNetworkState(),
+    // which accesses the already-destroyed m_logger).
+    weakPtrFactory().revokeAll();
+
     cancelPendingSeek();
     m_seekTimer.stop();
     dispatchToRendererQueue([](auto& renderer) {


### PR DESCRIPTION
#### 4193d2c83f3aec995d9b8d77ee81297727bc5b1a
<pre>
REGRESSION (301011@main): Crash in MediaPlayerPrivateMediaSourceAVFObjC::setNetworkState during destruction
&lt;<a href="https://bugs.webkit.org/show_bug.cgi?id=309455">https://bugs.webkit.org/show_bug.cgi?id=309455</a>&gt;
&lt;<a href="https://rdar.apple.com/172006984">rdar://172006984</a>&gt;

Reviewed by Jean-Yves Avenard.

Revoke all weak pointers at the start of the
`~MediaPlayerPrivateMediaSourceAVFObjC()` destructor to prevent
re-entrant callbacks during member destruction.  C++ destroys
`m_logger` before `m_mediaSourcePrivate` (reverse declaration
order), and the `m_mediaSourcePrivate` destructor can trigger
synchronous KVO notifications that invoke `WeakPtr`-guarded
callbacks on the partially-destroyed object.  Since the
`CanMakeWeakPtr` base class destructor runs after all member
destructors, `WeakPtr::get()` still succeeds, allowing
callbacks to access already-destroyed members.

* Source/WebCore/platform/graphics/avfoundation/objc/MediaPlayerPrivateMediaSourceAVFObjC.mm:
(WebCore::MediaPlayerPrivateMediaSourceAVFObjC::~MediaPlayerPrivateMediaSourceAVFObjC):

Originally-landed-as: 305413.419@rapid/safari-7624.2.5.110-branch (4424466acb2b). <a href="https://rdar.apple.com/176067520">rdar://176067520</a>
Canonical link: <a href="https://commits.webkit.org/313640@main">https://commits.webkit.org/313640@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4b8b16cb05f0b60b4774fc6599e97c43c6b44237

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163634 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37118 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30337 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172574 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/120091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165503 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37449 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37117 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127101 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/120091 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166593 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29378 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147127 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107655 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28427 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27060 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20277 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138326 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24844 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175079 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28010 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26509 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135405 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36788 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31162 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135388 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36502 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37573 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146639 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99640 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30698 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23491 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36283 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109429 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35781 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1518 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36031 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35928 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->