### PR TITLE
Add system trace points for Threaded Animation

### DIFF
--- a/Source/WTF/wtf/SystemTracing.h
+++ b/Source/WTF/wtf/SystemTracing.h
@@ -180,6 +180,8 @@ enum TracePointCode {
     WebXRCPFrameEndSubmissionEnd,
     TextExtractionStart,
     TextExtractionEnd,
+    UpdateThreadedAnimationsStart,
+    UpdateThreadedAnimationsEnd,
 
     GPUProcessRange = 16000,
     WakeUpAndApplyDisplayListStart,

--- a/Source/WebKit/Resources/Signposts/SystemTracePoints.plist
+++ b/Source/WebKit/Resources/Signposts/SystemTracePoints.plist
@@ -996,6 +996,18 @@
              </dict>
              <dict>
                  <key>Name</key>
+                 <string>Threaded Animations</string>
+                 <key>Type</key>
+                 <string>Interval</string>
+                 <key>Component</key>
+                 <string>47</string>
+                 <key>CodeBegin</key>
+                 <string>14015</string>
+                 <key>CodeEnd</key>
+                 <string>14016</string>
+             </dict>
+             <dict>
+                 <key>Name</key>
                  <string>Wake up and apply display list</string>
                  <key>Type</key>
                  <string>Interval</string>

--- a/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.mm
@@ -31,6 +31,7 @@
 #import "RemoteAnimationUtilities.h"
 #import "RemoteProgressBasedTimeline.h"
 #import <pal/spi/cocoa/QuartzCoreSPI.h>
+#import <wtf/SystemTracing.h>
 #import <wtf/TZoneMallocInlines.h>
 
 namespace WebKit {
@@ -172,6 +173,8 @@ void RemoteAnimationStack::applyEffects() const
 {
     if (!m_presentationModifierGroup)
         return;
+
+    TraceScope scope(UpdateThreadedAnimationsStart, UpdateThreadedAnimationsEnd);
 
     auto computedValues = computeValues();
 


### PR DESCRIPTION
#### 2ec0c7379f64e818f59bf2f34b246b548ea57ff0
<pre>
Add system trace points for Threaded Animation
<a href="https://bugs.webkit.org/show_bug.cgi?id=315243">https://bugs.webkit.org/show_bug.cgi?id=315243</a>
<a href="https://rdar.apple.com/177569301">rdar://177569301</a>

Reviewed by NOBODY (OOPS!).

Add a system trace point in `RemoteAnimationStack::applyEffects()`.

* Source/WTF/wtf/SystemTracing.h:
* Source/WebKit/Resources/Signposts/SystemTracePoints.plist:
* Source/WebKit/UIProcess/RemoteLayerTree/RemoteAnimationStack.mm:
(WebKit::RemoteAnimationStack::applyEffects const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ec0c7379f64e818f59bf2f34b246b548ea57ff0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163649 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37133 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30352 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172589 "Hash 2ec0c737 for PR 65341 does not build (failure)") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/120140 "Built successfully") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37464 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37132 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/172589 "Hash 2ec0c737 for PR 65341 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89609 "layout-tests (failure)") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166608 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29389 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147131 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/172589 "Hash 2ec0c737 for PR 65341 does not build (failure)") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28438 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27069 "Passed tests") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20292 "Hash 2ec0c737 for PR 65341 does not build (failure)") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/155800 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138337 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24848 "Passed tests") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175094 "Hash 2ec0c737 for PR 65341 does not build (failure)") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/24540 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28025 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26513 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/175094 "Hash 2ec0c737 for PR 65341 does not build (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36803 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31171 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/175094 "Hash 2ec0c737 for PR 65341 does not build (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37588 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146643 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99655 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30707 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23495 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/196051 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36298 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109444 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51116 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35796 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1522 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36046 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35943 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->