### PR TITLE
Reduce MotionMark weighting in PGO profiles

### DIFF
--- a/Tools/Scripts/pgo-profile
+++ b/Tools/Scripts/pgo-profile
@@ -5,7 +5,7 @@ import logging
 import os
 import subprocess
 
-from webkitpy.llvm_profile_utils import (LLVMProfileData, simplify_profile_weights,
+from webkitpy.llvm_profile_utils import (LLVMProfileData,
                                          merge_raw_profiles_in_directory_by_prefixes)
 
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s: %(message)s', datefmt='%Y-%m-%d %H:%M:%S')
@@ -13,7 +13,8 @@ logger = logging.getLogger()
 
 
 PROFILED_DYLIBS = ['JavaScriptCore', 'WebCore', 'WebKit']
-BENCHMARK_GROUP_WEIGHTS = [('speedometer3', 0.6), ('jetstream3', 0.2), ('motionmark', 0.2)]
+BENCHMARK_GROUP_WEIGHTS = [('speedometer3', 15), ('jetstream3', 5), ('motionmark', 2)]
+MAX_WEIGHT = 15
 
 
 def pad(string, max_length):
@@ -107,8 +108,10 @@ def combine(args):
 
     assert len(profile_weight_pairs) > 0, 'Must specify at least one group.'
 
-    profile_weight_pairs = simplify_profile_weights(profile_weight_pairs)
-    logger.info(f'Simplified group weights: {profile_weight_pairs}')
+    max_weight = max(weight for _, weight in profile_weight_pairs)
+    assert max_weight <= MAX_WEIGHT, \
+        f'Max weight {max_weight} exceeds MAX_WEIGHT={MAX_WEIGHT}.'
+    logger.info(f'Group weights: {profile_weight_pairs}')
 
     for lib in PROFILED_DYLIBS:
         logger.info(f'Merging {lib}')

--- a/Tools/Scripts/webkitpy/llvm_profile_utils.py
+++ b/Tools/Scripts/webkitpy/llvm_profile_utils.py
@@ -2,7 +2,6 @@
 
 import glob
 import logging
-import math
 import os
 import shlex
 import shutil
@@ -19,30 +18,6 @@ def locate_binary_xcrun(sdk, binary_name):
     if completed_process.returncode:
         return None
     return completed_process.stdout.strip()
-
-
-def simplify_profile_weights(profile_weights):
-    simplified_profile_weights = []
-
-    weight_sum = 0
-    max_weight = 0
-    # We need to turn percentages into weights > 1, but we don't want crazy high multipliers.
-    # For example, if we have weights 0.35 and 0.65, we don't need a 7:13 ratio when 5:9 is good enough.
-    max_multiplier = 15
-    for group, weight in profile_weights:
-        weight_sum = weight_sum + weight
-        if weight > max_weight:
-            max_weight = weight
-
-    gcd = int(max_weight * max_multiplier)
-    for group, weight in profile_weights:
-        gcd = math.gcd(gcd, int((weight / weight_sum) * max_multiplier))
-
-    for i in range(0, len(profile_weights)):
-        group, weight = profile_weights[i]
-        simplified_profile_weights.append((group, int((weight / weight_sum) * max_multiplier) // gcd))
-
-    return simplified_profile_weights
 
 
 class ExecutablesFromEnvAndXcode:


### PR DESCRIPTION
#### d619b1380b96897546b82b883695326d26a0ecaa
<pre>
Reduce MotionMark weighting in PGO profiles
<a href="https://bugs.webkit.org/show_bug.cgi?id=315244">https://bugs.webkit.org/show_bug.cgi?id=315244</a>
<a href="https://rdar.apple.com/176101330">rdar://176101330</a>

Reviewed by NOBODY (OOPS!).

Reduce the weighting we use for the MotionMark PGO profile when it is
merged with Speedometer and JetStream profiles before committing the
merged profile. Now, the weighting compensates for how long each
benchmark runs for to give them roughly equal influence over the
resulting PGO profile.

Also remove simplify_profile_weights and pass simplified weights
directly with a check that weights aren&apos;t too large since
simplify_profile_weights can significantly change the relative
weightings, which is a footgun.

* Tools/Scripts/pgo-profile:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d619b1380b96897546b82b883695326d26a0ecaa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166562 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40052 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33633 "Built successfully") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175610 "") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123818 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168428 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40485 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40060 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/175610 "") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91202 "2 flakes 3 failures") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169521 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31887 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149667 "Passed tests") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/175610 "") | | ⏳ 🛠 vision-apple 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/165882 "Found 1 webkitpy test failure: webkitscmpy.test.land_unittest.TestLandBitBucket.test_insert_review") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30864 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29564 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23751 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140835 "Found 1 new API test failure: TestWebKitAPI.IndexedDB.IndexedDBPersistence (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27364 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178144 "Built successfully") | | 
| | | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29071 "Found 1 new test failure: fast/scrolling/mac/slow-scrolling-overflow.html (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137858 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40122 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33711 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137776 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40810 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149162 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103536 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33067 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26027 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39320 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38717 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4117 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38962 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38860 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->