### PR TITLE
Scale down structure-heap reservation size with physical memory

### DIFF
--- a/Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.cpp
+++ b/Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.cpp
@@ -32,7 +32,11 @@
 #include "StructureID.h"
 #include <bmalloc/bmalloc.h>
 #include <wtf/BitVector.h>
+#include <wtf/RAMSize.h>
 
+#if OS(DARWIN)
+#include <wtf/cocoa/Entitlements.h>
+#endif
 #if CPU(ADDRESS64)
 #include <wtf/NeverDestroyed.h>
 WTF_ALLOW_UNSAFE_BUFFER_USAGE_BEGIN
@@ -94,9 +98,9 @@ class StructureMemoryManager {
 public:
     StructureMemoryManager()
     {
-        uintptr_t preferredStructureHeapSize = structureHeapAddressSize;
+        size_t preferredStructureHeapSize = computePreferredStructureHeapReservationSize();
         if (Options::structureHeapSizeInKB())
-            preferredStructureHeapSize = static_cast<uintptr_t>(Options::structureHeapSizeInKB()) * KB;
+            preferredStructureHeapSize = static_cast<size_t>(Options::structureHeapSizeInKB()) * KB;
         RELEASE_ASSERT(hasOneBitSet(preferredStructureHeapSize));
 
         uintptr_t mappedHeapSize = preferredStructureHeapSize;
@@ -163,7 +167,7 @@ public:
             constexpr size_t startIndex = 0;
             freeIndex = m_usedBlocks.findBit(startIndex, 0);
             ASSERT(freeIndex <= m_usedBlocks.bitCount());
-            RELEASE_ASSERT(g_jscConfig.sizeOfStructureHeap <= structureHeapAddressSize);
+            RELEASE_ASSERT(g_jscConfig.sizeOfStructureHeap <= computePreferredStructureHeapReservationSize());
             if (freeIndex * MarkedBlock::blockSize >= g_jscConfig.sizeOfStructureHeap)
                 return nullptr;
             // If we can't find a free block then `freeIndex == m_usedBlocks.bitCount()` and this set will grow the bit vector.
@@ -222,6 +226,11 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     }
 
 private:
+    static size_t computePreferredStructureHeapReservationSize();
+
+    // The actual preferred size will be the next power-of-two below this value
+    // This value results in a 512MiB reservation on 3GiB devices, 1GiB on 4GiB
+    static constexpr size_t maximumPercentageOfPhysicalMemoryToReserveWhenVAConstrained = 20;
     Lock m_lock;
     bool m_useSystemHeap { true };
     BitVector m_usedBlocks;
@@ -244,6 +253,51 @@ void StructureAlignedMemoryAllocator::freeAlignedMemory(void* block)
 void StructureAlignedMemoryAllocator::initializeStructureAddressSpace()
 {
     s_structureMemoryManager.construct();
+}
+
+size_t StructureMemoryManager::computePreferredStructureHeapReservationSize()
+{
+    static size_t cachedSize;
+    static std::once_flag onceKey;
+    std::call_once(onceKey, [] {
+        size_t baseSize { 0 };
+#if PLATFORM(PLAYSTATION) || OS(QNX)
+        baseSize = 128 * MB;
+#elif (PLATFORM(IOS_FAMILY) && !CPU(ARM64E)) || PLATFORM(WATCHOS) || PLATFORM(APPLETV)
+        baseSize = 512 * MB;
+#elif PLATFORM(IOS_FAMILY)
+        baseSize = 2 * GB;
+#else
+        baseSize = 4 * GB;
+#endif
+
+#if PLATFORM(IOS_FAMILY)
+        // For larger reservation sizes, its backing mapping can
+        // monopolize a significant fraction of all virtual memory.
+        // Preferably, we only want to do so when we have reason to expect that
+        // this reservation may actually be utilized. On systems with relatively
+        // little physical memory available vs. the size of the reservation, we
+        // should thus reserve less virtual memory to not waste it unnecessarily.
+
+        size_t physicalMemorySize = WTF::ramSizeDisregardingJetsamLimit();
+        RELEASE_ASSERT(physicalMemorySize);
+
+        bool isVaConstrained = !WTF::processHasEntitlement("com.apple.developer.kernel.extended-virtual-addressing");
+        if (isVaConstrained) {
+            size_t sizeBoundedByPhysicalMemory = std::min(baseSize, (physicalMemorySize * maximumPercentageOfPhysicalMemoryToReserveWhenVAConstrained) / 100);
+            RELEASE_ASSERT(sizeBoundedByPhysicalMemory);
+            cachedSize = std::bit_floor(sizeBoundedByPhysicalMemory);
+        } else
+            cachedSize = std::bit_floor(baseSize);
+#else
+        cachedSize = baseSize;
+#endif
+
+#if CPU(ADDRESS64)
+        RELEASE_ASSERT(cachedSize - 1 <= StructureID::structureIDMask, "StructureID relies on only the lower 32 bits of Structure addresses varying");
+#endif
+    });
+    return cachedSize;
 }
 
 #else // not CPU(ADDRESS64)

--- a/Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.h
+++ b/Source/JavaScriptCore/heap/StructureAlignedMemoryAllocator.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "AlignedMemoryAllocator.h"
+#include <cstddef>
 #include <wtf/FastMalloc.h>
 
 #if ENABLE(MALLOC_HEAP_BREAKDOWN)

--- a/Source/JavaScriptCore/runtime/JSCConfig.h
+++ b/Source/JavaScriptCore/runtime/JSCConfig.h
@@ -151,6 +151,11 @@ ALWAYS_INLINE PURE_FUNCTION uintptr_t startOfStructureHeap()
     return g_jscConfig.startOfStructureHeap;
 }
 
+ALWAYS_INLINE PURE_FUNCTION uintptr_t sizeOfStructureHeap()
+{
+    return g_jscConfig.sizeOfStructureHeap;
+}
+
 ALWAYS_INLINE PURE_FUNCTION uintptr_t structureIDBase()
 {
     return g_jscConfig.structureIDBase;

--- a/Source/JavaScriptCore/runtime/StructureID.h
+++ b/Source/JavaScriptCore/runtime/StructureID.h
@@ -34,29 +34,12 @@ namespace JSC {
 
 class Structure;
 
-#if CPU(ADDRESS64)
-
-#if defined(STRUCTURE_HEAP_ADDRESS_SIZE_IN_MB) && STRUCTURE_HEAP_ADDRESS_SIZE_IN_MB > 0
-constexpr uintptr_t structureHeapAddressSize = STRUCTURE_HEAP_ADDRESS_SIZE_IN_MB * MB;
-#elif PLATFORM(PLAYSTATION) || OS(QNX)
-constexpr uintptr_t structureHeapAddressSize = 128 * MB;
-#elif (PLATFORM(IOS_FAMILY) && !CPU(ARM64E)) || PLATFORM(WATCHOS) || PLATFORM(APPLETV)
-constexpr uintptr_t structureHeapAddressSize = 512 * MB;
-#elif PLATFORM(IOS_FAMILY)
-constexpr uintptr_t structureHeapAddressSize = 2 * GB;
-#else
-constexpr uintptr_t structureHeapAddressSize = 4 * GB;
-#endif
-
-#endif // CPU(ADDRESS64)
-
 class StructureID {
 public:
     static constexpr uint32_t nukedStructureIDBit = 1;
 
 #if CPU(ADDRESS64)
     static constexpr uintptr_t structureIDMask = static_cast<uintptr_t>(UINT_MAX);
-    static_assert(structureHeapAddressSize - 1 <= structureIDMask, "StructureID relies on only the lower 32 bits of Structure addresses varying");
 #endif
 
     constexpr StructureID() = default;
@@ -107,7 +90,7 @@ ALWAYS_INLINE Structure* StructureID::tryDecode() const
 ALWAYS_INLINE StructureID StructureID::encode(const Structure* structure)
 {
     ASSERT(structure);
-    ASSERT(startOfStructureHeap() <= reinterpret_cast<uintptr_t>(structure) && reinterpret_cast<uintptr_t>(structure) < startOfStructureHeap() + structureHeapAddressSize);
+    ASSERT(startOfStructureHeap() <= reinterpret_cast<uintptr_t>(structure) && reinterpret_cast<uintptr_t>(structure) < startOfStructureHeap() + g_jscConfig.sizeOfStructureHeap);
     auto result = StructureID(reinterpret_cast<uintptr_t>(structure));
     ASSERT(result.decode() == structure);
     return result;


### PR DESCRIPTION
#### cffeaa6ccbf42e8d5ff626cc9806f7eac3c66e6b
<pre>
Scale down structure-heap reservation size with physical memory
<a href="https://bugs.webkit.org/show_bug.cgi?id=315240">https://bugs.webkit.org/show_bug.cgi?id=315240</a>
<a href="https://rdar.apple.com/177567438">rdar://177567438</a>

Reviewed by Mark Lam.

This patch constrains the size of the StructureAlignedMemoryAllocator&apos;s
VA reservation so that it does not exceed 25% of the system&apos;s physical
memory size. The goal is to reduce virtual memory usage in cases where
we know that the full reservation would not be used (as we do not expect
to use e.g. 50% of system memory on JS Structures in a single process).
For most systems, this will not have a significant effect, as the
reservation size is already small relative to RAM, but on e.g. a 3GiB
iPad the reservation can currently be as big as 2GiB -- this patch will
reduce that to a maximum of 0.5GiB. The restriction only takes affect
for devices with embedded operating systems, and even there only in
processes which lack the
com.apple.developer.kernel.extended-virtual-addressing entitlement.
When that entitlement is present there is no restriction.
New reservation size by RAM size:
  - 3GiB RAM: 512MiB reservation
  - 4GiB RAM: 512MiB reservation
  - 5GiB RAM: 1GiB reservation
  - 6GiB RAM: 1GiB reservation
  ... 1GiB reservation ...
  - 10GiB RAM: 2GiB reservation
  and 2GiB thereafter.

Canonical link: <a href="https://commits.webkit.org/314156@main">https://commits.webkit.org/314156@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/537c80ca94ae90269796705f7402ba17bd22febd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165305 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38796 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32376 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174349 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122562 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c56bee7c-001e-4026-aedb-e668b0ddd504) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39133 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38800 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128458 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90413 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4f829e25-b74d-4df2-ab2d-b30d98e79dc5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168264 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30770 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148517 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108983 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/00c2cf6f-8307-44b7-89bd-be4d695c5ed5) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29818 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28440 "Passed tests") | [  ~~🛠 gtk3-libwebrtc~~](https://ews-build.webkit.org/#/builders/173/builds/22423 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157464 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139713 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26215 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176870 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26200 "Built successfully and passed tests") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/29767 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27920 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136779 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38864 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/32578 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136718 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36845 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39554 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148011 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101898 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31994 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24878 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38064 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111138 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198965 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37461 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2956 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37707 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37605 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->