### PR TITLE
[libpas] Add a guard page to the front of the compact-heap reservation

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_compact_heap_reservation.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_compact_heap_reservation.c
@@ -38,9 +38,8 @@
 
 size_t pas_compact_heap_reservation_size =
     (size_t)1 << PAS_COMPACT_PTR_BITS << PAS_INTERNAL_MIN_ALIGN_SHIFT;
-size_t pas_compact_heap_reservation_guard_size = 16;
+size_t pas_compact_heap_reservation_guard_size = 0;
 uintptr_t pas_compact_heap_reservation_base = 0;
-size_t pas_compact_heap_reservation_available_size = 0;
 size_t pas_compact_heap_reservation_bump = 0;
 
 #if PAS_PLATFORM(PLAYSTATION)
@@ -64,28 +63,32 @@ pas_aligned_allocation_result pas_compact_heap_reservation_try_allocate(size_t s
     if (!pas_compact_heap_reservation_base) {
         pas_aligned_allocation_result page_result;
 
+        pas_compact_heap_reservation_guard_size = pas_page_malloc_alignment();
+
 #if PAS_PLATFORM(PLAYSTATION)
         pas_zero_memory(&page_result, sizeof(pas_aligned_allocation_result));
 
         page_result.result = memory_extra_vss_reserve(pas_compact_heap_reservation_size, pas_page_malloc_alignment());
         PAS_ASSERT(page_result.result);
 #else
-        page_result = pas_page_malloc_try_allocate_without_deallocating_padding(
-            pas_compact_heap_reservation_size, pas_alignment_create_trivial(), false);
+        /* Make the first page of the reservation a real guard. A zero-valued
+           compact pointer dereferenced via _load_non_null decodes to base + 0;
+           with the guard in place that lands on PROT_NONE memory and faults
+           deterministically rather than wandering into a neighboring VM region. */
+        page_result = pas_page_malloc_try_allocate_with_guard_pages_without_deallocating_padding(
+            pas_compact_heap_reservation_size, pas_alignment_create_trivial(), false,
+            pas_compact_heap_reservation_guard_size);
         PAS_ASSERT(!page_result.left_padding_size);
         PAS_ASSERT(!page_result.right_padding_size);
         PAS_ASSERT(page_result.result);
         PAS_ASSERT(page_result.result_size == pas_compact_heap_reservation_size);
 #endif
 
-        pas_compact_heap_reservation_base =
-            (uintptr_t)page_result.result - pas_compact_heap_reservation_guard_size;
-        pas_compact_heap_reservation_available_size =
-            pas_compact_heap_reservation_size - pas_compact_heap_reservation_guard_size;
+        pas_compact_heap_reservation_base = (uintptr_t)page_result.result;
         pas_compact_heap_reservation_bump = pas_compact_heap_reservation_guard_size;
     }
 
-    reservation_end = pas_compact_heap_reservation_base + pas_compact_heap_reservation_available_size;
+    reservation_end = pas_compact_heap_reservation_base + pas_compact_heap_reservation_size;
     padding_start = pas_compact_heap_reservation_base + pas_compact_heap_reservation_bump;
     allocation_start = pas_round_up_to_power_of_2(padding_start, alignment);
 

--- a/Source/bmalloc/libpas/src/libpas/pas_compact_heap_reservation.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_compact_heap_reservation.h
@@ -34,7 +34,6 @@ PAS_BEGIN_EXTERN_C;
 PAS_API extern size_t pas_compact_heap_reservation_size;
 PAS_API extern size_t pas_compact_heap_reservation_guard_size;
 PAS_API extern uintptr_t pas_compact_heap_reservation_base;
-PAS_API extern size_t pas_compact_heap_reservation_available_size;
 PAS_API extern size_t pas_compact_heap_reservation_bump;
 
 /* FIXME: This should support pas_alignment at some point. */

--- a/Source/bmalloc/libpas/src/libpas/pas_page_malloc.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_malloc.c
@@ -284,6 +284,33 @@ pas_page_malloc_try_allocate_without_deallocating_padding(
     return result;
 }
 
+pas_aligned_allocation_result
+pas_page_malloc_try_allocate_with_guard_pages_without_deallocating_padding(
+    size_t size, pas_alignment alignment, bool may_contain_small_or_medium,
+    size_t guard_size)
+{
+    pas_aligned_allocation_result result;
+
+    PAS_ASSERT(pas_is_aligned(guard_size, pas_page_malloc_alignment()));
+    PAS_ASSERT(guard_size <= size);
+
+    result = pas_page_malloc_try_allocate_without_deallocating_padding(
+        size, alignment, may_contain_small_or_medium);
+    if (!result.result || !guard_size)
+        return result;
+
+#if PAS_OS(WINDOWS)
+    {
+        DWORD old_protect;
+        PAS_ASSERT(VirtualProtect(result.result, guard_size, PAGE_NOACCESS, &old_protect));
+    }
+#else
+    PAS_SYSCALL(mprotect(result.result, guard_size, PROT_NONE));
+#endif
+
+    return result;
+}
+
 #if PAS_USE_MADV_ZERO
 static void pas_page_malloc_zero_fill_latch_if_madv_zero_is_supported(void)
 {

--- a/Source/bmalloc/libpas/src/libpas/pas_page_malloc.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_page_malloc.h
@@ -62,6 +62,15 @@ PAS_API pas_aligned_allocation_result
 pas_page_malloc_try_allocate_without_deallocating_padding(
     size_t size, pas_alignment alignment, bool may_contain_small_or_medium);
 
+/* Same as pas_page_malloc_try_allocate_without_deallocating_padding, but the first
+   guard_size bytes of the returned region are made inaccessible (PROT_NONE / PAGE_NOACCESS)
+   to catch wild accesses through pointers that decode to the base of the allocation.
+   guard_size must be a multiple of pas_page_malloc_alignment() and not exceed size. */
+PAS_API pas_aligned_allocation_result
+pas_page_malloc_try_allocate_with_guard_pages_without_deallocating_padding(
+    size_t size, pas_alignment alignment, bool may_contain_small_or_medium,
+    size_t guard_size);
+
 PAS_API void pas_page_malloc_deallocate(void* base, size_t size);
 
 PAS_API void pas_page_malloc_zero_fill(void* base, size_t size);

--- a/Source/bmalloc/libpas/src/libpas/pas_report_crash_pgm_report.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_report_crash_pgm_report.h
@@ -65,7 +65,7 @@ typedef void *(*crash_reporter_memory_reader_t)(task_t task, vm_address_t addres
 
 /* This must be in sync between ReportCrash and libpas to generate a report. 
  * Make sure to bump version number after changing extraction structs and logic */
-static const unsigned pas_crash_report_version = 6;
+static const unsigned pas_crash_report_version = 7;
 
 /* Report sent back to the ReportCrash process. */
 typedef struct pas_report_crash_pgm_report pas_report_crash_pgm_report;

--- a/Source/bmalloc/libpas/src/libpas/pas_root.c
+++ b/Source/bmalloc/libpas/src/libpas/pas_root.c
@@ -90,7 +90,6 @@ void pas_root_construct(pas_root* root)
     root->compact_heap_reservation_base = &pas_compact_heap_reservation_base;
     root->compact_heap_reservation_size = &pas_compact_heap_reservation_size;
     root->compact_heap_reservation_guard_size = &pas_compact_heap_reservation_guard_size;
-    root->compact_heap_reservation_available_size = &pas_compact_heap_reservation_available_size;
     root->compact_heap_reservation_bump = &pas_compact_heap_reservation_bump;
     root->enumerable_page_malloc_page_list = &pas_enumerable_page_malloc_page_list;
     root->large_heap_physical_page_sharing_cache_page_list =

--- a/Source/bmalloc/libpas/src/libpas/pas_root.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_root.h
@@ -81,7 +81,6 @@ struct pas_root {
     uintptr_t* compact_heap_reservation_base;
     size_t* compact_heap_reservation_size;
     size_t* compact_heap_reservation_guard_size;
-    size_t* compact_heap_reservation_available_size;
     size_t* compact_heap_reservation_bump;
     pas_enumerable_range_list* enumerable_page_malloc_page_list;
     pas_enumerable_range_list* large_heap_physical_page_sharing_cache_page_list;

--- a/Source/bmalloc/libpas/src/test/IsoHeapChaosTests.cpp
+++ b/Source/bmalloc/libpas/src/test/IsoHeapChaosTests.cpp
@@ -626,8 +626,7 @@ void testAllocationChaos(unsigned numThreads, unsigned numIsolatedHeaps,
             addPageRange(
                 pas_range_create(
                     pas_compact_heap_reservation_base + pas_compact_heap_reservation_guard_size,
-                    pas_compact_heap_reservation_base + pas_compact_heap_reservation_guard_size
-                    + pas_compact_heap_reservation_size));
+                    pas_compact_heap_reservation_base + pas_compact_heap_reservation_size));
 
             bool enumerateResult = pas_enumerable_range_list_iterate(
                 &pas_enumerable_page_malloc_page_list, addPageRangeCallback, nullptr);


### PR DESCRIPTION
#### ba26b5242151233d8fe65f1834456cb27130dce2
<pre>
[libpas] Add a guard page to the front of the compact-heap reservation
<a href="https://bugs.webkit.org/show_bug.cgi?id=315126">https://bugs.webkit.org/show_bug.cgi?id=315126</a>
<a href="https://rdar.apple.com/177469163">rdar://177469163</a>

Reviewed by Dan Hecht.

Libpas&apos; compact-heap allocates metadata objects for which we want
to minimize the metadata overhead. This is achieved by creating a fixed
VA reservation and allocating objects as 8B aligned indices into the
heap.
Due to how the bounds of the range are computed (offset by
pas_compact_heap_reservation_guard_size) the first byte of compact
memory is actually accessed via compact-pointer index 2. libpas will
never give out indices 0 or 1. However, if a bug somehow zeroes
out a compact pointer, then the resulting index points to the memory
immediately-before the compact reservation. Unchecked accesses, such as
through pas_segregated_directory_data_ptr_load_non_null, will
consequently corrupt that memory, if it’s mapped.
This patch adds a guard page to the start of the VA reservation,
turning &apos;compact-nullptr&apos; accesses like those described above into
deterministic crashes.

No new tests as this is an implementation detail.

Canonical link: <a href="https://commits.webkit.org/313747@main">https://commits.webkit.org/313747@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5e633d57b88ba149d55b533e0e7569b8a546f9da

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163875 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37359 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30578 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172903 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8c7da656-b417-403d-9f10-fec36f175b80) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37691 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37358 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127296 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c0dbaa1e-1844-4fa8-a76b-2096aeeee40f) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166834 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29585 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147322 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107845 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a3cdd310-fc2d-4fc0-976d-9989d9069fe1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28631 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27252 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20668 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/156026 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138531 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25039 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175425 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/24767 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26707 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135604 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37029 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31362 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135579 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36566 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37814 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146834 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99951 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30894 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23689 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/196278 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36525 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51235 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36022 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1724 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36272 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36169 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->