### PR TITLE
Replace all remaining uses of `std::to_array()` with `WTF::toArray()` in WebKit

### DIFF
--- a/Source/JavaScriptCore/inspector/scripts/codegen/generate_cpp_protocol_types_implementation.py
+++ b/Source/JavaScriptCore/inspector/scripts/codegen/generate_cpp_protocol_types_implementation.py
@@ -90,7 +90,7 @@ class CppProtocolTypesImplementationGenerator(CppGenerator):
             return []
 
         lines = []
-        lines.append('static const auto enum_constant_values = std::to_array<ASCIILiteral>({')
+        lines.append('static const auto enum_constant_values = WTF::toArray<ASCIILiteral>({')
         lines.extend(['    "%s"_s,' % enum_value for enum_value in self.assigned_enum_values()])
         lines.append('});')
         lines.append('')
@@ -109,7 +109,7 @@ class CppProtocolTypesImplementationGenerator(CppGenerator):
             body_lines.extend([
                 'template<> std::optional<%s> parseEnumValueFromString<%s>(const String& protocolString)' % (cpp_protocol_type, cpp_protocol_type),
                 '{',
-                '    static const auto constantValues = std::to_array<size_t>({',
+                '    static const auto constantValues = WTF::toArray<size_t>({',
             ])
 
             enum_values = enum_type.enum_values()

--- a/Source/JavaScriptCore/inspector/scripts/codegen/generate_objc_protocol_type_conversions_header.py
+++ b/Source/JavaScriptCore/inspector/scripts/codegen/generate_objc_protocol_type_conversions_header.py
@@ -166,7 +166,7 @@ class ObjCProtocolTypeConversionsHeaderGenerator(ObjCGenerator):
         lines.append('template<>')
         lines.append('inline std::optional<%s> fromProtocolString(const String& value)' % objc_enum_name)
         lines.append('{')
-        lines.append('    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, %s>>({' % objc_enum_name)
+        lines.append('    static constexpr SortedArrayMap map { WTF::toArray<std::pair<ComparableASCIILiteral, %s>>({' % objc_enum_name)
         for enum_value in sorted(enum_values):
             lines.append('        { "%s"_s, %s%s },' % (enum_value, objc_enum_name, Generator.stylized_name_for_enum_value(enum_value)))
         lines.append('   }) };')

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-async-attribute.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-async-attribute.json-result
@@ -805,7 +805,7 @@ namespace Protocol {
 
 namespace TestHelpers {
 
-static const auto enum_constant_values = std::to_array<ASCIILiteral>({
+static const auto enum_constant_values = WTF::toArray<ASCIILiteral>({
     "red"_s,
     "green"_s,
     "blue"_s,
@@ -823,7 +823,7 @@ String getEnumConstantValue(int code) {
 
 template<> std::optional<Protocol::Database::PrimaryColors> parseEnumValueFromString<Protocol::Database::PrimaryColors>(const String& protocolString)
 {
-    static const auto constantValues = std::to_array<size_t>({
+    static const auto constantValues = WTF::toArray<size_t>({
         (size_t)Protocol::Database::PrimaryColors::Red,
         (size_t)Protocol::Database::PrimaryColors::Green,
         (size_t)Protocol::Database::PrimaryColors::Blue,
@@ -1464,7 +1464,7 @@ inline String toProtocolString(TestProtocolDatabasePrimaryColors value)
 template<>
 inline std::optional<TestProtocolDatabasePrimaryColors> fromProtocolString(const String& value)
 {
-    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabasePrimaryColors>>({
+    static constexpr SortedArrayMap map { WTF::toArray<std::pair<ComparableASCIILiteral, TestProtocolDatabasePrimaryColors>>({
         { "blue"_s, TestProtocolDatabasePrimaryColorsBlue },
         { "green"_s, TestProtocolDatabasePrimaryColorsGreen },
         { "red"_s, TestProtocolDatabasePrimaryColorsRed },
@@ -1491,7 +1491,7 @@ inline String toProtocolString(TestProtocolDatabaseExecuteSQLSyncOptionalReturnV
 template<>
 inline std::optional<TestProtocolDatabaseExecuteSQLSyncOptionalReturnValuesPrintColor> fromProtocolString(const String& value)
 {
-    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteSQLSyncOptionalReturnValuesPrintColor>>({
+    static constexpr SortedArrayMap map { WTF::toArray<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteSQLSyncOptionalReturnValuesPrintColor>>({
         { "black"_s, TestProtocolDatabaseExecuteSQLSyncOptionalReturnValuesPrintColorBlack },
         { "cyan"_s, TestProtocolDatabaseExecuteSQLSyncOptionalReturnValuesPrintColorCyan },
         { "magenta"_s, TestProtocolDatabaseExecuteSQLSyncOptionalReturnValuesPrintColorMagenta },
@@ -1519,7 +1519,7 @@ inline String toProtocolString(TestProtocolDatabaseExecuteSQLAsyncOptionalReturn
 template<>
 inline std::optional<TestProtocolDatabaseExecuteSQLAsyncOptionalReturnValuesPrintColor> fromProtocolString(const String& value)
 {
-    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteSQLAsyncOptionalReturnValuesPrintColor>>({
+    static constexpr SortedArrayMap map { WTF::toArray<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteSQLAsyncOptionalReturnValuesPrintColor>>({
         { "black"_s, TestProtocolDatabaseExecuteSQLAsyncOptionalReturnValuesPrintColorBlack },
         { "cyan"_s, TestProtocolDatabaseExecuteSQLAsyncOptionalReturnValuesPrintColorCyan },
         { "magenta"_s, TestProtocolDatabaseExecuteSQLAsyncOptionalReturnValuesPrintColorMagenta },
@@ -1547,7 +1547,7 @@ inline String toProtocolString(TestProtocolDatabaseExecuteSQLSyncPrintColor valu
 template<>
 inline std::optional<TestProtocolDatabaseExecuteSQLSyncPrintColor> fromProtocolString(const String& value)
 {
-    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteSQLSyncPrintColor>>({
+    static constexpr SortedArrayMap map { WTF::toArray<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteSQLSyncPrintColor>>({
         { "black"_s, TestProtocolDatabaseExecuteSQLSyncPrintColorBlack },
         { "cyan"_s, TestProtocolDatabaseExecuteSQLSyncPrintColorCyan },
         { "magenta"_s, TestProtocolDatabaseExecuteSQLSyncPrintColorMagenta },
@@ -1575,7 +1575,7 @@ inline String toProtocolString(TestProtocolDatabaseExecuteSQLAsyncPrintColor val
 template<>
 inline std::optional<TestProtocolDatabaseExecuteSQLAsyncPrintColor> fromProtocolString(const String& value)
 {
-    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteSQLAsyncPrintColor>>({
+    static constexpr SortedArrayMap map { WTF::toArray<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteSQLAsyncPrintColor>>({
         { "black"_s, TestProtocolDatabaseExecuteSQLAsyncPrintColorBlack },
         { "cyan"_s, TestProtocolDatabaseExecuteSQLAsyncPrintColorCyan },
         { "magenta"_s, TestProtocolDatabaseExecuteSQLAsyncPrintColorMagenta },

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-optional-call-return-parameters.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-optional-call-return-parameters.json-result
@@ -723,7 +723,7 @@ namespace Protocol {
 
 namespace TestHelpers {
 
-static const auto enum_constant_values = std::to_array<ASCIILiteral>({
+static const auto enum_constant_values = WTF::toArray<ASCIILiteral>({
     "red"_s,
     "green"_s,
     "blue"_s,
@@ -741,7 +741,7 @@ String getEnumConstantValue(int code) {
 
 template<> std::optional<Protocol::Database::PrimaryColors> parseEnumValueFromString<Protocol::Database::PrimaryColors>(const String& protocolString)
 {
-    static const auto constantValues = std::to_array<size_t>({
+    static const auto constantValues = WTF::toArray<size_t>({
         (size_t)Protocol::Database::PrimaryColors::Red,
         (size_t)Protocol::Database::PrimaryColors::Green,
         (size_t)Protocol::Database::PrimaryColors::Blue,
@@ -1338,7 +1338,7 @@ inline String toProtocolString(TestProtocolDatabasePrimaryColors value)
 template<>
 inline std::optional<TestProtocolDatabasePrimaryColors> fromProtocolString(const String& value)
 {
-    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabasePrimaryColors>>({
+    static constexpr SortedArrayMap map { WTF::toArray<std::pair<ComparableASCIILiteral, TestProtocolDatabasePrimaryColors>>({
         { "blue"_s, TestProtocolDatabasePrimaryColorsBlue },
         { "green"_s, TestProtocolDatabasePrimaryColorsGreen },
         { "red"_s, TestProtocolDatabasePrimaryColorsRed },
@@ -1365,7 +1365,7 @@ inline String toProtocolString(TestProtocolDatabaseExecuteAllOptionalParametersP
 template<>
 inline std::optional<TestProtocolDatabaseExecuteAllOptionalParametersPrintColor> fromProtocolString(const String& value)
 {
-    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteAllOptionalParametersPrintColor>>({
+    static constexpr SortedArrayMap map { WTF::toArray<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteAllOptionalParametersPrintColor>>({
         { "black"_s, TestProtocolDatabaseExecuteAllOptionalParametersPrintColorBlack },
         { "cyan"_s, TestProtocolDatabaseExecuteAllOptionalParametersPrintColorCyan },
         { "magenta"_s, TestProtocolDatabaseExecuteAllOptionalParametersPrintColorMagenta },
@@ -1395,7 +1395,7 @@ inline String toProtocolString(TestProtocolDatabaseExecuteAllOptionalParametersP
 template<>
 inline std::optional<TestProtocolDatabaseExecuteAllOptionalParametersPrintColor> fromProtocolString(const String& value)
 {
-    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteAllOptionalParametersPrintColor>>({
+    static constexpr SortedArrayMap map { WTF::toArray<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteAllOptionalParametersPrintColor>>({
         { "black"_s, TestProtocolDatabaseExecuteAllOptionalParametersPrintColorBlack },
         { "cyan"_s, TestProtocolDatabaseExecuteAllOptionalParametersPrintColorCyan },
         { "magenta"_s, TestProtocolDatabaseExecuteAllOptionalParametersPrintColorMagenta },
@@ -1423,7 +1423,7 @@ inline String toProtocolString(TestProtocolDatabaseExecuteNoOptionalParametersPr
 template<>
 inline std::optional<TestProtocolDatabaseExecuteNoOptionalParametersPrintColor> fromProtocolString(const String& value)
 {
-    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteNoOptionalParametersPrintColor>>({
+    static constexpr SortedArrayMap map { WTF::toArray<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteNoOptionalParametersPrintColor>>({
         { "black"_s, TestProtocolDatabaseExecuteNoOptionalParametersPrintColorBlack },
         { "cyan"_s, TestProtocolDatabaseExecuteNoOptionalParametersPrintColorCyan },
         { "magenta"_s, TestProtocolDatabaseExecuteNoOptionalParametersPrintColorMagenta },
@@ -1453,7 +1453,7 @@ inline String toProtocolString(TestProtocolDatabaseExecuteNoOptionalParametersPr
 template<>
 inline std::optional<TestProtocolDatabaseExecuteNoOptionalParametersPrintColor> fromProtocolString(const String& value)
 {
-    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteNoOptionalParametersPrintColor>>({
+    static constexpr SortedArrayMap map { WTF::toArray<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteNoOptionalParametersPrintColor>>({
         { "black"_s, TestProtocolDatabaseExecuteNoOptionalParametersPrintColorBlack },
         { "cyan"_s, TestProtocolDatabaseExecuteNoOptionalParametersPrintColorCyan },
         { "magenta"_s, TestProtocolDatabaseExecuteNoOptionalParametersPrintColorMagenta },

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/domain-exposed-as-other-name.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/domain-exposed-as-other-name.json-result
@@ -835,7 +835,7 @@ namespace Protocol {
 
 namespace TestHelpers {
 
-static const auto enum_constant_values = std::to_array<ASCIILiteral>({
+static const auto enum_constant_values = WTF::toArray<ASCIILiteral>({
     "red"_s,
     "green"_s,
     "blue"_s,
@@ -853,7 +853,7 @@ String getEnumConstantValue(int code) {
 
 template<> std::optional<Protocol::Database::PrimaryColors> parseEnumValueFromString<Protocol::Database::PrimaryColors>(const String& protocolString)
 {
-    static const auto constantValues = std::to_array<size_t>({
+    static const auto constantValues = WTF::toArray<size_t>({
         (size_t)Protocol::Database::PrimaryColors::Red,
         (size_t)Protocol::Database::PrimaryColors::Green,
         (size_t)Protocol::Database::PrimaryColors::Blue,
@@ -1540,7 +1540,7 @@ inline String toProtocolString(TestProtocolDatabasePrimaryColors value)
 template<>
 inline std::optional<TestProtocolDatabasePrimaryColors> fromProtocolString(const String& value)
 {
-    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabasePrimaryColors>>({
+    static constexpr SortedArrayMap map { WTF::toArray<std::pair<ComparableASCIILiteral, TestProtocolDatabasePrimaryColors>>({
         { "blue"_s, TestProtocolDatabasePrimaryColorsBlue },
         { "green"_s, TestProtocolDatabasePrimaryColorsGreen },
         { "red"_s, TestProtocolDatabasePrimaryColorsRed },
@@ -1567,7 +1567,7 @@ inline String toProtocolString(TestProtocolDatabaseExecuteSQLSyncOptionalReturnV
 template<>
 inline std::optional<TestProtocolDatabaseExecuteSQLSyncOptionalReturnValuesPrintColor> fromProtocolString(const String& value)
 {
-    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteSQLSyncOptionalReturnValuesPrintColor>>({
+    static constexpr SortedArrayMap map { WTF::toArray<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteSQLSyncOptionalReturnValuesPrintColor>>({
         { "black"_s, TestProtocolDatabaseExecuteSQLSyncOptionalReturnValuesPrintColorBlack },
         { "cyan"_s, TestProtocolDatabaseExecuteSQLSyncOptionalReturnValuesPrintColorCyan },
         { "magenta"_s, TestProtocolDatabaseExecuteSQLSyncOptionalReturnValuesPrintColorMagenta },
@@ -1595,7 +1595,7 @@ inline String toProtocolString(TestProtocolDatabaseExecuteSQLAsyncOptionalReturn
 template<>
 inline std::optional<TestProtocolDatabaseExecuteSQLAsyncOptionalReturnValuesPrintColor> fromProtocolString(const String& value)
 {
-    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteSQLAsyncOptionalReturnValuesPrintColor>>({
+    static constexpr SortedArrayMap map { WTF::toArray<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteSQLAsyncOptionalReturnValuesPrintColor>>({
         { "black"_s, TestProtocolDatabaseExecuteSQLAsyncOptionalReturnValuesPrintColorBlack },
         { "cyan"_s, TestProtocolDatabaseExecuteSQLAsyncOptionalReturnValuesPrintColorCyan },
         { "magenta"_s, TestProtocolDatabaseExecuteSQLAsyncOptionalReturnValuesPrintColorMagenta },
@@ -1623,7 +1623,7 @@ inline String toProtocolString(TestProtocolDatabaseExecuteSQLSyncPrintColor valu
 template<>
 inline std::optional<TestProtocolDatabaseExecuteSQLSyncPrintColor> fromProtocolString(const String& value)
 {
-    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteSQLSyncPrintColor>>({
+    static constexpr SortedArrayMap map { WTF::toArray<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteSQLSyncPrintColor>>({
         { "black"_s, TestProtocolDatabaseExecuteSQLSyncPrintColorBlack },
         { "cyan"_s, TestProtocolDatabaseExecuteSQLSyncPrintColorCyan },
         { "magenta"_s, TestProtocolDatabaseExecuteSQLSyncPrintColorMagenta },
@@ -1651,7 +1651,7 @@ inline String toProtocolString(TestProtocolDatabaseExecuteSQLAsyncPrintColor val
 template<>
 inline std::optional<TestProtocolDatabaseExecuteSQLAsyncPrintColor> fromProtocolString(const String& value)
 {
-    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteSQLAsyncPrintColor>>({
+    static constexpr SortedArrayMap map { WTF::toArray<std::pair<ComparableASCIILiteral, TestProtocolDatabaseExecuteSQLAsyncPrintColor>>({
         { "black"_s, TestProtocolDatabaseExecuteSQLAsyncPrintColorBlack },
         { "cyan"_s, TestProtocolDatabaseExecuteSQLAsyncPrintColorCyan },
         { "magenta"_s, TestProtocolDatabaseExecuteSQLAsyncPrintColorMagenta },

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/enum-values.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/enum-values.json-result
@@ -632,7 +632,7 @@ namespace Protocol {
 
 namespace TestHelpers {
 
-static const auto enum_constant_values = std::to_array<ASCIILiteral>({
+static const auto enum_constant_values = WTF::toArray<ASCIILiteral>({
     "shared"_s,
     "1"_s,
     "2"_s,
@@ -654,7 +654,7 @@ String getEnumConstantValue(int code) {
 
 template<> std::optional<Protocol::TypeDomain::Enum> parseEnumValueFromString<Protocol::TypeDomain::Enum>(const String& protocolString)
 {
-    static const auto constantValues = std::to_array<size_t>({
+    static const auto constantValues = WTF::toArray<size_t>({
         (size_t)Protocol::TypeDomain::Enum::Shared,
         (size_t)Protocol::TypeDomain::Enum::1,
         (size_t)Protocol::TypeDomain::Enum::2,
@@ -1169,7 +1169,7 @@ inline String toProtocolString(TestProtocolTypeDomainEnum value)
 template<>
 inline std::optional<TestProtocolTypeDomainEnum> fromProtocolString(const String& value)
 {
-    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolTypeDomainEnum>>({
+    static constexpr SortedArrayMap map { WTF::toArray<std::pair<ComparableASCIILiteral, TestProtocolTypeDomainEnum>>({
         { "1"_s, TestProtocolTypeDomainEnum1 },
         { "2"_s, TestProtocolTypeDomainEnum2 },
         { "shared"_s, TestProtocolTypeDomainEnumShared },

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/shadowed-optional-type-setters.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/shadowed-optional-type-setters.json-result
@@ -515,7 +515,7 @@ namespace Protocol {
 
 namespace TestHelpers {
 
-static const auto enum_constant_values = std::to_array<ASCIILiteral>({
+static const auto enum_constant_values = WTF::toArray<ASCIILiteral>({
     "null"_s,
     "string"_s,
     "array"_s,
@@ -529,7 +529,7 @@ String getEnumConstantValue(int code) {
 
 template<> std::optional<Protocol::Runtime::KeyPath::Type> parseEnumValueFromString<Protocol::Runtime::KeyPath::Type>(const String& protocolString)
 {
-    static const auto constantValues = std::to_array<size_t>({
+    static const auto constantValues = WTF::toArray<size_t>({
         (size_t)Protocol::Runtime::KeyPath::Type::Null,
         (size_t)Protocol::Runtime::KeyPath::Type::String,
         (size_t)Protocol::Runtime::KeyPath::Type::Array,
@@ -930,7 +930,7 @@ inline String toProtocolString(TestProtocolRuntimeKeyPathType value)
 template<>
 inline std::optional<TestProtocolRuntimeKeyPathType> fromProtocolString(const String& value)
 {
-    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolRuntimeKeyPathType>>({
+    static constexpr SortedArrayMap map { WTF::toArray<std::pair<ComparableASCIILiteral, TestProtocolRuntimeKeyPathType>>({
         { "array"_s, TestProtocolRuntimeKeyPathTypeArray },
         { "null"_s, TestProtocolRuntimeKeyPathTypeNull },
         { "string"_s, TestProtocolRuntimeKeyPathTypeString },

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-array-type.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-array-type.json-result
@@ -470,7 +470,7 @@ namespace Protocol {
 
 namespace TestHelpers {
 
-static const auto enum_constant_values = std::to_array<ASCIILiteral>({
+static const auto enum_constant_values = WTF::toArray<ASCIILiteral>({
     "Died"_s,
     "Fainted"_s,
     "Hungry"_s,
@@ -484,7 +484,7 @@ String getEnumConstantValue(int code) {
 
 template<> std::optional<Protocol::Debugger::Reason> parseEnumValueFromString<Protocol::Debugger::Reason>(const String& protocolString)
 {
-    static const auto constantValues = std::to_array<size_t>({
+    static const auto constantValues = WTF::toArray<size_t>({
         (size_t)Protocol::Debugger::Reason::Died,
         (size_t)Protocol::Debugger::Reason::Fainted,
         (size_t)Protocol::Debugger::Reason::Hungry,
@@ -877,7 +877,7 @@ inline String toProtocolString(TestProtocolDebuggerReason value)
 template<>
 inline std::optional<TestProtocolDebuggerReason> fromProtocolString(const String& value)
 {
-    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDebuggerReason>>({
+    static constexpr SortedArrayMap map { WTF::toArray<std::pair<ComparableASCIILiteral, TestProtocolDebuggerReason>>({
         { "Died"_s, TestProtocolDebuggerReasonDied },
         { "Fainted"_s, TestProtocolDebuggerReasonFainted },
         { "Hungry"_s, TestProtocolDebuggerReasonHungry },

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-enum-type.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-enum-type.json-result
@@ -472,7 +472,7 @@ namespace Protocol {
 
 namespace TestHelpers {
 
-static const auto enum_constant_values = std::to_array<ASCIILiteral>({
+static const auto enum_constant_values = WTF::toArray<ASCIILiteral>({
     "Pigs"_s,
     "Cows"_s,
     "Cats"_s,
@@ -490,7 +490,7 @@ String getEnumConstantValue(int code) {
 
 template<> std::optional<Protocol::Runtime::FarmAnimals> parseEnumValueFromString<Protocol::Runtime::FarmAnimals>(const String& protocolString)
 {
-    static const auto constantValues = std::to_array<size_t>({
+    static const auto constantValues = WTF::toArray<size_t>({
         (size_t)Protocol::Runtime::FarmAnimals::Pigs,
         (size_t)Protocol::Runtime::FarmAnimals::Cows,
         (size_t)Protocol::Runtime::FarmAnimals::Cats,
@@ -505,7 +505,7 @@ template<> std::optional<Protocol::Runtime::FarmAnimals> parseEnumValueFromStrin
 
 template<> std::optional<Protocol::Runtime::TwoLeggedAnimals> parseEnumValueFromString<Protocol::Runtime::TwoLeggedAnimals>(const String& protocolString)
 {
-    static const auto constantValues = std::to_array<size_t>({
+    static const auto constantValues = WTF::toArray<size_t>({
         (size_t)Protocol::Runtime::TwoLeggedAnimals::Ducks,
         (size_t)Protocol::Runtime::TwoLeggedAnimals::Hens,
         (size_t)Protocol::Runtime::TwoLeggedAnimals::Crows,
@@ -909,7 +909,7 @@ inline String toProtocolString(TestProtocolRuntimeFarmAnimals value)
 template<>
 inline std::optional<TestProtocolRuntimeFarmAnimals> fromProtocolString(const String& value)
 {
-    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolRuntimeFarmAnimals>>({
+    static constexpr SortedArrayMap map { WTF::toArray<std::pair<ComparableASCIILiteral, TestProtocolRuntimeFarmAnimals>>({
         { "Cats"_s, TestProtocolRuntimeFarmAnimalsCats },
         { "Cows"_s, TestProtocolRuntimeFarmAnimalsCows },
         { "Hens"_s, TestProtocolRuntimeFarmAnimalsHens },
@@ -937,7 +937,7 @@ inline String toProtocolString(TestProtocolRuntimeTwoLeggedAnimals value)
 template<>
 inline std::optional<TestProtocolRuntimeTwoLeggedAnimals> fromProtocolString(const String& value)
 {
-    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolRuntimeTwoLeggedAnimals>>({
+    static constexpr SortedArrayMap map { WTF::toArray<std::pair<ComparableASCIILiteral, TestProtocolRuntimeTwoLeggedAnimals>>({
         { "Crows"_s, TestProtocolRuntimeTwoLeggedAnimalsCrows },
         { "Ducks"_s, TestProtocolRuntimeTwoLeggedAnimalsDucks },
         { "Flamingos"_s, TestProtocolRuntimeTwoLeggedAnimalsFlamingos },

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-object-type.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-object-type.json-result
@@ -1207,7 +1207,7 @@ namespace Protocol {
 
 namespace TestHelpers {
 
-static const auto enum_constant_values = std::to_array<ASCIILiteral>({
+static const auto enum_constant_values = WTF::toArray<ASCIILiteral>({
     "None"_s,
     "Left"_s,
     "Middle"_s,
@@ -1224,7 +1224,7 @@ String getEnumConstantValue(int code) {
 
 template<> std::optional<Protocol::Database::MouseButton> parseEnumValueFromString<Protocol::Database::MouseButton>(const String& protocolString)
 {
-    static const auto constantValues = std::to_array<size_t>({
+    static const auto constantValues = WTF::toArray<size_t>({
         (size_t)Protocol::Database::MouseButton::None,
         (size_t)Protocol::Database::MouseButton::Left,
         (size_t)Protocol::Database::MouseButton::Middle,
@@ -1239,7 +1239,7 @@ template<> std::optional<Protocol::Database::MouseButton> parseEnumValueFromStri
 
 template<> std::optional<Protocol::Database::OptionalParameterBundle::Directionality> parseEnumValueFromString<Protocol::Database::OptionalParameterBundle::Directionality>(const String& protocolString)
 {
-    static const auto constantValues = std::to_array<size_t>({
+    static const auto constantValues = WTF::toArray<size_t>({
         (size_t)Protocol::Database::OptionalParameterBundle::Directionality::LTR,
         (size_t)Protocol::Database::OptionalParameterBundle::Directionality::RTL,
     });
@@ -1252,7 +1252,7 @@ template<> std::optional<Protocol::Database::OptionalParameterBundle::Directiona
 
 template<> std::optional<Protocol::Database::ParameterBundle::Directionality> parseEnumValueFromString<Protocol::Database::ParameterBundle::Directionality>(const String& protocolString)
 {
-    static const auto constantValues = std::to_array<size_t>({
+    static const auto constantValues = WTF::toArray<size_t>({
         (size_t)Protocol::Database::ParameterBundle::Directionality::LTR,
         (size_t)Protocol::Database::ParameterBundle::Directionality::RTL,
     });
@@ -1267,7 +1267,7 @@ template<> std::optional<Protocol::Database::ParameterBundle::Directionality> pa
 
 template<> std::optional<Protocol::Test::ParameterBundle::Directionality> parseEnumValueFromString<Protocol::Test::ParameterBundle::Directionality>(const String& protocolString)
 {
-    static const auto constantValues = std::to_array<size_t>({
+    static const auto constantValues = WTF::toArray<size_t>({
         (size_t)Protocol::Test::ParameterBundle::Directionality::LTR,
         (size_t)Protocol::Test::ParameterBundle::Directionality::RTL,
     });
@@ -1761,7 +1761,7 @@ inline String toProtocolString(TestProtocolDatabaseMouseButton value)
 template<>
 inline std::optional<TestProtocolDatabaseMouseButton> fromProtocolString(const String& value)
 {
-    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseMouseButton>>({
+    static constexpr SortedArrayMap map { WTF::toArray<std::pair<ComparableASCIILiteral, TestProtocolDatabaseMouseButton>>({
         { "Left"_s, TestProtocolDatabaseMouseButtonLeft },
         { "Middle"_s, TestProtocolDatabaseMouseButtonMiddle },
         { "None"_s, TestProtocolDatabaseMouseButtonNone },
@@ -1785,7 +1785,7 @@ inline String toProtocolString(TestProtocolDatabaseOptionalParameterBundleDirect
 template<>
 inline std::optional<TestProtocolDatabaseOptionalParameterBundleDirectionality> fromProtocolString(const String& value)
 {
-    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseOptionalParameterBundleDirectionality>>({
+    static constexpr SortedArrayMap map { WTF::toArray<std::pair<ComparableASCIILiteral, TestProtocolDatabaseOptionalParameterBundleDirectionality>>({
         { "LTR"_s, TestProtocolDatabaseOptionalParameterBundleDirectionalityLTR },
         { "RTL"_s, TestProtocolDatabaseOptionalParameterBundleDirectionalityRTL },
    }) };
@@ -1807,7 +1807,7 @@ inline String toProtocolString(TestProtocolDatabaseParameterBundleDirectionality
 template<>
 inline std::optional<TestProtocolDatabaseParameterBundleDirectionality> fromProtocolString(const String& value)
 {
-    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolDatabaseParameterBundleDirectionality>>({
+    static constexpr SortedArrayMap map { WTF::toArray<std::pair<ComparableASCIILiteral, TestProtocolDatabaseParameterBundleDirectionality>>({
         { "LTR"_s, TestProtocolDatabaseParameterBundleDirectionalityLTR },
         { "RTL"_s, TestProtocolDatabaseParameterBundleDirectionalityRTL },
    }) };
@@ -1829,7 +1829,7 @@ inline String toProtocolString(TestProtocolTestParameterBundleDirectionality val
 template<>
 inline std::optional<TestProtocolTestParameterBundleDirectionality> fromProtocolString(const String& value)
 {
-    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolTestParameterBundleDirectionality>>({
+    static constexpr SortedArrayMap map { WTF::toArray<std::pair<ComparableASCIILiteral, TestProtocolTestParameterBundleDirectionality>>({
         { "LTR"_s, TestProtocolTestParameterBundleDirectionalityLTR },
         { "RTL"_s, TestProtocolTestParameterBundleDirectionalityRTL },
    }) };

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/type-requiring-runtime-casts.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/type-requiring-runtime-casts.json-result
@@ -719,7 +719,7 @@ namespace Protocol {
 
 namespace TestHelpers {
 
-static const auto enum_constant_values = std::to_array<ASCIILiteral>({
+static const auto enum_constant_values = WTF::toArray<ASCIILiteral>({
     "Ducks"_s,
     "Hens"_s,
     "Crows"_s,
@@ -737,7 +737,7 @@ String getEnumConstantValue(int code) {
 
 template<> std::optional<Protocol::Test::UncastedAnimals> parseEnumValueFromString<Protocol::Test::UncastedAnimals>(const String& protocolString)
 {
-    static const auto constantValues = std::to_array<size_t>({
+    static const auto constantValues = WTF::toArray<size_t>({
         (size_t)Protocol::Test::UncastedAnimals::Pigs,
         (size_t)Protocol::Test::UncastedAnimals::Cows,
         (size_t)Protocol::Test::UncastedAnimals::Cats,
@@ -752,7 +752,7 @@ template<> std::optional<Protocol::Test::UncastedAnimals> parseEnumValueFromStri
 
 template<> std::optional<Protocol::Test::CastedAnimals> parseEnumValueFromString<Protocol::Test::CastedAnimals>(const String& protocolString)
 {
-    static const auto constantValues = std::to_array<size_t>({
+    static const auto constantValues = WTF::toArray<size_t>({
         (size_t)Protocol::Test::CastedAnimals::Ducks,
         (size_t)Protocol::Test::CastedAnimals::Hens,
         (size_t)Protocol::Test::CastedAnimals::Crows,
@@ -1279,7 +1279,7 @@ inline String toProtocolString(TestProtocolTestUncastedAnimals value)
 template<>
 inline std::optional<TestProtocolTestUncastedAnimals> fromProtocolString(const String& value)
 {
-    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolTestUncastedAnimals>>({
+    static constexpr SortedArrayMap map { WTF::toArray<std::pair<ComparableASCIILiteral, TestProtocolTestUncastedAnimals>>({
         { "Cats"_s, TestProtocolTestUncastedAnimalsCats },
         { "Cows"_s, TestProtocolTestUncastedAnimalsCows },
         { "Hens"_s, TestProtocolTestUncastedAnimalsHens },
@@ -1307,7 +1307,7 @@ inline String toProtocolString(TestProtocolTestCastedAnimals value)
 template<>
 inline std::optional<TestProtocolTestCastedAnimals> fromProtocolString(const String& value)
 {
-    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolTestCastedAnimals>>({
+    static constexpr SortedArrayMap map { WTF::toArray<std::pair<ComparableASCIILiteral, TestProtocolTestCastedAnimals>>({
         { "Crows"_s, TestProtocolTestCastedAnimalsCrows },
         { "Ducks"_s, TestProtocolTestCastedAnimalsDucks },
         { "Flamingos"_s, TestProtocolTestCastedAnimalsFlamingos },

--- a/Source/JavaScriptCore/inspector/scripts/tests/expected/webdriver-bidi-enum-validation.json-result
+++ b/Source/JavaScriptCore/inspector/scripts/tests/expected/webdriver-bidi-enum-validation.json-result
@@ -572,7 +572,7 @@ namespace Protocol {
 
 namespace TestHelpers {
 
-static const auto enum_constant_values = std::to_array<ASCIILiteral>({
+static const auto enum_constant_values = WTF::toArray<ASCIILiteral>({
     "shared"_s,
     "1"_s,
     "2"_s,
@@ -586,7 +586,7 @@ String getEnumConstantValue(int code) {
 
 template<> std::optional<Protocol::TypeDomain::Enum> parseEnumValueFromString<Protocol::TypeDomain::Enum>(const String& protocolString)
 {
-    static const auto constantValues = std::to_array<size_t>({
+    static const auto constantValues = WTF::toArray<size_t>({
         (size_t)Protocol::TypeDomain::Enum::Shared,
         (size_t)Protocol::TypeDomain::Enum::1,
         (size_t)Protocol::TypeDomain::Enum::2,
@@ -1051,7 +1051,7 @@ inline String toProtocolString(TestProtocolTypeDomainEnum value)
 template<>
 inline std::optional<TestProtocolTypeDomainEnum> fromProtocolString(const String& value)
 {
-    static constexpr SortedArrayMap map { std::to_array<std::pair<ComparableASCIILiteral, TestProtocolTypeDomainEnum>>({
+    static constexpr SortedArrayMap map { WTF::toArray<std::pair<ComparableASCIILiteral, TestProtocolTypeDomainEnum>>({
         { "1"_s, TestProtocolTypeDomainEnum1 },
         { "2"_s, TestProtocolTypeDomainEnum2 },
         { "shared"_s, TestProtocolTypeDomainEnumShared },

--- a/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
+++ b/Source/WebCore/bindings/scripts/CodeGeneratorJS.pm
@@ -2611,7 +2611,7 @@ sub GenerateEnumerationImplementationContent
         my $enumerationValueName = GetEnumerationValueName(shift(@sortedEnumerationValues));
         $result .= "        return ${className}::$enumerationValueName;\n";
     }
-    $result .= "    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, $className>>({\n";
+    $result .= "    static constexpr SortedArrayMap enumerationMapping { WTF::toArray<std::pair<ComparableASCIILiteral, $className>>({\n";
     for my $value (@sortedEnumerationValues) {
         my $enumerationValueName = GetEnumerationValueName($value);
         $result .= "        { \"$value\"_s, ${className}::$enumerationValueName },\n";

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp
@@ -77,7 +77,7 @@ template<> JSString* convertEnumerationToJS(VM& vm, TestCallbackInterface::Enum 
 
 template<> std::optional<TestCallbackInterface::Enum> parseEnumerationFromString<TestCallbackInterface::Enum>(const String& stringValue)
 {
-    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, TestCallbackInterface::Enum>>({
+    static constexpr SortedArrayMap enumerationMapping { WTF::toArray<std::pair<ComparableASCIILiteral, TestCallbackInterface::Enum>>({
         { "value1"_s, TestCallbackInterface::Enum::Value1 },
         { "value2"_s, TestCallbackInterface::Enum::Value2 },
     }) };

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONEnum.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONEnum.cpp
@@ -50,7 +50,7 @@ template<> JSString* convertEnumerationToJS(VM& vm, TestDefaultToJSONEnum enumer
 
 template<> std::optional<TestDefaultToJSONEnum> parseEnumerationFromString<TestDefaultToJSONEnum>(const String& stringValue)
 {
-    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, TestDefaultToJSONEnum>>({
+    static constexpr SortedArrayMap enumerationMapping { WTF::toArray<std::pair<ComparableASCIILiteral, TestDefaultToJSONEnum>>({
         { "EnumValue1"_s, TestDefaultToJSONEnum::EnumValue1 },
         { "EnumValue2"_s, TestDefaultToJSONEnum::EnumValue2 },
     }) };

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp
@@ -157,7 +157,7 @@ template<> std::optional<TestObj::EnumType> parseEnumerationFromString<TestObj::
 {
     if (stringValue.isEmpty())
         return TestObj::EnumType::EmptyString;
-    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, TestObj::EnumType>>({
+    static constexpr SortedArrayMap enumerationMapping { WTF::toArray<std::pair<ComparableASCIILiteral, TestObj::EnumType>>({
         { "EnumValue2"_s, TestObj::EnumType::EnumValue2 },
         { "EnumValue3"_s, TestObj::EnumType::EnumValue3 },
         { "enumValue1"_s, TestObj::EnumType::EnumValue1 },
@@ -196,7 +196,7 @@ template<> JSString* convertEnumerationToJS(VM& vm, TestObj::EnumTrailingComma e
 
 template<> std::optional<TestObj::EnumTrailingComma> parseEnumerationFromString<TestObj::EnumTrailingComma>(const String& stringValue)
 {
-    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, TestObj::EnumTrailingComma>>({
+    static constexpr SortedArrayMap enumerationMapping { WTF::toArray<std::pair<ComparableASCIILiteral, TestObj::EnumTrailingComma>>({
         { "enumValue1"_s, TestObj::EnumTrailingComma::EnumValue1 },
         { "enumValue2"_s, TestObj::EnumTrailingComma::EnumValue2 },
     }) };
@@ -240,7 +240,7 @@ template<> std::optional<TestObj::Optional> parseEnumerationFromString<TestObj::
 {
     if (stringValue.isEmpty())
         return TestObj::Optional::EmptyString;
-    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, TestObj::Optional>>({
+    static constexpr SortedArrayMap enumerationMapping { WTF::toArray<std::pair<ComparableASCIILiteral, TestObj::Optional>>({
         { "OptionalValue1"_s, TestObj::Optional::OptionalValue1 },
         { "OptionalValue2"_s, TestObj::Optional::OptionalValue2 },
         { "OptionalValue3"_s, TestObj::Optional::OptionalValue3 },
@@ -279,7 +279,7 @@ template<> JSString* convertEnumerationToJS(VM& vm, AlternateEnumName enumeratio
 
 template<> std::optional<AlternateEnumName> parseEnumerationFromString<AlternateEnumName>(const String& stringValue)
 {
-    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, AlternateEnumName>>({
+    static constexpr SortedArrayMap enumerationMapping { WTF::toArray<std::pair<ComparableASCIILiteral, AlternateEnumName>>({
         { "EnumValue2"_s, AlternateEnumName::EnumValue2 },
         { "enumValue1"_s, AlternateEnumName::EnumValue1 },
     }) };
@@ -317,7 +317,7 @@ template<> JSString* convertEnumerationToJS(VM& vm, TestObj::EnumA enumerationVa
 
 template<> std::optional<TestObj::EnumA> parseEnumerationFromString<TestObj::EnumA>(const String& stringValue)
 {
-    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, TestObj::EnumA>>({
+    static constexpr SortedArrayMap enumerationMapping { WTF::toArray<std::pair<ComparableASCIILiteral, TestObj::EnumA>>({
         { "A"_s, TestObj::EnumA::A },
     }) };
     if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); enumerationValue) [[likely]]
@@ -356,7 +356,7 @@ template<> JSString* convertEnumerationToJS(VM& vm, TestObj::EnumB enumerationVa
 
 template<> std::optional<TestObj::EnumB> parseEnumerationFromString<TestObj::EnumB>(const String& stringValue)
 {
-    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, TestObj::EnumB>>({
+    static constexpr SortedArrayMap enumerationMapping { WTF::toArray<std::pair<ComparableASCIILiteral, TestObj::EnumB>>({
         { "B"_s, TestObj::EnumB::B },
     }) };
     if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); enumerationValue) [[likely]]
@@ -395,7 +395,7 @@ template<> JSString* convertEnumerationToJS(VM& vm, TestObj::EnumC enumerationVa
 
 template<> std::optional<TestObj::EnumC> parseEnumerationFromString<TestObj::EnumC>(const String& stringValue)
 {
-    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, TestObj::EnumC>>({
+    static constexpr SortedArrayMap enumerationMapping { WTF::toArray<std::pair<ComparableASCIILiteral, TestObj::EnumC>>({
         { "C"_s, TestObj::EnumC::C },
     }) };
     if (auto* enumerationValue = enumerationMapping.tryGet(stringValue); enumerationValue) [[likely]]
@@ -434,7 +434,7 @@ template<> JSString* convertEnumerationToJS(VM& vm, TestObj::Kind enumerationVal
 
 template<> std::optional<TestObj::Kind> parseEnumerationFromString<TestObj::Kind>(const String& stringValue)
 {
-    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, TestObj::Kind>>({
+    static constexpr SortedArrayMap enumerationMapping { WTF::toArray<std::pair<ComparableASCIILiteral, TestObj::Kind>>({
         { "dead"_s, TestObj::Kind::Dead },
         { "quick"_s, TestObj::Kind::Quick },
     }) };
@@ -472,7 +472,7 @@ template<> JSString* convertEnumerationToJS(VM& vm, TestObj::Size enumerationVal
 
 template<> std::optional<TestObj::Size> parseEnumerationFromString<TestObj::Size>(const String& stringValue)
 {
-    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, TestObj::Size>>({
+    static constexpr SortedArrayMap enumerationMapping { WTF::toArray<std::pair<ComparableASCIILiteral, TestObj::Size>>({
         { "much-much-larger"_s, TestObj::Size::MuchMuchLarger },
         { "small"_s, TestObj::Size::Small },
     }) };
@@ -510,7 +510,7 @@ template<> JSString* convertEnumerationToJS(VM& vm, TestObj::Confidence enumerat
 
 template<> std::optional<TestObj::Confidence> parseEnumerationFromString<TestObj::Confidence>(const String& stringValue)
 {
-    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, TestObj::Confidence>>({
+    static constexpr SortedArrayMap enumerationMapping { WTF::toArray<std::pair<ComparableASCIILiteral, TestObj::Confidence>>({
         { "high"_s, TestObj::Confidence::High },
         { "kinda-low"_s, TestObj::Confidence::KindaLow },
     }) };
@@ -554,7 +554,7 @@ template<> std::optional<TestObj::EnumWithMissingValueDefault> parseEnumerationF
 {
     if (stringValue.isEmpty())
         return TestObj::EnumWithMissingValueDefault::EmptyString;
-    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefault>>({
+    static constexpr SortedArrayMap enumerationMapping { WTF::toArray<std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefault>>({
         { "value1"_s, TestObj::EnumWithMissingValueDefault::Value1 },
         { "value2"_s, TestObj::EnumWithMissingValueDefault::Value2 },
         { "value3"_s, TestObj::EnumWithMissingValueDefault::Value3 },
@@ -599,7 +599,7 @@ template<> std::optional<TestObj::EnumWithInvalidValueDefault> parseEnumerationF
 {
     if (stringValue.isEmpty())
         return TestObj::EnumWithInvalidValueDefault::EmptyString;
-    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, TestObj::EnumWithInvalidValueDefault>>({
+    static constexpr SortedArrayMap enumerationMapping { WTF::toArray<std::pair<ComparableASCIILiteral, TestObj::EnumWithInvalidValueDefault>>({
         { "value1"_s, TestObj::EnumWithInvalidValueDefault::Value1 },
         { "value2"_s, TestObj::EnumWithInvalidValueDefault::Value2 },
         { "value3"_s, TestObj::EnumWithInvalidValueDefault::Value3 },
@@ -644,7 +644,7 @@ template<> std::optional<TestObj::EnumWithMissingAndInvalidValueDefault> parseEn
 {
     if (stringValue.isEmpty())
         return TestObj::EnumWithMissingAndInvalidValueDefault::EmptyString;
-    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingAndInvalidValueDefault>>({
+    static constexpr SortedArrayMap enumerationMapping { WTF::toArray<std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingAndInvalidValueDefault>>({
         { "value1"_s, TestObj::EnumWithMissingAndInvalidValueDefault::Value1 },
         { "value2"_s, TestObj::EnumWithMissingAndInvalidValueDefault::Value2 },
         { "value3"_s, TestObj::EnumWithMissingAndInvalidValueDefault::Value3 },
@@ -689,7 +689,7 @@ template<> std::optional<TestObj::EnumWithMissingValueDefaultNoQuotes> parseEnum
 {
     if (stringValue.isEmpty())
         return TestObj::EnumWithMissingValueDefaultNoQuotes::EmptyString;
-    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefaultNoQuotes>>({
+    static constexpr SortedArrayMap enumerationMapping { WTF::toArray<std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefaultNoQuotes>>({
         { "value1"_s, TestObj::EnumWithMissingValueDefaultNoQuotes::Value1 },
         { "value2"_s, TestObj::EnumWithMissingValueDefaultNoQuotes::Value2 },
         { "value3"_s, TestObj::EnumWithMissingValueDefaultNoQuotes::Value3 },
@@ -734,7 +734,7 @@ template<> std::optional<TestObj::EnumWithMissingValueDefaultAsEmptyValue> parse
 {
     if (stringValue.isEmpty())
         return TestObj::EnumWithMissingValueDefaultAsEmptyValue::EmptyString;
-    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefaultAsEmptyValue>>({
+    static constexpr SortedArrayMap enumerationMapping { WTF::toArray<std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefaultAsEmptyValue>>({
         { "value1"_s, TestObj::EnumWithMissingValueDefaultAsEmptyValue::Value1 },
         { "value2"_s, TestObj::EnumWithMissingValueDefaultAsEmptyValue::Value2 },
         { "value3"_s, TestObj::EnumWithMissingValueDefaultAsEmptyValue::Value3 },
@@ -779,7 +779,7 @@ template<> std::optional<TestObj::EnumWithMissingValueDefaultNotInEnumValues> pa
 {
     if (stringValue.isEmpty())
         return TestObj::EnumWithMissingValueDefaultNotInEnumValues::EmptyString;
-    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefaultNotInEnumValues>>({
+    static constexpr SortedArrayMap enumerationMapping { WTF::toArray<std::pair<ComparableASCIILiteral, TestObj::EnumWithMissingValueDefaultNotInEnumValues>>({
         { "value1"_s, TestObj::EnumWithMissingValueDefaultNotInEnumValues::Value1 },
         { "value2"_s, TestObj::EnumWithMissingValueDefaultNotInEnumValues::Value2 },
         { "value3"_s, TestObj::EnumWithMissingValueDefaultNotInEnumValues::Value3 },

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneDictionary.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneDictionary.cpp
@@ -457,7 +457,7 @@ template<> JSString* convertEnumerationToJS(VM& vm, TestStandaloneDictionary::En
 
 template<> std::optional<TestStandaloneDictionary::EnumInStandaloneDictionaryFile> parseEnumerationFromString<TestStandaloneDictionary::EnumInStandaloneDictionaryFile>(const String& stringValue)
 {
-    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, TestStandaloneDictionary::EnumInStandaloneDictionaryFile>>({
+    static constexpr SortedArrayMap enumerationMapping { WTF::toArray<std::pair<ComparableASCIILiteral, TestStandaloneDictionary::EnumInStandaloneDictionaryFile>>({
         { "enumValue1"_s, TestStandaloneDictionary::EnumInStandaloneDictionaryFile::EnumValue1 },
         { "enumValue2"_s, TestStandaloneDictionary::EnumInStandaloneDictionaryFile::EnumValue2 },
     }) };

--- a/Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneEnumeration.cpp
+++ b/Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneEnumeration.cpp
@@ -55,7 +55,7 @@ template<> JSString* convertEnumerationToJS(VM& vm, TestStandaloneEnumeration en
 
 template<> std::optional<TestStandaloneEnumeration> parseEnumerationFromString<TestStandaloneEnumeration>(const String& stringValue)
 {
-    static constexpr SortedArrayMap enumerationMapping { std::to_array<std::pair<ComparableASCIILiteral, TestStandaloneEnumeration>>({
+    static constexpr SortedArrayMap enumerationMapping { WTF::toArray<std::pair<ComparableASCIILiteral, TestStandaloneEnumeration>>({
         { "enum-value3"_s, TestStandaloneEnumeration::EnumValue3 },
         { "enumValue1"_s, TestStandaloneEnumeration::EnumValue1 },
         { "enumValue2"_s, TestStandaloneEnumeration::EnumValue2 },

--- a/Source/WebCore/html/parser/create-html-entity-table
+++ b/Source/WebCore/html/parser/create-html-entity-table
@@ -95,7 +95,7 @@ output_file.write("""/*
 #include "config.h"
 #include "HTMLEntityTable.h"
 
-#include <array>
+#include <wtf/StdLibExtras.h>
 #include <wtf/text/ASCIILiteral.h>
 
 namespace WebCore {
@@ -177,13 +177,13 @@ output_file.write("""};
 
 """)
 
-output_file.write("static constexpr auto uppercaseOffset = std::to_array<uint16_t>({\n")
+output_file.write("static constexpr auto uppercaseOffset = WTF::toArray<uint16_t>({\n")
 for letter in string.ascii_uppercase:
     output_file.write("%d,\n" % index[letter])
 output_file.write("%d\n" % index['a'])
 output_file.write("""});
 
-static constexpr auto lowercaseOffset = std::to_array<uint16_t>({\n""")
+static constexpr auto lowercaseOffset = WTF::toArray<uint16_t>({\n""")
 for letter in string.ascii_lowercase:
     output_file.write("%d,\n" % index[letter])
 output_file.write("%d\n" % entity_count)


### PR DESCRIPTION
#### f1df550f3723dd3a7109c618852ca6f66c014a6d
<pre>
Replace all remaining uses of `std::to_array()` with `WTF::toArray()` in WebKit
<a href="https://bugs.webkit.org/show_bug.cgi?id=315245">https://bugs.webkit.org/show_bug.cgi?id=315245</a>
<a href="https://rdar.apple.com/177571697">rdar://177571697</a>

Reviewed by Chris Dumez.

Follow-up to 313448@main.

* Source/JavaScriptCore/inspector/scripts/codegen/generate_cpp_protocol_types_implementation.py:
(CppProtocolTypesImplementationGenerator._generate_enum_mapping):
(CppProtocolTypesImplementationGenerator._generate_enum_conversion_methods_for_domain.generate_conversion_method_body):
* Source/JavaScriptCore/inspector/scripts/codegen/generate_objc_protocol_type_conversions_header.py:
(ObjCProtocolTypeConversionsHeaderGenerator._generate_enum_from_protocol_string):
* Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-async-attribute.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/commands-with-optional-call-return-parameters.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/domain-exposed-as-other-name.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/enum-values.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/shadowed-optional-type-setters.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-array-type.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-enum-type.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/type-declaration-object-type.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/type-requiring-runtime-casts.json-result:
* Source/JavaScriptCore/inspector/scripts/tests/expected/webdriver-bidi-enum-validation.json-result:
* Source/WebCore/bindings/scripts/CodeGeneratorJS.pm:
(GenerateEnumerationImplementationContent):
* Source/WebCore/bindings/scripts/test/JS/JSTestCallbackInterface.cpp:
(WebCore::parseEnumerationFromString&lt;TestCallbackInterface::Enum&gt;):
* Source/WebCore/bindings/scripts/test/JS/JSTestDefaultToJSONEnum.cpp:
(WebCore::parseEnumerationFromString&lt;TestDefaultToJSONEnum&gt;):
* Source/WebCore/bindings/scripts/test/JS/JSTestObj.cpp:
(WebCore::parseEnumerationFromString&lt;TestObj::EnumType&gt;):
(WebCore::parseEnumerationFromString&lt;TestObj::EnumTrailingComma&gt;):
(WebCore::parseEnumerationFromString&lt;TestObj::Optional&gt;):
(WebCore::parseEnumerationFromString&lt;AlternateEnumName&gt;):
(WebCore::parseEnumerationFromString&lt;TestObj::EnumA&gt;):
(WebCore::parseEnumerationFromString&lt;TestObj::EnumB&gt;):
(WebCore::parseEnumerationFromString&lt;TestObj::EnumC&gt;):
(WebCore::parseEnumerationFromString&lt;TestObj::Kind&gt;):
(WebCore::parseEnumerationFromString&lt;TestObj::Size&gt;):
(WebCore::parseEnumerationFromString&lt;TestObj::Confidence&gt;):
(WebCore::parseEnumerationFromString&lt;TestObj::EnumWithMissingValueDefault&gt;):
(WebCore::parseEnumerationFromString&lt;TestObj::EnumWithInvalidValueDefault&gt;):
(WebCore::parseEnumerationFromString&lt;TestObj::EnumWithMissingAndInvalidValueDefault&gt;):
(WebCore::parseEnumerationFromString&lt;TestObj::EnumWithMissingValueDefaultNoQuotes&gt;):
(WebCore::parseEnumerationFromString&lt;TestObj::EnumWithMissingValueDefaultAsEmptyValue&gt;):
(WebCore::parseEnumerationFromString&lt;TestObj::EnumWithMissingValueDefaultNotInEnumValues&gt;):
* Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneDictionary.cpp:
(WebCore::parseEnumerationFromString&lt;TestStandaloneDictionary::EnumInStandaloneDictionaryFile&gt;):
* Source/WebCore/bindings/scripts/test/JS/JSTestStandaloneEnumeration.cpp:
(WebCore::parseEnumerationFromString&lt;TestStandaloneEnumeration&gt;):
* Source/WebCore/html/parser/create-html-entity-table:

Canonical link: <a href="https://commits.webkit.org/313663@main">https://commits.webkit.org/313663@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4edc75f1b27ceca3f1bef4fb1636efe04c0cd91c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163656 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37140 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30359 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172596 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/120147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165525 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37471 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37139 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127116 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/120147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166615 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29397 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147141 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107670 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28446 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27076 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20299 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/155807 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138345 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24858 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175101 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/24547 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28032 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26524 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135424 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36810 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31178 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135407 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36519 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37595 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146653 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99662 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30716 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23506 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/196058 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36306 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109451 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51119 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35803 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/1644 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36053 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35950 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->