### PR TITLE
Fix http/tests/xmlhttprequest/onabort-response-getters.html test failure

### DIFF
--- a/LayoutTests/http/tests/resources/nph-load-then-wait.cgi
+++ b/LayoutTests/http/tests/resources/nph-load-then-wait.cgi
@@ -1,0 +1,29 @@
+#!/usr/bin/perl -w
+
+use CGI;
+use File::stat;
+use Time::HiRes;
+
+$| = 1;
+
+my $query = CGI->new;
+my $name = $query->param('name');
+my $waitFor = $query->param('waitFor');
+my $mimeType = $query->param('mimeType');
+
+my $filesize = stat($name)->size;
+print "HTTP/1.1 200 OK\r\n";
+print "Content-Type: $mimeType\r\n";
+print "Content-Length: $filesize\r\n";
+print "Connection: close\r\n";
+print "\r\n";
+
+open(my $fh, '<', $name) or die;
+binmode $fh;
+my $data;
+while (read($fh, $data, 1024)) {
+    print $data;
+}
+close($fh);
+
+Time::HiRes::sleep($waitFor) if defined $waitFor;

--- a/LayoutTests/http/tests/xmlhttprequest/onabort-response-getters.html
+++ b/LayoutTests/http/tests/xmlhttprequest/onabort-response-getters.html
@@ -19,7 +19,7 @@
       var test = async_test(name)
       test.step(function() {
         var client = new XMLHttpRequest()
-        var url = "/resources/load-then-wait.cgi?name=../xmlhttprequest/" + fileName + "&waitFor=1&mimeType=" + mimeType
+        var url = "/resources/nph-load-then-wait.cgi?name=../xmlhttprequest/" + fileName + "&waitFor=1&mimeType=" + mimeType
         client.open("GET", url, true)
         setupClient(test, client)
         client.isAborting = false
@@ -56,7 +56,7 @@
       var test2 = async_test(name + " (aborting in loadend)")
       test2.step(function() {
         var client = new XMLHttpRequest()
-        var url = "/resources/load-then-wait.cgi?name=../xmlhttprequest/" + fileName + "&waitFor=1&mimeType=" + mimeType
+        var url = "/resources/nph-load-then-wait.cgi?name=../xmlhttprequest/" + fileName + "&waitFor=1&mimeType=" + mimeType
         client.open("GET", url, true)
         setupClient(test2, client)
 

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -3546,8 +3546,6 @@ imported/w3c/web-platform-tests/html/interaction/focus/sequential-focus-navigati
 
 http/tests/xmlhttprequest/gzip-content-type.html [ Failure ]
 
-webkit.org/b/162647 http/tests/xmlhttprequest/onabort-response-getters.html [ Pass Failure ]
-
 # TestExpectations doesn't seem to support test names containing space characters, so skip the whole
 # xhr test suite for now. See also webkit.org/b/264596.
 webkit.org/b/264596 imported/w3c/web-platform-tests/xhr/ [ Skip ]

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -2762,8 +2762,6 @@ webkit.org/b/130972 transitions/3d/interrupted-transition.html [ Pass Timeout ]
 
 webkit.org/b/162739 fast/images/gif-loop-count.html [ Pass ImageOnlyFailure ]
 
-webkit.org/b/162647 http/tests/xmlhttprequest/onabort-response-getters.html [ Pass Failure ]
-
 webkit.org/b/163755 imported/w3c/web-platform-tests/css/css-shapes/shape-outside/shape-image/shape-image-025.html [ ImageOnlyFailure ]
 
 # Variation fonts are not implemented earlier than iOS 11.

--- a/LayoutTests/platform/mac/TestExpectations
+++ b/LayoutTests/platform/mac/TestExpectations
@@ -965,10 +965,6 @@ compositing/video/poster.html [ Pass ImageOnlyFailure ]
 
 webkit.org/b/161883 imported/w3c/web-platform-tests/dom/nodes/ProcessingInstruction-escapes-1.xhtml [ Pass Failure ]
 
-
-
-webkit.org/b/162647 http/tests/xmlhttprequest/onabort-response-getters.html [ Pass Failure ]
-
 [ Debug ] fast/selectors/slow-style-sharing-with-long-cousin-list.html [ Skip ]
 
 


### PR DESCRIPTION
#### 63b4d8f6ae116a67e1f81e167a91ff50b3fa06de
<pre>
Fix http/tests/xmlhttprequest/onabort-response-getters.html test failure
<a href="https://bugs.webkit.org/show_bug.cgi?id=162647">https://bugs.webkit.org/show_bug.cgi?id=162647</a>
<a href="https://rdar.apple.com/177571266">rdar://177571266</a>

Reviewed by Sam Sneddon.

Apache uses Transfer-Encoding: chunked for CGI responses, stripping the Content-Length
header that load-then-wait.cgi outputs. Without it, progress events report total=0 so the
test condition e.total == e.loaded is never true and abort() is never called during progress.
The XHR completes normally and the response is non-null when the test expects null.

Switch the test to use a NPH (No Parsed Headers) CGI script that outputs the full HTTP response
directly to bypass Apache&apos;s header manipulation so Content-Length reaches client intact.

* LayoutTests/http/tests/resources/nph-load-then-wait.cgi: Added.
* LayoutTests/http/tests/xmlhttprequest/onabort-response-getters.html:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/platform/ios/TestExpectations:
* LayoutTests/platform/mac/TestExpectations:

Canonical link: <a href="https://commits.webkit.org/313905@main">https://commits.webkit.org/313905@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ce1ae2d82093cd9ffa80cc67bba2dc7dfdfad92d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164384 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37868 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31439 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173413 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121636 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ee802914-28ce-4445-a74f-312abfcd6bdc) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38202 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37869 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127729 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89904 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d5da1f72-ccd5-4f74-8e91-3ed768d4dd93) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167343 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30025 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147762 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108274 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/aff91b06-92f6-4b9f-81de-050a83b52eac) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29072 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27696 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21177 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138974 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25478 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175939 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27146 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136040 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37539 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31816 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136009 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36659 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38325 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147273 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100747 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31328 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24129 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37135 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36531 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2256 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36781 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36681 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->