### PR TITLE
[JSC] Remove unneeded m_tasks append in DeferredWorkTimer::cancelPendingWorkSafe

### DIFF
--- a/JSTests/wasm/stress/deferred-work-timer-cancel-duplicate-ticket.js
+++ b/JSTests/wasm/stress/deferred-work-timer-cancel-duplicate-ticket.js
@@ -1,0 +1,52 @@
+var N_REGISTRIES = 300;
+var N_DEFERRED_WORK1 = 400;
+var N_DEFERRED_WORK2 = 1500;
+
+var sab = new SharedArrayBuffer(8);
+var i32 = new Int32Array(sab);
+
+function setupChildGlobal() {
+    var childGlobal = createGlobalObject();
+    childGlobal.N_REGISTRIES = N_REGISTRIES;
+    childGlobal.eval(
+        'globalThis.__registries = [];' +
+        'for (var k = 0; k < this.N_REGISTRIES; k++) {' +
+        '    var fr = new FinalizationRegistry(function(h){});' +
+        '    (function(){ fr.register({}, 1); })();' +
+        '    globalThis.__registries.push(fr);' +
+        '}'
+    );
+    gc();
+    return childGlobal;
+}
+noDFG(setupChildGlobal);
+
+function run() {
+    var childGlobal = setupChildGlobal();
+    globalThis.p1 = Atomics.waitAsync(i32, 0, 0).value;
+    Atomics.notify(i32, 0);
+    childGlobal = null;
+    return 0;
+}
+noDFG(run);
+run();
+
+p1.then(function () {
+    for (var i = 0; i < N_DEFERRED_WORK1; i++)
+        setTimeout(function () { }, 10);
+});
+
+gc(); gc(); gc();
+
+var p2 = Atomics.waitAsync(i32, 0, 0).value;
+Atomics.notify(i32, 0);
+p2.then(function () {
+    for (var j = 0; j < N_DEFERRED_WORK2; j++)
+        setTimeout(function () { }, 50);
+
+    gc(); gc();
+    globalThis.__fns = [];
+    for (var k = 0; k < 10; k++) __fns.push(function () { });
+});
+
+setTimeout(function () { }, 200);

--- a/Source/JavaScriptCore/runtime/DeferredWorkTimer.cpp
+++ b/Source/JavaScriptCore/runtime/DeferredWorkTimer.cpp
@@ -258,7 +258,6 @@ void DeferredWorkTimer::cancelPendingWorkSafe(JSGlobalObject* globalObject)
     for (Ref<TicketData> ticket : *globalObject->m_weakTickets) {
         if (!ticket->isCancelled())
             cancelPendingWork(ticket.ptr());
-        m_tasks.append(std::make_tuple(ticket.ptr(), [](DeferredWorkTimer::Ticket) { }));
     }
     if (!isScheduled() && !m_currentlyRunningTask)
         setTimeUntilFire(0_s);


### PR DESCRIPTION
#### e7c63753e10a2fef6787c25f04e4238fb307075b
<pre>
[JSC] Remove unneeded m_tasks append in DeferredWorkTimer::cancelPendingWorkSafe
<a href="https://bugs.webkit.org/show_bug.cgi?id=312314">https://bugs.webkit.org/show_bug.cgi?id=312314</a>
<a href="https://rdar.apple.com/174738881">rdar://174738881</a>

Reviewed by Keith Miller.

cancelPendingWorkSafe() was unconditionally appending a (ticket, noop) entry to
m_tasks for every weak ticket of a dying global. This is unnecessary because
doWork() already has a removeIf(isCancelled) pass at the end that purges cancelled
tickets from m_pendingTickets without needing a m_tasks entry, and
setTimeUntilFire(0_s) already ensures doWork() fires to run that cleanup.

Test: JSTests/wasm/stress/deferred-work-timer-cancel-duplicate-ticket.js

Originally-landed-as: 305413.677@safari-7624-branch (09af279a99da). <a href="https://rdar.apple.com/176058867">rdar://176058867</a>
Canonical link: <a href="https://commits.webkit.org/313670@main">https://commits.webkit.org/313670@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e3476985e03533a38ccbd5259923206954f33fcd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163662 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37146 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30365 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172602 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/120153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37477 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37145 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127121 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/120153 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166621 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29400 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147138 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107675 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28449 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27081 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20305 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/155813 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138348 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24855 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175107 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/24553 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28038 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26521 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135426 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36816 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31183 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135409 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36524 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37601 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146650 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99668 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30720 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23503 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/196064 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36312 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109457 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51121 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35809 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1561 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36059 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35956 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->