### PR TITLE
[iOS] Defer ElementDidFocus IPC to the next rendering update

### DIFF
--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-053-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-053-expected.txt
@@ -1,4 +1,0 @@
-
-
-PASS Targetting a slotted auto-hidden element with focus makes it the active element
-

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/editing/other/exec-command-with-text-editor.tentative_type=text-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/editing/other/exec-command-with-text-editor.tentative_type=text-expected.txt
@@ -521,7 +521,7 @@ PASS In <input type="text"> in contenteditable, execCommand("selectall", false, 
 PASS In <input type="text"> in contenteditable, execCommand("undo", false, null), [a]bc): The command should be supported
 FAIL In <input type="text"> in contenteditable, execCommand("undo", false, null), [a]bc): The command should not be enabled assert_equals: expected false but got true
 FAIL In <input type="text"> in contenteditable, execCommand("undo", false, null), [a]bc): execCommand() should return false assert_equals: expected false but got true
-FAIL In <input type="text"> in contenteditable, execCommand("undo", false, null), [a]bc): <input>.value should be "[a]bc" assert_equals: expected "[a]bc" but got "abcc[]"
+PASS In <input type="text"> in contenteditable, execCommand("undo", false, null), [a]bc): <input>.value should be "[a]bc"
 FAIL In <input type="text"> in contenteditable, execCommand("undo", false, null), [a]bc): beforeinput.inputType should be undefined assert_equals: expected (undefined) undefined but got (string) "historyUndo"
 FAIL In <input type="text"> in contenteditable, execCommand("undo", false, null), [a]bc): beforeinput.target should be undefined assert_equals: expected (undefined) undefined but got (object) Element node <input id="target" type="text"></input>
 FAIL In <input type="text"> in contenteditable, execCommand("undo", false, null), [a]bc): input.inputType should be undefined assert_equals: expected (undefined) undefined but got (string) "historyUndo"

--- a/LayoutTests/platform/ios/imported/w3c/web-platform-tests/editing/other/exec-command-with-text-editor.tentative_type=textarea-expected.txt
+++ b/LayoutTests/platform/ios/imported/w3c/web-platform-tests/editing/other/exec-command-with-text-editor.tentative_type=textarea-expected.txt
@@ -523,7 +523,7 @@ PASS In <textarea> in contenteditable, execCommand("selectall", false, null), a[
 PASS In <textarea> in contenteditable, execCommand("undo", false, null), [a]bc): The command should be supported
 FAIL In <textarea> in contenteditable, execCommand("undo", false, null), [a]bc): The command should not be enabled assert_equals: expected false but got true
 FAIL In <textarea> in contenteditable, execCommand("undo", false, null), [a]bc): execCommand() should return false assert_equals: expected false but got true
-FAIL In <textarea> in contenteditable, execCommand("undo", false, null), [a]bc): <textarea>.value should be "[a]bc" assert_equals: expected "[a]bc" but got "abcc[]"
+PASS In <textarea> in contenteditable, execCommand("undo", false, null), [a]bc): <textarea>.value should be "[a]bc"
 FAIL In <textarea> in contenteditable, execCommand("undo", false, null), [a]bc): beforeinput.inputType should be undefined assert_equals: expected (undefined) undefined but got (string) "historyUndo"
 FAIL In <textarea> in contenteditable, execCommand("undo", false, null), [a]bc): beforeinput.target should be undefined assert_equals: expected (undefined) undefined but got (object) Element node <textarea id="target"></textarea>
 FAIL In <textarea> in contenteditable, execCommand("undo", false, null), [a]bc): input.inputType should be undefined assert_equals: expected (undefined) undefined but got (string) "historyUndo"

--- a/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
+++ b/Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm
@@ -3408,6 +3408,9 @@ void WebPage::completeSyntheticClick(std::optional<WebCore::FrameIdentifier> fra
     if ((!handledPress && !handledRelease) || !nodeRespondingToClick.isElementNode())
         send(Messages::WebPageProxy::DidNotHandleTapAsClick(roundedIntPoint(location)));
 
+#if PLATFORM(IOS_FAMILY)
+    flushPendingFocusedElementUpdateIfNeeded();
+#endif
     send(Messages::WebPageProxy::DidCompleteSyntheticClick());
 
 #if PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1848,6 +1848,9 @@ void WebPage::changeFont(WebCore::FontChanges&& changes)
 void WebPage::executeEditCommandWithCallback(const String& commandName, const String& argument, CompletionHandler<void()>&& completionHandler)
 {
     executeEditCommand(commandName, argument);
+#if PLATFORM(IOS_FAMILY)
+    flushPendingFocusedElementUpdateIfNeeded();
+#endif
     completionHandler();
 }
 
@@ -4925,6 +4928,9 @@ void WebPage::runJavaScriptInFrameInScriptWorld(RunJavaScriptParameters&& parame
             WEBPAGE_RELEASE_LOG_ERROR(Process, "runJavaScriptInFrameInScriptWorld: Request to run JavaScript failed with error %" PRIVATE_LOG_STRING, result.error()->message.utf8().data());
         else
             WEBPAGE_RELEASE_LOG(Process, "runJavaScriptInFrameInScriptWorld: Request to run JavaScript succeeded");
+#if PLATFORM(IOS_FAMILY)
+        flushPendingFocusedElementUpdateIfNeeded();
+#endif
         completionHandler(WTF::move(result));
     });
 }
@@ -5397,6 +5403,9 @@ void WebPage::updateRendering()
     protect(corePage())->updateRendering();
 
 #if PLATFORM(IOS_FAMILY)
+    if (auto pendingUpdate = std::exchange(m_pendingFocusedElementUpdate, { }))
+        emitDeferredFocusedElementUpdate(WTF::move(*pendingUpdate));
+
     findController().redraw();
     foundTextRangeController().redraw();
 #endif
@@ -7599,6 +7608,7 @@ void WebPage::resetFocusedElementForFrame(WebFrame* frame)
 
     if (frame->isMainFrame() || m_focusedElement->document().frame() == frame->coreLocalFrame()) {
 #if PLATFORM(IOS_FAMILY)
+        m_pendingFocusedElementUpdate = std::nullopt;
         m_sendAutocorrectionContextAfterFocusingElement = false;
         send(Messages::WebPageProxy::ElementDidBlur());
 #elif PLATFORM(MAC)
@@ -7612,8 +7622,15 @@ void WebPage::elementDidRefocus(Element& element, const FocusOptions& options)
 {
     elementDidFocus(element, options);
 
-    if (m_userIsInteracting)
-        scheduleFullEditorStateUpdate();
+    if (!m_userIsInteracting)
+        return;
+
+#if PLATFORM(IOS_FAMILY)
+    if (m_pendingFocusedElementUpdate)
+        return;
+#endif
+
+    scheduleFullEditorStateUpdate();
 }
 
 bool WebPage::shouldDispatchUpdateAfterFocusingElement(const Element& element) const
@@ -7743,12 +7760,7 @@ void WebPage::elementDidFocus(Element& element, const FocusOptions& options)
         if (isChangingFocusedElement && (m_userIsInteracting || m_keyboardIsAttached))
             m_sendAutocorrectionContextAfterFocusingElement = true;
 
-        auto information = focusedElementInformation();
-        if (!information)
-            return;
-
         RefPtr<API::Object> userData;
-
         m_formClient->willBeginInputSession(this, &element, protect(WebFrame::fromCoreFrame(*protect(element.document().frame()))).get(), m_userIsInteracting, userData);
 
         if (!userData) {
@@ -7758,9 +7770,17 @@ void WebPage::elementDidFocus(Element& element, const FocusOptions& options)
                     userData = userDataFromJSONData(*data);
             }
         }
-
-        information->preventScroll = options.preventScroll;
-        send(Messages::WebPageProxy::ElementDidFocus(information.value(), m_userIsInteracting, m_recentlyBlurredElement, m_lastActivityStateChanges, UserData(WebProcess::singleton().transformObjectsToHandles(userData.get()).get())));
+        m_pendingFocusedElementUpdate = PendingFocusedElementUpdate {
+            .element = element,
+            .options = options,
+            .userIsInteracting = m_userIsInteracting,
+            .recentlyBlurredElementSnapshot = m_recentlyBlurredElement,
+            .activityStateChanges = m_lastActivityStateChanges,
+            .userData = WTF::move(userData),
+        };
+        if (RefPtr formControlElement = dynamicDowncast<HTMLFormControlElement>(element))
+            m_pendingFocusedElementUpdate->isFocusingWithValidationMessage = formControlElement->isFocusingWithValidationMessage();
+        scheduleFullEditorStateUpdate();
 #elif PLATFORM(MAC)
         // FIXME: This can be unified with the iOS code above by bringing ElementDidFocus to macOS.
         // This also doesn't take other noneditable controls into account, such as input type color.
@@ -7773,6 +7793,9 @@ void WebPage::elementDidFocus(Element& element, const FocusOptions& options)
 void WebPage::elementDidBlur(WebCore::Element& element)
 {
     if (m_focusedElement == &element) {
+#if PLATFORM(IOS_FAMILY)
+        m_pendingFocusedElementUpdate = std::nullopt;
+#endif
         m_recentlyBlurredElement = WTF::move(m_focusedElement);
         callOnMainRunLoop([protectedThis = Ref { *this }] {
             if (protectedThis->m_recentlyBlurredElement) {

--- a/Source/WebKit/WebProcess/WebPage/WebPage.h
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.h
@@ -1083,6 +1083,9 @@ public:
     void elementDidRefocus(WebCore::Element&, const WebCore::FocusOptions&);
     void elementDidBlur(WebCore::Element&);
     static InputType inputTypeForElement(const WebCore::Element&);
+#if PLATFORM(IOS_FAMILY)
+    void flushPendingFocusedElementUpdateIfNeeded();
+#endif
     void focusedElementDidChangeInputMode(WebCore::Element&, WebCore::InputMode);
     void focusedSelectElementDidChangeOptions(const WebCore::HTMLSelectElement&);
     void resetFocusedElementForFrame(WebFrame*);
@@ -2237,6 +2240,7 @@ private:
 
 #if PLATFORM(IOS_FAMILY)
     std::optional<FocusedElementInformation> focusedElementInformation();
+    std::optional<FocusedElementInformation> focusedElementInformationWithoutLayout(WebCore::Element&);
     void generateSyntheticEditingCommand(SyntheticEditingCommandType);
     void setSelectedRangeDispatchingSyntheticMouseEventsIfNeeded(const WebCore::SimpleRange&, WebCore::Affinity);
     void dispatchSyntheticMouseEventsForSelectionGesture(SelectionTouch, const WebCore::IntPoint&);
@@ -3176,6 +3180,19 @@ private:
     CompletionHandler<void(InteractionInformationAtPosition&&)> m_pendingSynchronousPositionInformationReply;
     bool m_sendAutocorrectionContextAfterFocusingElement { false };
     std::unique_ptr<WebCore::IgnoreSelectionChangeForScope> m_ignoreSelectionChangeScopeForDictation;
+
+    struct PendingFocusedElementUpdate {
+        WeakPtr<WebCore::Element, WebCore::WeakPtrImplWithEventTargetData> element;
+        WebCore::FocusOptions options;
+        bool userIsInteracting { false };
+        bool isFocusingWithValidationMessage { false };
+        RefPtr<WebCore::Element> recentlyBlurredElementSnapshot;
+        OptionSet<WebCore::ActivityState> activityStateChanges;
+        RefPtr<API::Object> userData;
+    };
+    std::optional<PendingFocusedElementUpdate> m_pendingFocusedElementUpdate;
+
+    void emitDeferredFocusedElementUpdate(PendingFocusedElementUpdate&&);
 
     bool m_isMobileDoctype { false };
     bool m_hasAnyActiveTouchPoints { false };

--- a/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
+++ b/Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm
@@ -948,6 +948,7 @@ void WebPage::handleDoubleTapForDoubleClickAtPoint(const IntPoint& point, Option
 
 void WebPage::requestFocusedElementInformation(CompletionHandler<void(const std::optional<FocusedElementInformation>&)>&& completionHandler)
 {
+    flushPendingFocusedElementUpdateIfNeeded();
     std::optional<FocusedElementInformation> information;
     if (m_focusedElement)
         information = focusedElementInformation();
@@ -2629,7 +2630,7 @@ std::optional<FocusedElementInformation> WebPage::focusedElementInformation()
     RefPtr focusedOrMainFrame = page->focusController().focusedOrMainFrame();
     if (!focusedOrMainFrame)
         return std::nullopt;
-    RefPtr<Document> document = focusedOrMainFrame->document();
+    RefPtr document = focusedOrMainFrame->document();
     if (!document || !document->view())
         return std::nullopt;
 
@@ -2637,10 +2638,26 @@ std::optional<FocusedElementInformation> WebPage::focusedElementInformation()
     layoutIfNeeded();
 
     // Layout may have detached the document or caused a change of focus.
-    if (!document->view() || focusedElement != m_focusedElement)
+    if (!document->view() || focusedElement != m_focusedElement || !focusedElement)
         return std::nullopt;
 
-    scheduleFullEditorStateUpdate();
+    auto information = focusedElementInformationWithoutLayout(*focusedElement);
+    if (information)
+        scheduleFullEditorStateUpdate();
+    return information;
+}
+
+std::optional<FocusedElementInformation> WebPage::focusedElementInformationWithoutLayout(WebCore::Element& element)
+{
+    ASSERT(m_focusedElement == &element);
+    RefPtr focusedElement = &element;
+    Ref page = *m_page;
+    RefPtr focusedOrMainFrame = page->focusController().focusedOrMainFrame();
+    if (!focusedOrMainFrame)
+        return std::nullopt;
+    RefPtr document = focusedOrMainFrame->document();
+    if (!document || !document->view())
+        return std::nullopt;
 
     FocusedElementInformation information;
 
@@ -2812,6 +2829,35 @@ std::optional<FocusedElementInformation> WebPage::focusedElementInformation()
     information.shouldHideSoftTopScrollEdgeEffect = quirks.shouldHideSoftTopScrollEdgeEffectDuringFocus(*focusedElement);
 
     return information;
+}
+
+void WebPage::emitDeferredFocusedElementUpdate(PendingFocusedElementUpdate&& pending)
+{
+    RefPtr element = pending.element.get();
+    if (!element || element != m_focusedElement)
+        return;
+
+    Ref document = element->document();
+    if (!document->view())
+        return;
+
+    auto information = focusedElementInformationWithoutLayout(*element);
+    if (!information)
+        return;
+
+    information->preventScroll = pending.options.preventScroll;
+    information->isFocusingWithValidationMessage = pending.isFocusingWithValidationMessage;
+    send(Messages::WebPageProxy::ElementDidFocus(information.value(), pending.userIsInteracting, pending.recentlyBlurredElementSnapshot, pending.activityStateChanges, UserData(WebProcess::singleton().transformObjectsToHandles(pending.userData.get()).get())));
+}
+
+void WebPage::flushPendingFocusedElementUpdateIfNeeded()
+{
+    if (!m_pendingFocusedElementUpdate)
+        return;
+
+    auto pendingUpdate = std::exchange(m_pendingFocusedElementUpdate, { });
+    layoutIfNeeded();
+    emitDeferredFocusedElementUpdate(WTF::move(*pendingUpdate));
 }
 
 void WebPage::autofillLoginCredentials(const String& username, const String& password)
@@ -4705,6 +4751,7 @@ void WebPage::focusTextInputContextAndPlaceCaret(const ElementContext& elementCo
         return;
     }
     protect(targetFrame->selection())->setSelectedRange(makeSimpleRange(position), position.affinity(), WebCore::FrameSelection::ShouldCloseTyping::Yes, UserTriggered::Yes);
+    flushPendingFocusedElementUpdateIfNeeded();
     completionHandler(true);
 }
 


### PR DESCRIPTION
#### 64ee64bad41e5d511964c29b8ab00ee77269821a
<pre>
[iOS] Defer ElementDidFocus IPC to the next rendering update
<a href="https://bugs.webkit.org/show_bug.cgi?id=315247">https://bugs.webkit.org/show_bug.cgi?id=315247</a>
<a href="https://rdar.apple.com/177468274">rdar://177468274</a>

Reviewed by Wenson Hsieh.

On iOS, WebPage::elementDidFocus runs layoutIfNeeded() from a JS click handler
dispatched via simulateClick() in order to populate interactionRect for the
ElementDidFocus IPC. But, this is very expensive for form-heavy interactions.
Defer the IPC to the next rendering update. elementDidFocus() now stores the
gesture state into a member variable on WebPage,
ensures the next rendering update is scheduled, and then returns. Utilize
the fact that the next rendering update will already do layoutIfNeeded(). So when
WebPage::updateRendering() runs during that next rendering update,
Page::updateRendering() has already run its layout pass for the frame so we send the
IPC message with correct geometry for the focused element while avoiding extra
layoutIfNeeded() calls for each user-gesture-driven focus that would fire before
the next rendering update. This also means we are now sending fewer IPC messages
to the UI Process than before.

Remove and update iOS-specific test baselines that captured existing failures caused by the
extra layoutIfNeeded() in the iOS focus path. The exec-command
baselines had a FAIL for undo not clearing after .value
assignment on input/textarea inside contenteditable. The content-visibility
ios baseline had an extra newline (for some currently unknown reason) now
matches the generic baseline that matches MacOS baseline as well.

* LayoutTests/platform/ios/imported/w3c/web-platform-tests/css/css-contain/content-visibility/content-visibility-053-expected.txt: Removed.
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/editing/other/exec-command-with-text-editor.tentative_type=text-expected.txt:
* LayoutTests/platform/ios/imported/w3c/web-platform-tests/editing/other/exec-command-with-text-editor.tentative_type=textarea-expected.txt:
* Source/WebKit/WebProcess/WebPage/Cocoa/WebPageCocoa.mm:
(WebKit::WebPage::completeSyntheticClick):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::executeEditCommandWithCallback):
(WebKit::WebPage::runJavaScriptInFrameInScriptWorld):
(WebKit::WebPage::updateRendering):
(WebKit::WebPage::resetFocusedElementForFrame):
(WebKit::WebPage::elementDidRefocus):
(WebKit::WebPage::elementDidFocus):
(WebKit::WebPage::elementDidBlur):
* Source/WebKit/WebProcess/WebPage/WebPage.h:
* Source/WebKit/WebProcess/WebPage/ios/WebPageIOS.mm:
(WebKit::WebPage::requestFocusedElementInformation):
(WebKit::WebPage::focusedElementInformation):
(WebKit::WebPage::focusedElementInformationWithoutLayout):
(WebKit::WebPage::emitDeferredFocusedElementUpdate):
(WebKit::WebPage::flushPendingFocusedElementUpdateIfNeeded):
(WebKit::WebPage::focusTextInputContextAndPlaceCaret):

Canonical link: <a href="https://commits.webkit.org/315733@main">https://commits.webkit.org/315733@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6134353175996da4ffe5fe7036b5fc7b0de8fec2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/169829 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/43751 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/37141 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/179188 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/127541 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/122c250c-cee0-445d-8f4f-f143dd038591) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/44817 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/43381 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/132356 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/93255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5233638d-0802-4d27-80c3-d6d045e3a464) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/172788 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/35458 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/152765 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/112858 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ae5e821e-bb23-4468-b6c2-dfafc3fa5574) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/34142 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/32497 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/27886 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/144532 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/32164 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/181787 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/34495 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/36663 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/140809 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/43407 "Built successfully") | | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/140640 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37885 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/44096 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/29144 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/108391 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/35907 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/115861 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/42607 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/7244 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/41999 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/42254 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/42142 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->