### PR TITLE
[CMake] Forward --cmake from run-minibrowser/run-swiftbrowser to underlying perl scripts

### DIFF
--- a/Tools/Scripts/webkitpy/port/base.py
+++ b/Tools/Scripts/webkitpy/port/base.py
@@ -1254,12 +1254,16 @@ class Port(object):
         miniBrowser = self.path_to_script("old-run-minibrowser")
         args.append(self._config.flag_for_configuration(self.get_option('configuration')))
         args.append("--%s" % self.get_option('platform'))
+        if self.get_option('use_cmake'):
+            args.append('--cmake')
         return self._executive.run_command([miniBrowser] + args, stdout=None, cwd=self.webkit_base(), return_stderr=False, decode_output=False, ignore_errors=True)
 
     def run_swiftbrowser(self, args):
         swiftBrowser = self.path_to_script("run-swiftbrowser-perl-wrapper")
         args.append(self._config.flag_for_configuration(self.get_option('configuration')))
         args.append("--%s" % self.get_option('platform'))
+        if self.get_option('use_cmake'):
+            args.append('--cmake')
         return self._executive.run_command([swiftBrowser] + args, stdout=None, cwd=self.webkit_base(), return_stderr=False, decode_output=False, ignore_errors=True)
 
     def run_webdriver(self, args):


### PR DESCRIPTION
#### 62cd2f0590242948b4ff294d856ce2cf877777ab
<pre>
[CMake] Forward --cmake from run-minibrowser/run-swiftbrowser to underlying perl scripts
<a href="https://bugs.webkit.org/show_bug.cgi?id=315248">https://bugs.webkit.org/show_bug.cgi?id=315248</a>
<a href="https://rdar.apple.com/177574770">rdar://177574770</a>

Reviewed by Alan Baradlay.

Follow-up to 313522@main, which added --cmake to configuration_options()
but didn&apos;t thread it through Port.run_minibrowser() / Port.run_swiftbrowser().
As a result, `run-minibrowser --debug --cmake` accepted the flag at the
Python layer but never passed it to old-run-minibrowser, so webkitdirs.pm
fell back to the Xcode build tree and the launch failed to find the
CMake-built MiniBrowser.

Append --cmake to the args passed to old-run-minibrowser and
run-swiftbrowser-perl-wrapper when the option is set, matching how
--&lt;platform&gt; and --&lt;configuration&gt; are already forwarded.

* Tools/Scripts/webkitpy/port/base.py:
(Port.run_minibrowser):
(Port.run_swiftbrowser):

Canonical link: <a href="https://commits.webkit.org/313629@main">https://commits.webkit.org/313629@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fe378ab73f31947faa5d0d120544b429394af8a1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163667 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37151 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30370 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172607 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/120158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165536 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37482 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37150 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127123 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/120158 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166626 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/29405 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/147140 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107677 "Passed tests") | | ⏳ 🛠 vision-apple 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/162988 "Found 1 webkitpy test failure: webkitpy.scripts.measure_build_time_unittest.MeasureBuildTimeTest.test_clean_and_null_build") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28453 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/27085 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20310 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/138352 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24857 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175112 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26523 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135428 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36821 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31188 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135411 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36494 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37606 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146652 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99673 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30724 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/23505 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36317 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35814 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1532 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36064 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35961 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->