### PR TITLE
[JSC] Make RegExp::byteCodeCompileIfNecessary threadsafe

### DIFF
--- a/Source/JavaScriptCore/runtime/RegExp.cpp
+++ b/Source/JavaScriptCore/runtime/RegExp.cpp
@@ -224,6 +224,8 @@ static std::unique_ptr<Yarr::BytecodePattern> byteCodeCompilePattern(VM* vm, Yar
 
 void RegExp::byteCodeCompileIfNecessary(VM* vm)
 {
+    Locker locker { cellLock() };
+
     if (m_regExpBytecode)
         return;
 

--- a/Source/JavaScriptCore/runtime/RegExpInlines.h
+++ b/Source/JavaScriptCore/runtime/RegExpInlines.h
@@ -164,10 +164,16 @@ ALWAYS_INLINE int RegExp::matchInline(JSGlobalObject* nullOrGlobalObject, VM& vm
         }
 
         if (result == static_cast<int>(Yarr::JSRegExpResult::JITCodeFailure)) {
-            // JIT'ed code couldn't handle expression, so punt back to the interpreter.
-            byteCodeCompileIfNecessary(&vm);
-            if (m_state == ParseError)
-                return throwError();
+            // Punt to the bytecode interpreter. Only the mutator may compile bytecode; the compiler
+            // thread must use the bytecode that already exists, and bails out if there is no
+            // bytecode.
+            if constexpr (matchFrom == Yarr::MatchFrom::VMThread) {
+                byteCodeCompileIfNecessary(&vm);
+                if (m_state == ParseError)
+                    return throwError();
+            }
+            if (!m_regExpBytecode)
+                return -1;
             {
                 Yarr::MatchingContextHolder regExpContext(vm, this, matchFrom);
                 result = Yarr::interpret(m_regExpBytecode.get(), s, startOffset, reinterpret_cast<unsigned*>(offsetVector));
@@ -288,10 +294,16 @@ ALWAYS_INLINE MatchResult RegExp::matchInline(JSGlobalObject* nullOrGlobalObject
         if (result.start != static_cast<size_t>(Yarr::JSRegExpResult::JITCodeFailure))
             return result;
 
-        // JIT'ed code couldn't handle expression, so punt back to the interpreter.
-        byteCodeCompileIfNecessary(&vm);
-        if (m_state == ParseError)
-            return throwError();
+        // Punt to the bytecode interpreter. Only the mutator may compile bytecode; the compiler
+        // thread must use the bytecode that already exists, and bails out if there is no
+        // bytecode.
+        if constexpr (matchFrom == Yarr::MatchFrom::VMThread) {
+            byteCodeCompileIfNecessary(&vm);
+            if (m_state == ParseError)
+                return throwError();
+        }
+        if (!m_regExpBytecode)
+            return MatchResult::failed();
     }
 #endif
 


### PR DESCRIPTION
#### dcf25ed3c992c496906592b8381168530e87c768
<pre>
[JSC] Make RegExp::byteCodeCompileIfNecessary threadsafe
<a href="https://bugs.webkit.org/show_bug.cgi?id=309405">https://bugs.webkit.org/show_bug.cgi?id=309405</a>
<a href="https://rdar.apple.com/171888887">rdar://171888887</a>

Reviewed by Yusuke Suzuki.

RegExp::matchConcurrently shouldn&apos;t cause any compilation, but bail out if JIT
code for the regexp doesn&apos;t already exist. However, it is possible that a
RegExp has JIT code but no bytecode, in which case matchConcurrently can
incorrectly racily attempt to compile bytecode.

This PR makes byteCodeCompileIfNecessary threadsafe by taking the cell lock. It
also bails out of matchConcurrently if the regexp doesn&apos;t already have bytecode
when called from the compiler thread. Note that that check inside matchInline
does not need to take the cell lock at that spot, because matchConcurrently,
the caller, already takes the cell lock.

There is no new test because to manifest this race requires artificially adding
sleeps to threads.

* Source/JavaScriptCore/runtime/RegExp.cpp:
(JSC::RegExp::byteCodeCompileIfNecessary):
* Source/JavaScriptCore/runtime/RegExpInlines.h:
(JSC::RegExp::matchInline):

Originally-landed-as: 305413.415@rapid/safari-7624.2.5.110-branch (bfb699d9b999). <a href="https://rdar.apple.com/176067339">rdar://176067339</a>
Canonical link: <a href="https://commits.webkit.org/313689@main">https://commits.webkit.org/313689@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1664009e0829fa320d4719232e67b9cb3f42d45b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163853 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37337 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30556 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172881 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37669 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/37336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127277 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121104 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166812 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29564 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147297 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107826 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28610 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/37336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20646 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/156004 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138510 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25014 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175403 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/24745 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28229 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26682 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135583 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37007 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/37336 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135559 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36537 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37792 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146809 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99929 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30872 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23663 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/196256 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36503 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109648 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/51214 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36000 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1697 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36250 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36147 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->