### PR TITLE
Inherit creating document's CSP for SharedWorkers loaded from headerless URLs

### DIFF
--- a/LayoutTests/http/tests/security/contentSecurityPolicy/shared-worker-blob-url-inherits-csp-importScripts-blocked-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/shared-worker-blob-url-inherits-csp-importScripts-blocked-expected.txt
@@ -1,0 +1,3 @@
+This tests that a SharedWorker created from a blob: URL inherits the creating document's CSP, and that importScripts() is blocked accordingly.
+
+PASS threw exception NetworkError:  A network error occurred..

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/shared-worker-blob-url-inherits-csp-importScripts-blocked.html
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/shared-worker-blob-url-inherits-csp-importScripts-blocked.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Security-Policy" content="worker-src blob:; script-src 'unsafe-inline'">
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+</script>
+</head>
+<body>
+<p>This tests that a SharedWorker created from a blob: URL inherits the creating document's CSP, and that importScripts() is blocked accordingly.</p>
+<pre id="result"></pre>
+<script>
+function reportResultAndNotifyDone(message)
+{
+    document.getElementById("result").textContent = message;
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+var script = [
+    'self.loadedSource1 = false;',
+    'var exception;',
+    'onconnect = function(e) {',
+    '    var port = e.ports[0];',
+    '    try {',
+    '        importScripts("http://localhost:8000/workers/resources/worker-importScripts-source1.js");',
+    '    } catch (e) {',
+    '        exception = e;',
+    '    }',
+    '    if (!exception)',
+    '        port.postMessage("FAIL should have thrown a NetworkError. But did not throw an exception.");',
+    '    else {',
+    '        if (self.loadedSource1)',
+    '            port.postMessage("FAIL should not have loaded and executed the script.");',
+    '        else if (exception.name === "NetworkError")',
+    '            port.postMessage("PASS threw exception " + exception + ".");',
+    '        else',
+    '            port.postMessage("FAIL should throw NetworkError. Threw exception " + exception + ".");',
+    '    }',
+    '};',
+].join("\n");
+
+var worker;
+try {
+    worker = new SharedWorker(window.URL.createObjectURL(new Blob([script])));
+    worker.port.onmessage = function (event) { reportResultAndNotifyDone(event.data); };
+    worker.port.start();
+} catch (exception) {
+    reportResultAndNotifyDone("FAIL should not have thrown an exception when creating worker. Threw exception " + exception + ".");
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/shared-worker-data-url-inherits-csp-importScripts-blocked-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/shared-worker-data-url-inherits-csp-importScripts-blocked-expected.txt
@@ -1,0 +1,3 @@
+This tests that a SharedWorker created from a data: URL inherits the creating document's CSP, and that importScripts() is blocked accordingly.
+
+PASS threw exception NetworkError:  A network error occurred..

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/shared-worker-data-url-inherits-csp-importScripts-blocked.html
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/shared-worker-data-url-inherits-csp-importScripts-blocked.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Security-Policy" content="worker-src data:; script-src 'unsafe-inline'">
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+</script>
+</head>
+<body>
+<p>This tests that a SharedWorker created from a data: URL inherits the creating document's CSP, and that importScripts() is blocked accordingly.</p>
+<pre id="result"></pre>
+<script>
+function reportResultAndNotifyDone(message)
+{
+    document.getElementById("result").textContent = message;
+    if (window.testRunner)
+        testRunner.notifyDone();
+}
+
+var script = [
+    'self.loadedSource1 = false;',
+    'var exception;',
+    'onconnect = function(e) {',
+    '    var port = e.ports[0];',
+    '    try {',
+    '        importScripts("http://localhost:8000/workers/resources/worker-importScripts-source1.js");',
+    '    } catch (e) {',
+    '        exception = e;',
+    '    }',
+    '    if (!exception)',
+    '        port.postMessage("FAIL should have thrown a NetworkError. But did not throw an exception.");',
+    '    else {',
+    '        if (self.loadedSource1)',
+    '            port.postMessage("FAIL should not have loaded and executed the script.");',
+    '        else if (exception.name === "NetworkError")',
+    '            port.postMessage("PASS threw exception " + exception + ".");',
+    '        else',
+    '            port.postMessage("FAIL should throw NetworkError. Threw exception " + exception + ".");',
+    '    }',
+    '};',
+].join("\n");
+
+var worker;
+try {
+    worker = new SharedWorker("data:text/javascript," + encodeURIComponent(script));
+    worker.port.onmessage = function (event) { reportResultAndNotifyDone(event.data); };
+    worker.port.start();
+} catch (exception) {
+    reportResultAndNotifyDone("FAIL should not have thrown an exception when creating worker. Threw exception " + exception + ".");
+}
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/worker-data-set-timeout.sub-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/worker-data-set-timeout.sub-expected.txt
@@ -1,3 +1,3 @@
 
-FAIL Shared worker with data: url inherits CSP assert_equals: expected "setTimeout blocked" but got "setTimeout allowed"
+PASS Shared worker with data: url inherits CSP
 

--- a/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/iframe-blank-inherit.meta/upgrade/sharedworker-import-data.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/iframe-blank-inherit.meta/upgrade/sharedworker-import-data.https-expected.txt
@@ -1,8 +1,8 @@
 
 FAIL Upgrade-Insecure-Requests: Expects allowed for sharedworker-import-data to cross-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
 FAIL Upgrade-Insecure-Requests: Expects allowed for sharedworker-import-data to cross-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for sharedworker-import-data to cross-https origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+PASS Upgrade-Insecure-Requests: Expects allowed for sharedworker-import-data to cross-https origin and downgrade redirection from https context.
 FAIL Upgrade-Insecure-Requests: Expects allowed for sharedworker-import-data to same-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
 FAIL Upgrade-Insecure-Requests: Expects allowed for sharedworker-import-data to same-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for sharedworker-import-data to same-https origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+PASS Upgrade-Insecure-Requests: Expects allowed for sharedworker-import-data to same-https origin and downgrade redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-classic-data.http-rp/upgrade/fetch.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-classic-data.http-rp/upgrade/fetch.https-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL Upgrade-Insecure-Requests: Expects allowed for fetch to cross-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for fetch to cross-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for fetch to cross-https origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for fetch to same-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for fetch to same-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for fetch to same-https origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+PASS Upgrade-Insecure-Requests: Expects allowed for fetch to cross-http-downgrade origin and downgrade redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for fetch to cross-http-downgrade origin and no-redirect redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for fetch to cross-https origin and downgrade redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for fetch to same-http-downgrade origin and downgrade redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for fetch to same-http-downgrade origin and no-redirect redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for fetch to same-https origin and downgrade redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-classic-data.http-rp/upgrade/websocket.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-classic-data.http-rp/upgrade/websocket.https-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Upgrade-Insecure-Requests: Expects allowed for websocket to cross-ws-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for websocket to same-ws-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+PASS Upgrade-Insecure-Requests: Expects allowed for websocket to cross-ws-downgrade origin and no-redirect redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for websocket to same-ws-downgrade origin and no-redirect redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-classic-data.http-rp/upgrade/xhr.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-classic-data.http-rp/upgrade/xhr.https-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL Upgrade-Insecure-Requests: Expects allowed for xhr to cross-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for xhr to cross-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for xhr to cross-https origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for xhr to same-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for xhr to same-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for xhr to same-https origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+PASS Upgrade-Insecure-Requests: Expects allowed for xhr to cross-http-downgrade origin and downgrade redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for xhr to cross-http-downgrade origin and no-redirect redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for xhr to cross-https origin and downgrade redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for xhr to same-http-downgrade origin and downgrade redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for xhr to same-http-downgrade origin and no-redirect redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for xhr to same-https origin and downgrade redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-classic-data.meta/upgrade/fetch.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-classic-data.meta/upgrade/fetch.https-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL Upgrade-Insecure-Requests: Expects allowed for fetch to cross-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for fetch to cross-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for fetch to cross-https origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for fetch to same-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for fetch to same-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for fetch to same-https origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+PASS Upgrade-Insecure-Requests: Expects allowed for fetch to cross-http-downgrade origin and downgrade redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for fetch to cross-http-downgrade origin and no-redirect redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for fetch to cross-https origin and downgrade redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for fetch to same-http-downgrade origin and downgrade redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for fetch to same-http-downgrade origin and no-redirect redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for fetch to same-https origin and downgrade redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-classic-data.meta/upgrade/websocket.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-classic-data.meta/upgrade/websocket.https-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Upgrade-Insecure-Requests: Expects allowed for websocket to cross-ws-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for websocket to same-ws-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+PASS Upgrade-Insecure-Requests: Expects allowed for websocket to cross-ws-downgrade origin and no-redirect redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for websocket to same-ws-downgrade origin and no-redirect redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-classic-data.meta/upgrade/xhr.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-classic-data.meta/upgrade/xhr.https-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL Upgrade-Insecure-Requests: Expects allowed for xhr to cross-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for xhr to cross-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for xhr to cross-https origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for xhr to same-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for xhr to same-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for xhr to same-https origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+PASS Upgrade-Insecure-Requests: Expects allowed for xhr to cross-http-downgrade origin and downgrade redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for xhr to cross-http-downgrade origin and no-redirect redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for xhr to cross-https origin and downgrade redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for xhr to same-http-downgrade origin and downgrade redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for xhr to same-http-downgrade origin and no-redirect redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for xhr to same-https origin and downgrade redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-module-data.http-rp/upgrade/fetch.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-module-data.http-rp/upgrade/fetch.https-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL Upgrade-Insecure-Requests: Expects allowed for fetch to cross-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for fetch to cross-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for fetch to cross-https origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for fetch to same-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for fetch to same-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for fetch to same-https origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+PASS Upgrade-Insecure-Requests: Expects allowed for fetch to cross-http-downgrade origin and downgrade redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for fetch to cross-http-downgrade origin and no-redirect redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for fetch to cross-https origin and downgrade redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for fetch to same-http-downgrade origin and downgrade redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for fetch to same-http-downgrade origin and no-redirect redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for fetch to same-https origin and downgrade redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-module-data.http-rp/upgrade/websocket.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-module-data.http-rp/upgrade/websocket.https-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Upgrade-Insecure-Requests: Expects allowed for websocket to cross-ws-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for websocket to same-ws-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+PASS Upgrade-Insecure-Requests: Expects allowed for websocket to cross-ws-downgrade origin and no-redirect redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for websocket to same-ws-downgrade origin and no-redirect redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-module-data.http-rp/upgrade/xhr.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-module-data.http-rp/upgrade/xhr.https-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL Upgrade-Insecure-Requests: Expects allowed for xhr to cross-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for xhr to cross-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for xhr to cross-https origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for xhr to same-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for xhr to same-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for xhr to same-https origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+PASS Upgrade-Insecure-Requests: Expects allowed for xhr to cross-http-downgrade origin and downgrade redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for xhr to cross-http-downgrade origin and no-redirect redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for xhr to cross-https origin and downgrade redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for xhr to same-http-downgrade origin and downgrade redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for xhr to same-http-downgrade origin and no-redirect redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for xhr to same-https origin and downgrade redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-module-data.meta/upgrade/fetch.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-module-data.meta/upgrade/fetch.https-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL Upgrade-Insecure-Requests: Expects allowed for fetch to cross-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for fetch to cross-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for fetch to cross-https origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for fetch to same-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for fetch to same-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for fetch to same-https origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+PASS Upgrade-Insecure-Requests: Expects allowed for fetch to cross-http-downgrade origin and downgrade redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for fetch to cross-http-downgrade origin and no-redirect redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for fetch to cross-https origin and downgrade redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for fetch to same-http-downgrade origin and downgrade redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for fetch to same-http-downgrade origin and no-redirect redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for fetch to same-https origin and downgrade redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-module-data.meta/upgrade/websocket.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-module-data.meta/upgrade/websocket.https-expected.txt
@@ -1,4 +1,4 @@
 
-FAIL Upgrade-Insecure-Requests: Expects allowed for websocket to cross-ws-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for websocket to same-ws-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+PASS Upgrade-Insecure-Requests: Expects allowed for websocket to cross-ws-downgrade origin and no-redirect redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for websocket to same-ws-downgrade origin and no-redirect redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-module-data.meta/upgrade/xhr.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-module-data.meta/upgrade/xhr.https-expected.txt
@@ -1,8 +1,8 @@
 
-FAIL Upgrade-Insecure-Requests: Expects allowed for xhr to cross-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for xhr to cross-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for xhr to cross-https origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for xhr to same-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for xhr to same-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for xhr to same-https origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+PASS Upgrade-Insecure-Requests: Expects allowed for xhr to cross-http-downgrade origin and downgrade redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for xhr to cross-http-downgrade origin and no-redirect redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for xhr to cross-https origin and downgrade redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for xhr to same-http-downgrade origin and downgrade redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for xhr to same-http-downgrade origin and no-redirect redirection from https context.
+PASS Upgrade-Insecure-Requests: Expects allowed for xhr to same-https origin and downgrade redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/srcdoc-inherit.meta/upgrade/sharedworker-import-data.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/srcdoc-inherit.meta/upgrade/sharedworker-import-data.https-expected.txt
@@ -1,8 +1,8 @@
 
 FAIL Upgrade-Insecure-Requests: Expects allowed for sharedworker-import-data to cross-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
 FAIL Upgrade-Insecure-Requests: Expects allowed for sharedworker-import-data to cross-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for sharedworker-import-data to cross-https origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+PASS Upgrade-Insecure-Requests: Expects allowed for sharedworker-import-data to cross-https origin and downgrade redirection from https context.
 FAIL Upgrade-Insecure-Requests: Expects allowed for sharedworker-import-data to same-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
 FAIL Upgrade-Insecure-Requests: Expects allowed for sharedworker-import-data to same-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for sharedworker-import-data to same-https origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+PASS Upgrade-Insecure-Requests: Expects allowed for sharedworker-import-data to same-https origin and downgrade redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/top.http-rp/upgrade/sharedworker-import-data.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/top.http-rp/upgrade/sharedworker-import-data.https-expected.txt
@@ -1,8 +1,8 @@
 
 FAIL Upgrade-Insecure-Requests: Expects allowed for sharedworker-import-data to cross-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
 FAIL Upgrade-Insecure-Requests: Expects allowed for sharedworker-import-data to cross-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for sharedworker-import-data to cross-https origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+PASS Upgrade-Insecure-Requests: Expects allowed for sharedworker-import-data to cross-https origin and downgrade redirection from https context.
 FAIL Upgrade-Insecure-Requests: Expects allowed for sharedworker-import-data to same-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
 FAIL Upgrade-Insecure-Requests: Expects allowed for sharedworker-import-data to same-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for sharedworker-import-data to same-https origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+PASS Upgrade-Insecure-Requests: Expects allowed for sharedworker-import-data to same-https origin and downgrade redirection from https context.
 

--- a/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/top.meta/upgrade/sharedworker-import-data.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/top.meta/upgrade/sharedworker-import-data.https-expected.txt
@@ -1,8 +1,8 @@
 
 FAIL Upgrade-Insecure-Requests: Expects allowed for sharedworker-import-data to cross-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
 FAIL Upgrade-Insecure-Requests: Expects allowed for sharedworker-import-data to cross-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for sharedworker-import-data to cross-https origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+PASS Upgrade-Insecure-Requests: Expects allowed for sharedworker-import-data to cross-https origin and downgrade redirection from https context.
 FAIL Upgrade-Insecure-Requests: Expects allowed for sharedworker-import-data to same-http-downgrade origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
 FAIL Upgrade-Insecure-Requests: Expects allowed for sharedworker-import-data to same-http-downgrade origin and no-redirect redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
-FAIL Upgrade-Insecure-Requests: Expects allowed for sharedworker-import-data to same-https origin and downgrade redirection from https context. assert_equals: The resource request should be 'allowed'. expected "allowed" but got "blocked"
+PASS Upgrade-Insecure-Requests: Expects allowed for sharedworker-import-data to same-https origin and downgrade redirection from https context.
 

--- a/Source/WebCore/workers/shared/SharedWorkerScriptLoader.cpp
+++ b/Source/WebCore/workers/shared/SharedWorkerScriptLoader.cpp
@@ -29,6 +29,7 @@
 #include "ContextDestructionObserverInlines.h"
 #include "EventNames.h"
 #include "InspectorInstrumentation.h"
+#include "SecurityOrigin.h"
 #include "SharedWorker.h"
 #include "WorkerFetchResult.h"
 #include "WorkerInitializationData.h"
@@ -84,6 +85,17 @@ void SharedWorkerScriptLoader::notifyFinished(std::optional<ScriptExecutionConte
     }
 
     auto fetchResult = m_loader->fetchResult();
+
+    // These URLs carry no HTTP headers; inherit the creating document's
+    // CSP, matching Worker::didReceiveResponse().
+    if (scriptExecutionContext) {
+        const auto& responseURL = fetchResult.responseURL;
+        if (responseURL.protocolIsBlob() || responseURL.protocolIsFile() || SecurityOrigin::create(responseURL)->isOpaque()) {
+            if (CheckedPtr contentSecurityPolicy = scriptExecutionContext->contentSecurityPolicy())
+                fetchResult.contentSecurityPolicy = contentSecurityPolicy->responseHeaders();
+        }
+    }
+
     if (fetchResult.referrerPolicy.isNull() && scriptExecutionContext)
         fetchResult.referrerPolicy = referrerPolicyToString(scriptExecutionContext->referrerPolicy());
     m_completionHandler(WTF::move(fetchResult), WorkerInitializationData {


### PR DESCRIPTION
#### d65bd812f14143e94acb90b84096077e84c09bcc
<pre>
Inherit creating document&apos;s CSP for SharedWorkers loaded from headerless URLs
<a href="https://bugs.webkit.org/show_bug.cgi?id=308765">https://bugs.webkit.org/show_bug.cgi?id=308765</a>
<a href="https://rdar.apple.com/171287542">rdar://171287542</a>

Reviewed by Ryan Reno.

SharedWorkerScriptLoader::notifyFinished() does not inherit the creating
document&apos;s CSP when the worker URL carries no HTTP headers.
Worker::didReceiveResponse() already handles this for DedicatedWorkers by
checking for blob:, file:, and opaque-origin URLs.

Apply the same check in SharedWorkerScriptLoader so that the creating
context&apos;s CSP flows into the WorkerFetchResult before it reaches
SharedWorkerGlobalScope.

Tests: http/tests/security/contentSecurityPolicy/shared-worker-blob-url-inherits-csp-importScripts-blocked.html
       http/tests/security/contentSecurityPolicy/shared-worker-data-url-inherits-csp-importScripts-blocked.html

* LayoutTests/http/tests/security/contentSecurityPolicy/shared-worker-blob-url-inherits-csp-importScripts-blocked-expected.txt: Added.
* LayoutTests/http/tests/security/contentSecurityPolicy/shared-worker-blob-url-inherits-csp-importScripts-blocked.html: Added.
* LayoutTests/http/tests/security/contentSecurityPolicy/shared-worker-data-url-inherits-csp-importScripts-blocked-expected.txt: Added.
* LayoutTests/http/tests/security/contentSecurityPolicy/shared-worker-data-url-inherits-csp-importScripts-blocked.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/script-src/worker-data-set-timeout.sub-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/iframe-blank-inherit.meta/upgrade/sharedworker-import-data.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-classic-data.http-rp/upgrade/fetch.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-classic-data.http-rp/upgrade/websocket.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-classic-data.http-rp/upgrade/xhr.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-classic-data.meta/upgrade/fetch.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-classic-data.meta/upgrade/websocket.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-classic-data.meta/upgrade/xhr.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-module-data.http-rp/upgrade/fetch.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-module-data.http-rp/upgrade/websocket.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-module-data.http-rp/upgrade/xhr.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-module-data.meta/upgrade/fetch.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-module-data.meta/upgrade/websocket.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/sharedworker-module-data.meta/upgrade/xhr.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/srcdoc-inherit.meta/upgrade/sharedworker-import-data.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/top.http-rp/upgrade/sharedworker-import-data.https-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/upgrade-insecure-requests/gen/top.meta/upgrade/sharedworker-import-data.https-expected.txt:
* Source/WebCore/workers/shared/SharedWorkerScriptLoader.cpp:
(WebCore::SharedWorkerScriptLoader::notifyFinished):

Originally-landed-as: 305413.556@rapid/safari-7624.2.5.110-branch (7bbbcf272dea). <a href="https://rdar.apple.com/176062254">rdar://176062254</a>
Canonical link: <a href="https://commits.webkit.org/315016@main">https://commits.webkit.org/315016@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/3e12a96a270dca86184b9fe352439df87e380e96

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167805 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41302 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34897 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176863 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125486 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169671 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41737 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41315 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130550 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91761 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170764 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33008 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150788 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111067 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31989 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30687 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25595 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141978 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28483 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179405 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32452 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30201 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138970 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41374 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34844 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138854 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37399 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42062 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150275 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105276 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34131 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27154 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40566 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113817 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39963 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5257 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40214 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40108 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->