### PR TITLE
Pan gestures pass through scroll containers laid over vertical-rl body text (but only once the document's scrollingElement has been scrolled by about one viewport of width)

### DIFF
--- a/LayoutTests/fast/scrolling/ios/scroll-in-fixed-overlay-in-vertical-rl-expected.txt
+++ b/LayoutTests/fast/scrolling/ios/scroll-in-fixed-overlay-in-vertical-rl-expected.txt
@@ -1,0 +1,11 @@
+Verifies that a drag on the left side of the viewport, where a position:fixed overlay sits in a vertical-rl page, scrolls the overlay's contents and not the main page.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS overlayScrolled is true
+PASS documentScrolled is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/scrolling/ios/scroll-in-fixed-overlay-in-vertical-rl.html
+++ b/LayoutTests/fast/scrolling/ios/scroll-in-fixed-overlay-in-vertical-rl.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<style>
+    :root {
+        scrollbar-width: none;
+    }
+    body {
+        writing-mode: vertical-rl;
+        margin: 0;
+    }
+
+    #overlay {
+        position: fixed;
+        background-color: rgba(0, 0, 0, 0.25);
+        width: 50%;
+        overflow: auto;
+        top: 0;
+        left: 0;
+        bottom: 0;
+        border: 1px solid black;
+        box-sizing: border-box;
+    }
+
+    .scrollable-content {
+        width: 4000px;
+        height: 100%;
+    }
+</style>
+<script src="../../../resources/js-test.js"></script>
+<script src="../../../resources/ui-helper.js"></script>
+<script>
+    window.jsTestIsAsync = true;
+
+    var initialDocumentScrollLeft;
+    var initialOverlayScrollLeft;
+    var overlayScrolled;
+    var documentScrolled;
+
+    async function runTest()
+    {
+        description("Verifies that a drag on the left side of the viewport, where a position:fixed overlay sits in a vertical-rl page, scrolls the overlay's contents and not the main page.");
+
+        const overlay = document.getElementById('overlay');
+        const scrollingElement = document.scrollingElement;
+
+        initialDocumentScrollLeft = scrollingElement.scrollLeft;
+        initialOverlayScrollLeft = overlay.scrollLeft;
+
+        await UIHelper.callFunctionAndWaitForTargetScrollToFinish(overlay, async () => {
+            // Drag horizontally on the left side of the viewport, where the fixed overlay is rendered.
+            await UIHelper.dragFromPointToPoint(50, 300, 100, 300, 0.1);
+        });
+
+        overlayScrolled = overlay.scrollLeft !== initialOverlayScrollLeft;
+        documentScrolled = scrollingElement.scrollLeft !== initialDocumentScrollLeft;
+
+        shouldBeTrue("overlayScrolled");
+        shouldBeFalse("documentScrolled");
+
+        finishJSTest();
+    }
+    window.addEventListener('load', runTest, false);
+</script>
+</head>
+<body>
+    <div id="console"></div>
+    <div class="scrollable-content"></div>
+    <div id="overlay">
+        <div class="scrollable-content"></div>
+    </div>
+</body>
+</html>

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -267,17 +267,16 @@ typedef NS_ENUM(NSInteger, _WKPrintRenderingCallbackType) {
 
     WebKit::WebProcessPool::statistics().wkViewCount++;
 
-    _rootContentView = adoptNS([[UIView alloc] init]);
-    [_rootContentView layer].name = @"RootContent";
-    [_rootContentView layer].masksToBounds = NO;
-    [_rootContentView setAutoresizingMask:UIViewAutoresizingFlexibleWidth | UIViewAutoresizingFlexibleHeight];
-
     _fixedClippingView = adoptNS([[UIView alloc] init]);
     [_fixedClippingView layer].name = @"FixedClipping";
     [_fixedClippingView layer].masksToBounds = YES;
     [_fixedClippingView layer].anchorPoint = CGPointZero;
-
     [self addSubview:_fixedClippingView.get()];
+
+    _rootContentView = adoptNS([[UIView alloc] init]);
+    [_rootContentView layer].name = @"RootContent";
+    [_rootContentView layer].masksToBounds = NO;
+    [_rootContentView layer].anchorPoint = CGPointZero;
     [_fixedClippingView addSubview:_rootContentView.get()];
 
     if (!linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::LazyGestureRecognizerInstallation))
@@ -605,8 +604,11 @@ typedef NS_ENUM(NSInteger, _WKPrintRenderingCallbackType) {
     WebCore::FloatRect clippingBounds = [self bounds];
     clippingBounds.unite(fixedPositionRectForUI);
 
-    [_fixedClippingView setCenter:clippingBounds.location()]; // Not really the center since we set an anchor point.
+    [_fixedClippingView setCenter:clippingBounds.location()];
     [_fixedClippingView setBounds:clippingBounds];
+
+    [_rootContentView setCenter:clippingBounds.location()];
+    [_rootContentView setBounds:clippingBounds];
 }
 
 - (void)_didExitStableState

--- a/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm
@@ -1914,7 +1914,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
         }
     }
 
-    LOG_WITH_STREAM(UIHitTesting, stream << "hit-testing WKContentView subviews " << [[self recursiveDescription] UTF8String]);
+    LOG_WITH_STREAM(UIHitTesting, stream << "hit-testing at " << point << " subviews of WKContentView\n" << [[self recursiveDescription] UTF8String]);
     UIView* hitView = [super hitTest:point withEvent:event];
     LOG_WITH_STREAM(UIHitTesting, stream << " found view " << [hitView class] << " " << (void*)hitView);
     return hitView;


### PR DESCRIPTION
#### 2589295ae8a155339fc4de670d8e5593d4ba5395
<pre>
Pan gestures pass through scroll containers laid over vertical-rl body text (but only once the document&apos;s scrollingElement has been scrolled by about one viewport of width)
<a href="https://bugs.webkit.org/show_bug.cgi?id=298992">https://bugs.webkit.org/show_bug.cgi?id=298992</a>
<a href="https://rdar.apple.com/160788907">rdar://160788907</a>

Reviewed by Abrar Rahman Protyasha.

In certain configurations of RTL content on iOS, UI-side hit-testing
would fail to find targets scrollers once the document had been scrolled
away from the origin by some amount. In this configuration, scrollOrigin is
non-zero, and scrolling to the left goes into negative horizontal coordinates.

On iOS we have two UIViews at the root, `_fixedClippingView` and `_rootContentView`,
and we need to set up their geometry in this RTL config such that visible
parts of the view are always inside the layers, so that hit-testing passes through
them. This requires setting up `_rootContentView` exactly how we set up `_fixedClippingView`,
with origin and bounds that account for the negative coordinates.

Test: fast/scrolling/ios/scroll-in-fixed-overlay-in-vertical-rl.html

* LayoutTests/fast/scrolling/ios/scroll-in-fixed-overlay-in-vertical-rl-expected.txt: Added.
* LayoutTests/fast/scrolling/ios/scroll-in-fixed-overlay-in-vertical-rl.html: Added.
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView _commonInitializationWithProcessPool:configuration:]): Just re-order
to match the parenting order.
(-[WKContentView updateFixedClippingView:]):
* Source/WebKit/UIProcess/ios/WKContentViewInteraction.mm:
(-[WKContentView hitTest:withEvent:]):

Canonical link: <a href="https://commits.webkit.org/313665@main">https://commits.webkit.org/313665@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d03cacbed91d29603817344c65ba766ae12de182

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163676 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37160 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30379 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172616 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/120167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37491 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37159 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127129 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/120167 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166635 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29414 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147149 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107683 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28462 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27094 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20319 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138361 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24866 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175121 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28052 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26533 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135434 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36830 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31198 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135417 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36521 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37615 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146661 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99692 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30732 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23514 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36326 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109471 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35823 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1543 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36073 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35970 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->