### PR TITLE
Implement UIScriptController.insertAutofillSuggestion helper for iOS

### DIFF
--- a/LayoutTests/fast/forms/ios/insert-autofill-suggestion-expected.txt
+++ b/LayoutTests/fast/forms/ios/insert-autofill-suggestion-expected.txt
@@ -1,0 +1,11 @@
+
+Tests that UIHelper.insertAutofillSuggestion fills the focused username and password inputs in a same-origin login form on iOS.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS userValue is "frederik"
+PASS passwordValue is "famos"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/forms/ios/insert-autofill-suggestion.html
+++ b/LayoutTests/fast/forms/ios/insert-autofill-suggestion.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ useFlexibleViewport=true ] -->
+<html>
+<head>
+<script src="../../../resources/ui-helper.js"></script>
+<script src="../../../resources/js-test.js"></script>
+<meta name=viewport content="width=device-width, initial-scale=1, user-scalable=no">
+<style>
+body, html {
+    margin: 0;
+    padding: 0;
+}
+
+input {
+    display: block;
+    width: 200px;
+    height: 30px;
+    font-size: 16px;
+    margin: 8px;
+}
+</style>
+</head>
+<body>
+<input type="email" id="user" autocomplete="username">
+<input type="password" id="password" autocomplete="current-password">
+<pre id="description"></pre>
+<pre id="console"></pre>
+<script>
+description("Tests that UIHelper.insertAutofillSuggestion fills the focused username and password inputs in a same-origin login form on iOS.");
+jsTestIsAsync = true;
+
+addEventListener("load", async () => {
+    if (!window.testRunner)
+        return;
+
+    const userField = document.getElementById("user");
+    const userRect = userField.getBoundingClientRect();
+    await UIHelper.activateAndWaitForInputSessionAt(userRect.left + userRect.width / 2, userRect.top + userRect.height / 2);
+
+    await UIHelper.insertAutofillSuggestion("frederik", "famos");
+
+    window.userValue = document.getElementById("user").value;
+    window.passwordValue = document.getElementById("password").value;
+    shouldBeEqualToString("userValue", "frederik");
+    shouldBeEqualToString("passwordValue", "famos");
+    finishJSTest();
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/resources/ui-helper.js
+++ b/LayoutTests/resources/ui-helper.js
@@ -1418,6 +1418,15 @@ window.UIHelper = class UIHelper {
         return new Promise(resolve => testRunner.runUIScript(script, resolve));
     }
 
+    static insertAutofillSuggestion(username, password) {
+        const escapedUsername = JSON.stringify(String(username));
+        const escapedPassword = JSON.stringify(String(password));
+        const script = `uiController.insertAutofillSuggestion(${escapedUsername}, ${escapedPassword}, () => {
+            uiController.uiScriptComplete("");
+        });`;
+        return new Promise(resolve => testRunner.runUIScript(script, resolve));
+    }
+
     static isShowingDataListSuggestions()
     {
         return new Promise(resolve => {

--- a/Tools/DumpRenderTree/mac/UIScriptControllerMac.h
+++ b/Tools/DumpRenderTree/mac/UIScriptControllerMac.h
@@ -51,6 +51,7 @@ public:
     NSUndoManager *platformUndoManager() const override;
     void copyText(JSStringRef) override;
     void activateDataListSuggestion(unsigned, JSValueRef) override;
+    void insertAutofillSuggestion(JSStringRef, JSStringRef, JSValueRef) override;
     void setSpellCheckerResults(JSValueRef) override;
     void sendEventStream(JSStringRef, JSValueRef) override;
 

--- a/Tools/DumpRenderTree/mac/UIScriptControllerMac.mm
+++ b/Tools/DumpRenderTree/mac/UIScriptControllerMac.mm
@@ -106,6 +106,20 @@ void UIScriptControllerMac::activateDataListSuggestion(unsigned index, JSValueRe
     });
 }
 
+void UIScriptControllerMac::insertAutofillSuggestion(JSStringRef username, JSStringRef password, JSValueRef callback)
+{
+    // FIXME: Not implemented for Mac DumpRenderTree.
+    UNUSED_PARAM(username);
+    UNUSED_PARAM(password);
+
+    unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
+    WorkQueue::mainSingleton().dispatch([this, protectedThis = Ref { *this }, callbackID] {
+        if (!m_context)
+            return;
+        m_context->asyncTaskComplete(callbackID);
+    });
+}
+
 void UIScriptControllerMac::overridePreference(JSStringRef preferenceRef, JSStringRef valueRef)
 {
     WebPreferences *preferences = mainFrame.webView.preferences;

--- a/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
+++ b/Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl
@@ -273,6 +273,9 @@ interface UIScriptController {
     readonly attribute boolean isShowingDataListSuggestions;
     undefined activateDataListSuggestion(unsigned long index, object callback);
 
+    // Login credential autofill (UITextAutofillSuggestion).
+    undefined insertAutofillSuggestion(DOMString username, DOMString password, object callback);
+
     // <input type=color>
     undefined setSelectedColorForColorPicker(double red, double green, double blue);
     readonly attribute boolean isShowingColorPicker;

--- a/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
+++ b/Tools/TestRunnerShared/UIScriptContext/UIScriptController.h
@@ -337,6 +337,7 @@ public:
     virtual void setDefaultCalendarType(JSStringRef, JSStringRef) { notImplemented(); }
     virtual JSObjectRef inputViewBounds() const { notImplemented(); return nullptr; }
     virtual void activateDataListSuggestion(unsigned, JSValueRef) { notImplemented(); }
+    virtual void insertAutofillSuggestion(JSStringRef, JSStringRef, JSValueRef) { notImplemented(); }
     virtual void setSelectedColorForColorPicker(double, double, double) { notImplemented(); }
     virtual bool isShowingColorPicker() const { notImplemented(); return false; }
     virtual void setAppAccentColor(unsigned short, unsigned short, unsigned short) { notImplemented(); }

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h
@@ -146,6 +146,7 @@ private:
     void completeBackSwipe(JSValueRef) override;
     bool isShowingDataListSuggestions() const override;
     void activateDataListSuggestion(unsigned, JSValueRef) override;
+    void insertAutofillSuggestion(JSStringRef, JSStringRef, JSValueRef) override;
     void setSelectedColorForColorPicker(double, double, double) override;
     bool isShowingColorPicker() const override;
     void setKeyboardInputModeIdentifier(JSStringRef) override;

--- a/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
+++ b/Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm
@@ -1464,6 +1464,20 @@ void UIScriptControllerIOS::activateDataListSuggestion(unsigned index, JSValueRe
     }).get());
 }
 
+void UIScriptControllerIOS::insertAutofillSuggestion(JSStringRef username, JSStringRef password, JSValueRef callback)
+{
+    RetainPtr contentView = static_cast<id<UITextInputPrivate>>(platformContentView());
+    RetainPtr suggestion = [UITextAutofillSuggestion autofillSuggestionWithUsername:toWTFString(username).createNSString().get() password:toWTFString(password).createNSString().get()];
+    [contentView insertTextSuggestion:suggestion];
+
+    unsigned callbackID = m_context->prepareForAsyncTask(callback, CallbackTypeNonPersistent);
+    [webView() _doAfterNextPresentationUpdate:makeBlockPtr([this, protectedThis = Ref { *this }, callbackID] {
+        if (!m_context)
+            return;
+        m_context->asyncTaskComplete(callbackID);
+    }).get()];
+}
+
 bool UIScriptControllerIOS::isShowingDataListSuggestions() const
 {
     return [webView() _isShowingDataListSuggestions];


### PR DESCRIPTION
#### 79b5865339b485e64080621757ecb4b5b984d159
<pre>
Implement UIScriptController.insertAutofillSuggestion helper for iOS
<a href="https://bugs.webkit.org/show_bug.cgi?id=315253">https://bugs.webkit.org/show_bug.cgi?id=315253</a>
<a href="https://rdar.apple.com/177581560">rdar://177581560</a>

Reviewed by Wenson Hsieh.

Adds a test-only SPI to inject a UITextAutofillSuggestion into the
focused input, mirroring how a user would pick an autofill credential
from the iOS keyboard. This unblocks layout-test coverage of any code
path that depends on -[WKContentView insertTextSuggestion:]
including autofill IPC routing for cross-origin iframes under site
isolation.

* LayoutTests/fast/forms/ios/insert-autofill-suggestion-expected.txt: Added.
* LayoutTests/fast/forms/ios/insert-autofill-suggestion.html: Added.
* LayoutTests/resources/ui-helper.js:
(window.UIHelper.insertAutofillSuggestion):
* Tools/DumpRenderTree/mac/UIScriptControllerMac.h:
* Tools/DumpRenderTree/mac/UIScriptControllerMac.mm:
(WTR::UIScriptControllerMac::insertAutofillSuggestion):
* Tools/TestRunnerShared/UIScriptContext/Bindings/UIScriptController.idl:
* Tools/TestRunnerShared/UIScriptContext/UIScriptController.h:
(WTR::UIScriptController::insertAutofillSuggestion):
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.h:
* Tools/WebKitTestRunner/ios/UIScriptControllerIOS.mm:
(WTR::UIScriptControllerIOS::insertAutofillSuggestion):

Canonical link: <a href="https://commits.webkit.org/314511@main">https://commits.webkit.org/314511@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/db901e5aa328c7c616b60131aff9bc377fed8262

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166341 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39831 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33412 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175389 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/123596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c6152f46-e42d-4581-9567-12559015e2b2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168207 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40257 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39839 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129298 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/123596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/03d81867-aac0-432b-bdf0-0bc5c7bfe8fa) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169300 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/31680 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/149454 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109823 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b07237f9-cb46-44b1-8656-a74e60872b20) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30658 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/29358 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23529 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/140627 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27151 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177921 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28857 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137650 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39901 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33504 "Build is in progress. Recent messages:") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137572 "Found 1 new API test failure: WebKitGTK/TestSSL:/webkit/WebKitWebView/web-socket-tls-errors (failure)") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37058 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40589 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148948 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103235 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32862 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/25814 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39099 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38496 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3900 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38741 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38639 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->