### PR TITLE
CSS keyframe animation on SVG is smearing background

### DIFF
--- a/LayoutTests/svg/repaint/filter-css-animation-on-child-expected.html
+++ b/LayoutTests/svg/repaint/filter-css-animation-on-child-expected.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <title>SVG filter ancestor must repaint its full filter region when a child's CSS transform animates (expected)</title>
+  <style>
+    body { margin: 0; background: white; }
+  </style>
+</head>
+<body>
+  <svg width="300" height="100" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+      <filter id="f" filterUnits="userSpaceOnUse" x="0" y="0" width="300" height="100">
+        <feGaussianBlur stdDeviation="2"/>
+      </filter>
+    </defs>
+    <g filter="url(#f)">
+      <rect width="50" height="50" fill="red" style="transform: translateX(100px)"/>
+    </g>
+  </svg>
+</body>
+</html>

--- a/LayoutTests/svg/repaint/filter-css-animation-on-child.html
+++ b/LayoutTests/svg/repaint/filter-css-animation-on-child.html
@@ -1,0 +1,56 @@
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+  <title>SVG filter ancestor must repaint its full filter region when a child's CSS transform animates</title>
+  <script src="../../resources/ui-helper.js"></script>
+  <style>
+    body { margin: 0; background: white; }
+  </style>
+  <script>
+    if (window.testRunner) {
+      testRunner.waitUntilDone();
+      testRunner.dontForceRepaint();
+    }
+
+window.addEventListener('load', async function() {
+  const child = document.getElementById('child');
+  let step = 0;
+  const totalSteps = 20;
+
+  function animate() {
+    if (step < totalSteps) {
+      const x = (step / totalSteps) * 100;
+      child.style.transform = 'translateX(' + x + 'px)';
+      step++;
+      requestAnimationFrame(animate);
+    } else {
+      child.style.transform = 'translateX(100px)';
+      finishTest();
+    }
+  }
+
+  async function finishTest() {
+    await UIHelper.renderingUpdate();
+    await UIHelper.renderingUpdate();
+    document.documentElement.classList.remove('reftest-wait');
+    if (window.testRunner)
+      testRunner.notifyDone();
+  }
+
+  requestAnimationFrame(animate);
+});
+</script>
+</head>
+<body>
+  <svg width="300" height="100" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+      <filter id="f" filterUnits="userSpaceOnUse" x="0" y="0" width="300" height="100">
+        <feGaussianBlur stdDeviation="2"/>
+      </filter>
+    </defs>
+    <g filter="url(#f)">
+      <rect id="child" width="50" height="50" fill="red"/>
+    </g>
+  </svg>
+</body>
+</html>

--- a/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
+++ b/Source/WebCore/rendering/svg/SVGRenderSupport.cpp
@@ -93,6 +93,14 @@ std::optional<FloatRect> SVGRenderSupport::computeFloatVisibleRectInContainer(co
     // Translate to coords in our parent renderer, and then call computeFloatVisibleRectInContainer() on our parent.
     adjustedRect = renderer.localToParentTransform().mapRect(adjustedRect);
 
+    // If the parent applies a filter, the filter's output covers its full filter region whenever any
+    // input changes. Expand the propagated rect to that region so child-driven invalidations dirty
+    // the entire filter output, not just the child's local box.
+    if (auto* resources = SVGResourcesCache::cachedResourcesForRenderer(parent)) {
+        if (CheckedPtr filter = resources->filter())
+            adjustedRect.unite(filter->resourceBoundingBox(parent, context.repaintRectCalculation()));
+    }
+
     return parent.computeFloatVisibleRectInContainer(adjustedRect, container, context);
 }
 


### PR DESCRIPTION
#### b61d8e9eaf582705d485aacdc4594aed80575fad
<pre>
CSS keyframe animation on SVG is smearing background
<a href="https://bugs.webkit.org/show_bug.cgi?id=219379">https://bugs.webkit.org/show_bug.cgi?id=219379</a>
<a href="https://rdar.apple.com/71865841">rdar://71865841</a>

Reviewed by NOBODY (OOPS!).

When a CSS-animated SVG element (e.g. animated `transform` or `stroke-dashoffset`)
is a descendant of a `&lt;g filter=&quot;url(...)&quot;&gt;`, intermediate animation frames leave
behind a silhouette of the filter output that persists after the animation ends.

The descendant&apos;s invalidation propagates up via SVGRenderSupport::computeFloatVisibleRectInContainer,
which maps the rect through each ancestor&apos;s localToParentTransform but never
expands it by an ancestor filter&apos;s region. With filterUnits=&quot;userSpaceOnUse&quot;
the filtered ancestor&apos;s own m_repaintBoundingBox is constant across frames,
so its LayoutRepainter sees old == new and skips repaint. The descendant&apos;s
local repaint rect is therefore the only thing dirtied, and pixels of the
filter output (drop-shadow blur, offset, etc.) outside that rect are never
cleared.

Expand the propagated rect to include the ancestor&apos;s filter resourceBoundingBox
when walking up the SVG ancestor chain, mirroring how RenderBox folds CSS
filter outsets into visual overflow. LBSE is unaffected because it folds the
filter into the layer&apos;s visual overflow via SVGBoundingBoxComputation.

* Source/WebCore/rendering/svg/SVGRenderSupport.cpp:
(WebCore::SVGRenderSupport::computeFloatVisibleRectInContainer):
* LayoutTests/svg/repaint/filter-css-animation-on-child-expected.html: Added.
* LayoutTests/svg/repaint/filter-css-animation-on-child.html: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b61d8e9eaf582705d485aacdc4594aed80575fad

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163693 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37177 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30396 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172633 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/120184 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165562 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37508 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37176 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127145 "Found 13 new test failures: css3/blending/svg-blend-layer-filter.html svg/W3C-SVG-1.1/filters-blend-01-b.svg svg/W3C-SVG-1.1/filters-morph-01-f.svg svg/batik/filters/filterRegions.svg svg/batik/text/textProperties.svg svg/custom/use-disappears-after-style-update.svg svg/filters/color-interpolation-filters.svg svg/filters/feGaussianBlur.svg svg/filters/filter-placement-issue.svg svg/filters/filter-refresh.svg ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89619 "layout-tests (failure)") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166652 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29433 "Found 14 new test failures: css3/blending/svg-blend-layer-filter.html svg/W3C-SVG-1.1/filters-blend-01-b.svg svg/W3C-SVG-1.1/filters-example-01-b.svg svg/W3C-SVG-1.1/filters-gauss-01-b.svg svg/W3C-SVG-1.1/filters-morph-01-f.svg svg/batik/text/textProperties.svg svg/custom/use-disappears-after-style-update.svg svg/filters/color-interpolation-filters.svg svg/filters/feGaussianBlur.svg svg/filters/filter-placement-issue.svg ... (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147172 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107699 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28480 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27110 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20336 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138379 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24889 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175138 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28069 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26557 "Found 15 new test failures: css3/blending/svg-blend-layer-filter.html svg/W3C-SVG-1.1/filters-blend-01-b.svg svg/W3C-SVG-1.1/filters-example-01-b.svg svg/W3C-SVG-1.1/filters-gauss-01-b.svg svg/W3C-SVG-1.1/filters-morph-01-f.svg svg/batik/filters/filterRegions.svg svg/batik/text/textProperties.svg svg/custom/use-disappears-after-style-update.svg svg/filters/color-interpolation-filters.svg svg/filters/feGaussianBlur.svg ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135451 "Found 15 new test failures: css3/blending/svg-blend-layer-filter.html svg/W3C-SVG-1.1/filters-blend-01-b.svg svg/W3C-SVG-1.1/filters-example-01-b.svg svg/W3C-SVG-1.1/filters-gauss-01-b.svg svg/W3C-SVG-1.1/filters-morph-01-f.svg svg/batik/filters/filterRegions.svg svg/batik/text/textProperties.svg svg/custom/use-disappears-after-style-update.svg svg/filters/color-interpolation-filters.svg svg/filters/feGaussianBlur.svg ... (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36847 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31215 "Found 15 new test failures: css3/blending/svg-blend-layer-filter.html svg/W3C-SVG-1.1/filters-blend-01-b.svg svg/W3C-SVG-1.1/filters-example-01-b.svg svg/W3C-SVG-1.1/filters-gauss-01-b.svg svg/W3C-SVG-1.1/filters-morph-01-f.svg svg/batik/filters/filterRegions.svg svg/batik/text/textProperties.svg svg/custom/use-disappears-after-style-update.svg svg/filters/color-interpolation-filters.svg svg/filters/feGaussianBlur.svg ... (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135434 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37632 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146684 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99713 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30749 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23538 "Found 15 new test failures: css3/blending/svg-blend-layer-filter.html svg/W3C-SVG-1.1/filters-blend-01-b.svg svg/W3C-SVG-1.1/filters-example-01-b.svg svg/W3C-SVG-1.1/filters-gauss-01-b.svg svg/W3C-SVG-1.1/filters-morph-01-f.svg svg/batik/filters/filterRegions.svg svg/batik/text/textProperties.svg svg/custom/use-disappears-after-style-update.svg svg/filters/color-interpolation-filters.svg svg/filters/feGaussianBlur.svg ... (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36343 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109488 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35840 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1568 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36090 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35987 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->