### PR TITLE
Cherry-pick(s) 2f13ea25a5fe, b07dca9615f1. rdar://176061387

### DIFF
--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -3709,6 +3709,22 @@ public:
         }
     }
 
+    GetByStatus::LookupMode propertyLookupMode()
+    {
+        switch (op()) {
+        case GetByIdDirect:
+        case GetByIdDirectFlush:
+        case GetPrivateNameById:
+            return GetByStatus::LookupMode::Direct;
+        case GetById:
+        case GetByIdFlush:
+        case GetByIdMegamorphic:
+            return GetByStatus::LookupMode::Normal;
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+        }
+    }
+
     unsigned numberOfArgumentsToSkip()
     {
         ASSERT(hasNumberOfArgumentsToSkip());

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -3709,6 +3709,7 @@ public:
         }
     }
 
+<<<<<<< HEAD
     GetByStatus::LookupMode propertyLookupMode()
     {
         switch (op()) {
@@ -3725,6 +3726,8 @@ public:
         }
     }
 
+=======
+>>>>>>> b07dca9615f1 ([JSC] GetByStatus::computeFor should not walk proto chain for direct property access)
     unsigned numberOfArgumentsToSkip()
     {
         ASSERT(hasNumberOfArgumentsToSkip());


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://176061387 to main. [b07dca9615f1] caused a merge conflict. 

```[JSC] GetByStatus::computeFor should not walk proto chain for direct property access
https://bugs.webkit.org/show_bug.cgi?id=309519
rdar://171512268

Reviewed by Keith Miller.

When computing the GetByStatus, we should check if the property lookup is a
direct property access before doing a prototype walk since direct accesses are
not supposed to consult the prototype.

* Source/JavaScriptCore/bytecode/GetByStatus.cpp:
(JSC::GetByStatus::computeFor):
* Source/JavaScriptCore/bytecode/GetByStatus.h:
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter<AbstractStateType>::executeEffects):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::parseBlock):
* Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp:
(JSC::DFG::ConstantFoldingPhase::foldConstants):
* Source/JavaScriptCore/dfg/DFGNodeType.h:
(JSC::DFG::propertyLookupMode):

Originally-landed-as: 305413.572@rapid/safari-7624.2.5.110-branch (2f13ea25a5fe). rdar://176061387

Originally-landed-as: 313636@main (b07dca9615f1). rdar://176061387

[JSC] GetByStatus::computeFor should not walk proto chain for direct property access
https://bugs.webkit.org/show_bug.cgi?id=309519
rdar://171512268

Reviewed by Keith Miller.

When computing the GetByStatus, we should check if the property lookup is a
direct property access before doing a prototype walk since direct accesses are
not supposed to consult the prototype.

* Source/JavaScriptCore/bytecode/GetByStatus.cpp:
(JSC::GetByStatus::computeFor):
* Source/JavaScriptCore/bytecode/GetByStatus.h:
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter<AbstractStateType>::executeEffects):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::parseBlock):
* Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp:
(JSC::DFG::ConstantFoldingPhase::foldConstants):
* Source/JavaScriptCore/dfg/DFGNodeType.h:
(JSC::DFG::propertyLookupMode):

Originally-landed-as: 305413.572@rapid/safari-7624.2.5.110-branch (2f13ea25a5fe). rdar://176061387

```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/71017582f5e7248fea0a80d3a60efb5264ac09d0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163695 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37179 "Hash 71017582 for PR 65362 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30398 "Hash 71017582 for PR 65362 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172635 "Hash 71017582 for PR 65362 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/120186 "Hash 71017582 for PR 65362 does not build (failure)") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37510 "Hash 71017582 for PR 65362 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37178 "Hash 71017582 for PR 65362 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/172635 "Hash 71017582 for PR 65362 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/120186 "Hash 71017582 for PR 65362 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166654 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/37510 "Hash 71017582 for PR 65362 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/30398 "Hash 71017582 for PR 65362 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/172635 "Hash 71017582 for PR 65362 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/37510 "Hash 71017582 for PR 65362 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/37178 "Hash 71017582 for PR 65362 does not build (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20338 "Hash 71017582 for PR 65362 does not build (failure)") | 
| [❌ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/155846 "Hash 71017582 for PR 65362 does not build (failure)") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/37510 "Hash 71017582 for PR 65362 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/30398 "Hash 71017582 for PR 65362 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175140 "Hash 71017582 for PR 65362 does not build (failure)") | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/24586 "Hash 71017582 for PR 65362 does not build (failure)") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28071 "Failed to build and analyze WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/30398 "Hash 71017582 for PR 65362 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/175140 "Hash 71017582 for PR 65362 does not build (failure)") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36849 "Hash 71017582 for PR 65362 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/37178 "Hash 71017582 for PR 65362 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/175140 "Hash 71017582 for PR 65362 does not build (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37634 "Hash 71017582 for PR 65362 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/30398 "Hash 71017582 for PR 65362 does not build (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99720 "Built successfully") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/37634 "Hash 71017582 for PR 65362 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/30398 "Hash 71017582 for PR 65362 does not build (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/196097 "Built successfully") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36345 "Hash 71017582 for PR 65362 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109490 "Failed to build and analyze WebKit") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51128 "Passed tests") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35842 "Hash 71017582 for PR 65362 does not build (failure)") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/30398 "Hash 71017582 for PR 65362 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36092 "Hash 71017582 for PR 65362 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35989 "Hash 71017582 for PR 65362 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->