### PR TITLE
WebGL: UNSIGNED_INT drawElements() does not validate large indexes correctly

### DIFF
--- a/LayoutTests/fast/canvas/webgl/draw-elements-out-of-bounds-uint-index-expected.txt
+++ b/LayoutTests/fast/canvas/webgl/draw-elements-out-of-bounds-uint-index-expected.txt
@@ -4,6 +4,9 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 PASS context.drawElements(context.LINES, 1, context.UNSIGNED_INT, 0) generated expected GL error: INVALID_OPERATION.
 PASS context.drawElements(context.LINES, 1, context.UNSIGNED_INT, 0) generated expected GL error: INVALID_OPERATION.
+PASS context.drawElements(context.LINES, 1, context.UNSIGNED_INT, 0) generated expected GL error: INVALID_OPERATION.
+PASS context.drawElements(context.LINES, 1, context.UNSIGNED_INT, 0) generated expected GL error: INVALID_OPERATION.
+PASS context.drawElements(context.LINES, 1, context.UNSIGNED_INT, 0) generated expected GL error: INVALID_OPERATION.
 PASS successfullyParsed is true
 
 TEST COMPLETE

--- a/LayoutTests/fast/canvas/webgl/draw-elements-out-of-bounds-uint-index.html
+++ b/LayoutTests/fast/canvas/webgl/draw-elements-out-of-bounds-uint-index.html
@@ -13,39 +13,37 @@ description("Test of drawElements with out-of-bounds parameters using OES_elemen
 if (window.internals)
     window.internals.settings.setWebGLErrorsToConsoleEnabled(false);
 
-var context = create3DContext();
-var program = loadStandardProgram(context);
+var context;
+function runTest(contextType, index) {
+    context = document.createElement("canvas").getContext(contextType);
+    let program = loadStandardProgram(context);
+    context.useProgram(program);
+    if (contextType == "webgl") {
+        if (!context.getExtension("OES_element_index_uint"))
+            testPassed("no extension");
+    }
+    let buffer = context.createBuffer();
+    context.bindBuffer(context.ARRAY_BUFFER, buffer);
 
-context.useProgram(program);
-context.getExtension("OES_element_index_uint");
+    let data = new Uint8Array(0x100);
+    context.bufferData(context.ARRAY_BUFFER, data, context.STATIC_DRAW);
 
-var buffer = context.createBuffer();
-context.bindBuffer(context.ARRAY_BUFFER, buffer);
+    buffer = context.createBuffer();
+    context.bindBuffer(context.ELEMENT_ARRAY_BUFFER, buffer);
+    context.bufferData(context.ELEMENT_ARRAY_BUFFER, new Uint32Array([index]), context.STATIC_DRAW);
 
-var data = new Uint8Array(0x100);
-context.bufferData(context.ARRAY_BUFFER, data, context.STATIC_DRAW);
+    context.enableVertexAttribArray(0);
+    context.enableVertexAttribArray(1);
+    context.vertexAttribPointer(0, 1, context.UNSIGNED_BYTE, false, 0, 0);
+    context.vertexAttribPointer(1, 1, context.UNSIGNED_BYTE, false, 0, 0);
 
-buffer = context.createBuffer();
-context.bindBuffer(context.ELEMENT_ARRAY_BUFFER, buffer);
-
-data = new Uint32Array(new ArrayBuffer(0x10));
-data[0] = 0xffffffff;
-for (let i = 1; i < data.length; i++){
-    data[i] = 1;
+    shouldGenerateGLError(context, context.INVALID_OPERATION, "context.drawElements(context.LINES, 1, context.UNSIGNED_INT, 0)");
 }
-context.bufferData(context.ELEMENT_ARRAY_BUFFER, data, context.STATIC_DRAW);
 
-context.enableVertexAttribArray(0);
-context.enableVertexAttribArray(1);
-context.vertexAttribPointer(0, 1, context.UNSIGNED_BYTE, false, 0, 0);
-context.vertexAttribPointer(1, 1, context.UNSIGNED_BYTE, false, 0, 0);
-
-shouldGenerateGLError(context, context.INVALID_OPERATION, "context.drawElements(context.LINES, 1, context.UNSIGNED_INT, 0)");
-
-data[0] = 0xfffffffd;
-context.bufferData(context.ELEMENT_ARRAY_BUFFER, data, context.STATIC_DRAW);
-
-shouldGenerateGLError(context, context.INVALID_OPERATION, "context.drawElements(context.LINES, 1, context.UNSIGNED_INT, 0)");
+for (let index of [0xffffffff, 0xfffffffd, 0x80000000])
+    runTest("webgl", index);
+for (let index of [0xfffffffd, 0x80000000])
+    runTest("webgl2", index);
 </script>
 </body>
 </html>

--- a/Source/ThirdParty/ANGLE/src/libANGLE/validationES.h
+++ b/Source/ThirdParty/ANGLE/src/libANGLE/validationES.h
@@ -1189,13 +1189,13 @@ ANGLE_INLINE bool ValidateDrawElementsCommon(const Context *context,
             // If we use an index greater than our maximum supported index range, return an error.
             // The ES3 spec does not specify behaviour here, it is undefined, but ANGLE should
             // always return an error if possible here.
-            if (static_cast<GLint64>(indexRange.end()) >= context->getCaps().maxElementIndex)
+            if (indexRange.end() >= context->getCaps().maxElementIndex)
             {
                 ANGLE_VALIDATION_ERROR(GL_INVALID_OPERATION, err::kExceedsMaxElement);
                 return false;
             }
 
-            if (!ValidateDrawAttribs(context, entryPoint, static_cast<GLint64>(indexRange.end())))
+            if (!ValidateDrawAttribs(context, entryPoint, indexRange.end()))
             {
                 return false;
             }

--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/WebGLCompatibilityTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/WebGLCompatibilityTest.cpp
@@ -7821,6 +7821,82 @@ void main()
     EXPECT_GL_ERROR(GL_INVALID_OPERATION);
 }
 
+// Test that drawing a large GLuint index works.
+TEST_P(WebGL2CompatibilityTest, DrawLargeIndex)
+{
+    constexpr std::array<GLfloat, 4> kGreen = {0.0f, 1.0f, 0.0f, 1.0f};
+    constexpr GLuint offset = 0x80000000;
+    GLuint indexData[] = {0, 1, 2, 1, 3, 2};
+    for (auto& index : indexData)
+    {
+        index += offset;
+    }
+    float vertexData[] = {-1.0f, -1.0f, 1.0f, -1.0f, -1.0f, 1.0f, 1.0f, 1.0f};
+
+    GLBuffer indexBuffer;
+    ANGLE_GL_PROGRAM(program, essl1_shaders::vs::Simple(), essl1_shaders::fs::UniformColor());
+    GLint vPos = glGetAttribLocation(program, essl1_shaders::PositionAttrib());
+    ASSERT_NE(vPos, -1);
+    glUseProgram(program);
+    GLint colorUniformLocation =
+        glGetUniformLocation(program, angle::essl1_shaders::ColorUniform());
+    ASSERT_NE(colorUniformLocation, -1);
+
+    GLBuffer vertexBuffer;
+    glBindBuffer(GL_ARRAY_BUFFER, vertexBuffer);
+    glBufferData(GL_ARRAY_BUFFER, offset * sizeof(float) * 2 + sizeof(vertexData), nullptr, GL_STATIC_DRAW);
+    glBufferSubData(GL_ARRAY_BUFFER, offset * sizeof(float) * 2, sizeof(vertexData), vertexData);
+    glVertexAttribPointer(vPos, 2, GL_FLOAT, GL_FALSE, 0, nullptr);
+    glEnableVertexAttribArray(vPos);
+
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, indexBuffer);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(indexData), indexData, GL_DYNAMIC_DRAW);
+
+    glUniform4fv(colorUniformLocation, 1, kGreen.data());
+    ASSERT_GL_NO_ERROR();
+
+    glDrawElements(GL_TRIANGLES, 6, GL_UNSIGNED_INT, nullptr);
+    ASSERT_GL_NO_ERROR();
+    EXPECT_PIXEL_COLOR_EQ(getWindowWidth() - 1, 0, GLColor::green);
+    EXPECT_PIXEL_COLOR_EQ(0, getWindowHeight() - 1, GLColor::green);
+}
+
+// Test that drawing a large GLuint index is detected as out-of-bounds access.
+TEST_P(WebGL2CompatibilityTest, DrawLargeIndexOOB)
+{
+    constexpr GLuint offset = 0x80000000;
+    GLuint indexData[] = {0, 1, 2};
+    for (auto& index : indexData)
+    {
+        index += offset;
+    }
+    GLBuffer indexBuffer;
+    ANGLE_GL_PROGRAM(program, essl1_shaders::vs::Simple(), essl1_shaders::fs::UniformColor());
+    GLint vPos = glGetAttribLocation(program, essl1_shaders::PositionAttrib());
+    ASSERT_NE(vPos, -1);
+    glUseProgram(program);
+
+    GLBuffer vertexBuffer;
+    glBindBuffer(GL_ARRAY_BUFFER, vertexBuffer);
+    glBufferData(GL_ARRAY_BUFFER, 10, nullptr, GL_STATIC_DRAW);
+    glVertexAttribPointer(vPos, 2, GL_FLOAT, GL_FALSE, 0, nullptr);
+    glEnableVertexAttribArray(vPos);
+
+    glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, indexBuffer);
+    glBufferData(GL_ELEMENT_ARRAY_BUFFER, sizeof(indexData), indexData, GL_DYNAMIC_DRAW);
+
+    EXPECT_GL_NO_ERROR();
+    glDrawElements(GL_TRIANGLES, 3, GL_UNSIGNED_INT, nullptr);
+    if (!IsGLExtensionEnabled("GL_KHR_robust_buffer_access_behavior"))
+    {
+        EXPECT_GL_ERROR(GL_INVALID_OPERATION);
+    }
+    else
+    {
+        EXPECT_GL_NO_ERROR();
+    }
+}
+
 ANGLE_INSTANTIATE_TEST_ES2_AND_ES3(WebGLCompatibilityTest);
 
 ANGLE_INSTANTIATE_TEST_ES2(WebGL1CompatibilityTest);


### PR DESCRIPTION
#### 08713e96fc2ad608cac23d9692ce47d1084d8d1b
<pre>
WebGL: UNSIGNED_INT drawElements() does not validate large indexes correctly
<a href="https://bugs.webkit.org/show_bug.cgi?id=309120">https://bugs.webkit.org/show_bug.cgi?id=309120</a>
<a href="https://rdar.apple.com/171292767">rdar://171292767</a>

Reviewed by Dan Glastonbury.

Fix by removing the explicit static cast. The range type is uint32 and
can be converted to GLint64 implicitly and correctly. If the type is
changed to incompatible type (size_t), the implicit cast will warn.

* Source/ThirdParty/ANGLE/src/libANGLE/validationES.h:
(gl::ValidateDrawElementsCommon):
* Source/ThirdParty/ANGLE/src/tests/gl_tests/WebGLCompatibilityTest.cpp:

Originally-landed-as: 305413.413@safari-7624-branch (a3d82cd35967). <a href="https://rdar.apple.com/176066815">rdar://176066815</a>
Canonical link: <a href="https://commits.webkit.org/314991@main">https://commits.webkit.org/314991@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96cd9ef5585ab6560190be164edb2ce54fda2369

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167709 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41206 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34801 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176766 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125390 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41641 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41219 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130492 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170668 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32917 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150697 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111009 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/31898 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/30595 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25499 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141885 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28392 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179306 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30110 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138889 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41278 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34753 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138774 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37382 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41966 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150184 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105142 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34042 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27063 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40470 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39867 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5166 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40118 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40012 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->