### PR TITLE
[JSC] Promise.resolve should not folded to identity on Promise subclasses

### DIFF
--- a/JSTests/stress/promise-resolve-subclass-not-identity.js
+++ b/JSTests/stress/promise-resolve-subclass-not-identity.js
@@ -1,0 +1,24 @@
+class MyPromise extends Promise {
+    constructor(exec) { 
+        super(exec); 
+        this.inlineProp1 = 1;
+    }
+}
+Object.defineProperty(MyPromise.prototype, 'constructor', { value: {} });
+
+function test(p) {
+    let dummy = p.inlineProp1; 
+    return Promise.resolve(p);
+}
+noInline(test);
+
+let prom = new MyPromise((r) => r());
+
+for (let i = 0; i < 10000; i++) {
+    test(prom);
+}
+
+let result = test(prom);
+if (result === prom) {
+    throw new Error("Promise.resolve should not be identity for subclasses");
+}

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -5999,9 +5999,13 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
 
                 if (argument.isType(SpecPromiseObject)) {
                     if (m_graph.isWatchingPromiseSpeciesWatchpoint(node)) {
-                        didFoldClobberWorld();
-                        forNode(node) = argument;
-                        break;
+                        if (auto structure = argument.m_structure.onlyStructure()) {
+                            if (structure.get() == globalObject->promiseStructure()) {
+                                didFoldClobberWorld();
+                                forNode(node) = argument;
+                                break;
+                            }
+                        }
                     }
                 }
 

--- a/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp
@@ -2021,11 +2021,15 @@ private:
 
                         if (argument.isType(SpecPromiseObject)) {
                             if (m_graph.isWatchingPromiseSpeciesWatchpoint(node)) {
-                                m_interpreter.execute(indexInBlock); // Push CFA over this node after we get the state before.
-                                alreadyHandled = true; // Don't allow the default constant folder to do things to this.
-                                node->convertToIdentityOn(node->child2().node());
-                                changed = true;
-                                break;
+                                if (auto structure = argument.m_structure.onlyStructure()) {
+                                    if (structure.get() == globalObject->promiseStructure()) {
+                                        m_interpreter.execute(indexInBlock); // Push CFA over this node after we get the state before.
+                                        alreadyHandled = true; // Don't allow the default constant folder to do things to this.
+                                        node->convertToIdentityOn(node->child2().node());
+                                        changed = true;
+                                        break;
+                                    }
+                                }
                             }
                         }
 


### PR DESCRIPTION
#### 0f5acb567be089fa9dab007127f06c7bd1fdd6e5
<pre>
[JSC] Promise.resolve should not folded to identity on Promise subclasses
<a href="https://bugs.webkit.org/show_bug.cgi?id=309612">https://bugs.webkit.org/show_bug.cgi?id=309612</a>
<a href="https://rdar.apple.com/172195606">rdar://172195606</a>

Reviewed by Yijia Huang.

Per spec, Promise.resolve(x) acts as identity on x iff x.constructor is Promise
(more pedantically, if it is the same object as the `this` value that the
resolve function was called with, which, when called on the global Promise, is
Promise). DFG currently incorrectly folds all builtin Promise subclasses to
identity as well.

This PR fixes the constant folding and abstract interpreter by restricting the
folding to arguments that have the builtin promise structure, i.e. is not a
subclass.

Test: JSTests/stress/promise-resolve-subclass-not-identity.js
* JSTests/stress/promise-resolve-subclass-not-identity.js: Added.
(MyPromise):
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGConstantFoldingPhase.cpp:
(JSC::DFG::ConstantFoldingPhase::foldConstants):

Originally-landed-as: 305413.447@rapid/safari-7624.2.5.110-branch (8fb39d0d2bd3). <a href="https://rdar.apple.com/176065429">rdar://176065429</a>
Canonical link: <a href="https://commits.webkit.org/314995@main">https://commits.webkit.org/314995@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/08a1a42a7d3897cc73fc70d526ac5b00cd153a1f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163699 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37183 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30402 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172639 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/120190 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37514 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37182 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127148 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89621 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166658 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29435 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147170 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107702 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28482 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27113 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20342 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/155850 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138381 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24887 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175144 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/24590 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28075 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26555 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135454 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36853 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31218 "Found 1 new test failure: http/tests/storageAccess/deny-due-to-no-interaction-under-general-third-party-cookie-blocking-ephemeral.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135437 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37385 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37638 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146682 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99726 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30751 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23536 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/196101 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36349 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109494 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51130 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35846 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1566 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36096 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/35993 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->