### PR TITLE
Gate InstallMockContentFilter IPC behind AllowTestOnlyIPC

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -334,6 +334,16 @@ AllowTestOnlyIPC:
       default: false
   sharedPreferenceForWebProcess: true
 
+AllowTestOnlyMockContentFilterIPC:
+  type: bool
+  status: embedder
+  exposed: [ WebKit ]
+  webcoreBinding: none
+  defaultValue:
+    WebKit:
+      default: false
+  sharedPreferenceForWebProcess: true
+
 AllowTestOnlyOriginAccessAllowListIPC:
   type: bool
   status: embedder

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
@@ -133,7 +133,7 @@ messages -> NetworkConnectionToWebProcess WantsDispatchMessage {
     PrioritizeResourceLoads(Vector<WebCore::ResourceLoaderIdentifier> loadIdentifiers)
 
 #if ENABLE(CONTENT_FILTERING)
-    InstallMockContentFilter(WebCore::MockContentFilterSettings settings)
+    [EnabledBy=AllowTestOnlyMockContentFilterIPC] InstallMockContentFilter(WebCore::MockContentFilterSettings settings)
 #endif
 
     UseRedirectionForCurrentNavigation(WebCore::ResourceLoaderIdentifier resourceLoadIdentifier, WebCore::ResourceResponse response)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ContentFiltering.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ContentFiltering.mm
@@ -35,6 +35,7 @@
 #import <WebCore/MockContentFilterSettings.h>
 #import <WebKit/WKErrorRef.h>
 #import <WebKit/WKNavigationDelegatePrivate.h>
+#import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKProcessPoolPrivate.h>
 #import <WebKit/WKWebView.h>
 #import <WebKit/WKWebViewPrivate.h>
@@ -42,6 +43,7 @@
 #import <WebKit/WebKit.h>
 #import <WebKit/WebKitErrorsPrivate.h>
 #import <WebKit/_WKDownloadDelegate.h>
+#import <WebKit/_WKFeature.h>
 #import <WebKit/_WKRemoteObjectInterface.h>
 #import <WebKit/_WKRemoteObjectRegistry.h>
 #import <pal/spi/cocoa/NEFilterSourceSPI.h>
@@ -157,6 +159,12 @@ static RetainPtr<WKWebViewConfiguration> configurationWithContentFilterSettings(
 {
     auto configuration = retainPtr([WKWebViewConfiguration _test_configurationWithTestPlugInClassName:@"ContentFilteringPlugIn"]);
     RetainPtr contentFilterEnabler = adoptNS([[MockContentFilterEnabler alloc] initWithDecision:decision decisionPoint:decisionPoint]);
+    for (_WKFeature *feature in [WKPreferences _features]) {
+        if ([feature.key isEqualToString:@"AllowTestOnlyMockContentFilterIPC"]) {
+            [[configuration preferences] _setEnabled:YES forFeature:feature];
+            break;
+        }
+    }
     [[configuration processPool] _setObject:contentFilterEnabler.get() forBundleParameter:NSStringFromClass([MockContentFilterEnabler class])];
     return configuration;
 }

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IPCTestingAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/IPCTestingAPI.mm
@@ -951,6 +951,92 @@ TEST(IPCTestingAPI, AddOriginAccessAllowListEntryAllowedWithTestOnlyIPC)
     EXPECT_WK_STREQ(result, "FETCHED:cross-origin-data");
 }
 
+#if ENABLE(CONTENT_FILTERING)
+
+static NSString *installMockContentFilterAndNavigateVictim(bool allowMockContentFilterIPC)
+{
+    using namespace TestWebKitAPI;
+
+    HTTPServer attackerServer({
+        { "/attacker"_s, { "<!DOCTYPE html>"_s } },
+        { "/evil"_s, { "<!DOCTYPE html><body>REDIRECTED</body>"_s } },
+    });
+    HTTPServer victimServer({
+        { "/victim"_s, { "<!DOCTYPE html><body>ORIGINAL</body>"_s } },
+    });
+
+    RetainPtr configA = adoptNS([[WKWebViewConfiguration alloc] init]);
+    for (_WKFeature *feature in [WKPreferences _features]) {
+        if ([feature.key isEqualToString:@"IPCTestingAPIEnabled"])
+            [[configA preferences] _setEnabled:YES forFeature:feature];
+        if ([feature.key isEqualToString:@"AllowTestOnlyMockContentFilterIPC"])
+            [[configA preferences] _setEnabled:allowMockContentFilterIPC forFeature:feature];
+    }
+
+    RetainPtr configB = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configB setProcessPool:[configA processPool]];
+
+    RetainPtr webViewA = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configA.get()]);
+    RetainPtr webViewB = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configB.get()]);
+
+    [webViewA loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%u/attacker", attackerServer.port()]]]];
+    [webViewA _test_waitForDidFinishNavigation];
+
+    [webViewA stringByEvaluatingJavaScript:[NSString stringWithFormat:
+        @"IPC.sendMessage('Networking', 0,"
+        "  IPC.messages.NetworkConnectionToWebProcess_InstallMockContentFilter.name,"
+        "  ["
+        "    { type: 'bool', value: 1 },"
+        "    { type: 'uint8_t', value: 0 },"
+        "    { type: 'bool', value: 0 },"
+        "    { type: 'bool', value: 1 },"
+        "    { type: 'String', value: '' },"
+        "    { type: 'String', value: 'http://127.0.0.1:%u/evil' },"
+        "    { type: 'double', value: 0 }"
+        "  ]"
+        ")", attackerServer.port()]];
+
+    Util::runFor(0.5_s);
+
+    [webViewB loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:[NSString stringWithFormat:@"http://127.0.0.1:%u/victim", victimServer.port()]]]];
+    [webViewB _test_waitForDidFinishNavigation];
+
+    NSString *bodyText = [webViewB stringByEvaluatingJavaScript:@"document.body.innerText"];
+
+    if (allowMockContentFilterIPC) {
+        // Reset MockContentFilterSettings since it is a process-global singleton in the NetworkProcess.
+        [webViewA stringByEvaluatingJavaScript:
+            @"IPC.sendMessage('Networking', 0,"
+            "  IPC.messages.NetworkConnectionToWebProcess_InstallMockContentFilter.name,"
+            "  ["
+            "    { type: 'bool', value: 0 },"
+            "    { type: 'uint8_t', value: 0 },"
+            "    { type: 'bool', value: 0 },"
+            "    { type: 'bool', value: 0 },"
+            "    { type: 'String', value: '' },"
+            "    { type: 'String', value: '' },"
+            "    { type: 'double', value: 0 }"
+            "  ]"
+            ")"];
+
+        Util::runFor(0.5_s);
+    }
+
+    return bodyText;
+}
+
+TEST(IPCTestingAPI, InstallMockContentFilterRequiresTestOnlyIPC)
+{
+    EXPECT_WK_STREQ(installMockContentFilterAndNavigateVictim(false), "ORIGINAL");
+}
+
+TEST(IPCTestingAPI, InstallMockContentFilterRedirectsWithTestOnlyIPC)
+{
+    EXPECT_WK_STREQ(installMockContentFilterAndNavigateVictim(true), "REDIRECTED");
+}
+
+#endif // ENABLE(CONTENT_FILTERING)
+
 #endif
 
 #if !HAVE(WK_SECURE_CODING_NSURLREQUEST)

--- a/Tools/WebKitTestRunner/TestController.cpp
+++ b/Tools/WebKitTestRunner/TestController.cpp
@@ -1433,6 +1433,7 @@ void TestController::resetPreferencesToConsistentValues(const TestOptions& optio
 
         WKPreferencesSetBoolValueForKeyForTesting(preferences, options.allowTestOnlyIPC(), toWK("AllowTestOnlyIPC").get());
         WKPreferencesSetBoolValueForKeyForTesting(preferences, false, toWK("GlobalPrivacyControlEnabled").get());
+        WKPreferencesSetBoolValueForKeyForTesting(preferences, options.allowTestOnlyMockContentFilterIPC(), toWK("AllowTestOnlyMockContentFilterIPC").get());
         WKPreferencesSetBoolValueForKeyForTesting(preferences, options.allowTestOnlyOriginAccessAllowListIPC(), toWK("AllowTestOnlyOriginAccessAllowListIPC").get());
 
         for (const auto& [key, value] : options.boolWebPreferenceFeatures())

--- a/Tools/WebKitTestRunner/TestOptions.cpp
+++ b/Tools/WebKitTestRunner/TestOptions.cpp
@@ -178,6 +178,7 @@ const TestFeatures& TestOptions::defaults()
         features.boolTestRunnerFeatures = {
             { "allowsLinkPreview", true },
             { "allowTestOnlyIPC", false },
+            { "allowTestOnlyMockContentFilterIPC", true },
             { "allowTestOnlyOriginAccessAllowListIPC", true },
             { "appHighlightsEnabled", false },
             { "dumpJSConsoleLogInStdErr", false },
@@ -264,6 +265,7 @@ const std::unordered_map<std::string, TestHeaderKeyType>& TestOptions::keyTypeMa
         { "allowsLinkPreview", TestHeaderKeyType::BoolTestRunner },
         { "appHighlightsEnabled", TestHeaderKeyType::BoolTestRunner },
         { "allowTestOnlyIPC", TestHeaderKeyType::BoolTestRunner },
+        { "allowTestOnlyMockContentFilterIPC", TestHeaderKeyType::BoolTestRunner },
         { "allowTestOnlyOriginAccessAllowListIPC", TestHeaderKeyType::BoolTestRunner },
         { "dumpJSConsoleLogInStdErr", TestHeaderKeyType::BoolTestRunner },
         { "dumpResourceLoadCallbacks", TestHeaderKeyType::BoolTestRunner },

--- a/Tools/WebKitTestRunner/TestOptions.h
+++ b/Tools/WebKitTestRunner/TestOptions.h
@@ -56,6 +56,7 @@ public:
     bool allowsLinkPreview() const { return boolTestRunnerFeatureValue("allowsLinkPreview"); }
     bool appHighlightsEnabled() const { return boolTestRunnerFeatureValue("appHighlightsEnabled"); }
     bool allowTestOnlyIPC() const { return boolTestRunnerFeatureValue("allowTestOnlyIPC"); }
+    bool allowTestOnlyMockContentFilterIPC() const { return boolTestRunnerFeatureValue("allowTestOnlyMockContentFilterIPC"); }
     bool allowTestOnlyOriginAccessAllowListIPC() const { return boolTestRunnerFeatureValue("allowTestOnlyOriginAccessAllowListIPC"); }
     bool dumpJSConsoleLogInStdErr() const { return boolTestRunnerFeatureValue("dumpJSConsoleLogInStdErr"); }
     bool editable() const { return boolTestRunnerFeatureValue("editable"); }


### PR DESCRIPTION
#### f10b871ab9020a41d4e398647cfe587045ec8097
<pre>
Gate InstallMockContentFilter IPC behind AllowTestOnlyIPC
<a href="https://bugs.webkit.org/show_bug.cgi?id=309091">https://bugs.webkit.org/show_bug.cgi?id=309091</a>
<a href="https://rdar.apple.com/171645964">rdar://171645964</a>

Reviewed by Ryosuke Niwa.

InstallMockContentFilter IPC on NetworkConnectionToWebProcess overwrites
a process-global MockContentFilterSettings singleton, allowing a
compromised WebContent process to redirect or block navigations for all
connections in the NetworkProcess.

This message is only used by test infrastructure to configure mock
content filtering. Gate it behind EnabledBy=AllowTestOnlyIPC so it is
rejected unless the test-only flag is set

Test: Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in:
* Tools/TestWebKitAPI/Tests/WebKitCocoa/ContentFiltering.mm:
(configurationWithContentFilterSettings):
* Tools/TestWebKitAPI/Tests/WebKitCocoa/IPCTestingAPI.mm:
(InstallMockContentFilterRequiresTestOnlyIPC)):
(InstallMockContentFilterRedirectsWithTestOnlyIPC)):
* Tools/WebKitTestRunner/TestController.cpp:
(WTR::TestController::resetPreferencesToConsistentValues):
* Tools/WebKitTestRunner/TestOptions.cpp:
(WTR::TestOptions::defaults):
(WTR::TestOptions::keyTypeMapping):
* Tools/WebKitTestRunner/TestOptions.h:
(WTR::TestOptions::allowTestOnlyMockContentFilterIPC const):

Originally-landed-as: 305413.453@rapid/safari-7624.2.5.110-branch (12bfbd5b45c3). <a href="https://rdar.apple.com/176065359">rdar://176065359</a>
Canonical link: <a href="https://commits.webkit.org/315249@main">https://commits.webkit.org/315249@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/29ee5f4eaef9fa1d389c6e8212ee0b4d3bdab0fa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168492 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42049 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35638 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177825 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126193 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170358 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42425 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42011 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131153 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92242 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171451 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33610 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151417 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111664 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32596 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31296 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26516 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/161111 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142582 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180420 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/29739 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33144 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30821 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139590 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42061 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/35459 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139449 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37550 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42749 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106407 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34734 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/27794 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/201170 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41253 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114509 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/54031 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40650 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5877 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40901 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40795 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->