### PR TITLE
Scrollbar appearance does not adapt to element's explicit dark background color

### DIFF
--- a/LayoutTests/scrollbars/element-dark-background-overlay-style-expected.txt
+++ b/LayoutTests/scrollbars/element-dark-background-overlay-style-expected.txt
@@ -1,0 +1,6 @@
+
+PASS Opaque dark background-color flips per-element scrollbar overlay style to light
+PASS Opaque light background-color leaves per-element scrollbar overlay style as default
+PASS Translucent background-color leaves per-element scrollbar overlay style as default
+PASS Absent background-color leaves per-element scrollbar overlay style as default
+

--- a/LayoutTests/scrollbars/element-dark-background-overlay-style.html
+++ b/LayoutTests/scrollbars/element-dark-background-overlay-style.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<title>Element scrollbar overlay style adapts to opaque dark background-color</title>
+<script src="../resources/testharness.js"></script>
+<script src="../resources/testharnessreport.js"></script>
+
+<style>
+.scroller {
+    overflow-x: hidden;
+    overflow-y: scroll;
+    width: 100px;
+    height: 50px;
+}
+.scroller > .content {
+    width: 100px;
+    height: 200px;
+}
+#dark-bg { background-color: #111111; }
+#light-bg { background-color: #ffffff; }
+#translucent-bg { background-color: rgba(0, 0, 0, 0.5); }
+#no-bg { /* no background-color */ }
+</style>
+
+<div id="dark-bg" class="scroller"><div class="content"></div></div>
+<div id="light-bg" class="scroller"><div class="content"></div></div>
+<div id="translucent-bg" class="scroller"><div class="content"></div></div>
+<div id="no-bg" class="scroller"><div class="content"></div></div>
+
+<script>
+test(function() {
+    if (!window.internals)
+        return;
+    assert_equals(internals.scrollbarOverlayStyle(document.getElementById("dark-bg")), "light");
+}, "Opaque dark background-color flips per-element scrollbar overlay style to light");
+
+test(function() {
+    if (!window.internals)
+        return;
+    assert_equals(internals.scrollbarOverlayStyle(document.getElementById("light-bg")), "default");
+}, "Opaque light background-color leaves per-element scrollbar overlay style as default");
+
+test(function() {
+    if (!window.internals)
+        return;
+    assert_equals(internals.scrollbarOverlayStyle(document.getElementById("translucent-bg")), "default");
+}, "Translucent background-color leaves per-element scrollbar overlay style as default");
+
+test(function() {
+    if (!window.internals)
+        return;
+    assert_equals(internals.scrollbarOverlayStyle(document.getElementById("no-bg")), "default");
+}, "Absent background-color leaves per-element scrollbar overlay style as default");
+</script>

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.cpp
@@ -1258,6 +1258,22 @@ void RenderLayerScrollableArea::updateScrollbarPresenceAndState(std::optional<bo
         Ref { *m_vBar }->setEnabled(verticalBarState == ScrollbarState::Enabled);
 }
 
+void RenderLayerScrollableArea::recalculateScrollbarOverlayStyle()
+{
+    auto bg = m_layer.renderer().style().visitedDependentBackgroundColorApplyingColorFilter();
+
+    auto desiredStyle = (bg.isOpaque() && bg.lightness() <= 0.5f)
+        ? ScrollbarOverlayStyle::Light
+        : ScrollbarOverlayStyle::Default;
+
+    if (scrollbarOverlayStyle() == desiredStyle)
+        return;
+
+    setScrollbarOverlayStyle(desiredStyle);
+    m_layer.setNeedsCompositingGeometryUpdate();
+    invalidateScrollCorner(scrollCornerRect());
+}
+
 void RenderLayerScrollableArea::updateScrollbarsAfterStyleChange(const RenderStyle* oldStyle)
 {
     // Overflow is a box concept.
@@ -1278,6 +1294,8 @@ void RenderLayerScrollableArea::updateScrollbarsAfterStyleChange(const RenderSty
 
     if (!m_scrollDimensionsDirty)
         updateScrollableAreaSet(hasScrollableHorizontalOverflow() || hasScrollableVerticalOverflow());
+
+    recalculateScrollbarOverlayStyle();
 
     const auto scrollbarsHaveDarkAppearance = useDarkAppearanceForScrollbars();
     if (scrollbarsHaveDarkAppearance != m_useDarkAppearanceForScrollbars) {

--- a/Source/WebCore/rendering/RenderLayerScrollableArea.h
+++ b/Source/WebCore/rendering/RenderLayerScrollableArea.h
@@ -291,6 +291,8 @@ private:
     void updateScrollCornerStyle();
     void updateResizerStyle();
 
+    void recalculateScrollbarOverlayStyle();
+
     Ref<Scrollbar> createScrollbar(ScrollbarOrientation);
     void destroyScrollbar(ScrollbarOrientation);
 


### PR DESCRIPTION
#### b0b9354efa84410822b565d76e26c6a5271dfe26
<pre>
Scrollbar appearance does not adapt to element&apos;s explicit dark background
<a href="https://bugs.webkit.org/show_bug.cgi?id=315258">https://bugs.webkit.org/show_bug.cgi?id=315258</a>
<a href="https://rdar.apple.com/176725069">rdar://176725069</a>

Reviewed by NOBODY (OOPS!).

A per-element scroller with an opaque dark `background-color` gets the
default overlay scrollbar, which paints dark on dark and is nearly
invisible. Frame-level scrollers already adapt to the page background;
per-element scrollers do not. Blink and Gecko both pick a light scrollbar
in this case.

Recompute the scroller's overlay style at style-change time. If the
scroller's own background-color is opaque and its lightness is <= 0.5,
set ScrollbarOverlayStyle::Light. Otherwise leave it Default. When the
style flips, request a compositing geometry update and invalidate the
scroll corner so the change takes effect on the next paint.

The patch deliberately does not inspect descendants or color-scheme.
Per review feedback, CSS-only inspection of those signals is unreliable:
descendants always paint over the scroller's own background, can use
background-images, and the visible color under the scrollbar gutter can
change as the user scrolls. The fully accurate answer is pixel sampling,
which is too expensive to run at style-change time and is tracked
separately under rdar://16131424. This change addresses the common
opaque-bg case from the radar without claiming to handle the rest.

* Source/WebCore/rendering/RenderLayerScrollableArea.cpp:
(WebCore::RenderLayerScrollableArea::recalculateScrollbarOverlayStyle):
(WebCore::RenderLayerScrollableArea::updateScrollbarsAfterStyleChange):
* Source/WebCore/rendering/RenderLayerScrollableArea.h:
* LayoutTests/scrollbars/element-dark-background-overlay-style.html: Added.
* LayoutTests/scrollbars/element-dark-background-overlay-style-expected.txt: Added.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b6baa8b83d681de09221729e04fe6b8f41b47d47

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165518 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39008 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32589 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174560 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122773 "Built successfully") 
| [  ~~🧪 bindings~~](https://ews-build.webkit.org/#/builders/9/builds/167384 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39344 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39012 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128630 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90586 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168477 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30981 "Found 2 new test failures: fast/events/touch/ios/touch-event-regions-layer-tree/mousemove-mouseup.html fast/forms/ios/drag-range-track.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148705 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109155 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30018 "Found 2 new test failures: imported/w3c/web-platform-tests/css/css-images/gradients-with-border.html imported/w3c/web-platform-tests/css/css-images/multiple-position-color-stop-linear.html (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28621 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22638 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139883 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26403 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177084 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29994 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28109 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136956 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39077 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32761 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136891 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39765 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148199 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/102191 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32163 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25066 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38275 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111349 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37672 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3146 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37918 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37816 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->