### PR TITLE
[AutoFill Debugging] Include identifiers for elements that appear clickable

### DIFF
--- a/LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt
@@ -11,6 +11,7 @@ root
             'This button does nothing' […]
             input uid=… […] placeholder='Enter text here'
             uid=… role=button 'Clickable Div' […]
+            uid=… 'Clickable Div 2' […]
         section label='ARIA Labeling Examples'
             'Name Field' […]
             'Description' […]

--- a/LayoutTests/fast/text-extraction/debug-text-extraction-basic.html
+++ b/LayoutTests/fast/text-extraction/debug-text-extraction-basic.html
@@ -40,6 +40,18 @@ canvas {
 #error-text {
     display: none;
 }
+
+.clickable {
+    cursor: pointer;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    border-radius: 6px;
+    max-width: 120px;
+    text-align: center;
+}
+
+.clickable:hover {
+    opacity: 0.8;
+}
 </style>
 <script src="../../resources/ui-helper.js"></script>
 </head>
@@ -59,6 +71,7 @@ canvas {
         <div id="btn-help" aria-hidden="true">This button does nothing</div>
         <input type="text" class="focusable" placeholder="Enter text here" onfocus="this.style.backgroundColor='yellow'" onblur="this.style.backgroundColor=''" aria-required="true" aria-invalid="false" />
         <div class="interactive" tabindex="0"  role="button" onclick="this.textContent = 'Clicked!'" onkeydown="if(event.key==='Enter') this.click()" aria-pressed="false">Clickable Div</div>
+        <div class="clickable">Clickable Div 2</div>
     </section>
     <section id="section2" aria-label="ARIA Labeling Examples">
         <div id="label1">Name Field</div>

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -868,16 +868,40 @@ static bool areSameOrigin(Document& document, Document& other)
     return protect(document.securityOrigin())->isSameOriginAs(protect(other.securityOrigin()));
 }
 
-static bool isVisuallyDistinctContainer(const RenderStyle& style, const FloatRect& rect, const FloatRect&)
+static bool hasVisuallyDistinctStyling(const RenderStyle& style)
 {
     bool hasEnclosingBorder = style.border().hasVisibleBorder() && style.usedBorderTopWidth() && style.usedBorderRightWidth() && style.usedBorderBottomWidth() && style.usedBorderLeftWidth();
-    bool hasVisualStyling = style.hasBackground() || style.hasOutline() || !style.boxShadow().isNone() || style.hasExplicitlySetBorderRadius() || hasEnclosingBorder;
-    if (!hasVisualStyling)
+    return style.hasBackground() || style.hasOutline() || !style.boxShadow().isNone() || style.hasExplicitlySetBorderRadius() || hasEnclosingBorder;
+}
+
+static bool isVisuallyDistinctContainer(const RenderStyle& style, const FloatRect& rect)
+{
+    if (!hasVisuallyDistinctStyling(protect(style)))
         return false;
 
     static constexpr auto minimumWidth = 150;
     static constexpr auto minimumHeight = 90;
     return rect.width() >= minimumWidth && rect.height() >= minimumHeight;
+}
+
+static bool looksVisuallyClickable(const RenderObject& renderer)
+{
+    CheckedRef style = renderer.style();
+    if (style->cursorType() != CursorType::Pointer)
+        return false;
+
+    if (style->pointerEvents() == PointerEvents::None)
+        return false;
+
+    if (!hasVisuallyDistinctStyling(protect(style)))
+        return false;
+
+    CheckedPtr parent = renderer.parent();
+    if (!parent)
+        return false;
+
+    CheckedRef parentStyle = parent->style();
+    return parentStyle->cursorType() != CursorType::Pointer || parentStyle->pointerEvents() == PointerEvents::None;
 }
 
 static inline void extractRecursive(Node& node, Item& parentItem, TraversalContext& context)
@@ -909,7 +933,7 @@ static inline void extractRecursive(Node& node, Item& parentItem, TraversalConte
     bool pushedVisualBlockContainer = false;
     if (CheckedPtr renderer = node.renderer()) {
         auto nodeBounds = rootViewBounds(node);
-        if (isBlock && isVisuallyDistinctContainer(protect(renderer->style()).get(), nodeBounds, parentItem.rectInRootView)) {
+        if (isBlock && isVisuallyDistinctContainer(protect(renderer->style()).get(), nodeBounds)) {
             context.visualBlockContainerStack.append(context.nextVisualBlockContainerNumber++);
             pushedVisualBlockContainer = true;
         }
@@ -1027,6 +1051,16 @@ static inline void extractRecursive(Node& node, Item& parentItem, TraversalConte
         }
     }
 
+    bool shouldIdentifyClickableElement = [&] {
+        if (context.nodeIdentifierInclusion != NodeIdentifierInclusion::Interactive)
+            return false;
+
+        if (CheckedPtr renderer = node.renderer())
+            return looksVisuallyClickable(*renderer);
+
+        return false;
+    }();
+
     auto policy = [&] {
         if (eventListeners)
             return FallbackPolicy::Extract;
@@ -1041,6 +1075,9 @@ static inline void extractRecursive(Node& node, Item& parentItem, TraversalConte
             return FallbackPolicy::Extract;
 
         if (!clientAttributes.isEmpty())
+            return FallbackPolicy::Extract;
+
+        if (shouldIdentifyClickableElement)
             return FallbackPolicy::Extract;
 
         return FallbackPolicy::Skip;
@@ -1087,7 +1124,7 @@ static inline void extractRecursive(Node& node, Item& parentItem, TraversalConte
             isScrollable = std::holds_alternative<ScrollableItemData>(result);
 
             std::optional<NodeIdentifier> nodeIdentifier;
-            if (shouldIncludeNodeIdentifier(context.nodeIdentifierInclusion, eventListeners, AccessibilityObject::ariaRoleToWebCoreRole(role), result))
+            if (shouldIdentifyClickableElement || shouldIncludeNodeIdentifier(context.nodeIdentifierInclusion, eventListeners, AccessibilityObject::ariaRoleToWebCoreRole(role), result))
                 nodeIdentifier = node.nodeIdentifier();
 
             item = { {


### PR DESCRIPTION
#### 52f0fa51701de2abe589c80250124caab3cf1e48
<pre>
[AutoFill Debugging] Include identifiers for elements that appear clickable
<a href="https://bugs.webkit.org/show_bug.cgi?id=315256">https://bugs.webkit.org/show_bug.cgi?id=315256</a>
<a href="https://rdar.apple.com/177586494">rdar://177586494</a>

Reviewed by Richard Robinson and Abrar Rahman Protyasha.

Extract node identifiers for elements that appear clickable, even if a click or mouse-related event
listener isn&apos;t directly on the element itself. This encompasses elements which satisfy all of the
following criteria:

- Is styled with `cursor: pointer;`
- Parent is not styled with `cursor: pointer;`
- Is visually distinct (based on existing heuristics for markdown segmentation).

* LayoutTests/fast/text-extraction/debug-text-extraction-basic-expected.txt:
* LayoutTests/fast/text-extraction/debug-text-extraction-basic.html:

Adjust an existing layout test to cover this change.

* Source/WebCore/page/text-extraction/TextExtraction.cpp:
(WebCore::TextExtraction::hasVisuallyDistinctStyling):
(WebCore::TextExtraction::isVisuallyDistinctContainer):
(WebCore::TextExtraction::looksVisuallyClickable):
(WebCore::TextExtraction::extractRecursive):

Canonical link: <a href="https://commits.webkit.org/313662@main">https://commits.webkit.org/313662@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/e22c909a35d932f044ed63ed59ef12335889ded1

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163706 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37190 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30409 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172646 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/120197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165575 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37521 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37189 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127153 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/120197 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166665 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29438 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147178 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107707 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28485 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27119 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20349 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138384 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24895 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175151 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28082 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26563 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135464 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36860 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31224 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135442 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36518 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37645 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146690 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99734 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30754 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23544 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36356 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109501 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35853 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1574 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36103 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36000 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->