### PR TITLE
Potential 'overflow' issue committed to upstream libwebrtc

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/test/acm_random.h
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/test/acm_random.h
@@ -52,6 +52,13 @@ class ACMRandom {
     return (value >> 19) & 0xfff;
   }
 
+  uint16_t Rand10() {
+    const uint32_t value =
+        random_.Generate(testing::internal::Random::kMaxRange);
+    // There's a bit more entropy in the upper bits of this implementation.
+    return (value >> 21) & 0x3ff;
+  }
+
   uint8_t Rand8() {
     const uint32_t value =
         random_.Generate(testing::internal::Random::kMaxRange);

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/test/encode_api_test.cc
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/test/encode_api_test.cc
@@ -54,7 +54,8 @@ void *Memset16(void *dest, int val, size_t length) {
 }
 
 vpx_image_t *CreateImage(vpx_bit_depth_t bit_depth, vpx_img_fmt_t fmt,
-                         unsigned int width, unsigned int height) {
+                         unsigned int width, unsigned int height,
+                         libvpx_test::ACMRandom *rng = nullptr) {
   assert(fmt != VPX_IMG_FMT_NV12);
   if (bit_depth > VPX_BITS_8) {
     fmt = static_cast<vpx_img_fmt_t>(fmt | VPX_IMG_FMT_HIGHBITDEPTH);
@@ -62,26 +63,38 @@ vpx_image_t *CreateImage(vpx_bit_depth_t bit_depth, vpx_img_fmt_t fmt,
   vpx_image_t *image = vpx_img_alloc(nullptr, fmt, width, height, 1);
   if (!image) return image;
 
-  const int val = 1 << (bit_depth - 1);
+  auto get_val = [bit_depth, &rng]() {
+    if (rng != nullptr) {
+      switch (bit_depth) {
+        case VPX_BITS_8: return static_cast<int>(rng->Rand8());
+        case VPX_BITS_10: return static_cast<int>(rng->Rand10());
+        case VPX_BITS_12: return static_cast<int>(rng->Rand12());
+      }
+    }
+    return 1 << (bit_depth - 1);
+  };
+  const int val_y = get_val();
+  const int val_u = get_val();
+  const int val_v = get_val();
   const unsigned int uv_h =
       (image->d_h + image->y_chroma_shift) >> image->y_chroma_shift;
   const unsigned int uv_w =
       (image->d_w + image->x_chroma_shift) >> image->x_chroma_shift;
   if (bit_depth > VPX_BITS_8) {
     for (unsigned int i = 0; i < image->d_h; ++i) {
-      Memset16(image->planes[0] + i * image->stride[0], val, image->d_w);
+      Memset16(image->planes[0] + i * image->stride[0], val_y, image->d_w);
     }
     for (unsigned int i = 0; i < uv_h; ++i) {
-      Memset16(image->planes[1] + i * image->stride[1], val, uv_w);
-      Memset16(image->planes[2] + i * image->stride[2], val, uv_w);
+      Memset16(image->planes[1] + i * image->stride[1], val_u, uv_w);
+      Memset16(image->planes[2] + i * image->stride[2], val_v, uv_w);
     }
   } else {
     for (unsigned int i = 0; i < image->d_h; ++i) {
-      memset(image->planes[0] + i * image->stride[0], val, image->d_w);
+      memset(image->planes[0] + i * image->stride[0], val_y, image->d_w);
     }
     for (unsigned int i = 0; i < uv_h; ++i) {
-      memset(image->planes[1] + i * image->stride[1], val, uv_w);
-      memset(image->planes[2] + i * image->stride[2], val, uv_w);
+      memset(image->planes[1] + i * image->stride[1], val_u, uv_w);
+      memset(image->planes[2] + i * image->stride[2], val_v, uv_w);
     }
   }
 
@@ -1197,7 +1210,9 @@ class VP9Encoder {
 
   void Configure(unsigned int threads, unsigned int width, unsigned int height,
                  vpx_rc_mode end_usage, vpx_enc_deadline_t deadline);
-  void Encode(bool key_frame);
+  // If `rng` is non-null, use it to generate the image values for encoding.
+  // Otherwise the midpoint of the configured bitdepth is used.
+  void Encode(bool key_frame, libvpx_test::ACMRandom *rng = nullptr);
 
  private:
   const int speed_;
@@ -1264,10 +1279,10 @@ void VP9Encoder::Configure(unsigned int threads, unsigned int width,
       << vpx_codec_error_detail(&enc_);
 }
 
-void VP9Encoder::Encode(bool key_frame) {
+void VP9Encoder::Encode(bool key_frame, libvpx_test::ACMRandom *rng) {
   assert(initialized_);
   const vpx_codec_cx_pkt_t *pkt;
-  vpx_image_t *image = CreateImage(bit_depth_, fmt_, cfg_.g_w, cfg_.g_h);
+  vpx_image_t *image = CreateImage(bit_depth_, fmt_, cfg_.g_w, cfg_.g_h, rng);
   ASSERT_NE(image, nullptr);
   const vpx_enc_frame_flags_t frame_flags = key_frame ? VPX_EFLAG_FORCE_KF : 0;
   ASSERT_EQ(
@@ -2260,6 +2275,25 @@ TEST(EncodeAPI, PerFramePsnrNotSupportedWithLagInFrames) {
   vpx_img_free(image);
   ASSERT_EQ(vpx_codec_destroy(&enc), VPX_CODEC_OK);
 }
+
+TEST(EncodeAPI, Buganizer487259772ScaledRefs) {
+  libvpx_test::ACMRandom rng;
+  VP9Encoder encoder(/*speed=*/7, /*row_mt=*/0, VPX_BITS_8, VPX_IMG_FMT_I420);
+  encoder.Configure(/*threads=*/1, /*width=*/478, /*height=*/755, VPX_VBR,
+                    VPX_DL_REALTIME);
+  encoder.Configure(/*threads=*/1, /*width=*/387, /*height=*/438, VPX_VBR,
+                    VPX_DL_REALTIME);
+  encoder.Encode(/*key_frame=*/false, &rng);
+  encoder.Encode(/*key_frame=*/true, &rng);
+  encoder.Encode(/*key_frame=*/false, &rng);
+  encoder.Encode(/*key_frame=*/false, &rng);
+
+  encoder.Configure(/*threads=*/1, /*width=*/341, /*height=*/655, VPX_VBR,
+                    VPX_DL_REALTIME);
+  encoder.Encode(/*key_frame=*/false, &rng);
+  encoder.Encode(/*key_frame=*/false, &rng);
+}
+
 #endif  // CONFIG_VP9_ENCODER
 
 }  // namespace

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/encoder/vp9_pickmode.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libvpx/source/libvpx/vp9/encoder/vp9_pickmode.c
@@ -2285,6 +2285,18 @@ void vp9_pick_inter_mode(VP9_COMP *cpi, MACROBLOCK *x, TileDataEnc *tile_data,
     // need to compute best_pred_sad which is only used to skip golden NEWMV.
     if (use_golden_nonzeromv && this_mode == NEWMV && ref_frame == LAST_FRAME &&
         frame_mv[NEWMV][LAST_FRAME].as_int != INVALID_MV) {
+      struct buf_2d backup_yv12[MAX_MB_PLANE] = { { 0, 0 } };
+      const YV12_BUFFER_CONFIG *scaled_ref_frame =
+          vp9_get_scaled_ref_frame(cpi, ref_frame);
+      if (scaled_ref_frame) {
+        assert(scaled_ref_frame->y_width == cpi->Source->y_width &&
+               scaled_ref_frame->y_height == cpi->Source->y_height);
+        // Swap out the reference frame for a version that's been scaled to
+        // match the resolution of the current frame, allowing the existing
+        // motion search code to be used without additional modifications.
+        for (i = 0; i < MAX_MB_PLANE; i++) backup_yv12[i] = xd->plane[i].pre[0];
+        vp9_setup_pre_planes(xd, 0, scaled_ref_frame, mi_row, mi_col, NULL);
+      }
       const int pre_stride = xd->plane[0].pre[0].stride;
       const uint8_t *const pre_buf =
           xd->plane[0].pre[0].buf +
@@ -2293,6 +2305,9 @@ void vp9_pick_inter_mode(VP9_COMP *cpi, MACROBLOCK *x, TileDataEnc *tile_data,
       best_pred_sad = cpi->fn_ptr[bsize].sdf(
           x->plane[0].src.buf, x->plane[0].src.stride, pre_buf, pre_stride);
       x->pred_mv_sad[LAST_FRAME] = best_pred_sad;
+      if (scaled_ref_frame) {
+        for (i = 0; i < MAX_MB_PLANE; i++) xd->plane[i].pre[0] = backup_yv12[i];
+      }
     }
 
     if (this_mode != NEARESTMV && !comp_pred &&


### PR DESCRIPTION
#### 4d05d732e5a84f32675bef4cc135a2e7a9269a87
<pre>
Potential &apos;overflow&apos; issue committed to upstream libwebrtc
<a href="https://rdar.apple.com/171591550">rdar://171591550</a>

Reviewed by Jean-Yves Avenard.

Cherry-picking of <a href="https://github.com/webmproject/libvpx/commit/ab5ec7a1852f634b81d29ade3c5fa74056498973">https://github.com/webmproject/libvpx/commit/ab5ec7a1852f634b81d29ade3c5fa74056498973</a>, given WebKit uses that code path.

Originally-landed-as: 305413.428@rapid/safari-7624.2.5.110-branch (b29ab81cd8b0). <a href="https://rdar.apple.com/176066736">rdar://176066736</a>
Canonical link: <a href="https://commits.webkit.org/314998@main">https://commits.webkit.org/314998@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/61e7d5eadca251fac115cd31146d5befdfb53c45

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163709 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37193 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30412 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172649 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/120200 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37524 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37192 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127157 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89626 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166668 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29445 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147179 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107711 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28492 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27122 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20352 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138391 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24896 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175154 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26564 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135463 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36863 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31227 "Found 1 new test failure: http/tests/storageAccess/deny-due-to-no-interaction-under-general-third-party-cookie-blocking-ephemeral.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135446 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37387 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37648 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146691 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99741 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30760 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23545 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36359 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35856 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1575 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36106 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36003 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->