### PR TITLE
Cherry-pick(s) 33ae1ab583c7. rdar://176067106

### DIFF
--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -2447,9 +2447,15 @@ void NetworkStorageManager::importServiceWorkerRegistrationsForOrigin(const WebC
     if (m_closed)
         return completionHandler(std::nullopt);
 
+<<<<<<< HEAD
     RELEASE_LOG(Storage, "%p - NetworkStorageManager::importServiceWorkerRegistrationsForOrigin: Starting import", this);
     auto startTime = MonotonicTime::now();
     workQueue().dispatchWithQOS([this, protectedThis = Ref { *this }, topOrigin = crossThreadCopy(topOrigin), startTime, completionHandler = WTF::move(completionHandler)]() mutable {
+=======
+    RELEASE_LOG(Storage, "%p - NetworkStorageManager::importServiceWorkerRegistrations: Starting import", this);
+    auto startTime = MonotonicTime::now();
+    workQueue().dispatchWithQOS([this, protectedThis = Ref { *this }, startTime, completionHandler = WTF::move(completionHandler)]() mutable {
+>>>>>>> 33ae1ab583c7 (Bump QoS of the work queue during service worker registrations import)
         assertIsCurrent(workQueue());
 
         std::optional<Vector<WebCore::ServiceWorkerContextData>> result;
@@ -2470,6 +2476,7 @@ void NetworkStorageManager::importServiceWorkerRegistrationsForOrigin(const WebC
         }
 
         RunLoop::mainSingleton().dispatch([protectedThis = WTF::move(protectedThis), startTime, result = crossThreadCopy(WTF::move(result)), completionHandler = WTF::move(completionHandler)]() mutable {
+<<<<<<< HEAD
 #if !RELEASE_LOG_DISABLED
             auto elapsed = MonotonicTime::now() - startTime;
             RELEASE_LOG(Storage, "%p - NetworkStorageManager::importServiceWorkerRegistrationsForOrigin: Imported %zu registrations in %.0f ms", protectedThis.ptr(), result ? result->size() : 0, elapsed.milliseconds());
@@ -2519,6 +2526,16 @@ void NetworkStorageManager::importServiceWorkerOriginList(CompletionHandler<void
             completionHandler(WTF::move(result));
         });
     }, WorkQueue::QOS::UserInitiated);
+=======
+            auto elapsed = MonotonicTime::now() - startTime;
+            if (elapsed > 2_s)
+                RELEASE_LOG_ERROR(Storage, "%p - NetworkStorageManager::importServiceWorkerRegistrations: Imported %zu registrations in %.0f ms", protectedThis.ptr(), result ? result->size() : 0, elapsed.milliseconds());
+            else
+                RELEASE_LOG(Storage, "%p - NetworkStorageManager::importServiceWorkerRegistrations: Imported %zu registrations in %.0f ms", protectedThis.ptr(), result ? result->size() : 0, elapsed.milliseconds());
+            completionHandler(WTF::move(result));
+        });
+    }, WorkQueue::QOS::UserInitiated);
+>>>>>>> 33ae1ab583c7 (Bump QoS of the work queue during service worker registrations import)
 }
 
 void NetworkStorageManager::updateServiceWorkerRegistrations(Vector<WebCore::ServiceWorkerContextData>&& registrationsToUpdate, Vector<WebCore::ServiceWorkerRegistrationKey>&& registrationsToDelete, CompletionHandler<void(std::optional<Vector<WebCore::ServiceWorkerScripts>>)>&& completionHandler)


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://176067106 to main. [33ae1ab583c7] caused a merge conflict. 

```Bump QoS of the work queue during service worker registrations import
https://bugs.webkit.org/show_bug.cgi?id=309626
rdar://172236600

Reviewed by Sihui Liu.

Bump QoS of the work queue during service worker registrations import
from disk. Navigations are delayed until the import is complete and it
is thus important to treat the import with high (UserInitiated) priority.

* Source/WTF/wtf/SuspendableWorkQueue.cpp:
(WTF::SuspendableWorkQueue::dispatchWithQOS):
* Source/WTF/wtf/SuspendableWorkQueue.h:
* Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
(WebKit::NetworkStorageManager::importServiceWorkerRegistrations):

Originally-landed-as: 305413.439@rapid/safari-7624.2.5.110-branch (33ae1ab583c7). rdar://176067106

```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d1eaa8cf28cb1d3cbd206bef919948234a255569

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163710 "3 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37194 "Hash d1eaa8cf for PR 65373 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30413 "Hash d1eaa8cf for PR 65373 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172650 "Hash d1eaa8cf for PR 65373 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/120201 "Hash d1eaa8cf for PR 65373 does not build (failure)") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37525 "Hash d1eaa8cf for PR 65373 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37193 "Hash d1eaa8cf for PR 65373 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/172650 "Hash d1eaa8cf for PR 65373 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/120201 "Hash d1eaa8cf for PR 65373 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166669 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/37525 "Hash d1eaa8cf for PR 65373 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/30413 "Hash d1eaa8cf for PR 65373 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/172650 "Hash d1eaa8cf for PR 65373 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/37525 "Hash d1eaa8cf for PR 65373 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/37193 "Hash d1eaa8cf for PR 65373 does not build (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20353 "Hash d1eaa8cf for PR 65373 does not build (failure)") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/37525 "Hash d1eaa8cf for PR 65373 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/30413 "Hash d1eaa8cf for PR 65373 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175155 "Hash d1eaa8cf for PR 65373 does not build (failure)") | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28086 "Failed to build and analyze WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/30413 "Hash d1eaa8cf for PR 65373 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/175155 "Hash d1eaa8cf for PR 65373 does not build (failure)") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36864 "Hash d1eaa8cf for PR 65373 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/37193 "Hash d1eaa8cf for PR 65373 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/175155 "Hash d1eaa8cf for PR 65373 does not build (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37649 "Hash d1eaa8cf for PR 65373 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/30413 "Hash d1eaa8cf for PR 65373 does not build (failure)") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99742 "Hash d1eaa8cf for PR 65373 does not build (failure)") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/37649 "Hash d1eaa8cf for PR 65373 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/30413 "Hash d1eaa8cf for PR 65373 does not build (failure)") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36360 "Hash d1eaa8cf for PR 65373 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109505 "Failed to build and analyze WebKit") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35857 "Hash d1eaa8cf for PR 65373 does not build (failure)") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/30413 "Hash d1eaa8cf for PR 65373 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36107 "Hash d1eaa8cf for PR 65373 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36004 "Hash d1eaa8cf for PR 65373 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->