### PR TITLE
Fix ProxyingNetworkAgent message receiver leak across process swaps

### DIFF
--- a/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.cpp
+++ b/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.cpp
@@ -157,7 +157,28 @@ ProxyingNetworkAgent::ProxyingNetworkAgent(WebKit::WebPageAgentContext& context)
 {
 }
 
-ProxyingNetworkAgent::~ProxyingNetworkAgent() = default;
+ProxyingNetworkAgent::~ProxyingNetworkAgent()
+{
+    // Backstop in case Inspector teardown bypasses willDestroyFrontendAndBackend().
+    removeAllRegisteredReceivers();
+}
+
+void ProxyingNetworkAgent::removeAllRegisteredReceivers()
+{
+    // Iterate by ProcessIdentifier so we reach swapped-out processes that
+    // forEachWebContentProcess() no longer enumerates. We rely on the
+    // inspected WebPageProxy keeping its WebProcessProxy alive until after
+    // WebPageInspectorController tears down; cross-origin iframe processes
+    // are kept alive by their own page state. processForIdentifier() returning
+    // null would mean the proxy was already destructed, in which case
+    // m_messageReceiverMapCount would leak here -- ~AuxiliaryProcessProxy does
+    // not invalidate its receiver map.
+    for (auto& [key, _] : std::exchange(m_instrumentedProcessPageCounts, { })) {
+        auto [processID, pageID] = key;
+        if (RefPtr webProcess = WebKit::WebProcessProxy::processForIdentifier(processID))
+            webProcess->removeMessageReceiver(Messages::ProxyingNetworkAgent::messageReceiverName(), pageID);
+    }
+}
 
 void ProxyingNetworkAgent::didCreateFrontendAndBackend()
 {
@@ -221,21 +242,21 @@ CommandResult<void> ProxyingNetworkAgent::disable()
 
     m_enabled = false;
 
-    // Force-teardown: disable all processes unconditionally, bypassing refcount
-    // discipline in disableInstrumentationForProcess(). This is correct because
-    // disable() is called when the Network domain is torn down entirely --
-    // no per-frame refcount preservation is needed.
-    Ref inspectedPage = m_inspectedPage.get();
-    inspectedPage->forEachWebContentProcess([&](auto& webProcess, auto pageID) {
-        auto key = std::make_pair(webProcess.coreProcessIdentifier(), pageID);
-        if (!m_instrumentedProcessPageCounts.contains(key))
-            return;
-        Ref protectedWebProcess { webProcess };
-        protectedWebProcess->send(Messages::WebInspectorBackend::DisableNetworkInstrumentation { }, pageID);
-        protectedWebProcess->removeMessageReceiver(Messages::ProxyingNetworkAgent::messageReceiverName(), pageID);
-    });
-
-    m_instrumentedProcessPageCounts.clear();
+    // Force-teardown: disable all processes unconditionally, bypassing the
+    // refcount discipline in disableInstrumentationForProcess(). This is
+    // correct because disable() is called when the Network domain is torn
+    // down entirely -- no per-frame refcount preservation is needed.
+    //
+    // Iterate the registration map, not forEachWebContentProcess(): under
+    // Site Isolation a process may have swapped out while still holding our
+    // message receiver, in which case forEachWebContentProcess() would no
+    // longer enumerate it.
+    for (auto& [key, _] : m_instrumentedProcessPageCounts) {
+        auto [processID, pageID] = key;
+        if (RefPtr webProcess = WebKit::WebProcessProxy::processForIdentifier(processID))
+            webProcess->send(Messages::WebInspectorBackend::DisableNetworkInstrumentation { }, pageID);
+    }
+    removeAllRegisteredReceivers();
 
     return { };
 }

--- a/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.h
+++ b/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.h
@@ -108,6 +108,8 @@ private:
     void loadingFailed(ResourceID, double timestamp, const String& errorText, bool canceled);
     void requestServedFromMemoryCache(ResourceID, FrameID, ContextID, const String& documentURL, const WebCore::ResourceRequest&, const WebCore::ResourceResponse&, ResourceType, double timestamp);
 
+    void removeAllRegisteredReceivers();
+
     const UniqueRef<NetworkFrontendDispatcher> m_frontendDispatcher;
     const Ref<NetworkBackendDispatcher> m_backendDispatcher;
     WeakRef<WebKit::WebPageProxy> m_inspectedPage;


### PR DESCRIPTION
#### 0cf61b7a19b4202e3547751c4b016033582be19f
<pre>
Fix ProxyingNetworkAgent message receiver leak across process swaps
<a href="https://bugs.webkit.org/show_bug.cgi?id=314902">https://bugs.webkit.org/show_bug.cgi?id=314902</a>
<a href="https://rdar.apple.com/177178776">rdar://177178776</a>

Reviewed by Sihui Liu and Qianlang Chen.

ASSERTION FAILED: !m_messageReceiverMapCount in ~MessageReceiver, on
Tahoe Debug, observed flaking on http/tests/ssl/applepay/ApplePayButton.html
when the Inspector SI tests that ran before it left ProxyingNetworkAgent
registrations behind on swapped-out WebProcessProxy instances.

ProxyingNetworkAgent::enableInstrumentationForProcess registers itself
as a per-page IPC message receiver on each WebProcessProxy hosting a
frame. Under Site Isolation, when a frame swaps process (provisional
commit, cross-origin navigation), the swapped-out process leaves
forEachWebContentProcess() but its addMessageReceiver registration on
*this remains. disable() iterated forEachWebContentProcess() and so
only cleaned up currently-associated processes; m_instrumentedProcessPageCounts
was then cleared without removing receivers from the stale processes,
leaking m_messageReceiverMapCount on the agent. Once Inspector
disconnected and ~ProxyingNetworkAgent ran (when WebPageProxy itself
later died), MessageReceiver&apos;s destructor asserted.

* Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.h:
* Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.cpp:
(Inspector::ProxyingNetworkAgent::~ProxyingNetworkAgent):
  Drain any leftover receiver registrations as a backstop for teardown
  paths that bypass willDestroyFrontendAndBackend() -&gt; disable().
(Inspector::ProxyingNetworkAgent::removeAllRegisteredReceivers):
  Iterate m_instrumentedProcessPageCounts, look up each WebProcessProxy
  by ProcessIdentifier, and call removeMessageReceiver. Skip when the
  proxy is gone -- the inspected WebPageProxy keeps its main
  WebProcessProxy alive until after WebPageInspectorController tears
  down, and cross-origin iframe processes are kept alive by their own
  page state, so in practice the lookup succeeds.
(Inspector::ProxyingNetworkAgent::disable):
  Iterate the registration map directly instead of
  forEachWebContentProcess() so we notify and unregister from every
  process we registered against, including stale ones.

Canonical link: <a href="https://commits.webkit.org/313741@main">https://commits.webkit.org/313741@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/607a072008c4eb2fc275522383e69cab315c5316

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163865 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37349 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30568 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172893 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/50024d48-63c9-4fd8-b754-9dfa2babab66) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37681 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37348 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127288 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121116 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a81f0983-af32-456f-bef7-ba4b0947b4e1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166824 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29574 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147311 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107837 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/adc8e927-e2d3-4af9-9f2d-f5c8c73abd0f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28620 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27248 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20658 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138520 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175415 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28241 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26696 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135595 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37019 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31358 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135570 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36563 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37804 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146823 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99941 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30882 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23678 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36515 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109660 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36012 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1711 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36262 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36159 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->