### PR TITLE
SkiaCompositingLayer::paintWithIntermediateSurface: wrong clip rect offset

### DIFF
--- a/LayoutTests/css3/filters/backdrop/backdrop-inset-opacity-expected.html
+++ b/LayoutTests/css3/filters/backdrop/backdrop-inset-opacity-expected.html
@@ -1,0 +1,34 @@
+<!DOCTYPE html>
+<style>
+  #b {
+      position: absolute;
+      background: green;
+      width: 100px;
+      height: 100px;
+      left: 150px;
+      top: 50px;
+      opacity: 0.5;
+      will-change: transform;
+  }
+  #c {
+      position: absolute;
+      background: blue;
+      width: 100px;
+      height: 100px;
+      left: 50px;
+      top: 50px;
+      will-change: transform;
+  }
+  #backdrop {
+      position: absolute;
+      left: 70px;
+      top: 120px;
+      width: 160px;
+      height: 160px;
+      backdrop-filter: invert();
+  }
+</style>
+<div id=b>
+  <div id=c></div>
+</div>
+<div id="backdrop"></div>

--- a/LayoutTests/css3/filters/backdrop/backdrop-inset-opacity.html
+++ b/LayoutTests/css3/filters/backdrop/backdrop-inset-opacity.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<style>
+  #b {
+      position: absolute;
+      background: green;
+      width: 100px;
+      height: 100px;
+      left: 150px;
+      top: 50px;
+      opacity: 0.5;
+      will-change: transform;
+  }
+  #c {
+      position: absolute;
+      background: blue;
+      width: 100px;
+      height: 100px;
+      left: 50px;
+      top: 50px;
+      will-change: transform;
+  }
+  #backdrop {
+      position: absolute;
+      left: 50px;
+      top: 100px;
+      width: 200px;
+      height: 200px;
+      backdrop-filter: invert();
+      clip-path: inset(20px);
+  }
+</style>
+<div id=b>
+  <div id=c></div>
+</div>
+<div id="backdrop"></div>

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -741,7 +741,7 @@ void SkiaCompositingLayer::paintWithIntermediateSurface(SkCanvas& canvas, PaintC
 
     surfaceCanvas->clear(SK_ColorTRANSPARENT);
     surfaceCanvas->translate(-surfaceRect.x(), -surfaceRect.y());
-    SetForScope scopedOffset(context.offset, toIntSize(contentsRect.location()));
+    SetForScope scopedOffset(context.offset, toIntSize(surfaceRect.location()));
     paintFunction(*surfaceCanvas, context);
     grContext->flushAndSubmit(surface.get(), GrSyncCpu::kNo);
 


### PR DESCRIPTION
#### 8eaa75cdf165b7b4d3ee5dd0e712491e56248233
<pre>
SkiaCompositingLayer::paintWithIntermediateSurface: wrong clip rect offset
<a href="https://bugs.webkit.org/show_bug.cgi?id=314536">https://bugs.webkit.org/show_bug.cgi?id=314536</a>

Reviewed by Carlos Garcia Campos.

The clip rect offset should be surfaceRect.location(), not
contentsRect.location().

Test: css3/filters/backdrop/backdrop-inset-opacity.html

* LayoutTests/css3/filters/backdrop/backdrop-inset-opacity-expected.html: Added.
* LayoutTests/css3/filters/backdrop/backdrop-inset-opacity.html: Added.
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
(WebCore::SkiaCompositingLayer::paintWithIntermediateSurface):

Canonical link: <a href="https://commits.webkit.org/313649@main">https://commits.webkit.org/313649@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d9492eeef4d70d2512edfa09ea2b95615e83db24

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163715 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37199 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30418 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172655 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/120206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165584 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37530 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37198 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127161 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/120206 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166674 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29449 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147183 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107715 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28496 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/27126 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20358 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/138395 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24900 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175160 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28091 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26568 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/135474 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36869 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31231 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135450 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37654 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146695 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99749 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24919 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30764 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23549 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36365 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109510 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35862 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1579 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36112 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36009 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->