### PR TITLE
[Site Isolation] Add WebFrameProxy children manipulation and WebBackForwardCacheEntry caching foundations

### DIFF
--- a/Source/WebCore/history/BackForwardCache.cpp
+++ b/Source/WebCore/history/BackForwardCache.cpp
@@ -41,6 +41,7 @@
 #include "FocusController.h"
 #include "FrameDestructionObserverInlines.h"
 #include "FrameLoader.h"
+#include "FrameTree.h"
 #include "HTTPParsers.h"
 #include "HistoryController.h"
 #include "LocalDOMWindow.h"
@@ -50,7 +51,6 @@
 #include "LocalFrameView.h"
 #include "Logging.h"
 #include "Page.h"
-#include "RemoteFrame.h"
 #include "ScriptDisallowedScope.h"
 #include "SecurityOriginHash.h"
 #include "Settings.h"
@@ -555,17 +555,6 @@ bool BackForwardCache::addIfCacheable(BackForwardFrameItemIdentifier identifier,
     return isInBackForwardCache(identifier);
 }
 
-static bool hasRemoteFrameDescendant(const Frame& frame)
-{
-    for (auto* child = frame.tree().firstChild(); child; child = child->tree().nextSibling()) {
-        if (is<RemoteFrame>(*child))
-            return true;
-        if (hasRemoteFrameDescendant(*child))
-            return true;
-    }
-    return false;
-}
-
 bool BackForwardCache::addIfCacheable(HistoryItem& item, Page* page)
 {
     if (!page)
@@ -574,10 +563,8 @@ bool BackForwardCache::addIfCacheable(HistoryItem& item, Page* page)
     // Same-site BFCache is supported when the page has no cross-site
     // iframes. Cross-site iframes require UIProcess coordination for
     // suspension which is not yet implemented for the in-process path.
-    if (page->settings().siteIsolationEnabled()) {
-        if (RefPtr mainFrame = page->mainFrame(); mainFrame && hasRemoteFrameDescendant(*mainFrame))
-            return false;
-    }
+    if (page->settings().siteIsolationEnabled() && page->mainFrame().tree().hasRemoteFrameDescendant())
+        return false;
 
     if (!addIfCacheable(item.frameItemID(), *page, item.itemID()))
         return false;

--- a/Source/WebCore/page/FrameTree.cpp
+++ b/Source/WebCore/page/FrameTree.cpp
@@ -32,6 +32,7 @@
 #include "LocalFrameView.h"
 #include "Page.h"
 #include "PageGroup.h"
+#include "RemoteFrame.h"
 #include <stdarg.h>
 #include <wtf/Vector.h>
 #include <wtf/text/CString.h>
@@ -568,6 +569,15 @@ unsigned FrameTree::depth() const
     for (auto* parent = m_thisFrame.ptr(); parent; parent = parent->tree().parent())
         depth++;
     return depth;
+}
+
+bool FrameTree::hasRemoteFrameDescendant() const
+{
+    for (RefPtr frame = firstChild(); frame; frame = frame->tree().traverseNext(m_thisFrame.ptr())) {
+        if (is<RemoteFrame>(*frame))
+            return true;
+    }
+    return false;
 }
 
 AtomString FrameTree::uniqueName() const

--- a/Source/WebCore/page/FrameTree.h
+++ b/Source/WebCore/page/FrameTree.h
@@ -85,6 +85,8 @@ public:
     WEBCORE_EXPORT Frame& NODELETE top() const;
     unsigned NODELETE depth() const;
 
+    bool hasRemoteFrameDescendant() const;
+
     WEBCORE_EXPORT RefPtr<Frame> scopedChild(unsigned index) const;
     WEBCORE_EXPORT RefPtr<Frame> scopedChildByUniqueName(const AtomString&) const;
     RefPtr<Frame> scopedChildBySpecifiedName(const AtomString& name) const;

--- a/Source/WebKit/UIProcess/WebBackForwardCache.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardCache.cpp
@@ -180,6 +180,15 @@ void WebBackForwardCache::removeEntriesForProcess(WebProcessProxy& process)
                 return true;
             }
         }
+
+        // Check iframe processes referenced by cached WebFrameProxys (UI-driven
+        // same-site BFCache with cross-site iframes).
+        if (RefPtr cacheEntry = entry.backForwardCacheEntry()) {
+            if (cacheEntry->referencesIframeProcess(processIdentifier)) {
+                RELEASE_LOG(ProcessSwapping, "WebBackForwardCache::removeEntriesForProcess: iframe process terminated while in BFCache, invalidating cache entry");
+                return true;
+            }
+        }
         return false;
     });
 }

--- a/Source/WebKit/UIProcess/WebBackForwardCacheEntry.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardCacheEntry.cpp
@@ -31,6 +31,7 @@
 #include "WebBackForwardCache.h"
 #include "WebBackForwardListFrameItem.h"
 #include "WebBackForwardListItem.h"
+#include "WebFrameProxy.h"
 #include "WebProcessMessages.h"
 #include "WebProcessProxy.h"
 #include <wtf/TZoneMallocInlines.h>
@@ -100,6 +101,30 @@ RefPtr<WebProcessProxy> WebBackForwardCacheEntry::process() const
     ASSERT(process);
     ASSERT(!m_suspendedPage || process == &m_suspendedPage->process());
     return process;
+}
+
+void WebBackForwardCacheEntry::setCachedChildren(Vector<Ref<WebFrameProxy>>&& children)
+{
+    ASSERT(m_cachedChildren.isEmpty());
+    m_cachedChildren = WTF::move(children);
+}
+
+Vector<Ref<WebFrameProxy>> WebBackForwardCacheEntry::takeCachedChildren()
+{
+    return std::exchange(m_cachedChildren, { });
+}
+
+bool WebBackForwardCacheEntry::referencesIframeProcess(WebCore::ProcessIdentifier processIdentifier) const
+{
+    for (Ref<WebFrameProxy> root : m_cachedChildren) {
+        if (root->process().coreProcessIdentifier() == processIdentifier)
+            return true;
+        for (RefPtr frame = root->traverseNext().frame; frame; frame = frame->traverseNext().frame) {
+            if (frame->process().coreProcessIdentifier() == processIdentifier)
+                return true;
+        }
+    }
+    return false;
 }
 
 void WebBackForwardCacheEntry::expirationTimerFired()

--- a/Source/WebKit/UIProcess/WebBackForwardCacheEntry.h
+++ b/Source/WebKit/UIProcess/WebBackForwardCacheEntry.h
@@ -35,11 +35,13 @@
 #include <wtf/RunLoop.h>
 #include <wtf/SwiftBridging.h>
 #include <wtf/TZoneMalloc.h>
+#include <wtf/Vector.h>
 
 namespace WebKit {
 
 class SuspendedPageProxy;
 class WebBackForwardCache;
+class WebFrameProxy;
 class WebProcessProxy;
 
 class WebBackForwardCacheEntry : public RefCountedAndCanMakeWeakPtr<WebBackForwardCacheEntry> {
@@ -57,6 +59,16 @@ public:
     WebCore::ProcessIdentifier processIdentifier() const { return m_processIdentifier; }
     RefPtr<WebProcessProxy> process() const;
 
+    // Subframes of the cached main frame that were detached from
+    // m_mainFrame->m_childFrames on suspension. These are reattached on
+    // restore so walkers of the live frame tree never observe cached-page
+    // state while this entry is alive.
+    bool hasCachedChildren() const { return !m_cachedChildren.isEmpty(); }
+    void setCachedChildren(Vector<Ref<WebFrameProxy>>&&);
+    Vector<Ref<WebFrameProxy>> takeCachedChildren();
+
+    bool referencesIframeProcess(WebCore::ProcessIdentifier) const;
+
 private:
     WebBackForwardCacheEntry(WebBackForwardCache&, WebCore::BackForwardItemIdentifier, WebCore::BackForwardFrameItemIdentifier, WebCore::ProcessIdentifier, RefPtr<SuspendedPageProxy>&&);
 
@@ -67,6 +79,7 @@ private:
     Markable<WebCore::BackForwardItemIdentifier> m_backForwardItemID;
     Markable<WebCore::BackForwardFrameItemIdentifier> m_backForwardFrameItemID;
     RefPtr<SuspendedPageProxy> m_suspendedPage;
+    Vector<Ref<WebFrameProxy>> m_cachedChildren;
     RunLoop::Timer m_expirationTimer;
 } SWIFT_SHARED_REFERENCE(refWebBackForwardCacheEntry, derefWebBackForwardCacheEntry);
 

--- a/Source/WebKit/UIProcess/WebFrameProxy.cpp
+++ b/Source/WebKit/UIProcess/WebFrameProxy.cpp
@@ -715,6 +715,26 @@ void WebFrameProxy::removeChildFrames()
     m_childFrames.clear();
 }
 
+Vector<Ref<WebFrameProxy>> WebFrameProxy::takeChildFrames()
+{
+    Vector<Ref<WebFrameProxy>> frames;
+    frames.reserveInitialCapacity(m_childFrames.size());
+    for (auto& child : m_childFrames)
+        frames.append(child.copyRef());
+    m_childFrames.clear();
+    for (auto& frame : frames)
+        frame->m_parentFrame = nullptr;
+    return frames;
+}
+
+void WebFrameProxy::adoptChildFrames(Vector<Ref<WebFrameProxy>>&& frames)
+{
+    for (auto& frame : frames) {
+        frame->m_parentFrame = *this;
+        m_childFrames.add(WTF::move(frame));
+    }
+}
+
 bool WebFrameProxy::isFocused() const
 {
     auto* webPage = page();

--- a/Source/WebKit/UIProcess/WebFrameProxy.h
+++ b/Source/WebKit/UIProcess/WebFrameProxy.h
@@ -220,6 +220,9 @@ public:
     void disconnect();
     bool isConnected() const;
     void didCreateSubframe(WebCore::FrameIdentifier, String&& frameName, WebCore::SandboxFlags, WebCore::ReferrerPolicy, WebCore::ScrollbarMode);
+
+    Vector<Ref<WebFrameProxy>> takeChildFrames();
+    void adoptChildFrames(Vector<Ref<WebFrameProxy>>&&);
     ProcessID NODELETE processID() const;
     void prepareForProvisionalLoadInProcess(WebProcessProxy&, API::Navigation&, BrowsingContextGroup&, std::optional<WebCore::SecurityOriginData>, CompletionHandler<void(std::optional<WebCore::PageIdentifier>)>&&);
 


### PR DESCRIPTION
#### e16931a76e073054bf88567542c6d06469d3097e
<pre>
[Site Isolation] Add WebFrameProxy children manipulation and WebBackForwardCacheEntry caching foundations
<a href="https://bugs.webkit.org/show_bug.cgi?id=315105">https://bugs.webkit.org/show_bug.cgi?id=315105</a>
<a href="https://rdar.apple.com/177439863">rdar://177439863</a>

Reviewed by Sihui Liu.

Foundation APIs for the UI-driven multi-process BFCache. No call sites yet —
those land in the follow-up that wires the suspend / restore orchestration.

WebFrameProxy gains takeChildFrames/adoptChildFrames so the orchestrator
can detach a subframe subtree from m_childFrames on suspension and reattach
it on restore. takeChildFrames clears each detached frame&apos;s m_parentFrame;
adoptChildFrames re-parents each frame to the receiver. Walkers of the
live frame tree never observe cached-page state while a subtree is held by
a WebBackForwardCacheEntry.

WebBackForwardCacheEntry gains a slot for the detached subtree
(m_cachedChildren) with setCachedChildren / takeCachedChildren plumbing
and a hasCachedChildren predicate. referencesIframeProcess answers whether
the cached subtree references a given iframe ProcessIdentifier. The
corresponding iframe-process RemotePageProxies stay in the
BrowsingContextGroup throughout suspension so the cached and any new
active iframe document share the same WebPage in the iframe process —
mirroring how the main frame&apos;s WebPage is reused across same-site BFCache.

WebBackForwardCache::removeEntriesForProcess additionally checks
referencesIframeProcess so an iframe process termination drops every entry
that holds cached state for it. No-op until the orchestrator populates
m_cachedChildren.

FrameTree gains hasRemoteFrameDescendant() — re-home of the static helper
previously defined in BackForwardCache.cpp. BackForwardCache::addIfCacheable
uses the new method.

No new tests (foundation only — covered when the orchestration lands).

* Source/WebCore/history/BackForwardCache.cpp:
(WebCore::BackForwardCache::addIfCacheable):
(WebCore::hasRemoteFrameDescendant): Deleted.
* Source/WebCore/page/FrameTree.h:
* Source/WebCore/page/FrameTree.cpp:
(WebCore::FrameTree::hasRemoteFrameDescendant const):
* Source/WebKit/UIProcess/WebBackForwardCache.cpp:
(WebKit::WebBackForwardCache::removeEntriesForProcess):
* Source/WebKit/UIProcess/WebBackForwardCacheEntry.h:
* Source/WebKit/UIProcess/WebBackForwardCacheEntry.cpp:
(WebKit::WebBackForwardCacheEntry::setCachedChildren):
(WebKit::WebBackForwardCacheEntry::takeCachedChildren):
(WebKit::WebBackForwardCacheEntry::referencesIframeProcess const):
* Source/WebKit/UIProcess/WebFrameProxy.h:
* Source/WebKit/UIProcess/WebFrameProxy.cpp:
(WebKit::WebFrameProxy::takeChildFrames):
(WebKit::WebFrameProxy::adoptChildFrames):

Canonical link: <a href="https://commits.webkit.org/313713@main">https://commits.webkit.org/313713@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b4ab86a3d127b98b2ba4747a0f2c4660567517e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163957 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37441 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/30660 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172986 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165826 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37773 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37441 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/127372 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121208 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4326f064-4651-418d-ab29-2077ea0396fb) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166916 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29656 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/147401 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107920 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0a2f05fe-da06-40e0-bdab-040b4c5b60e9) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28702 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/27323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20750 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138603 "Passed tests") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/25118 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175511 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28333 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/26786 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/135682 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37111 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135654 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36547 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37896 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/146913 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100059 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30954 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/23769 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36705 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109752 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36104 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/1809 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36354 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36251 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->