### PR TITLE
GetPasteboardPathnamesForType IPC allows types-only pasteboard access to read file paths

### DIFF
--- a/Source/WebCore/platform/cocoa/DragDataCocoa.mm
+++ b/Source/WebCore/platform/cocoa/DragDataCocoa.mm
@@ -296,16 +296,7 @@ bool DragData::containsCompatibleContent(DraggingPurpose purpose) const
 
 bool DragData::containsPromise() const
 {
-    if (m_disallowFileAccess)
-        return false;
-    auto context = createPasteboardContext();
-    // FIXME: legacyFilesPromisePasteboardTypeSingleton() contains UTIs, not path names. Also, why do we
-    // think promises should only contain one file (or UTI)?
-    Vector<String> files;
-#if PLATFORM(MAC)
-    platformStrategies()->pasteboardStrategy()->getPathnamesForType(files, String(legacyFilesPromisePasteboardTypeSingleton()), m_pasteboardName, context.get());
-#endif
-    return files.size() == 1;
+    return !m_disallowFileAccess && !m_promisedFileMIMETypes.isEmpty();
 }
 
 bool DragData::containsURL(FilenameConversionPolicy) const

--- a/Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm
@@ -219,8 +219,7 @@ void WebPasteboardProxy::getPasteboardPathnamesForType(IPC::Connection& connecti
 {
     MESSAGE_CHECK_COMPLETION(!pasteboardType.isEmpty(), connection, completionHandler({ }, { }));
 
-    // FIXME: This should consult canAccessPasteboardData() instead, and avoid responding with file paths if it returns false.
-    if (!canAccessPasteboardTypes(connection, pasteboardName))
+    if (!canAccessPasteboardData(connection, pasteboardName))
         return completionHandler({ }, { });
 
     auto dataOwner = determineDataOwner(connection, pasteboardName, pageID, PasteboardAccessIntent::Read);

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/DragAndDropTestsMac.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/DragAndDropTestsMac.mm
@@ -35,6 +35,7 @@
 #import <WebCore/PasteboardCustomData.h>
 #import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKWebViewPrivate.h>
+#import <WebKit/_WKFeature.h>
 #import <wtf/FileSystem.h>
 
 #if ENABLE(DRAG_SUPPORT) && PLATFORM(MAC)
@@ -559,5 +560,78 @@ TEST(DragAndDropTests, DragEnterAndLeaveRelatedTarget)
     EXPECT_WK_STREQ("zoneB", [webView stringByEvaluatingJavaScript:@"leaveARelatedTarget"]);
     EXPECT_WK_STREQ("zoneA", [webView stringByEvaluatingJavaScript:@"enterBRelatedTarget"]);
 }
+
+#if ENABLE(IPC_TESTING_API)
+TEST(DragAndDropTests, PasteboardPathnamesRequireDataAccess)
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    for (_WKFeature *feature in [WKPreferences _features]) {
+        if ([feature.key isEqualToString:@"IPCTestingAPIEnabled"]) {
+            [[configuration preferences] _setEnabled:YES forFeature:feature];
+            break;
+        }
+    }
+
+    RetainPtr simulator = adoptNS([[DragAndDropSimulator alloc] initWithWebViewFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    RetainPtr webView = [simulator webView];
+    [webView synchronouslyLoadHTMLString:@R"TESTHTML(
+        <!DOCTYPE html>
+        <body style="width: 100vw; height: 100vh; margin: 0;">
+        <script>
+        var pathnameCount = -1;
+
+        document.body.addEventListener('dragenter', function(e) {
+            e.preventDefault();
+        });
+
+        document.body.addEventListener('dragover', function(e) {
+            e.preventDefault();
+            if (pathnameCount >= 0 || !window.IPC || !window.pasteboardName)
+                return;
+
+            try {
+                var reply = IPC.sendSyncMessage('UI', 0,
+                    IPC.messages.WebPasteboardProxy_GetPasteboardPathnamesForType.name,
+                    1000,
+                    [
+                        {type: 'String', value: window.pasteboardName},
+                        {type: 'String', value: 'NSFilenamesPboardType'},
+                        {type: 'bool', value: 0}
+                    ]);
+                if (reply && reply.buffer) {
+                    var buf = new Uint8Array(reply.buffer);
+                    pathnameCount = buf.length > 32 ? 1 : 0;
+                } else {
+                    pathnameCount = 0;
+                }
+            } catch (ex) {
+                pathnameCount = -2;
+            }
+        });
+
+        document.body.addEventListener('drop', function(e) {
+            e.preventDefault();
+        });
+        </script>
+        </body>
+        )TESTHTML"];
+
+    NSString *tempFile = [NSTemporaryDirectory() stringByAppendingPathComponent:@"test-pasteboard-access.txt"];
+    [@"test content" writeToFile:tempFile atomically:YES encoding:NSUTF8StringEncoding error:nil];
+
+    [simulator writeFiles:@[[NSURL fileURLWithPath:tempFile]]];
+
+    NSString *pbName = [simulator externalDragPasteboard].name;
+    [webView stringByEvaluatingJavaScript:[NSString stringWithFormat:@"window.pasteboardName = '%@'", pbName]];
+
+    [simulator runFrom:NSMakePoint(0, 0) to:NSMakePoint(200, 200)];
+
+    auto count = [webView stringByEvaluatingJavaScript:@"pathnameCount"].integerValue;
+    EXPECT_GE(count, 0);
+    EXPECT_EQ(0, count);
+
+    [[NSFileManager defaultManager] removeItemAtPath:tempFile error:nil];
+}
+#endif // ENABLE(IPC_TESTING_API)
 
 #endif // ENABLE(DRAG_SUPPORT) && PLATFORM(MAC)


### PR DESCRIPTION
#### 0d3713dbb6d9bfab077d388293fca5beb3a05e29
<pre>
GetPasteboardPathnamesForType IPC allows types-only pasteboard access to read file paths
<a href="https://bugs.webkit.org/show_bug.cgi?id=309384">https://bugs.webkit.org/show_bug.cgi?id=309384</a>
<a href="https://rdar.apple.com/170731738">rdar://170731738</a>

Reviewed by Darin Adler.

During drag-over, WebPageProxy::dragEntered() grants types-only pasteboard access.
getPasteboardPathnamesForType() was gated by canAccessPasteboardTypes(), which returns true for
types-only access, allowing file paths and sandbox extensions to be returned to the web process
before a drop occurs. Use canAccessPasteboardData() instead, which requires types and data access,
which is granted only at drop time.

We also need to update DragData::containsPromise() to avoid calling getPathnamesForType during
drag-over, since that would now be denied by the stricter access check. m_promisedFileMIMETypes is
already populated by the UI process from NSFilePromiseReceiver items in draggingEntered /
draggingUpdated and sent to the web process, so it is always available without any pasteboard
access. This also relaxes the old files.size() == 1 restriction, which doesn’t seem needed.

Test: Tools/TestWebKitAPI/Tests/mac/DragAndDropTestsMac.mm

* Source/WebCore/platform/cocoa/DragDataCocoa.mm:
(WebCore::DragData::containsPromise const):
* Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm:
(WebKit::WebPasteboardProxy::getPasteboardPathnamesForType):
* Tools/TestWebKitAPI/Tests/mac/DragAndDropTestsMac.mm:
(TEST(DragAndDropTests, PasteboardPathnamesRequireDataAccess)):

Originally-landed-as: 305413.424@rapid/safari-7624.2.5.110-branch (25efcd0fa47a). <a href="https://rdar.apple.com/176066984">rdar://176066984</a>
Canonical link: <a href="https://commits.webkit.org/315268@main">https://commits.webkit.org/315268@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ffb1010686c8a365566f7b353f3203aff917104c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168502 "9 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42059 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35648 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177832 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126203 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170368 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42435 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42021 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131156 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92245 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171461 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33613 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151427 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111667 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32599 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31304 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26527 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142585 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180430 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33154 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30831 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139595 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42071 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35467 "Found 1 new test failure: fast/speechsynthesis/speech-synthesis-utterance-gc.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139454 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37561 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42759 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106420 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34743 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27804 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41263 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114519 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40660 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5887 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40911 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40805 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->