### PR TITLE
Fix CSP policy loss in blob: URL inheritance when page sends multiple CSP headers

### DIFF
--- a/LayoutTests/http/tests/security/contentSecurityPolicy/blob-url-inherits-multiple-csp-policies-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/blob-url-inherits-multiple-csp-policies-expected.txt
@@ -1,0 +1,14 @@
+CONSOLE MESSAGE: Refused to execute a script because its hash, its nonce, or 'unsafe-inline' does not appear in the script-src directive of the Content Security Policy.
+Tests that a blob: URL iframe inherits ALL CSP policies from its creator document, not just the last one. When the creator has two enforced CSP headers where one blocks inline scripts, inline scripts inside the blob document should be blocked.
+
+
+
+--------
+Frame: '<!--frame1-->'
+--------
+
+
+--------
+Frame: '<!--frame2-->'
+--------
+PASS: Inline script was blocked by CSP.

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/blob-url-inherits-multiple-csp-policies.html
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/blob-url-inherits-multiple-csp-policies.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.dumpChildFramesAsText();
+    testRunner.waitUntilDone();
+}
+setTimeout(function() {
+    if (window.testRunner)
+        testRunner.notifyDone();
+}, 1000);
+</script>
+</head>
+<body>
+<p>Tests that a blob: URL iframe inherits ALL CSP policies from its creator document,
+not just the last one. When the creator has two enforced CSP headers where one blocks
+inline scripts, inline scripts inside the blob document should be blocked.</p>
+<iframe src="http://127.0.0.1:8000/security/contentSecurityPolicy/resources/echo-multiple-csp-blob-iframe.py"></iframe>
+</body>
+</html>

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/resources/create-blob-iframe.js
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/resources/create-blob-iframe.js
@@ -1,0 +1,12 @@
+var iframe = document.getElementById("blob-frame");
+var html = [
+    "<!DOCTYPE html>",
+    "<html><body>",
+    "<p id='result'>PASS: Inline script was blocked by CSP.</p>",
+    "<script>",
+    "document.getElementById('result').textContent = 'FAIL: Inline script executed (CSP policy was dropped).';",
+    "</" + "script>",
+    "</body></html>"
+].join("\n");
+var blob = new Blob([html], { type: "text/html" });
+iframe.src = URL.createObjectURL(blob);

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/resources/echo-multiple-csp-blob-iframe.py
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/resources/echo-multiple-csp-blob-iframe.py
@@ -1,0 +1,17 @@
+#!/usr/bin/env python3
+
+import sys
+
+sys.stdout.write(
+    'Content-Type: text/html; charset=UTF-8\r\n'
+    "Content-Security-Policy: script-src 'self'; frame-src blob:; default-src 'self'\r\n"
+    "Content-Security-Policy: script-src 'self' 'unsafe-inline'; frame-src blob:; default-src 'self'\r\n"
+    '\r\n'
+    '<!DOCTYPE html>\n'
+    '<html>\n'
+    '<body>\n'
+    '<iframe id="blob-frame"></iframe>\n'
+    '<script src="/security/contentSecurityPolicy/resources/create-blob-iframe.js"></script>\n'
+    '</body>\n'
+    '</html>\n'
+)

--- a/LayoutTests/imported/w3c/web-platform-tests/trusted-types/inheriting-csp-for-local-schemes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/trusted-types/inheriting-csp-for-local-schemes-expected.txt
@@ -4,7 +4,7 @@ PASS trusted-types directive should be inherited in local srcdoc frames
 PASS require-trusted-types-for directive should be inherited in local data frames
 PASS trusted-types directive should be inherited in local data frames
 PASS require-trusted-types-for directive should be inherited in local blob frames
-FAIL trusted-types directive should be inherited in local blob frames assert_not_equals: got disallowed value null
+PASS trusted-types directive should be inherited in local blob frames
 PASS require-trusted-types-for directive should be inherited in local about:blank frames
 PASS trusted-types directive should be inherited in local about:blank frames
 PASS require-trusted-types-for directive should not be inherited in local blank.html frames

--- a/Source/WebCore/page/csp/ContentSecurityPolicyResponseHeaders.cpp
+++ b/Source/WebCore/page/csp/ContentSecurityPolicyResponseHeaders.cpp
@@ -66,10 +66,10 @@ void ContentSecurityPolicyResponseHeaders::addPolicyHeadersTo(ResourceResponse& 
     for (const auto& header : m_headers) {
         switch (header.second) {
         case ContentSecurityPolicyHeaderType::Enforce:
-            response.setHTTPHeaderField(HTTPHeaderName::ContentSecurityPolicy, header.first);
+            response.addHTTPHeaderField(HTTPHeaderName::ContentSecurityPolicy, header.first);
             break;
         case ContentSecurityPolicyHeaderType::Report:
-            response.setHTTPHeaderField(HTTPHeaderName::ContentSecurityPolicyReportOnly, header.first);
+            response.addHTTPHeaderField(HTTPHeaderName::ContentSecurityPolicyReportOnly, header.first);
             break;
         }
     }


### PR DESCRIPTION
#### f8ed382fb244cc24f40767858ae369267075bd9a
<pre>
Fix CSP policy loss in blob: URL inheritance when page sends multiple CSP headers
<a href="https://bugs.webkit.org/show_bug.cgi?id=308906">https://bugs.webkit.org/show_bug.cgi?id=308906</a>
<a href="https://rdar.apple.com/168927377">rdar://168927377</a>

Reviewed by Anne van Kesteren.

A page with two or more CSP headers correctly enforces those policies on
itself, but blob: URLs it creates only see the last one. The policies
are correctly captured in the policy container, but
ContentSecurityPolicyResponseHeaders::addPolicyHeadersTo() writes them
to the blob response using ResourceResponse::setHTTPHeaderField(), which
overwrites policies rather than appending them together.

Change to use ResourceResponse::addHTTPHeaderField() which
comma-concatenates the values and preserves all CSP policies.

Test: http/tests/security/contentSecurityPolicy/blob-url-inherits-multiple-csp-policies.html

* LayoutTests/http/tests/security/contentSecurityPolicy/blob-url-inherits-multiple-csp-policies-expected.txt: Added.
* LayoutTests/http/tests/security/contentSecurityPolicy/blob-url-inherits-multiple-csp-policies.html: Added.
* LayoutTests/http/tests/security/contentSecurityPolicy/resources/create-blob-iframe.js: Added.
* LayoutTests/http/tests/security/contentSecurityPolicy/resources/echo-multiple-csp-blob-iframe.py: Added.
* LayoutTests/imported/w3c/web-platform-tests/trusted-types/inheriting-csp-for-local-schemes-expected.txt:
* Source/WebCore/page/csp/ContentSecurityPolicyResponseHeaders.cpp:
(WebCore::ContentSecurityPolicyResponseHeaders::addPolicyHeadersTo const):

Originally-landed-as: 305413.385@rapid/safari-7624.2.5.110-branch (a90148642299). <a href="https://rdar.apple.com/176066951">rdar://176066951</a>
Canonical link: <a href="https://commits.webkit.org/314996@main">https://commits.webkit.org/314996@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0eed6af03e0b67e75a935f7d6b069d0b9a8f39f7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163720 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37204 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30423 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172660 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/120362 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165589 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37535 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37203 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127167 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89628 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166679 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29453 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147187 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107717 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28500 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27129 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20363 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138399 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24904 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175165 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28096 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26572 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135477 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36874 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31234 "Found 1 new test failure: http/tests/webcodecs/audio-decoder-aac.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135453 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37388 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37659 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146699 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99755 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30767 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23553 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36370 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109515 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35867 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1583 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36117 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36014 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->