### PR TITLE
[css-values-5 attr()] Support pseudo-elements with non-trivial originating element

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-pseudo-elem-invalidation-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-pseudo-elem-invalidation-2-expected.txt
@@ -9,8 +9,8 @@ PASS CSS Values and Units Test: attr() invalidation of pseudo elements 1
 PASS CSS Values and Units Test: attr() invalidation of pseudo elements 2
 PASS CSS Values and Units Test: attr() invalidation of pseudo elements 3
 PASS CSS Values and Units Test: attr() invalidation of pseudo elements 4
-FAIL CSS Values and Units Test: attr() invalidation of pseudo elements 5 assert_not_equals: Change of attribute value should lead to invalidation of ::placeholder element style. got disallowed value "11px"
-FAIL CSS Values and Units Test: attr() invalidation of pseudo elements 6 assert_not_equals: Change of attribute value should lead to invalidation of ::file-selector-button element style. got disallowed value "11px"
-FAIL CSS Values and Units Test: attr() invalidation of pseudo elements 7 assert_not_equals: Change of attribute value should lead to invalidation of ::details-content element style. got disallowed value "16px"
+PASS CSS Values and Units Test: attr() invalidation of pseudo elements 5
+PASS CSS Values and Units Test: attr() invalidation of pseudo elements 6
+PASS CSS Values and Units Test: attr() invalidation of pseudo elements 7
 PASS CSS Values and Units Test: attr() invalidation of pseudo elements 8
 

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-pseudo-element-originating-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-pseudo-element-originating-expected.txt
@@ -1,0 +1,9 @@
+slotted
+
+PASS ::part() attr() resolves on shadow host
+PASS ::part() attr() with percentage type resolves on shadow host
+PASS ::part() attr() invalidation on host attribute change
+PASS ::part() attr() resolves on the originating host across exportparts
+PASS ::part() attr() invalidation across exportparts
+PASS ::slotted() attr() invalidation on the slotted element
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-pseudo-element-originating.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-pseudo-element-originating.html
@@ -1,0 +1,113 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+
+<title>attr() looks up on the originating element across shadow boundaries</title>
+<link rel="help" href="https://drafts.csswg.org/css-values-5/#funcdef-attr">
+<link rel="help" href="https://drafts.csswg.org/css-shadow-parts-1/#part">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<style>
+  /* ::part() rule from outside the shadow tree: attr() reads from the host. */
+  #host-part::part(label) {
+    color: attr(data-color type(<color>), red);
+    font-size: attr(data-size type(<percentage>), 100%);
+  }
+  /* ::part() reaching into a deeper shadow via exportparts: attr() reads from the
+     outer host (the rule's match target). */
+  #host-outer::part(inner-label) {
+    color: attr(data-color type(<color>), red);
+  }
+</style>
+
+<part-host id="host-part" data-color="green" data-size="200%"></part-host>
+<outer-host id="host-outer" data-color="green"></outer-host>
+
+<div id="slotted-host">
+  <template shadowrootmode="open">
+    <style>
+      /* ::slotted() rule inside a shadow tree: attr() reads from the slotted element. */
+      ::slotted(span) {
+        color: attr(data-color type(<color>), red);
+      }
+    </style>
+    <slot></slot>
+  </template>
+  <span data-color="green">slotted</span>
+</div>
+
+<script>
+  customElements.define("part-host", class extends HTMLElement {
+    connectedCallback() {
+      const root = this.attachShadow({ mode: "open" });
+      const span = document.createElement("span");
+      span.setAttribute("part", "label");
+      root.appendChild(span);
+    }
+  });
+
+  // outer-host wraps inner-host and exports inner-host's "label" part as "inner-label",
+  // so the document's #host-outer::part(inner-label) rule cascades two shadow boundaries deep.
+  customElements.define("inner-host", class extends HTMLElement {
+    connectedCallback() {
+      const root = this.attachShadow({ mode: "open" });
+      const span = document.createElement("span");
+      span.setAttribute("part", "label");
+      root.appendChild(span);
+    }
+  });
+  customElements.define("outer-host", class extends HTMLElement {
+    connectedCallback() {
+      const root = this.attachShadow({ mode: "open" });
+      const inner = document.createElement("inner-host");
+      inner.setAttribute("exportparts", "label: inner-label");
+      root.appendChild(inner);
+    }
+  });
+
+  test(() => {
+    const host = document.getElementById("host-part");
+    const part = host.shadowRoot.querySelector("[part='label']");
+    assert_equals(getComputedStyle(part).color, "rgb(0, 128, 0)",
+      "::part() attr() reads data-color from host");
+  }, "::part() attr() resolves on shadow host");
+
+  test(() => {
+    const host = document.getElementById("host-part");
+    const part = host.shadowRoot.querySelector("[part='label']");
+    assert_equals(getComputedStyle(part).fontSize, "32px",
+      "::part() attr() reads data-size from host");
+  }, "::part() attr() with percentage type resolves on shadow host");
+
+  test(() => {
+    const host = document.getElementById("host-part");
+    const part = host.shadowRoot.querySelector("[part='label']");
+    host.setAttribute("data-color", "blue");
+    assert_equals(getComputedStyle(part).color, "rgb(0, 0, 255)",
+      "::part() attr() invalidates when host attribute changes");
+  }, "::part() attr() invalidation on host attribute change");
+
+  test(() => {
+    const outer = document.getElementById("host-outer");
+    const inner = outer.shadowRoot.querySelector("inner-host");
+    const part = inner.shadowRoot.querySelector("[part='label']");
+    assert_equals(getComputedStyle(part).color, "rgb(0, 128, 0)",
+      "::part() across two shadow boundaries reads from the outer host");
+  }, "::part() attr() resolves on the originating host across exportparts");
+
+  test(() => {
+    const outer = document.getElementById("host-outer");
+    const inner = outer.shadowRoot.querySelector("inner-host");
+    const part = inner.shadowRoot.querySelector("[part='label']");
+    outer.setAttribute("data-color", "blue");
+    assert_equals(getComputedStyle(part).color, "rgb(0, 0, 255)",
+      "::part() across two shadow boundaries invalidates on outer host attribute change");
+  }, "::part() attr() invalidation across exportparts");
+
+  test(() => {
+    const slotted = document.querySelector("#slotted-host > span");
+    slotted.setAttribute("data-color", "blue");
+    assert_equals(getComputedStyle(slotted).color, "rgb(0, 0, 255)",
+      "::slotted() attr() invalidates when the slotted element's attribute changes");
+  }, "::slotted() attr() invalidation on the slotted element");
+</script>

--- a/Source/WebCore/style/AttributeChangeInvalidation.cpp
+++ b/Source/WebCore/style/AttributeChangeInvalidation.cpp
@@ -58,8 +58,14 @@ void AttributeChangeInvalidation::invalidateStyle(const QualifiedName& attribute
             mayAffectStyleInShadowTree = true;
         if (features.attributesAffectingHost.contains(attributeNameForLookups))
             shouldInvalidateCurrent = true;
-        else if (features.substitutionAttributeNamesInRules.contains(attributeNameForLookups))
+        else if (auto affectsShadowTree = features.substitutionAttributeNamesInRules.getOptional(attributeNameForLookups)) {
             shouldInvalidateCurrent = true;
+            // Only invalidate the host's shadow subtree if a shadow-piercing rule (::part(),
+            // ::placeholder, etc.) actually uses attr() on this attribute and the element has
+            // a shadow tree to invalidate.
+            if (m_element->shadowRoot() && *affectsShadowTree == RuleFeatureSet::AffectsShadowTree::Yes)
+                mayAffectStyleInShadowTree = true;
+        }
     });
 
     if (mayAffectStyleInShadowTree) {

--- a/Source/WebCore/style/RuleFeature.cpp
+++ b/Source/WebCore/style/RuleFeature.cpp
@@ -617,7 +617,12 @@ void RuleFeatureSet::add(const RuleFeatureSet& other)
     idsMatchingAncestorsInRules.addAll(other.idsMatchingAncestorsInRules);
     attributeLowercaseLocalNamesInRules.addAll(other.attributeLowercaseLocalNamesInRules);
     attributeLocalNamesInRules.addAll(other.attributeLocalNamesInRules);
-    substitutionAttributeNamesInRules.addAll(other.substitutionAttributeNamesInRules);
+    for (auto& [name, affectsShadowTree] : other.substitutionAttributeNamesInRules) {
+        if (affectsShadowTree == AffectsShadowTree::Yes)
+            substitutionAttributeNamesInRules.set(name, AffectsShadowTree::Yes);
+        else
+            substitutionAttributeNamesInRules.add(name, AffectsShadowTree::No);
+    }
 
     auto addMap = [&](auto& map, auto& otherMap) {
         for (auto& keyValuePair : otherMap) {
@@ -650,9 +655,13 @@ void RuleFeatureSet::add(const RuleFeatureSet& other)
     usesHasPseudoClass = usesHasPseudoClass || other.usesHasPseudoClass;
 }
 
-void RuleFeatureSet::registerSubstitutionAttribute(const AtomString& attributeName)
+void RuleFeatureSet::registerSubstitutionAttribute(const AtomString& attributeName, AffectsShadowTree affectsShadowTree)
 {
-    substitutionAttributeNamesInRules.add(attributeName.convertToASCIILowercase());
+    auto lowercaseName = attributeName.convertToASCIILowercase();
+    if (affectsShadowTree == AffectsShadowTree::Yes)
+        substitutionAttributeNamesInRules.set(lowercaseName, AffectsShadowTree::Yes);
+    else
+        substitutionAttributeNamesInRules.add(lowercaseName, AffectsShadowTree::No);
     attributeLowercaseLocalNamesInRules.add(attributeName);
     attributeLocalNamesInRules.add(attributeName);
 }

--- a/Source/WebCore/style/RuleFeature.h
+++ b/Source/WebCore/style/RuleFeature.h
@@ -132,7 +132,9 @@ struct RuleFeatureSet {
         HashSet<GenericHashKey<SelectorDeduplicationKey>> selectorDeduplicationSet;
     };
     void collectFeatures(CollectionContext&, const RuleData&, const Vector<Ref<const StyleRuleScope>>& scopeRules = { });
-    void registerSubstitutionAttribute(const AtomString&);
+
+    enum class AffectsShadowTree : bool { No, Yes };
+    void registerSubstitutionAttribute(const AtomString&, AffectsShadowTree = AffectsShadowTree::No);
 
     bool usesRelation(MatchElement::Relation relation) const { return usedRelations[std::to_underlying(relation)]; }
     void setUsesRelation(MatchElement::Relation relation) { usedRelations[std::to_underlying(relation)] = true; }
@@ -141,7 +143,9 @@ struct RuleFeatureSet {
     HashSet<AtomString> idsMatchingAncestorsInRules;
     HashSet<AtomString> attributeLowercaseLocalNamesInRules;
     HashSet<AtomString> attributeLocalNamesInRules;
-    HashSet<AtomString> substitutionAttributeNamesInRules;
+    // Maps the attribute name to whether at least one rule referencing it via attr() pierces a
+    // shadow boundary (e.g. ::part(), document author rules matching UA-shadow pseudos).
+    HashMap<AtomString, AffectsShadowTree> substitutionAttributeNamesInRules;
 
     HashMap<AtomString, std::unique_ptr<RuleFeatureVector>> idRules;
     HashMap<AtomString, std::unique_ptr<RuleFeatureVector>> classRules;

--- a/Source/WebCore/style/StyleBuilderState.cpp
+++ b/Source/WebCore/style/StyleBuilderState.cpp
@@ -150,9 +150,9 @@ RefPtr<Image> BuilderState::createStyleImage(const CSSValue& value) const
     return nullptr;
 }
 
-void BuilderState::registerSubstitutionAttribute(const AtomString& attributeLocalName)
+void BuilderState::registerSubstitutionAttribute(const AtomString& attributeLocalName, const Scope* targetScope)
 {
-    m_registeredSubstitutionAttributes.append(attributeLocalName);
+    m_registeredSubstitutionAttributes.append({ attributeLocalName, targetScope });
 }
 
 void BuilderState::adjustStyleForInterCharacterRuby()

--- a/Source/WebCore/style/StyleBuilderState.h
+++ b/Source/WebCore/style/StyleBuilderState.h
@@ -56,6 +56,7 @@ class BuilderState;
 class CustomPropertyRegistry;
 class Image;
 class LocalPropertyRegistry;
+class Scope;
 struct Color;
 struct FontFamilies;
 struct FontFeatureSettings;
@@ -83,6 +84,11 @@ enum class ApplyValueType : uint8_t { Value, Initial, Inherit };
 struct BuilderPositionTryFallback {
     RefPtr<const StyleProperties> properties;
     Vector<PositionTryFallbackTactic> tactics;
+};
+
+struct RegisteredSubstitutionAttribute {
+    AtomString name;
+    WeakPtr<const Scope> targetScope;
 };
 
 struct BuilderContext {
@@ -148,12 +154,14 @@ public:
     bool NODELETE useSVGZoomRules() const;
     bool NODELETE useSVGZoomRulesForLength() const;
 
-    ScopeOrdinal styleScopeOrdinal() const { return m_currentProperty->styleScopeOrdinal; }
+    // Defaults to Element when called outside property cascade application (e.g. attr() resolution
+    // during container-query evaluation), where there is no current property in flight.
+    ScopeOrdinal styleScopeOrdinal() const { return m_currentProperty ? m_currentProperty->styleScopeOrdinal : ScopeOrdinal::Element; }
 
     RefPtr<Image> createStyleImage(const CSSValue&) const;
 
-    const Vector<AtomString>& registeredSubstitutionAttributes() const LIFETIME_BOUND { return m_registeredSubstitutionAttributes; }
-    void registerSubstitutionAttribute(const AtomString& attributeLocalName);
+    const Vector<RegisteredSubstitutionAttribute>& registeredSubstitutionAttributes() const LIFETIME_BOUND { return m_registeredSubstitutionAttributes; }
+    void registerSubstitutionAttribute(const AtomString& attributeLocalName, const Scope* targetScope = nullptr);
 
     const CSSToLengthConversionData& cssToLengthConversionData() const LIFETIME_BOUND { return m_cssToLengthConversionData; }
 
@@ -269,7 +277,7 @@ private:
     const PropertyCascade* m_currentRollbackCascade { nullptr };
 
     bool m_fontDirty { false };
-    Vector<AtomString> m_registeredSubstitutionAttributes;
+    Vector<RegisteredSubstitutionAttribute> m_registeredSubstitutionAttributes;
 
     bool m_isBuildingKeyframeStyle { false };
     bool m_hasRevertRuleOrLayerInKeyframeStyle { false };

--- a/Source/WebCore/style/StyleResolver.cpp
+++ b/Source/WebCore/style/StyleResolver.cpp
@@ -83,6 +83,7 @@
 #include "StylePropertyShorthand.h"
 #include "StyleResolveForDocument.h"
 #include "StyleRule.h"
+#include "StyleScope.h"
 #include "StyleSheetContents.h"
 #include "StyleSingleAnimationRangeName.h"
 #include "TimingFunction.h"
@@ -776,8 +777,18 @@ void Resolver::applyMatchedProperties(State& state, const MatchResult& matchResu
 void Resolver::setGlobalStateAfterApplyingProperties(const BuilderState& builderState)
 {
     // FIXME: This stuff should be somewhere else.
-    for (auto& attribute : builderState.registeredSubstitutionAttributes())
-        ruleSets().mutableFeatures().registerSubstitutionAttribute(attribute);
+    auto* currentScope = builderState.element() ? &Scope::forNode(*builderState.element()) : nullptr;
+    for (auto& entry : builderState.registeredSubstitutionAttributes()) {
+        ruleSets().mutableFeatures().registerSubstitutionAttribute(entry.name);
+        // For attr() applied to a pseudo-element, the originating element's scope may be
+        // different from this resolver's (e.g. ::placeholder styled in a UA shadow scope, with
+        // the originating <input> in the document scope). Register there too so attribute
+        // changes on the originating element trigger AttributeChangeInvalidation; mark the entry
+        // as shadow-tree-affecting on the originating scope so we only invalidate the host's
+        // shadow subtree when a shadow-piercing rule is the source of the dependency.
+        if (CheckedPtr targetScope = entry.targetScope.get(); targetScope && targetScope.get() != currentScope)
+            const_cast<Scope&>(*targetScope).resolver().ruleSets().mutableFeatures().registerSubstitutionAttribute(entry.name, RuleFeatureSet::AffectsShadowTree::Yes);
+    }
     if (builderState.style().usesViewportUnits())
         document().setHasStyleWithViewportUnits();
 }

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -454,9 +454,30 @@ bool SubstitutionResolver::substituteAttrFunction(CSSParserTokenRange argumentsR
     if (!range.atEnd())
         return false;
 
-    m_styleBuilder.state().registerSubstitutionAttribute(attributeName);
     protect(m_styleBuilder.state().style())->setHasAttrContent();
 
+    if (!m_styleBuilder.state().element())
+        return false;
+
+    // https://drafts.csswg.org/css-values-5/#funcdef-attr
+    // "If [attr()] is applied to a pseudo-element, the attribute is looked up on the pseudo-element's
+    //  originating element." For rules cascading from outside the styled element's tree scope (::part(),
+    //  document author rules matching UA-shadow pseudos like ::placeholder), the originating element is
+    //  the rule's match target rather than the styled element.
+    auto originatingElement = [&] -> Ref<const Element> {
+        Ref styled = *m_styleBuilder.state().element();
+        auto scopeOrdinal = m_styleBuilder.state().styleScopeOrdinal();
+        if (scopeOrdinal <= ScopeOrdinal::ContainingHost) {
+            if (RefPtr host = hostForScopeOrdinal(styled, scopeOrdinal))
+                return host.releaseNonNull();
+        }
+        return styled;
+    };
+    Ref attributeElement = originatingElement();
+
+    // Register the substitution dependency on the originating element's scope so attribute changes
+    // trigger AttributeChangeInvalidation against the right rule features.
+    m_styleBuilder.state().registerSubstitutionAttribute(attributeName, protect(Scope::forNode(attributeElement)).ptr());
     // Resolve namespace prefix to URI.
     auto namespaceURI = [&] -> AtomString {
         auto& prefix = parsedName->namespacePrefix;
@@ -501,7 +522,7 @@ bool SubstitutionResolver::substituteAttrFunction(CSSParserTokenRange argumentsR
         return substituteFailure();
     }
 
-    auto& attributeValue = element->getAttribute(QualifiedName { nullAtom(), attributeName, namespaceURI });
+    auto& attributeValue = attributeElement->getAttribute(QualifiedName { nullAtom(), attributeName, namespaceURI });
 
     if (attributeValue.isNull())
         return substituteFailure();


### PR DESCRIPTION
#### 3c4400d8165838b1ae3e2ae72d77f0595875fe0c
<pre>
[css-values-5 attr()] Support pseudo-elements with non-trivial originating element
<a href="https://bugs.webkit.org/show_bug.cgi?id=315263">https://bugs.webkit.org/show_bug.cgi?id=315263</a>
<a href="https://rdar.apple.com/177595332">rdar://177595332</a>

Reviewed by Anne van Kesteren.

CSS Values 5 §8.7: &quot;If [attr()] is applied to a pseudo-element, the
attribute is looked up on the pseudo-element&apos;s originating element.&quot;

For pseudo-element rules cascading from outside the styled element&apos;s tree
scope (::part() across one or more open shadow boundaries, document
author rules matching UA-shadow pseudos like ::placeholder,
::file-selector-button, ::details-content), the styled element is a
shadow descendant rather than the rule&apos;s match target. The attribute
lookup landed on the shadow node, which has no author attributes, so
the substitution always failed and never reflected attribute changes on
the host.

Resolve the originating element from the property&apos;s style scope ordinal
(re-using the existing hostForScopeOrdinal walk, which already handles
deep ::part() across exportparts). Extend
BuilderState::registerSubstitutionAttribute with an optional target
scope so the substitution dependency is registered on the originating
element&apos;s resolver, not just the resolver running this resolution; and
extend AttributeChangeInvalidation to invalidate the host&apos;s shadow
subtree when a substitution-referenced attribute changes on the host.

Spec: <a href="https://drafts.csswg.org/css-values-5/#funcdef-attr">https://drafts.csswg.org/css-values-5/#funcdef-attr</a>

* LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-pseudo-elem-invalidation-2-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-pseudo-element-originating-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-values/attr-pseudo-element-originating.html: Added.
* Source/WebCore/style/AttributeChangeInvalidation.cpp:
(WebCore::Style::AttributeChangeInvalidation::invalidateStyle):
* Source/WebCore/style/StyleBuilderState.cpp:
(WebCore::Style::BuilderState::registerSubstitutionAttribute):
* Source/WebCore/style/StyleBuilderState.h:
* Source/WebCore/style/StyleResolver.cpp:
(WebCore::Style::Resolver::setGlobalStateAfterApplyingProperties):
* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::substituteAttrFunction):

Canonical link: <a href="https://commits.webkit.org/313684@main">https://commits.webkit.org/313684@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b99e555fcd43f2ba06829b710a4e87b93bb68061

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163772 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37256 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30475 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172796 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165641 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37587 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37255 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127209 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-values/attr-pseudo-elem-invalidation-2.html (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121023 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166731 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29493 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147227 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107758 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28540 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27169 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20565 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138439 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24944 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175320 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28148 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26612 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135515 "Found 1 new test failure: imported/w3c/web-platform-tests/css/css-values/attr-pseudo-elem-invalidation-2.html (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36926 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31275 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135491 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36533 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37711 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146739 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99837 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30807 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23593 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36422 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109567 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35919 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1623 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36169 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36066 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->