### PR TITLE
`SerializedScriptValue::deserialize` cannot be called more than once (affects BroadcastChannel postMessage())

### DIFF
--- a/LayoutTests/http/tests/broadcastchannel/.htaccess
+++ b/LayoutTests/http/tests/broadcastchannel/.htaccess
@@ -1,0 +1,4 @@
+<FilesMatch "postmessage-shared(arraybuffer|wasmmemory)\.html$">
+    Header set Cross-Origin-Opener-Policy "same-origin"
+    Header set Cross-Origin-Embedder-Policy "require-corp"
+</FilesMatch>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-array-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-array-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "Array:3"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-array.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-array.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() { return [1, 2, 3]; }, "Array:3");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-arraybuffer-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-arraybuffer-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "ArrayBuffer:8"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-arraybuffer.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-arraybuffer.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() { return new ArrayBuffer(8); }, "ArrayBuffer:8");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-audiodata-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-audiodata-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "AudioData:1:4"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-audiodata.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-audiodata.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() {
+    return new AudioData({
+        format: 'f32',
+        sampleRate: 44100,
+        numberOfFrames: 4,
+        numberOfChannels: 1,
+        timestamp: 0,
+        data: new Float32Array([0.5, 0.5, 0.5, 0.5])
+    });
+}, "AudioData:1:4");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-blob-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-blob-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "Blob:5:text/plain"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-blob.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-blob.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() { return new Blob(["hello"], {type: "text/plain"}); }, "Blob:5:text/plain");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-boolean-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-boolean-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "boolean:true"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-boolean.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-boolean.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() { return true; }, "boolean:true");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-date-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-date-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "Date:1000"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-date.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-date.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() { return new Date(1000); }, "Date:1000");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-domexception-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-domexception-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "DOMException:AbortError:aborted"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-domexception.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-domexception.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() { return new DOMException("aborted", "AbortError"); }, "DOMException:AbortError:aborted");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-encodedaudiochunk-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-encodedaudiochunk-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "EncodedAudioChunk:key:4"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-encodedaudiochunk.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-encodedaudiochunk.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() {
+    return new EncodedAudioChunk({type: "key", timestamp: 0, data: new Uint8Array([1, 2, 3, 4])});
+}, "EncodedAudioChunk:key:4");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-encodedvideochunk-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-encodedvideochunk-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "EncodedVideoChunk:key:4"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-encodedvideochunk.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-encodedvideochunk.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() {
+    return new EncodedVideoChunk({type: "key", timestamp: 0, data: new Uint8Array([1, 2, 3, 4])});
+}, "EncodedVideoChunk:key:4");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-error-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-error-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "TypeError:oops"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-error.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-error.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() { return new TypeError("oops"); }, "TypeError:oops");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-imagebitmap-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-imagebitmap-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "ImageBitmap:2x2"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-imagebitmap.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-imagebitmap.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() {
+    var canvas = new OffscreenCanvas(2, 2);
+    var ctx = canvas.getContext("2d");
+    ctx.fillStyle = "red";
+    ctx.fillRect(0, 0, 2, 2);
+    return createImageBitmap(canvas);
+}, "ImageBitmap:2x2");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-imagedata-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-imagedata-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "ImageData:2x2"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-imagedata.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-imagedata.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() { return new ImageData(2, 2); }, "ImageData:2x2");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-map-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-map-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "Map:2"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-map.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-map.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() { return new Map([["a", 1], ["b", 2]]); }, "Map:2");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-null-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-null-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "null"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-null.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-null.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() { return null; }, "null");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-number-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-number-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "number:42"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-number.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-number.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() { return 42; }, "number:42");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-object-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-object-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "Object"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-object.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-object.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() { return {a: 1}; }, "Object");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-regexp-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-regexp-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "RegExp:/abc/gi"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-regexp.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-regexp.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() { return /abc/gi; }, "RegExp:/abc/gi");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-set-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-set-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "Set:3"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-set.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-set.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() { return new Set([10, 20, 30]); }, "Set:3");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-sharedarraybuffer-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-sharedarraybuffer-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "SharedArrayBuffer:8"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-sharedarraybuffer.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-sharedarraybuffer.html
@@ -1,0 +1,10 @@
+<!DOCTYPE HTML><!-- webkit-test-runner [ jscOptions=--useSharedArrayBuffer=true ] -->
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() { return new SharedArrayBuffer(8); }, "SharedArrayBuffer:8");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-sharedwasmmemory-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-sharedwasmmemory-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "WebAssembly.Memory:65536"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-sharedwasmmemory.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-sharedwasmmemory.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() {
+    return new WebAssembly.Memory({initial: 1, maximum: 1, shared: true});
+}, "WebAssembly.Memory:65536");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-string-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-string-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "string:hello"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-string.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-string.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() { return "hello"; }, "string:hello");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-typedarray-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-typedarray-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "Uint8Array:4"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-typedarray.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-typedarray.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() { return new Uint8Array([1, 2, 3, 4]); }, "Uint8Array:4");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-videoframe-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-videoframe-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "VideoFrame:2x2"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-videoframe.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-videoframe.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() {
+    var data = new Uint8Array(2 * 2 * 4);
+    return new VideoFrame(data, {format: "RGBA", codedWidth: 2, codedHeight: 2, timestamp: 0});
+}, "VideoFrame:2x2");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-wasmmodule-expected.txt
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-wasmmodule-expected.txt
@@ -1,0 +1,2 @@
+PASS: All 10 workers received "WebAssembly.Module"
+

--- a/LayoutTests/http/tests/broadcastchannel/postmessage-wasmmodule.html
+++ b/LayoutTests/http/tests/broadcastchannel/postmessage-wasmmodule.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+<body>
+<pre id="output"></pre>
+<script src="resources/broadcastchannel-test-harness.js"></script>
+<script>
+broadcastChannelTest(function() {
+    return new WebAssembly.Module(new Uint8Array([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]));
+}, "WebAssembly.Module");
+</script>
+</body>
+</html>

--- a/LayoutTests/http/tests/broadcastchannel/resources/broadcastchannel-test-harness.js
+++ b/LayoutTests/http/tests/broadcastchannel/resources/broadcastchannel-test-harness.js
@@ -1,0 +1,125 @@
+const WORKER_COUNT = 10;
+
+function broadcastChannelTest(createValueFn, expected) {
+    if (window.testRunner) {
+        testRunner.dumpAsText();
+        testRunner.waitUntilDone();
+    }
+
+    var output = document.getElementById("output");
+    function log(msg) {
+        output.textContent += msg + "\n";
+    }
+
+    function done() {
+        clearTimeout(timer);
+        workers.forEach(function(w) { w.terminate(); });
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }
+
+    var workerCode = [
+        'function inspect(d) {',
+        '    if (d === null) return "null";',
+        '    if (d === undefined) return "undefined";',
+        '    if (typeof d === "string") return "string:" + d;',
+        '    if (typeof d === "number") return "number:" + d;',
+        '    if (typeof d === "boolean") return "boolean:" + d;',
+        '    if (d instanceof Date) return "Date:" + d.getTime();',
+        '    if (d instanceof RegExp) return "RegExp:" + d.toString();',
+        '    if (d instanceof DOMException) return "DOMException:" + d.name + ":" + d.message;',
+        '    if (d instanceof Error) return d.constructor.name + ":" + d.message;',
+        '    if (typeof SharedArrayBuffer !== "undefined" && d instanceof SharedArrayBuffer) return "SharedArrayBuffer:" + d.byteLength;',
+        '    if (d instanceof ArrayBuffer) return "ArrayBuffer:" + d.byteLength;',
+        '    if (d instanceof DataView) return "DataView:" + d.byteLength;',
+        '    if (ArrayBuffer.isView(d)) return d.constructor.name + ":" + d.length;',
+        '    if (d instanceof Blob) return "Blob:" + d.size + ":" + d.type;',
+        '    if (typeof ImageBitmap !== "undefined" && d instanceof ImageBitmap) return "ImageBitmap:" + d.width + "x" + d.height;',
+        '    if (d instanceof ImageData) return "ImageData:" + d.width + "x" + d.height;',
+        '    if (d instanceof Map) return "Map:" + d.size;',
+        '    if (d instanceof Set) return "Set:" + d.size;',
+        '    if (Array.isArray(d)) return "Array:" + d.length;',
+        '    if (typeof EncodedVideoChunk !== "undefined" && d instanceof EncodedVideoChunk) return "EncodedVideoChunk:" + d.type + ":" + d.byteLength;',
+        '    if (typeof VideoFrame !== "undefined" && d instanceof VideoFrame) {',
+		'        var result = "VideoFrame:" + d.codedWidth + "x" + d.codedHeight;',
+		'        d.close();',
+		'        return result;',
+		'    }',
+        '    if (typeof EncodedAudioChunk !== "undefined" && d instanceof EncodedAudioChunk) return "EncodedAudioChunk:" + d.type + ":" + d.byteLength;',
+        '    if (typeof AudioData !== "undefined" && d instanceof AudioData) return "AudioData:" + d.numberOfChannels + ":" + d.numberOfFrames;',
+        '    if (typeof MediaStreamTrack !== "undefined" && d instanceof MediaStreamTrack) return "MediaStreamTrack:" + d.kind;',
+        '    if (typeof MediaStreamTrackHandle !== "undefined" && d instanceof MediaStreamTrackHandle) return "MediaStreamTrackHandle";',
+        '    if (typeof WebAssembly !== "undefined" && d instanceof WebAssembly.Module) return "WebAssembly.Module";',
+        '    if (typeof WebAssembly !== "undefined" && d instanceof WebAssembly.Memory) return "WebAssembly.Memory:" + d.buffer.byteLength;',
+        '    if (typeof d === "object") return "Object";',
+        '    return "unknown:" + typeof d;',
+        '}',
+        'var bc = new BroadcastChannel("test");',
+        'bc.onmessage = function(event) {',
+        '    try {',
+        '        self.postMessage(inspect(event.data));',
+        '    } catch (e) {',
+        '        self.postMessage("ERROR:" + e.message);',
+        '    }',
+        '};',
+        'self.postMessage("READY");'
+    ].join("\n");
+
+    var blob = new Blob([workerCode], { type: "application/javascript" });
+    var url = URL.createObjectURL(blob);
+    var readyCount = 0;
+    var results = [];
+    var workers = [];
+
+    var timer = setTimeout(function() {
+        log("FAIL: Test timed out (" + readyCount + " of " + WORKER_COUNT + " workers ready, " + results.length + " of " + WORKER_COUNT + " results received)");
+        done();
+    }, 10000);
+
+    for (var i = 0; i < WORKER_COUNT; i++) {
+        var w = new Worker(url);
+        workers.push(w);
+        w.onmessage = function(e) {
+            if (e.data === "READY") {
+                if (++readyCount === WORKER_COUNT)
+                    postValue();
+            } else {
+                results.push(e.data);
+                if (results.length === WORKER_COUNT)
+                    checkResults();
+            }
+        };
+        w.onerror = function(e) {
+            log("FAIL: Worker error: " + e.message);
+            done();
+        };
+    }
+
+    function postValue() {
+        try {
+            Promise.resolve(createValueFn()).then(function(value) {
+                var bc = new BroadcastChannel("test");
+                bc.postMessage(value);
+                bc.close();
+            }, function(e) {
+                log("FAIL: Error creating value: " + e.message);
+                done();
+            });
+        } catch (e) {
+            log("FAIL: Error creating value: " + e.message);
+            done();
+        }
+    }
+
+    function checkResults() {
+        URL.revokeObjectURL(url);
+        var allSame = results.every(function(r) { return r === results[0]; });
+        if (allSame && results[0] === expected)
+            log("PASS: All " + WORKER_COUNT + " workers received \"" + expected + "\"");
+        else if (!allSame)
+            log("FAIL: Workers received mismatched results: " + JSON.stringify(results));
+        else
+            log("FAIL: Expected \"" + expected + "\" but got \"" + results[0] + "\"");
+        done();
+    }
+}

--- a/Source/WebCore/Modules/filesystem/FileSystemStorageConnection.cpp
+++ b/Source/WebCore/Modules/filesystem/FileSystemStorageConnection.cpp
@@ -82,6 +82,13 @@ FileSystemHandleKeepAlive& FileSystemHandleKeepAlive::operator=(FileSystemHandle
     return *this;
 }
 
+FileSystemHandleKeepAlive FileSystemHandleKeepAlive::copy() const
+{
+    if (!m_globalIdentifier || !m_connection)
+        return { };
+    return FileSystemHandleKeepAlive(ClientOrigin { m_origin }, *m_globalIdentifier, Ref { *m_connection });
+}
+
 RefPtr<FileSystemStorageConnection> fileSystemStorageConnectionForContext(ScriptExecutionContext& context)
 {
     if (auto* workerScope = dynamicDowncast<WorkerGlobalScope>(context))

--- a/Source/WebCore/Modules/filesystem/FileSystemStorageConnection.h
+++ b/Source/WebCore/Modules/filesystem/FileSystemStorageConnection.h
@@ -118,6 +118,8 @@ public:
     FileSystemHandleKeepAlive(const FileSystemHandleKeepAlive&) = delete;
     FileSystemHandleKeepAlive& operator=(const FileSystemHandleKeepAlive&) = delete;
 
+    WEBCORE_EXPORT FileSystemHandleKeepAlive copy() const;
+
     Markable<FileSystemHandleGlobalIdentifier> globalIdentifier() const { return m_globalIdentifier; }
 
 private:

--- a/Source/WebCore/bindings/js/SerializedScriptValue.cpp
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.cpp
@@ -43,6 +43,7 @@
 #include "FileSystemDirectoryHandle.h"
 #include "FileSystemFileHandle.h"
 #include "FileSystemHandleGlobalIdentifier.h"
+#include "HTMLCanvasElement.h"
 #include "IDBValue.h"
 #include "ImageBuffer.h"
 #include "JSAudioWorkletGlobalScope.h"
@@ -153,6 +154,7 @@
 #if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
 #include "JSOffscreenCanvas.h"
 #include "OffscreenCanvas.h"
+#include "PlaceholderRenderingContext.h"
 #endif
 
 namespace WebCore {
@@ -5554,6 +5556,78 @@ void validateSerializedResult(CloneSerializer& serializer, SerializationReturnCo
 #endif // ASSERT_ENABLED
 
 SerializedScriptValue::~SerializedScriptValue() = default;
+
+static std::unique_ptr<ArrayBufferContentsArray> copyArrayBufferContentsArray(const std::unique_ptr<ArrayBufferContentsArray>& source)
+{
+    if (!source)
+        return nullptr;
+    auto result = makeUnique<ArrayBufferContentsArray>();
+    result->reserveInitialCapacity(source->size());
+    for (auto& content : *source) {
+        result->append(JSC::ArrayBufferContents());
+        content.shareWith(result->last());
+    }
+    return result;
+}
+
+Ref<SerializedScriptValue> SerializedScriptValue::clone() const
+{
+    return create(m_internals->clone());
+}
+
+SerializedScriptValueInternals SerializedScriptValueInternals::clone() const
+{
+    return {
+        .data = data,
+        .arrayBufferContentsArray = copyArrayBufferContentsArray(arrayBufferContentsArray),
+#if ENABLE(WEB_RTC)
+        .detachedRTCDataChannels = detachedRTCDataChannels.map([](const auto& channel) {
+            return makeUnique<DetachedRTCDataChannel>(channel->identifier, channel->label.isolatedCopy(), channel->options.isolatedCopy(), channel->state);
+        }),
+#endif
+#if ENABLE(WEB_CODECS)
+        .serializedVideoChunks = serializedVideoChunks,
+        .serializedAudioChunks = serializedAudioChunks,
+#endif
+        .exposedMessagePortCount = exposedMessagePortCount,
+        .nonSerializedDataToken = nonSerializedDataToken,
+        .fileSystemHandleKeepAlives = fileSystemHandleKeepAlives.map([](const auto& alive) { return alive.copy(); }),
+#if ENABLE(WEB_CODECS)
+        .serializedVideoFrames = serializedVideoFrames,
+        .serializedAudioData = serializedAudioData,
+#endif
+#if ENABLE(WEB_RTC)
+        .serializedRTCEncodedAudioFrames = serializedRTCEncodedAudioFrames.map([](const auto& frame) { return frame->clone(); }),
+        .serializedRTCEncodedVideoFrames = serializedRTCEncodedVideoFrames.map([](const auto& frame) { return frame->clone(); }),
+#endif
+#if ENABLE(MEDIA_SOURCE_IN_WORKERS)
+        .detachedMediaSourceHandles = detachedMediaSourceHandles,
+#endif
+#if ENABLE(MEDIA_STREAM)
+        .detachedMediaStreamTracks = detachedMediaStreamTracks.map([](const auto& track) {
+            return track->copy();
+        }),
+        .detachedMediaStreamTrackHandles = detachedMediaStreamTrackHandles.map([](const auto& handle) {
+            return makeUnique<MediaStreamTrackHandleDataHolder>(MediaStreamTrackHandleDataHolder { handle->contextIdentifier, handle->track, handle->trackKeeper, handle->trackSourceObserver });
+        }),
+#endif
+        .sharedBufferContentsArray = copyArrayBufferContentsArray(sharedBufferContentsArray),
+        .detachedImageBitmaps = detachedImageBitmaps,
+#if ENABLE(OFFSCREEN_CANVAS_IN_WORKERS)
+        .detachedOffscreenCanvases = detachedOffscreenCanvases.map([](const auto& canvas) {
+            return makeUnique<DetachedOffscreenCanvas>(canvas->size(), canvas->originClean(), RefPtr { canvas->placeholderSource() });
+        }),
+        .inMemoryOffscreenCanvases = inMemoryOffscreenCanvases,
+#endif
+        .inMemoryMessagePorts = inMemoryMessagePorts,
+#if ENABLE(WEBASSEMBLY)
+        .wasmModulesArray = wasmModulesArray ? makeUnique<WasmModuleArray>(*wasmModulesArray) : nullptr,
+        .wasmMemoryHandlesArray = wasmMemoryHandlesArray ? makeUnique<WasmMemoryHandleArray>(*wasmMemoryHandlesArray) : nullptr,
+#endif
+        .blobHandles = blobHandles.map([](const auto& handle) { return handle.isolatedCopy(); }),
+        .memoryCost = memoryCost
+    };
+}
 
 SerializedScriptValue::SerializedScriptValue(Internals&& internals)
     : m_internals(makeUnique<Internals>(WTF::move(internals)))

--- a/Source/WebCore/bindings/js/SerializedScriptValue.h
+++ b/Source/WebCore/bindings/js/SerializedScriptValue.h
@@ -132,6 +132,8 @@ public:
     enum class DeserializationBehavior : uint8_t { Fail, Succeed, LegacyMapToNull, LegacyMapToUndefined, LegacyMapToEmptyObject };
     WEBCORE_EXPORT static DeserializationBehavior NODELETE deserializationBehavior(JSC::JSObject&);
 
+    WEBCORE_EXPORT Ref<SerializedScriptValue> clone() const;
+
 private:
     friend struct IPC::ArgumentCoder<SerializedScriptValue>;
 

--- a/Source/WebCore/bindings/js/SerializedScriptValueInternals.h
+++ b/Source/WebCore/bindings/js/SerializedScriptValueInternals.h
@@ -117,6 +117,8 @@ struct SerializedScriptValueInternals {
 #endif
     Vector<URLKeepingBlobAlive> blobHandles { };
     uint64_t memoryCost { 0 };
+
+    WEBCORE_EXPORT SerializedScriptValueInternals clone() const;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/html/ImageBitmap.cpp
+++ b/Source/WebCore/html/ImageBitmap.cpp
@@ -78,6 +78,14 @@ DetachedImageBitmap::DetachedImageBitmap(UniqueRef<SerializedImageBuffer> bitmap
 {
 }
 
+DetachedImageBitmap::DetachedImageBitmap(const DetachedImageBitmap& other)
+    : m_bitmap(makeUniqueRefFromNonNullUniquePtr(other.m_bitmap->clone()))
+    , m_originClean(other.m_originClean)
+    , m_premultiplyAlpha(other.m_premultiplyAlpha)
+    , m_forciblyPremultiplyAlpha(other.m_forciblyPremultiplyAlpha)
+{
+}
+
 DetachedImageBitmap::DetachedImageBitmap(DetachedImageBitmap&&) = default;
 
 DetachedImageBitmap::~DetachedImageBitmap() = default;

--- a/Source/WebCore/html/ImageBitmap.h
+++ b/Source/WebCore/html/ImageBitmap.h
@@ -73,6 +73,7 @@ template<typename> class ExceptionOr;
 
 class DetachedImageBitmap {
 public:
+    DetachedImageBitmap(const DetachedImageBitmap&);
     DetachedImageBitmap(DetachedImageBitmap&&);
     WEBCORE_EXPORT ~DetachedImageBitmap();
     DetachedImageBitmap& operator=(DetachedImageBitmap&&);

--- a/Source/WebCore/html/OffscreenCanvas.h
+++ b/Source/WebCore/html/OffscreenCanvas.h
@@ -89,6 +89,7 @@ public:
     WEBCORE_EXPORT ~DetachedOffscreenCanvas();
     const IntSize& size() const LIFETIME_BOUND { return m_size; }
     bool originClean() const { return m_originClean; }
+    const RefPtr<PlaceholderRenderingContextSource>& placeholderSource() const LIFETIME_BOUND { return m_placeholderSource; }
     RefPtr<PlaceholderRenderingContextSource> NODELETE takePlaceholderSource();
 
 private:

--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -178,6 +178,11 @@ public:
         return m_buffer->memoryCost();
     }
 
+    std::unique_ptr<SerializedImageBuffer> clone() const final
+    {
+        return makeUnique<DefaultSerializedImageBuffer>(m_buffer.get());
+    }
+
 private:
     RefPtr<ImageBuffer> m_buffer;
 };

--- a/Source/WebCore/platform/graphics/ImageBuffer.h
+++ b/Source/WebCore/platform/graphics/ImageBuffer.h
@@ -275,6 +275,7 @@ public:
     virtual ~SerializedImageBuffer() = default;
 
     virtual size_t memoryCost() const = 0;
+    virtual std::unique_ptr<SerializedImageBuffer> clone() const { return nullptr; }
 
     WEBCORE_EXPORT static RefPtr<ImageBuffer> sinkIntoImageBuffer(std::unique_ptr<SerializedImageBuffer>, GraphicsClient* = nullptr);
 

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackDataHolder.cpp
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackDataHolder.cpp
@@ -110,6 +110,11 @@ MediaStreamTrackData MediaStreamTrackData::isolatedCopy(ShouldUpdateId shouldUpd
     };
 }
 
+std::unique_ptr<MediaStreamTrackDataHolder> MediaStreamTrackDataHolder::copy() const
+{
+    return makeUnique<MediaStreamTrackDataHolder>(m_data.isolatedCopy(MediaStreamTrackData::ShouldUpdateId::No), m_source.copyRef());
+}
+
 } // namespace WebCore
 
 #endif // ENABLE(MEDIA_STREAM)

--- a/Source/WebCore/platform/mediastream/MediaStreamTrackDataHolder.h
+++ b/Source/WebCore/platform/mediastream/MediaStreamTrackDataHolder.h
@@ -65,6 +65,8 @@ public:
     MediaStreamTrackDataHolder(const MediaStreamTrackDataHolder&) = delete;
     MediaStreamTrackDataHolder& operator=(const MediaStreamTrackDataHolder&) = delete;
 
+    WEBCORE_EXPORT std::unique_ptr<MediaStreamTrackDataHolder> copy() const;
+
     MediaStreamTrackData& data() { return m_data; }
     Ref<RealtimeMediaSource>& source() { return m_source; }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h
@@ -141,7 +141,20 @@ public:
 
     const WebCore::ImageBuffer::Parameters& parameters() const LIFETIME_BOUND { return m_parameters; }
     const WebCore::ImageBufferBackend::Info& info() const LIFETIME_BOUND { return m_info; }
+
+    std::unique_ptr<WebCore::SerializedImageBuffer> clone() const final
+    {
+        return std::unique_ptr<WebCore::SerializedImageBuffer>(new RemoteSerializedImageBufferProxy(m_parameters, m_info, m_connection));
+    }
+
 private:
+    RemoteSerializedImageBufferProxy(const WebCore::ImageBuffer::Parameters& parameters, const WebCore::ImageBufferBackend::Info& info, const RefPtr<IPC::Connection>& connection)
+        : m_parameters(parameters)
+        , m_info(info)
+        , m_connection(connection)
+    {
+    }
+
     RefPtr<WebCore::ImageBuffer> sinkIntoImageBuffer() final
     {
         ASSERT_NOT_REACHED();

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebBroadcastChannelRegistry.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebBroadcastChannelRegistry.cpp
@@ -111,10 +111,18 @@ void WebBroadcastChannelRegistry::postMessageLocally(const WebCore::PartitionedS
         return;
 
     auto channelIdentifiersForName = channelsForOriginIterator->value;
+
+    size_t numberOfMessagesNeeded = channelIdentifiersForName.size();
+    for (auto& channelIdentifier : channelIdentifiersForName) {
+        if (channelIdentifier == sourceInProcess)
+            --numberOfMessagesNeeded;
+    }
+
     for (auto& channelIdentifier : channelIdentifiersForName) {
         if (channelIdentifier == sourceInProcess)
             continue;
-        WebCore::BroadcastChannel::dispatchMessageTo(channelIdentifier, message.copyRef(), [callbackAggregator] { });
+        auto messageToDispatch = numberOfMessagesNeeded-- > 1 ? message->clone() : WTF::move(message);
+        WebCore::BroadcastChannel::dispatchMessageTo(channelIdentifier, WTF::move(messageToDispatch), [callbackAggregator] { });
     }
 }
 


### PR DESCRIPTION
#### 84cde5ed5a90807649684eb2ebdfee75c6af4a45
<pre>
`SerializedScriptValue::deserialize` cannot be called more than once (affects BroadcastChannel postMessage())
<a href="https://rdar.apple.com/171134726">rdar://171134726</a>

Reviewed by Andy Estes and Ryosuke Niwa.

Since `::deserialize(...)` moves some of the SerializedScriptValue::Internals members, it cannot be called twice.

This is normally fine, but when a single message has multiple recipients via `BroadcastChannel.postMessage()`,
it ends up meaning that only the first recipient gets the complete message.

This patch adds SerializedScriptValue::clone() then uses it in the BroadcastChannel case, making sure each recipient
gets a full copy of the message.

Covered by layout tests that exercise each supported `SerializedScriptValue` type.

Tests: http/tests/broadcastchannel/postmessage-array.html
       http/tests/broadcastchannel/postmessage-arraybuffer.html
       http/tests/broadcastchannel/postmessage-audiodata.html
       http/tests/broadcastchannel/postmessage-blob.html
       http/tests/broadcastchannel/postmessage-boolean.html
       http/tests/broadcastchannel/postmessage-date.html
       http/tests/broadcastchannel/postmessage-domexception.html
       http/tests/broadcastchannel/postmessage-encodedaudiochunk.html
       http/tests/broadcastchannel/postmessage-encodedvideochunk.html
       http/tests/broadcastchannel/postmessage-error.html
       http/tests/broadcastchannel/postmessage-imagebitmap.html
       http/tests/broadcastchannel/postmessage-imagedata.html
       http/tests/broadcastchannel/postmessage-map.html
       http/tests/broadcastchannel/postmessage-mediastreamtrack.html
       http/tests/broadcastchannel/postmessage-null.html
       http/tests/broadcastchannel/postmessage-number.html
       http/tests/broadcastchannel/postmessage-object.html
       http/tests/broadcastchannel/postmessage-regexp.html
       http/tests/broadcastchannel/postmessage-set.html
       http/tests/broadcastchannel/postmessage-sharedarraybuffer.html
       http/tests/broadcastchannel/postmessage-sharedwasmmemory.html
       http/tests/broadcastchannel/postmessage-string.html
       http/tests/broadcastchannel/postmessage-typedarray.html
       http/tests/broadcastchannel/postmessage-videoframe.html
       http/tests/broadcastchannel/postmessage-wasmmodule.html

* LayoutTests/http/tests/broadcastchannel/.htaccess: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-array-expected.txt: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-array.html: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-arraybuffer-expected.txt: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-arraybuffer.html: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-audiodata-expected.txt: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-audiodata.html: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-blob-expected.txt: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-blob.html: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-boolean-expected.txt: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-boolean.html: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-date-expected.txt: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-date.html: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-domexception-expected.txt: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-domexception.html: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-encodedaudiochunk-expected.txt: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-encodedaudiochunk.html: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-encodedvideochunk-expected.txt: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-encodedvideochunk.html: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-error-expected.txt: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-error.html: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-imagebitmap-expected.txt: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-imagebitmap.html: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-imagedata-expected.txt: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-imagedata.html: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-map-expected.txt: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-map.html: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-null-expected.txt: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-null.html: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-number-expected.txt: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-number.html: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-object-expected.txt: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-object.html: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-regexp-expected.txt: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-regexp.html: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-set-expected.txt: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-set.html: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-sharedarraybuffer-expected.txt: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-sharedarraybuffer.html: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-sharedwasmmemory-expected.txt: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-sharedwasmmemory.html: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-string-expected.txt: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-string.html: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-typedarray-expected.txt: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-typedarray.html: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-videoframe-expected.txt: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-videoframe.html: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-wasmmodule-expected.txt: Added.
* LayoutTests/http/tests/broadcastchannel/postmessage-wasmmodule.html: Added.
* LayoutTests/http/tests/broadcastchannel/resources/broadcastchannel-test-harness.js: Added.
(log):
(done):
(w.onmessage):
(w.onerror):
(postValue.try):
(postValue):
(checkResults):
(broadcastChannelTest):
* Source/WebCore/Modules/filesystem/FileSystemStorageConnection.cpp:
(WebCore::FileSystemHandleKeepAlive::copy const):
* Source/WebCore/Modules/filesystem/FileSystemStorageConnection.h:
* Source/WebCore/bindings/js/SerializedScriptValue.cpp:
(WebCore::copyArrayBufferContentsArray):
(WebCore::SerializedScriptValue::clone const):
(WebCore::SerializedScriptValueInternals::clone const):
* Source/WebCore/bindings/js/SerializedScriptValue.h:
* Source/WebCore/bindings/js/SerializedScriptValueInternals.h:
* Source/WebCore/html/ImageBitmap.cpp:
(WebCore::DetachedImageBitmap::DetachedImageBitmap):
* Source/WebCore/html/ImageBitmap.h:
* Source/WebCore/html/OffscreenCanvas.h:
* Source/WebCore/platform/graphics/ImageBuffer.cpp:
* Source/WebCore/platform/graphics/ImageBuffer.h:
(WebCore::SerializedImageBuffer::clone const):
* Source/WebCore/platform/mediastream/MediaStreamTrackDataHolder.cpp:
(WebCore::MediaStreamTrackDataHolder::copy const):
* Source/WebCore/platform/mediastream/MediaStreamTrackDataHolder.h:
* Source/WebKit/WebProcess/GPU/graphics/RemoteImageBufferProxy.h:
(WebKit::RemoteSerializedImageBufferProxy::RemoteSerializedImageBufferProxy):
* Source/WebKit/WebProcess/WebCoreSupport/WebBroadcastChannelRegistry.cpp:
(WebKit::WebBroadcastChannelRegistry::postMessageLocally):

Originally-landed-as: 305413.445@safari-7624-branch (5a0c6501d0f5). <a href="https://rdar.apple.com/176065281">rdar://176065281</a>
Canonical link: <a href="https://commits.webkit.org/315347@main">https://commits.webkit.org/315347@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/9a5c4616612e4e6e32f626ee202ada2024508e5a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168763 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42322 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35917 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/178094 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126470 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170629 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42699 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42282 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131403 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171722 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33857 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/151678 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111907 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32844 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31557 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26789 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/142835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/31078 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180695 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33425 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35725 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139852 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42334 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/151148 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139696 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37613 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/43023 "Built successfully") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/28050 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106769 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34976 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114790 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41526 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/6138 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40923 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/41177 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/41068 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->