### PR TITLE
Use crop dimensions for extension calculation

### DIFF
--- a/Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/av1/encoder/extend.c
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/av1/encoder/extend.c
@@ -115,11 +115,11 @@ void av1_copy_and_extend_frame(const YV12_BUFFER_CONFIG *src,
   // Extend src frame in buffer
   const int et_y = dst->border;
   const int el_y = dst->border;
-  const int er_y =
-      AOMMAX(src->y_width + dst->border, ALIGN_POWER_OF_TWO(src->y_width, 6)) -
-      src->y_crop_width;
-  const int eb_y = AOMMAX(src->y_height + dst->border,
-                          ALIGN_POWER_OF_TWO(src->y_height, 6)) -
+  const int er_y = AOMMAX(src->y_crop_width + dst->border,
+                          ALIGN_POWER_OF_TWO(src->y_crop_width, 6)) -
+                   src->y_crop_width;
+  const int eb_y = AOMMAX(src->y_crop_height + dst->border,
+                          ALIGN_POWER_OF_TWO(src->y_crop_height, 6)) -
                    src->y_crop_height;
   const int uv_width_subsampling = src->subsampling_x;
   const int uv_height_subsampling = src->subsampling_y;

--- a/Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/test/encode_api_test.cc
+++ b/Source/ThirdParty/libwebrtc/Source/third_party/libaom/source/libaom/test/encode_api_test.cc
@@ -1729,4 +1729,37 @@ TEST(EncodeAPI, Issue449341177) {
   ASSERT_EQ(aom_codec_destroy(&enc), AOM_CODEC_OK);
 }
 
+TEST(EncodeAPI, SizeAlignOverflow) {
+  aom_codec_iface_t *iface = aom_codec_av1_cx();
+  aom_codec_enc_cfg_t cfg;
+  ASSERT_EQ(aom_codec_enc_config_default(iface, &cfg, AOM_USAGE_REALTIME),
+            AOM_CODEC_OK);
+
+  cfg.g_w = 16;
+  cfg.g_h = 16;
+  cfg.g_threads = 1;
+  cfg.g_lag_in_frames = 0;
+
+  aom_codec_ctx_t enc;
+  ASSERT_EQ(aom_codec_enc_init(&enc, iface, &cfg, 0), AOM_CODEC_OK);
+
+  // Bug aomdiea:480978101: size_align=32 causes w,h=32 while d_w,d_h=16
+  // This mismatch causes buffer overflow in av1_copy_and_extend_frame()
+  // if the fix is not present.
+  aom_image_t *img =
+      aom_img_alloc_with_border(NULL, AOM_IMG_FMT_NV12, /*d_w=*/16, /*d_h=*/16,
+                                /*align=*/32,
+                                /*size_align=*/32,
+                                /*border=*/15);
+  ASSERT_NE(img, nullptr);
+  memset(img->img_data, 128, img->sz);
+
+  // Should not crash with heap-buffer-overflow
+  EXPECT_EQ(aom_codec_encode(&enc, img, /*pts=*/0, /*duration=*/1, /*flags=*/0),
+            AOM_CODEC_OK);
+
+  aom_img_free(img);
+  ASSERT_EQ(aom_codec_destroy(&enc), AOM_CODEC_OK);
+}
+
 }  // namespace


### PR DESCRIPTION
#### 3758417301ef5705bd817c44542367ff5c5aa107
<pre>
Use crop dimensions for extension calculation
<a href="https://rdar.apple.com/171141150">rdar://171141150</a>

Reviewed by Jean-Yves Avenard.

We cherry-pick <a href="https://aomedia.googlesource.com/aom/+/7343efd164afc3c0f9f2a212052d77a3d7ea1a49.">https://aomedia.googlesource.com/aom/+/7343efd164afc3c0f9f2a212052d77a3d7ea1a49.</a>

Originally-landed-as: 305413.431@rapid/safari-7624.2.5.110-branch (b61e7ccad2c2). <a href="https://rdar.apple.com/176066941">rdar://176066941</a>
Canonical link: <a href="https://commits.webkit.org/313668@main">https://commits.webkit.org/313668@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/285c97670155952b01bc8df8979ae79646ca6e8c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163729 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37213 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30432 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172749 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/120375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37544 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37212 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127175 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/120375 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166688 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29459 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147198 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107725 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28506 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27136 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20522 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138405 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24915 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175293 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26583 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135494 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36883 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31241 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135470 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36522 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37668 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146710 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99767 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30776 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23564 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36379 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35876 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1594 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36126 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36023 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->