### PR TITLE
REGRESSION(305199@main): Crash in `SourceBufferPrivate::removeCodedFramesInternal`

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -256,6 +256,7 @@ fast/shapes/shape-outside-floats/shape-outside-imagedata-overflow.html [ Skip ]
 [ Debug ] fast/files/blob-stream-chunks.html [ Skip ]
 [ Debug ] security/decode-buffer-size.html [ Skip ]
 [ Debug ] security/text-decode-long-strings.html [ Skip ]
+[ Debug ] media/media-source/media-source-evict-invalid-time-crash.html [ Skip ]
 
 # Only iOS supports QuickLook
 quicklook [ Skip ]

--- a/LayoutTests/media/media-source/media-source-evict-invalid-time-crash-expected.txt
+++ b/LayoutTests/media/media-source/media-source-evict-invalid-time-crash-expected.txt
@@ -1,0 +1,19 @@
+This tests that the eviction algorithm does not crash when the intersection of track buffer ranges becomes empty during memory pressure eviction.
+RUN(video.src = URL.createObjectURL(source))
+RUN(video.disableRemotePlayback = true)
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer("video/mock; codecs=mock"))
+RUN(initSegment = makeAInit(500, [makeATrack(1, 'mock', TRACK_KIND.VIDEO), makeATrack(2, 'mock', TRACK_KIND.AUDIO)]))
+RUN(sourceBuffer.appendBuffer(initSegment))
+EVENT(updateend)
+RUN(sourceBuffer.appendBuffer(makeSyncSamples(1, 200, 400)))
+EVENT(updateend)
+RUN(sourceBuffer.appendBuffer(makeSyncSamples(2, 250, 450)))
+EVENT(updateend)
+RUN(video.currentTime = 200)
+RUN(internals.beginSimulatedMemoryPressure())
+EVENT(bufferedchange)
+RUN(internals.endSimulatedMemoryPressure())
+PASS: No crash from eviction with invalidTime.
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-evict-invalid-time-crash.html
+++ b/LayoutTests/media/media-source/media-source-evict-invalid-time-crash.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ManagedMediaSourceEnabled=true MediaSourceEnabled=true ] -->
+<html>
+<head>
+    <title>media-source-evict-invalid-time-crash</title>
+    <script src="mock-media-source.js"></script>
+    <script src="../../media/video-test.js"></script>
+    <script src="../../media/utilities.js"></script>
+    <script>
+    var source;
+    var sourceBuffer;
+    var initSegment;
+
+    if (window.internals)
+        internals.initializeMockMediaSource();
+
+    function makeSyncSamples(trackID, start, end) {
+        var samples = [];
+        for (var pts = start; pts < end; pts++)
+            samples.push(makeASample(pts, pts, 1, 1, trackID, SAMPLE_FLAG.SYNC));
+        return concatenateSamples(samples);
+    }
+
+    window.addEventListener('load', async event => {
+        findMediaElement();
+
+        source = new ManagedMediaSource();
+
+        run('video.src = URL.createObjectURL(source)');
+        run('video.disableRemotePlayback = true');
+        await waitFor(source, 'sourceopen');
+
+        run('sourceBuffer = source.addSourceBuffer("video/mock; codecs=mock")');
+        run("initSegment = makeAInit(500, [makeATrack(1, 'mock', TRACK_KIND.VIDEO), makeATrack(2, 'mock', TRACK_KIND.AUDIO)])");
+        run('sourceBuffer.appendBuffer(initSegment)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        run('sourceBuffer.appendBuffer(makeSyncSamples(1, 200, 400))');
+        await waitFor(sourceBuffer, 'updateend');
+
+        run('sourceBuffer.appendBuffer(makeSyncSamples(2, 250, 450))');
+        await waitFor(sourceBuffer, 'updateend');
+
+        run('video.currentTime = 200');
+        run('internals.beginSimulatedMemoryPressure()');
+        await waitFor(sourceBuffer, 'bufferedchange');
+
+        run('internals.endSimulatedMemoryPressure()');
+        consoleWrite('PASS: No crash from eviction with invalidTime.');
+        endTest();
+    });
+    </script>
+</head>
+<body>
+    This tests that the eviction algorithm does not crash when the intersection
+    of track buffer ranges becomes empty during memory pressure eviction.
+    <video controls></video>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -1817,6 +1817,7 @@ webkit.org/b/265919 media/track/media-source-audio-track.html [ Failure ]
 media/media-source/media-managedmse-memorypressure.html [ Timeout ]
 media/media-source/media-managedmse-memorypressure-inactive.html [ Timeout ]
 media/media-source/media-managedmse-eviction.html [ Timeout ]
+media/media-source/media-source-evict-invalid-time-crash.html [ Timeout ]
 
 webkit.org/b/211995 fast/images/animated-image-mp4.html [ Timeout ]
 

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -1634,6 +1634,10 @@ bool SourceBufferPrivate::evictFrames(uint64_t newDataSize, const MediaTime& cur
 
         do {
             auto rangeStartBeforeCurrentTime = minimumBufferedTime();
+            if (!rangeStartBeforeCurrentTime.isValid()) {
+                ASSERT_NOT_REACHED();
+                break;
+            }
             auto rangeEndBeforeCurrentTime = std::min(rangeStartBeforeCurrentTime + timeChunk, maximumRangeEnd);
 
             if (rangeStartBeforeCurrentTime >= rangeEndBeforeCurrentTime)
@@ -1666,6 +1670,10 @@ bool SourceBufferPrivate::evictFrames(uint64_t newDataSize, const MediaTime& cur
             });
 
             auto rangeEndAfterCurrentTime = buffered.maximumBufferedTime();
+            if (!rangeEndAfterCurrentTime.isValid()) {
+                ASSERT_NOT_REACHED();
+                break;
+            }
             auto rangeStartAfterCurrentTime = std::max(minimumRangeStartAfterCurrentTime, rangeEndAfterCurrentTime - timeChunk);
 
             if (rangeStartAfterCurrentTime >= rangeEndAfterCurrentTime)


### PR DESCRIPTION
#### 1fd5d97f197638adb0448f58f399e98797bc25cf
<pre>
REGRESSION(305199@main): Crash in `SourceBufferPrivate::removeCodedFramesInternal`
<a href="https://bugs.webkit.org/show_bug.cgi?id=308678">https://bugs.webkit.org/show_bug.cgi?id=308678</a>
<a href="https://rdar.apple.com/170833664">rdar://170833664</a>

Reviewed by Jer Noble.

Crash data indicates removeCodedFramesInternal can be called with an invalid end time. Since
305199@main, invalidTime comparisons return unordered, causing all comparison guards to evaluate to
false, which allows an invalid MediaTime to be used as a std::map key. We should return early if the
buffered time is invalid to avoid crashing.

Test: media/media-source/media-source-evict-invalid-time-crash.html

* LayoutTests/TestExpectations:
* LayoutTests/media/media-source/media-source-evict-invalid-time-crash-expected.txt: Added.
* LayoutTests/media/media-source/media-source-evict-invalid-time-crash.html: Added.
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::removeCodedFramesInternal):

Originally-landed-as: 305413.370@rapid/safari-7624.2.5.110-branch (f23e9cfe0406). <a href="https://rdar.apple.com/176067104">rdar://176067104</a>
Canonical link: <a href="https://commits.webkit.org/315066@main">https://commits.webkit.org/315066@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/74f5dfeddae474652a1cfd7700d42f66ade1dc7a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167927 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41424 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35024 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177222 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125620 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169793 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41859 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41438 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130643 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/91829 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170886 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33115 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150898 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111160 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32096 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30796 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25925 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142086 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28592 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179822 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32574 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30310 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139064 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41496 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34953 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138946 "Passed tests") | 
| [  ~~🛠 🧪 merge~~](https://ews-build.webkit.org/#/builders/19/builds/37432 "The change is no longer eligible for processing.") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42184 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150384 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105463 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25576 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34235 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27266 "Found 1 new test failure: imported/w3c/web-platform-tests/web-locks/acquire.https.any.sharedworker.html (failure)") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40688 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113940 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40085 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5366 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40336 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40230 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->