### PR TITLE
Cherry-pick 313118@main (071edf4eff8a). https://bugs.webkit.org/show_bug.cgi?id=314243

### DIFF
--- a/LayoutTests/fast/scrolling/ios/fixed-position-in-vertical-rl-expected.html
+++ b/LayoutTests/fast/scrolling/ios/fixed-position-in-vertical-rl-expected.html
@@ -1,0 +1,40 @@
+<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    :root {
+      scrollbar-width: none;
+    }
+    body {
+      writing-mode: vertical-rl;
+      margin: 0;
+    }
+
+    #overlay {
+      position: fixed;
+      background: red;
+      color: white;
+      width: 50%;
+      overflow: auto;
+      top: 0;
+      left: 0;
+      bottom: 0;
+      border: 1px solid black;
+      box-sizing: border-box;
+    }
+
+    .scrollable-content {
+        width: 4000px;
+        height: 100%;
+        background-color: green;
+    }
+  </style>
+</head>
+<body>
+  <div class="scrollable-content"></div>
+  <div id="overlay">
+      <div class="scrollable-content"></div>
+  </div>
+</body>
+</html>

--- a/LayoutTests/fast/scrolling/ios/fixed-position-in-vertical-rl.html
+++ b/LayoutTests/fast/scrolling/ios/fixed-position-in-vertical-rl.html
@@ -1,0 +1,54 @@
+<!DOCTYPE html><!-- webkit-test-runner [ useFlexibleViewport=true AsyncOverflowScrollingEnabled=true ] -->
+<html>
+<head>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    :root {
+      scrollbar-width: none;
+    }
+    body {
+      writing-mode: vertical-rl;
+      margin: 0;
+    }
+
+    #overlay {
+      position: fixed;
+      background: red;
+      color: white;
+      width: 50%;
+      overflow: auto;
+      top: 0;
+      left: 0;
+      bottom: 0;
+      border: 1px solid black;
+      box-sizing: border-box;
+    }
+
+    .scrollable-content {
+        width: 4000px;
+        height: 100%;
+        background-color: green;
+    }
+  </style>
+  <script src="../../../resources/ui-helper.js"></script>
+  <script>
+      window.addEventListener('load', async () => {
+          window.testRunner?.waitUntilDone();
+
+          await UIHelper.delayFor(0);
+          
+          const rightEdge = window.innerWidth;
+          await UIHelper.dragFromPointToPoint(rightEdge - 150, 300, rightEdge - 50, 300, 0.1);
+          await UIHelper.waitForTargetScrollAnimationToSettle(document.scrollingElement);
+
+          window.testRunner?.notifyDone();
+      }, false);
+  </script>
+</head>
+<body>
+  <div class="scrollable-content"></div>
+  <div id="overlay">
+      <div class="scrollable-content"></div>
+  </div>
+</body>
+</html>

--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -406,8 +406,14 @@ set(LLIntSettingsExtractor_PRIVATE_INCLUDE_DIRECTORIES
     $<TARGET_PROPERTY:JavaScriptCore,INCLUDE_DIRECTORIES>
     "${JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS_DIR}/JavaScriptCore"
 )
-set(LLIntSettingsExtractor_FRAMEWORKS ${JavaScriptCore_FRAMEWORKS})
-set(LLIntSettingsExtractor_DEPENDENCIES JavaScriptCore_CopyHeaders JavaScriptCore_CopyPrivateHeaders)
+
+set(LLIntSettingsExtractor_FRAMEWORKS)
+set(LLIntSettingsExtractor_DEPENDENCIES
+    JavaScriptCore_CopyHeaders
+    JavaScriptCore_CopyPrivateHeaders
+    WTF_CopyHeaders
+    bmalloc_CopyHeaders
+)
 WEBKIT_EXECUTABLE(LLIntSettingsExtractor)
 
 # LLIntSettingsExtractor target needs to have a direct or indirect
@@ -426,8 +432,15 @@ set(LLIntOffsetsExtractor_PRIVATE_INCLUDE_DIRECTORIES
     $<TARGET_PROPERTY:JavaScriptCore,INCLUDE_DIRECTORIES>
     "${JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS_DIR}/JavaScriptCore"
 )
-set(LLIntOffsetsExtractor_FRAMEWORKS ${JavaScriptCore_FRAMEWORKS})
-set(LLIntOffsetsExtractor_DEPENDENCIES JavaScriptCore_CopyHeaders JavaScriptCore_CopyPrivateHeaders JSCBuiltins)
+
+set(LLIntOffsetsExtractor_FRAMEWORKS)
+set(LLIntOffsetsExtractor_DEPENDENCIES
+    JSCBuiltins
+    JavaScriptCore_CopyHeaders
+    JavaScriptCore_CopyPrivateHeaders
+    WTF_CopyHeaders
+    bmalloc_CopyHeaders
+)
 WEBKIT_EXECUTABLE(LLIntOffsetsExtractor)
 
 # The build system will execute asm.rb every time LLIntOffsetsExtractor's mtime is newer than

--- a/Source/WebCore/loader/DocumentLoader.cpp
+++ b/Source/WebCore/loader/DocumentLoader.cpp
@@ -775,6 +775,18 @@ void DocumentLoader::willSendRequest(ResourceRequest&& newRequest, const Resourc
             stopLoadingForPolicyChange(navigationPolicyDecision == NavigationPolicyDecision::LoadWillContinueInAnotherProcess ? LoadWillContinueInAnotherProcess::Yes : LoadWillContinueInAnotherProcess::No);
             break;
         case NavigationPolicyDecision::ContinueLoad:
+            // The client may have updated the User-Agent (via webView.customUserAgent,
+            // WKWebpagePreferences._customUserAgent, an Inspector override, or a quirk
+            // triggered by the redirect target URL) during the policy callback. The
+            // redirected request still carries the previous request's User-Agent
+            // header, so FrameLoader::applyUserAgentIfNeeded() would skip it. Re-apply
+            // the authoritative UA here so all sources — including URL-dependent
+            // quirks — take effect on the redirected request.
+            if (RefPtr frameLoader = this->frameLoader()) {
+                String userAgent = frameLoader->userAgent(request.url());
+                if (!userAgent.isEmpty() && userAgent != request.httpUserAgent())
+                    request.setHTTPUserAgent(WTF::move(userAgent));
+            }
             break;
         }
 

--- a/Source/WebCore/page/LocalFrameView.cpp
+++ b/Source/WebCore/page/LocalFrameView.cpp
@@ -1851,11 +1851,11 @@ LayoutRect LocalFrameView::computeUpdatedLayoutViewportRect(const LayoutRect& la
         // The max stable layout viewport origin really depends on the size of the layout viewport itself, so we need to adjust the location of the layout viewport one final time to make sure it does not end up out of bounds of the document.
         // Without this adjustment (and with using the non-constrained unobscuredContentRect's size as the size of the layout viewport) the layout viewport can be pushed past the bounds of the document during rubber-banding, and cannot be pushed
         // back in until the user scrolls back in the other direction.
-        layoutViewportOrigin.setX(clampTo<float>(layoutViewportOrigin.x().toFloat(), 0, documentRect.width() - layoutViewportRect.width()));
-        layoutViewportOrigin.setY(clampTo<float>(layoutViewportOrigin.y().toFloat(), 0, documentRect.height() - layoutViewportRect.height()));
+        layoutViewportOrigin.setX(clampTo<float>(layoutViewportOrigin.x().toFloat(), documentRect.x(), documentRect.maxX() - layoutViewportRect.width()));
+        layoutViewportOrigin.setY(clampTo<float>(layoutViewportOrigin.y().toFloat(), documentRect.y(), documentRect.maxY() - layoutViewportRect.height()));
     }
     layoutViewportRect.setLocation(layoutViewportOrigin);
-    
+
     return layoutViewportRect;
 }
 

--- a/Source/WebCore/platform/graphics/FontCascade.cpp
+++ b/Source/WebCore/platform/graphics/FontCascade.cpp
@@ -881,6 +881,10 @@ FontCascade::CodePath FontCascade::characterRangeCodePath(std::span<const char16
                 return CodePath::Complex;
             if (supplementaryCharacter < 0x11CC0) // Marchen
                 return CodePath::Complex;
+            if (supplementaryCharacter < 0x16B00)
+                continue;
+            if (supplementaryCharacter < 0x16B90) // Pahawh Hmong
+                return CodePath::Complex;
             if (supplementaryCharacter < 0x1E900)
                 continue;
             if (supplementaryCharacter < 0x1E960) // Adlam

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp
@@ -181,8 +181,8 @@ NetworkResourceLoader::~NetworkResourceLoader()
     ASSERT(!m_networkLoad);
     ASSERT(!isSynchronous() || !m_synchronousLoadData->delayedReply);
     ASSERT(m_fileReferences.isEmpty());
-    if (m_responseCompletionHandler)
-        m_responseCompletionHandler(PolicyAction::Ignore);
+    while (!m_responseCompletionHandlers.isEmpty())
+        m_responseCompletionHandlers.takeFirst()(PolicyAction::Ignore);
 }
 
 Ref<NetworkConnectionToWebProcess> NetworkResourceLoader::protectedConnectionToWebProcess() const
@@ -607,7 +607,7 @@ void NetworkResourceLoader::cleanup(LoadResult result)
 
 void NetworkResourceLoader::convertToDownload(DownloadID downloadID, const ResourceRequest& request, const ResourceResponse& response)
 {
-    LOADER_RELEASE_LOG("convertToDownload: (downloadID=%" PRIu64 ", hasNetworkLoad=%d, hasResponseCompletionHandler=%d)", downloadID.toUInt64(), !!m_networkLoad, !!m_responseCompletionHandler);
+    LOADER_RELEASE_LOG("convertToDownload: (downloadID=%" PRIu64 ", hasNetworkLoad=%d, pendingResponseCompletionHandlers=%zu)", downloadID.toUInt64(), !!m_networkLoad, m_responseCompletionHandlers.size());
 
     RefPtr task = m_serviceWorkerFetchTask;
     if (task && task->convertToDownload(protectedConnectionToWebProcess()->networkProcess().checkedDownloadManager(), downloadID, request, response))
@@ -622,8 +622,12 @@ void NetworkResourceLoader::convertToDownload(DownloadID downloadID, const Resou
 
     auto networkLoad = std::exchange(m_networkLoad, nullptr);
 
-    if (m_responseCompletionHandler)
-        protectedConnectionToWebProcess()->networkProcess().checkedDownloadManager()->convertNetworkLoadToDownload(downloadID, networkLoad.releaseNonNull(), WTF::move(m_responseCompletionHandler), WTF::move(m_fileReferences), request, response);
+    if (!m_responseCompletionHandlers.isEmpty()) {
+        auto firstHandler = m_responseCompletionHandlers.takeFirst();
+        while (!m_responseCompletionHandlers.isEmpty())
+            m_responseCompletionHandlers.takeFirst()(PolicyAction::Ignore);
+        protectedConnectionToWebProcess()->networkProcess().checkedDownloadManager()->convertNetworkLoadToDownload(downloadID, networkLoad.releaseNonNull(), WTF::move(firstHandler), WTF::move(m_fileReferences), request, response);
+    }
 }
 
 void NetworkResourceLoader::abort()
@@ -686,7 +690,7 @@ void NetworkResourceLoader::transferToNewWebProcess(NetworkConnectionToWebProces
     if (parameters.options.resultingClientIdentifier && m_parameters.options.resultingClientIdentifier)
         send(Messages::WebResourceLoader::UpdateResultingClientIdentifier { *parameters.options.resultingClientIdentifier, *m_parameters.options.resultingClientIdentifier });
 
-    ASSERT(m_responseCompletionHandler || m_cacheEntryWaitingForContinueDidReceiveResponse || m_serviceWorkerFetchTask);
+    ASSERT(!m_responseCompletionHandlers.isEmpty() || m_cacheEntryWaitingForContinueDidReceiveResponse || m_serviceWorkerFetchTask);
     if (RefPtr serviceWorkerRegistration = m_serviceWorkerRegistration.get()) {
         if (RefPtr swConnection = newConnection.swConnection())
             swConnection->transferServiceWorkerLoadToNewWebProcess(*this, *serviceWorkerRegistration, parameters.request);
@@ -1058,7 +1062,7 @@ void NetworkResourceLoader::didReceiveResponse(ResourceResponse&& receivedRespon
             protectedConnectionToWebProcess()->networkProcess().protectedParentProcessConnection()->send(Messages::NetworkProcessProxy::ResourceLoadDidReceiveResponse(webPageProxyID(), resourceLoadInfo, response), 0);
 
         if (willWaitForContinueDidReceiveResponse) {
-            m_responseCompletionHandler = WTF::move(completionHandler);
+            m_responseCompletionHandlers.append(WTF::move(completionHandler));
             return;
         }
 
@@ -1559,7 +1563,7 @@ void NetworkResourceLoader::continueWillSendRequest(ResourceRequest&& newRequest
 
 void NetworkResourceLoader::continueDidReceiveResponse()
 {
-    LOADER_RELEASE_LOG("continueDidReceiveResponse: (hasCacheEntryWaitingForContinueDidReceiveResponse=%d, hasResponseCompletionHandler=%d)", !!m_cacheEntryWaitingForContinueDidReceiveResponse, !!m_responseCompletionHandler);
+    LOADER_RELEASE_LOG("continueDidReceiveResponse: (hasCacheEntryWaitingForContinueDidReceiveResponse=%d, pendingResponseCompletionHandlers=%zu)", !!m_cacheEntryWaitingForContinueDidReceiveResponse, m_responseCompletionHandlers.size());
     if (m_serviceWorkerFetchTask) {
         LOADER_RELEASE_LOG("continueDidReceiveResponse: continuing with ServiceWorkerFetchTask (fetchIdentifier=%" PRIu64 ")", m_serviceWorkerFetchTask->fetchIdentifier().toUInt64());
         protectedServiceWorkerFetchTask()->continueDidReceiveFetchResponse();
@@ -1572,8 +1576,8 @@ void NetworkResourceLoader::continueDidReceiveResponse()
         return;
     }
 
-    if (m_responseCompletionHandler)
-        m_responseCompletionHandler(PolicyAction::Use);
+    if (!m_responseCompletionHandlers.isEmpty())
+        m_responseCompletionHandlers.takeFirst()(PolicyAction::Use);
 }
 
 void NetworkResourceLoader::didSendData(uint64_t bytesSent, uint64_t totalBytesToBeSent)

--- a/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
+++ b/Source/WebKit/NetworkProcess/NetworkResourceLoader.h
@@ -44,6 +44,7 @@
 #include <WebCore/SecurityPolicyViolationEvent.h>
 #include <WebCore/SharedBuffer.h>
 #include <WebCore/Timer.h>
+#include <wtf/Deque.h>
 #include <wtf/MonotonicTime.h>
 #include <wtf/WeakPtr.h>
 
@@ -329,7 +330,9 @@ private:
     std::unique_ptr<NetworkCache::Entry> m_cacheEntryWaitingForContinueDidReceiveResponse;
     RefPtr<NetworkLoadChecker> m_networkLoadChecker;
     bool m_shouldRestartLoad { false };
-    ResponseCompletionHandler m_responseCompletionHandler;
+    // A Deque (rather than a single handler) is needed because multipart/x-mixed-replace responses
+    // can deliver follow-up parts before the WebProcess has approved the first one via ContinueDidReceiveResponse.
+    Deque<ResponseCompletionHandler> m_responseCompletionHandlers;
     bool m_shouldCaptureExtraNetworkLoadMetrics { false };
     bool m_isKeptAlive { false };
     std::unique_ptr<EarlyHintsResourceLoader> m_earlyHintsResourceLoader;

--- a/Source/WebKit/Platform/IPC/MessageReceiverMap.cpp
+++ b/Source/WebKit/Platform/IPC/MessageReceiverMap.cpp
@@ -27,7 +27,9 @@
 #include "MessageReceiverMap.h"
 
 #include "Decoder.h"
+#include "Logging.h"
 #include "MessageReceiver.h"
+#include <wtf/EnumTraits.h>
 
 namespace IPC {
 
@@ -106,13 +108,24 @@ void MessageReceiverMap::removeMessageReceiver(MessageReceiver& messageReceiver)
 
 void MessageReceiverMap::invalidate()
 {
-    for (auto& messageReceiver : m_globalMessageReceivers.values())
-        messageReceiver->willBeRemovedFromMessageReceiverMap();
+    for (auto& [name, messageReceiver] : m_globalMessageReceivers) {
+        if (messageReceiver)
+            messageReceiver->willBeRemovedFromMessageReceiverMap();
+        else {
+            RELEASE_LOG_FAULT(IPC, "MessageReceiverMap::invalidate(): %s failed to remove itself from the map before its destruction", WTF::String(WTF::enumName(name)).utf8().data());
+            ASSERT_NOT_REACHED();
+        }
+    }
     m_globalMessageReceivers.clear();
 
-
-    for (auto& messageReceiver : m_messageReceivers.values())
-        messageReceiver->willBeRemovedFromMessageReceiverMap();
+    for (auto& [nameAndDestinationID, messageReceiver] : m_messageReceivers) {
+        if (messageReceiver)
+            messageReceiver->willBeRemovedFromMessageReceiverMap();
+        else {
+            RELEASE_LOG_FAULT(IPC, "MessageReceiverMap::invalidate(): %s (destinationID=%" PRIu64 ") failed to remove itself from the map before its destruction", WTF::String(WTF::enumName(nameAndDestinationID.first)).utf8().data(), nameAndDestinationID.second);
+            ASSERT_NOT_REACHED();
+        }
+    }
     m_messageReceivers.clear();
 }
 

--- a/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
+++ b/Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp
@@ -28,9 +28,11 @@
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
+#include "WebExtensionControllerMessages.h"
 #include "WebExtensionControllerParameters.h"
 #include "WebExtensionControllerProxyMessages.h"
 #include "WebPageProxy.h"
+#include "WebProcessPool.h"
 #include <wtf/HashMap.h>
 #include <wtf/NeverDestroyed.h>
 
@@ -81,6 +83,10 @@ WebExtensionController::WebExtensionController(Ref<WebExtensionControllerConfigu
 WebExtensionController::~WebExtensionController()
 {
     webExtensionControllers().remove(identifier());
+
+    for (Ref pool : m_processPools)
+        pool->removeMessageReceiver(Messages::WebExtensionController::messageReceiverName(), identifier());
+
     unloadAll();
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebCore/FontCascade.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/FontCascade.cpp
@@ -38,6 +38,19 @@ static void testCodePath(char16_t codePoint, CodePath codePath)
     EXPECT_EQ(codePath, FontCascade::characterRangeCodePath(std::span<char16_t>(target))) << "target: " << static_cast<int>(target[0]);
 }
 
+static std::array<char16_t, 2> surrogatePair(char32_t supplementaryCharacter)
+{
+    char16_t high = 0xD800 + ((supplementaryCharacter - 0x10000) >> 10);
+    char16_t low = 0xDC00 + ((supplementaryCharacter - 0x10000) & 0x3FF);
+    return { high, low };
+}
+
+static void testSupplementaryCodePath(char32_t codePoint, CodePath codePath)
+{
+    auto target = surrogatePair(codePoint);
+    EXPECT_EQ(codePath, FontCascade::characterRangeCodePath(std::span<char16_t>(target))) << "target: U+" << std::hex << static_cast<uint32_t>(codePoint);
+}
+
 struct CodePathRange {
     char16_t start;
     char16_t end;
@@ -115,5 +128,15 @@ TEST(FontCascadeTest, characterRangeCodePath_NonSurrogates)
     testCodePathRange({ 0xFE00, 0xFE0F, CodePath::Complex });
     // U+FE20 through U+FE2F Combining half marks
     testCodePathRange({ 0xFE20, 0xFE2F, CodePath::Complex });
+}
+
+// Testing characterRangeCodePath for supplementary-plane codepoints
+TEST(FontCascadeTest, characterRangeCodePath_Surrogates)
+{
+    // U+16B00 through U+16B8F Pahawh Hmong
+    testSupplementaryCodePath(0x16B00, CodePath::Complex);
+    testSupplementaryCodePath(0x16B16, CodePath::Complex);
+    testSupplementaryCodePath(0x16B30, CodePath::Complex);
+    testSupplementaryCodePath(0x16B8F, CodePath::Complex);
 }
 }

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/CustomUserAgent.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/CustomUserAgent.mm
@@ -26,10 +26,16 @@
 #import "config.h"
 
 #import "DeprecatedGlobalValues.h"
+#import "HTTPServer.h"
 #import "PlatformUtilities.h"
 #import "TestNavigationDelegate.h"
+#import "TestWKWebView.h"
+#import <WebKit/WKPreferencesPrivate.h>
+#import <WebKit/WKWebpagePreferencesPrivate.h>
 #import <WebKit/WebKit.h>
 #import <wtf/RetainPtr.h>
+#import <wtf/text/MakeString.h>
+#import <wtf/text/WTFString.h>
 
 TEST(CustomUserAgent, UpdateCachedNavigatorUserAgent)
 {
@@ -61,3 +67,212 @@ TEST(CustomUserAgent, UpdateCachedNavigatorUserAgent)
     TestWebKitAPI::Util::run(&done);
     done = false;
 }
+
+namespace TestWebKitAPI {
+
+static String userAgentFromRequest(const Vector<char>& request)
+{
+    auto headers = String::fromUTF8(request.span()).split("\r\n"_s);
+    auto index = headers.findIf([](auto& header) {
+        return header.startsWith("User-Agent:"_s);
+    });
+    if (index == notFound)
+        return { };
+    return headers[index];
+}
+
+// Covers rdar://176265326. When the app updates webView.customUserAgent inside
+// decidePolicyForNavigationAction for a 302 redirect target, the redirected
+// request must carry the updated User-Agent even when no process swap occurs.
+TEST(CustomUserAgent, PageLevelCustomUserAgentUpdatedInsidePolicyAppliesToRedirectTarget)
+{
+    String receivedUserAgentOnTarget;
+    bool targetWasRequested = false;
+    HTTPServer server(HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> ConnectionTask {
+        while (true) {
+            auto request = co_await connection.awaitableReceiveHTTPRequest();
+            auto path = HTTPServer::parsePath(request);
+            if (path == "/redirect"_s) {
+                co_await connection.awaitableSend(makeString(
+                    "HTTP/1.1 302 Found\r\n"
+                    "Location: /target\r\n"
+                    "Content-Length: 0\r\n"
+                    "\r\n"_s));
+                continue;
+            }
+            if (path == "/target"_s) {
+                receivedUserAgentOnTarget = userAgentFromRequest(request);
+                targetWasRequested = true;
+                co_await connection.awaitableSend(
+                    "HTTP/1.1 200 OK\r\n"
+                    "Content-Length: 0\r\n"
+                    "\r\n"_s);
+                continue;
+            }
+            EXPECT_FALSE(true);
+        }
+    });
+
+    RetainPtr webView = adoptNS([TestWKWebView new]);
+    [webView setCustomUserAgent:@"Initial"];
+
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    navigationDelegate.get().decidePolicyForNavigationAction = ^(WKNavigationAction *navigationAction, void (^decisionHandler)(WKNavigationActionPolicy)) {
+        if ([navigationAction.request.URL.path isEqualToString:@"/target"])
+            webView.get().customUserAgent = @"Updated";
+        decisionHandler(WKNavigationActionPolicyAllow);
+    };
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    [webView loadRequest:server.request("/redirect"_s)];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    EXPECT_TRUE(targetWasRequested);
+    EXPECT_WK_STREQ("User-Agent: Updated", receivedUserAgentOnTarget.utf8().data());
+}
+
+// Same scenario as above, but using the WKWebpagePreferences SPI variant.
+// The app does not set a page-level custom UA; the delegate supplies one only
+// via preferences._customUserAgent inside the policy callback for /target.
+TEST(CustomUserAgent, WebpagePreferencesCustomUserAgentAppliesToRedirectTarget)
+{
+    String receivedUserAgentOnTarget;
+    bool targetWasRequested = false;
+    HTTPServer server(HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> ConnectionTask {
+        while (true) {
+            auto request = co_await connection.awaitableReceiveHTTPRequest();
+            auto path = HTTPServer::parsePath(request);
+            if (path == "/redirect"_s) {
+                co_await connection.awaitableSend(makeString(
+                    "HTTP/1.1 302 Found\r\n"
+                    "Location: /target\r\n"
+                    "Content-Length: 0\r\n"
+                    "\r\n"_s));
+                continue;
+            }
+            if (path == "/target"_s) {
+                receivedUserAgentOnTarget = userAgentFromRequest(request);
+                targetWasRequested = true;
+                co_await connection.awaitableSend(
+                    "HTTP/1.1 200 OK\r\n"
+                    "Content-Length: 0\r\n"
+                    "\r\n"_s);
+                continue;
+            }
+            EXPECT_FALSE(true);
+        }
+    });
+
+    RetainPtr webView = adoptNS([TestWKWebView new]);
+
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    navigationDelegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *navigationAction, WKWebpagePreferences *preferences, void (^decisionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
+        if ([navigationAction.request.URL.path isEqualToString:@"/target"])
+            preferences._customUserAgent = @"Updated";
+        decisionHandler(WKNavigationActionPolicyAllow, preferences);
+    };
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    [webView loadRequest:server.request("/redirect"_s)];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    EXPECT_TRUE(targetWasRequested);
+    EXPECT_WK_STREQ("User-Agent: Updated", receivedUserAgentOnTarget.utf8().data());
+}
+
+// Regression guard: when no custom UA is in effect, the redirect target must
+// still receive the default browser User-Agent unmodified by the fix.
+TEST(CustomUserAgent, NoCustomUserAgentRedirectUsesDefault)
+{
+    String receivedUserAgentOnTarget;
+    bool targetWasRequested = false;
+    HTTPServer server(HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> ConnectionTask {
+        while (true) {
+            auto request = co_await connection.awaitableReceiveHTTPRequest();
+            auto path = HTTPServer::parsePath(request);
+            if (path == "/redirect"_s) {
+                co_await connection.awaitableSend(makeString(
+                    "HTTP/1.1 302 Found\r\n"
+                    "Location: /target\r\n"
+                    "Content-Length: 0\r\n"
+                    "\r\n"_s));
+                continue;
+            }
+            if (path == "/target"_s) {
+                receivedUserAgentOnTarget = userAgentFromRequest(request);
+                targetWasRequested = true;
+                co_await connection.awaitableSend(
+                    "HTTP/1.1 200 OK\r\n"
+                    "Content-Length: 0\r\n"
+                    "\r\n"_s);
+                continue;
+            }
+            EXPECT_FALSE(true);
+        }
+    });
+
+    RetainPtr webView = adoptNS([TestWKWebView new]);
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    [webView loadRequest:server.request("/redirect"_s)];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    EXPECT_TRUE(targetWasRequested);
+    EXPECT_TRUE(receivedUserAgentOnTarget.startsWith("User-Agent: Mozilla/"_s));
+}
+
+// Same scenario as PageLevel above, but using the WKWebpagePreferences
+// _customUserAgentAsSiteSpecificQuirks SPI. That value is stored on the
+// DocumentLoader as a separate field from the regular customUserAgent, so the
+// fix must resolve it through FrameLoader::userAgent() rather than checking
+// the plain customUserAgent directly.
+TEST(CustomUserAgent, WebpagePreferencesCustomUserAgentAsSiteSpecificQuirksAppliesToRedirectTarget)
+{
+    String receivedUserAgentOnTarget;
+    bool targetWasRequested = false;
+    HTTPServer server(HTTPServer::UseCoroutines::Yes, [&](Connection connection) -> ConnectionTask {
+        while (true) {
+            auto request = co_await connection.awaitableReceiveHTTPRequest();
+            auto path = HTTPServer::parsePath(request);
+            if (path == "/redirect"_s) {
+                co_await connection.awaitableSend(makeString(
+                    "HTTP/1.1 302 Found\r\n"
+                    "Location: /target\r\n"
+                    "Content-Length: 0\r\n"
+                    "\r\n"_s));
+                continue;
+            }
+            if (path == "/target"_s) {
+                receivedUserAgentOnTarget = userAgentFromRequest(request);
+                targetWasRequested = true;
+                co_await connection.awaitableSend(
+                    "HTTP/1.1 200 OK\r\n"
+                    "Content-Length: 0\r\n"
+                    "\r\n"_s);
+                continue;
+            }
+            EXPECT_FALSE(true);
+        }
+    });
+
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    configuration.get().preferences._needsSiteSpecificQuirks = YES;
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectZero configuration:configuration.get()]);
+
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    navigationDelegate.get().decidePolicyForNavigationActionWithPreferences = ^(WKNavigationAction *navigationAction, WKWebpagePreferences *preferences, void (^decisionHandler)(WKNavigationActionPolicy, WKWebpagePreferences *)) {
+        if ([navigationAction.request.URL.path isEqualToString:@"/target"])
+            preferences._customUserAgentAsSiteSpecificQuirks = @"QuirkUA";
+        decisionHandler(WKNavigationActionPolicyAllow, preferences);
+    };
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    [webView loadRequest:server.request("/redirect"_s)];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    EXPECT_TRUE(targetWasRequested);
+    EXPECT_WK_STREQ("User-Agent: QuirkUA", receivedUserAgentOnTarget.utf8().data());
+}
+
+} // namespace TestWebKitAPI


### PR DESCRIPTION
#### 3621a3fadb652167cb31e24384455cb0f8f8ddf4
<pre>
Cherry-pick 313118@main (071edf4eff8a). <a href="https://bugs.webkit.org/show_bug.cgi?id=314243">https://bugs.webkit.org/show_bug.cgi?id=314243</a>

    RELEASE ASSERT: http/tests/security/contentSecurityPolicy/multipart-three-part.py is a flaky crash
    <a href="https://bugs.webkit.org/show_bug.cgi?id=314243">https://bugs.webkit.org/show_bug.cgi?id=314243</a>
    <a href="https://rdar.apple.com/169360779">rdar://169360779</a>

    Reviewed by Brent Fulgham and Brady Eidson.

    http/tests/security/contentSecurityPolicy/multipart-three-part.py is
    flaky because NetworkResourceLoader::didReceiveResponse() sometimes
    overwrites m_responseCompletionHandler before the previous one has been
    called, hitting the CompletionHandler destructor assertion.

    For a multipart/x-mixed-replace main resource, the network layer can
    deliver follow-up parts via didReceiveResponse() before the WebProcess
    has answered ContinueDidReceiveResponse for the first part. The first
    part&apos;s round-trip is async because it goes through
    DocumentLoader::responseReceived() -&gt; checkContentPolicy(), which IPCs
    to the UIProcess. Assigning the new completion handler over the still-
    pending one destroyed it without invoking it, asserting in
    CompletionHandler&apos;s destructor.

    Replace the single m_responseCompletionHandler with a Deque so each
    incoming response queues its own handler, and each ContinueDidReceive-
    Response IPC drains the front of the queue. This mirrors the WebProcess
    flow (it processes each part in order, sending one ContinueDidReceive-
    Response per approved part), so per-part validation is preserved. On
    loader teardown / convertToDownload, any remaining handlers are drained
    with PolicyAction::Ignore.

    No new tests, covered by existing test.

    * Source/WebKit/NetworkProcess/NetworkResourceLoader.cpp:
    (WebKit::NetworkResourceLoader::~NetworkResourceLoader):
    (WebKit::NetworkResourceLoader::convertToDownload):
    (WebKit::NetworkResourceLoader::transferToNewWebProcess):
    (WebKit::NetworkResourceLoader::didReceiveResponse):
    (WebKit::NetworkResourceLoader::continueDidReceiveResponse):
    * Source/WebKit/NetworkProcess/NetworkResourceLoader.h:

    Canonical link: <a href="https://commits.webkit.org/313118@main">https://commits.webkit.org/313118@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.657@webkitglib/2.52">https://commits.webkit.org/305877.657@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 13fffde7fc51bec2bb53d3d73d60112474a45f89
<pre>
Cherry-pick 313127@main (9a2a1a1b6932). <a href="https://bugs.webkit.org/show_bug.cgi?id=313542">https://bugs.webkit.org/show_bug.cgi?id=313542</a>

    [WebKit] Apply authoritative User-Agent on redirect after policy callback
    <a href="https://bugs.webkit.org/show_bug.cgi?id=313542">https://bugs.webkit.org/show_bug.cgi?id=313542</a>
    <a href="https://rdar.apple.com/176265326">rdar://176265326</a>

    Reviewed by Chris Dumez.

    When an application updates the custom User-Agent (via WKWebView.customUserAgent,
    WKWebpagePreferences._customUserAgent, or
    WKWebpagePreferences._customUserAgentAsSiteSpecificQuirks) from inside
    decidePolicyForNavigationAction for a 302 redirect target, the updated
    User-Agent is not applied to the request that actually gets sent to the server
    unless a process swap happens to be triggered by the cross-origin redirect.

    In the programmatic webView.load(_:) case there is no committed document yet,
    so the cross-origin redirect does not trigger a process swap. The redirected
    ResourceRequest carries the original request&apos;s User-Agent header through to the
    WebProcess, and FrameLoader::applyUserAgentIfNeeded() short-circuits because
    the header is already present. The request reaches the server with the stale
    UA.

    In the link-click case, the prior page is already committed, so the cross-site
    redirect triggers PSON. The replacement WebProcess rebuilds the request from
    scratch using the current page-level UA, and the fresh value reaches the
    server. This is incidental — the non-PSON path needs the same outcome.

    Re-apply the authoritative User-Agent inside DocumentLoader::willSendRequest()&apos;s
    navigation-policy completion handler when the decision is to continue the load.
    FrameLoader::userAgent(url) is the same function applyUserAgentIfNeeded() uses
    for initial requests and consults every UA source — storage-access quirks,
    WebsitePolicies site-specific-quirks UA, the regular customUserAgent,
    InspectorInstrumentation overrides, and the page-level m_userAgent — so
    resolving through it here covers all of them on the redirected request too,
    including URL-dependent quirks that differ between the initial URL and the
    redirect target. The write is skipped when the computed UA is empty or matches
    the header already on the request.

    * Source/WebCore/loader/DocumentLoader.cpp:
    (WebCore::DocumentLoader::willSendRequest):
    * Tools/TestWebKitAPI/Tests/WebKit/WKWebView/CustomUserAgent.mm:

    Canonical link: <a href="https://commits.webkit.org/313127@main">https://commits.webkit.org/313127@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.656@webkitglib/2.52">https://commits.webkit.org/305877.656@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### ba263efab8b5be32f957313ef80e84f86d94cd41
<pre>
Cherry-pick 313458@main (091658231ee4). <a href="https://bugs.webkit.org/show_bug.cgi?id=315062">https://bugs.webkit.org/show_bug.cgi?id=315062</a>

    Pahawh Hmong text is misrendered because it takes the simple text path
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315062">https://bugs.webkit.org/show_bug.cgi?id=315062</a>
    <a href="https://rdar.apple.com/167446860">rdar://167446860</a>

    Reviewed by Brent Fulgham.

    The supplementary-character table in FontCascade::characterRangeCodePath does
    not include the Pahawh Hmong block (U+16B00 - U+16B8F), so runs containing
    those codepoints fall through to the simple text path which does not position
    Pahawh Hmong tone marks correctly. Therefore add the range to the table so
    Pahawh Hmong is shaped on the complex text path, which positions the marks
    correctly.

    * Source/WebCore/platform/graphics/FontCascade.cpp:
    (WebCore::FontCascade::characterRangeCodePath):
    * Tools/TestWebKitAPI/Tests/WebCore/FontCascade.cpp:
    (TestWebKitAPI::surrogatePair):
    (TestWebKitAPI::testSupplementaryCodePath):
    (TEST):

    Canonical link: <a href="https://commits.webkit.org/313458@main">https://commits.webkit.org/313458@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.655@webkitglib/2.52">https://commits.webkit.org/305877.655@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 1572c7657fd9cdb3ec8d8755d607c649409244f4
<pre>
Cherry-pick 313494@main (825d9df3072f). <a href="https://bugs.webkit.org/show_bug.cgi?id=314930">https://bugs.webkit.org/show_bug.cgi?id=314930</a>

    StabilityTracer: Crash in IPC::MessageReceiverMap::invalidate()
    <a href="https://bugs.webkit.org/show_bug.cgi?id=314930">https://bugs.webkit.org/show_bug.cgi?id=314930</a>
    <a href="https://rdar.apple.com/177091898">rdar://177091898</a>

    Reviewed by Chris Dumez.

    The crash in IPC::MessageReceiverMap::invalidate() is most likely because either
    m_globalMessageReceivers or m_messageReceivers contain a WeakPtr&lt;MessageReceiver&gt;
    that is null and attempting to dereference it to call willBeRemovedFromMessageReceiverMap()
    hits the RELEASE_ASSERT in WeakPtr::operator-&gt;().

    The MessageReceiver destructor asserts that the MessageReceiver is not in any
    MessageReceiverMap. So these two maps should never contain a null WeakPtr. But
    given that we see this crash and it&apos;s not obvious which MessageReceiver is not
    removing itself from a map before destruction, we fix this crash by adding null
    checks in invalidate(). We also add an ASSERT and RELEASE_LOG_FAULT so that we
    can later catch which MessageReceiver is not removing itself from a map.

    Even though it&apos;s not clear from the crash log alone which MessageReceiver is not
    removing itself from a map, there is a case that we can speculatively fix:

    WebExtensionController is added to the map in WebExtensionController::addProcessPool()
    and removed in WebExtensionController::removeProcessPool(). But it seems possible
    that it can be destroyed without removeProcessPool() being called, and its destructor
    does not remove it from the map. This could possibly be the reason for the crash. So
    we ensure that the destructor will remove it.

    This is a speculative fix.

    * Source/WebKit/Platform/IPC/MessageReceiverMap.cpp:
    (IPC::MessageReceiverMap::invalidate):
    * Source/WebKit/UIProcess/Extensions/WebExtensionController.cpp:
    (WebKit::WebExtensionController::~WebExtensionController):

    Canonical link: <a href="https://commits.webkit.org/313494@main">https://commits.webkit.org/313494@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.654@webkitglib/2.52">https://commits.webkit.org/305877.654@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 0e3a9a16a766605299aede43b8b4f628d1135166
<pre>
Cherry-pick 313573@main (f774c2b1c4f1). <a href="https://bugs.webkit.org/show_bug.cgi?id=315117">https://bugs.webkit.org/show_bug.cgi?id=315117</a>

    [iOS] RTL/position fixed element can lose its contents when the document is scrolled
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315117">https://bugs.webkit.org/show_bug.cgi?id=315117</a>
    <a href="https://rdar.apple.com/177454608">rdar://177454608</a>

    Reviewed by Abrar Rahman Protyasha.

    In a side-scrolling RTL page on iOS, scrolling the main frame would cause content inside
    an overflow:scroll inside a fixedpos to disappear. The issue is that we&apos;d compute an incorrect
    layoutViewportRect in `_createVisibleContentRectUpdate`, and this was sent to the web
    process and used to compute layer coverage rects.

    `_createVisibleContentRectUpdate` passes the `ConstrainedToDocumentRect` flag to
    `LocalFrameView::computeUpdatedLayoutViewportRect()`, whose constraining logic was wrong
    with RTL where documentBounds.x() goes negative. So use that to clamp, instead of 0.

    I confirmed that the test case for b98e498a0, which added this code, still works.

    Test: fast/scrolling/ios/fixed-position-in-vertical-rl.html

    * LayoutTests/fast/scrolling/ios/fixed-position-in-vertical-rl-expected.html: Added.
    * LayoutTests/fast/scrolling/ios/fixed-position-in-vertical-rl.html: Added.
    * Source/WebCore/page/LocalFrameView.cpp:
    (WebCore::LocalFrameView::computeUpdatedLayoutViewportRect):

    Canonical link: <a href="https://commits.webkit.org/313573@main">https://commits.webkit.org/313573@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.653@webkitglib/2.52">https://commits.webkit.org/305877.653@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 591ea9f65ca1c679f48423cf4dadb69be2806326
<pre>
Cherry-pick 313606@main (6cfb79671c10). <a href="https://bugs.webkit.org/show_bug.cgi?id=315226">https://bugs.webkit.org/show_bug.cgi?id=315226</a>

    [CMake] touching a WTF .cpp file should not spend 11s doing LLInt stuff
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315226">https://bugs.webkit.org/show_bug.cgi?id=315226</a>
    <a href="https://rdar.apple.com/177555150">rdar://177555150</a>

    Reviewed by Brandon Stewart.

    12X speedup (12s =&gt; 1s) when touching wtf/Lock.cpp.

    * Source/JavaScriptCore/CMakeLists.txt: Changed LLInt extractors to depend on
    headers, and not on all the frameworks (including WTF) on which JSC depends.
    The extractors are very specifically designed to work this way.

    Otherwise whenever we touch a WTF .cpp file, we dirty the extracter&apos;s dependency,
    and then we have to build and run it again.

    Canonical link: <a href="https://commits.webkit.org/313606@main">https://commits.webkit.org/313606@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.652@webkitglib/2.52">https://commits.webkit.org/305877.652@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f533192f23bc7c8f7cafe5153d9206601b4b90a0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163736 "2 style errors") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/37220 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/30439 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172797 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/120987 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165605 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/37551 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/37219 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127210 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/120987 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166695 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/37551 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/30439 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107759 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/37551 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/37219 "The change is no longer eligible for processing.") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20529 "") | 
| [  ~~🛠 🧪 jsc-x86-64~~](https://ews-build.webkit.org/#/builders/20/builds/155887 "The change is no longer eligible for processing.") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/37551 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/30439 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175321 "Built successfully") | 
| [  ~~🛠 🧪 jsc-debug-arm64~~](https://ews-build.webkit.org/#/builders/171/builds/24627 "The change is no longer eligible for processing.") | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/28112 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/30439 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135516 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/36890 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/37219 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135492 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/37675 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/30439 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/99774 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24933 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/37675 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/30439 "The change is no longer eligible for processing.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/196138 "Built successfully") | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/36386 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/109531 "The change is no longer eligible for processing.") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51140 "Passed tests") | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/35883 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/30439 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/36133 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/36030 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->