### PR TITLE
[GTK][WPE] Skia Compositor: do not use SkSurface::writePixels for tile updates uploads

### DIFF
--- a/Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp
@@ -35,7 +35,6 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/core/SkColorSpace.h>
 #include <skia/gpu/ganesh/GrBackendSurface.h>
 #include <skia/gpu/ganesh/SkImageGanesh.h>
-#include <skia/gpu/ganesh/SkSurfaceGanesh.h>
 #include <skia/gpu/ganesh/gl/GrGLBackendSurface.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #include <wtf/SystemTracing.h>
@@ -97,14 +96,13 @@ void SkiaBackingStore::drawDebugBorders(SkCanvas& canvas, const SkPaint& paint)
         canvas.drawRect(SkRect(tile.rect()), paint);
 }
 
-bool SkiaBackingStore::Tile::tryEnsureSurface(const IntSize& size, CoordinatedTileBuffer& buffer, SkColorType colorType)
+void SkiaBackingStore::Tile::ensureTexture(const IntSize& size, CoordinatedTileBuffer& buffer)
 {
-    if (m_surface && m_surface->imageInfo().colorType() == colorType)
-        return true;
-
     OptionSet<BitmapTexture::Flags> flags;
     if (buffer.supportsAlpha())
         flags.add(BitmapTexture::Flags::SupportsAlpha);
+    if (buffer.pixelFormat() == PixelFormat::BGRA8)
+        flags.add(BitmapTexture::Flags::UseBGRALayout);
 
 #if USE(GBM)
     if (SkiaPaintingEngine::shouldUseLinearTileTextures()) {
@@ -116,29 +114,13 @@ bool SkiaBackingStore::Tile::tryEnsureSurface(const IntSize& size, CoordinatedTi
     }
 #endif
 
-    auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
-    auto texture = BitmapTexturePool::singleton().acquireTexture(size, flags);
-    unsigned textureID = texture->id();
-    GrGLTextureInfo externalTexture;
-    externalTexture.fTarget = GL_TEXTURE_2D;
-    externalTexture.fID = textureID;
-    externalTexture.fFormat = colorType == kRGBA_8888_SkColorType ? GL_RGBA8 : GL_BGRA8_EXT;
-    auto backendTexture = GrBackendTextures::MakeGL(texture->size().width(), texture->size().height(), skgpu::Mipmapped::kNo, externalTexture);
-    auto surface = SkSurfaces::WrapBackendTexture(grContext, backendTexture, kTopLeft_GrSurfaceOrigin, 0, colorType, SkColorSpace::MakeSRGB(), nullptr, +[](void* userData) {
-        static_cast<BitmapTexture*>(userData)->deref();
-    }, &texture.leakRef());
-    if (!surface)
-        return false;
-
-    auto* canvas = surface->getCanvas();
-    if (!canvas)
-        return false;
-
-    canvas->clear(SK_ColorTRANSPARENT);
-    m_surface = WTF::move(surface);
-    m_textureID = textureID;
-    m_cachedImage = nullptr;
-    return true;
+    if (m_texture) {
+        if (buffer.supportsAlpha() == m_texture->isOpaque())
+            m_texture->reset(size, flags);
+    } else {
+        m_texture = BitmapTexturePool::singleton().acquireTexture(size, flags);
+        m_cachedImage = nullptr;
+    }
 }
 
 void SkiaBackingStore::Tile::update(const IntRect& dirtyRect, const IntRect& tileRect, CoordinatedTileBuffer& buffer)
@@ -150,7 +132,7 @@ void SkiaBackingStore::Tile::update(const IntRect& dirtyRect, const IntRect& til
 
     if (unscaledTileRect != m_rect) {
         m_rect = unscaledTileRect;
-        m_surface = nullptr;
+        m_texture = nullptr;
     }
 
     if (buffer.isBackedByOpenGL()) {
@@ -158,35 +140,21 @@ void SkiaBackingStore::Tile::update(const IntRect& dirtyRect, const IntRect& til
         acceleratedBuffer.serverWait();
 
         Ref texture = acceleratedBuffer.texture();
-        GrBackendTexture backendTexture = texture->createSkiaBackendTexture();
         if (dirtyRect.size() == tileRect.size()) {
             // Fast path: whole tile content changed -- take ownership of the incoming texture, replacing the existing tile buffer (avoiding texture copies).
-            m_textureID = texture->id();
+            if (m_texture)
+                m_texture->swapTexture(texture.get());
+            else
+                m_texture = WTF::move(texture);
             m_cachedImage = nullptr;
-
-            if (m_surface) {
-                m_surface->replaceBackendTexture(backendTexture, kTopLeft_GrSurfaceOrigin, SkSurface::kDiscard_ContentChangeMode, +[](void* userData) {
-                    static_cast<BitmapTexture*>(userData)->deref();
-                }, &texture.leakRef());
-            } else {
-                auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
-                m_surface = SkSurfaces::WrapBackendTexture(grContext, backendTexture, kTopLeft_GrSurfaceOrigin, 0, kRGBA_8888_SkColorType, SkColorSpace::MakeSRGB(), nullptr, +[](void* userData) {
-                    static_cast<BitmapTexture*>(userData)->deref();
-                }, &texture.leakRef());
-            }
-        } else if (tryEnsureSurface(tileRect.size(), buffer, kRGBA_8888_SkColorType)) {
-            auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
-            auto image = SkImages::BorrowTextureFrom(grContext, backendTexture, kTopLeft_GrSurfaceOrigin, kRGBA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
-            SkPaint paint;
-            paint.setBlendMode(SkBlendMode::kSrc);
-            m_surface->getCanvas()->drawImageRect(image, SkRect::MakeWH(dirtyRect.width(), dirtyRect.height()), SkRect::Make(SkIRect(dirtyRect)),
-                SkSamplingOptions(SkFilterMode::kNearest, SkMipmapMode::kNone), &paint, SkCanvas::kFast_SrcRectConstraint);
+        } else {
+            ensureTexture(tileRect.size(), buffer);
+            m_texture->copyFromExternalTexture(texture->id(), dirtyRect, { });
         }
-    } else if (tryEnsureSurface(tileRect.size(), buffer, kBGRA_8888_SkColorType)) {
+    } else {
         auto& unacceleratedBuffer = static_cast<CoordinatedUnacceleratedTileBuffer&>(buffer);
-        auto imageInfo = SkImageInfo::Make(dirtyRect.width(), dirtyRect.height(), kBGRA_8888_SkColorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
-        SkPixmap pixmap(imageInfo, unacceleratedBuffer.data(), unacceleratedBuffer.stride());
-        m_surface->writePixels(pixmap, dirtyRect.x(), dirtyRect.y());
+        ensureTexture(tileRect.size(), buffer);
+        m_texture->updateContents(unacceleratedBuffer.data(), dirtyRect, { }, unacceleratedBuffer.stride(), buffer.pixelFormat());
     }
 
     WTFEndSignpost(this, SkiaBackingStoreTileUpdate);
@@ -194,16 +162,17 @@ void SkiaBackingStore::Tile::update(const IntRect& dirtyRect, const IntRect& til
 
 sk_sp<SkImage> SkiaBackingStore::Tile::image()
 {
-    // SkSurface::makeImageSnapshot() does a copy-on-write, but when the surface is wrapping an
-    // external texture, it always copies because it doesn't know if the texture will be modified
-    // externally. We know the texture won't change, so we can use our own cached image wihtout copying.
-    if (!m_cachedImage && m_surface) {
+    if (!m_cachedImage && m_texture) {
+        auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
+        ASSERT(grContext);
+
+        auto colorType = m_texture->flags().contains(BitmapTexture::Flags::UseBGRALayout) ? kBGRA_8888_SkColorType : kRGBA_8888_SkColorType;
         GrGLTextureInfo externalTexture;
         externalTexture.fTarget = GL_TEXTURE_2D;
-        externalTexture.fID = m_textureID;
-        externalTexture.fFormat = m_surface->imageInfo().colorType() == kRGBA_8888_SkColorType ? GL_RGBA8 : GL_BGRA8_EXT;
-        auto backendTexture = GrBackendTextures::MakeGL(m_surface->width(), m_surface->height(), skgpu::Mipmapped::kNo, externalTexture);
-        m_cachedImage = SkImages::BorrowTextureFrom(PlatformDisplay::sharedDisplay().skiaGrContext(), backendTexture, kTopLeft_GrSurfaceOrigin, m_surface->imageInfo().colorType(), kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
+        externalTexture.fID = m_texture->id();
+        externalTexture.fFormat = colorType == kBGRA_8888_SkColorType ? GL_BGRA8_EXT : GL_RGBA8;
+        auto backendTexture = GrBackendTextures::MakeGL(m_texture->size().width(), m_texture->size().height(), skgpu::Mipmapped::kNo, externalTexture);
+        m_cachedImage = SkImages::BorrowTextureFrom(grContext, backendTexture, kTopLeft_GrSurfaceOrigin, colorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
     }
     return m_cachedImage;
 }

--- a/Source/WebCore/platform/graphics/skia/SkiaBackingStore.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaBackingStore.h
@@ -64,12 +64,11 @@ private:
         sk_sp<SkImage> image();
 
     private:
-        bool tryEnsureSurface(const IntSize&, CoordinatedTileBuffer&, SkColorType);
+        void ensureTexture(const IntSize&, CoordinatedTileBuffer&);
 
         float m_scale { 1. };
         FloatRect m_rect;
-        sk_sp<SkSurface> m_surface;
-        unsigned m_textureID { 0 };
+        RefPtr<BitmapTexture> m_texture;
         sk_sp<SkImage> m_cachedImage;
     };
 

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
@@ -356,6 +356,9 @@ void BitmapTexture::updateContents(const void* srcData, const IntRect& targetRec
         adjustedSourceOffset = IntPoint(0, 0);
     }
 
+    GLint boundTexture = 0;
+    glGetIntegerv(m_binding, &boundTexture);
+
     glBindTexture(m_renderTarget, m_id);
 
     if (supportsUnpackSubimage) {
@@ -372,6 +375,8 @@ void BitmapTexture::updateContents(const void* srcData, const IntRect& targetRec
         glPixelStorei(GL_UNPACK_SKIP_ROWS, 0);
         glPixelStorei(GL_UNPACK_SKIP_PIXELS, 0);
     }
+
+    glBindTexture(m_renderTarget, boundTexture);
 }
 
 void BitmapTexture::updateContents(NativeImage* frameImage, const IntRect& targetRect, const IntPoint& offset)

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.cpp
@@ -108,7 +108,7 @@ void CoordinatedBackingStoreTile::processPendingUpdates()
         WTFBeginSignpost(this, CopyTextureCPUToGPU);
         ASSERT(!update.buffer->isBackedByOpenGL());
         auto& buffer = static_cast<CoordinatedUnacceleratedTileBuffer&>(update.buffer.get());
-        m_texture->updateContents(buffer.data(), update.sourceRect, update.bufferOffset, buffer.stride(), buffer.pixelFormat());
+        m_texture->updateContents(buffer.data(), update.sourceRect, update.bufferOffset, buffer.stride(), update.buffer->pixelFormat());
         WTFEndSignpost(this, CopyTextureCPUToGPU);
 
         WTFEndSignpost(this, CoordinatedSwapBuffer);

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.h
@@ -60,6 +60,7 @@ public:
     WEBCORE_EXPORT virtual ~CoordinatedTileBuffer();
 
     virtual IntSize size() const = 0;
+    virtual PixelFormat pixelFormat() const = 0;
     virtual bool isBackedByOpenGL() const = 0;
 
     bool supportsAlpha() const { return m_flags & SupportsAlpha; }
@@ -112,13 +113,12 @@ public:
     const unsigned char* data() const { return m_data.span().data(); }
     unsigned char* data() { return m_data.mutableSpan().data(); }
 
-    PixelFormat pixelFormat() const { return PixelFormat::BGRA8; }
-
 private:
     CoordinatedUnacceleratedTileBuffer(const IntSize&, Flags);
 
     bool isBackedByOpenGL() const final { return false; }
     IntSize size() const final { return m_size; }
+    PixelFormat pixelFormat() const final { return PixelFormat::BGRA8; }
 
 #if USE(SKIA)
     bool tryEnsureSurface() final;
@@ -153,6 +153,7 @@ private:
 
     bool isBackedByOpenGL() const final { return true; }
     IntSize size() const final;
+    PixelFormat pixelFormat() const final { return PixelFormat::RGBA8; }
 
     bool tryEnsureSurface() final;
     void completePainting() final;


### PR DESCRIPTION
#### 9449dafa6033769962b9e69add1efca8c53c315a
<pre>
[GTK][WPE] Skia Compositor: do not use SkSurface::writePixels for tile updates uploads
<a href="https://bugs.webkit.org/show_bug.cgi?id=315266">https://bugs.webkit.org/show_bug.cgi?id=315266</a>

Reviewed by Nikolas Zimmermann.

Using glTexSubImage2D performs much better. Also change the gpu code
path to use BitmapTexture API since it&apos;s simpler now that we don&apos;t use
SkSurface for cpu case.

* Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp:
(WebCore::SkiaBackingStore::Tile::ensureTexture):
(WebCore::SkiaBackingStore::Tile::update):
(WebCore::SkiaBackingStore::Tile::image):
(WebCore::SkiaBackingStore::Tile::tryEnsureSurface): Deleted.
* Source/WebCore/platform/graphics/skia/SkiaBackingStore.h:
* Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp:
(WebCore::BitmapTexture::updateContents):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedBackingStoreTile.cpp:
(WebCore::CoordinatedBackingStoreTile::processPendingUpdates):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedTileBuffer.h:

Canonical link: <a href="https://commits.webkit.org/313661@main">https://commits.webkit.org/313661@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/58b838db772c44401ade4c4f8f2155541b2e79a9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163773 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37257 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30476 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172798 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165642 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37588 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37256 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127211 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121024 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166732 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29492 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147228 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107760 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28539 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/27170 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20566 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138438 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24945 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175322 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28149 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26613 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135517 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36927 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31276 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135493 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37712 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146740 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99838 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24926 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30808 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23594 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36423 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109568 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35920 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1624 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36170 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36067 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->