### PR TITLE
ANGLE: Metal: Avoid showing windows for all currently run tests

### DIFF
--- a/Source/ThirdParty/ANGLE/src/tests/egl_tests/EGLDisplaySelectionTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/egl_tests/EGLDisplaySelectionTest.cpp
@@ -69,7 +69,7 @@ class EGLDisplaySelectionTestNoFixture : public EGLDisplaySelectionTest
     {
         mOSWindow = OSWindow::New();
         mOSWindow->initialize("EGLDisplaySelectionTestMultiDisplay", kWindowWidth, kWindowHeight);
-        setWindowVisible(mOSWindow, true);
+        setWindowVisible(mOSWindow, shouldShowWindow());
     }
 
     void initializeContextForDisplay(EGLDisplay display, EGLContext *context)

--- a/Source/ThirdParty/ANGLE/src/tests/egl_tests/EGLRobustnessTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/egl_tests/EGLRobustnessTest.cpp
@@ -35,7 +35,7 @@ class EGLRobustnessTest : public ANGLETest<>
     {
         mOSWindow = OSWindow::New();
         mOSWindow->initialize("EGLRobustnessTest", 500, 500);
-        setWindowVisible(mOSWindow, true);
+        setWindowVisible(mOSWindow, shouldShowWindow());
 
         const auto &platform = GetParam().eglParameters;
 

--- a/Source/ThirdParty/ANGLE/src/tests/egl_tests/EGLSurfaceTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/egl_tests/EGLSurfaceTest.cpp
@@ -744,7 +744,7 @@ TEST_P(EGLSurfaceTest, SurfaceUseAfterFreeBug)
 // Test that the window can be reset repeatedly before surface creation.
 TEST_P(EGLSurfaceTest, ResetNativeWindow)
 {
-    setWindowVisible(mOSWindow, true);
+    setWindowVisible(mOSWindow, shouldShowWindow());
 
     initializeDisplay();
 
@@ -3305,7 +3305,7 @@ TEST_P(EGLSurfaceTest, DISABLED_RandomClearTearing)
 // the app get over the problem.
 TEST_P(EGLSurfaceTest, DestroyAndRecreateWhileCurrent)
 {
-    setWindowVisible(mOSWindow, true);
+    setWindowVisible(mOSWindow, shouldShowWindow());
 
     initializeDisplay();
 
@@ -3863,7 +3863,7 @@ TEST_P(EGLSurfaceTest, ResizeAfterSwap)
     constexpr std::array<int, kSizeCount> kHeights{499, 200};
 
     // Necessary for some platforms (NVIDIA on Linux) if there is no per-frame window size query.
-    setWindowVisible(mOSWindow, true);
+    setWindowVisible(mOSWindow, shouldShowWindow());
 
     initializeDisplay();
     initializeSurfaceWithDefaultConfig(true);
@@ -3908,7 +3908,7 @@ TEST_P(EGLSurfaceTest, ResizeAfterSwapSkipSizeQuery)
     constexpr std::array<int, kSizeCount> kHeights{499, 200};
 
     // Necessary for some platforms (NVIDIA on Linux) if there is no per-frame window size query.
-    setWindowVisible(mOSWindow, true);
+    setWindowVisible(mOSWindow, shouldShowWindow());
 
     initializeDisplay();
     initializeSurfaceWithDefaultConfig(true);
@@ -3943,7 +3943,7 @@ TEST_P(EGLSurfaceTest, ResizeBeforeDraw)
     constexpr std::array<int, kSizeCount> kHeights{64, 499, 200};
 
     // Necessary for some platforms (NVIDIA on Linux) if there is no per-frame window size query.
-    setWindowVisible(mOSWindow, true);
+    setWindowVisible(mOSWindow, shouldShowWindow());
 
     initializeDisplay();
     initializeSurfaceWithDefaultConfig(true);
@@ -3996,7 +3996,7 @@ TEST_P(EGLSurfaceTest, ResizeBeforeDrawPostSizeQuery)
     constexpr std::array<int, kSizeCount> kHeights{64, 499, 200};
 
     // Necessary for some platforms (NVIDIA on Linux) if there is no per-frame window size query.
-    setWindowVisible(mOSWindow, true);
+    setWindowVisible(mOSWindow, shouldShowWindow());
 
     initializeDisplay();
     initializeSurfaceWithDefaultConfig(true);
@@ -4055,7 +4055,7 @@ TEST_P(EGLSurfaceTest, ResizeAfterDraw)
     constexpr std::array<int, kSizeCount> kHeights{64, 499, 200};
 
     // Necessary for some platforms (NVIDIA on Linux) if there is no per-frame window size query.
-    setWindowVisible(mOSWindow, true);
+    setWindowVisible(mOSWindow, shouldShowWindow());
 
     initializeDisplay();
     initializeSurfaceWithDefaultConfig(true);
@@ -4113,7 +4113,7 @@ TEST_P(EGLSurfaceTest, ResizeLargeWindow)
     constexpr std::array<int, kSizeCount> kHeights{999, 1079};
 
     // Necessary for some platforms (NVIDIA on Linux) if there is no per-frame window size query.
-    setWindowVisible(mOSWindow, true);
+    setWindowVisible(mOSWindow, shouldShowWindow());
 
     initializeDisplay();
     initializeSurfaceWithDefaultConfig(true);
@@ -4214,7 +4214,7 @@ TEST_P(EGLSurfaceTest, ResizeBeforeMakeCurrent)
     constexpr std::array<int, kSizeCount> kHeights{64, 499};
 
     // Necessary for some platforms (NVIDIA on Linux) if there is no per-frame window size query.
-    setWindowVisible(mOSWindow, true);
+    setWindowVisible(mOSWindow, shouldShowWindow());
 
     initializeDisplay();
     initializeSurfaceWithDefaultConfig(true);
@@ -4282,7 +4282,7 @@ TEST_P(EGLSurfaceTest, ResizeBeforeMakeCurrentPostSizeQuery)
     constexpr std::array<int, kSizeCount> kHeights{64, 499};
 
     // Necessary for some platforms (NVIDIA on Linux) if there is no per-frame window size query.
-    setWindowVisible(mOSWindow, true);
+    setWindowVisible(mOSWindow, shouldShowWindow());
 
     initializeDisplay();
     initializeSurfaceWithDefaultConfig(true);
@@ -4349,7 +4349,7 @@ TEST_P(EGLSurfaceTest, ResizeAndReadPixelsRobustANGLE)
     constexpr std::array<int, kSizeCount> kHeights{499, 200};
 
     // Necessary for some platforms (NVIDIA on Linux) if there is no per-frame window size query.
-    setWindowVisible(mOSWindow, true);
+    setWindowVisible(mOSWindow, shouldShowWindow());
 
     initializeDisplay();
     initializeSurfaceWithDefaultConfig(true);
@@ -4400,7 +4400,7 @@ TEST_P(EGLSurfaceTest, ResizeAndBlitFramebufferANGLE)
     constexpr std::array<int, kSizeCount> kHeights{499, 200};
 
     // Necessary for some platforms (NVIDIA on Linux) if there is no per-frame window size query.
-    setWindowVisible(mOSWindow, true);
+    setWindowVisible(mOSWindow, shouldShowWindow());
 
     initializeDisplay();
 
@@ -4476,7 +4476,7 @@ class EGLWindowSurfaceColorspaceTestES3 : public EGLSurfaceTest
 // Test interaction between GL_EXT_sRGB_write_control and default framebuffer
 TEST_P(EGLWindowSurfaceColorspaceTestES3, ToggleSrgbWriteControl)
 {
-    setWindowVisible(mOSWindow, true);
+    setWindowVisible(mOSWindow, shouldShowWindow());
 
     initializeDisplay();
 
@@ -4547,7 +4547,7 @@ TEST_P(EGLWindowSurfaceColorspaceTestES3, ToggleSrgbWriteControl)
 // wouldn't refresh the framebuffer
 TEST_P(EGLWindowSurfaceColorspaceTestES3, ToggleSrgbWriteControlWithinRenderPass)
 {
-    setWindowVisible(mOSWindow, true);
+    setWindowVisible(mOSWindow, shouldShowWindow());
 
     initializeDisplay();
 
@@ -4623,7 +4623,7 @@ TEST_P(EGLWindowSurfaceColorspaceTestES3, ToggleSrgbWriteControlWithinRenderPass
 TEST_P(EGLSurfaceTest, PreserveThenClearToBlack)
 {
     // Necessary for some platforms (NVIDIA on Linux) if there is no per-frame window size query.
-    setWindowVisible(mOSWindow, true);
+    setWindowVisible(mOSWindow, shouldShowWindow());
 
     initializeDisplay();
 
@@ -4669,7 +4669,7 @@ TEST_P(EGLSurfaceTest, PreserveThenClearToBlack)
 TEST_P(EGLSurfaceTest, PreserveThenBlend)
 {
     // Necessary for some platforms (NVIDIA on Linux) if there is no per-frame window size query.
-    setWindowVisible(mOSWindow, true);
+    setWindowVisible(mOSWindow, shouldShowWindow());
 
     initializeDisplay();
 
@@ -4715,7 +4715,7 @@ TEST_P(EGLSurfaceTest, PreserveThenBlend)
 TEST_P(EGLSurfaceTest, ClearThenPreserve)
 {
     // Necessary for some platforms (NVIDIA on Linux) if there is no per-frame window size query.
-    setWindowVisible(mOSWindow, true);
+    setWindowVisible(mOSWindow, shouldShowWindow());
 
     initializeDisplay();
 

--- a/Source/ThirdParty/ANGLE/src/tests/egl_tests/EGLSurfaceTestMac.mm
+++ b/Source/ThirdParty/ANGLE/src/tests/egl_tests/EGLSurfaceTestMac.mm
@@ -55,7 +55,7 @@ class EGLSurfaceTestMac : public ANGLETest<>
         // Create a window, context and surface if multisampling is possible.
         mOSWindow = OSWindow::New();
         mOSWindow->initialize("EGLSurfaceTestMac", kWindowWidth, kWindowHeight);
-        setWindowVisible(mOSWindow, true);
+        setWindowVisible(mOSWindow, shouldShowWindow());
 
         EGLint contextAttributes[] = {
             EGL_CONTEXT_MAJOR_VERSION_KHR,

--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/DrawBuffersTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/DrawBuffersTest.cpp
@@ -59,7 +59,7 @@ class DrawBuffersTest : public ANGLETest<>
         }
 
         // This test seems to fail on an nVidia machine when the window is hidden
-        setWindowVisible(getOSWindow(), true);
+        setWindowVisible(getOSWindow(), shouldShowWindow());
 
         glGenFramebuffers(1, &mFBO);
         glBindFramebuffer(GL_DRAW_FRAMEBUFFER, mFBO);

--- a/Source/ThirdParty/ANGLE/src/tests/gl_tests/RobustBufferAccessBehaviorTest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/gl_tests/RobustBufferAccessBehaviorTest.cpp
@@ -43,7 +43,7 @@ class RobustBufferAccessBehaviorTest : public ANGLETest<>
         {
             return false;
         }
-        setWindowVisible(mOSWindow, true);
+        setWindowVisible(mOSWindow, shouldShowWindow());
 
         Library *driverLib = ANGLETestEnvironment::GetDriverLibrary(getDriverType());
 

--- a/Source/ThirdParty/ANGLE/src/tests/test_utils/ANGLETest.cpp
+++ b/Source/ThirdParty/ANGLE/src/tests/test_utils/ANGLETest.cpp
@@ -171,6 +171,8 @@ const char *GetColorName(GLColorRGB color)
 // Always re-use displays when using --bot-mode in the test runner.
 bool gReuseDisplays = false;
 
+bool gAlwaysShowWindow = false;
+
 bool ShouldAlwaysForceNewDisplay(const PlatformParameters &params)
 {
     // When running WebGPU tests always force a new display.
@@ -443,6 +445,7 @@ constexpr char kDelayTestStart[]                 = "--delay-test-start=";
 constexpr char kRenderDoc[]                      = "--renderdoc";
 constexpr char kNoRenderDoc[]                    = "--no-renderdoc";
 constexpr char kDisableDebugLayers[]             = "--disable-debug-layers";
+constexpr char kAlwaysShowWindow[]               = "--always-show-window";
 
 void SetupEnvironmentVarsForCaptureReplay()
 {
@@ -621,9 +624,7 @@ void ANGLETestBase::initOSWindow()
         return;
     }
 
-    // On Linux we must keep the test windows visible. On Windows or Metal it doesn't seem to need
-    // it.
-    setWindowVisible(getOSWindow(), !(IsWindows() || IsMac() || IsIOS()));
+    setWindowVisible(getOSWindow(), shouldShowWindow());
 
     switch (mCurrentParams->driver)
     {
@@ -1720,6 +1721,13 @@ int ANGLETestBase::getClientMajorVersion() const
     return getGLWindow()->getClientMajorVersion();
 }
 
+bool ANGLETestBase::shouldShowWindow() const
+{
+    // On Linux we must keep the test windows visible. On Windows or Metal it doesn't seem to need
+    // it.
+    return gAlwaysShowWindow || !(IsWindows() || IsMac() || IsIOS());
+}
+
 int ANGLETestBase::getClientMinorVersion() const
 {
     return getGLWindow()->getClientMinorVersion();
@@ -1916,6 +1924,10 @@ void ANGLEProcessTestArgs(int *argc, char *argv[])
         else if (strncmp(argv[argIndex], kDisableDebugLayers, strlen(kDisableDebugLayers)) == 0)
         {
             gDisableDebugLayers = true;
+        }
+        else if (strncmp(argv[argIndex], kAlwaysShowWindow, strlen(kAlwaysShowWindow)) == 0)
+        {
+            gAlwaysShowWindow = true;
         }
     }
 }

--- a/Source/ThirdParty/ANGLE/src/tests/test_utils/ANGLETest.h
+++ b/Source/ThirdParty/ANGLE/src/tests/test_utils/ANGLETest.h
@@ -598,6 +598,8 @@ class ANGLETestBase : public ::testing::Test
         return mCurrentParams->getRenderer() == EGL_PLATFORM_ANGLE_TYPE_METAL_ANGLE;
     }
 
+    bool shouldShowWindow() const;
+
     bool isDriverSystemEgl() const
     {
         return mCurrentParams->driver == angle::GLESDriverType::SystemEGL;


### PR DESCRIPTION
#### 63eaffb4650db4fe6e2fe3905cdb260a2b584f66
<pre>
ANGLE: Metal: Avoid showing windows for all currently run tests
<a href="https://bugs.webkit.org/show_bug.cgi?id=315269">https://bugs.webkit.org/show_bug.cgi?id=315269</a>
<a href="https://rdar.apple.com/177601829">rdar://177601829</a>

Reviewed by Dan Glastonbury.

Makes it more ergonomic to develop, when the long test runs do not
steal focus.

* Source/ThirdParty/ANGLE/src/tests/egl_tests/EGLDisplaySelectionTest.cpp:
(EGLDisplaySelectionTestNoFixture::initializeWindow):
* Source/ThirdParty/ANGLE/src/tests/egl_tests/EGLRobustnessTest.cpp:
* Source/ThirdParty/ANGLE/src/tests/egl_tests/EGLSurfaceTest.cpp:
(angle::TEST_P):
* Source/ThirdParty/ANGLE/src/tests/egl_tests/EGLSurfaceTestMac.mm:
* Source/ThirdParty/ANGLE/src/tests/gl_tests/DrawBuffersTest.cpp:
(DrawBuffersTest::setupTest):
* Source/ThirdParty/ANGLE/src/tests/gl_tests/RobustBufferAccessBehaviorTest.cpp:
(angle::RobustBufferAccessBehaviorTest::initExtension):
* Source/ThirdParty/ANGLE/src/tests/test_utils/ANGLETest.cpp:
(ANGLETestBase::initOSWindow):
* Source/ThirdParty/ANGLE/src/tests/test_utils/ANGLETest.h:

Canonical link: <a href="https://commits.webkit.org/313716@main">https://commits.webkit.org/313716@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2380fa0381c612a81778e8721f6c383499ff3930

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163741 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37225 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30444 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172759 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/120992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37556 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37224 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127180 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/120992 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166700 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29466 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147210 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107730 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28513 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27145 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20534 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138412 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24927 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175283 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26595 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135488 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36895 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31250 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135464 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36551 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37680 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146722 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99779 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30782 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23576 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36391 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35888 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1606 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36138 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36035 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->