### PR TITLE
Hit-test of clip-path with nested objectBoundingBox <clipPath> uses wrong reference box

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/hit-test/clip-path-element-objectboundingbox-002-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-masking/hit-test/clip-path-element-objectboundingbox-002-expected.txt
@@ -1,5 +1,3 @@
 
-FAIL Hit-test of clip-path nested objectBoundingBox <clipPath> assert_equals: 150,150 expected Element node <div class="box"></div> but got Element node <body><div class="box"></div>
-<svg height="0">
-  <clipPat...
+PASS Hit-test of clip-path nested objectBoundingBox <clipPath>
 

--- a/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
+++ b/Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp
@@ -203,8 +203,14 @@ bool RenderSVGResourceClipper::hitTestClipContent(const FloatRect& objectBoundin
     SVGVisitedRendererTracking::Scope recursionScope(recursionTracking, *this);
 
     auto point = nodeAtPoint;
-    if (!pointInSVGClippingArea(point))
-        return false;
+
+    // If this <clipPath> has its own clip-path, the original target must also fall inside the
+    // nested clip region. objectBoundingBox units inside the nested clipPath resolve against
+    // the original referencing element's bounding box (passed in here), not this clipper's OBB.
+    if (CheckedPtr nestedClipper = svgClipperResourceFromStyle()) {
+        if (!nestedClipper->hitTestClipContent(objectBoundingBox, nodeAtPoint))
+            return false;
+    }
 
     if (clipPathUnits() == SVGUnitTypes::SVG_UNIT_TYPE_OBJECTBOUNDINGBOX) {
         AffineTransform applyTransform;

--- a/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
+++ b/Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp
@@ -335,8 +335,14 @@ bool LegacyRenderSVGResourceClipper::hitTestClipContent(const FloatRect& objectB
     SVGVisitedRendererTracking::Scope recursionScope(recursionTracking, *this);
 
     FloatPoint point = nodeAtPoint;
-    if (!SVGRenderSupport::pointInClippingArea(*this, point))
-        return false;
+
+    // Apply a nested clip-path on this <clipPath> using the original target's bounding box,
+    // not this clipper's OBB. SVGRenderSupport::pointInClippingArea() would incorrectly
+    // resolve objectBoundingBox units against *this->objectBoundingBox().
+    if (auto* resources = SVGResourcesCache::cachedResourcesForRenderer(*this)) {
+        if (auto* nestedClipper = resources->clipper(); nestedClipper && !nestedClipper->hitTestClipContent(objectBoundingBox, point))
+            return false;
+    }
 
     // The forward transform order is: OBB first, then local transform.
     // So the inverse order is: inverse local first, then inverse OBB.


### PR DESCRIPTION
#### 16340664d2de48560add5591dbaf9fb29a1f4694
<pre>
Hit-test of clip-path with nested objectBoundingBox &lt;clipPath&gt; uses wrong reference box
<a href="https://bugs.webkit.org/show_bug.cgi?id=315272">https://bugs.webkit.org/show_bug.cgi?id=315272</a>
<a href="https://rdar.apple.com/177605894">rdar://177605894</a>

Reviewed by Simon Fraser.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

When a &lt;clipPath&gt; referenced via clip-path itself carries a clip-path
attribute, hit-testing resolved the nested clipPath&apos;s objectBoundingBox
units against the inner &lt;clipPath&gt;&apos;s own bounding box instead of the
original referencing element&apos;s. RenderSVGResourceClipper::hitTestClipContent
(and the legacy variant) reached the nested clipper through
pointInSVGClippingArea / SVGRenderSupport::pointInClippingArea, both of
which forward *this-&gt;objectBoundingBox() — which for a &lt;clipPath&gt; is the
union of its children&apos;s bboxes (e.g. (0,0,0.5,0.5) for a 0.5×0.5 rect),
not the target&apos;s box.

Painting already handles this correctly: applyMaskClipping recurses with
the original targetRenderer/objectBoundingBox. Mirror that in hit-testing
by calling the nested clipper&apos;s hitTestClipContent directly with the
caller-supplied objectBoundingBox, instead of relying on pointInSVGClippingArea.

NOTE: This fixes bug in both Legacy and Layer Based SVG engines.

* LayoutTests/imported/w3c/web-platform-tests/css/css-masking/hit-test/clip-path-element-objectboundingbox-002-expected.txt: Progression
* Source/WebCore/rendering/svg/RenderSVGResourceClipper.cpp:
(WebCore::RenderSVGResourceClipper::hitTestClipContent):
* Source/WebCore/rendering/svg/legacy/LegacyRenderSVGResourceClipper.cpp:
(WebCore::LegacyRenderSVGResourceClipper::hitTestClipContent):

Canonical link: <a href="https://commits.webkit.org/313855@main">https://commits.webkit.org/313855@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6e54d596fb8c6ced5b9113c3690549a5e39a05f8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163750 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37234 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30453 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172772 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121001 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165619 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37565 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37233 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127191 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89633 "layout-tests (failure)") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166709 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29477 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147213 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107741 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28524 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27154 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20543 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138423 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24930 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175297 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28126 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26598 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135497 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36904 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31259 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135473 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36628 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37689 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146725 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99802 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30792 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23579 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36400 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109545 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35897 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1609 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36147 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36044 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->