### PR TITLE
Use requesting origin instead of active origin for DeviceOrientation permission request

### DIFF
--- a/Source/WebCore/page/Frame.cpp
+++ b/Source/WebCore/page/Frame.cpp
@@ -442,4 +442,5 @@ TextStream& operator<<(TextStream& ts, const Frame& frame)
     return ts;
 }
 
+
 } // namespace WebCore

--- a/Source/WebKit/Shared/FrameInfoData.cpp
+++ b/Source/WebKit/Shared/FrameInfoData.cpp
@@ -34,11 +34,13 @@ FrameInfoData legacyEmptyFrameInfo(WebCore::ResourceRequest&& request)
     constexpr bool isFocused { false };
     constexpr bool errorOccurred { false };
 
+    auto opaqueOrigin = WebCore::SecurityOriginData::createOpaque();
     return FrameInfoData {
         isMainFrame,
         FrameType::Local,
         WTF::move(request),
-        WebCore::SecurityOriginData::createOpaque(),
+        opaqueOrigin,
+        opaqueOrigin,
         String { },
         WebCore::generateFrameIdentifier(),
         std::nullopt,

--- a/Source/WebKit/Shared/FrameInfoData.h
+++ b/Source/WebKit/Shared/FrameInfoData.h
@@ -51,6 +51,7 @@ struct FrameInfoData {
     FrameType frameType { FrameType::Local };
     WebCore::ResourceRequest request;
     WebCore::SecurityOriginData securityOrigin;
+    WebCore::SecurityOriginData topOrigin;
     String frameName;
     WebCore::FrameIdentifier frameID;
     Markable<WebPageProxyIdentifier> webPageProxyID;

--- a/Source/WebKit/Shared/FrameInfoData.serialization.in
+++ b/Source/WebKit/Shared/FrameInfoData.serialization.in
@@ -29,6 +29,7 @@ struct WebKit::FrameInfoData {
     WebKit::FrameType frameType;
     WebCore::ResourceRequest request;
     WebCore::SecurityOriginData securityOrigin;
+    WebCore::SecurityOriginData topOrigin;
     String frameName;
     WebCore::FrameIdentifier frameID;
     Markable<WebKit::WebPageProxyIdentifier> webPageProxyID;

--- a/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
+++ b/Source/WebKit/UIProcess/Cocoa/UIDelegate.mm
@@ -1230,7 +1230,7 @@ void UIDelegate::UIClient::willCloseLocalInspector(WebPageProxy&, WebInspectorUI
 #if ENABLE(DEVICE_ORIENTATION)
 void UIDelegate::UIClient::shouldAllowDeviceOrientationAndMotionAccess(WebKit::WebPageProxy& page, WebFrameProxy& webFrameProxy, FrameInfoData&& frameInfo, CompletionHandler<void(bool)>&& completionHandler)
 {
-    Ref securityOrigin = WebCore::SecurityOrigin::create(page.pageLoadState().activeURL());
+    Ref securityOrigin = frameInfo.topOrigin.securityOrigin();
     RefPtr uiDelegate = m_uiDelegate.get();
     if (!uiDelegate || !uiDelegate->m_delegate.get() || !uiDelegate->m_delegateMethods.webViewRequestDeviceOrientationAndMotionPermissionForOriginDecisionHandler) {
         alertForPermission(page, MediaPermissionReason::DeviceOrientation, securityOrigin->data(), WTF::move(completionHandler));

--- a/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
+++ b/Source/WebKit/UIProcess/ProvisionalPageProxy.cpp
@@ -236,11 +236,13 @@ void ProvisionalPageProxy::cancel()
     ASSERT(mainFrame);
     auto error = WebKit::cancelledError(m_request);
     error.setType(WebCore::ResourceError::Type::Cancellation);
+    auto securityOriginData = SecurityOriginData::fromURLWithoutStrictOpaqueness(m_request.url());
     FrameInfoData frameInfo {
         true, // isMainFrame
         FrameType::Local,
         m_request,
-        SecurityOriginData::fromURLWithoutStrictOpaqueness(m_request.url()),
+        securityOriginData,
+        securityOriginData,
         { },
         mainFrame->frameID(),
         m_page ? std::optional { m_page->identifier() } : std::nullopt,

--- a/Source/WebKit/UIProcess/WebsiteData/WebDeviceOrientationAndMotionAccessController.cpp
+++ b/Source/WebKit/UIProcess/WebsiteData/WebDeviceOrientationAndMotionAccessController.cpp
@@ -45,24 +45,24 @@ WebDeviceOrientationAndMotionAccessController::WebDeviceOrientationAndMotionAcce
 
 void WebDeviceOrientationAndMotionAccessController::shouldAllowAccess(WebPageProxy& page, WebFrameProxy& frame, FrameInfoData&& frameInfo, bool mayPrompt, CompletionHandler<void(DeviceOrientationOrMotionPermissionState)>&& completionHandler)
 {
-    auto originData = SecurityOrigin::create(page.pageLoadState().activeURL())->data();
-    auto currentPermission = cachedDeviceOrientationPermission(originData);
+    auto requestOriginData = frameInfo.topOrigin;
+    auto currentPermission = cachedDeviceOrientationPermission(requestOriginData);
     if (currentPermission != DeviceOrientationOrMotionPermissionState::Prompt || !mayPrompt)
         return completionHandler(currentPermission);
 
-    auto& pendingRequests = m_pendingRequests.ensure(originData, [] {
+    auto& pendingRequests = m_pendingRequests.ensure(requestOriginData, [] {
         return Vector<CompletionHandler<void(WebCore::DeviceOrientationOrMotionPermissionState)>> { };
     }).iterator->value;
     pendingRequests.append(WTF::move(completionHandler));
     if (pendingRequests.size() > 1)
         return;
 
-    page.uiClient().shouldAllowDeviceOrientationAndMotionAccess(page, frame, WTF::move(frameInfo), [weakThis = WeakPtr { *this }, originData](bool granted) mutable {
+    page.uiClient().shouldAllowDeviceOrientationAndMotionAccess(page, frame, WTF::move(frameInfo), [weakThis = WeakPtr { *this }, requestOriginData](bool granted) mutable {
         RefPtr protectedThis = weakThis.get();
         if (!protectedThis)
             return;
-        protectedThis->m_deviceOrientationPermissionDecisions.set(originData, granted);
-        auto requests = protectedThis->m_pendingRequests.take(originData);
+        protectedThis->m_deviceOrientationPermissionDecisions.set(requestOriginData, granted);
+        auto requests = protectedThis->m_pendingRequests.take(requestOriginData);
         for (auto& completionHandler : requests)
             completionHandler(granted ? DeviceOrientationOrMotionPermissionState::Granted : DeviceOrientationOrMotionPermissionState::Denied);
     });

--- a/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
+++ b/Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp
@@ -117,6 +117,7 @@ std::optional<NavigationActionData> WebFrameLoaderClient::navigationActionData(c
         FrameType::Local,
         ResourceRequest { URL { requester.url } },
         requester.securityOrigin->data(),
+        requester.topOrigin->data(),
         { },
         WTF::move(originatingFrameID),
         originatingPageID,

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -302,9 +302,7 @@ FrameInfoData WebFrame::info(WithCertificateInfo withCertificateInfo) const
     RefPtr loadingFrame = m_provisionalFrame ? m_provisionalFrame : coreLocalFrame;
 
     WebFrameMetrics metrics;
-    SecurityOriginData securityOriginData;
     FrameType frameType = FrameType::Local;
-    String frameName;
     if (coreFrame) {
         if (RefPtr coreView = coreFrame->virtualView()) {
             IsScrollable isScrollable = hasHorizontalScrollbar() || hasVerticalScrollbar() ? IsScrollable::Yes : IsScrollable::No;
@@ -313,10 +311,8 @@ FrameInfoData WebFrame::info(WithCertificateInfo withCertificateInfo) const
             auto visibleContentSizeExcludingScrollbars = coreView->visibleContentRect().size();
             metrics = { isScrollable, contentSize, visibleContentSize, visibleContentSizeExcludingScrollbars };
         }
-        securityOriginData = SecurityOriginData::fromFrame(*coreFrame);
         if (coreFrame->frameType() == WebCore::Frame::FrameType::Remote)
             frameType = FrameType::Remote;
-        frameName = coreFrame->tree().specifiedName().string();
     }
 
     return {
@@ -324,8 +320,9 @@ FrameInfoData WebFrame::info(WithCertificateInfo withCertificateInfo) const
         frameType,
         // FIXME: This should use the full request.
         ResourceRequest(url()),
-        WTF::move(securityOriginData),
-        WTF::move(frameName),
+        coreFrame ? SecurityOriginData::fromFrame(*coreFrame) : SecurityOriginData { },
+        coreFrame ? coreFrame->topOrigin().data() : SecurityOriginData { },
+        coreFrame ? coreFrame->tree().specifiedName().string() : String(),
         frameID(),
         page ? std::optional { page->webPageProxyIdentifier() } : std::nullopt,
         parent ? std::optional { parent->frameID() } : std::nullopt,

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -1322,11 +1322,13 @@ Awaitable<std::optional<FrameTreeNodeData>> WebPage::getFrameTreeForBackForwardC
     RefPtr topDocument = page->localTopDocument();
     Ref mainFrame = page->mainFrame();
     RefPtr mainFrameOrigin = mainFrame->frameDocumentSecurityOrigin();
+    auto mainFrameOriginData = mainFrameOrigin ? SecurityOriginData { mainFrameOrigin->data() } : WebCore::SecurityOriginData::createOpaque();
     FrameInfoData data {
         true,
         mainFrame->frameType() == Frame::FrameType::Local ? FrameType::Local : FrameType::Remote,
         ResourceRequest { URL { page->mainFrameURL() } },
-        mainFrameOrigin ? SecurityOriginData { mainFrameOrigin->data() } : WebCore::SecurityOriginData::createOpaque(),
+        mainFrameOriginData,
+        mainFrameOriginData,
         mainFrame->tree().specifiedName().string(),
         mainFrame->frameID(),
         std::nullopt,

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/DeviceOrientation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/DeviceOrientation.mm
@@ -36,6 +36,7 @@
 #import <WebKit/WKPreferencesPrivate.h>
 #import <WebKit/WKUIDelegatePrivate.h>
 #import <WebKit/WKWebViewPrivateForTesting.h>
+#import <WebKit/_WKWebsiteDataStoreConfiguration.h>
 #import <wtf/Function.h>
 #import <wtf/HashMap.h>
 #import <wtf/RetainPtr.h>
@@ -457,6 +458,63 @@ TEST(WebKit, DeviceOrientationPermissionInIFrame)
 
     TestWebKitAPI::Util::run(&askedClientForPermission);
 
+}
+
+static constexpr auto requestPermissionPageBytes = R"TESTRESOURCE(
+<script>
+function requestPermission() {
+    DeviceOrientationEvent.requestPermission().then((result) => {
+        webkit.messageHandlers.testHandler.postMessage(result);
+    }).catch(() => {
+        webkit.messageHandlers.testHandler.postMessage('error');
+    });
+}
+</script>
+)TESTRESOURCE"_s;
+
+TEST(DeviceOrientation, PermissionOriginDuringPendingNavigation)
+{
+    TestWebKitAPI::HTTPServer server({
+        { "/source"_s, { requestPermissionPageBytes } },
+        { "/target"_s, { "hi"_s } }
+    }, TestWebKitAPI::HTTPServer::Protocol::HttpsProxy);
+
+    RetainPtr configuration = server.httpsProxyConfiguration();
+    RetainPtr messageHandler = adoptNS([[DeviceOrientationMessageHandler alloc] init]);
+    [[configuration userContentController] addScriptMessageHandler:messageHandler.get() name:@"testHandler"];
+
+    static RetainPtr<TestWKWebView> webView;
+    webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 800, 600) configuration:configuration.get()]);
+
+    RetainPtr permissionDelegate = adoptNS([[DeviceOrientationPermissionValidationDelegate alloc] init]);
+    [webView setUIDelegate:permissionDelegate.get()];
+
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [navigationDelegate allowAnyTLSCertificate];
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:[NSURL URLWithString:@"https://example1.com/source"]]];
+    [navigationDelegate waitForDidFinishNavigation];
+
+    // Start permission request on example1.com after navigation to example2.com starts
+    // and active URL is changed to example2.com.
+    navigationDelegate.get().didStartProvisionalNavigation = ^(WKWebView *, WKNavigation *) {
+        [webView evaluateJavaScript:@"requestPermission();" completionHandler:nil];
+    };
+    static bool receivedPermissionRequest = false;
+    didReceiveMessage = false;
+    [permissionDelegate setValidationHandler:[&](WKSecurityOrigin *origin, WKFrameInfo *frame) {
+        EXPECT_WK_STREQ(origin.protocol, @"https");
+        EXPECT_WK_STREQ(origin.host, @"example1.com");
+        EXPECT_WK_STREQ(frame.securityOrigin.protocol, @"https");
+        EXPECT_WK_STREQ(frame.securityOrigin.host, @"example1.com");
+        receivedPermissionRequest = true;
+    }];
+    [webView evaluateJavaScript:@"location.href = 'https://example2.com/target'" completionHandler:nil];
+    TestWebKitAPI::Util::run(&receivedPermissionRequest);
+
+    TestWebKitAPI::Util::run(&didReceiveMessage);
+    EXPECT_WK_STREQ(@"granted", receivedMessages.get()[0]);
 }
 
 #endif // ENABLE(DEVICE_ORIENTATION) && PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### a9810613686c552010aa8877434aae64943f4a1d
<pre>
Use requesting origin instead of active origin for DeviceOrientation permission request
<a href="https://rdar.apple.com/168597925">rdar://168597925</a>

Reviewed by Chris Dumez.

The current implementation uses active origin (origin being navigating to) instead of requesting origin in permission
prompt, and this might lead to permission being granted to a wrong origin.

API test: DeviceOrientation.PermissionOriginDuringPendingNavigation

* Source/WebCore/page/Frame.cpp:
* Source/WebKit/Shared/FrameInfoData.cpp:
(WebKit::legacyEmptyFrameInfo):
* Source/WebKit/Shared/FrameInfoData.h:
* Source/WebKit/Shared/FrameInfoData.serialization.in:
* Source/WebKit/UIProcess/Cocoa/UIDelegate.mm:
(WebKit::UIDelegate::UIClient::shouldAllowDeviceOrientationAndMotionAccess):
* Source/WebKit/UIProcess/ProvisionalPageProxy.cpp:
(WebKit::ProvisionalPageProxy::cancel):
* Source/WebKit/UIProcess/WebsiteData/WebDeviceOrientationAndMotionAccessController.cpp:
(WebKit::WebDeviceOrientationAndMotionAccessController::shouldAllowAccess):
* Source/WebKit/WebProcess/WebCoreSupport/WebFrameLoaderClient.cpp:
(WebKit::WebFrameLoaderClient::navigationActionData const):
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::info const):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::getFrameTreeForBackForwardCacheEntry):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/DeviceOrientation.mm:
((DeviceOrientation, PermissionOriginDuringPendingNavigation)):

Originally-landed-as: 305413.367@rapid/safari-7624.2.5.110-branch (322ddc5). <a href="https://rdar.apple.com/176067147">rdar://176067147</a>
Canonical link: <a href="https://commits.webkit.org/315163@main">https://commits.webkit.org/315163@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8eb46cb8528c8735c9ead0ceef7e171ef8821c7a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168207 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41763 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35325 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177535 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125908 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170073 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42139 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41720 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130896 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92006 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171166 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33361 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151165 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111408 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32347 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31053 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26231 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142333 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180135 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32858 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30570 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139332 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41776 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35212 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139195 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37495 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42464 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105838 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34482 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27532 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40968 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114224 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40365 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5625 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40616 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40510 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->