### PR TITLE
Cherry-pick(s) 2c99c891b64c. rdar://176067574

### DIFF
--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SwitchInputTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SwitchInputTests.mm
@@ -27,7 +27,11 @@
 
 #if PLATFORM(COCOA)
 
+<<<<<<< HEAD:Tools/TestWebKitAPI/Tests/WebKit/WKWebView/SwitchInputTests.mm
 #import "Helpers/ios/IOSMouseEventTestHarness.h"
+=======
+#import "IOSMouseEventTestHarness.h"
+>>>>>>> 2c99c891b64c (Haptic feedback for <input type=checkbox switch> can be triggered with a programmatic click on an associated label):Tools/TestWebKitAPI/Tests/WebKitCocoa/SwitchInputTests.mm
 #import "InstanceMethodSwizzler.h"
 #import "Helpers/PlatformUtilities.h"
 #import "Helpers/Test.h"


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://176067574 to main. The following sources [fc1ef83eae10] will still need to be cherry-picked once the conflict is resolved.

```Haptic feedback for <input type=checkbox switch> can be triggered with a programmatic click on an associated label
https://bugs.webkit.org/show_bug.cgi?id=309082
rdar://171635705

Reviewed by Lily Spiniolas, Wenson Hsieh, and Abrar Rahman Protyasha.

288403@main ensured that haptic feedback for <input type=checkbox switch> required
user activation. However, it is also desired that haptics are only triggered for
trusted events. This goal can currently be bypassed by calling `click()` on a label
associated with the input. The result is that calling `click()` on the label,
immediately following a user gesture, can allow for haptics to be programmatically
triggered.

The underlying issue is that untrusted click events on label elements become
trusted click events on the associated control. This is because
`Element::dispatchSimulatedClick` unconditionally sets `SimulatedClickSource::UserAgent`.
While this is desirable for accessibility use cases, it is incorrect when the
underlying event is untrusted.

Fix by specifying `SimulatedClickSource::Bindings` if there is an underlying
event and it is untrusted.

Tests: fast/forms/label/label-click-event-dispatch-untrusted.html
       Tools/TestWebKitAPI/Tests/WebKitCocoa/SwitchInputTests.mm

* LayoutTests/fast/forms/label/label-click-event-dispatch-untrusted-expected.txt: Added.
* LayoutTests/fast/forms/label/label-click-event-dispatch-untrusted.html: Added.
* Source/WebCore/dom/Element.cpp:
(WebCore::Element::dispatchSimulatedClick):

If there is an underlying event, the simulated click should be marked as from
"bindings", making it untrusted. This change is not made to `simulateClick` itself
since that is used by `Element::click()`, which has no underlying event and is
always untrusted.

* Tools/TestWebKitAPI/Tests/WebKitCocoa/SwitchInputTests.mm:
(TEST(SwitchInputTests, HapticFeedbackOnClick)):

Add a test to verify that haptics are still triggered for a trusted click.

(TEST(SwitchInputTests, HapticFeedbackRequiresUserGestureAndTrustedEvent)):

Update the `HapticFeedbackRequiresUserGesture` test to also perform a user
gesture, and ensure haptics cannot be triggered programmatically.

(TEST(SwitchInputTests, HapticFeedbackRequiresUserGesture)): Deleted.

Originally-landed-as: 305413.395@rapid/safari-7624.2.5.110-branch (2c99c891b64c). rdar://176067574

```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a68de2eab4cdd54f7c899dbc1e4181c8b9ca667d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163764 "3 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37248 "Hash a68de2ea for PR 65401 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30467 "Hash a68de2ea for PR 65401 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172786 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121015 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165633 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37579 "Hash a68de2ea for PR 65401 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37247 "Hash a68de2ea for PR 65401 does not build (failure)") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127202 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121015 "Build was cancelled. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (cancelled)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166723 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/37579 "Hash a68de2ea for PR 65401 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/30467 "Hash a68de2ea for PR 65401 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107751 "Passed tests") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/37579 "Hash a68de2ea for PR 65401 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/37247 "Hash a68de2ea for PR 65401 does not build (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20557 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/37579 "Hash a68de2ea for PR 65401 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/30467 "Hash a68de2ea for PR 65401 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175311 "Built successfully") | 
| | | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/30467 "Hash a68de2ea for PR 65401 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135509 "Passed tests") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36918 "Hash a68de2ea for PR 65401 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/37247 "Hash a68de2ea for PR 65401 does not build (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135485 "Passed tests") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37703 "Hash a68de2ea for PR 65401 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/30467 "Hash a68de2ea for PR 65401 does not build (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99822 "Built successfully") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/37703 "Hash a68de2ea for PR 65401 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/30467 "Hash a68de2ea for PR 65401 does not build (failure)") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36414 "Hash a68de2ea for PR 65401 does not build (failure)") | | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35911 "Hash a68de2ea for PR 65401 does not build (failure)") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/30467 "Hash a68de2ea for PR 65401 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36161 "Hash a68de2ea for PR 65401 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36058 "Hash a68de2ea for PR 65401 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->