### PR TITLE
Propagate CSP directives from the creating document to WorkletGlobalScope

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/worklets/audio-worklet-csp.https-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/worklets/audio-worklet-csp.https-expected.txt
@@ -1,9 +1,9 @@
 
 PASS A remote-origin worklet should be blocked by the script-src 'self' directive.
-FAIL A same-origin worklet importing a remote-origin script should be blocked by the script-src 'self' directive. assert_equals: expected "REJECTED" but got "RESOLVED"
+PASS A same-origin worklet importing a remote-origin script should be blocked by the script-src 'self' directive.
 PASS A remote-origin worklet importing a remote-origin script should be blocked by the script-src 'self' directive.
-FAIL A remote-origin-redirected worklet should be blocked by the script-src 'self' directive. assert_equals: expected "REJECTED" but got "RESOLVED"
-FAIL A same-origin worklet importing a remote-origin-redirected script should be blocked by the script-src 'self' directive. assert_equals: expected "REJECTED" but got "RESOLVED"
+PASS A remote-origin-redirected worklet should be blocked by the script-src 'self' directive.
+PASS A same-origin worklet importing a remote-origin-redirected script should be blocked by the script-src 'self' directive.
 PASS A remote-origin worklet should not be blocked because the script-src directive specifying the origin allows it.
 PASS A same-origin worklet importing a remote-origin script should not be blocked because the script-src directive specifying the origin allows it.
 PASS A remote-origin worklet importing a remote-origin script should not be blocked because the script-src directive specifying the origin allows it.

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -850,7 +850,7 @@ imported/w3c/web-platform-tests/service-workers/service-worker/registration-scri
 
 imported/w3c/web-platform-tests/content-security-policy/font-src/font-match-allowed.sub.html [ Pass ]
 imported/w3c/web-platform-tests/content-security-policy/frame-src/frame-src-same-document.sub.html [ Pass ]
-imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-self/worklet-audio.https.html [ Pass ]
+imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-self/worklet-audio.https.html [ Failure ]
 imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/script-src-wildcard/worklet-audio.https.html [ Pass ]
 imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-none/script-tag.http.html [ Pass ]
 imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-none/script-tag.https.html [ Pass ]
@@ -864,7 +864,7 @@ imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-s
 imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-wildcard/script-tag.https.html [ Pass ]
 imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-wildcard/worklet-audio-import-data.https.html [ Pass ]
 imported/w3c/web-platform-tests/content-security-policy/gen/top.http-rp/worker-src-wildcard/worklet-audio.https.html [ Pass ]
-imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-self/worklet-audio.https.html [ Pass ]
+imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-self/worklet-audio.https.html [ Failure ]
 imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/script-src-wildcard/worklet-audio.https.html [ Pass ]
 imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-none/script-tag.http.html [ Pass ]
 imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-none/script-tag.https.html [ Pass ]

--- a/LayoutTests/security/contentSecurityPolicy/audioworklet-inherits-allows-eval-expected.txt
+++ b/LayoutTests/security/contentSecurityPolicy/audioworklet-inherits-allows-eval-expected.txt
@@ -1,0 +1,3 @@
+This tests that the Content Security Policy (CSP) of the owner document allows an AudioWorklet to use eval() because the CSP lists unsafe-eval in script-src.
+
+PASS eval() was allowed by CSP.

--- a/LayoutTests/security/contentSecurityPolicy/audioworklet-inherits-allows-eval.html
+++ b/LayoutTests/security/contentSecurityPolicy/audioworklet-inherits-allows-eval.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline' 'unsafe-eval'">
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+</script>
+</head>
+<body>
+<p>This tests that the Content Security Policy (CSP) of the owner document allows an AudioWorklet to use eval() because the CSP lists unsafe-eval in script-src.</p>
+<pre id="result"></pre>
+<script>
+var context = new OfflineAudioContext(2, 100, 44100);
+context.audioWorklet.addModule("resources/audioworklet-inherits-allows-eval.js").then(() => {
+    var node = new AudioWorkletNode(context, 'eval-test');
+    node.port.onmessage = function(event) {
+        document.getElementById("result").textContent = event.data;
+        if (window.testRunner)
+            testRunner.notifyDone();
+    };
+}, (e) => {
+    document.getElementById("result").textContent = "FAIL: addModule rejected with " + e;
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/security/contentSecurityPolicy/audioworklet-inherits-blocks-eval-expected.txt
+++ b/LayoutTests/security/contentSecurityPolicy/audioworklet-inherits-blocks-eval-expected.txt
@@ -1,0 +1,4 @@
+This tests that the Content Security Policy (CSP) of the owner document blocks an AudioWorklet from using eval() because the CSP does not list unsafe-eval in script-src.
+
+PASS threw exception EvalError: Refused to evaluate a string as JavaScript because 'unsafe-eval' or 'trusted-types-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'self' 'unsafe-inline'".
+.

--- a/LayoutTests/security/contentSecurityPolicy/audioworklet-inherits-blocks-eval.html
+++ b/LayoutTests/security/contentSecurityPolicy/audioworklet-inherits-blocks-eval.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta http-equiv="Content-Security-Policy" content="script-src 'self' 'unsafe-inline'">
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+</script>
+</head>
+<body>
+<p>This tests that the Content Security Policy (CSP) of the owner document blocks an AudioWorklet from using eval() because the CSP does not list unsafe-eval in script-src.</p>
+<pre id="result"></pre>
+<script>
+var context = new OfflineAudioContext(2, 100, 44100);
+context.audioWorklet.addModule("resources/audioworklet-inherits-blocks-eval.js").then(() => {
+    var node = new AudioWorkletNode(context, 'eval-test');
+    node.port.onmessage = function(event) {
+        document.getElementById("result").textContent = event.data;
+        if (window.testRunner)
+            testRunner.notifyDone();
+    };
+}, (e) => {
+    document.getElementById("result").textContent = "FAIL: addModule rejected with " + e;
+    if (window.testRunner)
+        testRunner.notifyDone();
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/security/contentSecurityPolicy/resources/audioworklet-inherits-allows-eval.js
+++ b/LayoutTests/security/contentSecurityPolicy/resources/audioworklet-inherits-allows-eval.js
@@ -1,0 +1,17 @@
+class EvalTestProcessor extends AudioWorkletProcessor {
+    constructor() {
+        super();
+        var exception;
+        try {
+            eval("1 + 0");
+        } catch (e) {
+            exception = e;
+        }
+        if (!exception)
+            this.port.postMessage("PASS eval() was allowed by CSP.");
+        else
+            this.port.postMessage("FAIL eval() threw exception " + exception + ".");
+    }
+    process() { return false; }
+}
+registerProcessor('eval-test', EvalTestProcessor);

--- a/LayoutTests/security/contentSecurityPolicy/resources/audioworklet-inherits-blocks-eval.js
+++ b/LayoutTests/security/contentSecurityPolicy/resources/audioworklet-inherits-blocks-eval.js
@@ -1,0 +1,19 @@
+class EvalTestProcessor extends AudioWorkletProcessor {
+    constructor() {
+        super();
+        var exception;
+        try {
+            eval("1 + 0");
+        } catch (e) {
+            exception = e;
+        }
+        if (!exception)
+            this.port.postMessage("FAIL should throw EvalError. But did not throw an exception.");
+        else if (exception instanceof EvalError)
+            this.port.postMessage("PASS threw exception " + exception + ".");
+        else
+            this.port.postMessage("FAIL should throw EvalError. Threw exception " + exception + ".");
+    }
+    process() { return false; }
+}
+registerProcessor('eval-test', EvalTestProcessor);

--- a/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.cpp
@@ -60,6 +60,7 @@ RefPtr<AudioWorkletGlobalScope> AudioWorkletGlobalScope::tryCreate(AudioWorkletT
         return nullptr;
     auto scope = adoptRef(*new AudioWorkletGlobalScope(thread, vm.releaseNonNull(), parameters));
     scope->addToContextsMap();
+    scope->applyContentSecurityPolicyResponseHeaders(parameters.contentSecurityPolicyResponseHeaders);
     return scope;
 }
 

--- a/Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.cpp
@@ -35,6 +35,7 @@
 #include "AudioWorkletThread.h"
 #include "BaseAudioContext.h"
 #include "CacheStorageConnection.h"
+#include "ContentSecurityPolicy.h"
 #include "DocumentPage.h"
 #include "DocumentSettingsValues.h"
 #include "FileSystemStorageConnection.h"
@@ -63,7 +64,8 @@ static WorkletParameters generateWorkletParameters(AudioWorklet& worklet)
         worklet.audioContext() ? !worklet.audioContext()->isOfflineContext() : false,
         document->advancedPrivacyProtections(),
         document->noiseInjectionHashSalt(),
-        document->agentClusterID()
+        document->agentClusterID(),
+        protect(document->contentSecurityPolicy())->responseHeaders()
     };
 }
 

--- a/Source/WebCore/bindings/js/WorkerModuleScriptLoader.cpp
+++ b/Source/WebCore/bindings/js/WorkerModuleScriptLoader.cpp
@@ -93,7 +93,10 @@ void WorkerModuleScriptLoader::load(ScriptExecutionContext& context, URL&& sourc
             sourcePosition = document->currentParserSourcePosition();
 
         CheckedPtr contentSecurityPolicy = context.contentSecurityPolicy();
-        if (fetchOptions.destination == FetchOptions::Destination::Script) {
+        // Worklets and scripts are governed by script-src; workers are governed by worker-src.
+        bool shouldEnforceScriptSrc = fetchOptions.destination == FetchOptions::Destination::Script
+            || isWorkletDestination(fetchOptions.destination);
+        if (shouldEnforceScriptSrc) {
             cspCheckFailed = contentSecurityPolicy && !contentSecurityPolicy->allowScriptFromSource(m_sourceURL, WTF::move(sourcePosition));
             contentSecurityPolicyEnforcement = ContentSecurityPolicyEnforcement::EnforceScriptSrcDirective;
         } else {

--- a/Source/WebCore/loader/FetchOptions.h
+++ b/Source/WebCore/loader/FetchOptions.h
@@ -108,10 +108,15 @@ inline bool isNonSubresourceRequest(FetchOptions::Destination destination)
         || destination == FetchOptions::Destination::Worker;
 }
 
-inline bool isScriptLikeDestination(FetchOptions::Destination destination)
+inline bool isWorkletDestination(FetchOptions::Destination destination)
 {
     return destination == FetchOptions::Destination::Audioworklet
-        || destination == FetchOptions::Destination::Paintworklet
+        || destination == FetchOptions::Destination::Paintworklet;
+}
+
+inline bool isScriptLikeDestination(FetchOptions::Destination destination)
+{
+    return isWorkletDestination(destination)
         || destination == FetchOptions::Destination::Script
         || destination == FetchOptions::Destination::Serviceworker
         || destination == FetchOptions::Destination::Sharedworker

--- a/Source/WebCore/workers/WorkerGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerGlobalScope.cpp
@@ -205,11 +205,6 @@ bool WorkerGlobalScope::isSecureContext() const
     return m_topOrigin->isPotentiallyTrustworthy();
 }
 
-void WorkerGlobalScope::applyContentSecurityPolicyResponseHeaders(const ContentSecurityPolicyResponseHeaders& contentSecurityPolicyResponseHeaders)
-{
-    protect(contentSecurityPolicy())->didReceiveHeaders(contentSecurityPolicyResponseHeaders, String { });
-}
-
 // https://html.spec.whatwg.org/multipage/webappapis.html#parse-a-url
 URL WorkerGlobalScope::parseURL(const String& url) const
 {

--- a/Source/WebCore/workers/WorkerGlobalScope.h
+++ b/Source/WebCore/workers/WorkerGlobalScope.h
@@ -51,7 +51,6 @@ namespace WebCore {
 class CSSFontSelector;
 class CSSValuePool;
 class CacheStorageConnection;
-class ContentSecurityPolicyResponseHeaders;
 class Crypto;
 class CryptoKey;
 class FileSystemStorageConnection;
@@ -182,7 +181,6 @@ public:
 protected:
     WorkerGlobalScope(WorkerThreadType, const WorkerParameters&, Ref<SecurityOrigin>&&, WorkerThread&, Ref<SecurityOrigin>&& topOrigin, IDBClient::IDBConnectionProxy*, SocketProvider*, std::unique_ptr<WorkerClient>&&);
 
-    void applyContentSecurityPolicyResponseHeaders(const ContentSecurityPolicyResponseHeaders&);
     void updateSourceProviderBuffers(const ScriptBuffer& mainScript, const HashMap<URL, ScriptBuffer>& importedScripts);
 
     void addConsoleMessage(MessageSource, MessageLevel, const String& message, unsigned long requestIdentifier) override;

--- a/Source/WebCore/workers/WorkerOrWorkletGlobalScope.cpp
+++ b/Source/WebCore/workers/WorkerOrWorkletGlobalScope.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "WorkerOrWorkletGlobalScope.h"
 
+#include "ContentSecurityPolicy.h"
 #include "NoiseInjectionPolicy.h"
 #include "ScriptModuleLoader.h"
 #include "ServiceWorkerGlobalScope.h"
@@ -169,6 +170,11 @@ OptionSet<NoiseInjectionPolicy> WorkerOrWorkletGlobalScope::noiseInjectionPolici
 RefPtr<WorkerOrWorkletThread> WorkerOrWorkletGlobalScope::workerOrWorkletThread() const
 {
     return m_thread.get();
+}
+
+void WorkerOrWorkletGlobalScope::applyContentSecurityPolicyResponseHeaders(const ContentSecurityPolicyResponseHeaders& contentSecurityPolicyResponseHeaders)
+{
+    protect(contentSecurityPolicy())->didReceiveHeaders(contentSecurityPolicyResponseHeaders, String { });
 }
 
 } // namespace WebCore

--- a/Source/WebCore/workers/WorkerOrWorkletGlobalScope.h
+++ b/Source/WebCore/workers/WorkerOrWorkletGlobalScope.h
@@ -34,6 +34,7 @@
 
 namespace WebCore {
 
+class ContentSecurityPolicyResponseHeaders;
 class EventLoopTaskGroup;
 class ScriptModuleLoader;
 class WorkerEventLoop;
@@ -91,6 +92,8 @@ public:
 
 protected:
     WorkerOrWorkletGlobalScope(WorkerThreadType, PAL::SessionID, Ref<JSC::VM>&&, ReferrerPolicy, WorkerOrWorkletThread*, std::optional<uint64_t>, OptionSet<AdvancedPrivacyProtections>, std::optional<ScriptExecutionContextIdentifier> = std::nullopt);
+
+    void applyContentSecurityPolicyResponseHeaders(const ContentSecurityPolicyResponseHeaders&);
 
     // ScriptExecutionContext.
     bool isJSExecutionForbidden() const final;

--- a/Source/WebCore/worklets/PaintWorkletGlobalScope.cpp
+++ b/Source/WebCore/worklets/PaintWorkletGlobalScope.cpp
@@ -26,6 +26,7 @@
 #include "config.h"
 #include "PaintWorkletGlobalScope.h"
 
+#include "ContentSecurityPolicy.h"
 #include "Document.h"
 #include "JSCSSPaintCallback.h"
 #include "JSDOMConvertCallbacks.h"
@@ -49,6 +50,7 @@ RefPtr<PaintWorkletGlobalScope> PaintWorkletGlobalScope::tryCreate(Document& doc
         return nullptr;
     auto scope = adoptRef(*new PaintWorkletGlobalScope(document, vm.releaseNonNull(), WTF::move(code)));
     scope->addToContextsMap();
+    scope->applyContentSecurityPolicyResponseHeaders(protect(document.contentSecurityPolicy())->responseHeaders());
     return scope;
 }
 

--- a/Source/WebCore/worklets/WorkletParameters.h
+++ b/Source/WebCore/worklets/WorkletParameters.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include "AdvancedPrivacyProtections.h"
+#include "ContentSecurityPolicyResponseHeaders.h"
 #include "Settings.h"
 #include <JavaScriptCore/RuntimeFlags.h>
 #include <pal/SessionID.h>
@@ -45,9 +46,10 @@ struct WorkletParameters {
     OptionSet<AdvancedPrivacyProtections> advancedPrivacyProtections;
     std::optional<uint64_t> noiseInjectionHashSalt;
     String agentClusterID;
+    ContentSecurityPolicyResponseHeaders contentSecurityPolicyResponseHeaders;
 
-    WorkletParameters isolatedCopy() const & { return { windowURL.isolatedCopy(), jsRuntimeFlags, sampleRate, identifier.isolatedCopy(), sessionID, settingsValues.isolatedCopy(), referrerPolicy, isAudioContextRealTime, advancedPrivacyProtections, noiseInjectionHashSalt, agentClusterID.isolatedCopy() }; }
-    WorkletParameters isolatedCopy() && { return { WTF::move(windowURL).isolatedCopy(), jsRuntimeFlags, sampleRate, WTF::move(identifier).isolatedCopy(), sessionID, WTF::move(settingsValues).isolatedCopy(), referrerPolicy, isAudioContextRealTime, advancedPrivacyProtections, WTF::move(noiseInjectionHashSalt), WTF::move(agentClusterID).isolatedCopy() }; }
+    WorkletParameters isolatedCopy() const & { return { windowURL.isolatedCopy(), jsRuntimeFlags, sampleRate, identifier.isolatedCopy(), sessionID, settingsValues.isolatedCopy(), referrerPolicy, isAudioContextRealTime, advancedPrivacyProtections, noiseInjectionHashSalt, agentClusterID.isolatedCopy(), contentSecurityPolicyResponseHeaders.isolatedCopy() }; }
+    WorkletParameters isolatedCopy() && { return { WTF::move(windowURL).isolatedCopy(), jsRuntimeFlags, sampleRate, WTF::move(identifier).isolatedCopy(), sessionID, WTF::move(settingsValues).isolatedCopy(), referrerPolicy, isAudioContextRealTime, advancedPrivacyProtections, WTF::move(noiseInjectionHashSalt), WTF::move(agentClusterID).isolatedCopy(), WTF::move(contentSecurityPolicyResponseHeaders).isolatedCopy() }; }
 };
 
 } // namespace WebCore

--- a/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp
@@ -414,6 +414,7 @@ bool NetworkLoadChecker::isAllowedByContentSecurityPolicy(const ResourceRequest&
     switch (m_options.destination) {
     case FetchOptions::Destination::Audioworklet:
     case FetchOptions::Destination::Paintworklet:
+        return contentSecurityPolicy->allowScriptFromSource(request.url(), { }, redirectResponseReceived, preRedirectURL);
     case FetchOptions::Destination::Worker:
     case FetchOptions::Destination::Serviceworker:
     case FetchOptions::Destination::Sharedworker:


### PR DESCRIPTION
#### 933debd495d6ece891099cbe8e0f040afa5a4357
<pre>
Propagate CSP directives from the creating document to WorkletGlobalScope
<a href="https://bugs.webkit.org/show_bug.cgi?id=309004">https://bugs.webkit.org/show_bug.cgi?id=309004</a>
<a href="https://rdar.apple.com/170500592">rdar://170500592</a>

Reviewed by Ryan Reno.

WorkletGlobalScope is initialized with an empty ContentSecurityPolicy,
so CSP restrictions like blocking eval() are not enforced inside
AudioWorklet or PaintWorklet.

Fix by moving WorkerGlobalScope::applyContentSecurityPolicyResponseHeaders()
up to WorkerOrWorkletGlobalScope base class, adding the document&apos;s CSP
response headers to WorkletParameters and applying them in
AudioWorkletGlobalScope/PaintWorkletGlobalScope::tryCreate().

Fix CSP directive selection for worklet module fetches, which were
incorrectly checked against worker-src instead of script-src.

Tests: security/contentSecurityPolicy/audioworklet-inherits-allows-eval.html
       security/contentSecurityPolicy/audioworklet-inherits-blocks-eval.html

* LayoutTests/imported/w3c/web-platform-tests/worklets/audio-worklet-csp.https-expected.txt:
* LayoutTests/platform/glib/TestExpectations:
* LayoutTests/security/contentSecurityPolicy/audioworklet-inherits-allows-eval-expected.txt: Added.
* LayoutTests/security/contentSecurityPolicy/audioworklet-inherits-allows-eval.html: Added.
* LayoutTests/security/contentSecurityPolicy/audioworklet-inherits-blocks-eval-expected.txt: Added.
* LayoutTests/security/contentSecurityPolicy/audioworklet-inherits-blocks-eval.html: Added.
* LayoutTests/security/contentSecurityPolicy/resources/audioworklet-inherits-allows-eval.js: Added.
(EvalTestProcessor):
(EvalTestProcessor.prototype.process):
* LayoutTests/security/contentSecurityPolicy/resources/audioworklet-inherits-blocks-eval.js: Added.
(EvalTestProcessor):
(EvalTestProcessor.prototype.process):
* Source/WebCore/Modules/webaudio/AudioWorkletGlobalScope.cpp:
(WebCore::AudioWorkletGlobalScope::tryCreate):
* Source/WebCore/Modules/webaudio/AudioWorkletMessagingProxy.cpp:
(WebCore::generateWorkletParameters):
* Source/WebCore/bindings/js/WorkerModuleScriptLoader.cpp:
(WebCore::WorkerModuleScriptLoader::load):
* Source/WebCore/loader/FetchOptions.h:
(WebCore::isWorkletDestination):
(WebCore::isScriptLikeDestination):
* Source/WebCore/workers/WorkerGlobalScope.cpp:
(WebCore::WorkerGlobalScope::applyContentSecurityPolicyResponseHeaders): Deleted.
* Source/WebCore/workers/WorkerGlobalScope.h:
* Source/WebCore/workers/WorkerOrWorkletGlobalScope.cpp:
(WebCore::WorkerOrWorkletGlobalScope::applyContentSecurityPolicyResponseHeaders):
* Source/WebCore/workers/WorkerOrWorkletGlobalScope.h:
* Source/WebCore/worklets/PaintWorkletGlobalScope.cpp:
(WebCore::PaintWorkletGlobalScope::tryCreate):
* Source/WebCore/worklets/WorkletParameters.h:
(WebCore::WorkletParameters::isolatedCopy const):
(WebCore::WorkletParameters::isolatedCopy):
* Source/WebKit/NetworkProcess/NetworkLoadChecker.cpp:
(WebKit::NetworkLoadChecker::isAllowedByContentSecurityPolicy):

Originally-landed-as: 305413.406@rapid/safari-7624.2.5.110-branch (95fd4539c956). <a href="https://rdar.apple.com/176067205">rdar://176067205</a>
Canonical link: <a href="https://commits.webkit.org/315193@main">https://commits.webkit.org/315193@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccab98e3aa5284a84b1819dbcd32dc61c4d18d2b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168334 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41891 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35477 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177662 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126035 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170200 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42266 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41848 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131006 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92104 "2 flakes 5 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171293 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33475 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151285 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111518 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32461 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31164 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26358 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142447 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180262 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32986 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30696 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139443 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41903 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35334 "Found 1 new test failure: fast/speechsynthesis/speech-synthesis-speak.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139306 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37516 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42591 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150761 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106120 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34599 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27659 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41095 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114351 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40492 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5744 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40743 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40637 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->