### PR TITLE
[WIP] [CSS] Implement corner and corner-* shorthands

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-block-start-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-block-start-computed-expected.txt
@@ -1,0 +1,6 @@
+
+PASS Property corner-block-start value '0px round'
+PASS Property corner-block-start value '10px bevel'
+PASS Property corner-block-start value 'normal / 2px round'
+PASS Property corner-block-start value '4px 2% squircle / 1em scoop'
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-block-start-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-block-start-computed.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Borders and Box Decorations 4 Test: Computed values of 'corner-block-start'</title>
+<link rel="author" title="Chromium" href="https://chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shorthand">
+<meta name="assert" content="This test checks that the computed value of 'corner-block-start' is correct across writing mode variants.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+
+<div id="target"></div>
+
+<script>
+test_computed_value("corner-block-start", "0px round", "normal");
+test_computed_value("corner-block-start", "10px bevel");
+test_computed_value("corner-block-start", "normal / 2px round");
+test_computed_value("corner-block-start", "4px 2% squircle / 1em scoop", "4px 2% squircle / 16px scoop");
+</script>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-block-start-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-block-start-valid-expected.txt
@@ -1,0 +1,16 @@
+
+PASS e.style['corner-block-start'] = "10px bevel" should set the property value
+PASS e.style['corner-block-start'] = "round 10% / 2rem squircle" should set the property value
+PASS e.style['corner-block-start'] = "normal" should set the property value
+PASS e.style['corner-block-start'] = "4px 2% round / bevel 1em" should set the property value
+PASS e.style['corner-block-start'] = "10px bevel" should set border-start-end-radius
+PASS e.style['corner-block-start'] = "10px bevel" should set border-start-start-radius
+PASS e.style['corner-block-start'] = "10px bevel" should set corner-start-end-shape
+PASS e.style['corner-block-start'] = "10px bevel" should set corner-start-start-shape
+PASS e.style['corner-block-start'] = "10px bevel" should not set unrelated longhands
+PASS e.style['corner-block-start'] = "4px 2% round / 1em bevel" should set border-start-end-radius
+PASS e.style['corner-block-start'] = "4px 2% round / 1em bevel" should set border-start-start-radius
+PASS e.style['corner-block-start'] = "4px 2% round / 1em bevel" should set corner-start-end-shape
+PASS e.style['corner-block-start'] = "4px 2% round / 1em bevel" should set corner-start-start-shape
+PASS e.style['corner-block-start'] = "4px 2% round / 1em bevel" should not set unrelated longhands
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-block-start-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-block-start-valid.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Borders and Box Decorations 4 Test: Parsing 'corner-block-start' with valid values</title>
+<link rel="author" title="Chromium" href="https://chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shorthand">
+<meta name="assert" content="This test checks that 'corner-block-start' supports valid pair-corner values.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<script src="/css/support/shorthand-testcommon.js"></script>
+
+<script>
+test_valid_value("corner-block-start", "10px bevel");
+test_valid_value("corner-block-start", "round 10% / 2rem squircle", "10% round / 2rem squircle");
+test_valid_value("corner-block-start", "normal");
+test_valid_value("corner-block-start", "4px 2% round / bevel 1em", "4px 2% round / 1em bevel");
+
+test_shorthand_value("corner-block-start", "10px bevel", {
+  "border-start-start-radius": "10px",
+  "corner-start-start-shape": "bevel",
+  "border-start-end-radius": "10px",
+  "corner-start-end-shape": "bevel",
+});
+test_shorthand_value("corner-block-start", "4px 2% round / 1em bevel", {
+  "border-start-start-radius": "4px 2%",
+  "corner-start-start-shape": "round",
+  "border-start-end-radius": "1em",
+  "corner-start-end-shape": "bevel",
+});
+</script>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-block-start-writing-modes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-block-start-writing-modes-expected.txt
@@ -1,0 +1,5 @@
+
+PASS corner-block-start in horizontal-tb ltr
+PASS corner-block-start in horizontal-tb rtl
+PASS corner-block-start in vertical-rl ltr
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-block-start-writing-modes.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-block-start-writing-modes.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Borders and Box Decorations 4 Test: 'corner-block-start' in writing mode variants</title>
+<link rel="author" title="Chromium" href="https://chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shorthand">
+<meta name="assert" content="This test checks that 'corner-block-start' applies in horizontal and vertical writing modes.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div id="target"></div>
+
+<script>
+function runVariant(name, writingMode, direction) {
+  test(() => {
+    const target = document.getElementById('target');
+    target.style.cssText = '';
+    target.style.writingMode = writingMode;
+    target.style.direction = direction;
+    target.style.cornerBlockStart = '10px round / 20px bevel';
+
+    assert_equals(target.style.cornerBlockStart, '10px round / 20px bevel');
+
+    const computed = getComputedStyle(target).getPropertyValue('corner-block-start').trim();
+    assert_not_equals(computed, '', 'computed shorthand should not be empty');
+  }, name);
+}
+
+runVariant('corner-block-start in horizontal-tb ltr', 'horizontal-tb', 'ltr');
+runVariant('corner-block-start in horizontal-tb rtl', 'horizontal-tb', 'rtl');
+runVariant('corner-block-start in vertical-rl ltr', 'vertical-rl', 'ltr');
+</script>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shorthand-rendering-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shorthand-rendering-ref.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Borders 4: corner shorthand rendering reference</title>
+<style>
+  .box {
+    width: 160px;
+    height: 160px;
+    border: 24px solid rgb(0 128 0);
+    background: rgb(240 240 240);
+    border-top-left-radius: 36px;
+    border-top-right-radius: 18px;
+    border-bottom-right-radius: 28px;
+    border-bottom-left-radius: 20px;
+    corner-top-left-shape: round;
+    corner-top-right-shape: bevel;
+    corner-bottom-right-shape: scoop;
+    corner-bottom-left-shape: notch;
+  }
+</style>
+<div class="box"></div>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shorthand-rendering.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shorthand-rendering.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Borders 4: corner shorthand rendering</title>
+<link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shorthand">
+<link rel="match" href="corner-shorthand-rendering-ref.html">
+<style>
+  .box {
+    width: 160px;
+    height: 160px;
+    border: 24px solid rgb(0 128 0);
+    background: rgb(240 240 240);
+    corner: 36px round / 18px bevel / 28px scoop / 20px notch;
+  }
+</style>
+<div class="box"></div>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-top-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-top-computed-expected.txt
@@ -1,0 +1,6 @@
+
+PASS Property corner-top value '0px round'
+PASS Property corner-top value '10px bevel'
+PASS Property corner-top value 'normal / 2px round'
+PASS Property corner-top value '4px 2% squircle / 1em scoop'
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-top-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-top-computed.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Borders and Box Decorations 4 Test: Computed values of 'corner-top'</title>
+<link rel="author" title="Chromium" href="https://chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shorthand">
+<meta name="assert" content="This test checks that the computed value of 'corner-top' is correct.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+
+<div id="target"></div>
+
+<script>
+test_computed_value("corner-top", "0px round", "normal");
+test_computed_value("corner-top", "10px bevel");
+test_computed_value("corner-top", "normal / 2px round");
+test_computed_value("corner-top", "4px 2% squircle / 1em scoop", "4px 2% squircle / 16px scoop");
+</script>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-top-left-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-top-left-computed-expected.txt
@@ -1,0 +1,8 @@
+
+PASS Property corner-top-left value '0px round'
+PASS Property corner-top-left value 'normal'
+PASS Property corner-top-left value '4px round'
+PASS Property corner-top-left value '2% notch'
+PASS Property corner-top-left value '4px 2% squircle'
+PASS Property corner-top-left value 'superellipse(-0.5) 30% 10px'
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-top-left-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-top-left-computed.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Borders and Box Decorations 4 Test: Computed values of 'corner-top-left'</title>
+<link rel="author" title="Chromium" href="https://chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shorthand">
+<meta name="assert" content="This test checks that the computed value of 'corner-top-left' is correct.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+
+<div id="target"></div>
+
+<script>
+test_computed_value("corner-top-left", "0px round", "normal");
+test_computed_value("corner-top-left", "normal");
+test_computed_value("corner-top-left", "4px round");
+test_computed_value("corner-top-left", "2% notch");
+test_computed_value("corner-top-left", "4px 2% squircle");
+test_computed_value("corner-top-left", "superellipse(-0.5) 30% 10px", "30% 10px superellipse(-0.5)");
+</script>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-top-left-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-top-left-invalid-expected.txt
@@ -1,0 +1,12 @@
+
+PASS e.style['corner-top-left'] = "auto" should not set the property value
+PASS e.style['corner-top-left'] = "none" should not set the property value
+PASS e.style['corner-top-left'] = "scoop" should not set the property value
+PASS e.style['corner-top-left'] = "3% normal" should not set the property value
+PASS e.style['corner-top-left'] = "round round" should not set the property value
+PASS e.style['corner-top-left'] = "-1px" should not set the property value
+PASS e.style['corner-top-left'] = "10px" should not set the property value
+PASS e.style['corner-top-left'] = "4px 12px" should not set the property value
+PASS e.style['corner-top-left'] = "4px / normal" should not set the property value
+PASS e.style['corner-top-left'] = "round / 4px" should not set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-top-left-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-top-left-invalid.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Borders and Box Decorations 4 Test: Parsing 'corner-top-left' with invalid values</title>
+<link rel="author" title="Chromium" href="https://chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shorthand">
+<meta name="assert" content="This test checks that 'corner-top-left' rejects invalid values.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+
+<script>
+test_invalid_value("corner-top-left", "auto");
+test_invalid_value("corner-top-left", "none");
+test_invalid_value("corner-top-left", "scoop");
+test_invalid_value("corner-top-left", "3% normal");
+test_invalid_value("corner-top-left", "round round");
+test_invalid_value("corner-top-left", "-1px");
+test_invalid_value("corner-top-left", "10px");
+test_invalid_value("corner-top-left", "4px 12px");
+test_invalid_value("corner-top-left", "4px / normal");
+test_invalid_value("corner-top-left", "round / 4px");
+</script>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-top-left-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-top-left-valid-expected.txt
@@ -1,0 +1,13 @@
+
+PASS e.style['corner-top-left'] = "round 30%" should set the property value
+PASS e.style['corner-top-left'] = "10px bevel" should set the property value
+PASS e.style['corner-top-left'] = "normal" should set the property value
+PASS e.style['corner-top-left'] = "4px 2% round" should set the property value
+PASS e.style['corner-top-left'] = "superellipse(-0.5) 30% 10px" should set the property value
+PASS e.style['corner-top-left'] = "10px bevel" should set border-top-left-radius
+PASS e.style['corner-top-left'] = "10px bevel" should set corner-top-left-shape
+PASS e.style['corner-top-left'] = "10px bevel" should not set unrelated longhands
+PASS e.style['corner-top-left'] = "normal" should set border-top-left-radius
+PASS e.style['corner-top-left'] = "normal" should set corner-top-left-shape
+PASS e.style['corner-top-left'] = "normal" should not set unrelated longhands
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-top-left-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-top-left-valid.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Borders and Box Decorations 4 Test: Parsing 'corner-top-left' with valid values</title>
+<link rel="author" title="Chromium" href="https://chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shorthand">
+<meta name="assert" content="This test checks that 'corner-top-left' supports valid single-corner values.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<script src="/css/support/shorthand-testcommon.js"></script>
+
+<script>
+test_valid_value("corner-top-left", "round 30%", "30% round");
+test_valid_value("corner-top-left", "10px bevel");
+test_valid_value("corner-top-left", "normal");
+test_valid_value("corner-top-left", "4px 2% round");
+test_valid_value("corner-top-left", "superellipse(-0.5) 30% 10px", "30% 10px superellipse(-0.5)");
+
+test_shorthand_value("corner-top-left", "10px bevel", {
+  "border-top-left-radius": "10px",
+  "corner-top-left-shape": "bevel",
+});
+test_shorthand_value("corner-top-left", "normal", {
+  "border-top-left-radius": "0px",
+  "corner-top-left-shape": "round",
+});
+</script>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-top-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-top-valid-expected.txt
@@ -1,0 +1,16 @@
+
+PASS e.style['corner-top'] = "10px bevel" should set the property value
+PASS e.style['corner-top'] = "round 10% / 2rem squircle" should set the property value
+PASS e.style['corner-top'] = "normal" should set the property value
+PASS e.style['corner-top'] = "4px 2% round / bevel 1em" should set the property value
+PASS e.style['corner-top'] = "10px bevel" should set border-top-left-radius
+PASS e.style['corner-top'] = "10px bevel" should set border-top-right-radius
+PASS e.style['corner-top'] = "10px bevel" should set corner-top-left-shape
+PASS e.style['corner-top'] = "10px bevel" should set corner-top-right-shape
+PASS e.style['corner-top'] = "10px bevel" should not set unrelated longhands
+PASS e.style['corner-top'] = "4px 2% round / 1em bevel" should set border-top-left-radius
+PASS e.style['corner-top'] = "4px 2% round / 1em bevel" should set border-top-right-radius
+PASS e.style['corner-top'] = "4px 2% round / 1em bevel" should set corner-top-left-shape
+PASS e.style['corner-top'] = "4px 2% round / 1em bevel" should set corner-top-right-shape
+PASS e.style['corner-top'] = "4px 2% round / 1em bevel" should not set unrelated longhands
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-top-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-top-valid.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Borders and Box Decorations 4 Test: Parsing 'corner-top' with valid values</title>
+<link rel="author" title="Chromium" href="https://chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shorthand">
+<meta name="assert" content="This test checks that 'corner-top' supports valid pair-corner values.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<script src="/css/support/shorthand-testcommon.js"></script>
+
+<script>
+test_valid_value("corner-top", "10px bevel");
+test_valid_value("corner-top", "round 10% / 2rem squircle", "10% round / 2rem squircle");
+test_valid_value("corner-top", "normal");
+test_valid_value("corner-top", "4px 2% round / bevel 1em", "4px 2% round / 1em bevel");
+
+test_shorthand_value("corner-top", "10px bevel", {
+  "border-top-left-radius": "10px",
+  "corner-top-left-shape": "bevel",
+  "border-top-right-radius": "10px",
+  "corner-top-right-shape": "bevel",
+});
+test_shorthand_value("corner-top", "4px 2% round / 1em bevel", {
+  "border-top-left-radius": "4px 2%",
+  "corner-top-left-shape": "round",
+  "border-top-right-radius": "1em",
+  "corner-top-right-shape": "bevel",
+});
+</script>
+

--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shorthand-rendering-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shorthand-rendering-expected.txt
@@ -1,0 +1,6 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x224
+  RenderBlock {HTML} at (0,0) size 800x224
+    RenderBody {BODY} at (8,8) size 784x208
+      RenderBlock {DIV} at (0,0) size 208x208 [bgcolor=#F0F0F0] [border: (24px solid #008000)]

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1065,6 +1065,20 @@ CSSCornerShapeEnabled:
     WebCore:
       default: false
 
+CSSCornersShorthandEnabled:
+  type: bool
+  category: css
+  status: testable
+  humanReadableName: "CSS corner and corner-* shorthands"
+  humanReadableDescription: "Enable support for the CSS `corner` and per-corner shorthand properties combining border-radius and corner-shape."
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CSSCounterStyleAtRuleImageSymbolsEnabled:
   type: bool
   status: testable

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -4442,6 +4442,425 @@
                 "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
             }
         },
+        "corner-top-shape": {
+            "codegen-properties": {
+                "longhands": [
+                    "corner-top-left-shape",
+                    "corner-top-right-shape"
+                ],
+                "shorthand-pattern": "CoalescingPair",
+                "settings-flag": "cssCornerShapeEnabled",
+                "parser-grammar-unused": "<'corner-top-left-shape'>{1,2}",
+                "parser-grammar-unused-reason": "Needs support for shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-right-shape": {
+            "codegen-properties": {
+                "longhands": [
+                    "corner-top-right-shape",
+                    "corner-bottom-right-shape"
+                ],
+                "shorthand-pattern": "CoalescingPair",
+                "settings-flag": "cssCornerShapeEnabled",
+                "parser-grammar-unused": "<'corner-top-right-shape'>{1,2}",
+                "parser-grammar-unused-reason": "Needs support for shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-bottom-shape": {
+            "codegen-properties": {
+                "longhands": [
+                    "corner-bottom-left-shape",
+                    "corner-bottom-right-shape"
+                ],
+                "shorthand-pattern": "CoalescingPair",
+                "settings-flag": "cssCornerShapeEnabled",
+                "parser-grammar-unused": "<'corner-bottom-left-shape'>{1,2}",
+                "parser-grammar-unused-reason": "Needs support for shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-left-shape": {
+            "codegen-properties": {
+                "longhands": [
+                    "corner-top-left-shape",
+                    "corner-bottom-left-shape"
+                ],
+                "shorthand-pattern": "CoalescingPair",
+                "settings-flag": "cssCornerShapeEnabled",
+                "parser-grammar-unused": "<'corner-top-left-shape'>{1,2}",
+                "parser-grammar-unused-reason": "Needs support for shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-block-start-shape": {
+            "codegen-properties": {
+                "longhands": [
+                    "corner-start-start-shape",
+                    "corner-start-end-shape"
+                ],
+                "shorthand-pattern": "CoalescingPair",
+                "settings-flag": "cssCornerShapeEnabled",
+                "parser-grammar-unused": "<'corner-start-start-shape'>{1,2}",
+                "parser-grammar-unused-reason": "Needs support for shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-block-end-shape": {
+            "codegen-properties": {
+                "longhands": [
+                    "corner-end-start-shape",
+                    "corner-end-end-shape"
+                ],
+                "shorthand-pattern": "CoalescingPair",
+                "settings-flag": "cssCornerShapeEnabled",
+                "parser-grammar-unused": "<'corner-end-start-shape'>{1,2}",
+                "parser-grammar-unused-reason": "Needs support for shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-inline-start-shape": {
+            "codegen-properties": {
+                "longhands": [
+                    "corner-start-start-shape",
+                    "corner-end-start-shape"
+                ],
+                "shorthand-pattern": "CoalescingPair",
+                "settings-flag": "cssCornerShapeEnabled",
+                "parser-grammar-unused": "<'corner-start-start-shape'>{1,2}",
+                "parser-grammar-unused-reason": "Needs support for shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-inline-end-shape": {
+            "codegen-properties": {
+                "longhands": [
+                    "corner-start-end-shape",
+                    "corner-end-end-shape"
+                ],
+                "shorthand-pattern": "CoalescingPair",
+                "settings-flag": "cssCornerShapeEnabled",
+                "parser-grammar-unused": "<'corner-start-end-shape'>{1,2}",
+                "parser-grammar-unused-reason": "Needs support for shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-top-left": {
+            "codegen-properties": {
+                "longhands": [
+                    "border-top-left-radius",
+                    "corner-top-left-shape"
+                ],
+                "parser-function": "consumeCornerSingleShorthand",
+                "shorthand-style-extractor-pattern": "CornerSingle",
+                "settings-flag": "cssCornersShorthandEnabled",
+                "parser-grammar-unused": "normal | [ <'border-top-left-radius'> ]",
+                "parser-grammar-unused-reason": "Needs support for hand-written shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-top-right": {
+            "codegen-properties": {
+                "longhands": [
+                    "border-top-right-radius",
+                    "corner-top-right-shape"
+                ],
+                "parser-function": "consumeCornerSingleShorthand",
+                "shorthand-style-extractor-pattern": "CornerSingle",
+                "settings-flag": "cssCornersShorthandEnabled",
+                "parser-grammar-unused": "normal | [ <'border-top-right-radius'> ]",
+                "parser-grammar-unused-reason": "Needs support for hand-written shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-bottom-right": {
+            "codegen-properties": {
+                "longhands": [
+                    "border-bottom-right-radius",
+                    "corner-bottom-right-shape"
+                ],
+                "parser-function": "consumeCornerSingleShorthand",
+                "shorthand-style-extractor-pattern": "CornerSingle",
+                "settings-flag": "cssCornersShorthandEnabled",
+                "parser-grammar-unused": "normal | [ <'border-bottom-right-radius'> ]",
+                "parser-grammar-unused-reason": "Needs support for hand-written shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-bottom-left": {
+            "codegen-properties": {
+                "longhands": [
+                    "border-bottom-left-radius",
+                    "corner-bottom-left-shape"
+                ],
+                "parser-function": "consumeCornerSingleShorthand",
+                "shorthand-style-extractor-pattern": "CornerSingle",
+                "settings-flag": "cssCornersShorthandEnabled",
+                "parser-grammar-unused": "normal | [ <'border-bottom-left-radius'> ]",
+                "parser-grammar-unused-reason": "Needs support for hand-written shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-start-start": {
+            "codegen-properties": {
+                "longhands": [
+                    "border-start-start-radius",
+                    "corner-start-start-shape"
+                ],
+                "parser-function": "consumeCornerSingleShorthand",
+                "shorthand-style-extractor-pattern": "CornerSingle",
+                "settings-flag": "cssCornersShorthandEnabled",
+                "parser-grammar-unused": "normal | [ <'border-start-start-radius'> ]",
+                "parser-grammar-unused-reason": "Needs support for hand-written shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-start-end": {
+            "codegen-properties": {
+                "longhands": [
+                    "border-start-end-radius",
+                    "corner-start-end-shape"
+                ],
+                "parser-function": "consumeCornerSingleShorthand",
+                "shorthand-style-extractor-pattern": "CornerSingle",
+                "settings-flag": "cssCornersShorthandEnabled",
+                "parser-grammar-unused": "normal | [ <'border-start-end-radius'> ]",
+                "parser-grammar-unused-reason": "Needs support for hand-written shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-end-start": {
+            "codegen-properties": {
+                "longhands": [
+                    "border-end-start-radius",
+                    "corner-end-start-shape"
+                ],
+                "parser-function": "consumeCornerSingleShorthand",
+                "shorthand-style-extractor-pattern": "CornerSingle",
+                "settings-flag": "cssCornersShorthandEnabled",
+                "parser-grammar-unused": "normal | [ <'border-end-start-radius'> ]",
+                "parser-grammar-unused-reason": "Needs support for hand-written shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-end-end": {
+            "codegen-properties": {
+                "longhands": [
+                    "border-end-end-radius",
+                    "corner-end-end-shape"
+                ],
+                "parser-function": "consumeCornerSingleShorthand",
+                "shorthand-style-extractor-pattern": "CornerSingle",
+                "settings-flag": "cssCornersShorthandEnabled",
+                "parser-grammar-unused": "normal | [ <'border-end-end-radius'> ]",
+                "parser-grammar-unused-reason": "Needs support for hand-written shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-top": {
+            "codegen-properties": {
+                "longhands": [
+                    "border-top-left-radius", "corner-top-left-shape",
+                    "border-top-right-radius", "corner-top-right-shape"
+                ],
+                "parser-function": "consumeCornerPairShorthand",
+                "shorthand-style-extractor-pattern": "CornerPair",
+                "settings-flag": "cssCornersShorthandEnabled",
+                "parser-grammar-unused": "[ normal | <length-percentage [0,inf]> ]#",
+                "parser-grammar-unused-reason": "Needs support for hand-written shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-right": {
+            "codegen-properties": {
+                "longhands": [
+                    "border-top-right-radius", "corner-top-right-shape",
+                    "border-bottom-right-radius", "corner-bottom-right-shape"
+                ],
+                "parser-function": "consumeCornerPairShorthand",
+                "shorthand-style-extractor-pattern": "CornerPair",
+                "settings-flag": "cssCornersShorthandEnabled",
+                "parser-grammar-unused": "[ normal | <length-percentage [0,inf]> ]#",
+                "parser-grammar-unused-reason": "Needs support for hand-written shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-bottom": {
+            "codegen-properties": {
+                "longhands": [
+                    "border-bottom-left-radius", "corner-bottom-left-shape",
+                    "border-bottom-right-radius", "corner-bottom-right-shape"
+                ],
+                "parser-function": "consumeCornerPairShorthand",
+                "shorthand-style-extractor-pattern": "CornerPair",
+                "settings-flag": "cssCornersShorthandEnabled",
+                "parser-grammar-unused": "[ normal | <length-percentage [0,inf]> ]#",
+                "parser-grammar-unused-reason": "Needs support for hand-written shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-left": {
+            "codegen-properties": {
+                "longhands": [
+                    "border-top-left-radius", "corner-top-left-shape",
+                    "border-bottom-left-radius", "corner-bottom-left-shape"
+                ],
+                "parser-function": "consumeCornerPairShorthand",
+                "shorthand-style-extractor-pattern": "CornerPair",
+                "settings-flag": "cssCornersShorthandEnabled",
+                "parser-grammar-unused": "[ normal | <length-percentage [0,inf]> ]#",
+                "parser-grammar-unused-reason": "Needs support for hand-written shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-block-start": {
+            "codegen-properties": {
+                "longhands": [
+                    "border-start-start-radius", "corner-start-start-shape",
+                    "border-start-end-radius", "corner-start-end-shape"
+                ],
+                "parser-function": "consumeCornerPairShorthand",
+                "shorthand-style-extractor-pattern": "CornerPair",
+                "settings-flag": "cssCornersShorthandEnabled",
+                "parser-grammar-unused": "[ normal | <length-percentage [0,inf]> ]#",
+                "parser-grammar-unused-reason": "Needs support for hand-written shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-block-end": {
+            "codegen-properties": {
+                "longhands": [
+                    "border-end-start-radius", "corner-end-start-shape",
+                    "border-end-end-radius", "corner-end-end-shape"
+                ],
+                "parser-function": "consumeCornerPairShorthand",
+                "shorthand-style-extractor-pattern": "CornerPair",
+                "settings-flag": "cssCornersShorthandEnabled",
+                "parser-grammar-unused": "[ normal | <length-percentage [0,inf]> ]#",
+                "parser-grammar-unused-reason": "Needs support for hand-written shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-inline-start": {
+            "codegen-properties": {
+                "longhands": [
+                    "border-start-start-radius", "corner-start-start-shape",
+                    "border-end-start-radius", "corner-end-start-shape"
+                ],
+                "parser-function": "consumeCornerPairShorthand",
+                "shorthand-style-extractor-pattern": "CornerPair",
+                "settings-flag": "cssCornersShorthandEnabled",
+                "parser-grammar-unused": "[ normal | <length-percentage [0,inf]> ]#",
+                "parser-grammar-unused-reason": "Needs support for hand-written shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-inline-end": {
+            "codegen-properties": {
+                "longhands": [
+                    "border-start-end-radius", "corner-start-end-shape",
+                    "border-end-end-radius", "corner-end-end-shape"
+                ],
+                "parser-function": "consumeCornerPairShorthand",
+                "shorthand-style-extractor-pattern": "CornerPair",
+                "settings-flag": "cssCornersShorthandEnabled",
+                "parser-grammar-unused": "[ normal | <length-percentage [0,inf]> ]#",
+                "parser-grammar-unused-reason": "Needs support for hand-written shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner": {
+            "codegen-properties": {
+                "longhands": [
+                    "border-top-left-radius", "corner-top-left-shape",
+                    "border-top-right-radius", "corner-top-right-shape",
+                    "border-bottom-right-radius", "corner-bottom-right-shape",
+                    "border-bottom-left-radius", "corner-bottom-left-shape"
+                ],
+                "parser-function": "consumeCornerQuadShorthand",
+                "shorthand-style-extractor-pattern": "CornerQuad",
+                "settings-flag": "cssCornersShorthandEnabled",
+                "parser-grammar-unused": "[ normal | <length-percentage [0,inf]> ]#",
+                "parser-grammar-unused-reason": "Needs support for hand-written shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
         "counter-increment": {
             "animation-type": "discrete",
             "animation-type-comment": "Current spec animation type is 'by computed value'",
@@ -14616,7 +15035,7 @@
             }
         },
         "<corner-shape-value>": {
-            "grammar": "round | scoop | bevel | notch | straight | squircle | superellipse(<number [0,inf]> | infinity)",
+            "grammar": "round | scoop | bevel | notch | straight | squircle | superellipse(<number> | infinity)",
             "specification": {
                 "category": "css-borders",
                 "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"

--- a/Source/WebCore/css/ShorthandSerializer.cpp
+++ b/Source/WebCore/css/ShorthandSerializer.cpp
@@ -119,6 +119,10 @@ private:
     String serializeCommonValue(unsigned startIndex, unsigned count) const;
     String serializePair() const;
     String serializeQuad() const;
+    String serializeCornerSingle() const;
+    String serializeCornerPair() const;
+    String serializeCornerQuad() const;
+    String serializeOneCorner(unsigned radiusIndex, unsigned shapeIndex) const;
 
     String serializeLayered() const;
     String serializeCoordinatingListPropertyGroup() const;
@@ -343,7 +347,35 @@ String ShorthandSerializer::serialize()
     case CSSPropertyScrollMarginInline:
     case CSSPropertyScrollPaddingBlock:
     case CSSPropertyScrollPaddingInline:
+    case CSSPropertyCornerTopShape:
+    case CSSPropertyCornerRightShape:
+    case CSSPropertyCornerBottomShape:
+    case CSSPropertyCornerLeftShape:
+    case CSSPropertyCornerBlockStartShape:
+    case CSSPropertyCornerBlockEndShape:
+    case CSSPropertyCornerInlineStartShape:
+    case CSSPropertyCornerInlineEndShape:
         return serializePair();
+    case CSSPropertyCornerTopLeft:
+    case CSSPropertyCornerTopRight:
+    case CSSPropertyCornerBottomLeft:
+    case CSSPropertyCornerBottomRight:
+    case CSSPropertyCornerStartStart:
+    case CSSPropertyCornerStartEnd:
+    case CSSPropertyCornerEndStart:
+    case CSSPropertyCornerEndEnd:
+        return serializeCornerSingle();
+    case CSSPropertyCornerTop:
+    case CSSPropertyCornerRight:
+    case CSSPropertyCornerBottom:
+    case CSSPropertyCornerLeft:
+    case CSSPropertyCornerBlockStart:
+    case CSSPropertyCornerBlockEnd:
+    case CSSPropertyCornerInlineStart:
+    case CSSPropertyCornerInlineEnd:
+        return serializeCornerPair();
+    case CSSPropertyCorner:
+        return serializeCornerQuad();
     case CSSPropertyBlockStep:
     case CSSPropertyBorderBlockEnd:
     case CSSPropertyBorderBlockStart:
@@ -517,6 +549,83 @@ String ShorthandSerializer::serializeQuad() const
 {
     ASSERT(length() == 4);
     return Quad::serialize(serializeLonghandValue(0), serializeLonghandValue(1), serializeLonghandValue(2), serializeLonghandValue(3));
+}
+
+static bool cornerShorthandRadiusIsZero(const CSSValue& value)
+{
+    auto* pair = dynamicDowncast<CSSValuePair>(value);
+    if (!pair)
+        return false;
+    auto isZero = [](const CSSValue& v) {
+        auto* primitive = dynamicDowncast<CSSPrimitiveValue>(v);
+        return primitive && primitive->isLength() && !primitive->resolveAsLengthDeprecated();
+    };
+    return isZero(pair->first()) && isZero(pair->second());
+}
+
+static bool cornerShorthandShapeIsRound(const CSSValue& value)
+{
+    auto* keyword = dynamicDowncast<CSSKeywordValue>(value);
+    return keyword && keyword->valueID() == CSSValueRound;
+}
+
+String ShorthandSerializer::serializeOneCorner(unsigned radiusIndex, unsigned shapeIndex) const
+{
+    RefPtr radius = m_longhandValues[radiusIndex];
+    RefPtr shape = m_longhandValues[shapeIndex];
+    if (!radius || !shape)
+        return String();
+    if (cornerShorthandRadiusIsZero(*radius) && cornerShorthandShapeIsRound(*shape))
+        return "normal"_s;
+    auto radiusStr = serializeLonghandValue(radiusIndex);
+    auto shapeStr = serializeLonghandValue(shapeIndex);
+    return makeString(radiusStr, ' ', shapeStr);
+}
+
+String ShorthandSerializer::serializeCornerSingle() const
+{
+    ASSERT(length() == 2);
+    return serializeOneCorner(0, 1);
+}
+
+String ShorthandSerializer::serializeCornerPair() const
+{
+    ASSERT(length() == 4);
+    auto first = serializeOneCorner(0, 1);
+    auto second = serializeOneCorner(2, 3);
+    if (first.isNull() || second.isNull())
+        return String();
+    if (first == second)
+        return first;
+    return makeString(first, " / "_s, second);
+}
+
+String ShorthandSerializer::serializeCornerQuad() const
+{
+    ASSERT(length() == 8);
+    std::array<String, 4> corners {
+        serializeOneCorner(0, 1),
+        serializeOneCorner(2, 3),
+        serializeOneCorner(4, 5),
+        serializeOneCorner(6, 7),
+    };
+    for (const auto& s : corners) {
+        if (s.isNull())
+            return String();
+    }
+    bool showBL = corners[1] != corners[3];
+    bool showBR = showBL || corners[0] != corners[2];
+    bool showTR = showBR || corners[0] != corners[1];
+
+    StringBuilder result;
+    result.append(corners[0]);
+    if (showTR)
+        result.append(" / "_s, corners[1]);
+    if (showBR)
+        result.append(" / "_s, corners[2]);
+    if (showBL)
+        result.append(" / "_s, corners[3]);
+    return result.toString();
 }
 
 class LayerValues {

--- a/Source/WebCore/css/parser/CSSPropertyParserCustom.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserCustom.h
@@ -152,6 +152,9 @@ public:
     static bool consumeBorderSpacingShorthand(CSSParserTokenRange&, PropertyParserState&, const StylePropertyShorthand&, PropertyParserResult&);
     static bool consumeBorderRadiusShorthand(CSSParserTokenRange&, PropertyParserState&, const StylePropertyShorthand&, PropertyParserResult&);
     static bool consumeWebkitBorderRadiusShorthand(CSSParserTokenRange&, PropertyParserState&, const StylePropertyShorthand&, PropertyParserResult&);
+    static bool consumeCornerSingleShorthand(CSSParserTokenRange&, PropertyParserState&, const StylePropertyShorthand&, PropertyParserResult&);
+    static bool consumeCornerPairShorthand(CSSParserTokenRange&, PropertyParserState&, const StylePropertyShorthand&, PropertyParserResult&);
+    static bool consumeCornerQuadShorthand(CSSParserTokenRange&, PropertyParserState&, const StylePropertyShorthand&, PropertyParserResult&);
     static bool consumeBorderImageShorthand(CSSParserTokenRange&, PropertyParserState&, const StylePropertyShorthand&, PropertyParserResult&);
     static bool consumeWebkitBorderImageShorthand(CSSParserTokenRange&, PropertyParserState&, const StylePropertyShorthand&, PropertyParserResult&);
     static bool consumeMaskBorderShorthand(CSSParserTokenRange&, PropertyParserState&, const StylePropertyShorthand&, PropertyParserResult&);
@@ -731,6 +734,134 @@ inline bool PropertyParserCustom::consumeWebkitBorderRadiusShorthand(CSSParserTo
     result.addPropertyForCurrentShorthand(state, CSSPropertyBorderTopRightRadius, WebCore::CSS::createCSSValue(state.pool, borderRadius->topRight()));
     result.addPropertyForCurrentShorthand(state, CSSPropertyBorderBottomRightRadius, WebCore::CSS::createCSSValue(state.pool, borderRadius->bottomRight()));
     result.addPropertyForCurrentShorthand(state, CSSPropertyBorderBottomLeftRadius, WebCore::CSS::createCSSValue(state.pool, borderRadius->bottomLeft()));
+    return true;
+}
+
+// MARK: - Corner / Corner-* shorthands (combined border-radius + corner-shape)
+//
+// Grammar (per corner): normal | <corner-shape>? <border-radius-corner> <corner-shape>?
+// Multiple corners are separated by '/' and follow the standard 1-to-N expansion.
+
+namespace CornerShorthandHelpers {
+
+inline Ref<CSSValue> zeroRadius()
+{
+    auto zero = CSSPrimitiveValue::create(0, CSSUnitType::CSS_PX);
+    return CSSValuePair::create(zero.copyRef(), WTF::move(zero));
+}
+
+inline Ref<CSSValue> roundShape()
+{
+    return CSSKeywordValue::create(CSSValueRound);
+}
+
+inline bool consumeOneCorner(CSSParserTokenRange& range, PropertyParserState& state, CSSPropertyID radiusProperty, CSSPropertyID shapeProperty, RefPtr<CSSValue>& radiusOut, RefPtr<CSSValue>& shapeOut)
+{
+    if (range.peek().id() == CSSValueNormal) {
+        range.consumeIncludingWhitespace();
+        radiusOut = zeroRadius();
+        shapeOut = roundShape();
+        return true;
+    }
+    shapeOut = CSSPropertyParsing::parseStylePropertyLonghand(range, shapeProperty, state);
+    radiusOut = CSSPropertyParsing::parseStylePropertyLonghand(range, radiusProperty, state);
+    if (!radiusOut)
+        return false;
+    if (!shapeOut)
+        shapeOut = CSSPropertyParsing::parseStylePropertyLonghand(range, shapeProperty, state);
+    return shapeOut != nullptr;
+}
+
+} // namespace CornerShorthandHelpers
+
+inline bool PropertyParserCustom::consumeCornerSingleShorthand(CSSParserTokenRange& range, PropertyParserState& state, const StylePropertyShorthand& shorthand, PropertyParserResult& result)
+{
+    ASSERT(shorthand.length() == 2);
+    auto longhands = shorthand.properties();
+    RefPtr<CSSValue> radius;
+    RefPtr<CSSValue> shape;
+    if (!CornerShorthandHelpers::consumeOneCorner(range, state, longhands[0], longhands[1], radius, shape))
+        return false;
+    if (!range.atEnd())
+        return false;
+
+    result.addPropertyForCurrentShorthand(state, longhands[0], radius.releaseNonNull());
+    result.addPropertyForCurrentShorthand(state, longhands[1], shape.releaseNonNull());
+    return true;
+}
+
+inline bool PropertyParserCustom::consumeCornerPairShorthand(CSSParserTokenRange& range, PropertyParserState& state, const StylePropertyShorthand& shorthand, PropertyParserResult& result)
+{
+    // Two-corner side shorthand: longhands are [radius0, shape0, radius1, shape1].
+    ASSERT(shorthand.length() == 4);
+    auto longhands = shorthand.properties();
+    std::array<RefPtr<CSSValue>, 2> radii;
+    std::array<RefPtr<CSSValue>, 2> shapes;
+
+    for (size_t i = 0; i < 2; ++i) {
+        if (!CornerShorthandHelpers::consumeOneCorner(range, state, longhands[i * 2], longhands[i * 2 + 1], radii[i], shapes[i]))
+            return false;
+        if (i == 1)
+            break;
+        if (!consumeSlashIncludingWhitespace(range))
+            break;
+    }
+    if (!range.atEnd())
+        return false;
+
+    if (!radii[1])
+        radii[1] = radii[0];
+    if (!shapes[1])
+        shapes[1] = shapes[0];
+
+    for (size_t i = 0; i < 2; ++i) {
+        result.addPropertyForCurrentShorthand(state, longhands[i * 2], radii[i].releaseNonNull());
+        result.addPropertyForCurrentShorthand(state, longhands[i * 2 + 1], shapes[i].releaseNonNull());
+    }
+    return true;
+}
+
+inline bool PropertyParserCustom::consumeCornerQuadShorthand(CSSParserTokenRange& range, PropertyParserState& state, const StylePropertyShorthand& shorthand, PropertyParserResult& result)
+{
+    // Master `corner`: longhands are [radius0, shape0, radius1, shape1, radius2, shape2, radius3, shape3]
+    // in order top-left, top-right, bottom-right, bottom-left.
+    ASSERT(shorthand.length() == 8);
+    auto longhands = shorthand.properties();
+    std::array<RefPtr<CSSValue>, 4> radii;
+    std::array<RefPtr<CSSValue>, 4> shapes;
+
+    size_t count = 0;
+    for (size_t i = 0; i < 4; ++i, ++count) {
+        if (!CornerShorthandHelpers::consumeOneCorner(range, state, longhands[i * 2], longhands[i * 2 + 1], radii[i], shapes[i]))
+            return false;
+        if (i == 3)
+            break;
+        if (!consumeSlashIncludingWhitespace(range))
+            break;
+    }
+    if (!range.atEnd())
+        return false;
+
+    // 1-to-4 expansion (mirrors complete4Sides on a CSS quad).
+    if (count == 0)
+        return false;
+    if (count < 2) {
+        radii[1] = radii[0];
+        shapes[1] = shapes[0];
+    }
+    if (count < 3) {
+        radii[2] = radii[0];
+        shapes[2] = shapes[0];
+    }
+    if (count < 4) {
+        radii[3] = radii[1];
+        shapes[3] = shapes[1];
+    }
+
+    for (size_t i = 0; i < 4; ++i) {
+        result.addPropertyForCurrentShorthand(state, longhands[i * 2], radii[i].releaseNonNull());
+        result.addPropertyForCurrentShorthand(state, longhands[i * 2 + 1], shapes[i].releaseNonNull());
+    }
     return true;
 }
 

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -1686,6 +1686,107 @@ inline void extractCoalescingQuadShorthandSerialization(ExtractorState& state, S
     builder.shrink(offsetAfterTop);
 }
 
+// MARK: - Corner / corner-* shorthand extractors
+//
+// Each "corner" output is `<border-radius-corner> <corner-shape>` (or `normal`
+// when the radius is 0px and the shape is round), per drafts.csswg.org/css-borders-4.
+// Pair and quad shorthands emit slash-separated corners with 4->1 / 2->1 collapsing.
+
+inline bool isCornerNormalValue(const CSSValue* radius, const CSSValue* shape)
+{
+    auto* pair = dynamicDowncast<CSSValuePair>(radius);
+    if (!pair)
+        return false;
+    auto isZero = [](const CSSValue& v) {
+        auto* primitive = dynamicDowncast<CSSPrimitiveValue>(v);
+        return primitive && primitive->isLength() && !primitive->resolveAsLengthDeprecated();
+    };
+    if (!isZero(pair->first()) || !isZero(pair->second()))
+        return false;
+    auto* shapeIdent = dynamicDowncast<CSSKeywordValue>(shape);
+    return shapeIdent && shapeIdent->valueID() == CSSValueRound;
+}
+
+inline RefPtr<CSSValue> buildCornerValue(RefPtr<CSSValue> radius, RefPtr<CSSValue> shape)
+{
+    if (!radius || !shape)
+        return nullptr;
+    if (isCornerNormalValue(radius.get(), shape.get()))
+        return CSSKeywordValue::create(CSSValueNormal);
+    return CSSValuePair::create(radius.releaseNonNull(), shape.releaseNonNull());
+}
+
+inline RefPtr<CSSValue> extractCornerSingleShorthand(ExtractorState& state, const StylePropertyShorthand& shorthand)
+{
+    auto longhands = shorthand.properties();
+    auto radius = ExtractorGenerated::extractValue(state, longhands[0]);
+    auto shape = ExtractorGenerated::extractValue(state, longhands[1]);
+    return buildCornerValue(WTF::move(radius), WTF::move(shape));
+}
+
+inline void extractCornerSingleShorthandSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const StylePropertyShorthand& shorthand)
+{
+    if (auto value = extractCornerSingleShorthand(state, shorthand))
+        builder.append(value->cssText(context));
+}
+
+inline RefPtr<CSSValue> extractCornerPairShorthand(ExtractorState& state, const StylePropertyShorthand& shorthand)
+{
+    auto longhands = shorthand.properties();
+    ASSERT(longhands.size() == 4);
+    auto first = buildCornerValue(ExtractorGenerated::extractValue(state, longhands[0]), ExtractorGenerated::extractValue(state, longhands[1]));
+    auto second = buildCornerValue(ExtractorGenerated::extractValue(state, longhands[2]), ExtractorGenerated::extractValue(state, longhands[3]));
+    if (!first || !second)
+        return nullptr;
+
+    CSSValueListBuilder list;
+    bool collapse = compareCSSValuePtr(first, second);
+    list.append(first.releaseNonNull());
+    if (!collapse)
+        list.append(second.releaseNonNull());
+    return CSSValueList::createSlashSeparated(WTF::move(list));
+}
+
+inline void extractCornerPairShorthandSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const StylePropertyShorthand& shorthand)
+{
+    if (auto value = extractCornerPairShorthand(state, shorthand))
+        builder.append(value->cssText(context));
+}
+
+inline RefPtr<CSSValue> extractCornerQuadShorthand(ExtractorState& state, const StylePropertyShorthand& shorthand)
+{
+    auto longhands = shorthand.properties();
+    ASSERT(longhands.size() == 8);
+    std::array<RefPtr<CSSValue>, 4> corners;
+    for (size_t i = 0; i < 4; ++i) {
+        corners[i] = buildCornerValue(ExtractorGenerated::extractValue(state, longhands[i * 2]), ExtractorGenerated::extractValue(state, longhands[i * 2 + 1]));
+        if (!corners[i])
+            return nullptr;
+    }
+
+    // Mirror Chromium logic: collapse 4 -> 3 -> 2 -> 1.
+    // corners are [TL, TR, BR, BL].
+    bool showBL = !compareCSSValuePtr(corners[1], corners[3]);
+    bool showBR = showBL || !compareCSSValuePtr(corners[0], corners[2]);
+    bool showTR = showBR || !compareCSSValuePtr(corners[0], corners[1]);
+
+    CSSValueListBuilder list;
+    list.append(corners[0].releaseNonNull());
+    if (showTR)
+        list.append(corners[1].releaseNonNull());
+    if (showBR)
+        list.append(corners[2].releaseNonNull());
+    if (showBL)
+        list.append(corners[3].releaseNonNull());
+    return CSSValueList::createSlashSeparated(WTF::move(list));
+}
+
+inline void extractCornerQuadShorthandSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const StylePropertyShorthand& shorthand)
+{
+    if (auto value = extractCornerQuadShorthand(state, shorthand))
+        builder.append(value->cssText(context));
+}
+
 inline RefPtr<CSSValue> extractBorderShorthand(ExtractorState& state, std::span<const CSSPropertyID> sections)
 {
     auto value = ExtractorGenerated::extractValue(state, sections[0]);

--- a/Source/WebCore/style/values/borders/StyleCornerShapeValue.cpp
+++ b/Source/WebCore/style/values/borders/StyleCornerShapeValue.cpp
@@ -72,14 +72,14 @@ auto CSSValueConversion<CornerShapeValue>::operator()(BuilderState& state, const
     if (RefPtr keywordValue = dynamicDowncast<CSSKeywordValue>(superellipseDescriptor)) {
         switch (keywordValue->valueID()) {
         case CSSValueInfinity:
-            return { SuperellipseFunction { Number<CSS::Nonnegative>(std::numeric_limits<double>::infinity()) } };
+            return { SuperellipseFunction { Number<CSS::All>(std::numeric_limits<double>::infinity()) } };
         default:
             state.setCurrentPropertyInvalidAtComputedValueTime();
-            return { SuperellipseFunction { Number<CSS::Nonnegative>(std::numeric_limits<double>::infinity()) } };
+            return { SuperellipseFunction { Number<CSS::All>(std::numeric_limits<double>::infinity()) } };
         }
     }
 
-    return { SuperellipseFunction { toStyleFromCSSValue<Number<CSS::Nonnegative>>(state, superellipseDescriptor) } };
+    return { SuperellipseFunction { toStyleFromCSSValue<Number<CSS::All>>(state, superellipseDescriptor) } };
 }
 
 // MARK: - Blending

--- a/Source/WebCore/style/values/borders/StyleCornerShapeValue.h
+++ b/Source/WebCore/style/values/borders/StyleCornerShapeValue.h
@@ -34,7 +34,7 @@ class RenderStyle;
 namespace Style {
 
 // NOTE: the keyword value "infinity" is represented as the standard double value `std::numeric_limits<double>::infinity()`.
-using SuperellipseFunction = FunctionNotation<CSSValueSuperellipse, Number<CSS::Nonnegative>>;
+using SuperellipseFunction = FunctionNotation<CSSValueSuperellipse, Number<CSS::All>>;
 
 // https://drafts.csswg.org/css-borders-4/#typedef-corner-shape-value
 struct CornerShapeValue {


### PR DESCRIPTION
WIP — pushing to see what EWS thinks; ports https://chromium-review.googlesource.com/c/chromium/src/+/7747994 (CSS corner and corner-* shorthands) to WebKit.<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1b8c959e84ce5766f17e6b7003a5a53a408876e2

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163767 "1 style error") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37251 "Hash 1b8c959e for PR 65403 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30470 "Hash 1b8c959e for PR 65403 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172789 "Hash 1b8c959e for PR 65403 does not build (failure)") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165636 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37582 "Hash 1b8c959e for PR 65403 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37250 "Hash 1b8c959e for PR 65403 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/172789 "Hash 1b8c959e for PR 65403 does not build (failure)") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121018 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166726 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/37582 "Hash 1b8c959e for PR 65403 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/30470 "Hash 1b8c959e for PR 65403 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/172789 "Hash 1b8c959e for PR 65403 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/37582 "Hash 1b8c959e for PR 65403 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/37250 "Hash 1b8c959e for PR 65403 does not build (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20560 "Hash 1b8c959e for PR 65403 does not build (failure)") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/155918 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/37582 "Hash 1b8c959e for PR 65403 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/30470 "Hash 1b8c959e for PR 65403 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175314 "Hash 1b8c959e for PR 65403 does not build (failure)") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/24658 "Built successfully and passed tests") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28143 "Failed to build and analyze WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/30470 "Hash 1b8c959e for PR 65403 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/175314 "Hash 1b8c959e for PR 65403 does not build (failure)") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36921 "Hash 1b8c959e for PR 65403 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/37250 "Hash 1b8c959e for PR 65403 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/175314 "Hash 1b8c959e for PR 65403 does not build (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37706 "Hash 1b8c959e for PR 65403 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/30470 "Hash 1b8c959e for PR 65403 does not build (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/99827 "The change is no longer eligible for processing.") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/37706 "Hash 1b8c959e for PR 65403 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/30470 "Hash 1b8c959e for PR 65403 does not build (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/196169 "Built successfully") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36417 "Hash 1b8c959e for PR 65403 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109562 "Failed to build and analyze WebKit") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51143 "Passed tests") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35914 "Hash 1b8c959e for PR 65403 does not build (failure)") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/30470 "Hash 1b8c959e for PR 65403 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36164 "Hash 1b8c959e for PR 65403 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36061 "Hash 1b8c959e for PR 65403 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->