### PR TITLE
[WPE][GTK] Expose target-frame main-frame status on WebKitNavigationAction

### DIFF
--- a/Source/WebKit/UIProcess/API/glib/WebKitNavigationAction.cpp
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNavigationAction.cpp
@@ -209,3 +209,27 @@ const char* webkit_navigation_action_get_frame_name(WebKitNavigationAction* navi
     }
     return navigation->frameName->data();
 }
+
+/**
+ * webkit_navigation_action_is_for_main_frame:
+ * @navigation: a #WebKitNavigationAction
+ *
+ * Returns whether the @navigation targets the main frame.
+ *
+ * Returns %TRUE for navigations that create a new top-level browsing
+ * context (such as a link with target="_blank"), since the new context
+ * is a main frame, and for navigations targeting the existing main
+ * frame. Returns %FALSE for navigations targeting a sub-frame, such
+ * as an iframe loading its document.
+ *
+ * Returns: %TRUE if the navigation targets the main frame, %FALSE if
+ *   it targets a sub-frame.
+ *
+ * Since: 2.54
+ */
+gboolean webkit_navigation_action_is_for_main_frame(WebKitNavigationAction* navigation)
+{
+    g_return_val_if_fail(navigation, FALSE);
+    auto* targetFrame = navigation->action->targetFrame();
+    return !targetFrame || targetFrame->isMainFrame();
+}

--- a/Source/WebKit/UIProcess/API/glib/WebKitNavigationAction.h.in
+++ b/Source/WebKit/UIProcess/API/glib/WebKitNavigationAction.h.in
@@ -83,6 +83,9 @@ webkit_navigation_action_is_redirect         (WebKitNavigationAction *navigation
 WEBKIT_API const char *
 webkit_navigation_action_get_frame_name      (WebKitNavigationAction *navigation);
 
+WEBKIT_API gboolean
+webkit_navigation_action_is_for_main_frame   (WebKitNavigationAction *navigation);
+
 G_END_DECLS
 
 #endif

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestWebKitPolicyClient.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKPage/glib/TestWebKitPolicyClient.cpp
@@ -172,6 +172,7 @@ static void testNavigationPolicy(PolicyClientTest* test, gconstpointer)
     g_assert_cmpint(webkit_navigation_action_get_modifiers(navigationAction), ==, 0);
     g_assert_false(webkit_navigation_action_is_redirect(navigationAction));
     g_assert_null(webkit_navigation_action_get_frame_name(navigationAction));
+    g_assert_true(webkit_navigation_action_is_for_main_frame(navigationAction));
     WebKitURIRequest* request = webkit_navigation_action_get_request(navigationAction);
     g_assert_cmpstr(webkit_uri_request_get_uri(request), ==, "http://webkitgtk.org/");
 
@@ -290,6 +291,8 @@ static void testNewWindowPolicy(PolicyClientTest* test, gconstpointer)
     WebKitNavigationPolicyDecision* decision = WEBKIT_NAVIGATION_POLICY_DECISION(test->m_previousPolicyDecision.get());
     WebKitNavigationAction* navigationAction = webkit_navigation_policy_decision_get_navigation_action(decision);
     g_assert_cmpstr(webkit_navigation_action_get_frame_name(navigationAction), ==, "_blank");
+    // A new top-level browsing context is itself a main frame, so this is TRUE.
+    g_assert_true(webkit_navigation_action_is_for_main_frame(navigationAction));
 
     // Using a short timeout is a bit ugly here, but it's hard to get around because if we block
     // the new window signal we cannot halt the main loop in the create callback. If we
@@ -317,8 +320,84 @@ static void serverCallback(SoupServer* server, SoupServerMessage* message, const
     } else if (g_str_equal(path, "/redirect")) {
         soup_server_message_set_status(message, SOUP_STATUS_MOVED_PERMANENTLY, nullptr);
         soup_message_headers_append(soup_server_message_get_response_headers(message), "Location", "/");
+    } else if (g_str_equal(path, "/iframe-parent")) {
+        static const char* iframeParentHTML = "<html><body>Parent<iframe src='/iframe-child'></iframe></body></html>";
+        soup_server_message_set_status(message, SOUP_STATUS_OK, nullptr);
+        auto* responseBody = soup_server_message_get_response_body(message);
+        soup_message_body_append(responseBody, SOUP_MEMORY_STATIC, iframeParentHTML, strlen(iframeParentHTML));
+        soup_message_body_complete(responseBody);
+    } else if (g_str_equal(path, "/iframe-child")) {
+        static const char* iframeChildHTML = "<html><body>Child</body></html>";
+        soup_server_message_set_status(message, SOUP_STATUS_OK, nullptr);
+        auto* responseBody = soup_server_message_get_response_body(message);
+        soup_message_body_append(responseBody, SOUP_MEMORY_STATIC, iframeChildHTML, strlen(iframeChildHTML));
+        soup_message_body_complete(responseBody);
     } else
         soup_server_message_set_status(message, SOUP_STATUS_NOT_FOUND, nullptr);
+}
+
+class NavigationActionForMainFrameTest: public WebViewTest {
+public:
+    MAKE_GLIB_TEST_FIXTURE(NavigationActionForMainFrameTest);
+
+    static gboolean decidePolicyCallback(WebKitWebView*, WebKitPolicyDecision* decision, WebKitPolicyDecisionType type, NavigationActionForMainFrameTest* test)
+    {
+        if (type != WEBKIT_POLICY_DECISION_TYPE_NAVIGATION_ACTION)
+            return FALSE;
+
+        auto* navigationDecision = WEBKIT_NAVIGATION_POLICY_DECISION(decision);
+        auto* navigationAction = webkit_navigation_policy_decision_get_navigation_action(navigationDecision);
+        auto* request = webkit_navigation_action_get_request(navigationAction);
+        bool isForMainFrame = webkit_navigation_action_is_for_main_frame(navigationAction);
+        test->m_decisions.append({ CString(webkit_uri_request_get_uri(request)), isForMainFrame });
+        return FALSE;
+    }
+
+    NavigationActionForMainFrameTest()
+    {
+        g_signal_connect(m_webView.get(), "decide-policy", G_CALLBACK(decidePolicyCallback), this);
+    }
+
+    bool findDecisionForURI(const CString& uri) const
+    {
+        for (const auto& decision : m_decisions) {
+            if (decision.first == uri)
+                return decision.second;
+        }
+        g_assert_not_reached();
+        return false;
+    }
+
+    bool hasDecisionForURI(const CString& uri) const
+    {
+        for (const auto& decision : m_decisions) {
+            if (decision.first == uri)
+                return true;
+        }
+        return false;
+    }
+
+    Vector<std::pair<CString, bool>> m_decisions;
+};
+
+static void testNavigationActionForMainFrame(NavigationActionForMainFrameTest* test, gconstpointer)
+{
+    auto parentURI = kServer->getURIForPath("/iframe-parent");
+    auto childURI = kServer->getURIForPath("/iframe-child");
+
+    test->loadURI(parentURI.data());
+    test->waitUntilLoadFinished();
+
+    // The iframe's navigation policy decision is dispatched while the parent
+    // document is being parsed, so it should already be recorded by the time
+    // the main frame's load-finished signal fires. If not, give it a moment.
+    if (!test->hasDecisionForURI(childURI))
+        test->wait(1);
+
+    g_assert_true(test->hasDecisionForURI(parentURI));
+    g_assert_true(test->findDecisionForURI(parentURI));
+    g_assert_true(test->hasDecisionForURI(childURI));
+    g_assert_false(test->findDecisionForURI(childURI));
 }
 
 static void testAutoplayPolicy(PolicyClientTest* test, gconstpointer)
@@ -364,6 +443,7 @@ void beforeAll()
     PolicyClientTest::add("WebKitPolicyClient", "navigation-policy", testNavigationPolicy);
     PolicyClientTest::add("WebKitPolicyClient", "response-policy", testResponsePolicy);
     PolicyClientTest::add("WebKitPolicyClient", "autoplay-policy", testAutoplayPolicy);
+    NavigationActionForMainFrameTest::add("WebKitPolicyClient", "navigation-action-for-main-frame", testNavigationActionForMainFrame);
     // WARNING: This test must come last, it uses racey constructs that
     // interfere nondeterminisically with any test running after it.
     // https://bugs.webkit.org/show_bug.cgi?id=213190


### PR DESCRIPTION
## Summary
Adds `webkit_navigation_action_is_for_main_frame()` to the WebKitGTK/WPE GLib binding, mirroring `WKNavigationAction.targetFrame.isMainFrame` on the Cocoa port. Returns TRUE when the navigation targets the existing main frame or creates a new top-level browsing context (target="_blank", `window.open(url, name)` with no existing frame), FALSE for sub-frame navigations (iframes loading their src).

## Motivation

Embedders connecting to `WebKitWebView::decide-policy` currently cannot tell a same-tab `<a href="…">` navigation apart from an iframe's initial src load. `webkit_navigation_action_get_frame_name()` only returns the *named* target frame from `<a target="…">` / `window.open(url, name)`, which is NULL for ordinary iframe loads. Apps that route some navigations to nested webviews (e.g. cross-origin auth flows) end up treating auto-loaded auth iframes as if they were main-frame navigations. Cocoa clients have never had this problem because their binding surfaces `targetFrame.isMainFrame`.

## Implementation

Pure binding plumbing. `API::NavigationAction::targetFrame()` already exists and exposes `API::FrameInfo::isMainFrame()`; this just surfaces that one bit through the GLib API. No new GObject type, no behavior change to existing API.

## Test plan

- [x] EWS GTK / WPE builds green
- [x] New `NavigationActionForMainFrameTest` (loads  `/iframe-parent` containing an `<iframe src='/iframe-child'>`, asserts  the parent URI records TRUE and the iframe URI records FALSE) passes
- [x] Existing `testNavigationPolicy` / `testNewWindowPolicy` assertions still pass (extended to assert the new accessor is TRUE for main document loads and target="_blank" navigations)<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dfee9415743182cde38d5a4d83eb2af17c267cdd

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163768 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37252 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30471 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172790 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165637 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37583 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37251 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127205 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121019 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166727 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29489 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147224 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107754 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28536 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/27166 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20561 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138435 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24941 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175315 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28144 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26609 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135511 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36922 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31272 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135487 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37707 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146736 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/99828 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30804 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23590 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36418 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109563 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35915 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1620 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36165 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36062 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->