### PR TITLE
Non-unified build fixes for May 21st, 2026

### DIFF
--- a/Source/WebCore/Modules/fetch/FetchResponse.cpp
+++ b/Source/WebCore/Modules/fetch/FetchResponse.cpp
@@ -31,7 +31,7 @@
 #include "FetchResponse.h"
 
 #include "ContextDestructionObserverInlines.h"
-#include "Document.h"
+#include "DocumentQuirks.h"
 #include "FetchRequest.h"
 #include "FetchResponseBodyLoader.h"
 #include "HTTPParsers.h"

--- a/Source/WebCore/css/parser/CSSPropertyParserConsumer+Masking.cpp
+++ b/Source/WebCore/css/parser/CSSPropertyParserConsumer+Masking.cpp
@@ -39,6 +39,7 @@
 #include "CSSPropertyParserConsumer+Background.h"
 #include "CSSPropertyParserConsumer+CSSPrimitiveValueResolver.h"
 #include "CSSPropertyParserConsumer+Ident.h"
+#include "CSSPropertyParserConsumer+Image.h"
 #include "CSSPropertyParserConsumer+LengthDefinitions.h"
 #include "CSSPropertyParserConsumer+LengthPercentageDefinitions.h"
 #include "CSSPropertyParserConsumer+MetaConsumer.h"

--- a/Source/WebCore/css/values/non-standard/CSSWebkitBoxReflect.cpp
+++ b/Source/WebCore/css/values/non-standard/CSSWebkitBoxReflect.cpp
@@ -27,6 +27,7 @@
 #include "CSSWebkitBoxReflect.h"
 
 #include "CSSKeywordValue.h"
+#include "CSSPrimitiveNumericTypes+Serialization.h"
 #include "CSSWebkitBoxReflectValue.h"
 
 namespace WebCore {

--- a/Source/WebCore/inspector/InspectorIdentifierRegistry.cpp
+++ b/Source/WebCore/inspector/InspectorIdentifierRegistry.cpp
@@ -29,7 +29,7 @@
 #include "Document.h"
 #include "DocumentLoader.h"
 #include "FrameDestructionObserverInlines.h"
-#include "LocalFrame.h"
+#include "LocalFrameInlines.h"
 #include <JavaScriptCore/IdentifiersFactory.h>
 #include <wtf/TZoneMallocInlines.h>
 

--- a/Source/WebCore/platform/graphics/skia/SkiaBackingStore.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaBackingStore.h
@@ -34,6 +34,7 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #include <wtf/HashMap.h>
 
 namespace WebCore {
+class BitmapTexture;
 class CoordinatedTileBuffer;
 
 class SkiaBackingStore {

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -27,6 +27,7 @@
 #include "SkiaCompositingLayer.h"
 
 #if USE(COORDINATED_GRAPHICS) && USE(SKIA)
+#include "BitmapTexture.h"
 #include "CoordinatedAnimatedBackingStoreClient.h"
 #include "CoordinatedImageBackingStore.h"
 #include "CoordinatedPlatformLayerBuffer.h"

--- a/Source/WebCore/style/values/backgrounds/StyleBorderImageSlice.h
+++ b/Source/WebCore/style/values/backgrounds/StyleBorderImageSlice.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/StylePrimitiveNumeric.h>
+#include <WebCore/StylePrimitiveNumericTypes.h>
 
 namespace WebCore {
 

--- a/Source/WebCore/style/values/masking/StyleMaskBorderSlice.h
+++ b/Source/WebCore/style/values/masking/StyleMaskBorderSlice.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/StylePrimitiveNumeric.h>
+#include <WebCore/StylePrimitiveNumericTypes.h>
 
 namespace WebCore {
 


### PR DESCRIPTION
#### d41cdf3ca80249467bfa70b6f9cbb3f617e44304
<pre>
Non-unified build fixes for May 21st, 2026
<a href="https://bugs.webkit.org/show_bug.cgi?id=315290">https://bugs.webkit.org/show_bug.cgi?id=315290</a>

Unreviewed build fix.

* Source/WebCore/Modules/fetch/FetchResponse.cpp:
* Source/WebCore/css/parser/CSSPropertyParserConsumer+Masking.cpp:
* Source/WebCore/css/values/non-standard/CSSWebkitBoxReflect.cpp:
* Source/WebCore/inspector/InspectorIdentifierRegistry.cpp:
* Source/WebCore/platform/graphics/skia/SkiaBackingStore.h:
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
* Source/WebCore/style/values/backgrounds/StyleBorderImageSlice.h:
* Source/WebCore/style/values/masking/StyleMaskBorderSlice.h:

Canonical link: <a href="https://commits.webkit.org/313679@main">https://commits.webkit.org/313679@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7a0bc30cbfb65d132b3b26d8ba98fde9cf13073f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163805 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37289 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30508 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172833 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165674 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37621 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37288 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127243 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121056 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166764 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29522 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147259 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107792 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28569 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27197 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20598 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/138468 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24976 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175354 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28181 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26644 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135547 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36959 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31303 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135523 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37744 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146771 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99881 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24931 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30835 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23625 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36455 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109600 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35952 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1659 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36202 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36099 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->