### PR TITLE
AX: When focused on an empty password input, context menu from VO-Shift-M is opened in the middle of the page rather than next to the input

### DIFF
--- a/LayoutTests/accessibility/mac/bounds-for-range-on-empty-text-control-expected.txt
+++ b/LayoutTests/accessibility/mac/bounds-for-range-on-empty-text-control-expected.txt
@@ -1,0 +1,11 @@
+This test ensures that boundsForRange returns a valid caret rect for the (0, 0) range on empty text controls, so that ATs (e.g. VoiceOver's VO-Shift-M context menu) can position UI next to the caret rather than at a fallback location like the middle of the page.
+
+PASS: caretSizeIsNonEmpty(emptyPassword.boundsForRange(0, 0)) === true
+PASS: caretSizeIsNonEmpty(filledPassword.boundsForRange(0, 0)) === true
+PASS: caretSizeIsNonEmpty(emptyText.boundsForRange(0, 0)) === true
+PASS: caretSizeIsNonEmpty(emptyTextarea.boundsForRange(0, 0)) === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/accessibility/mac/bounds-for-range-on-empty-text-control.html
+++ b/LayoutTests/accessibility/mac/bounds-for-range-on-empty-text-control.html
@@ -1,0 +1,43 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<script src="../../resources/accessibility-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<input type="password" id="empty-password">
+<input type="password" id="filled-password" value="abc">
+<input type="text" id="empty-text">
+<textarea id="empty-textarea"></textarea>
+
+<script>
+var output = "This test ensures that boundsForRange returns a valid caret rect for the (0, 0) range on empty text controls, so that ATs (e.g. VoiceOver's VO-Shift-M context menu) can position UI next to the caret rather than at a fallback location like the middle of the page.\n\n";
+
+// Format from makeBoundsDescription: "{{x, y}, {w, h}}". Position is masked to -1, -1 because it's
+// platform dependent, so we can only assert on size here.
+function caretSizeIsNonEmpty(boundsString) {
+    var match = boundsString.match(/\{\{[^}]+\}, \{(-?\d+\.\d+), (-?\d+\.\d+)\}\}/);
+    if (!match)
+        return false;
+    return parseFloat(match[1]) > 0 && parseFloat(match[2]) > 0;
+}
+
+if (window.accessibilityController) {
+    var emptyPassword = accessibilityController.accessibleElementById("empty-password");
+    output += expect("caretSizeIsNonEmpty(emptyPassword.boundsForRange(0, 0))", "true");
+
+    var filledPassword = accessibilityController.accessibleElementById("filled-password");
+    output += expect("caretSizeIsNonEmpty(filledPassword.boundsForRange(0, 0))", "true");
+
+    var emptyText = accessibilityController.accessibleElementById("empty-text");
+    output += expect("caretSizeIsNonEmpty(emptyText.boundsForRange(0, 0))", "true");
+
+    var emptyTextarea = accessibilityController.accessibleElementById("empty-textarea");
+    output += expect("caretSizeIsNonEmpty(emptyTextarea.boundsForRange(0, 0))", "true");
+
+    debug(output);
+}
+</script>
+</body>
+</html>

--- a/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
+++ b/Source/WebCore/accessibility/AccessibilityRenderObject.cpp
@@ -2179,10 +2179,19 @@ IntRect AccessibilityRenderObject::doAXBoundsForRangeUsingCharacterOffset(const 
 {
     if (!allowsTextRanges())
         return { };
-    auto range = rangeForCharacterRange(characterRange);
-    if (!range)
-        return { };
-    return boundsForRange(*range);
+
+    if (std::optional range = rangeForCharacterRange(characterRange))
+        return boundsForRange(*range);
+
+    if (!characterRange.location && !characterRange.length && !getLengthForTextRange()) {
+        // rangeForCharacterRange returns nullopt for the (0, 0) range on an empty text control to
+        // avoid creating an uneditable VisibleSelection in setSelectedRange. For bounds queries we
+        // still want a valid caret rect (e.g. so VoiceOver can position the VO-Shift-M context menu
+        // next to the input rather than in the middle of the page).
+        if (std::optional fallbackRange = makeSimpleRange(visiblePositionForIndex(0)))
+            return boundsForRange(*fallbackRange);
+    }
+    return { };
 }
 
 AccessibilityObject* AccessibilityRenderObject::accessibilityImageMapHitTest(HTMLAreaElement& area, const IntPoint& point) const


### PR DESCRIPTION
#### 63168d28d1bc309c8b3608db2d485bcd7cacf9c3
<pre>
AX: When focused on an empty password input, context menu from VO-Shift-M is opened in the middle of the page rather than next to the input
<a href="https://bugs.webkit.org/show_bug.cgi?id=315202">https://bugs.webkit.org/show_bug.cgi?id=315202</a>
<a href="https://rdar.apple.com/177531795">rdar://177531795</a>

Reviewed by Dominic Mazzoni.

NSAccessibilityBoundsForRangeParameterizedAttribute returned a zero-size rect
for the (0, 0) range on empty native text controls, so VoiceOver had no caret
location to anchor the VO-Shift-M context menu and fell back to the middle of
the page.

doAXBoundsForRangeUsingCharacterOffset routed through rangeForCharacterRange,
which has an early return for empty text controls. In this case, fall back to
a visiblePositionForIndex(0)-based rect, rooting the context menu at the
origin of the text control as is expected.

* LayoutTests/accessibility/mac/bounds-for-range-on-empty-text-control-expected.txt: Added.
* LayoutTests/accessibility/mac/bounds-for-range-on-empty-text-control.html: Added.
* Source/WebCore/accessibility/AccessibilityRenderObject.cpp:
(WebCore::AccessibilityRenderObject::doAXBoundsForRangeUsingCharacterOffset const):

Canonical link: <a href="https://commits.webkit.org/313691@main">https://commits.webkit.org/313691@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2ba05ad8e59393da49d970bee7d1a370ac5344fa

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163807 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37291 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30510 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172835 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165676 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37623 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37290 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127242 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121058 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166766 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29526 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147260 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107791 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28573 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27201 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20600 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138472 "Found 1 new API test failure: TestWebKitAPI.CopyHTML.CopySelectedTextInTextDocument (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/24977 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175356 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28183 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26645 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135548 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36961 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31307 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135524 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36538 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37746 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146772 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99883 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30836 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23626 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36457 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109602 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35954 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1660 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36204 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36101 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->