### PR TITLE
[Site Isolation] Fix imported/w3c/web-platform-tests/fetch/api/redirect/redirect-keepalive.https.any.html

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/resources/keepalive-helper.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/fetch/api/resources/keepalive-helper.js
@@ -136,8 +136,9 @@ function keepaliveRedirectTest(desc, {
     iframe.src = getKeepAliveAndRedirectIframeUrl(
         tokenToStash, origin1, origin2, withPreflight);
     document.body.appendChild(iframe);
+    const messagePromise = getTokenFromMessage();
     await iframeLoaded(iframe);
-    assert_equals(await getTokenFromMessage(), tokenToStash);
+    assert_equals(await messagePromise, tokenToStash);
     if (unloadIframe) {
       iframe.remove();
     }

--- a/LayoutTests/platform/ios-site-isolation/TestExpectations
+++ b/LayoutTests/platform/ios-site-isolation/TestExpectations
@@ -238,7 +238,6 @@ imported/w3c/web-platform-tests/css/css-view-transitions/root-element-cv-hidden-
 imported/w3c/web-platform-tests/css/css-viewport/zoom/zoom-iframe-dynamic.html [ Failure ]
 imported/w3c/web-platform-tests/editing/crashtests/collapse-selection-into-textarea-and-createLink.html [ Failure ]
 imported/w3c/web-platform-tests/fetch/api/basic/keepalive.any.html [ Failure ]
-imported/w3c/web-platform-tests/fetch/api/redirect/redirect-keepalive.https.any.html [ Failure ]
 imported/w3c/web-platform-tests/fetch/metadata/generated/element-frame.sub.html [ Failure ]
 imported/w3c/web-platform-tests/FileAPI/url/url-in-tags-revoke.window.html [ Failure ]
 imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-replace-with-cross-origin-redirect.sub.html [ Failure ]


### PR DESCRIPTION
#### 22958c53ebcae5a0ed21b38e492e5ad10db62223
<pre>
[Site Isolation] Fix imported/w3c/web-platform-tests/fetch/api/redirect/redirect-keepalive.https.any.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=315301">https://bugs.webkit.org/show_bug.cgi?id=315301</a>
<a href="https://rdar.apple.com/177637364">rdar://177637364</a>

Reviewed by NOBODY (OOPS!).

imported/w3c/web-platform-tests/fetch/api/redirect/redirect-keepalive.https.any.html is flakily timing out under Site
Isolation. The test flow is:
1. Load event is fired on cross-site frame&apos;s window: it posts message to parent
2. Notify frame&apos;s owner element to fire load event
3. Load event is fired on iframe element in main frame: it registers message event handler
4. Message event is fired on main frame&apos;s window
So, the test relies on step 3 to always happen before step 4 (otherwise, there is no handler for the message event).
However under Site Isolation, iframe process sends IPC messages for step 1 and step 2, and messages will arrive at the
main frame process in the same order — PostMessageToRemote arrives first. The first PostMessageToRemote message posts a
task to event loop and the second message DispatchLoadEventToFrameOwnerElement dispatches load event synchronously. So
there is a chance the event loop task is fired before load event is dispatch -- and the test can time out.

There is a open spec issue about this and not settled yet: <a href="https://github.com/whatwg/html/issues/4730.">https://github.com/whatwg/html/issues/4730.</a> To make the test
more robust, fix it by making test register message event handler sooner.

* LayoutTests/imported/w3c/web-platform-tests/fetch/api/resources/keepalive-helper.js:
* LayoutTests/platform/ios-site-isolation/TestExpectations:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/22958c53ebcae5a0ed21b38e492e5ad10db62223

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163835 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37319 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30538 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172863 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121086 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5f92bc31-01f9-4f2d-b70a-4839127f90f9) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37651 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37318 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127265 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89640 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9782d5c5-1fad-40f3-b276-27bb6abd1f60) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166794 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29543 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147283 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107814 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/461b706f-f456-4daf-889d-ac5f739e7303) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28590 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27224 "") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20628 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138489 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25000 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175385 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26668 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135571 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36989 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31331 "") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135547 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37774 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146795 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99911 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30862 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23649 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36485 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35982 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1683 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36232 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36129 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->