### PR TITLE
import-w3c-tests: Skip -webkit- prefix rewrite when prefixed form already present in same CSS block

### DIFF
--- a/Tools/Scripts/webkitpy/w3c/test_converter.py
+++ b/Tools/Scripts/webkitpy/w3c/test_converter.py
@@ -83,11 +83,11 @@ class _W3CTestConverter(HTMLParser):
         css_property_value_file = self.path_from_webkit_root('Source', 'WebCore', 'css', 'CSSValueKeywords.in')
 
         self.prefixed_properties = self.read_webkit_prefixed_css_property_list(css_property_file)
-        prop_regex = r'([\s{]|^)(' + "|".join(prop.replace('-webkit-', '') for prop in self.prefixed_properties) + r')(\s+:|:)'
+        prop_regex = r'(?P<leading_char>[\s{]|^)(?P<property_name>' + "|".join(prop.replace('-webkit-', '') for prop in self.prefixed_properties) + r')(?P<trailing_colon>\s+:|:)'
         self.prop_re = re.compile(prop_regex)
 
         self.prefixed_property_values = self.legacy_read_webkit_prefixed_css_property_list(css_property_value_file)
-        prop_value_regex = r'(:\s*|^\s*)(' + "|".join(value.replace('-webkit-', '') for value in self.prefixed_property_values) + r')(\s*;|\s*}|\s*$)'
+        prop_value_regex = r'(?P<leading_char>:\s*|^\s*)(?P<property_name>' + "|".join(value.replace('-webkit-', '') for value in self.prefixed_property_values) + r')(?P<trailing_colon>\s*;|\s*}|\s*$)'
         self.prop_value_re = re.compile(prop_value_regex)
 
     def output(self):
@@ -158,18 +158,32 @@ class _W3CTestConverter(HTMLParser):
 
     def add_webkit_prefix_following_regex(self, text, regex):
         converted_list = set()
-        text_chunks = []
-        cur_pos = 0
-        for m in regex.finditer(text):
-            text_chunks.extend([text[cur_pos:m.start()], m.group(1), '-webkit-', m.group(2), m.group(3)])
-            converted_list.add(m.group(2))
-            cur_pos = m.end()
-        text_chunks.append(text[cur_pos:])
+
+        def replace_if_not_already_prefixed(match):
+            leading_char = match.group('leading_char')
+            property_name = match.group('property_name')
+            trailing_colon = match.group('trailing_colon')
+
+            block_start = text.rfind('{', 0, match.start())
+            if block_start == -1:
+                block_start = 0
+            block_end = text.find('}', match.end())
+            if block_end == -1:
+                block_end = len(text)
+            enclosing_block = text[block_start:block_end]
+
+            if f'-webkit-{property_name}' in enclosing_block:
+                return f'{leading_char}{property_name}{trailing_colon}'
+
+            converted_list.add(property_name)
+            return f'{leading_char}-webkit-{property_name}{trailing_colon}'
+
+        converted_text = regex.sub(replace_if_not_already_prefixed, text)
 
         for item in converted_list:
             _log.info('  converting %s', item)
 
-        return (converted_list, ''.join(text_chunks))
+        return (converted_list, converted_text)
 
     def convert_reference_relpaths(self, text):
         """ Searches |text| for instances of files in reference_support_info and updates the relative path to be correct for the new ref file location"""

--- a/Tools/Scripts/webkitpy/w3c/test_converter_unittest.py
+++ b/Tools/Scripts/webkitpy/w3c/test_converter_unittest.py
@@ -271,6 +271,18 @@ CONTENT OF TEST
         self.verify_prefixed_properties(converted, test_content[0])
         self.verify_prefixed_property_values(converted, test_content[1])
 
+    def test_no_conversion_when_prefixed_already_present(self):
+        """ Tests that a property is not prefixed when the -webkit- version is already in the same CSS block """
+        css = """.foo {
+    -webkit-user-select: none;
+    user-select: none;
+}"""
+        converter = _W3CTestConverter(DUMMY_PATH, DUMMY_FILENAME, None)
+        with OutputCapture():
+            result = converter.add_webkit_prefix_to_unprefixed_properties_and_values(css)
+        self.assertEqual(len(result[0]), 0, 'No properties should be converted when webkit version is already present')
+        self.assertEqual(result[2].count('-webkit-user-select'), 1, 'Should not produce duplicate -webkit-user-select')
+
     def test_convert_attributes_if_needed(self):
         """ Tests convert_attributes_if_needed() using a reference file that has some relative src paths """
 

--- a/Tools/Scripts/webkitpy/w3c/test_importer_unittest.py
+++ b/Tools/Scripts/webkitpy/w3c/test_importer_unittest.py
@@ -170,6 +170,32 @@ class TestImporterTest(unittest.TestCase):
         self.assertTrue('src="/resources/testharness.js"' in fs.read_text_file('/mock-checkout/LayoutTests/w3c/web-platform-tests/t/test.html'))
         self.assertTrue('src="/resources/testharness.js"' in fs.read_text_file('/mock-checkout/LayoutTests/w3c/web-platform-tests/css/t/test.html'))
 
+    def test_no_duplicate_webkit_prefix_when_both_forms_present(self):
+        """ End-to-end check: importing a WPT test that already has both -webkit-user-select and user-select must not produce two -webkit-user-select declarations. """
+        upstream_test = '''<!DOCTYPE html>
+<html><head>
+<script src="/resources/testharness.js"></script>
+<style>
+.foo {
+    -webkit-user-select: none;
+    user-select: none;
+}
+</style>
+</head><body></body></html>'''
+
+        FAKE_FILES = {
+            f'{FAKE_WPT_DIR}/t/test.html': upstream_test,
+            '/mock-checkout/Source/WebCore/css/CSSProperties.json': '{"properties": {"-webkit-user-select": {"values": ["auto", "text", "none", "all"]}}}',
+            '/mock-checkout/Source/WebCore/css/CSSValueKeywords.in': '',
+        }
+        FAKE_FILES.update(FAKE_RESOURCES)
+
+        fs = self.import_downloaded_tests(['--no-fetch', '--import-all', '--no-clean-dest-dir', '-d', 'w3c'], FAKE_FILES)
+
+        imported = fs.read_text_file('/mock-checkout/LayoutTests/w3c/web-platform-tests/t/test.html')
+        self.assertEqual(imported.count('-webkit-user-select'), 1, 'Imported test should not have duplicate -webkit-user-select')
+        self.assertIn('user-select: none;', imported, 'Standard user-select declaration should be preserved')
+
     def test_skip_test_import_download(self):
         FAKE_FILES = {}
         FAKE_FILES.update(FAKE_RESOURCES)


### PR DESCRIPTION
#### 5628fb4ef2b84175e905cfd2a85836bc348f376d
<pre>
import-w3c-tests: Skip -webkit- prefix rewrite when prefixed form already present in same CSS block
<a href="https://bugs.webkit.org/show_bug.cgi?id=315234">https://bugs.webkit.org/show_bug.cgi?id=315234</a>
<a href="https://rdar.apple.com/177563727">rdar://177563727</a>

Reviewed by NOBODY (OOPS!).

The W3C test converter rewrites unprefixed CSS properties (e.g. user-select)
to their -webkit- prefixed counterparts when WebKit only supports the prefixed
form. When upstream WPT authors write both forms in the same rule, the rewrite
produces two identical -webkit- declarations.

Before rewriting a match, look at the enclosing CSS rule block (between `{`
and `}`) and skip the rewrite if -webkit-&lt;property&gt; already appears there.

* Tools/Scripts/webkitpy/w3c/test_converter.py:
(_W3CTestConverter.__init__):
(_W3CTestConverter.add_webkit_prefix_following_regex):
* Tools/Scripts/webkitpy/w3c/test_converter_unittest.py:
(W3CTestConverterTest.test_no_conversion_when_prefixed_already_present):
* Tools/Scripts/webkitpy/w3c/test_importer_unittest.py:
(TestImporterTest.test_no_duplicate_webkit_prefix_when_both_forms_present):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5628fb4ef2b84175e905cfd2a85836bc348f376d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163841 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37325 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30544 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172869 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121092 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0fd7c88f-8a85-4e12-8f51-3cb82eff47ed) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165710 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37657 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37324 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127268 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89642 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/7005900a-91f1-4230-a756-aae1d91c6b57) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166800 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29552 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147292 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107817 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4bfc55ea-d237-408b-9eb6-39555b9a2265) 
| [❌ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/163162 "Found 1 webkitpy test failure: webkitpy.scripts.measure_build_time_unittest.MeasureBuildTimeTest.test_clean_and_null_build") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28599 "Passed tests") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27229 "") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20634 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138499 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25009 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175391 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26677 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135574 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/36995 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31336 "") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135550 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37780 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146804 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99917 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30857 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23658 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36491 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/35988 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1692 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36238 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36135 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->