### PR TITLE
[Site Isolation] Enable Site Isolation by default (draft for EWS)

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -7798,7 +7798,7 @@ ShrinksStandaloneImagesToFit:
 
 SiteIsolationEnabled:
   type: bool
-  status: unstable
+  status: internal
   category: security
   humanReadableName: "Site Isolation"
   humanReadableDescription: "Put cross-origin iframes in a different process"
@@ -7806,7 +7806,7 @@ SiteIsolationEnabled:
     WebKitLegacy:
       default: false
     WebKit:
-      default: false
+      default: true
     WebCore:
       default: false
   sharedPreferenceForWebProcess: true


### PR DESCRIPTION
#### 7982c0936b33c27f9c2d72fcf21d7cc548de97e5
<pre>
[Site Isolation] Enable Site Isolation by default (draft for EWS)
<a href="https://bugs.webkit.org/show_bug.cgi?id=314699">https://bugs.webkit.org/show_bug.cgi?id=314699</a>

Reviewed by NOBODY (OOPS!).

Flip SiteIsolationEnabled to default=true on WebKit (UIProcess) so EWS
runs the full test suite under Site Isolation. Status changed from
unstable to internal — unstable&apos;s FEATURE_DEFAULT_VALIDATION asserts
that the default must be off; internal carries no implied default.

Combined with the auto-enable of MultiProcessBackForwardCacheEnabled
(bug 314699), this exercises the same-site + cross-site iframe BFCache
path via every existing SI-aware test that previously needed to opt in.

DRAFT — for EWS visibility only. Not for landing.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7982c0936b33c27f9c2d72fcf21d7cc548de97e5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166463 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39953 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33534 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175511 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123718 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cba69c08-ffb1-47be-98c9-63a28776e9da) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40379 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39961 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129410 "Failure limit exceed. At least found 392 new test failures: animations/no-cancelation-when-entering-page-cache.html animations/resume-after-page-cache.html compositing/accelerated-layers-after-back-2.html compositing/page-cache-back-crash.html compositing/show-composited-iframe-on-back-button.html fast/canvas/webgl/canvas-webgl-page-cache.html fast/dom/HTMLAnchorElement/anchor-in-noscroll-iframe-crash.html fast/dom/Window/timer-resume-on-navigation-back.html fast/dom/window-load-crash.html fast/encoding/frame-default-enc.html ... (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91142 "Exiting early after 60 failures. 90 tests run. 60 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ad3682b8-8407-46a6-9563-c94913c2a4b0) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169422 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31797 "Found 60 new test failures: animations/no-cancelation-when-entering-page-cache.html animations/resume-after-page-cache.html compositing/accelerated-layers-after-back.html compositing/iframes/page-cache-layer-tree.html compositing/page-cache-back-crash.html compositing/show-composited-iframe-on-back-button.html fast/canvas/webgl/canvas-webgl-page-cache.html fast/dom/Window/timer-resume-on-navigation-back.html fast/dom/window-load-crash.html fast/events/before-unload-navigate-different-window.html ... (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149569 "Found 16 new API test failures: TestWebKitAPI.WKBackForwardList.PageCacheGoBackAfterNavigatingSameSiteIframe2, TestWebKitAPI.WKContentRuleListStoreTest.ModifyHeaders, TestWebKitAPI.ProcessSwap.QuickBackForwardNavigationWithoutPSON, TestWebKitAPI.ProcessSwap.TerminatedSuspendedPageProcess, TestWebKitAPI.ProcessSwap.GoBackToSuspendedPageWithMainFrameIDThatIsNotOne, TestWebKitAPI.ProcessSwap.SwapOnFormSubmission, TestWebKitAPI.WebpagePreferences.ExtensionPageAdvancedPrivacyProtectionsReferrer, TestWebKitAPI.SiteIsolation.QueryFramesStateAfterNavigating, TestWebKitAPI.AdvancedPrivacyProtections.DoNotHideReferrerInPopupWindow, TestWebKitAPI.MouseEventTests.ProcessSwapWithDeferredMouseMoveEventCompletion ... (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109935 "Found 8 new API test failures: WPE/TestWebKitWebView:/webkit/WebKitWebView/fullscreen, WPE/TestWebKitWebContext:/webkit/WebKitSecurityManager/file-xhr, WPE/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/page-id, WPE/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/navigation-policy, WPE/TestLoaderClient:/webkit/WebKitURIResponse/http-headers, WPE/TestWebsiteData:/webkit/WebKitWebsiteData/cache, WPE/TestFrame:/webkit/WebKitFrame/subframe, WPE/TestUIClient:/webkit/WebKitWebView/geolocation-permission-requests (failure)") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ea53fd1d-3ee5-4e59-b4ca-7f39a77f8267) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30774 "Found 43 new test failures: imported/w3c/web-platform-tests/content-security-policy/inheritance/history.sub.html imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-background-mismatch-dynamic-cross-origin.sub.html imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-background-mismatch-opaque-cross-origin-001.sub.html imported/w3c/web-platform-tests/css/css-color-adjust/rendering/dark-color-scheme/color-scheme-iframe-background-mismatch-opaque-cross-origin-002.sub.html imported/w3c/web-platform-tests/css/css-view-transitions/navigation/no-view-transition-with-cross-origin-redirect.sub.html imported/w3c/web-platform-tests/css/css-viewport/zoom/iframe-zoom.sub.html imported/w3c/web-platform-tests/fetch/api/basic/keepalive.any.html imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/pageswap/pageswap-replace-with-cross-origin-redirect.sub.html imported/w3c/web-platform-tests/html/browsers/browsing-the-web/history-traversal/srcdoc/srcdoc-history-entries.html imported/w3c/web-platform-tests/html/browsers/browsing-the-web/navigating-across-documents/same-origin-top-navigation-without-user-activation.window.html ... (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29473 "Found 39 new API test failures: TestWebKitAPI.LoadWebArchive.WebArchiveToSiteAndBack, TestWebKitAPI.ProcessSwap.NavigationWithLockedHistoryWithoutPSON, TestWebKitAPI.WebpagePreferences.UpdateWebsitePoliciesInvalid, TestWebKitAPI.WKWebView.PrivateBrowsingAffectsLocalStorage, TestWebKitAPI.LoadWebArchive.FileWebArchiveToDataWebArchiveAndBack, TestWebKitAPI.CopyHTML.SanitizationPreservesRelativeURLInAttributedString, TestWebKitAPI.LoadWebArchive.FailNavigationFromNonClientOrUserInitiatedWindowOpen, TestWebKitAPI.WebArchive.CookieAccessAfterLoadData, TestWebKitAPI.JSHandle.Basic, TestWebKitAPI.ProcessSwap.SwapOnFormSubmission ... (failure)") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23651 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158620 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140743 "Found 16 new API test failures: TestWebKitAPI.WKBackForwardList.PageCacheGoBackAfterNavigatingSameSiteIframe2, TestWebKitAPI.InAppBrowserPrivacy.NonAppBoundUserStyleSheetForSpecificWebViewFails, TestWebKitAPI.WKContentRuleListStoreTest.ModifyHeaders, TestWebKitAPI.WKNavigation.ShouldGoToBackForwardListItem, TestWebKitAPI.WebKit.LockdownModeDefaultFirstUseMessage, TestWebKitAPI.ProcessSwap.TerminatedSuspendedPageProcess, TestWebKitAPI.ProcessSwap.SwapOnFormSubmission, TestWebKitAPI.TextStyleFontSize.Startup, TestWebKitAPI.WebKit.LockdownModeAskAgainFirstUseMessage, TestWebKitAPI.WebpagePreferences.ExtensionPageAdvancedPrivacyProtectionsReferrer ... (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27266 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178044 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/27357 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30945 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28972 "Found 60 new test failures: accessibility/mac/client/range-values.html animations/no-cancelation-when-entering-page-cache.html compositing/accelerated-layers-after-back-2.html compositing/accelerated-layers-after-back.html compositing/iframes/page-cache-layer-tree.html compositing/page-cache-back-crash.html compositing/show-composited-iframe-on-back-button.html fast/canvas/webgl/canvas-webgl-page-cache.html fast/css/variables/rule-property-get-css-value.html fast/dom/Window/timer-resume-on-navigation-back.html ... (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137765 "Failure limit exceed. At least found 382 new test failures: animations/no-cancelation-when-entering-page-cache.html compositing/accelerated-layers-after-back-2.html compositing/page-cache-back-crash.html compositing/show-composited-iframe-on-back-button.html fast/canvas/webgl/canvas-webgl-page-cache.html fast/dom/window-load-crash.html fast/encoding/frame-default-enc.html fast/events/event-timing-back-forward-cache-duration.html fast/events/pagehide-timeout.html fast/events/pagehide-xhr-open.html ... (failure)") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40023 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33619 "Found 60 new test failures: accessibility/mac/input-replacevalue-userinfo.html animations/no-cancelation-when-entering-page-cache.html compositing/accelerated-layers-after-back-2.html compositing/accelerated-layers-after-back.html compositing/iframes/page-cache-layer-tree.html compositing/page-cache-back-crash.html compositing/show-composited-iframe-on-back-button.html editing/pasteboard/drag-drop-input-in-svg.svg editing/selection/crash-on-shift-click.html editing/selection/doubleclick-whitespace-live-range.html ... (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137684 "Found 7 new API test failures: WebKitGTK/TestWebKitPolicyClient:/webkit/WebKitPolicyClient/navigation-policy, WebKitGTK/TestFrame:/webkit/WebKitFrame/subframe, WebKitGTK/TestUIClient:/webkit/WebKitWebView/geolocation-permission-requests, WebKitGTK/TestLoaderClient:/webkit/WebKitURIResponse/http-headers, WebKitGTK/TestWebsiteData:/webkit/WebKitWebsiteData/cache, WebKitGTK/TestWebProcessExtensions:/webkit/WebKitWebProcessExtension/page-id, WebKitGTK/TestWebKitWebContext:/webkit/WebKitSecurityManager/file-xhr (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40711 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149063 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103419 "Built successfully") | | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32979 "Found 1 new test failure: interaction-region/paused-video-regions.html (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25929 "Found 60 new test failures: animations/no-cancelation-when-entering-page-cache.html compositing/accelerated-layers-after-back-2.html compositing/accelerated-layers-after-back.html compositing/iframes/page-cache-layer-tree.html compositing/page-cache-back-crash.html compositing/show-composited-iframe-on-back-button.html fast/canvas/webgl/canvas-webgl-page-cache.html fast/css-grid-layout/grid-item-z-index-stacking-context.html fast/css-intrinsic-dimensions/max-width-unconstrained.html fast/css/variables/variable-reference-override-cached.html ... (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/199142 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39221 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112296 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53455 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38618 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4015 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38863 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38761 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->