### PR TITLE
[CSS Grid] Resolve grid item percent block-size against definite row tracks during column intrinsic sizing

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/grid-fit-content-width-percent-height-aspect-ratio-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/grid-fit-content-width-percent-height-aspect-ratio-001-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 100px; height: 100px; background: green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/grid-fit-content-width-percent-height-aspect-ratio-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/grid-fit-content-width-percent-height-aspect-ratio-001.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#algo-track-sizing">
+<link rel="match" href="../../reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 400px;">
+  <div style="display: grid; width: fit-content; background: green; height: 100px; grid-template-rows: 50px;">
+    <div style="height: 100%;">
+      <canvas width="20" height="10" style="height: 100%;"></canvas>
+    </div>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/grid-float-intrinsic-width-percent-height-aspect-ratio-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/grid-float-intrinsic-width-percent-height-aspect-ratio-001-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 100px; height: 100px; background: green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/grid-float-intrinsic-width-percent-height-aspect-ratio-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/grid-float-intrinsic-width-percent-height-aspect-ratio-001.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#algo-track-sizing">
+<link rel="match" href="../../reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 400px;">
+  <div style="display: grid; float: left; background: green; height: 100px; grid-template-rows: 50px;">
+    <div style="height: 100%;">
+      <canvas width="20" height="10" style="height: 100%;"></canvas>
+    </div>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/grid-inline-grid-intrinsic-width-percent-height-aspect-ratio-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/grid-inline-grid-intrinsic-width-percent-height-aspect-ratio-001-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 100px; height: 100px; background: green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/grid-inline-grid-intrinsic-width-percent-height-aspect-ratio-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/grid-inline-grid-intrinsic-width-percent-height-aspect-ratio-001.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#algo-track-sizing">
+<link rel="match" href="../../reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 400px;">
+  <div style="display: inline-grid; background: green; height: 100px; grid-template-rows: 50px;">
+    <div style="height: 100%;">
+      <canvas width="20" height="10" style="height: 100%;"></canvas>
+    </div>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/grid-max-content-width-percent-height-aspect-ratio-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/grid-max-content-width-percent-height-aspect-ratio-001-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 100px; height: 100px; background: green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/grid-max-content-width-percent-height-aspect-ratio-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/grid-max-content-width-percent-height-aspect-ratio-001.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#algo-track-sizing">
+<link rel="match" href="../../reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 400px;">
+  <div style="display: grid; width: max-content; background: green; height: 100px; grid-template-rows: 50px;">
+    <div style="height: 100%;">
+      <canvas width="20" height="10" style="height: 100%;"></canvas>
+    </div>
+  </div>
+</div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/grid-min-content-width-percent-height-aspect-ratio-001-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/grid-min-content-width-percent-height-aspect-ratio-001-expected.html
@@ -1,0 +1,3 @@
+<!DOCTYPE html>
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 100px; height: 100px; background: green;"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/grid-min-content-width-percent-height-aspect-ratio-001.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/layout-algorithm/grid-min-content-width-percent-height-aspect-ratio-001.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#algo-track-sizing">
+<link rel="match" href="../../reference/ref-filled-green-100px-square-only.html">
+<p>Test passes if there is a filled green square.</p>
+<div style="width: 400px;">
+  <div style="display: grid; width: min-content; background: green; height: 100px; grid-template-rows: 50px;">
+    <div style="height: 100%;">
+      <canvas width="20" height="10" style="height: 100%;"></canvas>
+    </div>
+  </div>
+</div>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -6392,9 +6392,6 @@ webkit.org/b/215476 [ Release ] imported/w3c/web-platform-tests/css/css-grid/abs
 
 webkit.org/b/215476 [ Release ] imported/w3c/web-platform-tests/css/css-text/overflow-wrap/overflow-wrap-break-word-long-crash.html [ Pass Timeout ]
 
-webkit.org/b/227283 imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-inline-contribution-001.html [ ImageOnlyFailure ]
-webkit.org/b/227283 imported/w3c/web-platform-tests/css/css-grid/grid-items/grid-item-inline-contribution-002.html [ ImageOnlyFailure ]
-
 webkit.org/b/215929 compositing/video/poster.html [ Pass Timeout ]
 
 webkit.org/b/223900 compositing/video/video-update-rendering.html [ Pass Failure ]

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.cpp
@@ -48,6 +48,45 @@
 
 namespace WebCore {
 
+class ScopedGridAreaContentLogicalHeight {
+public:
+    ScopedGridAreaContentLogicalHeight(RenderBox& gridItem, RenderBox::GridAreaSize size)
+        : m_gridItem(gridItem)
+        , m_previous(gridItem.gridAreaContentLogicalHeight())
+    {
+        m_gridItem->setGridAreaContentLogicalHeight(size);
+    }
+    ~ScopedGridAreaContentLogicalHeight()
+    {
+        if (m_previous)
+            m_gridItem->setGridAreaContentLogicalHeight(*m_previous);
+        else
+            m_gridItem->clearGridAreaContentLogicalHeight();
+    }
+private:
+    CheckedRef<RenderBox> m_gridItem;
+    std::optional<RenderBox::GridAreaSize> m_previous;
+};
+
+class ScopedOverridingContentSizeForGridItem {
+public:
+    ScopedOverridingContentSizeForGridItem(const RenderGrid& grid, RenderBox& gridItem, LayoutUnit size, Style::GridTrackSizingDirection direction)
+        : m_grid(grid)
+        , m_gridItem(gridItem)
+        , m_direction(direction)
+    {
+        GridLayoutFunctions::setOverridingContentSizeForGridItem(m_grid, m_gridItem, size, m_direction);
+    }
+    ~ScopedOverridingContentSizeForGridItem()
+    {
+        GridLayoutFunctions::clearOverridingContentSizeForGridItem(m_grid, m_gridItem, m_direction);
+    }
+private:
+    CheckedRef<const RenderGrid> m_grid;
+    CheckedRef<RenderBox> m_gridItem;
+    Style::GridTrackSizingDirection m_direction;
+};
+
 WTF_MAKE_TZONE_ALLOCATED_IMPL(GridTrack);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(GridTrackSizingAlgorithm);
 WTF_MAKE_TZONE_ALLOCATED_IMPL(GridTrackSizingAlgorithmStrategy);
@@ -1048,21 +1087,31 @@ LayoutUnit GridTrackSizingAlgorithmStrategy::minContentContributionForGridItem(R
         bool needsGridItemMinContentContributionForSecondColumnPass = sizingState() == GridTrackSizingAlgorithm::SizingState::ColumnSizingSecondIteration
             && gridLayoutState.containsLayoutRequirementForGridItem(gridItem, ItemLayoutRequirement::MinContentContributionForSecondColumnPass);
 
+        bool isComputingColumnIntrinsicWidthForNonOrthogonalItem = this->isComputingColumnIntrinsicWidthForNonOrthogonalItem(gridItem);
+
         // FIXME: It's unclear if we should return the intrinsic width or the preferred width.
         // See http://lists.w3.org/Archives/Public/www-style/2013Jan/0245.html
-        if (gridItem.shouldInvalidatePreferredWidths() ||  needsGridItemMinContentContributionForSecondColumnPass)
+        if (gridItem.shouldInvalidatePreferredWidths() || needsGridItemMinContentContributionForSecondColumnPass || isComputingColumnIntrinsicWidthForNonOrthogonalItem)
             gridItem.setNeedsPreferredWidthsUpdate();
 
-        if (needsGridItemMinContentContributionForSecondColumnPass) {
-            auto rowSize = renderGrid()->gridAreaBreadthForGridItemIncludingAlignmentOffsets(gridItem, Style::GridTrackSizingDirection::Rows);
-            auto stretchedSize = !GridLayoutFunctions::isOrthogonalGridItem(*renderGrid(), gridItem) ? gridItem.constrainLogicalHeightByMinMax(rowSize, { }) : gridItem.constrainLogicalWidthByMinMax(rowSize, renderGrid()->contentBoxWidth(), *renderGrid());
-            GridLayoutFunctions::setOverridingContentSizeForGridItem(*renderGrid(), gridItem, stretchedSize, Style::GridTrackSizingDirection::Rows);
-        }
-
-        auto minContentLogicalWidth = gridItem.minPreferredLogicalWidth();
-
-        if (needsGridItemMinContentContributionForSecondColumnPass)
-            GridLayoutFunctions::clearOverridingContentSizeForGridItem(*renderGrid(), gridItem, Style::GridTrackSizingDirection::Rows);
+        // Row-axis override for preferred-width computation:
+        // - intrinsic column sizing: gridAreaContentLogicalHeight = sum of definite max
+        //   row tracks (https://drafts.csswg.org/css-grid-2/#algo-track-sizing).
+        // - second-column-pass min-content: stretched row size as the item's content size.
+        auto minPreferredLogicalWidth = [&] {
+            if (isComputingColumnIntrinsicWidthForNonOrthogonalItem) {
+                if (auto rowsEstimate = m_algorithm.estimatedGridAreaBreadthForGridItem(gridItem, Style::GridTrackSizingDirection::Rows)) {
+                    ScopedGridAreaContentLogicalHeight scope(gridItem, rowsEstimate);
+                    return gridItem.minPreferredLogicalWidth();
+                }
+            } else if (needsGridItemMinContentContributionForSecondColumnPass) {
+                auto rowSize = renderGrid()->gridAreaBreadthForGridItemIncludingAlignmentOffsets(gridItem, Style::GridTrackSizingDirection::Rows);
+                auto stretchedSize = !GridLayoutFunctions::isOrthogonalGridItem(*renderGrid(), gridItem) ? gridItem.constrainLogicalHeightByMinMax(rowSize, { }) : gridItem.constrainLogicalWidthByMinMax(rowSize, renderGrid()->contentBoxWidth(), *renderGrid());
+                ScopedOverridingContentSizeForGridItem scope(*renderGrid(), gridItem, stretchedSize, Style::GridTrackSizingDirection::Rows);
+                return gridItem.minPreferredLogicalWidth();
+            }
+            return gridItem.minPreferredLogicalWidth();
+        }();
 
         auto minLogicalWidth = [&] {
             auto gridItemLogicalMinWidth = gridItem.style().logicalMinWidth();
@@ -1076,7 +1125,7 @@ LayoutUnit GridTrackSizingAlgorithmStrategy::minContentContributionForGridItem(R
             return 0_lu;
         }();
 
-        return std::max(minContentLogicalWidth, minLogicalWidth) + GridLayoutFunctions::marginLogicalSizeForGridItem(*renderGrid(), gridItemInlineDirection, gridItem) + m_algorithm.baselineOffsetForGridItem(gridItem, direction());
+        return std::max(minPreferredLogicalWidth, minLogicalWidth) + GridLayoutFunctions::marginLogicalSizeForGridItem(*renderGrid(), gridItemInlineDirection, gridItem) + m_algorithm.baselineOffsetForGridItem(gridItem, direction());
     }
 
     if (updateOverridingContainingBlockContentSizeForGridItem(gridItem, gridItemInlineDirection)) {
@@ -1101,11 +1150,27 @@ LayoutUnit GridTrackSizingAlgorithmStrategy::maxContentContributionForGridItem(R
     if (direction() == gridItemInlineDirection) {
         if (isComputingInlineSizeContainment())
             return { };
+
+        bool isComputingColumnIntrinsicWidthForNonOrthogonalItem = this->isComputingColumnIntrinsicWidthForNonOrthogonalItem(gridItem);
+
         // FIXME: It's unclear if we should return the intrinsic width or the preferred width.
         // See http://lists.w3.org/Archives/Public/www-style/2013Jan/0245.html
-        if (gridItem.shouldInvalidatePreferredWidths())
+        if (gridItem.shouldInvalidatePreferredWidths() || isComputingColumnIntrinsicWidthForNonOrthogonalItem)
             gridItem.setNeedsPreferredWidthsUpdate();
-        return gridItem.maxPreferredLogicalWidth() + GridLayoutFunctions::marginLogicalSizeForGridItem(*renderGrid(), gridItemInlineDirection, gridItem) + m_algorithm.baselineOffsetForGridItem(gridItem, direction());
+
+        // Row-axis override for preferred-width computation: gridAreaContentLogicalHeight =
+        // sum of definite max row tracks (https://drafts.csswg.org/css-grid-2/#algo-track-sizing).
+        auto maxPreferredLogicalWidth = [&] {
+            if (isComputingColumnIntrinsicWidthForNonOrthogonalItem) {
+                if (auto rowsEstimate = m_algorithm.estimatedGridAreaBreadthForGridItem(gridItem, Style::GridTrackSizingDirection::Rows)) {
+                    ScopedGridAreaContentLogicalHeight scope(gridItem, rowsEstimate);
+                    return gridItem.maxPreferredLogicalWidth();
+                }
+            }
+            return gridItem.maxPreferredLogicalWidth();
+        }();
+
+        return maxPreferredLogicalWidth + GridLayoutFunctions::marginLogicalSizeForGridItem(*renderGrid(), gridItemInlineDirection, gridItem) + m_algorithm.baselineOffsetForGridItem(gridItem, direction());
     }
 
     if (updateOverridingContainingBlockContentSizeForGridItem(gridItem, gridItemInlineDirection)) {
@@ -1252,6 +1317,13 @@ void GridTrackSizingAlgorithm::cacheBaselineAlignedItem(const RenderBox& item, S
         if (cachingRowSubgridsForRootGrid && gridItemParentIsSubgridRowsOfRootGrid)
             m_rowSubgridsWithBaselineAlignedItems.add(*gridItemParent);
     }
+}
+
+bool GridTrackSizingAlgorithmStrategy::isComputingColumnIntrinsicWidthForNonOrthogonalItem(const RenderBox& gridItem) const
+{
+    return sizingOperation() == SizingOperation::IntrinsicSizeComputation
+        && sizingState() == GridTrackSizingAlgorithm::SizingState::ColumnSizingFirstIteration
+        && !GridLayoutFunctions::isOrthogonalGridItem(*renderGrid(), gridItem);
 }
 
 bool GridTrackSizingAlgorithmStrategy::updateOverridingContainingBlockContentSizeForGridItem(RenderBox& gridItem, Style::GridTrackSizingDirection direction, std::optional<LayoutUnit> overrideSize) const

--- a/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
+++ b/Source/WebCore/rendering/GridTrackSizingAlgorithm.h
@@ -381,11 +381,13 @@ protected:
 
     LayoutUnit logicalHeightForGridItem(RenderBox&, RenderGridLayoutState&) const;
     bool updateOverridingContainingBlockContentSizeForGridItem(RenderBox&, Style::GridTrackSizingDirection, std::optional<LayoutUnit> = std::nullopt) const;
+    bool isComputingColumnIntrinsicWidthForNonOrthogonalItem(const RenderBox&) const;
 
     // GridTrackSizingAlgorithm accessors for subclasses.
     LayoutUnit computeTrackBasedSize() const { return m_algorithm.computeTrackBasedSize(); }
     Style::GridTrackSizingDirection direction() const { return m_algorithm.m_direction; }
     GridTrackSizingAlgorithm::SizingState sizingState() const { return m_algorithm.m_sizingState; }
+    SizingOperation sizingOperation() const { return m_algorithm.m_sizingOperation; }
     double findFrUnitSize(const GridSpan& tracksSpan, LayoutUnit leftOverSpace) const { return m_algorithm.findFrUnitSize(tracksSpan, leftOverSpace); }
     void distributeSpaceToTracks(Vector<CheckedRef<GridTrack>>& tracks, LayoutUnit& availableLogicalSpace) const { m_algorithm.distributeSpaceToTracks<TrackSizeComputationVariant::NotCrossingFlexibleTracks, TrackSizeComputationPhase::MaximizeTracks>(tracks, nullptr, availableLogicalSpace); }
     const RenderGrid* renderGrid() const { return m_algorithm.m_renderGrid; }


### PR DESCRIPTION
#### 352ccb3b04ce2e03b9e62f1b4578162cd5dd73ea
<pre>
[CSS Grid] Resolve grid item percent block-size against definite row tracks during column intrinsic sizing
<a href="https://bugs.webkit.org/show_bug.cgi?id=227283">https://bugs.webkit.org/show_bug.cgi?id=227283</a>
<a href="https://rdar.apple.com/79955935">rdar://79955935</a>

Reviewed by Alan Baradlay.

According the the track sizing algorithm, when we are doing the first
iteration of column sizing we are supposed to use the sum of the
definite max track sizing functions for the available block axis space
for items that need it:
<a href="https://drafts.csswg.org/css-grid-2/#algo-track-sizing">https://drafts.csswg.org/css-grid-2/#algo-track-sizing</a>

For example
&lt;div style=&quot;width: 400px;&quot;&gt;
  &lt;div style=&quot;display: grid; width: min-content; background: green; height: 100px; grid-template-rows: 50px;&quot;&gt;
    &lt;div style=&quot;height: 100%;&quot;&gt;
      &lt;canvas width=&quot;20&quot; height=&quot;10&quot; style=&quot;height: 100%;&quot;&gt;&lt;/canvas&gt;
    &lt;/div&gt;
  &lt;/div&gt;
&lt;/div&gt;
Here the size of the columns depends on the available block space since
the replaced element will resolve the % height against any definite
space in that axis and then compute the width from that and the aspect
ratio.

To fix this we can make sure that the grid area&apos;s height for the grid
item is set to the sum of the max track sizing functions if that is a
definite value. The track sizing algorithm already keeps track of which
step of the algorithm we are in along with if we are computing the
intrinsic sizes of the grid so we can reuse that logic as well.

I also added a couple of RAII helper classes to make sure that these
sizes are scoped properly to avoid keeping them around to longer than
they need to (similar to what RenderFlexibleBox does).

Canonical link: <a href="https://commits.webkit.org/313927@main">https://commits.webkit.org/313927@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/dcf6d4520a630829a78faa9d9358ba2c326f1d7d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164582 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38066 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31637 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173616 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0de97f2b-13a1-43ca-ab79-70d42d7f1b86) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166451 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38400 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38068 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127885 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121834 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/37540478-ab11-4e76-aac8-90436dae40d9) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167541 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/30183 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/147929 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108430 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fb4789c4-e173-44af-a2e6-19c55d949de2) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29230 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/27858 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21375 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139133 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25645 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176140 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/28961 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27314 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/136205 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38135 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31981 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136169 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36671 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38825 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147440 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100979 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31443 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/24296 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37333 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/110377 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36731 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2359 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36979 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36879 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->