### PR TITLE
Update Some Bots to macOS Tahoe 26.5

### DIFF
--- a/Tools/CISupport/build-webkit-org/config.json
+++ b/Tools/CISupport/build-webkit-org/config.json
@@ -107,58 +107,58 @@
                   {
                     "name": "bot10001",
                     "platform": "mac-tahoe",
-                    "os": "macOS Tahoe 26.2-25C56",
+                    "os": "macOS Tahoe 26.5-25F71",
                     "device": "Mac16,11",
-                    "xcode": "Xcode 26.2-17C52"
+                    "xcode": "Xcode 26.5-17F42"
                   },
                   {
                     "name": "bot10002",
                     "platform": "mac-tahoe",
-                    "os": "macOS Tahoe 26.2-25C56",
+                    "os": "macOS Tahoe 26.5-25F71",
                     "device": "Mac16,11",
-                    "xcode": "Xcode 26.2-17C52"
+                    "xcode": "Xcode 26.5-17F42"
                   },
                   {
                     "name": "bot10003",
                     "platform": "mac-tahoe",
-                    "os": "macOS Tahoe 26.2-25C56",
+                    "os": "macOS Tahoe 26.5-25F71",
                     "device": "Mac16,11",
-                    "xcode": "Xcode 26.2-17C52"
+                    "xcode": "Xcode 26.5-17F42"
                   },
                   {
                     "name": "bot10004",
                     "platform": "mac-tahoe",
-                    "os": "macOS Tahoe 26.2-25C56",
+                    "os": "macOS Tahoe 26.5-25F71",
                     "device": "Mac16,11",
-                    "xcode": "Xcode 26.2-17C52"
+                    "xcode": "Xcode 26.5-17F42"
                   },
                   {
                     "name": "bot10005",
                     "platform": "mac-tahoe",
-                    "os": "macOS Tahoe 26.2-25C56",
+                    "os": "macOS Tahoe 26.5-25F71",
                     "device": "Mac16,11",
-                    "xcode": "Xcode 26.2-17C52"
+                    "xcode": "Xcode 26.5-17F42"
                   },
                   {
                     "name": "bot10006",
                     "platform": "mac-tahoe",
-                    "os": "macOS Tahoe 26.2-25C56",
+                    "os": "macOS Tahoe 26.5-25F71",
                     "device": "Mac16,11",
-                    "xcode": "Xcode 26.2-17C52"
+                    "xcode": "Xcode 26.5-17F42"
                   },
                   {
                     "name": "bot10007",
                     "platform": "mac-tahoe",
-                    "os": "macOS Tahoe 26.2-25C56",
+                    "os": "macOS Tahoe 26.5-25F71",
                     "device": "Mac16,11",
-                    "xcode": "Xcode 26.2-17C52"
+                    "xcode": "Xcode 26.5-17F42"
                   },
                   {
                     "name": "bot10008",
                     "platform": "mac-tahoe",
-                    "os": "macOS Tahoe 26.2-25C56",
+                    "os": "macOS Tahoe 26.5-25F71",
                     "device": "Mac16,11",
-                    "xcode": "Xcode 26.2-17C52"
+                    "xcode": "Xcode 26.5-17F42"
                   },
                   {
                     "name": "bot10009",


### PR DESCRIPTION
#### 5c44d94aba7534afeaee7982b4116f5d59274451
<pre>
Update Some Bots to macOS Tahoe 26.5
<a href="https://bugs.webkit.org/show_bug.cgi?id=315314">https://bugs.webkit.org/show_bug.cgi?id=315314</a>
<a href="https://rdar.apple.com/177645508">rdar://177645508</a>

Reviewed by Jonathan Bedard.

Update Some Bots to macOS Tahoe 26.5

* Tools/CISupport/build-webkit-org/config.json:

Canonical link: <a href="https://commits.webkit.org/313693@main">https://commits.webkit.org/313693@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7e19bed975a6eab5416679c3f80ebc287c6ddb42

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163854 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37338 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30557 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172882 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c340051c-7ff6-4b80-a064-ce050d1aeb95) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165723 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37670 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37337 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127276 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121105 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dd013a6f-28dc-464a-b4e9-e1940cfde039) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166813 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29562 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147299 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107825 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c0966736-5c33-42cc-affc-99e61e67c6ef) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28608 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27241 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20647 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138508 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25016 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175404 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26684 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135584 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/163251 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37008 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31349 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135560 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37793 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146811 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99930 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24938 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30870 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23665 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36504 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36001 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1699 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36251 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36148 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->