### PR TITLE
Web Extensions: cookies.get() and cookies.getAll() have empty results on first launch.

### DIFF
--- a/Source/WebKit/UIProcess/API/APIHTTPCookieStore.cpp
+++ b/Source/WebKit/UIProcess/API/APIHTTPCookieStore.cpp
@@ -77,7 +77,7 @@ void HTTPCookieStore::filterAppBoundCookies(Vector<WebCore::Cookie>&& cookies, C
 
 void HTTPCookieStore::cookies(CompletionHandler<void(Vector<WebCore::Cookie>&&)>&& completionHandler)
 {
-    if (RefPtr networkProcess = networkProcessIfExists()) {
+    if (RefPtr networkProcess = networkProcessLaunchingIfNecessary()) {
         networkProcess->sendWithAsyncReply(Messages::WebCookieManager::GetAllCookies(m_sessionID), [this, protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler)] (Vector<WebCore::Cookie>&& cookies) mutable {
             filterAppBoundCookies(WTF::move(cookies), WTF::move(completionHandler));
         });
@@ -87,7 +87,7 @@ void HTTPCookieStore::cookies(CompletionHandler<void(Vector<WebCore::Cookie>&&)>
 
 void HTTPCookieStore::cookiesForURL(WTF::URL&& url, CompletionHandler<void(Vector<WebCore::Cookie>&&)>&& completionHandler)
 {
-    if (RefPtr networkProcess = networkProcessIfExists()) {
+    if (RefPtr networkProcess = networkProcessLaunchingIfNecessary()) {
         networkProcess->sendWithAsyncReply(Messages::WebCookieManager::GetCookies(m_sessionID, url), [this, protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler)] (Vector<WebCore::Cookie>&& cookies) mutable {
             filterAppBoundCookies(WTF::move(cookies), WTF::move(completionHandler));
         });

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPICookies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPICookies.mm
@@ -28,7 +28,10 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #import "Helpers/cocoa/WebExtensionUtilities.h"
+#import <WebKit/WKHTTPCookieStorePrivate.h>
 #import <WebKit/WKWebExtensionCommand.h>
+#import <WebKit/WKWebsiteDataStorePrivate.h>
+#import <signal.h>
 #import <wtf/darwin/DispatchExtras.h>
 
 namespace TestWebKitAPI {
@@ -713,6 +716,55 @@ TEST(WKWebExtensionAPICookies, ChangedEvent)
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];
 
     [manager run];
+}
+
+TEST(WKWebExtensionAPICookies, GetAllAfterNetworkProcessTermination)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"const cookies = await browser.test.assertSafeResolve(() => browser.cookies.getAll({ url: 'http://example.com/' }))",
+        @"browser.test.assertTrue(Array.isArray(cookies), 'Cookies should be an array')",
+        @"browser.test.assertEq(cookies?.length, 1, 'There should be 1 cookie')",
+        @"browser.test.assertEq(cookies[0]?.name, 'testCookie')",
+        @"browser.test.assertEq(cookies[0]?.value, 'testValue')",
+        @"browser.test.notifyPass()"
+    ]);
+
+    auto manager = Util::loadExtension(cookiesManifest, @{ @"background.js": backgroundScript });
+
+    auto *matchPattern = [WKWebExtensionMatchPattern matchPatternWithString:@"*://*.example.com/*"];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];
+
+    auto *cookieStore = WKWebsiteDataStore.defaultDataStore.httpCookieStore;
+    auto *cookie = [NSHTTPCookie cookieWithProperties:@{
+        NSHTTPCookieName: @"testCookie",
+        NSHTTPCookieValue: @"testValue",
+        NSHTTPCookieDomain: @".example.com",
+        NSHTTPCookiePath: @"/",
+        NSHTTPCookieExpires: [NSDate dateWithTimeIntervalSinceNow:3600]
+    }];
+
+    __block bool done = false;
+    [cookieStore setCookie:cookie completionHandler:^{
+        [cookieStore _flushCookiesToDiskWithCompletionHandler:^{
+            done = true;
+        }];
+    }];
+
+    Util::run(&done);
+
+    // Kill the network process to simulate a cold start (e.g. after app relaunch). With the fix,
+    // cookies.getAll() launches the network process on demand and reads the persisted cookie.
+    kill([WKWebsiteDataStore.defaultDataStore _networkProcessIdentifier], SIGKILL);
+    Util::runFor(0.1_s);
+
+    [manager run];
+
+    done = false;
+    [cookieStore deleteCookie:cookie completionHandler:^{
+        done = true;
+    }];
+
+    Util::run(&done);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### 0148d3419af1784ee6a6350d9fd49ddf58d824c8
<pre>
Web Extensions: cookies.get() and cookies.getAll() have empty results on first launch.
<a href="https://webkit.org/b/315310">https://webkit.org/b/315310</a>
<a href="https://rdar.apple.com/177380008">rdar://177380008</a>

Reviewed by Brian Weinstein.

When the network process hasn&apos;t launched yet — as is common on the first cookie query after
app launch — the two cookie-reading methods silently returned empty results. They now launch
the network process on demand, consistent with the write and observer methods in the same class.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPICookies.mm

* Source/WebKit/UIProcess/API/APIHTTPCookieStore.cpp:
(API::HTTPCookieStore::cookies): Use `networkProcessLaunchingIfNecessary()` to launch the network
process on demand rather than silently returning empty results when it isn&apos;t running.
(API::HTTPCookieStore::cookiesForURL): Ditto.

* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPICookies.mm:
(TestWebKitAPI::TEST(WKWebExtensionAPICookies, GetAllAfterNetworkProcessTermination)):
Added. Verifies `browser.cookies.getAll()` returns persisted cookies after the network process is
killed, simulating a cold-start scenario.

Canonical link: <a href="https://commits.webkit.org/313745@main">https://commits.webkit.org/313745@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/692282c245e474411dc188c87999f752435936bc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163856 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37340 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30559 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172884 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ef5a9b64-77bb-4642-ace3-2dc334d80894) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165725 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37672 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37339 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127279 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121107 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/54349980-a20a-4aeb-a018-f375b05e0cd6) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166815 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29568 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147302 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107828 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c40c5b96-82bc-4749-ab93-999d98fd1b2f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28614 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27242 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20649 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138514 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25019 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175406 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28232 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26687 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135587 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37010 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31350 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135562 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37795 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146814 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99932 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24960 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30873 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23668 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36506 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109651 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36003 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1702 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36253 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36150 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->