### PR TITLE
[GTK][WPE] Handle GL contexts without GL_EXT_texture_format_BGRA8888

### DIFF
--- a/Source/WebCore/platform/graphics/ColorMatrix.h
+++ b/Source/WebCore/platform/graphics/ColorMatrix.h
@@ -174,6 +174,16 @@ constexpr ColorMatrix<3, 3> saturationColorMatrix(float amount)
     };
 }
 
+constexpr ColorMatrix<5, 4> swapRedBlueMatrix()
+{
+    return ColorMatrix<5, 4> {
+        0.0f, 0.0f, 1.0f, 0.0f, 0.0f,
+        0.0f, 1.0f, 0.0f, 0.0f, 0.0f,
+        1.0f, 0.0f, 0.0f, 0.0f, 0.0f,
+        0.0f, 0.0f, 0.0f, 1.0f, 0.0f,
+    };
+}
+
 // NOTE: hueRotateColorMatrix is not constexpr due to use of cos/sin which are not constexpr yet.
 inline ColorMatrix<3, 3> hueRotateColorMatrix(float angleInDegrees)
 {

--- a/Source/WebCore/platform/graphics/egl/GLContext.cpp
+++ b/Source/WebCore/platform/graphics/egl/GLContext.cpp
@@ -642,6 +642,7 @@ const GLContext::GLExtensions& GLContext::glExtensions() const
         m_glExtensions.APPLE_sync = isExtensionSupported(extensionsString, "GL_APPLE_sync");
         m_glExtensions.OES_packed_depth_stencil = isExtensionSupported(extensionsString, "GL_OES_packed_depth_stencil");
         m_glExtensions.EXT_YUV_target = isExtensionSupported(extensionsString, "GL_EXT_YUV_target");
+        m_glExtensions.EXT_texture_format_BGRA8888 = isExtensionSupported(extensionsString, "GL_EXT_texture_format_BGRA8888");
 #if USE(VULKAN)
         m_glExtensions.EXT_memory_object = isExtensionSupported(extensionsString, "GL_EXT_memory_object");
 #endif

--- a/Source/WebCore/platform/graphics/egl/GLContext.h
+++ b/Source/WebCore/platform/graphics/egl/GLContext.h
@@ -102,6 +102,7 @@ public:
         bool APPLE_sync { false };
         bool OES_packed_depth_stencil { false };
         bool EXT_YUV_target { false };
+        bool EXT_texture_format_BGRA8888 { false };
 #if USE(VULKAN)
         bool EXT_memory_object { false };
 #endif

--- a/Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp
@@ -31,7 +31,9 @@
 #include "CoordinatedTileBuffer.h"
 #include "PlatformDisplay.h"
 #include "SkiaPaintingEngine.h"
+#include "SkiaUtilities.h"
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkColorFilter.h>
 #include <skia/core/SkColorSpace.h>
 #include <skia/gpu/ganesh/GrBackendSurface.h>
 #include <skia/gpu/ganesh/SkImageGanesh.h>
@@ -77,6 +79,9 @@ void SkiaBackingStore::paintToCanvas(SkCanvas& canvas, const SkPaint& paint)
     FloatRect layerRect = { { }, m_size };
 
     auto tilePaint = paint;
+    if (needsBGRAToRGBASwap())
+        tilePaint.setColorFilter(SkiaUtilities::composeFilterWithRedBlueSwap(paint.refColorFilter()));
+
     for (auto& tile : m_tiles.values()) {
         if (canvas.quickReject(tile.rect()))
             continue;
@@ -175,6 +180,18 @@ sk_sp<SkImage> SkiaBackingStore::Tile::image()
         m_cachedImage = SkImages::BorrowTextureFrom(grContext, backendTexture, kTopLeft_GrSurfaceOrigin, colorType, kPremul_SkAlphaType, SkColorSpace::MakeSRGB());
     }
     return m_cachedImage;
+}
+
+bool SkiaBackingStore::needsBGRAToRGBASwap() const
+{
+    // Rendering mode (accelerated vs. unaccelerated) and BGRA-extension
+    // availability are both process-global, so every tile in this backing
+    // store agrees on the swap state. Inspecting any textured tile suffices.
+    for (const auto& tile : m_tiles.values()) {
+        if (const auto& texture = tile.texture())
+            return texture->needsBGRAToRGBASwap();
+    }
+    return false;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/skia/SkiaBackingStore.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaBackingStore.h
@@ -34,6 +34,7 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 #include <wtf/HashMap.h>
 
 namespace WebCore {
+class BitmapTexture;
 class CoordinatedTileBuffer;
 
 class SkiaBackingStore {
@@ -62,6 +63,7 @@ private:
         void update(const IntRect& dirtyRect, const IntRect& tileRect, CoordinatedTileBuffer&);
         const FloatRect& rect() const LIFETIME_BOUND { return m_rect; }
         sk_sp<SkImage> image();
+        const RefPtr<BitmapTexture>& texture() const LIFETIME_BOUND { return m_texture; }
 
     private:
         void ensureTexture(const IntSize&, CoordinatedTileBuffer&);
@@ -71,6 +73,8 @@ private:
         RefPtr<BitmapTexture> m_texture;
         sk_sp<SkImage> m_cachedImage;
     };
+
+    bool needsBGRAToRGBASwap() const;
 
     HashMap<uint32_t, Tile> m_tiles;
     FloatSize m_size;

--- a/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp
@@ -42,6 +42,7 @@
 #include "SkiaCompositingLayerOverlapRegions.h"
 #include "SkiaUtilities.h"
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkColorFilter.h>
 #include <skia/core/SkFont.h>
 #include <skia/core/SkPathBuilder.h>
 #include <skia/core/SkRRect.h>
@@ -481,6 +482,7 @@ void SkiaCompositingLayer::paintSelf(SkCanvas& canvas, PaintContext& context)
         }
 
         sk_sp<SkImage> image;
+        bool needsBGRAToRGBASwap = false;
 
         if (m_contentsBuffer) {
             if (is<CoordinatedPlatformLayerBufferHolePunch>(*m_contentsBuffer)) {
@@ -490,11 +492,15 @@ void SkiaCompositingLayer::paintSelf(SkCanvas& canvas, PaintContext& context)
 #endif
                 paint.setColor(SK_ColorTRANSPARENT);
                 canvas.drawRect(SkRect(m_contentsRect), paint);
-            } else
+            } else {
                 image = m_contentsBuffer->skiaImage();
+                needsBGRAToRGBASwap = m_contentsBuffer->needsBGRAToRGBASwap();
+            }
         } else if (auto* buffer = m_imageBackingStore->buffer()) {
             image = buffer->skiaImage();
-            if (!m_contentsTiling.size.isEmpty()) {
+            // The image backing store always wraps a NativeImage uploaded via
+            // surface->writePixels into an RGBA-storage texture, so no swap.
+            if (image && !m_contentsTiling.size.isEmpty()) {
                 sk_sp<SkImage> tileImage = std::exchange(image, nullptr);
                 SkMatrix matrix;
                 matrix.setScale(m_contentsTiling.size.width() / tileImage->width(), m_contentsTiling.size.height() / tileImage->height());
@@ -505,6 +511,8 @@ void SkiaCompositingLayer::paintSelf(SkCanvas& canvas, PaintContext& context)
         }
 
         if (image) {
+            if (needsBGRAToRGBASwap)
+                paint.setColorFilter(SkiaUtilities::composeFilterWithRedBlueSwap(paint.refColorFilter()));
             canvas.drawImageRect(image, SkRect::MakeSize(SkSize::Make(image->dimensions())), SkRect(m_contentsRect),
                 SkSamplingOptions(SkFilterMode::kLinear, SkMipmapMode::kNone), &paint, SkCanvas::kFast_SrcRectConstraint);
         }

--- a/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.cpp
@@ -75,27 +75,35 @@ RefPtr<SkiaGPUAtlas> SkiaGPUAtlas::create(const SkiaImageAtlasLayout& layout, Re
 
 void SkiaGPUAtlas::uploadImages()
 {
-    Vector<uint8_t> conversionBuffer;
+    // The atlas's storage byte order is locked at creation: kBGRA on contexts with
+    // GL_EXT_texture_format_BGRA8888, kRGBA otherwise (UseBGRALayout was sanitized
+    // away). Each upload must match the storage byte order - every entry shares one
+    // m_pixelFormat, and BitmapTexture::updateContents asserts on partial-region
+    // pixel-format changes. So the fast path is "source already matches storage";
+    // the slow path is an SkImage::readPixels conversion for the rare mismatched
+    // entry. On each platform, the typical source colorType already matches storage
+    // (BGRA on BGRA-capable, RGBA on the sanitized path), so we hit the fast path.
+    const bool storageIsBGRA = m_atlasTexture->flags().contains(BitmapTexture::Flags::UseBGRALayout);
+    const SkColorType storageColorType = storageIsBGRA ? kBGRA_8888_SkColorType : kRGBA_8888_SkColorType;
 
-    // Returns pixel data for atlas upload — either a zero-copy reference to the original
-    // pixels (fast path) or a converted sRGB copy (for non-sRGB images).
-    auto pixelDataInSRGB = [&conversionBuffer](const sk_sp<SkImage>& image) -> std::optional<std::pair<const void*, size_t>> {
+    Vector<uint8_t> conversionBuffer;
+    auto pixelsMatchingStorage = [&](const sk_sp<SkImage>& image) -> std::optional<std::pair<const void*, size_t>> {
         SkPixmap pixmap;
         if (!image->peekPixels(&pixmap))
             return std::nullopt;
 
-        if (auto* colorSpace = image->colorSpace(); !colorSpace || colorSpace->isSRGB())
+        auto* colorSpace = image->colorSpace();
+        if (image->colorType() == storageColorType && (!colorSpace || colorSpace->isSRGB()))
             return std::pair { pixmap.addr(), pixmap.rowBytes() };
 
-        // Convert to sRGB using Skia's built-in color space conversion.
-        auto srgbInfo = SkImageInfo::Make(image->width(), image->height(), image->colorType(), image->alphaType(), SkColorSpace::MakeSRGB());
-        size_t srgbRowBytes = srgbInfo.minRowBytes();
-        conversionBuffer.resize(srgbInfo.computeMinByteSize());
+        auto dstInfo = SkImageInfo::Make(image->width(), image->height(), storageColorType, image->alphaType(), SkColorSpace::MakeSRGB());
+        size_t dstRowBytes = dstInfo.minRowBytes();
+        conversionBuffer.resize(dstInfo.computeMinByteSize());
 
-        if (!image->readPixels(static_cast<GrDirectContext*>(nullptr), srgbInfo, conversionBuffer.mutableSpan().data(), srgbRowBytes, 0, 0))
+        if (!image->readPixels(static_cast<GrDirectContext*>(nullptr), dstInfo, conversionBuffer.mutableSpan().data(), dstRowBytes, 0, 0))
             return std::nullopt;
 
-        return std::pair { static_cast<const void*>(conversionBuffer.mutableSpan().data()), srgbRowBytes };
+        return std::pair { static_cast<const void*>(conversionBuffer.mutableSpan().data()), dstRowBytes };
     };
 
 #if USE(GBM)
@@ -105,7 +113,7 @@ void SkiaGPUAtlas::uploadImages()
             RELEASE_ASSERT_WITH_MESSAGE(writeScope, "Failed to map GPU buffer for atlas upload");
 
             for (const auto& entry : m_layout->entries()) {
-                if (auto pixels = pixelDataInSRGB(entry.rasterImage))
+                if (auto pixels = pixelsMatchingStorage(entry.rasterImage))
                     gpuBuffer->updateContents(*writeScope, pixels->first, entry.atlasRect, pixels->second);
             }
 
@@ -114,9 +122,10 @@ void SkiaGPUAtlas::uploadImages()
     }
 #endif
 
-    // GL fallback: use BitmapTexture::updateContents() per entry.
+    // GL fallback: pass the atlas's logical pixelFormat (BGRA8) so the compositor's
+    // draw-time R<->B swap shader fires on contexts where storage was forced to RGBA.
     for (const auto& entry : m_layout->entries()) {
-        if (auto pixels = pixelDataInSRGB(entry.rasterImage))
+        if (auto pixels = pixelsMatchingStorage(entry.rasterImage))
             m_atlasTexture->updateContents(pixels->first, entry.atlasRect, IntPoint::zero(), pixels->second, PixelFormat::BGRA8);
     }
 }

--- a/Source/WebCore/platform/graphics/skia/SkiaUtilities.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaUtilities.cpp
@@ -29,17 +29,19 @@
 #if USE(SKIA)
 
 #include "BitmapTexture.h"
+#include "ColorMatrix.h"
 #include "ColorSpaceSkia.h"
 #include "GLFence.h"
 #include "GraphicsTypes.h"
 #include "NotImplemented.h"
 #include "PlatformDisplay.h"
-
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
+#include <skia/core/SkColorFilter.h>
 #include <skia/gpu/ganesh/SkImageGanesh.h>
 #include <skia/gpu/ganesh/SkSurfaceGanesh.h>
 #include <skia/gpu/ganesh/gl/GrGLBackendSurface.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
+#include <wtf/NeverDestroyed.h>
 
 #if USE(LIBEPOXY)
 #include <epoxy/gl.h>
@@ -198,6 +200,14 @@ SkBlendMode toSkiaBlendMode(BlendMode blendMode, std::optional<CompositeOperator
     }
 
     return SkBlendMode::kSrcOver;
+}
+
+sk_sp<SkColorFilter> composeFilterWithRedBlueSwap(const sk_sp<SkColorFilter>& base)
+{
+    static NeverDestroyed<sk_sp<SkColorFilter>> swap {
+        SkColorFilters::Matrix(swapRedBlueMatrix().data().data())
+    };
+    return base ? base->makeComposed(swap.get()) : swap.get();
 }
 
 } // namespace SkiaUtilities

--- a/Source/WebCore/platform/graphics/skia/SkiaUtilities.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaUtilities.h
@@ -37,6 +37,7 @@ WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/gpu/ganesh/GrDirectContext.h>
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_END
 
+class SkColorFilter;
 class SkImage;
 class SkSurface;
 class SkSurfaceProps;
@@ -82,6 +83,11 @@ std::unique_ptr<GLFence> flushAndSubmitImageWithFence(GrDirectContext*, const sk
 std::unique_ptr<GLFence> flushAndSubmitWithFence(GrDirectContext*);
 
 SkBlendMode toSkiaBlendMode(BlendMode, std::optional<CompositeOperator> = std::nullopt);
+
+// Returns a filter that applies an R<->B channel swap on top of `base` (or just
+// the swap if `base` is null). Composition order means the swap runs first, so
+// it operates on the raw texel order (BGRA bytes uploaded into an RGBA texture).
+sk_sp<SkColorFilter> composeFilterWithRedBlueSwap(const sk_sp<SkColorFilter>& base);
 
 } // namespace SkiaUtilities
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp
@@ -72,6 +72,25 @@ static const GLenum s_pixelDataType = GL_UNSIGNED_BYTE;
 
 namespace WebCore {
 
+// Without EXT_texture_format_BGRA8888, GL_BGRA{,8_EXT} cannot be used as a 2D
+// texture's internal format. Drop UseBGRALayout from the storage flags so the
+// texture is allocated as GL_RGBA; callers must independently keep m_pixelFormat
+// set to BGRA8 so colorConvertFlags() requests a draw-time R<->B swap.
+static OptionSet<BitmapTexture::Flags> sanitizeFlagsForGLContext(OptionSet<BitmapTexture::Flags> flags)
+{
+    if (flags.contains(BitmapTexture::Flags::UseBGRALayout)) {
+        auto* glContext = GLContext::current();
+        if (!glContext || !glContext->glExtensions().EXT_texture_format_BGRA8888)
+            flags.remove(BitmapTexture::Flags::UseBGRALayout);
+    }
+    return flags;
+}
+
+static PixelFormat pixelFormatForFlags(OptionSet<BitmapTexture::Flags> flags)
+{
+    return flags.contains(BitmapTexture::Flags::UseBGRALayout) ? PixelFormat::BGRA8 : PixelFormat::RGBA8;
+}
+
 void BitmapTexture::determineRenderTargetAndBinding()
 {
     if (m_flags.contains(Flags::ExternalOESRenderTarget)) {
@@ -86,7 +105,10 @@ void BitmapTexture::determineRenderTargetAndBinding()
 
 GLenum BitmapTexture::textureFormat() const
 {
-    return m_flags.contains(Flags::UseBGRALayout) ? GL_BGRA : GL_RGBA;
+    if (!m_flags.contains(Flags::UseBGRALayout))
+        return GL_RGBA;
+    ASSERT(GLContext::current() && GLContext::current()->glExtensions().EXT_texture_format_BGRA8888);
+    return GL_BGRA;
 }
 
 GLenum depthBufferFormat()
@@ -99,9 +121,9 @@ GLenum depthBufferFormat()
 }
 
 BitmapTexture::BitmapTexture(const IntSize& size, OptionSet<Flags> flags)
-    : m_flags(flags)
+    : m_flags(sanitizeFlagsForGLContext(flags))
     , m_size(size)
-    , m_pixelFormat(flags.contains(Flags::UseBGRALayout) ? PixelFormat::BGRA8 : PixelFormat::RGBA8)
+    , m_pixelFormat(pixelFormatForFlags(flags))
 {
     determineRenderTargetAndBinding();
 
@@ -111,17 +133,17 @@ BitmapTexture::BitmapTexture(const IntSize& size, OptionSet<Flags> flags)
 #if USE(GBM)
     if (m_flags.contains(Flags::BackedByDMABuf)) {
         OptionSet<MemoryMappedGPUBuffer::BufferFlag> bufferFlags;
-        if (flags.contains(Flags::ForceLinearBuffer)) {
-            ASSERT(!flags.contains(Flags::ForceVivanteSuperTiledBuffer));
+        if (m_flags.contains(Flags::ForceLinearBuffer)) {
+            ASSERT(!m_flags.contains(Flags::ForceVivanteSuperTiledBuffer));
             bufferFlags.add(MemoryMappedGPUBuffer::BufferFlag::ForceLinear);
         }
 
-        if (flags.contains(Flags::ForceVivanteSuperTiledBuffer)) {
-            ASSERT(!flags.contains(Flags::ForceLinearBuffer));
+        if (m_flags.contains(Flags::ForceVivanteSuperTiledBuffer)) {
+            ASSERT(!m_flags.contains(Flags::ForceLinearBuffer));
             bufferFlags.add(MemoryMappedGPUBuffer::BufferFlag::ForceVivanteSuperTiled);
         }
 
-        if (flags.contains(Flags::UseBGRALayout))
+        if (m_flags.contains(Flags::UseBGRALayout))
             bufferFlags.add(MemoryMappedGPUBuffer::BufferFlag::UseBGRALayout);
 
         m_memoryMappedGPUBuffer = MemoryMappedGPUBuffer::create(m_size, bufferFlags);
@@ -203,8 +225,9 @@ bool BitmapTexture::allocateTextureFromMemoryMappedGPUBuffer()
 
 #if USE(GBM) || OS(ANDROID)
 BitmapTexture::BitmapTexture(EGLImage image, const IntSize& size, OptionSet<Flags> flags)
-    : m_flags(flags)
+    : m_flags(sanitizeFlagsForGLContext(flags))
     , m_size(size)
+    , m_pixelFormat(pixelFormatForFlags(flags))
 {
     determineRenderTargetAndBinding();
 
@@ -246,9 +269,9 @@ void BitmapTexture::reset(const IntSize& size, OptionSet<Flags> flags)
     RELEASE_ASSERT(m_flags.contains(Flags::BackedByDMABuf) == flags.contains(Flags::BackedByDMABuf));
 #endif
 
-    m_flags = flags;
+    m_flags = sanitizeFlagsForGLContext(flags);
     m_shouldClear = true;
-    m_pixelFormat = flags.contains(Flags::UseBGRALayout) ? PixelFormat::BGRA8 : PixelFormat::RGBA8;
+    m_pixelFormat = pixelFormatForFlags(flags);
     m_filterOperation = nullptr;
 
     if (!flags.contains(Flags::DepthBuffer)) {
@@ -585,6 +608,11 @@ OptionSet<TextureMapperFlags> BitmapTexture::colorConvertFlags() const
 #else
     return TextureMapperFlags::ShouldConvertTextureARGBToRGBA;
 #endif
+}
+
+bool BitmapTexture::needsBGRAToRGBASwap() const
+{
+    return colorConvertFlags().contains(TextureMapperFlags::ShouldConvertTextureBGRAToRGBA);
 }
 
 #if USE(SKIA)

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexture.h
@@ -92,6 +92,7 @@ public:
     const IntSize& size() const { return m_size; };
     size_t sizeInBytes() const;
     OptionSet<Flags> flags() const { return m_flags; }
+    PixelFormat pixelFormat() const { return m_pixelFormat; }
     bool isOpaque() const { return !m_flags.contains(Flags::SupportsAlpha); }
 
     void bindAsSurface();
@@ -114,6 +115,7 @@ public:
     void copyFromExternalTexture(GLuint sourceTextureID, const IntRect& targetRect, const IntSize& sourceOffset);
 
     OptionSet<TextureMapperFlags> colorConvertFlags() const;
+    bool needsBGRAToRGBASwap() const;
 
 #if USE(SKIA)
     GrBackendTexture createSkiaBackendTexture() const;

--- a/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.cpp
+++ b/Source/WebCore/platform/graphics/texmap/BitmapTexturePool.cpp
@@ -72,6 +72,7 @@ Ref<BitmapTexture> BitmapTexturePool::acquireTexture(const IntSize& size, Option
 {
     ASSERT(GLContextWrapper::currentContext());
     Locker locker { m_lock };
+    auto requestedPixelFormat = flags.contains(BitmapTexture::Flags::UseBGRALayout) ? PixelFormat::BGRA8 : PixelFormat::RGBA8;
     Entry* selectedEntry = std::find_if(m_textures.begin(), m_textures.end(), [&](Entry& entry) {
         return entry.texture->refCount() == 1
             && entry.texture->size() == size
@@ -80,7 +81,7 @@ Ref<BitmapTexture> BitmapTexturePool::acquireTexture(const IntSize& size, Option
             && entry.texture->flags().contains(BitmapTexture::Flags::ForceLinearBuffer) == flags.contains(BitmapTexture::Flags::ForceLinearBuffer)
             && entry.texture->flags().contains(BitmapTexture::Flags::ForceVivanteSuperTiledBuffer) == flags.contains(BitmapTexture::Flags::ForceVivanteSuperTiledBuffer)
 #endif
-            && entry.texture->flags().contains(BitmapTexture::Flags::UseBGRALayout) == flags.contains(BitmapTexture::Flags::UseBGRALayout)
+            && entry.texture->pixelFormat() == requestedPixelFormat
             && entry.texture->flags().contains(BitmapTexture::Flags::DepthBuffer) == flags.contains(BitmapTexture::Flags::DepthBuffer)
             && entry.texture->flags().contains(BitmapTexture::Flags::NearestFiltering) == flags.contains(BitmapTexture::Flags::NearestFiltering);
     });

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBuffer.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBuffer.h
@@ -67,6 +67,8 @@ public:
 
 #if USE(SKIA)
     virtual sk_sp<SkImage> skiaImage() { return nullptr; }
+
+    virtual bool needsBGRAToRGBASwap() const { return false; }
 #endif
 
 protected:

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.cpp
@@ -129,12 +129,20 @@ bool CoordinatedPlatformLayerBufferNativeImage::tryEnsureBuffer(UseSkiaForCompos
     if (useSkiaForCompositing == UseSkiaForCompositing::Yes) {
         auto& display = PlatformDisplay::sharedDisplay();
         GLContext::ScopedGLContextCurrent scopedCurrent(*display.skiaGLContext());
+
+        // Use BGRA storage only when the GL extension is available and the
+        // source pixmap is already BGRA. Otherwise fall back to RGBA - Skia's
+        // writePixels handles any channel-order conversion during upload.
+        auto* glContext = GLContext::current();
+        const bool useBGRA = glContext && glContext->glExtensions().EXT_texture_format_BGRA8888 && image->imageInfo().colorType() == kBGRA_8888_SkColorType;
+        const SkColorType surfaceColorType = useBGRA ? kBGRA_8888_SkColorType : kRGBA_8888_SkColorType;
+
         GrGLTextureInfo externalTexture;
         externalTexture.fTarget = GL_TEXTURE_2D;
         externalTexture.fID = texture->id();
-        externalTexture.fFormat = image->imageInfo().colorType() == kRGBA_8888_SkColorType ? GL_RGBA8 : GL_BGRA8_EXT;
+        externalTexture.fFormat = useBGRA ? GL_BGRA8_EXT : GL_RGBA8;
         auto backendTexture = GrBackendTextures::MakeGL(texture->size().width(), texture->size().height(), skgpu::Mipmapped::kNo, externalTexture);
-        auto surface = SkSurfaces::WrapBackendTexture(display.skiaGrContext(), backendTexture, kTopLeft_GrSurfaceOrigin, 0, image->imageInfo().colorType(), SkColorSpace::MakeSRGB(), nullptr);
+        auto surface = SkSurfaces::WrapBackendTexture(display.skiaGrContext(), backendTexture, kTopLeft_GrSurfaceOrigin, 0, surfaceColorType, SkColorSpace::MakeSRGB(), nullptr);
         if (!surface)
             return false;
 
@@ -166,6 +174,11 @@ sk_sp<SkImage> CoordinatedPlatformLayerBufferNativeImage::skiaImage()
         return nullptr;
 
     return m_buffer->skiaImage();
+}
+
+bool CoordinatedPlatformLayerBufferNativeImage::needsBGRAToRGBASwap() const
+{
+    return m_buffer && m_buffer->needsBGRAToRGBASwap();
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.h
@@ -45,6 +45,7 @@ private:
 
 #if USE(SKIA)
     sk_sp<SkImage> skiaImage() override;
+    bool needsBGRAToRGBASwap() const override;
 #endif
 
     enum class UseSkiaForCompositing : bool { No, Yes };

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.cpp
@@ -85,8 +85,6 @@ sk_sp<SkImage> CoordinatedPlatformLayerBufferRGB::skiaImage()
 {
     waitForContentsIfNeeded();
 
-    ASSERT(!m_texture || !m_texture->colorConvertFlags().contains(TextureMapperFlags::ShouldConvertTextureBGRAToRGBA));
-
     auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
     ASSERT(grContext);
     GrGLTextureInfo externalTexture;
@@ -96,6 +94,11 @@ sk_sp<SkImage> CoordinatedPlatformLayerBufferRGB::skiaImage()
     auto backendTexture = GrBackendTextures::MakeGL(m_size.width(), m_size.height(), skgpu::Mipmapped::kNo, externalTexture);
     auto origin = m_flags.contains(TextureMapperFlags::ShouldFlipTexture) ? kBottomLeft_GrSurfaceOrigin : kTopLeft_GrSurfaceOrigin;
     return SkImages::BorrowTextureFrom(grContext, backendTexture, origin, kRGBA_8888_SkColorType, kPremul_SkAlphaType, sRGBColorSpaceSingleton());
+}
+
+bool CoordinatedPlatformLayerBufferRGB::needsBGRAToRGBASwap() const
+{
+    return m_texture && m_texture->needsBGRAToRGBASwap();
 }
 #endif
 

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.h
@@ -47,6 +47,7 @@ private:
 
 #if USE(SKIA)
     sk_sp<SkImage> skiaImage() override;
+    bool needsBGRAToRGBASwap() const override;
 #endif
 
     RefPtr<BitmapTexture> m_texture;

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.cpp
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.cpp
@@ -304,6 +304,11 @@ sk_sp<SkImage> CoordinatedPlatformLayerBufferVideo::skiaImage()
 
     return nullptr;
 }
+
+bool CoordinatedPlatformLayerBufferVideo::needsBGRAToRGBASwap() const
+{
+    return m_buffer && m_buffer->needsBGRAToRGBASwap();
+}
 #endif
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.h
+++ b/Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.h
@@ -47,6 +47,7 @@ private:
 
 #if USE(SKIA)
     sk_sp<SkImage> skiaImage() override;
+    bool needsBGRAToRGBASwap() const override;
 #endif
 
     std::unique_ptr<CoordinatedPlatformLayerBuffer> createBufferIfNeeded(bool gstGLEnabled);


### PR DESCRIPTION
#### 42d6e73304bb6849b5f9da93f8091927af9b5807
<pre>
[GTK][WPE] Handle GL contexts without GL_EXT_texture_format_BGRA8888
<a href="https://bugs.webkit.org/show_bug.cgi?id=315316">https://bugs.webkit.org/show_bug.cgi?id=315316</a>

Reviewed by NOBODY (OOPS!).

On GL contexts lacking GL_EXT_texture_format_BGRA8888, BGRA cannot be used as
a texture&apos;s internal format. Sanitize UseBGRALayout out of BitmapTexture&apos;s
flags in that case so storage is allocated as GL_RGBA, while keeping
m_pixelFormat at BGRA8 to drive a draw-time R&lt;-&gt;B swap via SkColorFilter
at the compositor&apos;s paint sites (SkiaBackingStore tile loop and
SkiaCompositingLayer::paintSelf). The CoordinatedPlatformLayerBufferNativeImage
upload path now gates its BGRA Skia surface on both the extension&apos;s presence
and the source&apos;s colorType.

SkiaGPUAtlas::uploadImages always claimed PixelFormat::BGRA8 regardless of
the source rasterImage&apos;s actual colorType; it now converts the source pixels
to the atlas&apos;s storage byte order, falling back to a software readPixels only
when source and storage disagree.

* Source/WebCore/platform/graphics/ColorMatrix.h:
(WebCore::swapRedBlueMatrix):
* Source/WebCore/platform/graphics/egl/GLContext.cpp:
(WebCore::GLContext::glExtensions const):
* Source/WebCore/platform/graphics/egl/GLContext.h:
* Source/WebCore/platform/graphics/skia/SkiaBackingStore.cpp:
(WebCore::SkiaBackingStore::paintToCanvas):
(WebCore::SkiaBackingStore::needsBGRAToRGBASwap const):
* Source/WebCore/platform/graphics/skia/SkiaBackingStore.h:
* Source/WebCore/platform/graphics/skia/SkiaCompositingLayer.cpp:
(WebCore::SkiaCompositingLayer::paintSelf):
* Source/WebCore/platform/graphics/skia/SkiaGPUAtlas.cpp:
(WebCore::SkiaGPUAtlas::uploadImages):
* Source/WebCore/platform/graphics/skia/SkiaUtilities.cpp:
(WebCore::SkiaUtilities::composeFilterWithRedBlueSwap):
* Source/WebCore/platform/graphics/skia/SkiaUtilities.h:
* Source/WebCore/platform/graphics/texmap/BitmapTexture.cpp:
(WebCore::sanitizeFlagsForGLContext):
(WebCore::pixelFormatForFlags):
(WebCore::BitmapTexture::textureFormat const):
(WebCore::BitmapTexture::BitmapTexture):
(WebCore::BitmapTexture::reset):
(WebCore::BitmapTexture::needsBGRAToRGBASwap const):
* Source/WebCore/platform/graphics/texmap/BitmapTexture.h:
* Source/WebCore/platform/graphics/texmap/BitmapTexturePool.cpp:
(WebCore::BitmapTexturePool::acquireTexture):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBuffer.h:
(WebCore::CoordinatedPlatformLayerBuffer::needsBGRAToRGBASwap const):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.cpp:
(WebCore::CoordinatedPlatformLayerBufferNativeImage::tryEnsureBuffer):
(WebCore::CoordinatedPlatformLayerBufferNativeImage::needsBGRAToRGBASwap const):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferNativeImage.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.cpp:
(WebCore::CoordinatedPlatformLayerBufferRGB::skiaImage):
(WebCore::CoordinatedPlatformLayerBufferRGB::needsBGRAToRGBASwap const):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferRGB.h:
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.cpp:
(WebCore::CoordinatedPlatformLayerBufferVideo::needsBGRAToRGBASwap const):
* Source/WebCore/platform/graphics/texmap/coordinated/CoordinatedPlatformLayerBufferVideo.h:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/42d6e73304bb6849b5f9da93f8091927af9b5807

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163866 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37350 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30569 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172894 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121117 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165735 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37682 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37349 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127291 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89648 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166825 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29582 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147318 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107840 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28628 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27249 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20659 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138528 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25035 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175416 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28242 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26703 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135597 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37020 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31359 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135572 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37805 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146830 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99942 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30888 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23685 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36516 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109661 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36013 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1718 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36263 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36160 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->