### PR TITLE
REGRESSION(310189@main): Occasional UI process crash under DisplayLink callbacks (SwipeProgressTracker can fail to deregister from DisplayLink)

### DIFF
--- a/Source/WebKit/UIProcess/mac/SwipeProgressTrackerMac.h
+++ b/Source/WebKit/UIProcess/mac/SwipeProgressTrackerMac.h
@@ -35,6 +35,7 @@
 namespace WebKit {
 
 class WebBackForwardListItem;
+class WebProcessPool;
 
 class SwipeProgressTracker final : public DisplayLink::Client {
     WTF_MAKE_TZONE_ALLOCATED(SwipeProgressTracker);
@@ -88,6 +89,7 @@ private:
     WeakRef<ViewGestureController> m_viewGestureController;
     WeakRef<WebPageProxy> m_webPageProxy;
     WebPageProxyIdentifier m_pageIdentifier;
+    WeakPtr<WebProcessPool> m_processPool;
 };
 
 } // namespace WebKit

--- a/Source/WebKit/UIProcess/mac/SwipeProgressTrackerMac.mm
+++ b/Source/WebKit/UIProcess/mac/SwipeProgressTrackerMac.mm
@@ -59,6 +59,7 @@ SwipeProgressTracker::SwipeProgressTracker(WebPageProxy& webPageProxy, ViewGestu
     : m_viewGestureController(viewGestureController)
     , m_webPageProxy(webPageProxy)
     , m_pageIdentifier(webPageProxy.identifier())
+    , m_processPool(webPageProxy.configuration().processPool())
 {
 }
 
@@ -251,14 +252,9 @@ void SwipeProgressTracker::stopDisplayLinkObserver()
     if (!m_displayLinkObserverID)
         return;
 
-    RefPtr page = m_webPageProxy.get();
-    if (!page) {
-        m_displayLinkObserverID = std::nullopt;
-        return;
-    }
+    if (RefPtr processPool = m_processPool.get())
+        processPool->displayLinks().stopDisplayLinks(*this);
 
-    auto displayID = page->displayID().value_or(0);
-    page->configuration().processPool().displayLinks().stopDisplayLink(*this, *m_displayLinkObserverID, displayID);
     m_displayLinkObserverID = std::nullopt;
 }
 


### PR DESCRIPTION
#### 63ac45d3bc31b8703a439422e2070ff5d7ec57c5
<pre>
REGRESSION(310189@main): Occasional UI process crash under DisplayLink callbacks (SwipeProgressTracker can fail to deregister from DisplayLink)
<a href="https://bugs.webkit.org/show_bug.cgi?id=315317">https://bugs.webkit.org/show_bug.cgi?id=315317</a>
<a href="https://rdar.apple.com/177623797">rdar://177623797</a>

Reviewed by Tim Horton.

Each DisplayLink::Client is responsible for removing its own entry from
the DisplayLinkCollection map before destruction. Ohterwise, subsequent
CVDisplayLink callbacks will perform a UAF on these stale client objects.

SwipeProgressTracker::stopDisplayLinkObserver previously called
stopDisplayLink (keyed by display ID). Some code analysis suggests there
are two paths where we don&apos;t actually remove this client from the map:

1. The WebPageProxy weak ref deref&apos;d to null.
2. The window crossed displays between start and end of the display link
   observer. existingDisplayLinkForDisplay returns a different (or null)
   DisplayLink, then.

In this patch, we take inspiration from WebProcessProxy, and cache the
WebProcessPool weakly at SwipeProgressTracker construction, so that
deregistration does not depend on WebPageProxy still being alive, and
swithces stopDisplayLinkObserver to the stopDisplayLinks, instead, which
walks every DisplayLink and removes the client unconditionally.

No new tests, unfortunately, since the existing swipe testing helpers
bypass startAnimation, so never register a DisplayLink::Client. We
should write a follow-up patch that adds the necessary harness and a
regression test.

* Source/WebKit/UIProcess/mac/SwipeProgressTrackerMac.h:
* Source/WebKit/UIProcess/mac/SwipeProgressTrackerMac.mm:
(WebKit::SwipeProgressTracker::SwipeProgressTracker):
(WebKit::SwipeProgressTracker::stopDisplayLinkObserver):

Canonical link: <a href="https://commits.webkit.org/313698@main">https://commits.webkit.org/313698@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7c0e243ba82e9a9b0603ac2017756d1e73330dff

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163871 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37355 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30574 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172899 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/66eea3e1-50d3-4839-b6cf-be3fb85e04d8) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37687 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37354 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127294 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121122 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a3a8a2a4-d0d0-4928-822a-587f4578fb57) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166830 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29578 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147313 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107843 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b397bf43-9379-4480-80b4-b6b6a06d8e64) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28624 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27250 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20664 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138524 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175421 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28247 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26698 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135601 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37025 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31360 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135576 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37810 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146825 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99947 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24940 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30887 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23680 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36521 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109666 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36018 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1713 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36268 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36165 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->