### PR TITLE
REGRESSION(308209@main): Top and bottom fixed position elements flicker when rubber band scrolling

### DIFF
--- a/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm
@@ -3173,6 +3173,7 @@ static bool scrollViewCanScroll(UIScrollView *scrollView)
         _page->updateVisibleContentRectsLocally(*info);
         auto layoutViewport = _page->unconstrainedLayoutViewportRect();
         _page->adjustLayersForLayoutViewport(_page->unobscuredContentRect().location(), layoutViewport, _page->displayedContentScale());
+        [_contentView updateFixedClippingView:layoutViewport];
     }
 }
 

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h
@@ -104,6 +104,7 @@
 - (UIView *)_colorExtensionViewForTesting:(UIRectEdge)edge;
 
 @property (nonatomic, readonly) BOOL _hasPendingVisibleContentRectUpdateTimerForTesting;
+@property (nonatomic, readonly) CGRect _fixedClippingViewBoundsForTesting;
 
 @end
 

--- a/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
+++ b/Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm
@@ -553,6 +553,11 @@ static void dumpUIView(TextStream& ts, UIView *view, bool traverse)
     return _pendingInteractiveObscuredInsetsChangeTimer && _pendingInteractiveObscuredInsetsChangeTimer->isActive();
 }
 
+- (CGRect)_fixedClippingViewBoundsForTesting
+{
+    return [_contentView _fixedClippingViewBoundsForTesting];
+}
+
 @end
 
 #endif // PLATFORM(IOS_FAMILY)

--- a/Source/WebKit/UIProcess/ios/WKContentView.h
+++ b/Source/WebKit/UIProcess/ios/WKContentView.h
@@ -78,6 +78,9 @@ using LayerHostingContextID = uint32_t;
 
 - (void)didUpdateVisibleRect:(const WebKit::VisibleContentRectUpdateInfo &)visibleContentRectUpdateInfo sendEvenIfUnchanged:(BOOL)sendEvenIfUnchanged;
 
+- (void)updateFixedClippingView:(WebCore::FloatRect)fixedPositionRectForUI;
+- (CGRect)_fixedClippingViewBoundsForTesting;
+
 - (void)didFinishScrolling;
 - (void)didZoomToScale:(CGFloat)scale;
 - (void)willStartZoomOrScroll;

--- a/Source/WebKit/UIProcess/ios/WKContentView.mm
+++ b/Source/WebKit/UIProcess/ios/WKContentView.mm
@@ -611,6 +611,11 @@ typedef NS_ENUM(NSInteger, _WKPrintRenderingCallbackType) {
     [_rootContentView setBounds:clippingBounds];
 }
 
+- (CGRect)_fixedClippingViewBoundsForTesting
+{
+    return [_fixedClippingView bounds];
+}
+
 - (void)_didExitStableState
 {
     _needsDeferredEndScrollingSelectionUpdate = self.shouldHideSelectionInFixedPositionWhenScrolling;

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WKScrollViewTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WKScrollViewTests.mm
@@ -1307,6 +1307,45 @@ TEST(WKScrollViewTests, FixedLayerPositionDoesNotFreezeDuringInteractiveObscured
     EXPECT_LE(maxDeviation, 2);
 }
 
+TEST(WKScrollViewTests, FixedClippingViewTracksRubberBandDuringInteractiveObscuredInsetsChange)
+{
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:CGRectMake(0, 0, 400, 800)]);
+
+    auto insets = UIEdgeInsetsMake(50, 0, 0, 0);
+    [webView _setObscuredInsets:insets];
+    RetainPtr scrollView = [webView scrollView];
+    [scrollView setContentInsetAdjustmentBehavior:UIScrollViewContentInsetAdjustmentNever];
+    [scrollView setContentInset:insets];
+
+    [webView synchronouslyLoadTestPageNamed:@"simple-tall"];
+    [webView waitForNextPresentationUpdate];
+
+    // Park past home so the upcoming scroll is itself a rubber-band frame, not a mode transition.
+    [scrollView setContentOffset:CGPointMake(0, -100)];
+    [webView waitForNextVisibleContentRectUpdate];
+
+    [webView _beginInteractiveObscuredInsetsChange];
+
+    // Drive a deeper rubber-band scroll.
+    [scrollView setContentOffset:CGPointMake(0, -150)];
+    [webView waitForNextPresentationUpdate];
+
+    // The clip view's bounds origin should track the current unobscured content rect's Y
+    // (= scrollOffset.y + topInset = -100), even while updates to WebContent are throttled.
+    CGRect clipBounds = [webView _fixedClippingViewBoundsForTesting];
+    EXPECT_NEAR(clipBounds.origin.y, -100.0, 1.0);
+
+    // Drive another rubber-band step within the visible content rect throttle window to confirm we keep
+    // updating the clip rect frame-to-frame, not only on the first throttled frame.
+    [scrollView setContentOffset:CGPointMake(0, -200)];
+    [webView waitForNextPresentationUpdate];
+
+    clipBounds = [webView _fixedClippingViewBoundsForTesting];
+    EXPECT_NEAR(clipBounds.origin.y, -150.0, 1.0);
+
+    [webView _endInteractiveObscuredInsetsChange];
+}
+
 } // namespace TestWebKitAPI
 
 #endif // PLATFORM(IOS_FAMILY)


### PR DESCRIPTION
#### 13e748d81951d3ddbec66cd496c6cd47fe772117
<pre>
REGRESSION(308209@main): Top and bottom fixed position elements flicker when rubber band scrolling
<a href="https://bugs.webkit.org/show_bug.cgi?id=315320">https://bugs.webkit.org/show_bug.cgi?id=315320</a>
<a href="https://rdar.apple.com/176226179">rdar://176226179</a>

Reviewed by Tim Horton.

When we throttle visible content rect updates to the WebContent process, we will still update layer positions and
scrolling tree state in the UI process. However, we were missing one change that the full unthrottled path does which
is to update the WKContentView&apos;s fixed clipping view bounds. Stale data here leads to fixed positioned elements flickering
when doing a rubber band scroll while changing obscured insets interactively in iOS Safari.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WKScrollViewTests.mm

* Source/WebKit/UIProcess/API/ios/WKWebViewIOS.mm:
(-[WKWebView _updateViewportRelativeLayersOutOfBand]):
* Source/WebKit/UIProcess/API/ios/WKWebViewPrivateForTestingIOS.h:
* Source/WebKit/UIProcess/API/ios/WKWebViewTestingIOS.mm:
(-[WKWebView _fixedClippingViewBoundsForTesting]):
* Source/WebKit/UIProcess/ios/WKContentView.h:
* Source/WebKit/UIProcess/ios/WKContentView.mm:
(-[WKContentView _fixedClippingViewBoundsForTesting]):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/ios/WKScrollViewTests.mm:
(TestWebKitAPI::(WKScrollViewTests, FixedClippingViewTracksRubberBandDuringInteractiveObscuredInsetsChange)):

Canonical link: <a href="https://commits.webkit.org/313759@main">https://commits.webkit.org/313759@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/1c68b54d7395779f9c1456d8f29ea21a9492d4bf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163874 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37358 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30577 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172902 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/20f74c2d-53b3-44d1-b6e5-30176983fbd2) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165743 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37690 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37357 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127298 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121125 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4c664a58-d74a-494f-bc15-9bcf18cace45) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166833 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29586 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147321 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107847 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/80fd25f1-d1fe-4921-aaf6-7b735baf7332) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28632 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27253 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20667 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138532 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25038 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175424 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28250 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26706 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135605 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37028 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31363 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135580 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36576 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37813 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146833 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99950 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30893 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23688 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36524 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109669 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36021 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1723 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36271 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36168 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->