### PR TITLE
[Tools][SDK] Improve container SDK warnings

### DIFF
--- a/Tools/Scripts/webkitpy/port/linux_container_sdk_utils.py
+++ b/Tools/Scripts/webkitpy/port/linux_container_sdk_utils.py
@@ -93,16 +93,6 @@ def _env_var_should_be_forwarded(name):
     return False
 
 
-def _print_prominent_warning(lines):
-    bar = '=' * 78
-    print('', file=sys.stderr)
-    print(bar, file=sys.stderr)
-    for line in lines:
-        print(line, file=sys.stderr)
-    print(bar, file=sys.stderr)
-    print('', file=sys.stderr)
-
-
 def _read_first_line_of(path):
     try:
         with open(path, 'r') as f:
@@ -114,6 +104,21 @@ def _read_first_line_of(path):
 def _read_running_sdk_version():
     # Set by the wkdev-sdk Containerfile (`RUN echo "${WKDEV_SDK_VERSION}" > /etc/wkdev-sdk-version`).
     return _read_first_line_of('/etc/wkdev-sdk-version')
+
+
+def _read_container_name():
+    """Return the podman --name of the current container, or None.
+
+    podman writes /run/.containerenv inside every container it spawns; the
+    `name=` line holds the value passed to `podman run --name`."""
+    try:
+        with open('/run/.containerenv', 'r') as f:
+            for line in f:
+                if line.startswith('name='):
+                    return line.split('=', 1)[1].strip().strip('"') or None
+    except OSError:
+        pass
+    return None
 
 
 def _source_dir():
@@ -465,14 +470,13 @@ def maybe_enter_webkit_container_sdk(argv=None):
     if os.environ.get('WEBKIT_CONTAINER_SDK') == '1':
         running_version = _read_running_sdk_version()
         if running_version and running_version != pinned_version:
-            _print_prominent_warning([
-                'WARNING: WebKit Container SDK version mismatch.',
-                '         Running container SDK version: {}'.format(running_version),
-                '         Pinned by .wkdev-sdk-version:  {}'.format(pinned_version),
-                '         Re-run any wrapper script (build-webkit, run-webkit-tests, ...)',
-                '         from the host to launch a fresh container at the pinned version.',
-                '         Continuing with the current container.',
-            ])
+            container_name = _read_container_name() or 'wkdev'
+            print(
+                'WARNING: WebKit Container SDK version mismatch ({} running, {} pinned). '
+                'Run `wkdev-update {}` on the host and re-enter to update.'.format(
+                    running_version, pinned_version, container_name),
+                file=sys.stderr,
+            )
         return
 
     # Auto-enter is opt-in: bots and users flip it on via the environment.
@@ -486,12 +490,11 @@ def maybe_enter_webkit_container_sdk(argv=None):
 
     # Host side: podman is the only prerequisite.
     if not shutil.which('podman'):
-        _print_prominent_warning([
-            "WARNING: 'podman' was not found on $PATH.",
-            '         WebKit Container SDK auto-launch is disabled; continuing on the host.',
-            '         Builds and tests may not work correctly outside the SDK.',
-            '         See {}'.format(WEBKIT_CONTAINER_SDK_DOCS_URL),
-        ])
+        print(
+            "WARNING: 'podman' not found on $PATH; WebKit Container SDK auto-launch disabled, "
+            "continuing on the host (see {}).".format(WEBKIT_CONTAINER_SDK_DOCS_URL),
+            file=sys.stderr,
+        )
         return
 
     # Container-internal home is bind-mounted from a host directory that must


### PR DESCRIPTION
#### f5e15c2944d771e77f207a3a95bb27321198a454
<pre>
[Tools][SDK] Improve container SDK warnings
<a href="https://bugs.webkit.org/show_bug.cgi?id=315321">https://bugs.webkit.org/show_bug.cgi?id=315321</a>

Reviewed by Carlos Alberto Lopez Perez.

The in-SDK version mismatch warning told users to re-run wrapper
scripts from the host, but the regular wkdev SDK container is
non-ephemeral and needs updates via `wkdev-update &lt;container?&gt;`.
Replace with a single-line warning carrying the correct command
picking up the container&apos;s name from /run/.containerenv. Apply
the same one-line treatment to the host-side podman-missing
warning.

* Tools/Scripts/webkitpy/port/linux_container_sdk_utils.py:
(_env_var_should_be_forwarded):
(_read_container_name):
(maybe_enter_webkit_container_sdk):
(_print_prominent_warning): Deleted.

Canonical link: <a href="https://commits.webkit.org/313690@main">https://commits.webkit.org/313690@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f945491c2e9084c45253eade8549da33d0663bfc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163878 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37362 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/30581 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172906 "Failed to checkout and rebase branch from PR 65436") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165747 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37694 "Built successfully") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/37361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/172906 "Failed to checkout and rebase branch from PR 65436") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121129 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166837 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/29587 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/147323 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/172906 "Failed to checkout and rebase branch from PR 65436") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/163199 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28633 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/37361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20671 "Failed to checkout and rebase branch from PR 65436") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/138533 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/25040 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175428 "Failed to checkout and rebase branch from PR 65436") | 
| | | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/26708 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/175428 "Failed to checkout and rebase branch from PR 65436") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37032 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/37361 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/175428 "Failed to checkout and rebase branch from PR 65436") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37817 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/146835 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99956 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24937 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/30895 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/23690 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36528 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36025 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/1727 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36275 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36172 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->