### PR TITLE
Web Inspector: Style sheets created via CSSOM (ex: adoptedStyleSheets) are marked as "User Agent Style Sheet" and not editable in Styles sidebar

### DIFF
--- a/LayoutTests/inspector/css/getMatchedStylesForNodeAdoptedStyleSheet-expected.txt
+++ b/LayoutTests/inspector/css/getMatchedStylesForNodeAdoptedStyleSheet-expected.txt
@@ -1,0 +1,5 @@
+Testing that rules from a constructable CSSStyleSheet attached via document.adoptedStyleSheets are reported with Author origin (not User Agent), so they appear editable in the Web Inspector. Tracking bug.
+
+PASS: Should have a rule matching "div#target".
+PASS: Adopted stylesheet rule should have "author" origin, not "user-agent".
+

--- a/LayoutTests/inspector/css/getMatchedStylesForNodeAdoptedStyleSheet.html
+++ b/LayoutTests/inspector/css/getMatchedStylesForNodeAdoptedStyleSheet.html
@@ -1,0 +1,64 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../http/tests/inspector/resources/protocol-test.js"></script>
+<script>
+const sheet = new CSSStyleSheet();
+sheet.replaceSync(`div#target { background: steelblue; height: 100px; }`);
+document.adoptedStyleSheets = [sheet];
+
+async function test()
+{
+    try {
+        await InspectorProtocol.awaitCommand({
+            method: "Page.enable",
+            params: {},
+        });
+
+        let {root} = await InspectorProtocol.awaitCommand({
+            method: "DOM.getDocument",
+            params: {},
+        });
+
+        let {nodeId} = await InspectorProtocol.awaitCommand({
+            method: "DOM.querySelector",
+            params: {
+                nodeId: root.nodeId,
+                selector: "div#target",
+            },
+        });
+
+        let {matchedCSSRules} = await InspectorProtocol.awaitCommand({
+            method: "CSS.getMatchedStylesForNode",
+            params: {
+                nodeId,
+                includePseudo: false,
+                includeInherited: false,
+            },
+        });
+
+        let adoptedRule = null;
+        for (let ruleMatch of matchedCSSRules) {
+            const selector = ruleMatch.rule.selectorList ? ruleMatch.rule.selectorList.text : "";
+            if (selector === "div#target") {
+                adoptedRule = ruleMatch.rule;
+                break;
+            }
+        }
+
+        ProtocolTest.expectThat(!!adoptedRule, "Should have a rule matching \"div#target\".");
+        if (adoptedRule)
+            ProtocolTest.expectEqual(adoptedRule.origin, "author", "Adopted stylesheet rule should have \"author\" origin, not \"user-agent\".");
+    } catch (error) {
+        ProtocolTest.log(error);
+    } finally {
+        ProtocolTest.completeTest();
+    }
+}
+</script>
+</head>
+<body onLoad="runTest()">
+<p>Testing that rules from a constructable CSSStyleSheet attached via document.adoptedStyleSheets are reported with Author origin (not User Agent), so they appear editable in the Web Inspector. <a href="https://bugs.webkit.org/show_bug.cgi?id=277893">Tracking bug</a>.</p>
+<div id="target"></div>
+</body>
+</html>

--- a/LayoutTests/platform/mac-site-isolation/TestExpectations
+++ b/LayoutTests/platform/mac-site-isolation/TestExpectations
@@ -448,3 +448,7 @@ http/tests/security/frameNavigation/not-opener.html [ Failure ]
 # This test has different output with site isolation enabled. A copy with site isolation enabled is
 # stored and run separately at http/tests/site-isolation/inspector/unit-tests/target-manager.html.
 inspector/unit-tests/target-manager.html [ Skip ]
+
+# Inspector protocol commands (e.g. CSS.getMatchedStylesForNode) return
+# "Not yet implemented for frame targets" under site isolation.
+inspector/css/getMatchedStylesForNodeAdoptedStyleSheet.html [ Skip ]

--- a/Source/WebCore/inspector/InspectorStyleSheet.cpp
+++ b/Source/WebCore/inspector/InspectorStyleSheet.cpp
@@ -1679,14 +1679,18 @@ bool InspectorStyleSheet::ensureText()
         return true;
 
     String text;
-    if (m_pageStyleSheet->wasMutated()) {
-        // This style sheet in memory no longer matches its original text from static source.
-        // Reconstruct its current text by serializing the contained CSSRules.
+    bool wasMutated = m_pageStyleSheet->wasMutated();
+    if (wasMutated || m_pageStyleSheet->wasConstructedByJS()) {
+        // A mutated stylesheet's in-memory rules no longer match its original source text.
+        // A constructable stylesheet (e.g. `new CSSStyleSheet()` populated by `replaceSync()`)
+        // has no underlying source at all. In both cases, reconstruct text by serializing
+        // the contained CSSRules so the inspector has source ranges to work with.
         if (!styleSheetTextFromCSSRuleSerialization(&text))
             return false;
 
         m_parsedStyleSheet->setText(text);
-        fireStyleSheetChanged();
+        if (wasMutated)
+            fireStyleSheetChanged();
         return true;
     }
 

--- a/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
+++ b/Source/WebCore/inspector/agents/InspectorCSSAgent.cpp
@@ -1333,11 +1333,19 @@ Inspector::Protocol::CSS::StyleSheetOrigin InspectorCSSAgent::detectOrigin(CSSSt
     if (m_creatingViaInspectorStyleSheet)
         return Inspector::Protocol::CSS::StyleSheetOrigin::Inspector;
 
-    if (pageStyleSheet && !pageStyleSheet->ownerNode() && pageStyleSheet->href().isEmpty())
-        return Inspector::Protocol::CSS::StyleSheetOrigin::UserAgent;
+    if (pageStyleSheet) {
+        // Constructable stylesheets (`new CSSStyleSheet()`, used via `adoptedStyleSheets`)
+        // have no owner node and no href, so guard against them before applying the
+        // ownerNode/href heuristic for user-agent stylesheets.
+        if (pageStyleSheet->wasConstructedByJS())
+            return Inspector::Protocol::CSS::StyleSheetOrigin::Author;
 
-    if (pageStyleSheet && pageStyleSheet->contents().isUserStyleSheet())
-        return Inspector::Protocol::CSS::StyleSheetOrigin::User;
+        if (!pageStyleSheet->ownerNode() && pageStyleSheet->href().isEmpty())
+            return Inspector::Protocol::CSS::StyleSheetOrigin::UserAgent;
+
+        if (pageStyleSheet->contents().isUserStyleSheet())
+            return Inspector::Protocol::CSS::StyleSheetOrigin::User;
+    }
 
     if (!ownerDocument)
         return Inspector::Protocol::CSS::StyleSheetOrigin::Author;


### PR DESCRIPTION
#### 1b4889fc81b5295780350e6310ff46eae5efdf4d
<pre>
Web Inspector: Style sheets created via CSSOM (ex: adoptedStyleSheets) are marked as &quot;User Agent Style Sheet&quot; and not editable in Styles sidebar
<a href="https://bugs.webkit.org/show_bug.cgi?id=277893">https://bugs.webkit.org/show_bug.cgi?id=277893</a>
<a href="https://rdar.apple.com/134101594">rdar://134101594</a>

Reviewed by Devin Rousso.

Constructable CSSStyleSheets (`new CSSStyleSheet()` adopted via
`document.adoptedStyleSheets`) have no owner node and no href, so
InspectorCSSAgent::detectOrigin() misclassified them as User Agent
stylesheets. The frontend then rendered their rules as locked /
uneditable.

Even after correcting the origin to Author, clicking to edit a
property crashed in CSSStyleDeclaration._rangeAfterPropertyAtIndex
because constructable sheets have no underlying source text, so
InspectorStyleSheet::ensureText() returned false and rule source
ranges never populated.

* Source/WebCore/inspector/agents/InspectorCSSAgent.cpp:
(WebCore::InspectorCSSAgent::detectOrigin): Classify constructable
stylesheets as Author before the no-owner/no-href UA heuristic.

* Source/WebCore/inspector/InspectorStyleSheet.cpp:
(WebCore::InspectorStyleSheet::ensureText): Synthesize text by
serializing in-memory CSSRules for constructable stylesheets, the
same path already used for mutated stylesheets.

* LayoutTests/inspector/css/getMatchedStylesForNodeAdoptedStyleSheet.html: Added.
* LayoutTests/inspector/css/getMatchedStylesForNodeAdoptedStyleSheet-expected.txt: Added.

* LayoutTests/platform/mac-site-isolation/TestExpectations: Skip the new
test under site isolation, where inspector protocol commands return
&quot;Not yet implemented for frame targets&quot;.

Canonical link: <a href="https://commits.webkit.org/313738@main">https://commits.webkit.org/313738@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b9a45a2bacd94769d8e9a53053592c085dc96492

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163956 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37440 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30659 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172985 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165825 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37772 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37440 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127370 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121207 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166915 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29653 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147400 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107918 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28699 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27320 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20749 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138600 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25117 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175510 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28332 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26785 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135680 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37110 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31432 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135652 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36560 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37895 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146912 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100058 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30952 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23768 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36704 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109751 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36103 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1808 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36353 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36250 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->