### PR TITLE
[check-webkit-style] WPT linter failures from -expected.html files

### DIFF
--- a/Tools/Scripts/webkitpy/style/checker.py
+++ b/Tools/Scripts/webkitpy/style/checker.py
@@ -463,7 +463,8 @@ _PATH_RULES_SPECIFIER = [
      ['-wpt/lint']),
 
     ([  # WebKit's expectations.
-      '-expected.txt'],
+      '-expected.',
+      '-expected-mismatch.'],
      ['-wpt/lint']),
 
     ([  # Dummy .html files generated from .any.js templates by

--- a/Tools/Scripts/webkitpy/style/checker_unittest.py
+++ b/Tools/Scripts/webkitpy/style/checker_unittest.py
@@ -256,6 +256,14 @@ class GlobalVariablesTest(unittest.TestCase):
         assertNoCheck(os.path.join('Source', 'WebCore', 'PAL', 'pal', 'spi'),
                       "readability/naming/underscores")
 
+        # WebKit expected results inside the WPT tree should not be wpt-linted.
+        wpt_base = os.path.join('LayoutTests', 'imported', 'w3c', 'web-platform-tests')
+        assertCheck(os.path.join(wpt_base, 'css', 'foo.html'), 'wpt/lint')
+        assertNoCheck(os.path.join(wpt_base, 'css', 'foo-expected.txt'), 'wpt/lint')
+        assertNoCheck(os.path.join(wpt_base, 'css', 'foo-expected.html'), 'wpt/lint')
+        assertNoCheck(os.path.join(wpt_base, 'css', 'foo-expected.png'), 'wpt/lint')
+        assertNoCheck(os.path.join(wpt_base, 'css', 'foo-expected-mismatch.html'), 'wpt/lint')
+
     def test_max_reports_per_category(self):
         """Check that _MAX_REPORTS_PER_CATEGORY is valid."""
         all_categories = self._all_categories()


### PR DESCRIPTION
#### 4020cd7adc69397afe64c7415ceea5c5c44a1c13
<pre>
[check-webkit-style] WPT linter failures from -expected.html files
<a href="https://bugs.webkit.org/show_bug.cgi?id=315318">https://bugs.webkit.org/show_bug.cgi?id=315318</a>
<a href="https://rdar.apple.com/177649888">rdar://177649888</a>

Reviewed by Anne van Kesteren.

We should be ignoring all expected files, not just the txt ones.

* Tools/Scripts/webkitpy/style/checker.py:
* Tools/Scripts/webkitpy/style/checker_unittest.py:
(GlobalVariablesTest.test_path_rules_specifier):

Canonical link: <a href="https://commits.webkit.org/313711@main">https://commits.webkit.org/313711@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/521a67424e45af729042bb9ac33853879e45abe8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163900 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37384 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30603 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172928 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165769 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37716 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37384 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127320 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121151 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166859 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29607 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147337 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107869 "Passed tests") | | ⏳ 🛠 vision-apple 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/163221 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28653 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27272 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20693 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138553 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25054 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175450 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26722 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135627 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37054 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31383 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135602 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37839 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146849 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/99991 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24949 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30916 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23704 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36590 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36047 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1741 "Passed tests") | | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36297 "Hash 521a6742 for PR 65443 does not build (failure)") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36194 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->