### PR TITLE
[Safer CPP] Address issues in BitmapImage source files

### DIFF
--- a/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations
@@ -454,8 +454,6 @@ platform/animation/AcceleratedEffectValues.cpp
 platform/cocoa/PlaybackSessionModelMediaElement.mm
 platform/cocoa/VideoPresentationModelVideoElement.mm
 platform/encryptedmedia/CDMProxy.h
-platform/graphics/BitmapImage.cpp
-platform/graphics/BitmapImageSource.cpp
 platform/graphics/DisplayRefreshMonitorManager.h
 platform/graphics/FontCache.cpp
 platform/graphics/FontRanges.cpp

--- a/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
+++ b/Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations
@@ -46,7 +46,6 @@ platform/cocoa/SearchPopupMenuCocoa.mm
 platform/cocoa/UserAgentCocoa.mm
 platform/cocoa/WebAVPlayerLayer.mm
 [ Mac ] platform/gamepad/mac/HIDGamepadElement.cpp
-platform/graphics/BitmapImageDescriptor.cpp
 platform/graphics/avfoundation/AVTrackPrivateAVFObjCImpl.mm
 platform/graphics/avfoundation/AudioSourceProviderAVFObjC.mm
 platform/graphics/avfoundation/FormatDescriptionUtilities.cpp

--- a/Source/WebCore/platform/graphics/BitmapImage.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImage.cpp
@@ -71,12 +71,12 @@ BitmapImage::BitmapImage(Ref<NativeImage>&& image)
 
 EncodedDataStatus BitmapImage::dataChanged(bool allDataReceived)
 {
-    return m_source->dataChanged(data(), allDataReceived);
+    return m_source->dataChanged(protect(data()), allDataReceived);
 }
 
 void BitmapImage::dataReplaced()
 {
-    return m_source->dataReplaced(data());
+    return m_source->dataReplaced(protect(data()));
 }
 
 void BitmapImage::destroyDecodedData(bool destroyAll)

--- a/Source/WebCore/platform/graphics/BitmapImageDescriptor.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImageDescriptor.cpp
@@ -262,7 +262,7 @@ SubsamplingLevel BitmapImageDescriptor::subsamplingLevelForScaleFactor(GraphicsC
         return SubsamplingLevel::Default;
 
     // Never use subsampled images for drawing into PDF contexts.
-    if (context.hasPlatformContext() && CGContextGetType(context.platformContext()) == kCGContextTypePDF)
+    if (context.hasPlatformContext() && CGContextGetType(protect(context.platformContext())) == kCGContextTypePDF)
         return SubsamplingLevel::Default;
 
     float scale = std::min(float(1), std::max(scaleFactor.width(), scaleFactor.height()));

--- a/Source/WebCore/platform/graphics/BitmapImageSource.cpp
+++ b/Source/WebCore/platform/graphics/BitmapImageSource.cpp
@@ -64,13 +64,13 @@ ImageDecoder* BitmapImageSource::decoder(FragmentedSharedBuffer* data) const
     if (!m_decoder)
         return nullptr;
 
-    m_decoder->setEncodedDataStatusChangeCallback([weakThis = ThreadSafeWeakPtr { *this }] (auto status) {
+    protect(m_decoder)->setEncodedDataStatusChangeCallback([weakThis = ThreadSafeWeakPtr { *this }] (auto status) {
         if (RefPtr protectedThis = weakThis.get())
             protectedThis->encodedDataStatusChanged(status);
     });
 
     if (auto expectedContentLength = this->expectedContentLength())
-        m_decoder->setExpectedContentSize(expectedContentLength);
+        protect(m_decoder)->setExpectedContentSize(expectedContentLength);
 
     return m_decoder.get();
 }
@@ -103,10 +103,10 @@ void BitmapImageSource::encodedDataStatusChanged(EncodedDataStatus status)
     ASSERT(m_decoder);
 
     if (status >= EncodedDataStatus::SizeAvailable)
-        m_frames.resizeToFit(m_decoder->frameCount());
+        m_frames.resizeToFit(protect(m_decoder)->frameCount());
 
     if (auto imageObserver = this->imageObserver())
-        imageObserver->encodedDataStatusChanged(*m_bitmapImage, status);
+        imageObserver->encodedDataStatusChanged(protect(*m_bitmapImage), status);
 }
 
 EncodedDataStatus BitmapImageSource::dataChanged(FragmentedSharedBuffer* data, bool allDataReceived)
@@ -162,7 +162,7 @@ void BitmapImageSource::decodedSizeChanged(long long decodedSize)
         return;
 
     if (auto imageObserver = this->imageObserver())
-        imageObserver->decodedSizeChanged(*m_bitmapImage, decodedSize);
+        imageObserver->decodedSizeChanged(protect(*m_bitmapImage), decodedSize);
 }
 
 void BitmapImageSource::decodedSizeIncreased(unsigned decodedSize)
@@ -220,7 +220,7 @@ bool BitmapImageSource::canDestroyDecodedData() const
         return true;
 
     if (auto imageObserver = this->imageObserver())
-        return imageObserver->canDestroyDecodedData(*m_bitmapImage);
+        return imageObserver->canDestroyDecodedData(protect(*m_bitmapImage));
 
     return true;
 }
@@ -240,7 +240,7 @@ void BitmapImageSource::clearFrameBufferCache()
     if (!m_decoder)
         return;
 
-    m_decoder->clearFrameBufferCache(currentFrameIndex());
+    protect(m_decoder)->clearFrameBufferCache(currentFrameIndex());
 }
 
 EncodedDataStatus BitmapImageSource::setData(FragmentedSharedBuffer* data, bool allDataReceived)
@@ -262,7 +262,7 @@ void BitmapImageSource::resetData()
     m_decoder = nullptr;
 
     if (m_bitmapImage)
-        setData(m_bitmapImage->data(), m_allDataReceived);
+        setData(protect(m_bitmapImage->data()), m_allDataReceived);
 }
 
 void BitmapImageSource::dataReplaced(FragmentedSharedBuffer* data)
@@ -325,7 +325,7 @@ bool BitmapImageSource::isAnimationAllowed() const
 
     // ImageObserver may disallow animation.
     if (auto imageObserver = this->imageObserver())
-        return imageObserver->allowsAnimation(*m_bitmapImage);
+        return imageObserver->allowsAnimation(protect(*m_bitmapImage));
 
     return true;
 }
@@ -364,7 +364,7 @@ void BitmapImageSource::stopDecodingWorkQueue()
     if (!m_workQueue || !m_workQueue->isIdle())
         return;
 
-    m_workQueue->stop();
+    protect(m_workQueue)->stop();
 }
 
 bool BitmapImageSource::isPendingDecodingAtIndex(unsigned index, SubsamplingLevel subsamplingLevel, const DecodingOptions& options) const
@@ -372,7 +372,7 @@ bool BitmapImageSource::isPendingDecodingAtIndex(unsigned index, SubsamplingLeve
     if (!m_workQueue)
         return false;
 
-    return m_workQueue->isPendingDecodingAtIndex(index, subsamplingLevel, options);
+    return protect(m_workQueue)->isPendingDecodingAtIndex(index, subsamplingLevel, options);
 }
 
 std::optional<DecodingDestination> BitmapImageSource::compatibleDecodingDestinationWithOptionsAtIndex(unsigned index, SubsamplingLevel subsamplingLevel, const DecodingOptions& options) const
@@ -435,7 +435,7 @@ void BitmapImageSource::imageFrameAtIndexAvailable(unsigned index, ImageAnimatin
         return;
 
     if (auto imageObserver = this->imageObserver())
-        imageObserver->imageFrameAvailable(*m_bitmapImage, animatingState, nullptr, decodingStatus);
+        imageObserver->imageFrameAvailable(protect(*m_bitmapImage), animatingState, nullptr, decodingStatus);
 }
 
 void BitmapImageSource::imageFrameDecodeAtIndexHasFinished(unsigned index, ImageAnimatingState animatingState, DecodingStatus decodingStatus)
@@ -486,10 +486,10 @@ void BitmapImageSource::cacheMetadataAtIndex(unsigned index, SubsamplingLevel su
 
     auto& frame = m_frames[index];
 
-    m_decoder->fetchFrameMetaDataAtIndex(index, subsamplingLevel, options, frame);
+    protect(m_decoder)->fetchFrameMetaDataAtIndex(index, subsamplingLevel, options, frame);
 
     if (repetitionCount())
-        frame.m_duration = m_decoder->frameDurationAtIndex(index);
+        frame.m_duration = protect(m_decoder)->frameDurationAtIndex(index);
 }
 
 void BitmapImageSource::cacheNativeImageAtIndex(unsigned index, SubsamplingLevel subsamplingLevel, const DecodingOptions& options, Ref<NativeImage>&& nativeImage)
@@ -552,7 +552,7 @@ DecodingStatus BitmapImageSource::requestNativeImageAtIndex(unsigned index, Subs
 
     LOG(Images, "BitmapImageSource::%s - %p - url: %s. Decoding for frame at index = %d will be requested.", __FUNCTION__, this, sourceUTF8().data(), index);
 
-    workQueue().dispatch({ index, subsamplingLevel, animatingState, options });
+    protect(workQueue())->dispatch({ index, subsamplingLevel, animatingState, options });
 
     if (m_clearDecoderAfterAsyncFrameRequestForTesting)
         resetData();
@@ -602,7 +602,7 @@ Expected<Ref<NativeImage>, DecodingStatus> BitmapImageSource::nativeImageAtIndex
     else {
         auto decodingOptions = DecodingOptions { DecodingMode::Synchronous, decodingDestination };
 
-        auto result = m_decoder->createNativeImageAtIndex(index, subsamplingLevel, decodingOptions);
+        auto result = protect(m_decoder)->createNativeImageAtIndex(index, subsamplingLevel, decodingOptions);
         if (!result)
             return makeUnexpected(DecodingStatus::Invalid);
 
@@ -717,7 +717,7 @@ void BitmapImageSource::setHasHDRContentForTesting()
     m_hasHDRContentForTesting = true;
 
     if (auto imageObserver = this->imageObserver())
-        imageObserver->imageContentChanged(*m_bitmapImage);
+        imageObserver->imageContentChanged(protect(*m_bitmapImage));
 }
 
 DecodingStatus BitmapImageSource::frameDecodingStatusAtIndex(unsigned index) const
@@ -732,17 +732,17 @@ RefPtr<ImageObserver> BitmapImageSource::imageObserver() const
 
 String BitmapImageSource::mimeType() const
 {
-    return m_bitmapImage ? m_bitmapImage->mimeType() : emptyString();
+    return m_bitmapImage ? protect(m_bitmapImage)->mimeType() : emptyString();
 }
 
 long long BitmapImageSource::expectedContentLength() const
 {
-    return m_bitmapImage ? m_bitmapImage->expectedContentLength() : 0;
+    return m_bitmapImage ? protect(m_bitmapImage)->expectedContentLength() : 0;
 }
 
 CString BitmapImageSource::sourceUTF8() const
 {
-    return m_bitmapImage ? m_bitmapImage->sourceUTF8() : ""_s;
+    return m_bitmapImage ? protect(m_bitmapImage)->sourceUTF8() : ""_s;
 }
 
 void BitmapImageSource::setMinimumDecodingDurationForTesting(Seconds duration)
@@ -755,7 +755,7 @@ void BitmapImageSource::dump(TextStream& ts) const
     ts.dumpProperty("source-utf8"_s, sourceUTF8());
 
     if (m_workQueue)
-        m_workQueue->dump(ts);
+        protect(m_workQueue)->dump(ts);
 
     if (m_frameAnimator)
         m_frameAnimator->dump(ts);


### PR DESCRIPTION
#### 874b9082dbb66d9363933a1b396b354192df700d
<pre>
[Safer CPP] Address issues in BitmapImage source files
<a href="https://bugs.webkit.org/show_bug.cgi?id=315327">https://bugs.webkit.org/show_bug.cgi?id=315327</a>
<a href="https://rdar.apple.com/177668920">rdar://177668920</a>

Reviewed by NOBODY (OOPS!).

Address remaining SaferCPP issues in the following source files:
BitmapImage.cpp
BitmapImageDescriptor.cpp
BitmapImageSource.cpp

* Source/WebCore/SaferCPPExpectations/UncountedCallArgsCheckerExpectations:
* Source/WebCore/SaferCPPExpectations/UnretainedCallArgsCheckerExpectations:
* Source/WebCore/platform/graphics/BitmapImage.cpp:
(WebCore::BitmapImage::dataChanged):
(WebCore::BitmapImage::dataReplaced):
* Source/WebCore/platform/graphics/BitmapImageDescriptor.cpp:
(WebCore::BitmapImageDescriptor::subsamplingLevelForScaleFactor const):
* Source/WebCore/platform/graphics/BitmapImageSource.cpp:
(WebCore::BitmapImageSource::decoder const):
(WebCore::BitmapImageSource::encodedDataStatusChanged):
(WebCore::BitmapImageSource::decodedSizeChanged):
(WebCore::BitmapImageSource::canDestroyDecodedData const):
(WebCore::BitmapImageSource::clearFrameBufferCache):
(WebCore::BitmapImageSource::resetData):
(WebCore::BitmapImageSource::isAnimationAllowed const):
(WebCore::BitmapImageSource::stopDecodingWorkQueue):
(WebCore::BitmapImageSource::isPendingDecodingAtIndex const):
(WebCore::BitmapImageSource::imageFrameAtIndexAvailable):
(WebCore::BitmapImageSource::cacheMetadataAtIndex):
(WebCore::BitmapImageSource::requestNativeImageAtIndex):
(WebCore::BitmapImageSource::nativeImageAtIndexCacheIfNeeded):
(WebCore::BitmapImageSource::setHasHDRContentForTesting):
(WebCore::BitmapImageSource::mimeType const):
(WebCore::BitmapImageSource::expectedContentLength const):
(WebCore::BitmapImageSource::sourceUTF8 const):
(WebCore::BitmapImageSource::dump const):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/874b9082dbb66d9363933a1b396b354192df700d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164388 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37872 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31443 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173417 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121640 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ff7aa0eb-5521-4617-9708-272c158f5dbf) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166257 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38206 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37873 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127732 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89907 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9278911b-af81-44aa-bae7-9a8f689a5a58) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167347 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30024 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147759 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108277 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/be15d34c-ae54-4c27-ae10-8f65b7d23738) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29071 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27699 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21181 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138973 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25475 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175943 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28766 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27143 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136042 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37543 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31819 "Found 1 new test failure: http/tests/storage/storage-map-leaking.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136011 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38329 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147270 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100746 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31330 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24126 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37139 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110183 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36535 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2184 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36785 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36685 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->