### PR TITLE
[Build Speed] Prepare for larger unified build bundles

### DIFF
--- a/Source/JavaScriptCore/ftl/FTLLocation.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLocation.cpp
@@ -39,14 +39,14 @@ namespace JSC { namespace FTL {
 
 using namespace B3;
 
-Location Location::forValueRep(const ValueRep& rep)
+Location Location::forValueRep(const B3::ValueRep& rep)
 {
     switch (rep.kind()) {
-    case ValueRep::Register:
+    case B3::ValueRep::Register:
         return forRegister(rep.reg(), 0);
-    case ValueRep::Stack:
+    case B3::ValueRep::Stack:
         return forIndirect(GPRInfo::callFrameRegister, rep.offsetFromFP());
-    case ValueRep::Constant:
+    case B3::ValueRep::Constant:
         return forConstant(rep.value());
     default:
         RELEASE_ASSERT_NOT_REACHED();

--- a/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp
@@ -113,7 +113,7 @@ namespace JSC { namespace Wasm {
 using ErrorType = String;
 using PartialResult = Expected<void, ErrorType>;
 using UnexpectedResult = std::unexpected<ErrorType>;
-struct Value { };
+struct IPIntValue { };
 
 // ControlBlock
 
@@ -208,11 +208,11 @@ public:
     static constexpr bool shouldFuseBranchCompare = false;
 
     using ControlType = IPIntControlType;
-    using ExpressionType = Value;
+    using ExpressionType = IPIntValue;
     using CallType = CallLinkInfo::CallType;
-    using ResultList = Vector<Value, 8>;
+    using ResultList = Vector<IPIntValue, 8>;
 
-    using ExpressionList = Vector<Value, 1>;
+    using ExpressionList = Vector<IPIntValue, 1>;
     using ControlEntry = FunctionParser<IPIntGenerator>::ControlEntry;
     using ControlStack = FunctionParser<IPIntGenerator>::ControlStack;
     using Stack = FunctionParser<IPIntGenerator>::Stack;
@@ -238,7 +238,7 @@ public:
 
     [[nodiscard]] PartialResult addArguments(const RTT&);
     [[nodiscard]] PartialResult addLocal(Type, uint32_t);
-    Value addConstant(Type, uint64_t);
+    IPIntValue addConstant(Type, uint64_t);
 
     // SIMD
 
@@ -696,7 +696,7 @@ IPIntGenerator::IPIntGenerator(ModuleInformation& info, FunctionCodeIndex functi
     return { };
 }
 
-Value IPIntGenerator::addConstant(Type, uint64_t)
+IPIntValue IPIntGenerator::addConstant(Type, uint64_t)
 {
     changeStackSize(1);
     return { };
@@ -2421,7 +2421,7 @@ void IPIntGenerator::convertTryToCatch(ControlType& tryBlock, CatchKind catchKin
         convertTryToCatch(block, CatchKind::Catch);
 
     for (unsigned i = 0; i < signature.argumentCount(); i++)
-        results.append(Value { });
+        results.append(IPIntValue { });
 
     ASSERT(block.stackSize() == m_parser->getControlEntryStackHeightInValues());
     m_stackSize = block.stackSize();
@@ -2721,7 +2721,7 @@ void IPIntGenerator::endTryTable(const ControlType& data)
 {
     const auto& block = entry.controlData;
     for (unsigned i = 0; i < block.signature().returnCount(); i ++)
-        entry.enclosedExpressionStack.constructAndAppend(block.signature().returnType(i), Value { });
+        entry.enclosedExpressionStack.constructAndAppend(block.signature().returnType(i), IPIntValue { });
     m_stackSize = block.stackSize();
     changeStackSize(block.signature().returnCount());
 
@@ -2822,7 +2822,9 @@ void IPIntGenerator::addTailCallCommonData(const RTT&, const CallInformation& ca
         return { };
     }
 
-    results.appendUsingFunctor(signature.returnCount(), [](unsigned) { return Value { }; });
+    results.appendUsingFunctor(signature.returnCount(), [](unsigned) {
+        return IPIntValue { };
+    });
     changeStackSize(signature.returnCount() - signature.argumentCount());
 
     Checked<uint32_t> frameSize = WTF::roundUpToMultipleOf<stackAlignmentBytes()>(callConvention.headerAndArgumentStackSizeInBytes);
@@ -2870,7 +2872,9 @@ void IPIntGenerator::addTailCallCommonData(const RTT&, const CallInformation& ca
         return { };
     }
 
-    results.appendUsingFunctor(signature.returnCount(), [](unsigned) { return Value { }; });
+    results.appendUsingFunctor(signature.returnCount(), [](unsigned) {
+        return IPIntValue { };
+    });
     const unsigned callIndex = 1;
     changeStackSize(signature.returnCount() - signature.argumentCount() - callIndex);
 
@@ -2919,7 +2923,9 @@ void IPIntGenerator::addTailCallCommonData(const RTT&, const CallInformation& ca
         return { };
     }
 
-    results.appendUsingFunctor(signature.returnCount(), [](unsigned) { return Value { }; });
+    results.appendUsingFunctor(signature.returnCount(), [](unsigned) {
+        return IPIntValue { };
+    });
     const unsigned callRef = 1;
     changeStackSize(signature.returnCount() - signature.argumentCount() - callRef);
 

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUTextureImpl.cpp
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUTextureImpl.cpp
@@ -39,10 +39,8 @@ namespace WebCore::WebGPU {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(TextureImpl);
 
-TextureImpl::TextureImpl(WebGPUPtr<WGPUTexture>&& texture, TextureFormat format, TextureDimension dimension, ConvertToBackingContext& convertToBackingContext)
-    : m_format(format)
-    , m_dimension(dimension)
-    , m_backing(WTF::move(texture))
+TextureImpl::TextureImpl(WebGPUPtr<WGPUTexture>&& texture, TextureFormat, TextureDimension, ConvertToBackingContext& convertToBackingContext)
+    : m_backing(WTF::move(texture))
     , m_convertToBackingContext(convertToBackingContext)
 {
 }

--- a/Source/WebCore/Modules/WebGPU/Implementation/WebGPUTextureImpl.h
+++ b/Source/WebCore/Modules/WebGPU/Implementation/WebGPUTextureImpl.h
@@ -69,9 +69,6 @@ private:
 
     void setLabelInternal(const String&) final;
 
-    TextureFormat m_format { TextureFormat::Rgba8unorm };
-    TextureDimension m_dimension { TextureDimension::_2d };
-
     WebGPUPtr<WGPUTexture> m_backing;
     const Ref<ConvertToBackingContext> m_convertToBackingContext;
 };

--- a/Source/WebCore/inspector/agents/RuntimeAgentUtilities.h
+++ b/Source/WebCore/inspector/agents/RuntimeAgentUtilities.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#include "DOMWrapperWorld.h"
+#include <JavaScriptCore/InspectorProtocolObjects.h>
+
+namespace WebCore {
+
+inline Inspector::Protocol::Runtime::ExecutionContextType toProtocol(DOMWrapperWorld::Type type)
+{
+    switch (type) {
+    case DOMWrapperWorld::Type::Normal:
+        return Inspector::Protocol::Runtime::ExecutionContextType::Normal;
+    case DOMWrapperWorld::Type::User:
+        return Inspector::Protocol::Runtime::ExecutionContextType::User;
+    case DOMWrapperWorld::Type::Internal:
+        return Inspector::Protocol::Runtime::ExecutionContextType::Internal;
+    }
+
+    ASSERT_NOT_REACHED();
+    return Inspector::Protocol::Runtime::ExecutionContextType::Internal;
+}
+
+} // namespace WebCore

--- a/Source/WebCore/inspector/agents/frame/FrameRuntimeAgent.cpp
+++ b/Source/WebCore/inspector/agents/frame/FrameRuntimeAgent.cpp
@@ -40,6 +40,7 @@
 #include "LocalFrame.h"
 #include "LocalFrameInlines.h"
 #include "Page.h"
+#include "RuntimeAgentUtilities.h"
 #include "ScriptController.h"
 #include "SecurityOrigin.h"
 #include "UserGestureEmulationScope.h"
@@ -166,21 +167,6 @@ void FrameRuntimeAgent::unmuteConsole()
 String FrameRuntimeAgent::frameIdForProtocol() const
 {
     return makeString("frame-"_s, m_frameIdentifier.toUInt64());
-}
-
-static Inspector::Protocol::Runtime::ExecutionContextType NODELETE toProtocol(DOMWrapperWorld::Type type)
-{
-    switch (type) {
-    case DOMWrapperWorld::Type::Normal:
-        return Inspector::Protocol::Runtime::ExecutionContextType::Normal;
-    case DOMWrapperWorld::Type::User:
-        return Inspector::Protocol::Runtime::ExecutionContextType::User;
-    case DOMWrapperWorld::Type::Internal:
-        return Inspector::Protocol::Runtime::ExecutionContextType::Internal;
-    }
-
-    ASSERT_NOT_REACHED();
-    return Inspector::Protocol::Runtime::ExecutionContextType::Internal;
 }
 
 void FrameRuntimeAgent::reportExecutionContextCreation()

--- a/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp
+++ b/Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp
@@ -42,6 +42,7 @@
 #include "LocalFrame.h"
 #include "Page.h"
 #include "PageInspectorController.h"
+#include "RuntimeAgentUtilities.h"
 #include "ScriptController.h"
 #include "SecurityOrigin.h"
 #include "UserGestureEmulationScope.h"
@@ -160,21 +161,6 @@ void PageRuntimeAgent::reportExecutionContextCreation()
             notifyContextCreated(frameId, globalObject, jsWindowProxy->world(), securityOrigin.ptr());
         }
     });
-}
-
-static Inspector::Protocol::Runtime::ExecutionContextType NODELETE toProtocol(DOMWrapperWorld::Type type)
-{
-    switch (type) {
-    case DOMWrapperWorld::Type::Normal:
-        return Inspector::Protocol::Runtime::ExecutionContextType::Normal;
-    case DOMWrapperWorld::Type::User:
-        return Inspector::Protocol::Runtime::ExecutionContextType::User;
-    case DOMWrapperWorld::Type::Internal:
-        return Inspector::Protocol::Runtime::ExecutionContextType::Internal;
-    }
-
-    ASSERT_NOT_REACHED();
-    return Inspector::Protocol::Runtime::ExecutionContextType::Internal;
 }
 
 void PageRuntimeAgent::notifyContextCreated(const Inspector::Protocol::Network::FrameId& frameId, JSC::JSGlobalObject* globalObject, const DOMWrapperWorld& world, SecurityOrigin* securityOrigin)

--- a/Source/WebKit/Headers.cmake
+++ b/Source/WebKit/Headers.cmake
@@ -122,7 +122,6 @@ set(WebKit_PUBLIC_FRAMEWORK_HEADERS
     UIProcess/API/cpp/WKRetainPtr.h
 
     WebProcess/InjectedBundle/API/c/WKBundle.h
-    WebProcess/InjectedBundle/API/c/WKBundleAPICast.h
     WebProcess/InjectedBundle/API/c/WKBundleBackForwardList.h
     WebProcess/InjectedBundle/API/c/WKBundleBackForwardListItem.h
     WebProcess/InjectedBundle/API/c/WKBundleDOMWindowExtension.h

--- a/Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.cpp
+++ b/Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.cpp
@@ -30,6 +30,7 @@
 
 #include "DaemonDecoder.h"
 #include "DaemonEncoder.h"
+#include "Logging.h"
 #include "NetworkSession.h"
 #include <wtf/TZoneMallocInlines.h>
 

--- a/Source/WebKit/Shared/API/Cocoa/WKRemoteObject.mm
+++ b/Source/WebKit/Shared/API/Cocoa/WKRemoteObject.mm
@@ -52,7 +52,7 @@
     return [super conformsToProtocol:protocol] || protocol_conformsToProtocol(retainPtr([_interface protocol]).get(), protocol);
 }
 
-static const char* methodArgumentTypeEncodingForSelector(Protocol *protocol, SEL selector)
+static const char* wkRemoteObject_methodArgumentTypeEncodingForSelector(Protocol *protocol, SEL selector)
 {
     // First look at required methods.
     struct objc_method_description method = protocol_getMethodDescription(protocol, selector, YES, YES);
@@ -74,7 +74,7 @@ static const char* methodArgumentTypeEncodingForSelector(Protocol *protocol, SEL
 
     RetainPtr protocol = [_interface protocol];
 
-    const char* types = methodArgumentTypeEncodingForSelector(protocol.get(), selector);
+    const char* types = wkRemoteObject_methodArgumentTypeEncodingForSelector(protocol.get(), selector);
     if (!types) {
         // We didn't find anything the protocol, fall back to the superclass.
         return [super methodSignatureForSelector:selector];

--- a/Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistry.mm
+++ b/Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistry.mm
@@ -36,6 +36,7 @@
 #import "WKRemoteObjectCoder.h"
 #import "WKSharedAPICast.h"
 #import "WebPage.h"
+#import "WebPageProxy.h"
 #import "WebRemoteObjectRegistry.h"
 #import "_WKRemoteObjectInterface.h"
 #import <objc/runtime.h>

--- a/Source/WebKit/Shared/ResourceLoadInfo.h
+++ b/Source/WebKit/Shared/ResourceLoadInfo.h
@@ -27,6 +27,7 @@
 
 #include "NetworkResourceLoadIdentifier.h"
 #include <WebCore/FrameIdentifier.h>
+#include <wtf/Markable.h>
 #include <wtf/URL.h>
 #include <wtf/UUID.h>
 #include <wtf/WallTime.h>

--- a/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMatchPattern.mm
+++ b/Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMatchPattern.mm
@@ -222,7 +222,7 @@ WK_OBJECT_DEALLOC_IMPL_ON_MAIN_THREAD(WKWebExtensionMatchPattern, WebExtensionMa
     return [self matchesURL:urlToMatch options:0];
 }
 
-static OptionSet<WebKit::WebExtensionMatchPattern::Options> NODELETE toImpl(WKWebExtensionMatchPatternOptions options)
+static OptionSet<WebKit::WebExtensionMatchPattern::Options> NODELETE matchPatternOptionsToImpl(WKWebExtensionMatchPatternOptions options)
 {
     OptionSet<WebKit::WebExtensionMatchPattern::Options> result;
 
@@ -247,7 +247,7 @@ static OptionSet<WebKit::WebExtensionMatchPattern::Options> NODELETE toImpl(WKWe
 
     NSParameterAssert([urlToMatch isKindOfClass:NSURL.class]);
 
-    return protect(*_webExtensionMatchPattern)->matchesURL(urlToMatch, toImpl(options));
+    return protect(*_webExtensionMatchPattern)->matchesURL(urlToMatch, matchPatternOptionsToImpl(options));
 }
 
 - (BOOL)matchesPattern:(WKWebExtensionMatchPattern *)patternToMatch
@@ -262,7 +262,7 @@ static OptionSet<WebKit::WebExtensionMatchPattern::Options> NODELETE toImpl(WKWe
 
     NSParameterAssert([patternToMatch isKindOfClass:WKWebExtensionMatchPattern.class]);
 
-    return protect(*_webExtensionMatchPattern)->matchesPattern(protect(*patternToMatch->_webExtensionMatchPattern), toImpl(options));
+    return protect(*_webExtensionMatchPattern)->matchesPattern(protect(*patternToMatch->_webExtensionMatchPattern), matchPatternOptionsToImpl(options));
 }
 
 #pragma mark WKObject protocol implementation

--- a/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
+++ b/Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm
@@ -765,7 +765,7 @@ ALLOW_DEPRECATED_IMPLEMENTATIONS_BEGIN
 
 - (void)showWritingTools:(id)sender
 {
-    WTRequestedTool tool = (WTRequestedTool)[sender tag];
+    WTRequestedTool tool = (WTRequestedTool)[(id<NSValidatedUserInterfaceItem>)sender tag];
     if (tool == -1)
         tool = WTRequestedToolIndex;
 

--- a/Source/WebKit/WebKit.xcodeproj/project.pbxproj
+++ b/Source/WebKit/WebKit.xcodeproj/project.pbxproj
@@ -551,6 +551,7 @@
 		1C5ACFA82A96F8C400C041C0 /* JSWebExtensionAPIWindowsEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C5ACFA42A96F8C300C041C0 /* JSWebExtensionAPIWindowsEvent.h */; };
 		1C5ACFAC2A96F8D500C041C0 /* JSWebExtensionAPITabs.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C5ACFAA2A96F8D500C041C0 /* JSWebExtensionAPITabs.h */; };
 		1C5ACFAE2A96F9D300C041C0 /* WebExtensionAPITabs.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C5ACFAD2A96F9D300C041C0 /* WebExtensionAPITabs.h */; };
+		9C9869C1ABBFCCDAD348DF4F /* WebExtensionAPIKeys.h in Headers */ = {isa = PBXBuildFile; fileRef = 760CF4A4920709706E98B98C /* WebExtensionAPIKeys.h */; };
 		1C5ACFB02A96F9F200C041C0 /* WebExtensionAPIWindows.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C5ACFAF2A96F9F200C041C0 /* WebExtensionAPIWindows.h */; };
 		1C5ACFB22A96FA0000C041C0 /* WebExtensionAPIWindowsEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C5ACFB12A96FA0000C041C0 /* WebExtensionAPIWindowsEvent.h */; };
 		1C5DC46A290B271A0061EC62 /* WebExtensionAPIRuntime.h in Headers */ = {isa = PBXBuildFile; fileRef = 1C5DC469290B239C0061EC62 /* WebExtensionAPIRuntime.h */; };
@@ -4315,6 +4316,7 @@
 		1C5ACFA92A96F8D400C041C0 /* JSWebExtensionAPITabs.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = JSWebExtensionAPITabs.mm; sourceTree = "<group>"; };
 		1C5ACFAA2A96F8D500C041C0 /* JSWebExtensionAPITabs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSWebExtensionAPITabs.h; sourceTree = "<group>"; };
 		1C5ACFAD2A96F9D300C041C0 /* WebExtensionAPITabs.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionAPITabs.h; sourceTree = "<group>"; };
+		760CF4A4920709706E98B98C /* WebExtensionAPIKeys.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionAPIKeys.h; sourceTree = "<group>"; };
 		1C5ACFAF2A96F9F200C041C0 /* WebExtensionAPIWindows.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionAPIWindows.h; sourceTree = "<group>"; };
 		1C5ACFB12A96FA0000C041C0 /* WebExtensionAPIWindowsEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WebExtensionAPIWindowsEvent.h; sourceTree = "<group>"; };
 		1C5ACFB32A96FA1900C041C0 /* WebExtensionAPIWindowsEventCocoa.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = WebExtensionAPIWindowsEventCocoa.mm; sourceTree = "<group>"; };
@@ -11123,6 +11125,7 @@
 				1C0590702DFA1115000406F9 /* WebExtensionAPIDOMCocoa.mm */,
 				B6544F952937E46900034EB0 /* WebExtensionAPIEventCocoa.mm */,
 				1C5DC465290B23890061EC62 /* WebExtensionAPIExtensionCocoa.mm */,
+				760CF4A4920709706E98B98C /* WebExtensionAPIKeys.h */,
 				B6E5F2A6299C10B100DBCEA3 /* WebExtensionAPILocalizationCocoa.mm */,
 				1CCEE4562B098B4C0034E059 /* WebExtensionAPIMenusCocoa.mm */,
 				1C5DC4512908A9D00061EC62 /* WebExtensionAPINamespaceCocoa.mm */,
@@ -18958,6 +18961,7 @@
 				1C05906F2DFA1039000406F9 /* WebExtensionAPIDOM.h in Headers */,
 				B6544F932937E45100034EB0 /* WebExtensionAPIEvent.h in Headers */,
 				1C5DC46D290B271E0061EC62 /* WebExtensionAPIExtension.h in Headers */,
+				9C9869C1ABBFCCDAD348DF4F /* WebExtensionAPIKeys.h in Headers */,
 				B6E5F2A5299C105500DBCEA3 /* WebExtensionAPILocalization.h in Headers */,
 				1CCEE4552B098B070034E059 /* WebExtensionAPIMenus.h in Headers */,
 				1C5DC46C290B271E0061EC62 /* WebExtensionAPINamespace.h in Headers */,

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm
@@ -29,6 +29,7 @@
 
 #import "config.h"
 #import "WebExtensionAPIAction.h"
+#import "WebExtensionAPIKeys.h"
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
@@ -49,23 +50,8 @@
 #import <UIKit/UIKit.h>
 #endif
 
-static NSString * const tabIdKey = @"tabId";
-static NSString * const windowIdKey = @"windowId";
-
-static NSString * const imageDataKey = @"imageData";
-static NSString * const pathKey = @"path";
-static NSString * const popupKey = @"popup";
-static NSString * const textKey = @"text";
-static NSString * const titleKey = @"title";
-
 #if ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
-static NSString * const variantsKey = @"variants";
 // FIXME: <https://webkit.org/b/300927> Deprecate `color_schemes` key.
-static NSString * const deprecatedColorSchemesKey = @"color_schemes";
-static NSString * const colorSchemesKey = @"colorSchemes";
-static NSString * const lightKey = @"light";
-static NSString * const darkKey = @"dark";
-static NSString * const anyKey = @"any";
 #endif
 
 namespace WebKit {

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIAlarmsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIAlarmsCocoa.mm
@@ -29,6 +29,7 @@
 
 #import "config.h"
 #import "WebExtensionAPIAlarms.h"
+#import "WebExtensionAPIKeys.h"
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
@@ -44,15 +45,6 @@
 #import <wtf/DateMath.h>
 
 namespace WebKit {
-
-static NSString * const whenKey = @"when";
-static NSString * const delayInMinutesKey = @"delayInMinutes";
-static NSString * const periodInMinutesKey = @"periodInMinutes";
-
-static NSString * const nameKey = @"name";
-static NSString * const scheduledTimeKey = @"scheduledTime";
-
-static NSString * const emptyAlarmName = @"";
 
 static inline NSDictionary *toWebAPI(const WebExtensionAlarmParameters& alarm)
 {

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIBookmarksCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIBookmarksCocoa.mm
@@ -32,6 +32,7 @@
 #import "WebExtensionAPIBookmarks.h"
 #import "CocoaHelpers.h"
 #import "MessageSenderInlines.h"
+#import "WebExtensionAPIKeys.h"
 #import "WebExtensionBookmarksParameters.h"
 #import "WebExtensionContextMessages.h"
 #import "WebProcess.h"
@@ -40,17 +41,6 @@
 
 namespace WebKit {
 
-static NSString * const idKey = @"id";
-static NSString * const urlKey = @"url";
-static NSString * const titleKey = @"title";
-static NSString * const indexKey = @"index";
-static NSString * const parentIdKey = @"parentId";
-static NSString * const dateAddedKey = @"dateAdded";
-static NSString * const typeKey = @"type";
-static NSString * const queryKey = @"query";
-static NSString * const childrenKey = @"children";
-static NSString * const bookmarkKey = @"bookmark";
-static NSString * const folderKey = @"folder";
 
 static NSDictionary *toAPI(const WebExtensionBookmarksParameters& node)
 {

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICommandsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICommandsCocoa.mm
@@ -29,6 +29,7 @@
 
 #import "config.h"
 #import "WebExtensionAPICommands.h"
+#import "WebExtensionAPIKeys.h"
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
@@ -47,10 +48,6 @@
 
 namespace WebKit {
 
-static NSString * const descriptionKey = @"description";
-static NSString * const shortcutKey = @"shortcut";
-static NSString * const newShortcutKey = @"newShortcut";
-static NSString * const oldShortcutKey = @"oldShortcut";
 
 static inline NSDictionary *toAPI(const WebExtensionCommandParameters& command)
 {

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICookiesCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICookiesCocoa.mm
@@ -29,6 +29,7 @@
 
 #import "config.h"
 #import "WebExtensionAPICookies.h"
+#import "WebExtensionAPIKeys.h"
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
@@ -44,28 +45,6 @@
 #import <wtf/cocoa/VectorCocoa.h>
 
 namespace WebKit {
-
-static NSString * const domainKey = @"domain";
-static NSString * const expirationDateKey = @"expirationDate";
-static NSString * const hostOnlyKey = @"hostOnly";
-static NSString * const httpOnlyKey = @"httpOnly";
-static NSString * const idKey = @"id";
-static NSString * const incognitoKey = @"incognito";
-static NSString * const pathKey = @"path";
-static NSString * const sameSiteKey = @"sameSite";
-static NSString * const secureKey = @"secure";
-static NSString * const sessionKey = @"session";
-static NSString * const storeIdKey = @"storeId";
-static NSString * const tabIdsKey = @"tabIds";
-static NSString * const urlKey = @"url";
-static NSString * const valueKey = @"value";
-
-static NSString * const noRestrictionKey = @"no_restriction";
-static NSString * const laxKey = @"lax";
-static NSString * const strictKey = @"strict";
-
-static NSString * const ephemeralPrefix = @"ephemeral-";
-static NSString * const persistentPrefix = @"persistent-";
 
 static inline std::optional<PAL::SessionID> toImpl(NSString *storeID)
 {

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm
@@ -29,6 +29,7 @@
 
 #import "config.h"
 #import "WebExtensionAPIDeclarativeNetRequest.h"
+#import "WebExtensionAPIKeys.h"
 
 #import "CocoaHelpers.h"
 #import "JSWebExtensionWrapper.h"
@@ -51,45 +52,7 @@
 
 namespace WebKit {
 
-static NSString * const disableRulesetsKey = @"disableRulesetIds";
-static NSString * const enableRulesetsKey = @"enableRulesetIds";
-
-static NSString * const regexKey = @"regex";
-static NSString * const regexIsCaseSensitiveKey = @"isCaseSensitive";
-static NSString * const regexRequireCapturingKey = @"requireCapturing";
-
-static NSString * const actionCountDisplayActionCountAsBadgeTextKey = @"displayActionCountAsBadgeText";
-static NSString * const actionCountTabUpdateKey = @"tabUpdate";
-static NSString * const actionCountTabIDKey = @"tabId";
-static NSString * const actionCountIncrementKey = @"increment";
-
-static NSString * const getMatchedRulesTabIDKey = @"tabId";
-static NSString * const getMatchedRulesMinTimeStampKey = @"minTimeStamp";
-
-static NSString * const getDynamicOrSessionRulesRuleIDsKey = @"ruleIds";
-
-static NSString * const addRulesKey = @"addRules";
-static NSString * const removeRulesKey = @"removeRuleIds";
-
 #if ENABLE(DNR_ON_RULE_MATCHED_DEBUG)
-static NSString * const requestKey = @"request";
-static NSString * const documentIdKey = @"documentId";
-static NSString * const documentLifecycleKey = @"documentLifecycle";
-static NSString * const frameIdKey = @"frameId";
-static NSString * const frameTypeKey = @"frameType";
-static NSString * const initiatorKey = @"initiator";
-static NSString * const methodKey = @"method";
-static NSString * const parentDocumentIdKey = @"parentDocumentId";
-static NSString * const parentFrameIdKey = @"parentFrameId";
-static NSString * const requestIdKey = @"requestId";
-static NSString * const tabIdKey = @"tabId";
-static NSString * const typeKey = @"type";
-static NSString * const urlKey = @"url";
-
-static NSString * const ruleKey = @"rule";
-static NSString * const extensionIdKey = @"extensionId";
-static NSString * const ruleIdKey = @"ruleId";
-static NSString * const rulesetIdKey = @"rulesetId";
 
 static inline NSDictionary *toWebAPI(const WebCore::ContentRuleListMatchedRule& matchedRuleInfo)
 {

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm
@@ -29,6 +29,7 @@
 
 #import "config.h"
 #import "WebExtensionAPIDevToolsInspectedWindow.h"
+#import "WebExtensionAPIKeys.h"
 
 #if ENABLE(WK_WEB_EXTENSIONS) && ENABLE(INSPECTOR_EXTENSIONS)
 
@@ -40,12 +41,6 @@
 #import "WebExtensionTabIdentifier.h"
 #import "WebExtensionUtilities.h"
 #import "WebProcess.h"
-
-static NSString * const frameURLKey = @"frameURL";
-static NSString * const ignoreCacheKey = @"ignoreCache";
-
-static NSString * const isExceptionKey = @"isException";
-static NSString * const valueKey = @"value";
 
 namespace WebKit {
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm
@@ -29,6 +29,7 @@
 
 #import "config.h"
 #import "WebExtensionAPIExtension.h"
+#import "WebExtensionAPIKeys.h"
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
@@ -39,13 +40,6 @@
 #import "WebExtensionUtilities.h"
 #import "WebPage.h"
 #import "WebProcess.h"
-
-static NSString * const typeKey = @"type";
-static NSString * const tabIdKey = @"tabId";
-static NSString * const windowIdKey = @"windowId";
-
-static NSString * const popupKey = @"popup";
-static NSString * const tabKey = @"tab";
 
 namespace WebKit {
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIKeys.h
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIKeys.h
@@ -1,0 +1,248 @@
+/*
+ * Copyright (C) 2026 Apple Inc. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#import <Foundation/Foundation.h>
+
+static NSString * const accessLevelKey = @"accessLevel";
+static NSString * const accessLevelTrustedAndUntrustedContexts = @"TRUSTED_AND_UNTRUSTED_CONTEXTS";
+static NSString * const accessLevelTrustedContexts = @"TRUSTED_CONTEXTS";
+static NSString * const actionClickBehaviorKey = @"openPanelOnActionClick";
+static NSString * const actionCountDisplayActionCountAsBadgeTextKey = @"displayActionCountAsBadgeText";
+static NSString * const actionCountIncrementKey = @"increment";
+static NSString * const actionCountTabIDKey = @"tabId";
+static NSString * const actionCountTabUpdateKey = @"tabUpdate";
+static NSString * const activeKey = @"active";
+static NSString * const addRulesKey = @"addRules";
+static NSString * const allFramesKey = @"allFrames";
+static NSString * const allKey = @"all";
+static NSString * const alwaysOnTopKey = @"alwaysOnTop";
+static NSString * const anyKey = @"any";
+static NSString * const argsKey = @"args";
+static NSString * const argumentsKey = @"arguments";
+static NSString * const audibleKey = @"audible";
+static NSString * const audioKey = @"audio";
+static NSString * const authorValue = @"author";
+static NSString * const basicSchemeKey = @"basic";
+static NSString * const bookmarkKey = @"bookmark";
+static NSString * const bypassCacheKey = @"bypassCache";
+static NSString * const bytesKey = @"bytes";
+static NSString * const challengerKey = @"challenger";
+static NSString * const checkboxKey = @"checkbox";
+static NSString * const checkedKey = @"checked";
+static NSString * const childrenKey = @"children";
+static NSString * const codeKey = @"code";
+static NSString * const colorSchemesKey = @"colorSchemes";
+static NSString * const commandKey = @"command";
+static NSString * const completeKey = @"complete";
+static NSString * const contextsKey = @"contexts";
+static NSString * const cssKey = @"css";
+static NSString * const cssOriginKey = @"cssOrigin";
+static NSString * const currentWindowKey = @"currentWindow";
+static NSString * const darkKey = @"dark";
+static NSString * const dateAddedKey = @"dateAdded";
+static NSString * const delayInMinutesKey = @"delayInMinutes";
+static NSString * const deprecatedColorSchemesKey = @"color_schemes";
+static NSString * const deprecatedIconVariantsKey = @"icon_variants";
+static NSString * const descriptionKey = @"description";
+static NSString * const digestSchemeKey = @"digest";
+static NSString * const disableRulesetsKey = @"disableRulesetIds";
+static NSString * const documentEnd = @"document_end";
+static NSString * const documentIdKey = @"documentId";
+static NSString * const documentIdle = @"document_idle";
+static NSString * const documentIDsKey = @"documentIds";
+static NSString * const documentLifecycleKey = @"documentLifecycle";
+static NSString * const documentStart = @"document_start";
+static NSString * const documentURLPatternsKey = @"documentUrlPatterns";
+static NSString * const domainKey = @"domain";
+static NSString * const editableKey = @"editable";
+static NSString * const emptyAlarmName = @"";
+static NSString * const emptyDataURLValue = @"data:,";
+static NSString * const emptyTitleValue = @"";
+static NSString * const emptyURLValue = @"";
+static NSString * const enabledKey = @"enabled";
+static NSString * const enableRulesetsKey = @"enableRulesetIds";
+static NSString * const ephemeralPrefix = @"ephemeral-";
+static NSString * const errorKey = @"error";
+static NSString * const excludeMatchesKey = @"excludeMatches";
+static NSString * const expirationDateKey = @"expirationDate";
+static NSString * const extensionIdKey = @"extensionId";
+static NSString * const fileKey = @"file";
+static NSString * const filesKey = @"files";
+static NSString * const focusedKey = @"focused";
+static NSString * const folderKey = @"folder";
+static NSString * const formatKey = @"format";
+static NSString * const formDataKey = @"formData";
+static NSString * const frameIdKey = @"frameId";
+static NSString * const frameIDKey = @"frameId";
+static NSString * const frameIDsKey = @"frameIds";
+static NSString * const frameTypeKey = @"frameType";
+static NSString * const frameURLKey = @"frameURL";
+static NSString * const fromCacheKey = @"fromCache";
+static NSString * const fromIndexKey = @"fromIndex";
+static NSString * const fullscreenKey = @"fullscreen";
+static NSString * const funcKey = @"func";
+static NSString * const functionKey = @"function";
+static NSString * const getDynamicOrSessionRulesRuleIDsKey = @"ruleIds";
+static NSString * const getMatchedRulesMinTimeStampKey = @"minTimeStamp";
+static NSString * const getMatchedRulesTabIDKey = @"tabId";
+static NSString * const heightKey = @"height";
+static NSString * const hiddenKey = @"hidden";
+static NSString * const highlightedKey = @"highlighted";
+static NSString * const hostKey = @"host";
+static NSString * const hostOnlyKey = @"hostOnly";
+static NSString * const httpOnlyKey = @"httpOnly";
+static NSString * const iconsKey = @"icons";
+static NSString * const iconVariantsKey = @"iconVariants";
+static NSString * const idKey = @"id";
+static NSString * const idsKey = @"ids";
+static NSString * const ignoreCacheKey = @"ignoreCache";
+static NSString * const imageDataKey = @"imageData";
+static NSString * const imageKey = @"image";
+static NSString * const incognitoKey = @"incognito";
+static NSString * const indexKey = @"index";
+static NSString * const initiatorKey = @"initiator";
+static NSString * const isArticleKey = @"isArticle";
+static NSString * const isExceptionKey = @"isException";
+static NSString * const isInReaderModeKey = @"isInReaderMode";
+static NSString * const isolatedWorld = @"isolated";
+static NSString * const isProxyKey = @"isProxy";
+static NSString * const isWindowClosingKey = @"isWindowClosing";
+static NSString * const jpegValue = @"jpeg";
+static NSString * const jsKey = @"js";
+static NSString * const lastFocusedWindowKey = @"lastFocusedWindow";
+static NSString * const laxKey = @"lax";
+static NSString * const leftKey = @"left";
+static NSString * const lightKey = @"light";
+static NSString * const linkTextKey = @"linkText";
+static NSString * const linkURLKey = @"linkUrl";
+static NSString * const loadingKey = @"loading";
+static NSString * const mainWorld = @"main";
+static NSString * const matchesKey = @"matches";
+static NSString * const matchOriginAsFallbackKey = @"matchOriginAsFallback";
+static NSString * const maximizedKey = @"maximized";
+static NSString * const mediaTypeKey = @"mediaType";
+static NSString * const menuItemIDKey = @"menuItemId";
+static NSString * const methodKey = @"method";
+static NSString * const minimizedKey = @"minimized";
+static NSString * const mutedInfoKey = @"mutedInfo";
+static NSString * const mutedKey = @"muted";
+static NSString * const nameKey = @"name";
+static NSString * const newPositionKey = @"newPosition";
+static NSString * const newShortcutKey = @"newShortcut";
+static NSString * const newWindowIdKey = @"newWindowId";
+static NSString * const noRestrictionKey = @"no_restriction";
+static NSString * const normalKey = @"normal";
+static NSString * const oldPositionKey = @"oldPosition";
+static NSString * const oldShortcutKey = @"oldShortcut";
+static NSString * const oldWindowIdKey = @"oldWindowId";
+static NSString * const onclickKey = @"onclick";
+static NSString * const openerTabIdKey = @"openerTabId";
+static NSString * const openInReaderModeKey = @"openInReaderMode";
+static NSString * const originKey = @"origin";
+static NSString * const originsKey = @"origins";
+static NSString * const pageURLKey = @"pageUrl";
+static NSString * const panelKey = @"panel";
+static NSString * const parentDocumentIdKey = @"parentDocumentId";
+static NSString * const parentFrameIdKey = @"parentFrameId";
+static NSString * const parentIdKey = @"parentId";
+static NSString * const parentMenuItemIDKey = @"parentMenuItemId";
+static NSString * const pathKey = @"path";
+static NSString * const periodInMinutesKey = @"periodInMinutes";
+static NSString * const permissionsKey = @"permissions";
+static NSString * const persistAcrossSessionsKey = @"persistAcrossSessions";
+static NSString * const persistentPrefix = @"persistent-";
+static NSString * const pinnedKey = @"pinned";
+static NSString * const pngValue = @"png";
+static NSString * const populateKey = @"populate";
+static NSString * const popupKey = @"popup";
+static NSString * const portKey = @"port";
+static NSString * const previousTabIdKey = @"previousTabId";
+static NSString * const previousVersionKey = @"previousVersion";
+static NSString * const qualityKey = @"quality";
+static NSString * const queryKey = @"query";
+static NSString * const radioKey = @"radio";
+static NSString * const rawKey = @"raw";
+static NSString * const realmKey = @"realm";
+static NSString * const reasonKey = @"reason";
+static NSString * const redirectURLKey = @"redirectUrl";
+static NSString * const regexIsCaseSensitiveKey = @"isCaseSensitive";
+static NSString * const regexKey = @"regex";
+static NSString * const regexRequireCapturingKey = @"requireCapturing";
+static NSString * const removeRulesKey = @"removeRuleIds";
+static NSString * const requestBodyKey = @"requestBody";
+static NSString * const requestHeadersKey = @"requestHeaders";
+static NSString * const requestIdKey = @"requestId";
+static NSString * const requestKey = @"request";
+static NSString * const responseHeadersKey = @"responseHeaders";
+static NSString * const ruleIdKey = @"ruleId";
+static NSString * const ruleKey = @"rule";
+static NSString * const rulesetIdKey = @"rulesetId";
+static NSString * const runAtKey = @"runAt";
+static NSString * const sameSiteKey = @"sameSite";
+static NSString * const scheduledTimeKey = @"scheduledTime";
+static NSString * const schemeKey = @"scheme";
+static NSString * const secureKey = @"secure";
+static NSString * const selectedKey = @"selected";
+static NSString * const selectionTextKey = @"selectionText";
+static NSString * const separatorKey = @"separator";
+static NSString * const sessionKey = @"session";
+static NSString * const shortcutKey = @"shortcut";
+static NSString * const srcURLKey = @"srcUrl";
+static NSString * const stateKey = @"state";
+static NSString * const statusCodeKey = @"statusCode";
+static NSString * const statusKey = @"status";
+static NSString * const statusLineKey = @"statusLine";
+static NSString * const storeIdKey = @"storeId";
+static NSString * const strictKey = @"strict";
+static NSString * const tabIdKey = @"tabId";
+static NSString * const tabIDKey = @"tabId";
+static NSString * const tabIdsKey = @"tabIds";
+static NSString * const tabKey = @"tab";
+static NSString * const tabsKey = @"tabs";
+static NSString * const targetKey = @"target";
+static NSString * const targetURLPatternsKey = @"targetUrlPatterns";
+static NSString * const textKey = @"text";
+static NSString * const timeStampKey = @"timeStamp";
+static NSString * const titleKey = @"title";
+static NSString * const toIndexKey = @"toIndex";
+static NSString * const topKey = @"top";
+static NSString * const typeKey = @"type";
+static NSString * const unknownLanguageValue = @"und";
+static NSString * const urlKey = @"url";
+static NSString * const userValue = @"user";
+static NSString * const valueKey = @"value";
+static NSString * const variantsKey = @"variants";
+static NSString * const versionKey = @"version";
+static NSString * const videoKey = @"video";
+static NSString * const visibleKey = @"visible";
+static NSString * const wasCheckedKey = @"wasChecked";
+static NSString * const whenKey = @"when";
+static NSString * const widthKey = @"width";
+static NSString * const windowIdKey = @"windowId";
+static NSString * const windowTypeKey = @"windowType";
+static NSString * const windowTypesKey = @"windowTypes";
+static NSString * const worldKey = @"world";

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm
@@ -29,6 +29,7 @@
 
 #import "config.h"
 #import "WebExtensionAPIMenus.h"
+#import "WebExtensionAPIKeys.h"
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
@@ -49,47 +50,9 @@
 #import <WebCore/LocalFrameInlines.h>
 #import <wtf/cocoa/VectorCocoa.h>
 
-static NSString * const checkedKey = @"checked";
-static NSString * const contextsKey = @"contexts";
-static NSString * const commandKey = @"command";
-static NSString * const documentURLPatternsKey = @"documentUrlPatterns";
-static NSString * const enabledKey = @"enabled";
-static NSString * const iconsKey = @"icons";
-static NSString * const idKey = @"id";
-static NSString * const onclickKey = @"onclick";
-static NSString * const parentIdKey = @"parentId";
-static NSString * const targetURLPatternsKey = @"targetUrlPatterns";
-static NSString * const titleKey = @"title";
-static NSString * const visibleKey = @"visible";
-
 #if ENABLE(WK_WEB_EXTENSIONS_ICON_VARIANTS)
-static NSString * const iconVariantsKey = @"iconVariants";
 // FIXME: <https://webkit.org/b/300927> Deprecate `icon_variants` key.
-static NSString * const deprecatedIconVariantsKey = @"icon_variants";
 #endif
-
-static NSString * const normalKey = @"normal";
-static NSString * const checkboxKey = @"checkbox";
-static NSString * const radioKey = @"radio";
-static NSString * const separatorKey = @"separator";
-
-static NSString * const allKey = @"all";
-
-static NSString * const editableKey = @"editable";
-static NSString * const frameIDKey = @"frameId";
-static NSString * const linkTextKey = @"linkText";
-static NSString * const linkURLKey = @"linkUrl";
-static NSString * const mediaTypeKey = @"mediaType";
-static NSString * const menuItemIDKey = @"menuItemId";
-static NSString * const pageURLKey = @"pageUrl";
-static NSString * const parentMenuItemIDKey = @"parentMenuItemId";
-static NSString * const selectionTextKey = @"selectionText";
-static NSString * const srcURLKey = @"srcUrl";
-static NSString * const wasCheckedKey = @"wasChecked";
-
-static NSString * const imageKey = @"image";
-static NSString * const audioKey = @"audio";
-static NSString * const videoKey = @"video";
 
 namespace WebKit {
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm
@@ -29,6 +29,7 @@
 
 #import "config.h"
 #import "WebExtensionAPIPermissions.h"
+#import "WebExtensionAPIKeys.h"
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
@@ -44,8 +45,6 @@
 
 namespace WebKit {
 
-static NSString * const permissionsKey = @"permissions";
-static NSString * const originsKey = @"origins";
 
 void WebExtensionAPIPermissions::getAll(Ref<WebExtensionCallbackHandler>&& callback)
 {

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm
@@ -29,6 +29,7 @@
 
 #import "config.h"
 #import "WebExtensionAPIRuntime.h"
+#import "WebExtensionAPIKeys.h"
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
@@ -54,16 +55,6 @@
 #import <wtf/CallbackAggregator.h>
 #import <wtf/text/MakeString.h>
 
-static NSString * const idKey = @"id";
-static NSString * const frameIdKey = @"frameId";
-static NSString * const tabKey = @"tab";
-static NSString * const urlKey = @"url";
-static NSString * const originKey = @"origin";
-static NSString * const nameKey = @"name";
-static NSString * const reasonKey = @"reason";
-static NSString * const previousVersionKey = @"previousVersion";
-static NSString * const documentIdKey = @"documentId";
-static NSString * const versionKey = @"version";
 
 namespace WebKit {
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIScriptingCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIScriptingCocoa.mm
@@ -29,6 +29,7 @@
 
 #import "config.h"
 #import "WebExtensionAPIScripting.h"
+#import "WebExtensionAPIKeys.h"
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
@@ -50,38 +51,6 @@
 #import "WebProcess.h"
 #import <WebCore/UserGestureIndicator.h>
 #import <wtf/cocoa/VectorCocoa.h>
-
-static NSString * const allFramesKey = @"allFrames";
-static NSString * const argsKey = @"args";
-static NSString * const argumentsKey = @"arguments";
-static NSString * const cssKey = @"css";
-static NSString * const cssOriginKey = @"cssOrigin";
-static NSString * const documentIDsKey = @"documentIds";
-static NSString * const filesKey = @"files";
-static NSString * const frameIDsKey = @"frameIds";
-static NSString * const funcKey = @"func";
-static NSString * const functionKey = @"function";
-static NSString * const tabIDKey = @"tabId";
-static NSString * const targetKey = @"target";
-static NSString * const worldKey = @"world";
-
-static NSString * const excludeMatchesKey = @"excludeMatches";
-static NSString * const idsKey = @"ids";
-static NSString * const jsKey = @"js";
-static NSString * const matchOriginAsFallbackKey = @"matchOriginAsFallback";
-static NSString * const matchesKey = @"matches";
-static NSString * const persistAcrossSessionsKey = @"persistAcrossSessions";
-static NSString * const runAtKey = @"runAt";
-
-static NSString * const mainWorld = @"main";
-static NSString * const isolatedWorld = @"isolated";
-
-static NSString * const authorValue = @"author";
-static NSString * const userValue = @"user";
-
-static NSString * const documentEnd = @"document_end";
-static NSString * const documentIdle = @"document_idle";
-static NSString * const documentStart = @"document_start";
 
 // FIXME: <https://webkit.org/b/261765> Consider adding support for injectImmediately.
 // FIXME: <https://webkit.org/b/264829> Add support for matchOriginAsFallback.

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidePanelCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidePanelCocoa.mm
@@ -29,6 +29,7 @@
 
 #import "config.h"
 #import "WebExtensionAPISidePanel.h"
+#import "WebExtensionAPIKeys.h"
 
 #if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
 
@@ -41,9 +42,6 @@
 
 namespace WebKit {
 
-static NSString * const tabIdKey = @"tabId";
-static NSString * const windowIdKey = @"windowId";
-static NSString * const actionClickBehaviorKey = @"openPanelOnActionClick";
 
 static ParseResult parseTabIdentifier(NSDictionary *options)
 {

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidebarActionCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidebarActionCocoa.mm
@@ -29,6 +29,7 @@
 
 #include "config.h"
 #import "WebExtensionAPISidebarAction.h"
+#import "WebExtensionAPIKeys.h"
 
 #if ENABLE(WK_WEB_EXTENSIONS_SIDEBAR)
 
@@ -41,10 +42,6 @@
 
 namespace WebKit {
 
-static NSString * const tabIdKey = @"tabId";
-static NSString * const windowIdKey = @"windowId";
-static NSString * const panelKey = @"panel";
-static NSString * const titleKey = @"title";
 
 static ParseResult parseSidebarActionDetails(NSDictionary *details)
 {

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm
@@ -29,6 +29,7 @@
 
 #import "config.h"
 #import "WebExtensionAPIStorageArea.h"
+#import "WebExtensionAPIKeys.h"
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
@@ -44,9 +45,6 @@
 #import "WebProcess.h"
 #import <wtf/cocoa/VectorCocoa.h>
 
-static NSString * const accessLevelKey = @"accessLevel";
-static NSString * const accessLevelTrustedContexts = @"TRUSTED_CONTEXTS";
-static NSString * const accessLevelTrustedAndUntrustedContexts = @"TRUSTED_AND_UNTRUSTED_CONTEXTS";
 
 namespace WebKit {
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm
@@ -29,6 +29,7 @@
 
 #import "config.h"
 #import "WebExtensionAPITabs.h"
+#import "WebExtensionAPIKeys.h"
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
@@ -55,81 +56,6 @@
 #import <WebCore/UserGestureIndicator.h>
 #import <wtf/cocoa/VectorCocoa.h>
 #import <wtf/text/Base64.h>
-
-static NSString * const idKey = @"id";
-static NSString * const urlKey = @"url";
-static NSString * const titleKey = @"title";
-
-static NSString * const windowIdKey = @"windowId";
-static NSString * const indexKey = @"index";
-static NSString * const openerTabIdKey = @"openerTabId";
-
-static NSString * const widthKey = @"width";
-static NSString * const heightKey = @"height";
-
-static NSString * const activeKey = @"active";
-static NSString * const highlightedKey = @"highlighted";
-static NSString * const selectedKey = @"selected";
-static NSString * const incognitoKey = @"incognito";
-static NSString * const pinnedKey = @"pinned";
-static NSString * const audibleKey = @"audible";
-
-static NSString * const mutedInfoKey = @"mutedInfo";
-static NSString * const mutedKey = @"muted";
-
-static NSString * const statusKey = @"status";
-static NSString * const loadingKey = @"loading";
-static NSString * const completeKey = @"complete";
-
-static NSString * const isArticleKey = @"isArticle";
-static NSString * const isInReaderModeKey = @"isInReaderMode";
-static NSString * const openInReaderModeKey = @"openInReaderMode";
-
-static NSString * const currentWindowKey = @"currentWindow";
-static NSString * const hiddenKey = @"hidden";
-static NSString * const lastFocusedWindowKey = @"lastFocusedWindow";
-static NSString * const windowTypeKey = @"windowType";
-
-static NSString * const bypassCacheKey = @"bypassCache";
-
-static NSString * const oldWindowIdKey = @"oldWindowId";
-static NSString * const oldPositionKey = @"oldPosition";
-
-static NSString * const newWindowIdKey = @"newWindowId";
-static NSString * const newPositionKey = @"newPosition";
-
-static NSString * const previousTabIdKey = @"previousTabId";
-static NSString * const tabIdKey = @"tabId";
-
-static NSString * const fromIndexKey = @"fromIndex";
-static NSString * const toIndexKey = @"toIndex";
-
-static NSString * const isWindowClosingKey = @"isWindowClosing";
-
-static NSString * const tabIdsKey = @"tabIds";
-
-static NSString * const formatKey = @"format";
-static NSString * const pngValue = @"png";
-static NSString * const jpegValue = @"jpeg";
-
-static NSString * const qualityKey = @"quality";
-
-static NSString * const frameIdKey = @"frameId";
-static NSString * const documentIdKey = @"documentId";
-static NSString * const nameKey = @"name";
-
-static NSString * const allFramesKey = @"allFrames";
-static NSString * const codeKey = @"code";
-static NSString * const fileKey = @"file";
-static NSString * const cssOriginKey = @"cssOrigin";
-
-static NSString * const authorValue = @"author";
-static NSString * const userValue = @"user";
-
-static NSString * const emptyURLValue = @"";
-static NSString * const emptyTitleValue = @"";
-static NSString * const emptyDataURLValue = @"data:,";
-static NSString * const unknownLanguageValue = @"und";
 
 namespace WebKit {
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationCocoa.mm
@@ -29,6 +29,7 @@
 
 #import "config.h"
 #import "MessageSenderInlines.h"
+#import "WebExtensionAPIKeys.h"
 #import "WebExtensionAPINamespace.h"
 #import "WebExtensionAPIWebNavigation.h"
 #import "WebExtensionContext.h"
@@ -51,7 +52,6 @@ static NSString *tabIdKey = @"tabId";
 static NSString *timeStampKey = @"timeStamp";
 static NSString *urlKey = @"url";
 
-static NSString * const emptyURLValue = @"";
 
 static NSDictionary *toWebAPI(WebExtensionFrameParameters frameInfo)
 {

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestCocoa.mm
@@ -30,6 +30,7 @@
 #import "config.h"
 #import "FormDataReference.h"
 #import "ResourceLoadInfo.h"
+#import "WebExtensionAPIKeys.h"
 #import "WebExtensionAPINamespace.h"
 #import "WebExtensionAPIWebRequest.h"
 #import <WebCore/HTTPStatusCodes.h>
@@ -37,37 +38,6 @@
 #import <wtf/URLParser.h>
 
 #if ENABLE(WK_WEB_EXTENSIONS)
-
-static NSString * const formDataKey = @"formData";
-static NSString * const rawKey = @"raw";
-static NSString * const bytesKey = @"bytes";
-static NSString * const errorKey = @"error";
-
-static NSString * const parentFrameIdKey = @"parentFrameId";
-static NSString * const requestIdKey = @"requestId";
-static NSString * const timeStampKey = @"timeStamp";
-static NSString * const typeKey = @"type";
-static NSString * const methodKey = @"method";
-static NSString * const redirectURLKey = @"redirectUrl";
-
-static NSString * const valueKey = @"value";
-
-static NSString * const statusLineKey = @"statusLine";
-static NSString * const statusCodeKey = @"statusCode";
-static NSString * const fromCacheKey = @"fromCache";
-
-static NSString * const schemeKey = @"scheme";
-static NSString * const challengerKey = @"challenger";
-static NSString * const hostKey = @"host";
-static NSString * const portKey = @"port";
-static NSString * const isProxyKey = @"isProxy";
-static NSString * const digestSchemeKey = @"digest";
-static NSString * const basicSchemeKey = @"basic";
-static NSString * const realmKey = @"realm";
-
-static NSString * const requestBodyKey = @"requestBody";
-static NSString * const requestHeadersKey = @"requestHeaders";
-static NSString * const responseHeadersKey = @"responseHeaders";
 
 namespace WebKit {
 

--- a/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
+++ b/Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm
@@ -29,6 +29,7 @@
 
 #import "config.h"
 #import "WebExtensionAPIWindows.h"
+#import "WebExtensionAPIKeys.h"
 
 #if ENABLE(WK_WEB_EXTENSIONS)
 
@@ -43,34 +44,6 @@
 #import "WebExtensionUtilities.h"
 #import "WebExtensionWindowIdentifier.h"
 #import "WebProcess.h"
-
-static NSString * const populateKey = @"populate";
-
-static NSString * const windowTypesKey = @"windowTypes";
-static NSString * const normalKey = @"normal";
-static NSString * const popupKey = @"popup";
-
-static NSString * const minimizedKey = @"minimized";
-static NSString * const maximizedKey = @"maximized";
-static NSString * const fullscreenKey = @"fullscreen";
-
-static NSString * const focusedKey = @"focused";
-static NSString * const incognitoKey = @"incognito";
-static NSString * const stateKey = @"state";
-static NSString * const typeKey = @"type";
-
-static NSString * const topKey = @"top";
-static NSString * const leftKey = @"left";
-static NSString * const widthKey = @"width";
-static NSString * const heightKey = @"height";
-
-static NSString * const tabsKey = @"tabs";
-
-static NSString * const idKey = @"id";
-static NSString * const alwaysOnTopKey = @"alwaysOnTop";
-
-static NSString * const urlKey = @"url";
-static NSString * const tabIdKey = @"tabId";
 
 namespace WebKit {
 

--- a/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp
+++ b/Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp
@@ -114,7 +114,7 @@ JSValueRef callWithArguments(JSObjectRef callbackFunction, JSRetainPtr<JSGlobalC
         return nil;
 
     auto* globalObject = toJS(globalContext.get());
-    RefPtr context = globalObject ? downcast<JSDOMGlobalObject>(globalObject)->scriptExecutionContext() : nullptr;
+    RefPtr context = globalObject ? downcast<WebCore::JSDOMGlobalObject>(globalObject)->scriptExecutionContext() : nullptr;
     if (!context || context->activeDOMObjectsAreStopped())
         return nil;
 

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebNavigationURLFilter.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebNavigationURLFilter.mm
@@ -36,6 +36,7 @@
 #import <WebKit/WebNSURLExtras.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
+#import <wtf/text/MakeString.h>
 
 using namespace WebKit;
 

--- a/Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebRequestFilter.mm
+++ b/Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebRequestFilter.mm
@@ -38,14 +38,14 @@
 #import "WebExtensionTabIdentifier.h"
 #import "WebExtensionUtilities.h"
 #import "WebExtensionWindowIdentifier.h"
+#import "WebProcess/Extensions/API/Cocoa/WebExtensionAPIKeys.h"
 #import "_WKResourceLoadInfo.h"
+#import <wtf/text/MakeString.h>
 
 using namespace WebKit;
 
-static NSString *urlsKey = @"urls";
-static NSString *typesKey = @"types";
-
-static NSString *windowIdKey = @"windowId";
+static NSString * const urlsKey = @"urls";
+static NSString * const typesKey = @"types";
 
 _WKWebExtensionWebRequestResourceType NODELETE toWebExtensionWebRequestResourceType(const ResourceLoadInfo& resourceLoadInfo)
 {

--- a/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitInjectedBundleMain.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitInjectedBundleMain.cpp
@@ -21,7 +21,7 @@
 
 #include "InjectedBundle.h"
 #include "WebProcessExtensionManager.h"
-#include <WebKit/WKBundleAPICast.h>
+#include "WKBundleAPICast.h"
 #include <WebKit/WKBundleInitialize.h>
 
 using namespace WebKit;

--- a/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp
+++ b/Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp
@@ -84,8 +84,6 @@
 
 namespace WebKit {
 using namespace WebCore;
-using namespace JSC;
-
 RefPtr<InjectedBundle> InjectedBundle::create(WebProcessCreationParameters& parameters, RefPtr<API::Object>&& initializationUserData)
 {
     TraceScope scope(TracePointCode::CreateInjectedBundleStart, TracePointCode::CreateInjectedBundleEnd);
@@ -229,7 +227,7 @@ void InjectedBundle::garbageCollectJavaScriptObjectsOnAlternateThreadForDebuggin
 
 size_t InjectedBundle::javaScriptObjectsCount()
 {
-    JSLockHolder lock(commonVM());
+    JSC::JSLockHolder lock(commonVM());
     return commonVM().heap.objectCount();
 }
 
@@ -239,7 +237,7 @@ void InjectedBundle::reportException(JSContextRef context, JSValueRef exception)
         return;
 
     JSC::JSGlobalObject* globalObject = toJS(context);
-    JSLockHolder lock(globalObject);
+    JSC::JSLockHolder lock(globalObject);
 
     WebCore::reportExceptionIfJSDOMWindow(globalObject, toJS(globalObject, exception));
 }
@@ -298,7 +296,7 @@ std::optional<WTF::UUID> InjectedBundle::webNotificationID(JSContextRef jsContex
 Ref<API::Data> InjectedBundle::createWebDataFromUint8Array(JSContextRef context, JSValueRef data)
 {
     JSC::JSGlobalObject* globalObject = toJS(context);
-    JSLockHolder lock(globalObject);
+    JSC::JSLockHolder lock(globalObject);
     RefPtr<Uint8Array> arrayData = WebCore::toUnsharedUint8Array(globalObject->vm(), toJS(globalObject, data));
     return API::Data::create(arrayData->span());
 }

--- a/Source/WebKit/WebProcess/Plugins/PluginView.cpp
+++ b/Source/WebKit/WebProcess/Plugins/PluginView.cpp
@@ -89,7 +89,6 @@
 #include <wtf/text/StringBuilder.h>
 
 namespace WebKit {
-using namespace JSC;
 using namespace WebCore;
 
 class PluginView::Stream : public RefCounted<PluginView::Stream>, NetscapePlugInStreamLoaderClient {

--- a/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebFrame.cpp
@@ -142,7 +142,6 @@
 #endif
 
 namespace WebKit {
-using namespace JSC;
 using namespace WebCore;
 
 static uint64_t NODELETE generateListenerID()
@@ -1164,7 +1163,7 @@ JSValueRef WebFrame::jsWrapperForWorld(InjectedBundleCSSStyleDeclarationHandle* 
 
     auto* globalObject = protect(localFrame->script())->globalObject(protect(world->coreWorld()));
 
-    JSLockHolder lock(globalObject);
+    JSC::JSLockHolder lock(globalObject);
     return toRef(globalObject, toJS(globalObject, globalObject, cssStyleDeclarationHandle->coreCSSStyleDeclaration()));
 }
 
@@ -1176,7 +1175,7 @@ JSValueRef WebFrame::jsWrapperForWorld(InjectedBundleNodeHandle* nodeHandle, Inj
 
     auto* globalObject = protect(localFrame->script())->globalObject(protect(world->coreWorld()));
 
-    JSLockHolder lock(globalObject);
+    JSC::JSLockHolder lock(globalObject);
     RefPtr coreNode = nodeHandle->coreNode();
     return toRef(globalObject, coreNode ? toJS(globalObject, globalObject, coreNode.releaseNonNull()) : JSC::jsNull());
 }
@@ -1189,7 +1188,7 @@ JSValueRef WebFrame::jsWrapperForWorld(InjectedBundleRangeHandle* rangeHandle, I
 
     auto* globalObject = protect(localFrame->script())->globalObject(protect(world->coreWorld()));
 
-    JSLockHolder lock(globalObject);
+    JSC::JSLockHolder lock(globalObject);
     return toRef(globalObject, toJS(globalObject, globalObject, Ref { rangeHandle->coreRange() }.get()));
 }
 
@@ -1587,7 +1586,7 @@ static Ref<WebKitJSHandle> createJSHandle(Node& node)
     auto* lexicalGlobalObject = document->globalObject();
     RELEASE_ASSERT(lexicalGlobalObject->template inherits<JSDOMGlobalObject>());
     auto* domGlobalObject = downcast<JSDOMGlobalObject>(lexicalGlobalObject);
-    JSLockHolder locker { lexicalGlobalObject };
+    JSC::JSLockHolder locker { lexicalGlobalObject };
     return WebKitJSHandle::create(toJS(lexicalGlobalObject, domGlobalObject, node).toObject(lexicalGlobalObject));
 }
 

--- a/Source/WebKit/WebProcess/WebPage/WebPage.cpp
+++ b/Source/WebKit/WebProcess/WebPage/WebPage.cpp
@@ -513,7 +513,6 @@
 #endif
 
 namespace WebKit {
-using namespace JSC;
 using namespace WebCore;
 
 static const Seconds pageScrollHysteresisDuration { 300_ms };
@@ -4842,7 +4841,7 @@ void WebPage::runJavaScript(WebFrame* frame, RunJavaScriptParameters&& parameter
         parameters.removeTransientActivation
     };
 
-    JSLockHolder lock(commonVM());
+    JSC::JSLockHolder lock(commonVM());
     protect(protect(frame->coreLocalFrame())->script())->executeAsynchronousUserAgentScriptInWorld(protect(world->coreWorld()), WTF::move(coreParameters), WTF::move(resolveFunction));
 }
 
@@ -5129,7 +5128,7 @@ void WebPage::updatePreferences(const WebPreferencesStore& store)
     settings.setRequiresUserGestureForAudioPlayback(requiresUserGestureForMedia || store.getBoolValueForKey(WebPreferencesKey::requiresUserGestureForAudioPlaybackKey()));
     settings.setUserInterfaceDirectionPolicy(static_cast<WebCore::UserInterfaceDirectionPolicy>(store.getUInt32ValueForKey(WebPreferencesKey::userInterfaceDirectionPolicyKey())));
     settings.setSystemLayoutDirection(static_cast<TextDirection>(store.getUInt32ValueForKey(WebPreferencesKey::systemLayoutDirectionKey())));
-    settings.setJavaScriptRuntimeFlags(static_cast<RuntimeFlags>(store.getUInt32ValueForKey(WebPreferencesKey::javaScriptRuntimeFlagsKey())));
+    settings.setJavaScriptRuntimeFlags(static_cast<JSC::RuntimeFlags>(store.getUInt32ValueForKey(WebPreferencesKey::javaScriptRuntimeFlagsKey())));
     settings.setStorageBlockingPolicy(static_cast<StorageBlockingPolicy>(store.getUInt32ValueForKey(WebPreferencesKey::storageBlockingPolicyKey())));
     settings.setEditableLinkBehavior(static_cast<WebCore::EditableLinkBehavior>(store.getUInt32ValueForKey(WebPreferencesKey::editableLinkBehaviorKey())));
 #if ENABLE(DATA_DETECTION)

--- a/Source/WebKit/WebProcess/WebProcess.cpp
+++ b/Source/WebKit/WebProcess/WebProcess.cpp
@@ -294,7 +294,6 @@ static const Seconds nonVisibleProcessMemoryCleanupDelay { 120_s };
 #endif
 
 namespace WebKit {
-using namespace JSC;
 using namespace WebCore;
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebProcess);
@@ -512,7 +511,7 @@ void WebProcess::initializeWebProcess(WebProcessCreationParameters&& parameters,
             if (m_pagesInWindows.isEmpty() && critical == Critical::No)
                 critical = Critical::Yes;
 
-            if (Options::dumpHeapOnLowMemory()) [[unlikely]]
+            if (JSC::Options::dumpHeapOnLowMemory()) [[unlikely]]
                 GarbageCollectionController::singleton().dumpHeap();
 
 #if PLATFORM(COCOA)

--- a/Source/WebKitLegacy/mac/DOM/DOM.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOM.mm
@@ -79,16 +79,14 @@
 #import <WebCore/WebCoreThreadMessage.h>
 #endif
 
-using namespace JSC;
-using namespace WebCore;
 
 //------------------------------------------------------------------------------------------
 // DOMNode
 
-typedef HashMap<const QualifiedName::QualifiedNameImpl*, Class> ObjCClassMap;
+typedef HashMap<const WebCore::QualifiedName::QualifiedNameImpl*, Class> ObjCClassMap;
 static ObjCClassMap* elementClassMap;
 
-static void addElementClass(const QualifiedName& tag, Class objCClass)
+static void addElementClass(const WebCore::QualifiedName& tag, Class objCClass)
 {
     elementClassMap->set(tag.impl(), objCClass);
 }
@@ -98,85 +96,85 @@ static void createElementClassMap()
     // Create the table.
     elementClassMap = new ObjCClassMap;
 
-    addElementClass(HTMLNames::aTag, [DOMHTMLAnchorElement class]);
-    addElementClass(HTMLNames::appletTag, [DOMHTMLAppletElement class]);
-    addElementClass(HTMLNames::areaTag, [DOMHTMLAreaElement class]);
-    addElementClass(HTMLNames::baseTag, [DOMHTMLBaseElement class]);
-    addElementClass(HTMLNames::basefontTag, [DOMHTMLBaseFontElement class]);
-    addElementClass(HTMLNames::bodyTag, [DOMHTMLBodyElement class]);
-    addElementClass(HTMLNames::brTag, [DOMHTMLBRElement class]);
-    addElementClass(HTMLNames::buttonTag, [DOMHTMLButtonElement class]);
-    addElementClass(HTMLNames::canvasTag, [DOMHTMLCanvasElement class]);
-    addElementClass(HTMLNames::captionTag, [DOMHTMLTableCaptionElement class]);
-    addElementClass(HTMLNames::colTag, [DOMHTMLTableColElement class]);
-    addElementClass(HTMLNames::colgroupTag, [DOMHTMLTableColElement class]);
-    addElementClass(HTMLNames::delTag, [DOMHTMLModElement class]);
-    addElementClass(HTMLNames::dirTag, [DOMHTMLDirectoryElement class]);
-    addElementClass(HTMLNames::divTag, [DOMHTMLDivElement class]);
-    addElementClass(HTMLNames::dlTag, [DOMHTMLDListElement class]);
-    addElementClass(HTMLNames::embedTag, [DOMHTMLEmbedElement class]);
-    addElementClass(HTMLNames::fieldsetTag, [DOMHTMLFieldSetElement class]);
-    addElementClass(HTMLNames::fontTag, [DOMHTMLFontElement class]);
-    addElementClass(HTMLNames::formTag, [DOMHTMLFormElement class]);
-    addElementClass(HTMLNames::frameTag, [DOMHTMLFrameElement class]);
-    addElementClass(HTMLNames::framesetTag, [DOMHTMLFrameSetElement class]);
-    addElementClass(HTMLNames::h1Tag, [DOMHTMLHeadingElement class]);
-    addElementClass(HTMLNames::h2Tag, [DOMHTMLHeadingElement class]);
-    addElementClass(HTMLNames::h3Tag, [DOMHTMLHeadingElement class]);
-    addElementClass(HTMLNames::h4Tag, [DOMHTMLHeadingElement class]);
-    addElementClass(HTMLNames::h5Tag, [DOMHTMLHeadingElement class]);
-    addElementClass(HTMLNames::h6Tag, [DOMHTMLHeadingElement class]);
-    addElementClass(HTMLNames::headTag, [DOMHTMLHeadElement class]);
-    addElementClass(HTMLNames::hrTag, [DOMHTMLHRElement class]);
-    addElementClass(HTMLNames::htmlTag, [DOMHTMLHtmlElement class]);
-    addElementClass(HTMLNames::iframeTag, [DOMHTMLIFrameElement class]);
-    addElementClass(HTMLNames::imgTag, [DOMHTMLImageElement class]);
-    addElementClass(HTMLNames::inputTag, [DOMHTMLInputElement class]);
-    addElementClass(HTMLNames::insTag, [DOMHTMLModElement class]);
-    addElementClass(HTMLNames::labelTag, [DOMHTMLLabelElement class]);
-    addElementClass(HTMLNames::legendTag, [DOMHTMLLegendElement class]);
-    addElementClass(HTMLNames::liTag, [DOMHTMLLIElement class]);
-    addElementClass(HTMLNames::linkTag, [DOMHTMLLinkElement class]);
-    addElementClass(HTMLNames::listingTag, [DOMHTMLPreElement class]);
-    addElementClass(HTMLNames::mapTag, [DOMHTMLMapElement class]);
-    addElementClass(HTMLNames::marqueeTag, [DOMHTMLMarqueeElement class]);
-    addElementClass(HTMLNames::menuTag, [DOMHTMLMenuElement class]);
-    addElementClass(HTMLNames::metaTag, [DOMHTMLMetaElement class]);
-    addElementClass(HTMLNames::objectTag, [DOMHTMLObjectElement class]);
-    addElementClass(HTMLNames::olTag, [DOMHTMLOListElement class]);
-    addElementClass(HTMLNames::optgroupTag, [DOMHTMLOptGroupElement class]);
-    addElementClass(HTMLNames::optionTag, [DOMHTMLOptionElement class]);
-    addElementClass(HTMLNames::pTag, [DOMHTMLParagraphElement class]);
-    addElementClass(HTMLNames::paramTag, [DOMHTMLParamElement class]);
-    addElementClass(HTMLNames::preTag, [DOMHTMLPreElement class]);
-    addElementClass(HTMLNames::qTag, [DOMHTMLQuoteElement class]);
-    addElementClass(HTMLNames::scriptTag, [DOMHTMLScriptElement class]);
-    addElementClass(HTMLNames::selectTag, [DOMHTMLSelectElement class]);
-    addElementClass(HTMLNames::styleTag, [DOMHTMLStyleElement class]);
-    addElementClass(HTMLNames::tableTag, [DOMHTMLTableElement class]);
-    addElementClass(HTMLNames::tbodyTag, [DOMHTMLTableSectionElement class]);
-    addElementClass(HTMLNames::tdTag, [DOMHTMLTableCellElement class]);
-    addElementClass(HTMLNames::textareaTag, [DOMHTMLTextAreaElement class]);
-    addElementClass(HTMLNames::tfootTag, [DOMHTMLTableSectionElement class]);
-    addElementClass(HTMLNames::thTag, [DOMHTMLTableCellElement class]);
-    addElementClass(HTMLNames::theadTag, [DOMHTMLTableSectionElement class]);
-    addElementClass(HTMLNames::titleTag, [DOMHTMLTitleElement class]);
-    addElementClass(HTMLNames::trTag, [DOMHTMLTableRowElement class]);
-    addElementClass(HTMLNames::ulTag, [DOMHTMLUListElement class]);
-    addElementClass(HTMLNames::videoTag, [DOMHTMLVideoElement class]);
-    addElementClass(HTMLNames::xmpTag, [DOMHTMLPreElement class]);
+    addElementClass(WebCore::HTMLNames::aTag, [DOMHTMLAnchorElement class]);
+    addElementClass(WebCore::HTMLNames::appletTag, [DOMHTMLAppletElement class]);
+    addElementClass(WebCore::HTMLNames::areaTag, [DOMHTMLAreaElement class]);
+    addElementClass(WebCore::HTMLNames::baseTag, [DOMHTMLBaseElement class]);
+    addElementClass(WebCore::HTMLNames::basefontTag, [DOMHTMLBaseFontElement class]);
+    addElementClass(WebCore::HTMLNames::bodyTag, [DOMHTMLBodyElement class]);
+    addElementClass(WebCore::HTMLNames::brTag, [DOMHTMLBRElement class]);
+    addElementClass(WebCore::HTMLNames::buttonTag, [DOMHTMLButtonElement class]);
+    addElementClass(WebCore::HTMLNames::canvasTag, [DOMHTMLCanvasElement class]);
+    addElementClass(WebCore::HTMLNames::captionTag, [DOMHTMLTableCaptionElement class]);
+    addElementClass(WebCore::HTMLNames::colTag, [DOMHTMLTableColElement class]);
+    addElementClass(WebCore::HTMLNames::colgroupTag, [DOMHTMLTableColElement class]);
+    addElementClass(WebCore::HTMLNames::delTag, [DOMHTMLModElement class]);
+    addElementClass(WebCore::HTMLNames::dirTag, [DOMHTMLDirectoryElement class]);
+    addElementClass(WebCore::HTMLNames::divTag, [DOMHTMLDivElement class]);
+    addElementClass(WebCore::HTMLNames::dlTag, [DOMHTMLDListElement class]);
+    addElementClass(WebCore::HTMLNames::embedTag, [DOMHTMLEmbedElement class]);
+    addElementClass(WebCore::HTMLNames::fieldsetTag, [DOMHTMLFieldSetElement class]);
+    addElementClass(WebCore::HTMLNames::fontTag, [DOMHTMLFontElement class]);
+    addElementClass(WebCore::HTMLNames::formTag, [DOMHTMLFormElement class]);
+    addElementClass(WebCore::HTMLNames::frameTag, [DOMHTMLFrameElement class]);
+    addElementClass(WebCore::HTMLNames::framesetTag, [DOMHTMLFrameSetElement class]);
+    addElementClass(WebCore::HTMLNames::h1Tag, [DOMHTMLHeadingElement class]);
+    addElementClass(WebCore::HTMLNames::h2Tag, [DOMHTMLHeadingElement class]);
+    addElementClass(WebCore::HTMLNames::h3Tag, [DOMHTMLHeadingElement class]);
+    addElementClass(WebCore::HTMLNames::h4Tag, [DOMHTMLHeadingElement class]);
+    addElementClass(WebCore::HTMLNames::h5Tag, [DOMHTMLHeadingElement class]);
+    addElementClass(WebCore::HTMLNames::h6Tag, [DOMHTMLHeadingElement class]);
+    addElementClass(WebCore::HTMLNames::headTag, [DOMHTMLHeadElement class]);
+    addElementClass(WebCore::HTMLNames::hrTag, [DOMHTMLHRElement class]);
+    addElementClass(WebCore::HTMLNames::htmlTag, [DOMHTMLHtmlElement class]);
+    addElementClass(WebCore::HTMLNames::iframeTag, [DOMHTMLIFrameElement class]);
+    addElementClass(WebCore::HTMLNames::imgTag, [DOMHTMLImageElement class]);
+    addElementClass(WebCore::HTMLNames::inputTag, [DOMHTMLInputElement class]);
+    addElementClass(WebCore::HTMLNames::insTag, [DOMHTMLModElement class]);
+    addElementClass(WebCore::HTMLNames::labelTag, [DOMHTMLLabelElement class]);
+    addElementClass(WebCore::HTMLNames::legendTag, [DOMHTMLLegendElement class]);
+    addElementClass(WebCore::HTMLNames::liTag, [DOMHTMLLIElement class]);
+    addElementClass(WebCore::HTMLNames::linkTag, [DOMHTMLLinkElement class]);
+    addElementClass(WebCore::HTMLNames::listingTag, [DOMHTMLPreElement class]);
+    addElementClass(WebCore::HTMLNames::mapTag, [DOMHTMLMapElement class]);
+    addElementClass(WebCore::HTMLNames::marqueeTag, [DOMHTMLMarqueeElement class]);
+    addElementClass(WebCore::HTMLNames::menuTag, [DOMHTMLMenuElement class]);
+    addElementClass(WebCore::HTMLNames::metaTag, [DOMHTMLMetaElement class]);
+    addElementClass(WebCore::HTMLNames::objectTag, [DOMHTMLObjectElement class]);
+    addElementClass(WebCore::HTMLNames::olTag, [DOMHTMLOListElement class]);
+    addElementClass(WebCore::HTMLNames::optgroupTag, [DOMHTMLOptGroupElement class]);
+    addElementClass(WebCore::HTMLNames::optionTag, [DOMHTMLOptionElement class]);
+    addElementClass(WebCore::HTMLNames::pTag, [DOMHTMLParagraphElement class]);
+    addElementClass(WebCore::HTMLNames::paramTag, [DOMHTMLParamElement class]);
+    addElementClass(WebCore::HTMLNames::preTag, [DOMHTMLPreElement class]);
+    addElementClass(WebCore::HTMLNames::qTag, [DOMHTMLQuoteElement class]);
+    addElementClass(WebCore::HTMLNames::scriptTag, [DOMHTMLScriptElement class]);
+    addElementClass(WebCore::HTMLNames::selectTag, [DOMHTMLSelectElement class]);
+    addElementClass(WebCore::HTMLNames::styleTag, [DOMHTMLStyleElement class]);
+    addElementClass(WebCore::HTMLNames::tableTag, [DOMHTMLTableElement class]);
+    addElementClass(WebCore::HTMLNames::tbodyTag, [DOMHTMLTableSectionElement class]);
+    addElementClass(WebCore::HTMLNames::tdTag, [DOMHTMLTableCellElement class]);
+    addElementClass(WebCore::HTMLNames::textareaTag, [DOMHTMLTextAreaElement class]);
+    addElementClass(WebCore::HTMLNames::tfootTag, [DOMHTMLTableSectionElement class]);
+    addElementClass(WebCore::HTMLNames::thTag, [DOMHTMLTableCellElement class]);
+    addElementClass(WebCore::HTMLNames::theadTag, [DOMHTMLTableSectionElement class]);
+    addElementClass(WebCore::HTMLNames::titleTag, [DOMHTMLTitleElement class]);
+    addElementClass(WebCore::HTMLNames::trTag, [DOMHTMLTableRowElement class]);
+    addElementClass(WebCore::HTMLNames::ulTag, [DOMHTMLUListElement class]);
+    addElementClass(WebCore::HTMLNames::videoTag, [DOMHTMLVideoElement class]);
+    addElementClass(WebCore::HTMLNames::xmpTag, [DOMHTMLPreElement class]);
 }
 
-static Class lookupElementClass(const QualifiedName& tag)
+static Class lookupElementClass(const WebCore::QualifiedName& tag)
 {
     // Do a special lookup to ignore element prefixes
     if (tag.hasPrefix())
-        return elementClassMap->get(QualifiedName(nullAtom(), tag.localName(), tag.namespaceURI()).impl());
+        return elementClassMap->get(WebCore::QualifiedName(nullAtom(), tag.localName(), tag.namespaceURI()).impl());
     
     return elementClassMap->get(tag.impl());
 }
 
-static Class elementClass(const QualifiedName& tag, Class defaultClass)
+static Class elementClass(const WebCore::QualifiedName& tag, Class defaultClass)
 {
     if (!elementClassMap)
         createElementClassMap();
@@ -188,12 +186,12 @@ static Class elementClass(const QualifiedName& tag, Class defaultClass)
 
 #if PLATFORM(IOS_FAMILY)
 
-static WKQuad wkQuadFromFloatQuad(const FloatQuad& inQuad)
+static WKQuad wkQuadFromFloatQuad(const WebCore::FloatQuad& inQuad)
 {
     return { inQuad.p1(), inQuad.p2(), inQuad.p3(), inQuad.p4() };
 }
 
-static NSArray *kit(const Vector<FloatQuad>& quads)
+static NSArray *kit(const Vector<WebCore::FloatQuad>& quads)
 {
     return createNSArray(quads, [] (auto& quad) {
         return adoptNS([[WKQuadObject alloc] initWithQuad:wkQuadFromFloatQuad(quad)]);
@@ -254,7 +252,7 @@ IGNORE_WARNINGS_BEGIN("objc-protocol-method-implementation")
 
 IGNORE_WARNINGS_END
 
-- (Bindings::RootObject*)_rootObject
+- (JSC::Bindings::RootObject*)_rootObject
 {
     auto* frame = core(self)->document().frame();
     if (!frame)
@@ -264,40 +262,40 @@ IGNORE_WARNINGS_END
 
 @end
 
-Class kitClass(Node* impl)
+Class kitClass(WebCore::Node* impl)
 {
     switch (impl->nodeType()) {
-    case NodeType::Element:
-        if (RefPtr htmlElement = dynamicDowncast<HTMLElement>(*impl))
+    case WebCore::NodeType::Element:
+        if (RefPtr htmlElement = dynamicDowncast<WebCore::HTMLElement>(*impl))
             return elementClass(htmlElement->tagQName(), [DOMHTMLElement class]);
         return [DOMElement class];
-    case NodeType::Attribute:
+    case WebCore::NodeType::Attribute:
         return [DOMAttr class];
-    case NodeType::Text:
+    case WebCore::NodeType::Text:
         return [DOMText class];
-    case NodeType::CDATASection:
+    case WebCore::NodeType::CDATASection:
         return [DOMCDATASection class];
-    case NodeType::ProcessingInstruction:
+    case WebCore::NodeType::ProcessingInstruction:
         return [DOMProcessingInstruction class];
-    case NodeType::Comment:
+    case WebCore::NodeType::Comment:
         return [DOMComment class];
-    case NodeType::Document:
-        if (is<HTMLDocument>(impl))
+    case WebCore::NodeType::Document:
+        if (is<WebCore::HTMLDocument>(impl))
             return [DOMHTMLDocument class];
         return [DOMDocument class];
-    case NodeType::DocumentType:
+    case WebCore::NodeType::DocumentType:
         return [DOMDocumentType class];
-    case NodeType::DocumentFragment:
+    case WebCore::NodeType::DocumentFragment:
         return [DOMDocumentFragment class];
     }
     ASSERT_NOT_REACHED();
     return nil;
 }
 
-id <DOMEventTarget> kit(EventTarget* target)
+id<DOMEventTarget> kit(WebCore::EventTarget* target)
 {
-    // We don't have Objective-C bindings for XMLHttpRequest, LocalDOMWindow, and other non-Node targets.
-    return is<Node>(target) ? kit(downcast<Node>(target)) : nil;
+    // We don't have Objective-C bindings for XMLHttpRequest, LocalDOMWindow, and other non-WebCore::Node targets.
+    return is<WebCore::Node>(target) ? kit(downcast<WebCore::Node>(target)) : nil;
 }
 
 @implementation DOMNode (DOMNodeExtensions)
@@ -309,7 +307,7 @@ id <DOMEventTarget> kit(EventTarget* target)
 #endif
 {
     auto& node = *core(self);
-    node.document().updateLayout(LayoutOptions::IgnorePendingStylesheets);
+    node.document().updateLayout(WebCore::LayoutOptions::IgnorePendingStylesheets);
     auto* renderer = node.renderer();
     if (!renderer)
 #if PLATFORM(IOS_FAMILY)
@@ -336,7 +334,7 @@ id <DOMEventTarget> kit(EventTarget* target)
 - (WKQuad)absoluteQuadAndInsideFixedPosition:(BOOL *)insideFixed
 {
     auto& node = *core(self);
-    node.document().updateLayout(LayoutOptions::IgnorePendingStylesheets);
+    node.document().updateLayout(WebCore::LayoutOptions::IgnorePendingStylesheets);
     auto* renderer = node.renderer();
     if (!renderer) {
         if (insideFixed)
@@ -344,7 +342,7 @@ id <DOMEventTarget> kit(EventTarget* target)
         return zeroQuad();
     }
 
-    Vector<FloatQuad> quads;
+    Vector<WebCore::FloatQuad> quads;
     bool wasFixed = false;
     renderer->absoluteQuads(quads, &wasFixed);
     if (insideFixed)
@@ -361,7 +359,7 @@ id <DOMEventTarget> kit(EventTarget* target)
 - (CGRect)boundingBoxUsingTransforms
 {
     auto& node = *core(self);
-    node.document().updateLayout(LayoutOptions::IgnorePendingStylesheets);
+    node.document().updateLayout(WebCore::LayoutOptions::IgnorePendingStylesheets);
     auto* renderer = node.renderer();
     if (!renderer)
         return CGRectZero;
@@ -372,7 +370,7 @@ id <DOMEventTarget> kit(EventTarget* target)
 - (NSArray *)lineBoxQuads
 {
     auto& node = *core(self);
-    node.document().updateLayout(LayoutOptions::IgnorePendingStylesheets);
+    node.document().updateLayout(WebCore::LayoutOptions::IgnorePendingStylesheets);
     WebCore::RenderObject *renderer = node.renderer();
     if (!renderer)
         return nil;
@@ -381,10 +379,10 @@ id <DOMEventTarget> kit(EventTarget* target)
     return kit(quads);
 }
 
-- (Element*)_linkElement
+- (WebCore::Element*)_linkElement
 {
     for (auto* node = core(self); node; node = node->parentNode()) {
-        if (auto* element = dynamicDowncast<Element>(*node); element && element->isLink())
+        if (auto* element = dynamicDowncast<WebCore::Element>(*node); element && element->isLink())
             return element;
     }
     return nullptr;
@@ -395,7 +393,7 @@ id <DOMEventTarget> kit(EventTarget* target)
     auto* link = [self _linkElement];
     if (!link)
         return nil;
-    return link->document().encodingParseURL(link->getAttribute(HTMLNames::hrefAttr)).createNSURL().autorelease();
+    return link->document().encodingParseURL(link->getAttribute(WebCore::HTMLNames::hrefAttr)).createNSURL().autorelease();
 }
 
 - (NSString *)hrefTarget
@@ -403,7 +401,7 @@ id <DOMEventTarget> kit(EventTarget* target)
     auto* link = [self _linkElement];
     if (!link)
         return nil;
-    return link->getAttribute(HTMLNames::targetAttr).createNSString().autorelease();
+    return link->getAttribute(WebCore::HTMLNames::targetAttr).createNSString().autorelease();
 }
 
 - (CGRect)hrefFrame
@@ -428,9 +426,9 @@ id <DOMEventTarget> kit(EventTarget* target)
 - (NSString *)hrefTitle
 {
     auto* link = [self _linkElement];
-    if (!is<HTMLElement>(link))
+    if (!is<WebCore::HTMLElement>(link))
         return nil;
-    return link->document().displayStringModifiedByEncoding(downcast<HTMLElement>(*link).title()).createNSString().autorelease();
+    return link->document().displayStringModifiedByEncoding(downcast<WebCore::HTMLElement>(*link).title()).createNSString().autorelease();
 }
 
 - (CGRect)boundingFrame
@@ -441,20 +439,20 @@ id <DOMEventTarget> kit(EventTarget* target)
 - (WKQuad)innerFrameQuad // takes transforms into account
 {
     auto& node = *core(self);
-    node.document().updateLayout(LayoutOptions::IgnorePendingStylesheets);
+    node.document().updateLayout(WebCore::LayoutOptions::IgnorePendingStylesheets);
     auto* renderer = node.renderer();
     if (!renderer)
         return zeroQuad();
 
     auto& style = renderer->style();
-    IntRect boundingBox = renderer->absoluteBoundingBoxRect(true /* use transforms*/);
+    WebCore::IntRect boundingBox = renderer->absoluteBoundingBoxRect(true /* use transforms*/);
 
     boundingBox.move(WebCore::Style::evaluate<float>(style.usedBorderLeftWidth(), WebCore::Style::ZoomNeeded { }), WebCore::Style::evaluate<float>(style.usedBorderTopWidth(), WebCore::Style::ZoomNeeded { }));
     boundingBox.setWidth(boundingBox.width() - WebCore::Style::evaluate<float>(style.usedBorderLeftWidth(), WebCore::Style::ZoomNeeded { }) - WebCore::Style::evaluate<float>(style.usedBorderRightWidth(), WebCore::Style::ZoomNeeded { }));
     boundingBox.setHeight(boundingBox.height() - WebCore::Style::evaluate<float>(style.usedBorderBottomWidth(), WebCore::Style::ZoomNeeded { }) - WebCore::Style::evaluate<float>(style.usedBorderTopWidth(), WebCore::Style::ZoomNeeded { }));
 
     // FIXME: This function advertises returning a quad, but it actually returns a bounding box (so there is no rotation, for instance).
-    return wkQuadFromFloatQuad(FloatQuad(boundingBox));
+    return wkQuadFromFloatQuad(WebCore::FloatQuad(boundingBox));
 }
 
 - (float)computedFontSize
@@ -467,7 +465,7 @@ id <DOMEventTarget> kit(EventTarget* target)
 
 - (DOMNode *)nextFocusNode
 {
-    Page* page = core(self)->document().page();
+    WebCore::Page* page = core(self)->document().page();
     if (!page)
         return nil;
     return kit(page->focusController().nextFocusableElement(*core(self)).element.get());
@@ -475,7 +473,7 @@ id <DOMEventTarget> kit(EventTarget* target)
 
 - (DOMNode *)previousFocusNode
 {
-    Page* page = core(self)->document().page();
+    WebCore::Page* page = core(self)->document().page();
     if (!page)
         return nil;
     return kit(page->focusController().previousFocusableElement(*core(self)).element.get());
@@ -503,10 +501,10 @@ id <DOMEventTarget> kit(EventTarget* target)
 - (NSArray *)textRects
 {
     auto& node = *core(self);
-    node.document().updateLayout(LayoutOptions::IgnorePendingStylesheets);
+    node.document().updateLayout(WebCore::LayoutOptions::IgnorePendingStylesheets);
     if (!node.renderer())
         return nil;
-    return createNSArray(RenderObject::absoluteTextRects(makeRangeSelectingNodeContents(node))).autorelease();
+    return createNSArray(WebCore::RenderObject::absoluteTextRects(makeRangeSelectingNodeContents(node))).autorelease();
 }
 
 @end
@@ -515,10 +513,10 @@ id <DOMEventTarget> kit(EventTarget* target)
 
 + (id)_nodeFromJSWrapper:(JSObjectRef)jsWrapper
 {
-    JSObject* object = toJS(jsWrapper);
-    if (!object->inherits<JSNode>())
+    JSC::JSObject* object = toJS(jsWrapper);
+    if (!object->inherits<WebCore::JSNode>())
         return nil;
-    return kit(&uncheckedDowncast<JSNode>(object)->wrapped());
+    return kit(&uncheckedDowncast<WebCore::JSNode>(object)->wrapped());
 }
 
 - (void)getPreviewSnapshotImage:(CGImageRef*)cgImage andRects:(NSArray **)rects
@@ -531,18 +529,18 @@ id <DOMEventTarget> kit(EventTarget* target)
 
     auto& node = *core(self);
 
-    constexpr OptionSet<TextIndicatorOption> options {
-        TextIndicatorOption::TightlyFitContent,
-        TextIndicatorOption::RespectTextColor,
-        TextIndicatorOption::PaintBackgrounds,
-        TextIndicatorOption::UseBoundingRectAndPaintAllContentForComplexRanges,
-        TextIndicatorOption::IncludeMarginIfRangeMatchesSelection
+    constexpr OptionSet<WebCore::TextIndicatorOption> options {
+        WebCore::TextIndicatorOption::TightlyFitContent,
+        WebCore::TextIndicatorOption::RespectTextColor,
+        WebCore::TextIndicatorOption::PaintBackgrounds,
+        WebCore::TextIndicatorOption::UseBoundingRectAndPaintAllContentForComplexRanges,
+        WebCore::TextIndicatorOption::IncludeMarginIfRangeMatchesSelection
     };
     const float margin = 4 / node.document().page()->pageScaleFactor();
-    auto textIndicator = TextIndicator::createWithRange(makeRangeSelectingNodeContents(node), options, TextIndicatorPresentationTransition::None, FloatSize(margin, margin));
+    auto textIndicator = WebCore::TextIndicator::createWithRange(makeRangeSelectingNodeContents(node), options, WebCore::TextIndicatorPresentationTransition::None, WebCore::FloatSize(margin, margin));
 
     if (textIndicator) {
-        if (Image* image = textIndicator->contentImage()) {
+        if (WebCore::Image* image = textIndicator->contentImage()) {
             auto contentImage = image->nativeImage()->platformImage();
             *cgImage = contentImage.autorelease();
         }
@@ -550,22 +548,22 @@ id <DOMEventTarget> kit(EventTarget* target)
 
     if (!*cgImage) {
         if (auto* renderer = node.renderer()) {
-            FloatRect boundingBox;
+            WebCore::FloatRect boundingBox;
             if (renderer->isRenderImage())
-                boundingBox = downcast<RenderImage>(*renderer).absoluteContentQuad().enclosingBoundingBox();
+                boundingBox = downcast<WebCore::RenderImage>(*renderer).absoluteContentQuad().enclosingBoundingBox();
             else
                 boundingBox = renderer->absoluteBoundingBoxRect();
             boundingBox.inflate(margin);
-            *rects = @[makeNSArrayElement(node.document().frame()->view()->contentsToWindow(enclosingIntRect(boundingBox)))];
+            *rects = @[makeNSArrayElement(node.document().frame()->view()->contentsToWindow(WebCore::enclosingIntRect(boundingBox)))];
         }
         return;
     }
 
-    FloatPoint origin = textIndicator->textBoundingRectInRootViewCoordinates().location();
+    WebCore::FloatPoint origin = textIndicator->textBoundingRectInRootViewCoordinates().location();
     *rects = createNSArray(textIndicator->textRectsInBoundingRectCoordinates(), [&] (CGRect rect) {
         rect.origin.x += origin.x();
         rect.origin.y += origin.y();
-        return makeNSArrayElement(node.document().frame()->view()->contentsToWindow(enclosingIntRect(rect)));
+        return makeNSArrayElement(node.document().frame()->view()->contentsToWindow(WebCore::enclosingIntRect(rect)));
     }).autorelease();
 }
 
@@ -580,8 +578,8 @@ id <DOMEventTarget> kit(EventTarget* target)
 #endif
 {
     auto range = makeSimpleRange(*core(self));
-    range.start.document().updateLayout(LayoutOptions::IgnorePendingStylesheets);
-    return unionRect(RenderObject::absoluteTextRects(range));
+    range.start.document().updateLayout(WebCore::LayoutOptions::IgnorePendingStylesheets);
+    return unionRect(WebCore::RenderObject::absoluteTextRects(range));
 }
 
 #if PLATFORM(MAC)
@@ -599,7 +597,7 @@ id <DOMEventTarget> kit(EventTarget* target)
 
 #if PLATFORM(MAC)
     // iOS uses CGImageRef for drag images, which doesn't support separate logical/physical sizes.
-    IntSize size([renderedImage size]);
+    WebCore::IntSize size([renderedImage size]);
     size.scale(1 / frame->page()->deviceScaleFactor());
     [renderedImage setSize:size];
 #endif
@@ -610,8 +608,8 @@ id <DOMEventTarget> kit(EventTarget* target)
 - (NSArray *)textRects
 {
     auto range = makeSimpleRange(*core(self));
-    range.start.document().updateLayout(LayoutOptions::IgnorePendingStylesheets);
-    return createNSArray(RenderObject::absoluteTextRects(range)).autorelease();
+    range.start.document().updateLayout(WebCore::LayoutOptions::IgnorePendingStylesheets);
+    return createNSArray(WebCore::RenderObject::absoluteTextRects(range)).autorelease();
 }
 
 - (NSArray *)lineBoxRects
@@ -632,9 +630,9 @@ id <DOMEventTarget> kit(EventTarget* target)
 - (NSImage *)image
 {
     auto* renderer = core(self)->renderer();
-    if (!is<RenderImage>(renderer))
+    if (!is<WebCore::RenderImage>(renderer))
         return nil;
-    auto* cachedImage = downcast<RenderImage>(*renderer).cachedImage();
+    auto* cachedImage = downcast<WebCore::RenderImage>(*renderer).cachedImage();
     if (!cachedImage || cachedImage->errorOccurred())
         return nil;
     return cachedImage->imageForRenderer(renderer)->adapter().nsImage();
@@ -660,9 +658,9 @@ id <DOMEventTarget> kit(EventTarget* target)
 {
     // FIXME: Could we move this function to WebCore::Element and autogenerate?
     auto* renderer = core(self)->renderer();
-    if (!is<RenderImage>(renderer))
+    if (!is<WebCore::RenderImage>(renderer))
         return nil;
-    auto* cachedImage = downcast<RenderImage>(*renderer).cachedImage();
+    auto* cachedImage = downcast<WebCore::RenderImage>(*renderer).cachedImage();
     if (!cachedImage || cachedImage->errorOccurred())
         return nil;
     return (__bridge NSData *)cachedImage->imageForRenderer(renderer)->adapter().tiffRepresentation();
@@ -690,18 +688,18 @@ id <DOMEventTarget> kit(EventTarget* target)
 
 - (BOOL)_mediaQueryMatchesForOrientation:(int)orientation
 {
-    auto& document = static_cast<HTMLLinkElement*>(core(self))->document();
+    auto& document = static_cast<WebCore::HTMLLinkElement*>(core(self))->document();
     auto* frameView = document.frame() ? document.frame()->view() : 0;
     if (!frameView)
         return false;
     int layoutWidth = frameView->layoutWidth();
     int layoutHeight = frameView->layoutHeight();
-    IntSize savedFixedLayoutSize = frameView->fixedLayoutSize();
+    WebCore::IntSize savedFixedLayoutSize = frameView->fixedLayoutSize();
     bool savedUseFixedLayout = frameView->useFixedLayout();
     if ((orientation == WebMediaQueryOrientationPortrait && layoutWidth > layoutHeight) ||
         (orientation == WebMediaQueryOrientationLandscape && layoutWidth < layoutHeight)) {
         // temporarily swap the orientation for the evaluation
-        frameView->setFixedLayoutSize(IntSize(layoutHeight, layoutWidth));
+        frameView->setFixedLayoutSize(WebCore::IntSize(layoutHeight, layoutWidth));
         frameView->setUseFixedLayout(true);
     }
         
@@ -715,7 +713,7 @@ id <DOMEventTarget> kit(EventTarget* target)
 
 - (BOOL)_mediaQueryMatches
 {
-    return downcast<HTMLLinkElement>(core(self))->mediaAttributeMatches();
+    return downcast<WebCore::HTMLLinkElement>(core(self))->mediaAttributeMatches();
 }
 
 @end
@@ -812,7 +810,7 @@ WebCore::NodeFilter* core(DOMNodeFilter *wrapper)
         raiseTypeErrorException();
     
     auto result = core(self)->acceptNodeRethrowingException(*core(node));
-    return result.type() == CallbackResultType::Success ? result.releaseReturnValue() : NodeFilter::FILTER_REJECT;
+    return result.type() == WebCore::CallbackResultType::Success ? result.releaseReturnValue() : WebCore::NodeFilter::FILTER_REJECT;
 }
 
 @end

--- a/Source/WebKitLegacy/mac/DOM/DOMAttr.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMAttr.mm
@@ -32,6 +32,7 @@
 #import "DOMNodeInternal.h"
 #import <WebCore/Element.h>
 #import "ExceptionHandlers.h"
+#import <WebCore/HTMLNames.h>
 #import <WebCore/JSExecState.h>
 #import <WebCore/StyleProperties.h>
 #import <WebCore/ThreadCheck.h>

--- a/Source/WebKitLegacy/mac/DOM/DOMNode.mm
+++ b/Source/WebKitLegacy/mac/DOM/DOMNode.mm
@@ -42,20 +42,19 @@
 #import <WebCore/WebCoreObjCExtras.h>
 #import <WebCore/WebScriptObjectPrivate.h>
 
-using namespace WebCore;
 
-static inline Node& unwrap(DOMNode& wrapper)
+static inline WebCore::Node& unwrap(DOMNode& wrapper)
 {
     ASSERT(wrapper._internal);
-    return reinterpret_cast<Node&>(*wrapper._internal);
+    return reinterpret_cast<WebCore::Node&>(*wrapper._internal);
 }
 
-Node* core(DOMNode *wrapper)
+WebCore::Node* core(DOMNode *wrapper)
 {
     return wrapper ? &unwrap(*wrapper) : nullptr;
 }
 
-DOMNode *kit(Node* value)
+DOMNode *kit(WebCore::Node* value)
 {
     WebCoreThreadViolationCheckRoundOne();
     if (!value)
@@ -84,139 +83,139 @@ DOMNode *kit(Node* value)
 
 - (NSString *)nodeName
 {
-    JSMainThreadNullState state;
+    WebCore::JSMainThreadNullState state;
     return unwrap(*self).nodeName().createNSString().autorelease();
 }
 
 - (NSString *)nodeValue
 {
-    JSMainThreadNullState state;
+    WebCore::JSMainThreadNullState state;
     return unwrap(*self).nodeValue().createNSString().autorelease();
 }
 
 - (void)setNodeValue:(NSString *)newNodeValue
 {
-    JSMainThreadNullState state;
+    WebCore::JSMainThreadNullState state;
     unwrap(*self).setNodeValue(newNodeValue);
 }
 
 - (unsigned short)nodeType
 {
-    JSMainThreadNullState state;
+    WebCore::JSMainThreadNullState state;
     return std::to_underlying(unwrap(*self).nodeType());
 }
 
 - (DOMNode *)parentNode
 {
-    JSMainThreadNullState state;
+    WebCore::JSMainThreadNullState state;
     return kit(unwrap(*self).parentNode());
 }
 
 - (DOMNodeList *)childNodes
 {
-    JSMainThreadNullState state;
+    WebCore::JSMainThreadNullState state;
     return kit(unwrap(*self).childNodes().ptr());
 }
 
 - (DOMNode *)firstChild
 {
-    JSMainThreadNullState state;
+    WebCore::JSMainThreadNullState state;
     return kit(unwrap(*self).firstChild());
 }
 
 - (DOMNode *)lastChild
 {
-    JSMainThreadNullState state;
+    WebCore::JSMainThreadNullState state;
     return kit(unwrap(*self).lastChild());
 }
 
 - (DOMNode *)previousSibling
 {
-    JSMainThreadNullState state;
+    WebCore::JSMainThreadNullState state;
     return kit(unwrap(*self).previousSibling());
 }
 
 - (DOMNode *)nextSibling
 {
-    JSMainThreadNullState state;
+    WebCore::JSMainThreadNullState state;
     return kit(unwrap(*self).nextSibling());
 }
 
 - (DOMDocument *)ownerDocument
 {
-    JSMainThreadNullState state;
+    WebCore::JSMainThreadNullState state;
     return kit(&unwrap(*self).document());
 }
 
 - (NSString *)namespaceURI
 {
-    JSMainThreadNullState state;
+    WebCore::JSMainThreadNullState state;
     return unwrap(*self).namespaceURI().createNSString().autorelease();
 }
 
 - (NSString *)prefix
 {
-    JSMainThreadNullState state;
+    WebCore::JSMainThreadNullState state;
     return unwrap(*self).prefix().createNSString().autorelease();
 }
 
 - (void)setPrefix:(NSString *)newPrefix
 {
-    JSMainThreadNullState state;
+    WebCore::JSMainThreadNullState state;
     raiseOnDOMError(unwrap(*self).setPrefix(newPrefix));
 }
 
 - (NSString *)localName
 {
-    JSMainThreadNullState state;
+    WebCore::JSMainThreadNullState state;
     return unwrap(*self).localName().createNSString().autorelease();
 }
 
 - (DOMNamedNodeMap *)attributes
 {
-    JSMainThreadNullState state;
+    WebCore::JSMainThreadNullState state;
     return kit(unwrap(*self).attributesMap());
 }
 
 - (NSString *)baseURI
 {
-    JSMainThreadNullState state;
+    WebCore::JSMainThreadNullState state;
     return unwrap(*self).baseURI().string().createNSString().autorelease();
 }
 
 - (NSString *)textContent
 {
-    JSMainThreadNullState state;
+    WebCore::JSMainThreadNullState state;
     return unwrap(*self).textContent().createNSString().autorelease();
 }
 
 - (void)setTextContent:(NSString *)newTextContent
 {
-    JSMainThreadNullState state;
+    WebCore::JSMainThreadNullState state;
     unwrap(*self).setTextContent(newTextContent);
 }
 
 - (BOOL)isConnected
 {
-    JSMainThreadNullState state;
+    WebCore::JSMainThreadNullState state;
     return unwrap(*self).isConnected();
 }
 
 - (DOMElement *)parentElement
 {
-    JSMainThreadNullState state;
+    WebCore::JSMainThreadNullState state;
     return kit(unwrap(*self).parentElement());
 }
 
 - (BOOL)isContentEditable
 {
-    JSMainThreadNullState state;
+    WebCore::JSMainThreadNullState state;
     return unwrap(*self).isContentEditable();
 }
 
 - (DOMNode *)insertBefore:(DOMNode *)newChild refChild:(DOMNode *)refChild
 {
-    JSMainThreadNullState state;
+    WebCore::JSMainThreadNullState state;
     if (!newChild)
         raiseTypeErrorException();
     raiseOnDOMError(unwrap(*self).insertBefore(*core(newChild), core(refChild)));
@@ -225,7 +224,7 @@ DOMNode *kit(Node* value)
 
 - (DOMNode *)replaceChild:(DOMNode *)newChild oldChild:(DOMNode *)oldChild
 {
-    JSMainThreadNullState state;
+    WebCore::JSMainThreadNullState state;
     if (!newChild)
         raiseTypeErrorException();
     if (!oldChild)
@@ -236,7 +235,7 @@ DOMNode *kit(Node* value)
 
 - (DOMNode *)removeChild:(DOMNode *)oldChild
 {
-    JSMainThreadNullState state;
+    WebCore::JSMainThreadNullState state;
     if (!oldChild)
         raiseTypeErrorException();
     raiseOnDOMError(unwrap(*self).removeChild(*core(oldChild)));
@@ -245,7 +244,7 @@ DOMNode *kit(Node* value)
 
 - (DOMNode *)appendChild:(DOMNode *)newChild
 {
-    JSMainThreadNullState state;
+    WebCore::JSMainThreadNullState state;
     if (!newChild)
         raiseTypeErrorException();
     raiseOnDOMError(unwrap(*self).appendChild(*core(newChild)));
@@ -254,19 +253,19 @@ DOMNode *kit(Node* value)
 
 - (BOOL)hasChildNodes
 {
-    JSMainThreadNullState state;
+    WebCore::JSMainThreadNullState state;
     return unwrap(*self).hasChildNodes();
 }
 
 - (DOMNode *)cloneNode:(BOOL)deep
 {
-    JSMainThreadNullState state;
+    WebCore::JSMainThreadNullState state;
     return kit(raiseOnDOMError(unwrap(*self).cloneNodeForBindings(deep)).ptr());
 }
 
 - (void)normalize
 {
-    JSMainThreadNullState state;
+    WebCore::JSMainThreadNullState state;
     unwrap(*self).normalize();
 }
 
@@ -277,87 +276,87 @@ DOMNode *kit(Node* value)
 
 - (BOOL)hasAttributes
 {
-    JSMainThreadNullState state;
+    WebCore::JSMainThreadNullState state;
     return unwrap(*self).hasAttributes();
 }
 
 - (BOOL)isSameNode:(DOMNode *)other
 {
-    JSMainThreadNullState state;
+    WebCore::JSMainThreadNullState state;
     return unwrap(*self).isSameNode(core(other));
 }
 
 - (BOOL)isEqualNode:(DOMNode *)other
 {
-    JSMainThreadNullState state;
+    WebCore::JSMainThreadNullState state;
     return unwrap(*self).isEqualNode(core(other));
 }
 
 - (NSString *)lookupPrefix:(NSString *)inNamespaceURI
 {
-    JSMainThreadNullState state;
+    WebCore::JSMainThreadNullState state;
     return unwrap(*self).lookupPrefix(inNamespaceURI).createNSString().autorelease();
 }
 
 - (NSString *)lookupNamespaceURI:(NSString *)inPrefix
 {
-    JSMainThreadNullState state;
+    WebCore::JSMainThreadNullState state;
     return unwrap(*self).lookupNamespaceURI(inPrefix).createNSString().autorelease();
 }
 
 - (BOOL)isDefaultNamespace:(NSString *)inNamespaceURI
 {
-    JSMainThreadNullState state;
+    WebCore::JSMainThreadNullState state;
     return unwrap(*self).isDefaultNamespace(inNamespaceURI);
 }
 
 - (unsigned short)compareDocumentPosition:(DOMNode *)other
 {
-    JSMainThreadNullState state;
+    WebCore::JSMainThreadNullState state;
     if (!other)
-        return Node::DOCUMENT_POSITION_DISCONNECTED;
+        return WebCore::Node::DOCUMENT_POSITION_DISCONNECTED;
     return unwrap(*self).compareDocumentPosition(*core(other));
 }
 
 - (BOOL)contains:(DOMNode *)other
 {
-    JSMainThreadNullState state;
+    WebCore::JSMainThreadNullState state;
     return unwrap(*self).contains(core(other));
 }
 
 - (void)inspect
 {
-    JSMainThreadNullState state;
+    WebCore::JSMainThreadNullState state;
     unwrap(*self).inspect();
 }
 
 - (void)addEventListener:(NSString *)type listener:(id <DOMEventListener>)listener useCapture:(BOOL)useCapture
 {
-    JSMainThreadNullState state;
-    unwrap(*self).addEventListenerForBindings(type, ObjCEventListener::wrap(listener), static_cast<bool>(useCapture));
+    WebCore::JSMainThreadNullState state;
+    unwrap(*self).addEventListenerForBindings(type, WebCore::ObjCEventListener::wrap(listener), static_cast<bool>(useCapture));
 }
 
 - (void)addEventListener:(NSString *)type :(id <DOMEventListener>)listener :(BOOL)useCapture
 {
-    JSMainThreadNullState state;
-    unwrap(*self).addEventListenerForBindings(type, ObjCEventListener::wrap(listener), static_cast<bool>(useCapture));
+    WebCore::JSMainThreadNullState state;
+    unwrap(*self).addEventListenerForBindings(type, WebCore::ObjCEventListener::wrap(listener), static_cast<bool>(useCapture));
 }
 
 - (void)removeEventListener:(NSString *)type listener:(id <DOMEventListener>)listener useCapture:(BOOL)useCapture
 {
-    JSMainThreadNullState state;
-    unwrap(*self).removeEventListenerForBindings(type, ObjCEventListener::wrap(listener), static_cast<bool>(useCapture));
+    WebCore::JSMainThreadNullState state;
+    unwrap(*self).removeEventListenerForBindings(type, WebCore::ObjCEventListener::wrap(listener), static_cast<bool>(useCapture));
 }
 
 - (void)removeEventListener:(NSString *)type :(id <DOMEventListener>)listener :(BOOL)useCapture
 {
-    JSMainThreadNullState state;
-    unwrap(*self).removeEventListenerForBindings(type, ObjCEventListener::wrap(listener), static_cast<bool>(useCapture));
+    WebCore::JSMainThreadNullState state;
+    unwrap(*self).removeEventListenerForBindings(type, WebCore::ObjCEventListener::wrap(listener), static_cast<bool>(useCapture));
 }
 
 - (BOOL)dispatchEvent:(DOMEvent *)event
 {
-    JSMainThreadNullState state;
+    WebCore::JSMainThreadNullState state;
     if (!event)
         raiseTypeErrorException();
     return raiseOnDOMError(unwrap(*self).dispatchEventForBindings(*core(event)));

--- a/Source/WebKitLegacy/mac/DOM/WebDOMOperations.mm
+++ b/Source/WebKitLegacy/mac/DOM/WebDOMOperations.mm
@@ -67,8 +67,6 @@
 #import <wtf/Assertions.h>
 #import <wtf/text/MakeString.h>
 
-using namespace WebCore;
-using namespace JSC;
 
 @implementation DOMElement (WebDOMElementOperationsPrivate)
 
@@ -80,9 +78,9 @@ using namespace JSC;
     if (!value)
         return 0;
 
-    JSGlobalObject* lexicalGlobalObject = toJS(context);
-    JSLockHolder lock(lexicalGlobalObject);
-    return kit(JSElement::toWrapped(lexicalGlobalObject->vm(), toJS(lexicalGlobalObject, value)));
+    JSC::JSGlobalObject* lexicalGlobalObject = toJS(context);
+    JSC::JSLockHolder lock(lexicalGlobalObject);
+    return kit(WebCore::JSElement::toWrapped(lexicalGlobalObject->vm(), toJS(lexicalGlobalObject, value)));
 }
 
 @end
@@ -92,13 +90,13 @@ using namespace JSC;
 - (WebArchive *)webArchive
 {
     WebCore::LegacyWebArchive::ArchiveOptions options { WebCore::LegacyWebArchive::ShouldSaveScriptsFromMemoryCache::No };
-    return adoptNS([[WebArchive alloc] _initWithCoreLegacyWebArchive:LegacyWebArchive::create(*core(self), WTF::move(options))]).autorelease();
+    return adoptNS([[WebArchive alloc] _initWithCoreLegacyWebArchive:WebCore::LegacyWebArchive::create(*core(self), WTF::move(options))]).autorelease();
 }
 
 - (WebArchive *)webArchiveByFilteringSubframes:(WebArchiveSubframeFilter)webArchiveSubframeFilter
 {
     WebCore::LegacyWebArchive::ArchiveOptions options { WebCore::LegacyWebArchive::ShouldSaveScriptsFromMemoryCache::No };
-    auto webArchive = adoptNS([[WebArchive alloc] _initWithCoreLegacyWebArchive:LegacyWebArchive::create(*core(self), WTF::move(options), [webArchiveSubframeFilter](LocalFrame& subframe) -> bool {
+    RetainPtr webArchive = adoptNS([[WebArchive alloc] _initWithCoreLegacyWebArchive:WebCore::LegacyWebArchive::create(*core(self), WTF::move(options), [webArchiveSubframeFilter](WebCore::LocalFrame& subframe) -> bool {
         return webArchiveSubframeFilter(kit(&subframe));
     })]);
 
@@ -109,11 +107,11 @@ using namespace JSC;
 
 - (BOOL)isHorizontalWritingMode
 {
-    Node* node = core(self);
+    WebCore::Node* node = core(self);
     if (!node)
         return YES;
     
-    RenderObject* renderer = node->renderer();
+    WebCore::RenderObject* renderer = node->renderer();
     if (!renderer)
         return YES;
     
@@ -122,14 +120,14 @@ using namespace JSC;
 
 - (void)hidePlaceholder
 {
-    if (auto node = core(self); is<HTMLTextFormControlElement>(node))
-        downcast<HTMLTextFormControlElement>(*node).setCanShowPlaceholder(false);
+    if (auto node = core(self); is<WebCore::HTMLTextFormControlElement>(node))
+        downcast<WebCore::HTMLTextFormControlElement>(*node).setCanShowPlaceholder(false);
 }
 
 - (void)showPlaceholderIfNecessary
 {
-    if (auto node = core(self); is<HTMLTextFormControlElement>(node))
-        downcast<HTMLTextFormControlElement>(*node).setCanShowPlaceholder(true);
+    if (auto node = core(self); is<WebCore::HTMLTextFormControlElement>(node))
+        downcast<WebCore::HTMLTextFormControlElement>(*node).setCanShowPlaceholder(true);
 }
 
 #endif
@@ -142,9 +140,9 @@ using namespace JSC;
 {
     auto& node = *core(self);
 
-    String markupString = serializeFragment(node, SerializedNodes::SubtreeIncludingNode);
+    String markupString = serializeFragment(node, WebCore::SerializedNodes::SubtreeIncludingNode);
     auto nodeType = node.nodeType();
-    if (nodeType != NodeType::Document && nodeType != NodeType::DocumentType)
+    if (nodeType != WebCore::NodeType::Document && nodeType != WebCore::NodeType::DocumentType)
         markupString = makeString(documentTypeString(node.document()), markupString);
 
     return markupString.createNSString().autorelease();
@@ -193,13 +191,13 @@ using namespace JSC;
 - (WebArchive *)webArchive
 {
     WebCore::LegacyWebArchive::ArchiveOptions options { WebCore::LegacyWebArchive::ShouldSaveScriptsFromMemoryCache::No };
-    return adoptNS([[WebArchive alloc] _initWithCoreLegacyWebArchive:LegacyWebArchive::create(makeSimpleRange(*core(self)), WTF::move(options))]).autorelease();
+    return adoptNS([[WebArchive alloc] _initWithCoreLegacyWebArchive:WebCore::LegacyWebArchive::create(makeSimpleRange(*core(self)), WTF::move(options))]).autorelease();
 }
 
 - (NSString *)markupString
 {
     auto range = makeSimpleRange(*core(self));
-    return makeString(documentTypeString(range.start.document()), serializePreservingVisualAppearance(range, nullptr, AnnotateForInterchange::Yes)).createNSString().autorelease();
+    return makeString(documentTypeString(range.start.document()), serializePreservingVisualAppearance(range, nullptr, WebCore::AnnotateForInterchange::Yes)).createNSString().autorelease();
 }
 
 @end
@@ -226,22 +224,22 @@ using namespace JSC;
 
 - (BOOL)_isAutofilled
 {
-    return downcast<HTMLInputElement>(core((DOMElement *)self))->autofilled();
+    return downcast<WebCore::HTMLInputElement>(core((DOMElement *)self))->autofilled();
 }
 
 - (BOOL)_isAutoFilledAndViewable
 {
-    return downcast<HTMLInputElement>(core((DOMElement *)self))->autofilledAndViewable();
+    return downcast<WebCore::HTMLInputElement>(core((DOMElement *)self))->autofilledAndViewable();
 }
 
 - (void)_setAutofilled:(BOOL)autofilled
 {
-    downcast<HTMLInputElement>(core((DOMElement *)self))->setAutofilled(autofilled);
+    downcast<WebCore::HTMLInputElement>(core((DOMElement *)self))->setAutofilled(autofilled);
 }
 
 - (void)_setAutoFilledAndViewable:(BOOL)autoFilledAndViewable
 {
-    downcast<HTMLInputElement>(core((DOMElement *)self))->setAutofilledAndViewable(autoFilledAndViewable);
+    downcast<WebCore::HTMLInputElement>(core((DOMElement *)self))->setAutofilledAndViewable(autoFilledAndViewable);
 }
 
 @end
@@ -256,24 +254,24 @@ using namespace JSC;
 @end
 
 #if !PLATFORM(IOS_FAMILY)
-static NSEventPhase NODELETE toNSEventPhase(PlatformWheelEventPhase platformPhase)
+static NSEventPhase NODELETE toNSEventPhase(WebCore::PlatformWheelEventPhase platformPhase)
 {
     switch (platformPhase) {
-    case PlatformWheelEventPhase::None:
+    case WebCore::PlatformWheelEventPhase::None:
         return NSEventPhaseNone;
-    case PlatformWheelEventPhase::Began:
+    case WebCore::PlatformWheelEventPhase::Began:
         return NSEventPhaseBegan;
-    case PlatformWheelEventPhase::Stationary:
+    case WebCore::PlatformWheelEventPhase::Stationary:
         return NSEventPhaseStationary;
-    case PlatformWheelEventPhase::Changed:
+    case WebCore::PlatformWheelEventPhase::Changed:
         return NSEventPhaseChanged;
-    case PlatformWheelEventPhase::Ended:
+    case WebCore::PlatformWheelEventPhase::Ended:
         return NSEventPhaseEnded;
-    case PlatformWheelEventPhase::Cancelled:
+    case WebCore::PlatformWheelEventPhase::Cancelled:
         return NSEventPhaseCancelled;
-    case PlatformWheelEventPhase::MayBegin:
+    case WebCore::PlatformWheelEventPhase::MayBegin:
         return NSEventPhaseMayBegin;
-    case PlatformWheelEventPhase::WillBegin:
+    case WebCore::PlatformWheelEventPhase::WillBegin:
         return NSEventPhaseNone;
     }
 

--- a/Source/WebKitLegacy/mac/History/WebBackForwardList.mm
+++ b/Source/WebKitLegacy/mac/History/WebBackForwardList.mm
@@ -41,6 +41,7 @@
 #import <JavaScriptCore/InitializeThreading.h>
 #import <WebCore/BackForwardCache.h>
 #import <WebCore/HistoryItem.h>
+#import <WebCore/LocalFrameInlines.h>
 #import <WebCore/Settings.h>
 #import <WebCore/ThreadCheck.h>
 #import <WebCore/WebCoreJITOperations.h>

--- a/Source/WebKitLegacy/mac/Misc/WebCoreStatistics.mm
+++ b/Source/WebKitLegacy/mac/Misc/WebCoreStatistics.mm
@@ -46,7 +46,6 @@
 #import <WebCore/RenderTreeAsText.h>
 #import <WebCore/RenderView.h>
 
-using namespace JSC;
 using namespace WebCore;
 
 @implementation WebCoreStatistics
@@ -58,25 +57,25 @@ using namespace WebCore;
 
 + (size_t)javaScriptObjectsCount
 {
-    JSLockHolder lock(commonVM());
+    JSC::JSLockHolder lock(commonVM());
     return commonVM().heap.objectCount();
 }
 
 + (size_t)javaScriptGlobalObjectsCount
 {
-    JSLockHolder lock(commonVM());
+    JSC::JSLockHolder lock(commonVM());
     return commonVM().heap.globalObjectCount();
 }
 
 + (size_t)javaScriptProtectedObjectsCount
 {
-    JSLockHolder lock(commonVM());
+    JSC::JSLockHolder lock(commonVM());
     return commonVM().heap.protectedObjectCount();
 }
 
 + (size_t)javaScriptProtectedGlobalObjectsCount
 {
-    JSLockHolder lock(commonVM());
+    JSC::JSLockHolder lock(commonVM());
     return commonVM().heap.protectedGlobalObjectCount();
 }
 
@@ -93,13 +92,13 @@ static RetainPtr<NSCountedSet> createNSCountedSet(const HashCountedSet<ASCIILite
 
 + (NSCountedSet *)javaScriptProtectedObjectTypeCounts
 {
-    JSLockHolder lock(commonVM());
+    JSC::JSLockHolder lock(commonVM());
     return createNSCountedSet(commonVM().heap.protectedObjectTypeCounts()).autorelease();
 }
 
 + (NSCountedSet *)javaScriptObjectTypeCounts
 {
-    JSLockHolder lock(commonVM());
+    JSC::JSLockHolder lock(commonVM());
     return createNSCountedSet(commonVM().heap.objectTypeCounts()).autorelease();
 }
 
@@ -160,13 +159,13 @@ static RetainPtr<NSCountedSet> createNSCountedSet(const HashCountedSet<ASCIILite
 
 + (BOOL)shouldPrintExceptions
 {
-    JSLockHolder lock(commonVM());
+    JSC::JSLockHolder lock(commonVM());
     return FrameConsoleClient::shouldPrintExceptions();
 }
 
 + (void)setShouldPrintExceptions:(BOOL)print
 {
-    JSLockHolder lock(commonVM());
+    JSC::JSLockHolder lock(commonVM());
     FrameConsoleClient::setShouldPrintExceptions(print);
 }
 
@@ -183,10 +182,10 @@ static RetainPtr<NSCountedSet> createNSCountedSet(const HashCountedSet<ASCIILite
 + (NSDictionary *)memoryStatistics
 {
     auto fastMallocStatistics = WTF::fastMallocStatistics();
-    JSLockHolder lock(commonVM());
+    JSC::JSLockHolder lock(commonVM());
     size_t heapSize = commonVM().heap.size();
     size_t heapFree = commonVM().heap.capacity() - heapSize;
-    auto globalMemoryStats = globalMemoryStatistics();
+    auto globalMemoryStats = JSC::globalMemoryStatistics();
     return @{
         @"FastMallocReservedVMBytes": @(fastMallocStatistics.reservedVMBytes),
         @"FastMallocCommittedVMBytes": @(fastMallocStatistics.committedVMBytes),
@@ -227,7 +226,7 @@ static RetainPtr<NSCountedSet> createNSCountedSet(const HashCountedSet<ASCIILite
 
 + (size_t)javaScriptReferencedObjectsCount
 {
-    JSLockHolder lock(commonVM());
+    JSC::JSLockHolder lock(commonVM());
     return commonVM().heap.protectedObjectCount();
 }
 

--- a/Source/WebKitLegacy/mac/WebView/WebHTMLViewInternal.h
+++ b/Source/WebKitLegacy/mac/WebView/WebHTMLViewInternal.h
@@ -37,7 +37,8 @@
 
 namespace WebCore {
 class CachedImage;
-    class KeyboardEvent;
+class KeyboardEvent;
+enum class ScrollbarWidth : uint8_t;
 }
 
 #if PLATFORM(MAC)

--- a/Source/WebKitLegacy/mac/WebView/WebImmediateActionController.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebImmediateActionController.mm
@@ -38,6 +38,7 @@
 #import "WebViewInternal.h"
 #import <WebCore/DataDetection.h>
 #import <WebCore/DictionaryLookup.h>
+#import <WebCore/Document.h>
 #import <WebCore/EditingHTMLConverter.h>
 #import <WebCore/Editor.h>
 #import <WebCore/EventHandler.h>
@@ -52,6 +53,7 @@
 #import <WebCore/Range.h>
 #import <WebCore/RenderElement.h>
 #import <WebCore/RenderObject.h>
+#import <WebCore/RenderStyle+GettersInlines.h>
 #import <WebCore/TextIndicator.h>
 #import <WebCore/TextIterator.h>
 #import <objc/objc-class.h>

--- a/Source/WebKitLegacy/mac/WebView/WebViewRenderingUpdateScheduler.mm
+++ b/Source/WebKitLegacy/mac/WebView/WebViewRenderingUpdateScheduler.mm
@@ -36,6 +36,8 @@
 #import <wtf/RuntimeApplicationChecks.h>
 #endif
 
+#import <wtf/SetForScope.h>
+
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebViewRenderingUpdateScheduler);
 
 WebViewRenderingUpdateScheduler::WebViewRenderingUpdateScheduler(WebView* webView)

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NavigationAPI.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NavigationAPI.mm
@@ -26,6 +26,7 @@
 #import "config.h"
 
 #import "Helpers/PlatformUtilities.h"
+#import "Helpers/Test.h"
 #import "Helpers/cocoa/HTTPServer.h"
 #import "Helpers/cocoa/TestNavigationDelegate.h"
 #import "Helpers/cocoa/TestWKWebView.h"


### PR DESCRIPTION
#### 8916f524a78a73e365f45b78665ecc5bcdd249ac
<pre>
[Build Speed] Prepare for larger unified build bundles
<a href="https://bugs.webkit.org/show_bug.cgi?id=315331">https://bugs.webkit.org/show_bug.cgi?id=315331</a>
<a href="https://rdar.apple.com/177672801">rdar://177672801</a>

Reviewed by Brent Fulgham.

This isn&apos;t a build speedup, but it enables larger bundles, and larger bundles
are a build speedup because they amortize per-translation-unit overhead (which
is still really high despite our elaborate prefix headers).

Split out duplicate definitions into headers.

Renamed ambiguous / generic global scope variables to be more specific.

Removed some &apos;using&apos; directives in WebKit.framework and replaced with explicit
namespacing instead.

* Source/JavaScriptCore/ftl/FTLLocation.cpp:
(JSC::FTL::Location::forValueRep):
* Source/JavaScriptCore/wasm/WasmIPIntGenerator.cpp:
(JSC::Wasm::IPIntGenerator::addConstant):
(JSC::Wasm::IPIntGenerator::addCatchToUnreachable):
(JSC::Wasm::IPIntGenerator::addEndToUnreachable):
(JSC::Wasm::IPIntGenerator::addCall):
(JSC::Wasm::IPIntGenerator::addCallIndirect):
(JSC::Wasm::IPIntGenerator::addCallRef):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUTextureImpl.cpp:
(WebCore::WebGPU::TextureImpl::TextureImpl):
* Source/WebCore/Modules/WebGPU/Implementation/WebGPUTextureImpl.h:
* Source/WebCore/inspector/agents/RuntimeAgentUtilities.h: Copied from Source/WebKit/Shared/ResourceLoadInfo.h.
(WebCore::toProtocol):
* Source/WebCore/inspector/agents/frame/FrameRuntimeAgent.cpp:
(WebCore::toProtocol): Deleted.
* Source/WebCore/inspector/agents/page/PageRuntimeAgent.cpp:
(WebCore::toProtocol): Deleted.
* Source/WebKit/NetworkProcess/Notifications/WebPushDaemonConnection.cpp:
* Source/WebKit/Shared/API/Cocoa/WKRemoteObject.mm:
(wkRemoteObject_methodArgumentTypeEncodingForSelector):
(-[WKRemoteObject methodSignatureForSelector:]):
(methodArgumentTypeEncodingForSelector): Deleted.
* Source/WebKit/Shared/API/Cocoa/_WKRemoteObjectRegistry.mm:
* Source/WebKit/Headers.cmake:
* Source/WebKit/Shared/ResourceLoadInfo.h:
* Source/WebKit/UIProcess/API/Cocoa/WKWebExtensionMatchPattern.mm:
(matchPatternOptionsToImpl):
(-[WKWebExtensionMatchPattern matchesURL:options:]):
(-[WKWebExtensionMatchPattern matchesPattern:options:]):
(toImpl): Deleted.
* Source/WebKit/UIProcess/API/mac/WKWebViewMac.mm:
(-[WKWebView showWritingTools:]):
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIActionCocoa.mm:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIAlarmsCocoa.mm:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIBookmarksCocoa.mm:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICommandsCocoa.mm:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPICookiesCocoa.mm:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDeclarativeNetRequestCocoa.mm:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIDevToolsInspectedWindowCocoa.mm:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIExtensionCocoa.mm:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIKeys.h: Added.
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIMenusCocoa.mm:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIPermissionsCocoa.mm:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIRuntimeCocoa.mm:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIScriptingCocoa.mm:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidePanelCocoa.mm:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPISidebarActionCocoa.mm:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIStorageAreaCocoa.mm:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPITabsCocoa.mm:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebNavigationCocoa.mm:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWebRequestCocoa.mm:
* Source/WebKit/WebProcess/Extensions/API/Cocoa/WebExtensionAPIWindowsCocoa.mm:
* Source/WebKit/WebProcess/Extensions/Bindings/JSWebExtensionWrapper.cpp:
(WebKit::callWithArguments):
* Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebNavigationURLFilter.mm:
* Source/WebKit/WebProcess/Extensions/Cocoa/_WKWebExtensionWebRequestFilter.mm:
* Source/WebKit/WebProcess/InjectedBundle/API/glib/WebKitInjectedBundleMain.cpp:
* Source/WebKit/WebProcess/InjectedBundle/InjectedBundle.cpp:
(WebKit::InjectedBundle::javaScriptObjectsCount):
(WebKit::InjectedBundle::reportException):
(WebKit::InjectedBundle::createWebDataFromUint8Array):
* Source/WebKit/WebProcess/Plugins/PluginView.cpp:
* Source/WebKit/WebProcess/WebPage/WebFrame.cpp:
(WebKit::WebFrame::jsWrapperForWorld):
(WebKit::createJSHandle):
* Source/WebKit/WebProcess/WebPage/WebPage.cpp:
(WebKit::WebPage::runJavaScript):
(WebKit::WebPage::updatePreferences):
* Source/WebKit/WebProcess/WebProcess.cpp:
(WebKit::WebProcess::initializeWebProcess):
* Source/WebKitLegacy/mac/DOM/DOM.mm:
(addElementClass):
(createElementClassMap):
(lookupElementClass):
(elementClass):
(wkQuadFromFloatQuad):
(kit):
(-[DOMNode _rootObject]):
(kitClass):
(-[DOMNode boundingBox]):
(-[DOMNode absoluteQuadAndInsideFixedPosition:]):
(-[DOMNode boundingBoxUsingTransforms]):
(-[DOMNode lineBoxQuads]):
(-[DOMNode hrefURL]):
(-[DOMNode hrefTarget]):
(-[DOMNode hrefTitle]):
(-[DOMNode innerFrameQuad]):
(-[DOMNode textRects]):
(+[DOMNode _nodeFromJSWrapper:]):
(-[DOMNode getPreviewSnapshotImage:andRects:]):
(-[DOMRange boundingBox]):
(-[DOMRange renderedImageForcingBlackText:renderedImageForcingBlackText:]):
(-[DOMRange textRects]):
(-[DOMElement image]):
(-[DOMElement _imageTIFFRepresentation]):
(-[DOMHTMLLinkElement _mediaQueryMatchesForOrientation:]):
(-[DOMHTMLLinkElement _mediaQueryMatches]):
(-[DOMNodeFilter acceptNode:]):
* Source/WebKitLegacy/mac/DOM/DOMAttr.mm:
* Source/WebKitLegacy/mac/DOM/DOMNode.mm:
(unwrap):
(core):
(kit):
(-[DOMNode nodeName]):
(-[DOMNode nodeValue]):
(-[DOMNode setNodeValue:]):
(-[DOMNode nodeType]):
(-[DOMNode parentNode]):
(-[DOMNode childNodes]):
(-[DOMNode firstChild]):
(-[DOMNode lastChild]):
(-[DOMNode previousSibling]):
(-[DOMNode nextSibling]):
(-[DOMNode ownerDocument]):
(-[DOMNode namespaceURI]):
(-[DOMNode prefix]):
(-[DOMNode setPrefix:]):
(-[DOMNode localName]):
(-[DOMNode attributes]):
(-[DOMNode baseURI]):
(-[DOMNode textContent]):
(-[DOMNode setTextContent:]):
(-[DOMNode isConnected]):
(-[DOMNode parentElement]):
(-[DOMNode isContentEditable]):
(-[DOMNode insertBefore:refChild:]):
(-[DOMNode replaceChild:oldChild:]):
(-[DOMNode removeChild:]):
(-[DOMNode appendChild:]):
(-[DOMNode hasChildNodes]):
(-[DOMNode cloneNode:]):
(-[DOMNode normalize]):
(-[DOMNode hasAttributes]):
(-[DOMNode isSameNode:]):
(-[DOMNode isEqualNode:]):
(-[DOMNode lookupPrefix:]):
(-[DOMNode lookupNamespaceURI:]):
(-[DOMNode isDefaultNamespace:]):
(-[DOMNode compareDocumentPosition:]):
(-[DOMNode contains:]):
(-[DOMNode inspect]):
(-[DOMNode addEventListener:listener:useCapture:]):
(-[DOMNode addEventListener:::]):
(-[DOMNode removeEventListener:listener:useCapture:]):
(-[DOMNode removeEventListener:::]):
(-[DOMNode dispatchEvent:]):
* Source/WebKitLegacy/mac/DOM/WebDOMOperations.mm:
(+[DOMElement _DOMElementFromJSContext:value:]):
(-[DOMNode webArchive]):
(-[DOMNode webArchiveByFilteringSubframes:]):
(-[DOMNode isHorizontalWritingMode]):
(-[DOMNode markupString]):
(-[DOMRange webArchive]):
(-[DOMRange markupString]):
(-[DOMHTMLInputElement _isAutofilled]):
(-[DOMHTMLInputElement _isAutoFilledAndViewable]):
(-[DOMHTMLInputElement _setAutofilled:]):
(-[DOMHTMLInputElement _setAutoFilledAndViewable:]):
(toNSEventPhase):
* Source/WebKitLegacy/mac/History/WebBackForwardList.mm:
* Source/WebKitLegacy/mac/Misc/WebCoreStatistics.mm:
(+[WebCoreStatistics javaScriptObjectsCount]):
(+[WebCoreStatistics javaScriptGlobalObjectsCount]):
(+[WebCoreStatistics javaScriptProtectedObjectsCount]):
(+[WebCoreStatistics javaScriptProtectedGlobalObjectsCount]):
(+[WebCoreStatistics javaScriptProtectedObjectTypeCounts]):
(+[WebCoreStatistics javaScriptObjectTypeCounts]):
(+[WebCoreStatistics shouldPrintExceptions]):
(+[WebCoreStatistics setShouldPrintExceptions:]):
(+[WebCoreStatistics memoryStatistics]):
(+[WebCoreStatistics javaScriptReferencedObjectsCount]):
* Source/WebKitLegacy/mac/WebView/WebHTMLViewInternal.h:
* Source/WebKitLegacy/mac/WebView/WebImmediateActionController.mm:
* Source/WebKitLegacy/mac/WebView/WebViewRenderingUpdateScheduler.mm:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/NavigationAPI.mm:

Canonical link: <a href="https://commits.webkit.org/313731@main">https://commits.webkit.org/313731@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45ae81455b967d351ab70f042e8e60430a00b50f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163989 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37473 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30692 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173018 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/439f5bf0-ed3a-4857-92d6-03cdb41c558f) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165858 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37806 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37473 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127396 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121240 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2e311464-c455-43d1-85eb-c3c60b40b214) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166948 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29681 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147423 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107944 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28727 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27351 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20782 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/156140 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/138628 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25140 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175543 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/24881 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28365 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/26808 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135705 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37143 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31463 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135677 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37928 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146935 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100113 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24957 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30981 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23791 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/196392 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36737 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109784 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51317 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36136 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/1836 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36386 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36283 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->