### PR TITLE
Cherry-pick(s) bfb699d9b999. rdar://176067339

### DIFF
--- a/Source/JavaScriptCore/runtime/RegExpInlines.h
+++ b/Source/JavaScriptCore/runtime/RegExpInlines.h
@@ -164,6 +164,7 @@ ALWAYS_INLINE int RegExp::matchInline(JSGlobalObject* nullOrGlobalObject, VM& vm
         }
 
         if (result == static_cast<int>(Yarr::JSRegExpResult::JITCodeFailure)) {
+<<<<<<< HEAD
             // Punt to the bytecode interpreter. Only the mutator may compile bytecode; the compiler
             // thread must use the bytecode that already exists, and bails out if there is no
             // bytecode.
@@ -174,6 +175,16 @@ ALWAYS_INLINE int RegExp::matchInline(JSGlobalObject* nullOrGlobalObject, VM& vm
             }
             if (!m_regExpBytecode)
                 return -1;
+=======
+            // JIT'ed code couldn't handle expression, so punt back to the interpreter.
+            if constexpr (matchFrom == Yarr::MatchFrom::CompilerThread) {
+                if (!m_regExpBytecode)
+                    return -1;
+            }
+            byteCodeCompileIfNecessary(&vm);
+            if (m_state == ParseError)
+                return throwError();
+>>>>>>> bfb699d9b999 ([JSC] Make RegExp::byteCodeCompileIfNecessary threadsafe)
             {
                 Yarr::MatchingContextHolder regExpContext(vm, this, matchFrom);
                 result = Yarr::interpret(m_regExpBytecode.get(), s, startOffset, reinterpret_cast<unsigned*>(offsetVector));
@@ -294,6 +305,7 @@ ALWAYS_INLINE MatchResult RegExp::matchInline(JSGlobalObject* nullOrGlobalObject
         if (result.start != static_cast<size_t>(Yarr::JSRegExpResult::JITCodeFailure))
             return result;
 
+<<<<<<< HEAD
         // Punt to the bytecode interpreter. Only the mutator may compile bytecode; the compiler
         // thread must use the bytecode that already exists, and bails out if there is no
         // bytecode.
@@ -304,6 +316,16 @@ ALWAYS_INLINE MatchResult RegExp::matchInline(JSGlobalObject* nullOrGlobalObject
         }
         if (!m_regExpBytecode)
             return MatchResult::failed();
+=======
+        // JIT'ed code couldn't handle expression, so punt back to the interpreter.
+        if constexpr (matchFrom == Yarr::MatchFrom::CompilerThread) {
+            if (!m_regExpBytecode)
+                return MatchResult::failed();
+        }
+        byteCodeCompileIfNecessary(&vm);
+        if (m_state == ParseError)
+            return throwError();
+>>>>>>> bfb699d9b999 ([JSC] Make RegExp::byteCodeCompileIfNecessary threadsafe)
     }
 #endif
 


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://176067339 to main. The following sources [dcf25ed3c992] will still need to be cherry-picked once the conflict is resolved.

```[JSC] Make RegExp::byteCodeCompileIfNecessary threadsafe
https://bugs.webkit.org/show_bug.cgi?id=309405
rdar://171888887

Reviewed by Yusuke Suzuki.

RegExp::matchConcurrently shouldn't cause any compilation, but bail out if JIT
code for the regexp doesn't already exist. However, it is possible that a
RegExp has JIT code but no bytecode, in which case matchConcurrently can
incorrectly racily attempt to compile bytecode.

This PR makes byteCodeCompileIfNecessary threadsafe by taking the cell lock. It
also bails out of matchConcurrently if the regexp doesn't already have bytecode
when called from the compiler thread. Note that that check inside matchInline
does not need to take the cell lock at that spot, because matchConcurrently,
the caller, already takes the cell lock.

There is no new test because to manifest this race requires artificially adding
sleeps to threads.

* Source/JavaScriptCore/runtime/RegExp.cpp:
(JSC::RegExp::byteCodeCompileIfNecessary):
* Source/JavaScriptCore/runtime/RegExpInlines.h:
(JSC::RegExp::matchInline):

Originally-landed-as: 305413.415@rapid/safari-7624.2.5.110-branch (bfb699d9b999). rdar://176067339

```

<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/747c1540b29ebbc0b8c987a1108cc0816b6e78a3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163931 "6 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37415 "Hash 747c1540 for PR 65452 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30634 "Hash 747c1540 for PR 65452 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172960 "Hash 747c1540 for PR 65452 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121182 "Hash 747c1540 for PR 65452 does not build (failure)") 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37747 "Hash 747c1540 for PR 65452 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37415 "Hash 747c1540 for PR 65452 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/172960 "Hash 747c1540 for PR 65452 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/121182 "Hash 747c1540 for PR 65452 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166890 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/37747 "Hash 747c1540 for PR 65452 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/30634 "Hash 747c1540 for PR 65452 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/172960 "Hash 747c1540 for PR 65452 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/37747 "Hash 747c1540 for PR 65452 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/37415 "Hash 747c1540 for PR 65452 does not build (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20724 "Hash 747c1540 for PR 65452 does not build (failure)") | 
| [❌ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/156082 "Hash 747c1540 for PR 65452 does not build (failure)") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/37747 "Hash 747c1540 for PR 65452 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/30634 "Hash 747c1540 for PR 65452 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175484 "Hash 747c1540 for PR 65452 does not build (failure)") | 
| [❌ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/24823 "Hash 747c1540 for PR 65452 does not build (failure)") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28307 "Failed to build and analyze WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/30634 "Hash 747c1540 for PR 65452 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/175484 "Hash 747c1540 for PR 65452 does not build (failure)") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37085 "Hash 747c1540 for PR 65452 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/37415 "Hash 747c1540 for PR 65452 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/175484 "Hash 747c1540 for PR 65452 does not build (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37870 "Hash 747c1540 for PR 65452 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/30634 "Hash 747c1540 for PR 65452 does not build (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100025 "Built successfully") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/37870 "Hash 747c1540 for PR 65452 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/30634 "Hash 747c1540 for PR 65452 does not build (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/196334 "Built successfully") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36677 "Hash 747c1540 for PR 65452 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109726 "Failed to build and analyze WebKit") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51283 "Passed tests") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36078 "Hash 747c1540 for PR 65452 does not build (failure)") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/30634 "Hash 747c1540 for PR 65452 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36328 "Hash 747c1540 for PR 65452 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36225 "Hash 747c1540 for PR 65452 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->