### PR TITLE
Fix heap-use-after-free in AudioVideoRendererAVFObjC::setTimeObserver when callback re-entrantly reinstalls the time observer

### DIFF
--- a/LayoutTests/media/audio-video-renderer-time-observer-reinstall-crash-expected.txt
+++ b/LayoutTests/media/audio-video-renderer-time-observer-reinstall-crash-expected.txt
@@ -1,0 +1,6 @@
+
+RUN(video.play())
+EVENT(playing)
+EXPECTED (video.currentTime > '0') OK
+END OF TEST
+

--- a/LayoutTests/media/audio-video-renderer-time-observer-reinstall-crash.html
+++ b/LayoutTests/media/audio-video-renderer-time-observer-reinstall-crash.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+<title>AudioVideoRenderer time-observer reinstall during first tick should not crash the GPU process</title>
+<script src="video-test.js"></script>
+<script>
+    async function init()
+    {
+        findMediaElement();
+
+        video.src = "content/test-vp8.webm";
+        video.muted = true;
+
+        run('video.play()');
+        await waitFor(video, 'playing');
+        await testExpectedEventually('video.currentTime', 0, '>');
+
+        endTest();
+    }
+</script>
+</head>
+<body onload="init();">
+    <video></video>
+</body>
+</html>

--- a/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
+++ b/Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm
@@ -581,11 +581,16 @@ void AudioVideoRendererAVFObjC::setTimeObserver(Seconds interval, Function<void(
         __block ThreadSafeWeakPtr weakThis = *this;
         m_timeChangedObserver = [m_synchronizer addPeriodicTimeObserverForInterval:PAL::toCMTime(MediaTime::createWithSeconds(interval)) queue:mainDispatchQueueSingleton() usingBlock:^(CMTime time) {
             if (RefPtr protectedThis = weakThis.get()) {
-                if (!protectedThis->m_currentTimeDidChangeCallback)
+                // The callback may re-enter setTimeObserver(); move m_currentTimeDidChangeCallback to the stack so re-assignment doesn't free it while it is still running.
+                auto callback = std::exchange(protectedThis->m_currentTimeDidChangeCallback, { });
+                if (!callback)
                     return;
 
                 auto clampedTime = CMTIME_IS_NUMERIC(time) ? protectedThis->clampTimeToLastSeekTime(PAL::toMediaTime(time)) : MediaTime::zeroTime();
-                protectedThis->m_currentTimeDidChangeCallback(clampedTime);
+                callback(clampedTime);
+
+                if (!protectedThis->m_currentTimeDidChangeCallback)
+                    protectedThis->m_currentTimeDidChangeCallback = WTF::move(callback);
             }
         }];
     }


### PR DESCRIPTION
#### c3d7359329d6b7a16f8143a8eb74cb71c6cad44a
<pre>
Fix heap-use-after-free in AudioVideoRendererAVFObjC::setTimeObserver when callback re-entrantly reinstalls the time observer
<a href="https://bugs.webkit.org/show_bug.cgi?id=315339">https://bugs.webkit.org/show_bug.cgi?id=315339</a>
<a href="https://rdar.apple.com/177666693">rdar://177666693</a>

Reviewed by NOBODY (OOPS!).

Guard m_currentTimeDidChangeCallback against re-entrant replacement during its own invocation
by moving it to a stack local via std::exchange, restoring it only if no new callback was installed.

Test: media/audio-video-renderer-time-observer-reinstall-crash.html

* LayoutTests/media/audio-video-renderer-time-observer-reinstall-crash-expected.txt: Added.
* LayoutTests/media/audio-video-renderer-time-observer-reinstall-crash.html: Added.
* Source/WebCore/platform/graphics/avfoundation/AudioVideoRendererAVFObjC.mm:
(WebCore::AudioVideoRendererAVFObjC::setTimeObserver):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c3d7359329d6b7a16f8143a8eb74cb71c6cad44a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163940 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37424 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30643 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/172969 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165809 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37756 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37424 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127358 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121191 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166899 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29639 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147377 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107906 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28685 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27306 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20733 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138585 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25094 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175494 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28316 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26762 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135668 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37094 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31418 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135640 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37879 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146889 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100034 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30935 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23745 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36682 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109735 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36087 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1782 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36337 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36234 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->