### PR TITLE
NetworkSocketChannel leaks when a worker WebSocket is closed by the server

### DIFF
--- a/LayoutTests/http/tests/websocket/tests/hybi/handshake-fail-with-200-ok_wsh.py
+++ b/LayoutTests/http/tests/websocket/tests/hybi/handshake-fail-with-200-ok_wsh.py
@@ -1,0 +1,21 @@
+from pywebsocket3 import handshake
+from pywebsocket3.handshake.hybi import compute_accept_from_unicode
+
+
+def web_socket_do_extra_handshake(request):
+    # Reply with 200 OK instead of 101 Switching Protocols. The handshake
+    # validation in the network stack fails on the wrong status code, so the
+    # client surfaces an error and tears down the connection.
+    msg = b"HTTP/1.1 200 OK\r\n"
+    msg += b"Upgrade: websocket\r\n"
+    msg += b"Connection: Upgrade\r\n"
+    msg += b"Sec-WebSocket-Accept: "
+    msg += compute_accept_from_unicode(request.headers_in["Sec-WebSocket-Key"])
+    msg += b"\r\n"
+    msg += b"\r\n"
+    request.connection.write(msg)
+    raise handshake.AbortedByUserException("Abort the connection")
+
+
+def web_socket_transfer_data(request):
+    pass

--- a/LayoutTests/http/tests/websocket/tests/hybi/worker-handshake-failure-cleanup-expected.txt
+++ b/LayoutTests/http/tests/websocket/tests/hybi/worker-handshake-failure-cleanup-expected.txt
@@ -1,0 +1,9 @@
+Verifies that NetworkSocketChannel is cleaned up in the network process when a worker WebSocket fails the handshake and the worker self-terminates. https://bugs.webkit.org/show_bug.cgi?id=315342
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS NetworkSocketChannel count returned to 0 after worker WebSockets terminated.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/websocket/tests/hybi/worker-handshake-failure-cleanup.html
+++ b/LayoutTests/http/tests/websocket/tests/hybi/worker-handshake-failure-cleanup.html
@@ -1,0 +1,58 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script type="text/javascript">
+description("Verifies that NetworkSocketChannel is cleaned up in the network process when a worker WebSocket fails the handshake and the worker self-terminates. https://bugs.webkit.org/show_bug.cgi?id=315342");
+
+window.jsTestIsAsync = true;
+
+if (!window.internals) {
+    testFailed("This test requires window.internals.");
+    finishJSTest();
+}
+
+const WORKER_COUNT = 5;
+let workersDone = 0;
+
+function spawnWorker()
+{
+    const blob = new Blob([
+        `const ws = new WebSocket("ws://127.0.0.1:8880/websocket/tests/hybi/handshake-fail-with-200-ok");
+         ws.onerror = () => {};
+         ws.onclose = () => { postMessage("done"); self.close(); };`
+    ], { type: "application/javascript" });
+    const w = new Worker(URL.createObjectURL(blob));
+    w.onmessage = () => {
+        if (++workersDone === WORKER_COUNT)
+            pollUntilCleanedUp();
+    };
+}
+
+async function pollUntilCleanedUp()
+{
+    // With the fix, the network-side count drops to 0 within milliseconds of
+    // the worker WebSockets terminating. With the leak, it never returns to 0.
+    for (let i = 0; i < 100; ++i) {
+        const count = await internals.numberOfWebSocketChannelsInNetworkProcess();
+        if (count === 0) {
+            testPassed("NetworkSocketChannel count returned to 0 after worker WebSockets terminated.");
+            finishJSTest();
+            return;
+        }
+        await new Promise(resolve => setTimeout(resolve, 50));
+    }
+    const finalCount = await internals.numberOfWebSocketChannelsInNetworkProcess();
+    testFailed(`NetworkSocketChannel count never returned to 0 (final count: ${finalCount}).`);
+    finishJSTest();
+}
+
+for (let i = 0; i < WORKER_COUNT; ++i)
+    spawnWorker();
+</script>
+</body>
+</html>

--- a/Source/WebCore/page/SocketProvider.h
+++ b/Source/WebCore/page/SocketProvider.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/WebTransportConnectionInfo.h>
+#include <wtf/CompletionHandler.h>
 #include <wtf/NativePromise.h>
 #include <wtf/Ref.h>
 #include <wtf/ThreadSafeRefCounted.h>
@@ -52,6 +53,8 @@ class WEBCORE_EXPORT SocketProvider : public ThreadSafeRefCounted<SocketProvider
 public:
     virtual RefPtr<ThreadableWebSocketChannel> createWebSocketChannel(Document&, WebSocketChannelClient&) = 0;
     virtual std::pair<RefPtr<WebTransportSession>, Ref<WebTransportSessionPromise>> initializeWebTransportSession(ScriptExecutionContext&, WebTransportSessionClient&, const URL&, const WebTransportOptions&) = 0;
+
+    virtual void countWebSocketChannelsForTesting(CompletionHandler<void(unsigned)>&& completionHandler) { completionHandler(0); }
 
 #if USE(LIBRICE)
     virtual RefPtr<RiceBackend> createRiceBackend(RiceBackendClient&) = 0;

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -237,6 +237,7 @@
 #include "Settings.h"
 #include "ShadowRoot.h"
 #include "ShouldPartitionCookie.h"
+#include "SocketProvider.h"
 #include "SourceBuffer.h"
 #include "SpeechSynthesisUtterance.h"
 #include "SpellChecker.h"
@@ -7125,6 +7126,23 @@ void Internals::whenServiceWorkerIsTerminated(ServiceWorker& worker, DOMPromiseD
 {
     return ServiceWorkerProvider::singleton().serviceWorkerConnection().whenServiceWorkerIsTerminatedForTesting(worker.identifier(), [promise = WTF::move(promise)]() mutable {
         promise.resolve();
+    });
+}
+
+void Internals::numberOfWebSocketChannelsInNetworkProcess(DOMPromiseDeferred<IDLUnsignedLong>&& promise)
+{
+    RefPtr document = contextDocument();
+    if (!document) {
+        promise.reject(ExceptionCode::InvalidStateError);
+        return;
+    }
+    RefPtr page = document->page();
+    if (!page) {
+        promise.reject(ExceptionCode::InvalidStateError);
+        return;
+    }
+    page->socketProvider().countWebSocketChannelsForTesting([promise = WTF::move(promise)](unsigned count) mutable {
+        promise.resolve(count);
     });
 }
 

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1170,6 +1170,8 @@ public:
     void whenServiceWorkerIsTerminated(ServiceWorker&, DOMPromiseDeferred<void>&&);
     NO_RETURN_DUE_TO_CRASH void terminateWebContentProcess();
 
+    void numberOfWebSocketChannelsInNetworkProcess(DOMPromiseDeferred<IDLUnsignedLong>&&);
+
 #if ENABLE(APPLE_PAY)
     ExceptionOr<Ref<MockPaymentCoordinator>> mockPaymentCoordinator(Document&);
 #endif

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1315,6 +1315,8 @@ enum ContentsFormat {
     Promise<undefined> whenServiceWorkerIsTerminated(ServiceWorker worker);
     undefined terminateWebContentProcess();
 
+    Promise<unsigned long> numberOfWebSocketChannelsInNetworkProcess();
+
 #if defined(ENABLE_APPLE_PAY) && ENABLE_APPLE_PAY
     [CallWith=CurrentDocument, Conditional=APPLE_PAY] readonly attribute MockPaymentCoordinator mockPaymentCoordinator;
 #endif

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -551,6 +551,11 @@ void NetworkConnectionToWebProcess::removeSocketChannel(WebSocketIdentifier iden
     m_networkSocketChannels.remove(identifier);
 }
 
+void NetworkConnectionToWebProcess::countWebSocketChannelsForTesting(CompletionHandler<void(uint32_t)>&& completionHandler)
+{
+    completionHandler(static_cast<uint32_t>(m_networkSocketChannels.size()));
+}
+
 NetworkSession* NetworkConnectionToWebProcess::networkSession()
 {
     return m_networkProcess->networkSession(m_sessionID);

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -349,6 +349,7 @@ private:
     void setCaptureExtraNetworkLoadMetricsEnabled(bool);
 
     void createSocketChannel(const WebCore::ResourceRequest&, const String& protocol, WebCore::WebSocketIdentifier, WebPageProxyIdentifier, std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::PageIdentifier>, const WebCore::ClientOrigin&, bool hadMainFrameMainResourcePrivateRelayed, bool allowPrivacyProxy, OptionSet<WebCore::AdvancedPrivacyProtections>, WebCore::StoredCredentialsPolicy);
+    void countWebSocketChannelsForTesting(CompletionHandler<void(uint32_t)>&&);
 
     void establishSharedWorkerServerConnection();
     void unregisterSharedWorkerConnection();

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
@@ -81,6 +81,8 @@ messages -> NetworkConnectionToWebProcess WantsDispatchMessage {
 
     [EnabledBy=WebSocketEnabled] CreateSocketChannel(WebCore::ResourceRequest request, String protocol, WebCore::WebSocketIdentifier identifier, WebKit::WebPageProxyIdentifier webPageProxyID, std::optional<WebCore::FrameIdentifier> frameID, std::optional<WebCore::PageIdentifier> pageID, struct WebCore::ClientOrigin clientOrigin, bool hadMainFrameMainResourcePrivateRelayed, bool allowPrivacyProxy, OptionSet<WebCore::AdvancedPrivacyProtections> protections, enum:uint8_t WebCore::StoredCredentialsPolicy storedCredentialsPolicy)
 
+    CountWebSocketChannelsForTesting() -> (uint32_t count)
+
     ClearPageSpecificData(WebCore::PageIdentifier pageID);
 
     [EnabledBy=StorageAccessAPIEnabled] RemoveStorageAccessForFrame(WebCore::FrameIdentifier frameID, WebCore::PageIdentifier pageID);

--- a/Source/WebKit/WebProcess/Network/WebSocketChannel.cpp
+++ b/Source/WebKit/WebProcess/Network/WebSocketChannel.cpp
@@ -97,6 +97,17 @@ WebSocketChannel::WebSocketChannel(WebPageProxyIdentifier webPageProxyID, Docume
 
 WebSocketChannel::~WebSocketChannel()
 {
+    // Ensure the network process tears down its NetworkSocketChannel even when
+    // none of the explicit close/disconnect paths ran. This happens for worker
+    // WebSockets on a peer-initiated close: WorkerThreadableWebSocketChannel::Peer::didClose
+    // nulls its RefPtr<WebSocketChannel> before the worker can call disconnect(),
+    // so without this the Close IPC would never be sent and the network-side
+    // channel would leak. m_needsToCallClose is only true once connect()
+    // successfully sent a CreateSocketChannel IPC and Close hasn't been sent
+    // since, so the destructor doesn't send a stray Close for channels the
+    // network process never knew about.
+    if (m_needsToCallClose)
+        MessageSender::send(Messages::NetworkSocketChannel::Close { WebCore::ThreadableWebSocketChannel::CloseEventCodeGoingAway, { } });
     WebProcess::singleton().webSocketChannelManager().removeChannel(*this);
 }
 
@@ -162,6 +173,7 @@ WebSocketChannel::ConnectStatus WebSocketChannel::connect(const URL& url, const 
     }();
 
     MessageSender::send(Messages::NetworkConnectionToWebProcess::CreateSocketChannel { *request, protocol, identifier(), m_webPageProxyID, std::optional(frame->frameID()), frame->pageID(), document->clientOrigin(), WebProcess::singleton().hadMainFrameMainResourcePrivateRelayed(), policySourceFrame->allowPrivacyProxy(), policySourceFrame->advancedPrivacyProtections(), storedCredentialsPolicy });
+    m_needsToCallClose = true;
     return ConnectStatus::OK;
 }
 
@@ -245,6 +257,7 @@ void WebSocketChannel::close(int code, const String& reason)
     m_inspector.didSendWebSocketFrame(closingFrame);
 
     MessageSender::send(Messages::NetworkSocketChannel::Close { code, reason });
+    m_needsToCallClose = false;
 }
 
 void WebSocketChannel::fail(String&& reason)
@@ -260,6 +273,7 @@ void WebSocketChannel::fail(String&& reason)
         return;
 
     MessageSender::send(Messages::NetworkSocketChannel::Close { WebCore::ThreadableWebSocketChannel::CloseEventCodeGoingAway, reason });
+    m_needsToCallClose = false;
     didClose(WebCore::ThreadableWebSocketChannel::CloseEventCodeAbnormalClosure, { });
 }
 
@@ -271,7 +285,10 @@ void WebSocketChannel::disconnect()
 
     m_inspector.didCloseWebSocket();
 
-    MessageSender::send(Messages::NetworkSocketChannel::Close { WebCore::ThreadableWebSocketChannel::CloseEventCodeGoingAway, { } });
+    if (m_needsToCallClose) {
+        MessageSender::send(Messages::NetworkSocketChannel::Close { WebCore::ThreadableWebSocketChannel::CloseEventCodeGoingAway, { } });
+        m_needsToCallClose = false;
+    }
 }
 
 void WebSocketChannel::didConnect(String&& subprotocol, String&& extensions)

--- a/Source/WebKit/WebProcess/Network/WebSocketChannel.h
+++ b/Source/WebKit/WebProcess/Network/WebSocketChannel.h
@@ -112,6 +112,7 @@ private:
     String m_extensions;
     size_t m_bufferedAmount { 0 };
     bool m_isClosing { false };
+    bool m_needsToCallClose { false };
     const Ref<WebCore::NetworkSendQueue> m_messageQueue;
     WebCore::WebSocketChannelInspector m_inspector;
     WebCore::ResourceRequest m_handshakeRequest;

--- a/Source/WebKit/WebProcess/Network/WebSocketProvider.cpp
+++ b/Source/WebKit/WebProcess/Network/WebSocketProvider.cpp
@@ -31,6 +31,7 @@
 #include "config.h"
 #include "WebSocketProvider.h"
 
+#include "NetworkConnectionToWebProcessMessages.h"
 #include "NetworkProcessConnection.h"
 #include "WebProcess.h"
 #include "WebSocketChannelManager.h"
@@ -50,6 +51,11 @@ using namespace WebCore;
 RefPtr<ThreadableWebSocketChannel> WebSocketProvider::createWebSocketChannel(Document& document, WebSocketChannelClient& client)
 {
     return WebKit::WebSocketChannel::create(m_webPageProxyID, document, client);
+}
+
+void WebSocketProvider::countWebSocketChannelsForTesting(CompletionHandler<void(unsigned)>&& completionHandler)
+{
+    WebProcess::singleton().ensureNetworkProcessConnection().connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::CountWebSocketChannelsForTesting { }, WTF::move(completionHandler));
 }
 
 WebSocketProvider::~WebSocketProvider() = default;

--- a/Source/WebKit/WebProcess/Network/WebSocketProvider.h
+++ b/Source/WebKit/WebProcess/Network/WebSocketProvider.h
@@ -42,6 +42,7 @@ public:
 private:
     RefPtr<WebCore::ThreadableWebSocketChannel> createWebSocketChannel(WebCore::Document&, WebCore::WebSocketChannelClient&) final;
     std::pair<RefPtr<WebCore::WebTransportSession>, Ref<WebCore::WebTransportSessionPromise>> initializeWebTransportSession(WebCore::ScriptExecutionContext&, WebCore::WebTransportSessionClient&, const URL&, const WebCore::WebTransportOptions&) final;
+    void countWebSocketChannelsForTesting(CompletionHandler<void(unsigned)>&&) final;
 
     explicit WebSocketProvider(WebPageProxyIdentifier);
 


### PR DESCRIPTION
#### f391b9f442fc44d4d93ed3b20733202d154b0a79
<pre>
NetworkSocketChannel leaks when a worker WebSocket is closed by the server
<a href="https://bugs.webkit.org/show_bug.cgi?id=315342">https://bugs.webkit.org/show_bug.cgi?id=315342</a>
<a href="https://rdar.apple.com/130167032">rdar://130167032</a>

Reviewed by Youenn Fablet.

When a worker-scoped WebSocket is closed by the peer, the
WebProcess-side WebKit::WebSocketChannel never sends the Close IPC to
the network process, so NetworkSocketChannel sits in State::Closing
forever and its underlying NSURLSessionWebSocketTask leaks.

The chain on a peer-initiated close (network process delivers DidClose):

  WebSocketChannel::didClose (main thread)
    -&gt; client-&gt;didClose, where client is WorkerThreadableWebSocketChannel::Peer
       -&gt; Peer::didClose sets m_mainWebSocketChannel = nullptr
          (drops the only strong ref to WebKit::WebSocketChannel)
    -&gt; WebSocketChannel::didClose returns
       -&gt; protectedThis goes out of scope, last ref drops
          -&gt; ~WebSocketChannel runs (currently does not send Close)

The path that *would* send the Close IPC is
Peer::~Peer -&gt; m_mainWebSocketChannel-&gt;disconnect(), but
m_mainWebSocketChannel was already nulled in Peer::didClose, so ~Peer
is a no-op. The worker-side WebSocket::didClose handler eventually
calls socket.m_channel-&gt;disconnect(), but in the worker case
m_channel is the WorkerThreadableWebSocketChannel, whose Bridge::disconnect
only nullifies local state and does not send any IPC.

The document-scoped path is unaffected because there
WebSocket::m_channel is the WebKit::WebSocketChannel directly, and
WebSocket::didClose&apos;s task does m_channel-&gt;disconnect() against it,
which sends the IPC explicitly.

Fix this by sending the Close IPC from ~WebSocketChannel when none of
the explicit close/disconnect paths sent it. A new m_needsToCallClose
flag is set to true in WebSocketChannel::connect() once the
CreateSocketChannel IPC has actually been sent (so connect() failures
that returned early don&apos;t leave a stale flag), and is cleared whenever
close()/fail()/disconnect() send a Close IPC. The destructor then
sends Close only when the flag is still set, ensuring a single Close
IPC per network-process channel and none for channels the network
process never knew about.

TEST: http/tests/websocket/tests/hybi/worker-handshake-failure-cleanup.html

* LayoutTests/http/tests/websocket/tests/hybi/handshake-fail-with-200-ok_wsh.py: Added.
(web_socket_do_extra_handshake):
(web_socket_transfer_data):
* LayoutTests/http/tests/websocket/tests/hybi/worker-handshake-failure-cleanup-expected.txt: Added.
* LayoutTests/http/tests/websocket/tests/hybi/worker-handshake-failure-cleanup.html: Added.
* Source/WebCore/page/SocketProvider.h:
* Source/WebCore/testing/Internals.cpp:
(WebCore::Internals::numberOfWebSocketChannelsInNetworkProcess):
* Source/WebCore/testing/Internals.h:
* Source/WebCore/testing/Internals.idl:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
(WebKit::NetworkConnectionToWebProcess::countWebSocketChannelsForTesting):
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
* Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in:
* Source/WebKit/WebProcess/Network/WebSocketChannel.cpp:
(WebKit::WebSocketChannel::~WebSocketChannel):
(WebKit::WebSocketChannel::connect):
(WebKit::WebSocketChannel::close):
(WebKit::WebSocketChannel::fail):
(WebKit::WebSocketChannel::disconnect):
* Source/WebKit/WebProcess/Network/WebSocketChannel.h:
* Source/WebKit/WebProcess/Network/WebSocketProvider.cpp:
(WebKit::WebSocketProvider::countWebSocketChannelsForTesting):
* Source/WebKit/WebProcess/Network/WebSocketProvider.h:

Canonical link: <a href="https://commits.webkit.org/313770@main">https://commits.webkit.org/313770@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/23219df7fa24b4d2ef1828d00d9a9436f48bfecc

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164004 "1 style error") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37488 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30707 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173033 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1bfd18de-84e1-494d-9ee8-df192a058ec9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165873 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37821 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37488 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127409 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121255 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/45fce7fd-827c-4046-9d66-89f6c57dd79d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166963 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29691 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147438 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107957 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2ef5ff37-1946-47a3-bce7-7b49e9e00d37) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28737 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27367 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20797 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138638 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25155 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175558 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28380 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26823 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135718 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37158 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31479 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135690 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37943 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146950 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100132 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24974 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30992 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23806 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36752 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109799 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36151 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1852 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36401 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36298 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->