### PR TITLE
[CSS] Implement corner and corner-* shorthands + corner-shape rendering

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-block-start-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-block-start-computed-expected.txt
@@ -1,0 +1,6 @@
+
+PASS Property corner-block-start value '0px round'
+PASS Property corner-block-start value '10px bevel'
+PASS Property corner-block-start value 'normal / 2px round'
+PASS Property corner-block-start value '4px 2% squircle / 1em scoop'
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-block-start-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-block-start-computed.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Borders and Box Decorations 4 Test: Computed values of 'corner-block-start'</title>
+<link rel="author" title="Chromium" href="https://chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shorthand">
+<meta name="assert" content="This test checks that the computed value of 'corner-block-start' is correct across writing mode variants.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+
+<div id="target"></div>
+
+<script>
+test_computed_value("corner-block-start", "0px round", "normal");
+test_computed_value("corner-block-start", "10px bevel");
+test_computed_value("corner-block-start", "normal / 2px round");
+test_computed_value("corner-block-start", "4px 2% squircle / 1em scoop", "4px 2% squircle / 16px scoop");
+</script>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-block-start-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-block-start-valid-expected.txt
@@ -1,0 +1,16 @@
+
+PASS e.style['corner-block-start'] = "10px bevel" should set the property value
+PASS e.style['corner-block-start'] = "round 10% / 2rem squircle" should set the property value
+PASS e.style['corner-block-start'] = "normal" should set the property value
+PASS e.style['corner-block-start'] = "4px 2% round / bevel 1em" should set the property value
+PASS e.style['corner-block-start'] = "10px bevel" should set border-start-end-radius
+PASS e.style['corner-block-start'] = "10px bevel" should set border-start-start-radius
+PASS e.style['corner-block-start'] = "10px bevel" should set corner-start-end-shape
+PASS e.style['corner-block-start'] = "10px bevel" should set corner-start-start-shape
+PASS e.style['corner-block-start'] = "10px bevel" should not set unrelated longhands
+PASS e.style['corner-block-start'] = "4px 2% round / 1em bevel" should set border-start-end-radius
+PASS e.style['corner-block-start'] = "4px 2% round / 1em bevel" should set border-start-start-radius
+PASS e.style['corner-block-start'] = "4px 2% round / 1em bevel" should set corner-start-end-shape
+PASS e.style['corner-block-start'] = "4px 2% round / 1em bevel" should set corner-start-start-shape
+PASS e.style['corner-block-start'] = "4px 2% round / 1em bevel" should not set unrelated longhands
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-block-start-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-block-start-valid.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Borders and Box Decorations 4 Test: Parsing 'corner-block-start' with valid values</title>
+<link rel="author" title="Chromium" href="https://chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shorthand">
+<meta name="assert" content="This test checks that 'corner-block-start' supports valid pair-corner values.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<script src="/css/support/shorthand-testcommon.js"></script>
+
+<script>
+test_valid_value("corner-block-start", "10px bevel");
+test_valid_value("corner-block-start", "round 10% / 2rem squircle", "10% round / 2rem squircle");
+test_valid_value("corner-block-start", "normal");
+test_valid_value("corner-block-start", "4px 2% round / bevel 1em", "4px 2% round / 1em bevel");
+
+test_shorthand_value("corner-block-start", "10px bevel", {
+  "border-start-start-radius": "10px",
+  "corner-start-start-shape": "bevel",
+  "border-start-end-radius": "10px",
+  "corner-start-end-shape": "bevel",
+});
+test_shorthand_value("corner-block-start", "4px 2% round / 1em bevel", {
+  "border-start-start-radius": "4px 2%",
+  "corner-start-start-shape": "round",
+  "border-start-end-radius": "1em",
+  "corner-start-end-shape": "bevel",
+});
+</script>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-block-start-writing-modes-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-block-start-writing-modes-expected.txt
@@ -1,0 +1,5 @@
+
+PASS corner-block-start in horizontal-tb ltr
+PASS corner-block-start in horizontal-tb rtl
+PASS corner-block-start in vertical-rl ltr
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-block-start-writing-modes.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-block-start-writing-modes.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Borders and Box Decorations 4 Test: 'corner-block-start' in writing mode variants</title>
+<link rel="author" title="Chromium" href="https://chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shorthand">
+<meta name="assert" content="This test checks that 'corner-block-start' applies in horizontal and vertical writing modes.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<div id="target"></div>
+
+<script>
+function runVariant(name, writingMode, direction) {
+  test(() => {
+    const target = document.getElementById('target');
+    target.style.cssText = '';
+    target.style.writingMode = writingMode;
+    target.style.direction = direction;
+    target.style.cornerBlockStart = '10px round / 20px bevel';
+
+    assert_equals(target.style.cornerBlockStart, '10px round / 20px bevel');
+
+    const computed = getComputedStyle(target).getPropertyValue('corner-block-start').trim();
+    assert_not_equals(computed, '', 'computed shorthand should not be empty');
+  }, name);
+}
+
+runVariant('corner-block-start in horizontal-tb ltr', 'horizontal-tb', 'ltr');
+runVariant('corner-block-start in horizontal-tb rtl', 'horizontal-tb', 'rtl');
+runVariant('corner-block-start in vertical-rl ltr', 'vertical-rl', 'ltr');
+</script>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shorthand-rendering-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shorthand-rendering-ref.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Borders 4: corner shorthand rendering reference</title>
+<style>
+  .box {
+    width: 160px;
+    height: 160px;
+    border: 24px solid rgb(0 128 0);
+    background: rgb(240 240 240);
+    border-top-left-radius: 36px;
+    border-top-right-radius: 18px;
+    border-bottom-right-radius: 28px;
+    border-bottom-left-radius: 20px;
+    corner-top-left-shape: round;
+    corner-top-right-shape: bevel;
+    corner-bottom-right-shape: scoop;
+    corner-bottom-left-shape: notch;
+  }
+</style>
+<div class="box"></div>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shorthand-rendering.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shorthand-rendering.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Borders 4: corner shorthand rendering</title>
+<link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shorthand">
+<link rel="match" href="corner-shorthand-rendering-ref.html">
+<style>
+  .box {
+    width: 160px;
+    height: 160px;
+    border: 24px solid rgb(0 128 0);
+    background: rgb(240 240 240);
+    corner: 36px round / 18px bevel / 28px scoop / 20px notch;
+  }
+</style>
+<div class="box"></div>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-top-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-top-computed-expected.txt
@@ -1,0 +1,6 @@
+
+PASS Property corner-top value '0px round'
+PASS Property corner-top value '10px bevel'
+PASS Property corner-top value 'normal / 2px round'
+PASS Property corner-top value '4px 2% squircle / 1em scoop'
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-top-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-top-computed.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Borders and Box Decorations 4 Test: Computed values of 'corner-top'</title>
+<link rel="author" title="Chromium" href="https://chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shorthand">
+<meta name="assert" content="This test checks that the computed value of 'corner-top' is correct.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+
+<div id="target"></div>
+
+<script>
+test_computed_value("corner-top", "0px round", "normal");
+test_computed_value("corner-top", "10px bevel");
+test_computed_value("corner-top", "normal / 2px round");
+test_computed_value("corner-top", "4px 2% squircle / 1em scoop", "4px 2% squircle / 16px scoop");
+</script>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-top-left-computed-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-top-left-computed-expected.txt
@@ -1,0 +1,8 @@
+
+PASS Property corner-top-left value '0px round'
+PASS Property corner-top-left value 'normal'
+PASS Property corner-top-left value '4px round'
+PASS Property corner-top-left value '2% notch'
+PASS Property corner-top-left value '4px 2% squircle'
+PASS Property corner-top-left value 'superellipse(-0.5) 30% 10px'
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-top-left-computed.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-top-left-computed.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Borders and Box Decorations 4 Test: Computed values of 'corner-top-left'</title>
+<link rel="author" title="Chromium" href="https://chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shorthand">
+<meta name="assert" content="This test checks that the computed value of 'corner-top-left' is correct.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/computed-testcommon.js"></script>
+
+<div id="target"></div>
+
+<script>
+test_computed_value("corner-top-left", "0px round", "normal");
+test_computed_value("corner-top-left", "normal");
+test_computed_value("corner-top-left", "4px round");
+test_computed_value("corner-top-left", "2% notch");
+test_computed_value("corner-top-left", "4px 2% squircle");
+test_computed_value("corner-top-left", "superellipse(-0.5) 30% 10px", "30% 10px superellipse(-0.5)");
+</script>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-top-left-invalid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-top-left-invalid-expected.txt
@@ -1,0 +1,12 @@
+
+PASS e.style['corner-top-left'] = "auto" should not set the property value
+PASS e.style['corner-top-left'] = "none" should not set the property value
+PASS e.style['corner-top-left'] = "scoop" should not set the property value
+PASS e.style['corner-top-left'] = "3% normal" should not set the property value
+PASS e.style['corner-top-left'] = "round round" should not set the property value
+PASS e.style['corner-top-left'] = "-1px" should not set the property value
+PASS e.style['corner-top-left'] = "10px" should not set the property value
+PASS e.style['corner-top-left'] = "4px 12px" should not set the property value
+PASS e.style['corner-top-left'] = "4px / normal" should not set the property value
+PASS e.style['corner-top-left'] = "round / 4px" should not set the property value
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-top-left-invalid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-top-left-invalid.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Borders and Box Decorations 4 Test: Parsing 'corner-top-left' with invalid values</title>
+<link rel="author" title="Chromium" href="https://chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shorthand">
+<meta name="assert" content="This test checks that 'corner-top-left' rejects invalid values.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+
+<script>
+test_invalid_value("corner-top-left", "auto");
+test_invalid_value("corner-top-left", "none");
+test_invalid_value("corner-top-left", "scoop");
+test_invalid_value("corner-top-left", "3% normal");
+test_invalid_value("corner-top-left", "round round");
+test_invalid_value("corner-top-left", "-1px");
+test_invalid_value("corner-top-left", "10px");
+test_invalid_value("corner-top-left", "4px 12px");
+test_invalid_value("corner-top-left", "4px / normal");
+test_invalid_value("corner-top-left", "round / 4px");
+</script>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-top-left-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-top-left-valid-expected.txt
@@ -1,0 +1,13 @@
+
+PASS e.style['corner-top-left'] = "round 30%" should set the property value
+PASS e.style['corner-top-left'] = "10px bevel" should set the property value
+PASS e.style['corner-top-left'] = "normal" should set the property value
+PASS e.style['corner-top-left'] = "4px 2% round" should set the property value
+PASS e.style['corner-top-left'] = "superellipse(-0.5) 30% 10px" should set the property value
+PASS e.style['corner-top-left'] = "10px bevel" should set border-top-left-radius
+PASS e.style['corner-top-left'] = "10px bevel" should set corner-top-left-shape
+PASS e.style['corner-top-left'] = "10px bevel" should not set unrelated longhands
+PASS e.style['corner-top-left'] = "normal" should set border-top-left-radius
+PASS e.style['corner-top-left'] = "normal" should set corner-top-left-shape
+PASS e.style['corner-top-left'] = "normal" should not set unrelated longhands
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-top-left-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-top-left-valid.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Borders and Box Decorations 4 Test: Parsing 'corner-top-left' with valid values</title>
+<link rel="author" title="Chromium" href="https://chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shorthand">
+<meta name="assert" content="This test checks that 'corner-top-left' supports valid single-corner values.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<script src="/css/support/shorthand-testcommon.js"></script>
+
+<script>
+test_valid_value("corner-top-left", "round 30%", "30% round");
+test_valid_value("corner-top-left", "10px bevel");
+test_valid_value("corner-top-left", "normal");
+test_valid_value("corner-top-left", "4px 2% round");
+test_valid_value("corner-top-left", "superellipse(-0.5) 30% 10px", "30% 10px superellipse(-0.5)");
+
+test_shorthand_value("corner-top-left", "10px bevel", {
+  "border-top-left-radius": "10px",
+  "corner-top-left-shape": "bevel",
+});
+test_shorthand_value("corner-top-left", "normal", {
+  "border-top-left-radius": "0px",
+  "corner-top-left-shape": "round",
+});
+</script>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-top-valid-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-top-valid-expected.txt
@@ -1,0 +1,16 @@
+
+PASS e.style['corner-top'] = "10px bevel" should set the property value
+PASS e.style['corner-top'] = "round 10% / 2rem squircle" should set the property value
+PASS e.style['corner-top'] = "normal" should set the property value
+PASS e.style['corner-top'] = "4px 2% round / bevel 1em" should set the property value
+PASS e.style['corner-top'] = "10px bevel" should set border-top-left-radius
+PASS e.style['corner-top'] = "10px bevel" should set border-top-right-radius
+PASS e.style['corner-top'] = "10px bevel" should set corner-top-left-shape
+PASS e.style['corner-top'] = "10px bevel" should set corner-top-right-shape
+PASS e.style['corner-top'] = "10px bevel" should not set unrelated longhands
+PASS e.style['corner-top'] = "4px 2% round / 1em bevel" should set border-top-left-radius
+PASS e.style['corner-top'] = "4px 2% round / 1em bevel" should set border-top-right-radius
+PASS e.style['corner-top'] = "4px 2% round / 1em bevel" should set corner-top-left-shape
+PASS e.style['corner-top'] = "4px 2% round / 1em bevel" should set corner-top-right-shape
+PASS e.style['corner-top'] = "4px 2% round / 1em bevel" should not set unrelated longhands
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-top-valid.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-top-valid.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Borders and Box Decorations 4 Test: Parsing 'corner-top' with valid values</title>
+<link rel="author" title="Chromium" href="https://chromium.org">
+<link rel="help" href="https://drafts.csswg.org/css-borders-4/#corner-shorthand">
+<meta name="assert" content="This test checks that 'corner-top' supports valid pair-corner values.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="/css/support/parsing-testcommon.js"></script>
+<script src="/css/support/shorthand-testcommon.js"></script>
+
+<script>
+test_valid_value("corner-top", "10px bevel");
+test_valid_value("corner-top", "round 10% / 2rem squircle", "10% round / 2rem squircle");
+test_valid_value("corner-top", "normal");
+test_valid_value("corner-top", "4px 2% round / bevel 1em", "4px 2% round / 1em bevel");
+
+test_shorthand_value("corner-top", "10px bevel", {
+  "border-top-left-radius": "10px",
+  "corner-top-left-shape": "bevel",
+  "border-top-right-radius": "10px",
+  "corner-top-right-shape": "bevel",
+});
+test_shorthand_value("corner-top", "4px 2% round / 1em bevel", {
+  "border-top-left-radius": "4px 2%",
+  "corner-top-left-shape": "round",
+  "border-top-right-radius": "1em",
+  "corner-top-right-shape": "bevel",
+});
+</script>
+

--- a/LayoutTests/platform/mac/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shorthand-rendering-expected.txt
+++ b/LayoutTests/platform/mac/imported/w3c/web-platform-tests/css/css-borders/corner-shape/corner-shorthand-rendering-expected.txt
@@ -1,0 +1,6 @@
+layer at (0,0) size 800x600
+  RenderView at (0,0) size 800x600
+layer at (0,0) size 800x224
+  RenderBlock {HTML} at (0,0) size 800x224
+    RenderBody {BODY} at (8,8) size 784x208
+      RenderBlock {DIV} at (0,0) size 208x208 [bgcolor=#F0F0F0] [border: (24px solid #008000)]

--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1065,6 +1065,20 @@ CSSCornerShapeEnabled:
     WebCore:
       default: false
 
+CSSCornersShorthandEnabled:
+  type: bool
+  category: css
+  status: testable
+  humanReadableName: "CSS corner and corner-* shorthands"
+  humanReadableDescription: "Enable support for the CSS `corner` and per-corner shorthand properties combining border-radius and corner-shape."
+  defaultValue:
+    WebKitLegacy:
+      default: false
+    WebKit:
+      default: false
+    WebCore:
+      default: false
+
 CSSCounterStyleAtRuleImageSymbolsEnabled:
   type: bool
   status: testable

--- a/Source/WebCore/css/CSSProperties.json
+++ b/Source/WebCore/css/CSSProperties.json
@@ -4442,6 +4442,425 @@
                 "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
             }
         },
+        "corner-top-shape": {
+            "codegen-properties": {
+                "longhands": [
+                    "corner-top-left-shape",
+                    "corner-top-right-shape"
+                ],
+                "shorthand-pattern": "CoalescingPair",
+                "settings-flag": "cssCornerShapeEnabled",
+                "parser-grammar-unused": "<'corner-top-left-shape'>{1,2}",
+                "parser-grammar-unused-reason": "Needs support for shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-right-shape": {
+            "codegen-properties": {
+                "longhands": [
+                    "corner-top-right-shape",
+                    "corner-bottom-right-shape"
+                ],
+                "shorthand-pattern": "CoalescingPair",
+                "settings-flag": "cssCornerShapeEnabled",
+                "parser-grammar-unused": "<'corner-top-right-shape'>{1,2}",
+                "parser-grammar-unused-reason": "Needs support for shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-bottom-shape": {
+            "codegen-properties": {
+                "longhands": [
+                    "corner-bottom-left-shape",
+                    "corner-bottom-right-shape"
+                ],
+                "shorthand-pattern": "CoalescingPair",
+                "settings-flag": "cssCornerShapeEnabled",
+                "parser-grammar-unused": "<'corner-bottom-left-shape'>{1,2}",
+                "parser-grammar-unused-reason": "Needs support for shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-left-shape": {
+            "codegen-properties": {
+                "longhands": [
+                    "corner-top-left-shape",
+                    "corner-bottom-left-shape"
+                ],
+                "shorthand-pattern": "CoalescingPair",
+                "settings-flag": "cssCornerShapeEnabled",
+                "parser-grammar-unused": "<'corner-top-left-shape'>{1,2}",
+                "parser-grammar-unused-reason": "Needs support for shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-block-start-shape": {
+            "codegen-properties": {
+                "longhands": [
+                    "corner-start-start-shape",
+                    "corner-start-end-shape"
+                ],
+                "shorthand-pattern": "CoalescingPair",
+                "settings-flag": "cssCornerShapeEnabled",
+                "parser-grammar-unused": "<'corner-start-start-shape'>{1,2}",
+                "parser-grammar-unused-reason": "Needs support for shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-block-end-shape": {
+            "codegen-properties": {
+                "longhands": [
+                    "corner-end-start-shape",
+                    "corner-end-end-shape"
+                ],
+                "shorthand-pattern": "CoalescingPair",
+                "settings-flag": "cssCornerShapeEnabled",
+                "parser-grammar-unused": "<'corner-end-start-shape'>{1,2}",
+                "parser-grammar-unused-reason": "Needs support for shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-inline-start-shape": {
+            "codegen-properties": {
+                "longhands": [
+                    "corner-start-start-shape",
+                    "corner-end-start-shape"
+                ],
+                "shorthand-pattern": "CoalescingPair",
+                "settings-flag": "cssCornerShapeEnabled",
+                "parser-grammar-unused": "<'corner-start-start-shape'>{1,2}",
+                "parser-grammar-unused-reason": "Needs support for shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-inline-end-shape": {
+            "codegen-properties": {
+                "longhands": [
+                    "corner-start-end-shape",
+                    "corner-end-end-shape"
+                ],
+                "shorthand-pattern": "CoalescingPair",
+                "settings-flag": "cssCornerShapeEnabled",
+                "parser-grammar-unused": "<'corner-start-end-shape'>{1,2}",
+                "parser-grammar-unused-reason": "Needs support for shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-top-left": {
+            "codegen-properties": {
+                "longhands": [
+                    "border-top-left-radius",
+                    "corner-top-left-shape"
+                ],
+                "parser-function": "consumeCornerSingleShorthand",
+                "shorthand-style-extractor-pattern": "CornerSingle",
+                "settings-flag": "cssCornersShorthandEnabled",
+                "parser-grammar-unused": "normal | [ <'border-top-left-radius'> ]",
+                "parser-grammar-unused-reason": "Needs support for hand-written shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-top-right": {
+            "codegen-properties": {
+                "longhands": [
+                    "border-top-right-radius",
+                    "corner-top-right-shape"
+                ],
+                "parser-function": "consumeCornerSingleShorthand",
+                "shorthand-style-extractor-pattern": "CornerSingle",
+                "settings-flag": "cssCornersShorthandEnabled",
+                "parser-grammar-unused": "normal | [ <'border-top-right-radius'> ]",
+                "parser-grammar-unused-reason": "Needs support for hand-written shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-bottom-right": {
+            "codegen-properties": {
+                "longhands": [
+                    "border-bottom-right-radius",
+                    "corner-bottom-right-shape"
+                ],
+                "parser-function": "consumeCornerSingleShorthand",
+                "shorthand-style-extractor-pattern": "CornerSingle",
+                "settings-flag": "cssCornersShorthandEnabled",
+                "parser-grammar-unused": "normal | [ <'border-bottom-right-radius'> ]",
+                "parser-grammar-unused-reason": "Needs support for hand-written shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-bottom-left": {
+            "codegen-properties": {
+                "longhands": [
+                    "border-bottom-left-radius",
+                    "corner-bottom-left-shape"
+                ],
+                "parser-function": "consumeCornerSingleShorthand",
+                "shorthand-style-extractor-pattern": "CornerSingle",
+                "settings-flag": "cssCornersShorthandEnabled",
+                "parser-grammar-unused": "normal | [ <'border-bottom-left-radius'> ]",
+                "parser-grammar-unused-reason": "Needs support for hand-written shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-start-start": {
+            "codegen-properties": {
+                "longhands": [
+                    "border-start-start-radius",
+                    "corner-start-start-shape"
+                ],
+                "parser-function": "consumeCornerSingleShorthand",
+                "shorthand-style-extractor-pattern": "CornerSingle",
+                "settings-flag": "cssCornersShorthandEnabled",
+                "parser-grammar-unused": "normal | [ <'border-start-start-radius'> ]",
+                "parser-grammar-unused-reason": "Needs support for hand-written shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-start-end": {
+            "codegen-properties": {
+                "longhands": [
+                    "border-start-end-radius",
+                    "corner-start-end-shape"
+                ],
+                "parser-function": "consumeCornerSingleShorthand",
+                "shorthand-style-extractor-pattern": "CornerSingle",
+                "settings-flag": "cssCornersShorthandEnabled",
+                "parser-grammar-unused": "normal | [ <'border-start-end-radius'> ]",
+                "parser-grammar-unused-reason": "Needs support for hand-written shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-end-start": {
+            "codegen-properties": {
+                "longhands": [
+                    "border-end-start-radius",
+                    "corner-end-start-shape"
+                ],
+                "parser-function": "consumeCornerSingleShorthand",
+                "shorthand-style-extractor-pattern": "CornerSingle",
+                "settings-flag": "cssCornersShorthandEnabled",
+                "parser-grammar-unused": "normal | [ <'border-end-start-radius'> ]",
+                "parser-grammar-unused-reason": "Needs support for hand-written shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-end-end": {
+            "codegen-properties": {
+                "longhands": [
+                    "border-end-end-radius",
+                    "corner-end-end-shape"
+                ],
+                "parser-function": "consumeCornerSingleShorthand",
+                "shorthand-style-extractor-pattern": "CornerSingle",
+                "settings-flag": "cssCornersShorthandEnabled",
+                "parser-grammar-unused": "normal | [ <'border-end-end-radius'> ]",
+                "parser-grammar-unused-reason": "Needs support for hand-written shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-top": {
+            "codegen-properties": {
+                "longhands": [
+                    "border-top-left-radius", "corner-top-left-shape",
+                    "border-top-right-radius", "corner-top-right-shape"
+                ],
+                "parser-function": "consumeCornerPairShorthand",
+                "shorthand-style-extractor-pattern": "CornerPair",
+                "settings-flag": "cssCornersShorthandEnabled",
+                "parser-grammar-unused": "[ normal | <length-percentage [0,inf]> ]#",
+                "parser-grammar-unused-reason": "Needs support for hand-written shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-right": {
+            "codegen-properties": {
+                "longhands": [
+                    "border-top-right-radius", "corner-top-right-shape",
+                    "border-bottom-right-radius", "corner-bottom-right-shape"
+                ],
+                "parser-function": "consumeCornerPairShorthand",
+                "shorthand-style-extractor-pattern": "CornerPair",
+                "settings-flag": "cssCornersShorthandEnabled",
+                "parser-grammar-unused": "[ normal | <length-percentage [0,inf]> ]#",
+                "parser-grammar-unused-reason": "Needs support for hand-written shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-bottom": {
+            "codegen-properties": {
+                "longhands": [
+                    "border-bottom-left-radius", "corner-bottom-left-shape",
+                    "border-bottom-right-radius", "corner-bottom-right-shape"
+                ],
+                "parser-function": "consumeCornerPairShorthand",
+                "shorthand-style-extractor-pattern": "CornerPair",
+                "settings-flag": "cssCornersShorthandEnabled",
+                "parser-grammar-unused": "[ normal | <length-percentage [0,inf]> ]#",
+                "parser-grammar-unused-reason": "Needs support for hand-written shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-left": {
+            "codegen-properties": {
+                "longhands": [
+                    "border-top-left-radius", "corner-top-left-shape",
+                    "border-bottom-left-radius", "corner-bottom-left-shape"
+                ],
+                "parser-function": "consumeCornerPairShorthand",
+                "shorthand-style-extractor-pattern": "CornerPair",
+                "settings-flag": "cssCornersShorthandEnabled",
+                "parser-grammar-unused": "[ normal | <length-percentage [0,inf]> ]#",
+                "parser-grammar-unused-reason": "Needs support for hand-written shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-block-start": {
+            "codegen-properties": {
+                "longhands": [
+                    "border-start-start-radius", "corner-start-start-shape",
+                    "border-start-end-radius", "corner-start-end-shape"
+                ],
+                "parser-function": "consumeCornerPairShorthand",
+                "shorthand-style-extractor-pattern": "CornerPair",
+                "settings-flag": "cssCornersShorthandEnabled",
+                "parser-grammar-unused": "[ normal | <length-percentage [0,inf]> ]#",
+                "parser-grammar-unused-reason": "Needs support for hand-written shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-block-end": {
+            "codegen-properties": {
+                "longhands": [
+                    "border-end-start-radius", "corner-end-start-shape",
+                    "border-end-end-radius", "corner-end-end-shape"
+                ],
+                "parser-function": "consumeCornerPairShorthand",
+                "shorthand-style-extractor-pattern": "CornerPair",
+                "settings-flag": "cssCornersShorthandEnabled",
+                "parser-grammar-unused": "[ normal | <length-percentage [0,inf]> ]#",
+                "parser-grammar-unused-reason": "Needs support for hand-written shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-inline-start": {
+            "codegen-properties": {
+                "longhands": [
+                    "border-start-start-radius", "corner-start-start-shape",
+                    "border-end-start-radius", "corner-end-start-shape"
+                ],
+                "parser-function": "consumeCornerPairShorthand",
+                "shorthand-style-extractor-pattern": "CornerPair",
+                "settings-flag": "cssCornersShorthandEnabled",
+                "parser-grammar-unused": "[ normal | <length-percentage [0,inf]> ]#",
+                "parser-grammar-unused-reason": "Needs support for hand-written shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner-inline-end": {
+            "codegen-properties": {
+                "longhands": [
+                    "border-start-end-radius", "corner-start-end-shape",
+                    "border-end-end-radius", "corner-end-end-shape"
+                ],
+                "parser-function": "consumeCornerPairShorthand",
+                "shorthand-style-extractor-pattern": "CornerPair",
+                "settings-flag": "cssCornersShorthandEnabled",
+                "parser-grammar-unused": "[ normal | <length-percentage [0,inf]> ]#",
+                "parser-grammar-unused-reason": "Needs support for hand-written shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
+        "corner": {
+            "codegen-properties": {
+                "longhands": [
+                    "border-top-left-radius", "corner-top-left-shape",
+                    "border-top-right-radius", "corner-top-right-shape",
+                    "border-bottom-right-radius", "corner-bottom-right-shape",
+                    "border-bottom-left-radius", "corner-bottom-left-shape"
+                ],
+                "parser-function": "consumeCornerQuadShorthand",
+                "shorthand-style-extractor-pattern": "CornerQuad",
+                "settings-flag": "cssCornersShorthandEnabled",
+                "parser-grammar-unused": "[ normal | <length-percentage [0,inf]> ]#",
+                "parser-grammar-unused-reason": "Needs support for hand-written shorthand grammars."
+            },
+            "specification": {
+                "category": "css-borders",
+                "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"
+            }
+        },
         "counter-increment": {
             "animation-type": "discrete",
             "animation-type-comment": "Current spec animation type is 'by computed value'",
@@ -14616,7 +15035,7 @@
             }
         },
         "<corner-shape-value>": {
-            "grammar": "round | scoop | bevel | notch | straight | squircle | superellipse(<number [0,inf]> | infinity)",
+            "grammar": "round | scoop | bevel | notch | square | squircle | superellipse(<number> | infinity | -infinity)",
             "specification": {
                 "category": "css-borders",
                 "url": "https://drafts.csswg.org/css-borders-4/#corner-shaping"

--- a/Source/WebCore/css/CSSValueKeywords.in
+++ b/Source/WebCore/css/CSSValueKeywords.in
@@ -962,10 +962,14 @@ padding-box
 scoop
 // bevel
 notch
+// `straight` is an outdated WebKit-only alias retained for source compatibility;
+// the spec keyword (and the one we accept and serialize) is `square`.
 straight
+// square (already defined above)
 squircle
 superellipse
-// infinity
+// infinity (already defined further below)
+// -infinity (already defined further below)
 
 //
 // CSS_PROP_MASK_CLIP

--- a/Source/WebCore/css/ShorthandSerializer.cpp
+++ b/Source/WebCore/css/ShorthandSerializer.cpp
@@ -119,6 +119,10 @@ private:
     String serializeCommonValue(unsigned startIndex, unsigned count) const;
     String serializePair() const;
     String serializeQuad() const;
+    String serializeCornerSingle() const;
+    String serializeCornerPair() const;
+    String serializeCornerQuad() const;
+    String serializeOneCorner(unsigned radiusIndex, unsigned shapeIndex) const;
 
     String serializeLayered() const;
     String serializeCoordinatingListPropertyGroup() const;
@@ -343,7 +347,35 @@ String ShorthandSerializer::serialize()
     case CSSPropertyScrollMarginInline:
     case CSSPropertyScrollPaddingBlock:
     case CSSPropertyScrollPaddingInline:
+    case CSSPropertyCornerTopShape:
+    case CSSPropertyCornerRightShape:
+    case CSSPropertyCornerBottomShape:
+    case CSSPropertyCornerLeftShape:
+    case CSSPropertyCornerBlockStartShape:
+    case CSSPropertyCornerBlockEndShape:
+    case CSSPropertyCornerInlineStartShape:
+    case CSSPropertyCornerInlineEndShape:
         return serializePair();
+    case CSSPropertyCornerTopLeft:
+    case CSSPropertyCornerTopRight:
+    case CSSPropertyCornerBottomLeft:
+    case CSSPropertyCornerBottomRight:
+    case CSSPropertyCornerStartStart:
+    case CSSPropertyCornerStartEnd:
+    case CSSPropertyCornerEndStart:
+    case CSSPropertyCornerEndEnd:
+        return serializeCornerSingle();
+    case CSSPropertyCornerTop:
+    case CSSPropertyCornerRight:
+    case CSSPropertyCornerBottom:
+    case CSSPropertyCornerLeft:
+    case CSSPropertyCornerBlockStart:
+    case CSSPropertyCornerBlockEnd:
+    case CSSPropertyCornerInlineStart:
+    case CSSPropertyCornerInlineEnd:
+        return serializeCornerPair();
+    case CSSPropertyCorner:
+        return serializeCornerQuad();
     case CSSPropertyBlockStep:
     case CSSPropertyBorderBlockEnd:
     case CSSPropertyBorderBlockStart:
@@ -517,6 +549,83 @@ String ShorthandSerializer::serializeQuad() const
 {
     ASSERT(length() == 4);
     return Quad::serialize(serializeLonghandValue(0), serializeLonghandValue(1), serializeLonghandValue(2), serializeLonghandValue(3));
+}
+
+static bool cornerShorthandRadiusIsZero(const CSSValue& value)
+{
+    auto* pair = dynamicDowncast<CSSValuePair>(value);
+    if (!pair)
+        return false;
+    auto isZero = [](const CSSValue& v) {
+        auto* primitive = dynamicDowncast<CSSPrimitiveValue>(v);
+        return primitive && primitive->isLength() && !primitive->resolveAsLengthDeprecated();
+    };
+    return isZero(pair->first()) && isZero(pair->second());
+}
+
+static bool cornerShorthandShapeIsRound(const CSSValue& value)
+{
+    auto* keyword = dynamicDowncast<CSSKeywordValue>(value);
+    return keyword && keyword->valueID() == CSSValueRound;
+}
+
+String ShorthandSerializer::serializeOneCorner(unsigned radiusIndex, unsigned shapeIndex) const
+{
+    RefPtr radius = m_longhandValues[radiusIndex];
+    RefPtr shape = m_longhandValues[shapeIndex];
+    if (!radius || !shape)
+        return String();
+    if (cornerShorthandRadiusIsZero(*radius) && cornerShorthandShapeIsRound(*shape))
+        return "normal"_s;
+    auto radiusStr = serializeLonghandValue(radiusIndex);
+    auto shapeStr = serializeLonghandValue(shapeIndex);
+    return makeString(radiusStr, ' ', shapeStr);
+}
+
+String ShorthandSerializer::serializeCornerSingle() const
+{
+    ASSERT(length() == 2);
+    return serializeOneCorner(0, 1);
+}
+
+String ShorthandSerializer::serializeCornerPair() const
+{
+    ASSERT(length() == 4);
+    auto first = serializeOneCorner(0, 1);
+    auto second = serializeOneCorner(2, 3);
+    if (first.isNull() || second.isNull())
+        return String();
+    if (first == second)
+        return first;
+    return makeString(first, " / "_s, second);
+}
+
+String ShorthandSerializer::serializeCornerQuad() const
+{
+    ASSERT(length() == 8);
+    std::array<String, 4> corners {
+        serializeOneCorner(0, 1),
+        serializeOneCorner(2, 3),
+        serializeOneCorner(4, 5),
+        serializeOneCorner(6, 7),
+    };
+    for (const auto& s : corners) {
+        if (s.isNull())
+            return String();
+    }
+    bool showBL = corners[1] != corners[3];
+    bool showBR = showBL || corners[0] != corners[2];
+    bool showTR = showBR || corners[0] != corners[1];
+
+    StringBuilder result;
+    result.append(corners[0]);
+    if (showTR)
+        result.append(" / "_s, corners[1]);
+    if (showBR)
+        result.append(" / "_s, corners[2]);
+    if (showBL)
+        result.append(" / "_s, corners[3]);
+    return result.toString();
 }
 
 class LayerValues {

--- a/Source/WebCore/css/parser/CSSPropertyParserCustom.h
+++ b/Source/WebCore/css/parser/CSSPropertyParserCustom.h
@@ -152,6 +152,9 @@ public:
     static bool consumeBorderSpacingShorthand(CSSParserTokenRange&, PropertyParserState&, const StylePropertyShorthand&, PropertyParserResult&);
     static bool consumeBorderRadiusShorthand(CSSParserTokenRange&, PropertyParserState&, const StylePropertyShorthand&, PropertyParserResult&);
     static bool consumeWebkitBorderRadiusShorthand(CSSParserTokenRange&, PropertyParserState&, const StylePropertyShorthand&, PropertyParserResult&);
+    static bool consumeCornerSingleShorthand(CSSParserTokenRange&, PropertyParserState&, const StylePropertyShorthand&, PropertyParserResult&);
+    static bool consumeCornerPairShorthand(CSSParserTokenRange&, PropertyParserState&, const StylePropertyShorthand&, PropertyParserResult&);
+    static bool consumeCornerQuadShorthand(CSSParserTokenRange&, PropertyParserState&, const StylePropertyShorthand&, PropertyParserResult&);
     static bool consumeBorderImageShorthand(CSSParserTokenRange&, PropertyParserState&, const StylePropertyShorthand&, PropertyParserResult&);
     static bool consumeWebkitBorderImageShorthand(CSSParserTokenRange&, PropertyParserState&, const StylePropertyShorthand&, PropertyParserResult&);
     static bool consumeMaskBorderShorthand(CSSParserTokenRange&, PropertyParserState&, const StylePropertyShorthand&, PropertyParserResult&);
@@ -731,6 +734,135 @@ inline bool PropertyParserCustom::consumeWebkitBorderRadiusShorthand(CSSParserTo
     result.addPropertyForCurrentShorthand(state, CSSPropertyBorderTopRightRadius, WebCore::CSS::createCSSValue(state.pool, borderRadius->topRight()));
     result.addPropertyForCurrentShorthand(state, CSSPropertyBorderBottomRightRadius, WebCore::CSS::createCSSValue(state.pool, borderRadius->bottomRight()));
     result.addPropertyForCurrentShorthand(state, CSSPropertyBorderBottomLeftRadius, WebCore::CSS::createCSSValue(state.pool, borderRadius->bottomLeft()));
+    return true;
+}
+
+// MARK: - Corner / Corner-* shorthands (combined border-radius + corner-shape)
+//
+// Grammar (per corner): normal | <corner-shape>? <border-radius-corner> <corner-shape>?
+// Multiple corners are separated by '/' and follow the standard 1-to-N expansion.
+
+namespace CornerShorthandHelpers {
+
+inline Ref<CSSValue> zeroRadius()
+{
+    auto zero = CSSPrimitiveValue::create(0, CSSUnitType::CSS_PX);
+    return CSSValuePair::create(zero.copyRef(), WTF::move(zero));
+}
+
+inline Ref<CSSValue> roundShape()
+{
+    return CSSKeywordValue::create(CSSValueRound);
+}
+
+inline bool consumeOneCorner(CSSParserTokenRange& range, PropertyParserState& state, CSSPropertyID radiusProperty, CSSPropertyID shapeProperty, RefPtr<CSSValue>& radiusOut, RefPtr<CSSValue>& shapeOut)
+{
+    if (range.peek().id() == CSSValueNormal) {
+        range.consumeIncludingWhitespace();
+        radiusOut = zeroRadius();
+        shapeOut = roundShape();
+        return true;
+    }
+    shapeOut = CSSPropertyParsing::parseStylePropertyLonghand(range, shapeProperty, state);
+    radiusOut = CSSPropertyParsing::parseStylePropertyLonghand(range, radiusProperty, state);
+    if (!radiusOut)
+        return false;
+    if (!shapeOut)
+        shapeOut = CSSPropertyParsing::parseStylePropertyLonghand(range, shapeProperty, state);
+    return shapeOut != nullptr;
+}
+
+} // namespace CornerShorthandHelpers
+
+inline bool PropertyParserCustom::consumeCornerSingleShorthand(CSSParserTokenRange& range, PropertyParserState& state, const StylePropertyShorthand& shorthand, PropertyParserResult& result)
+{
+    ASSERT(shorthand.length() == 2);
+    auto longhands = shorthand.properties();
+    RefPtr<CSSValue> radius;
+    RefPtr<CSSValue> shape;
+    if (!CornerShorthandHelpers::consumeOneCorner(range, state, longhands[0], longhands[1], radius, shape))
+        return false;
+    if (!range.atEnd())
+        return false;
+
+    result.addPropertyForCurrentShorthand(state, longhands[0], radius.releaseNonNull());
+    result.addPropertyForCurrentShorthand(state, longhands[1], shape.releaseNonNull());
+    return true;
+}
+
+inline bool PropertyParserCustom::consumeCornerPairShorthand(CSSParserTokenRange& range, PropertyParserState& state, const StylePropertyShorthand& shorthand, PropertyParserResult& result)
+{
+    // Two-corner side shorthand: longhands are [radius0, shape0, radius1, shape1].
+    ASSERT(shorthand.length() == 4);
+    auto longhands = shorthand.properties();
+    std::array<RefPtr<CSSValue>, 2> radii;
+    std::array<RefPtr<CSSValue>, 2> shapes;
+
+    size_t count = 0;
+    for (size_t i = 0; i < 2; ++i) {
+        if (!CornerShorthandHelpers::consumeOneCorner(range, state, longhands[i * 2], longhands[i * 2 + 1], radii[i], shapes[i]))
+            return false;
+        ++count;
+        if (i == 1)
+            break;
+        if (!consumeSlashIncludingWhitespace(range))
+            break;
+    }
+    if (!range.atEnd() || !count)
+        return false;
+
+    if (count < 2) {
+        radii[1] = radii[0];
+        shapes[1] = shapes[0];
+    }
+
+    for (size_t i = 0; i < 2; ++i) {
+        result.addPropertyForCurrentShorthand(state, longhands[i * 2], radii[i].releaseNonNull());
+        result.addPropertyForCurrentShorthand(state, longhands[i * 2 + 1], shapes[i].releaseNonNull());
+    }
+    return true;
+}
+
+inline bool PropertyParserCustom::consumeCornerQuadShorthand(CSSParserTokenRange& range, PropertyParserState& state, const StylePropertyShorthand& shorthand, PropertyParserResult& result)
+{
+    // Master `corner`: longhands are [radius0, shape0, radius1, shape1, radius2, shape2, radius3, shape3]
+    // in order top-left, top-right, bottom-right, bottom-left.
+    ASSERT(shorthand.length() == 8);
+    auto longhands = shorthand.properties();
+    std::array<RefPtr<CSSValue>, 4> radii;
+    std::array<RefPtr<CSSValue>, 4> shapes;
+
+    size_t count = 0;
+    for (size_t i = 0; i < 4; ++i) {
+        if (!CornerShorthandHelpers::consumeOneCorner(range, state, longhands[i * 2], longhands[i * 2 + 1], radii[i], shapes[i]))
+            return false;
+        ++count;
+        if (i == 3)
+            break;
+        if (!consumeSlashIncludingWhitespace(range))
+            break;
+    }
+    if (!range.atEnd() || !count)
+        return false;
+
+    // 1-to-4 expansion (mirrors complete4Sides on a CSS quad).
+    if (count < 2) {
+        radii[1] = radii[0];
+        shapes[1] = shapes[0];
+    }
+    if (count < 3) {
+        radii[2] = radii[0];
+        shapes[2] = shapes[0];
+    }
+    if (count < 4) {
+        radii[3] = radii[1];
+        shapes[3] = shapes[1];
+    }
+
+    for (size_t i = 0; i < 4; ++i) {
+        result.addPropertyForCurrentShorthand(state, longhands[i * 2], radii[i].releaseNonNull());
+        result.addPropertyForCurrentShorthand(state, longhands[i * 2 + 1], shapes[i].releaseNonNull());
+    }
     return true;
 }
 

--- a/Source/WebCore/css/scripts/process-css-properties.py
+++ b/Source/WebCore/css/scripts/process-css-properties.py
@@ -168,6 +168,9 @@ class Schema:
 class Name(object):
     special_case_name_to_id = {
         "url": "URL",
+        # Spec values whose canonical id differs from the dash-stripped CamelCase
+        # of their textual name. Keep in sync with CSSValueKeywords.in.
+        "-infinity": "NegativeInfinity",
     }
 
     def __init__(self, name):

--- a/Source/WebCore/rendering/BorderShape.cpp
+++ b/Source/WebCore/rendering/BorderShape.cpp
@@ -38,8 +38,42 @@
 #include "LayoutRoundedRect.h"
 #include "Path.h"
 #include "RenderStyle+GettersInlines.h"
+#include <algorithm>
+#include <cmath>
+#include <limits>
 
 namespace WebCore {
+
+static constexpr float kRoundExponent = 2.0f;
+static constexpr float kBevelExponent = 1.0f;
+static constexpr float kStraightThreshold = 16.0f;   // exponent >= this => straight
+static constexpr float kNotchThreshold = 1.0f / kStraightThreshold; // exponent <= this => notch
+
+static float extractCornerExponent(const Style::CornerShapeValue& shape)
+{
+    // CornerShapeValue stores the spec `superellipse parameter` (log2 of the
+    // curve exponent). Convert it to a curve exponent here for the path builder.
+    auto e = shape.exponent();
+    if (std::isnan(e))
+        return kRoundExponent;
+    auto f = static_cast<float>(e);
+    if (!std::isfinite(f))
+        return std::numeric_limits<float>::infinity();
+    if (f <= 0.0f)
+        return 0.0f;
+    return f;
+}
+
+static std::array<float, 4> extractCornerExponents(const RenderStyle& style)
+{
+    const auto& shapes = style.border().cornerShapes;
+    return {
+        extractCornerExponent(shapes.topLeft()),
+        extractCornerExponent(shapes.topRight()),
+        extractCornerExponent(shapes.bottomRight()),
+        extractCornerExponent(shapes.bottomLeft()),
+    };
+}
 
 static void zeroRadiiForOpenEdges(LayoutRoundedRectRadii& radii, RectEdges<bool> closedEdges)
 {
@@ -82,6 +116,7 @@ BorderShape BorderShape::shapeForBorderRect(const RenderStyle& style, const Layo
 BorderShape BorderShape::shapeForBorderRect(const RenderStyle& style, const LayoutRect& borderRect, const RectEdges<LayoutUnit>& overrideBorderWidths, RectEdges<bool> closedEdges)
 {
     auto usedBorderWidths = applyClosedEdges(overrideBorderWidths, closedEdges);
+    auto exponents = extractCornerExponents(style);
 
     if (style.border().hasBorderRadius()) {
         auto radii = Style::evaluate<LayoutRoundedRectRadii>(style.borderRadii(), borderRect.size(), style.usedZoomForLength());
@@ -91,7 +126,7 @@ BorderShape BorderShape::shapeForBorderRect(const RenderStyle& style, const Layo
         if (!radii.areRenderableInRect(borderRect))
             radii.makeRenderableInRect(borderRect);
 
-        return BorderShape { borderRect, usedBorderWidths, radii };
+        return BorderShape { borderRect, usedBorderWidths, radii, exponents };
     }
 
     return BorderShape { borderRect, usedBorderWidths };
@@ -100,6 +135,7 @@ BorderShape BorderShape::shapeForBorderRect(const RenderStyle& style, const Layo
 BorderShape BorderShape::shapeForOffsetRect(const RenderStyle& style, const LayoutRect& borderRect, const LayoutRect& offsetRect, const RectEdges<LayoutUnit>& edgeWidths, RectEdges<bool> closedEdges)
 {
     auto usedEdgeWidths = applyClosedEdges(edgeWidths, closedEdges);
+    auto exponents = extractCornerExponents(style);
 
     if (style.border().hasBorderRadius()) {
         auto radii = Style::evaluate<LayoutRoundedRectRadii>(style.borderRadii(), borderRect.size(), style.usedZoomForLength());
@@ -115,7 +151,7 @@ BorderShape BorderShape::shapeForOffsetRect(const RenderStyle& style, const Layo
         if (!radii.areRenderableInRect(offsetRect))
             radii.makeRenderableInRect(offsetRect);
 
-        return BorderShape { offsetRect, usedEdgeWidths, radii };
+        return BorderShape { offsetRect, usedEdgeWidths, radii, exponents };
     }
 
     return BorderShape { offsetRect, usedEdgeWidths };
@@ -137,9 +173,27 @@ BorderShape::BorderShape(const LayoutRect& borderRect, const RectEdges<LayoutUni
     ASSERT(m_borderRect.isRenderable());
 }
 
+BorderShape::BorderShape(const LayoutRect& borderRect, const RectEdges<LayoutUnit>& borderWidths, const LayoutRoundedRectRadii& radii, const std::array<float, 4>& cornerExponents)
+    : m_borderRect(borderRect, radii)
+    , m_innerEdgeRect(computeInnerEdgeRoundedRect(m_borderRect, borderWidths))
+    , m_borderWidths(borderWidths)
+    , m_cornerExponents(cornerExponents)
+{
+    ASSERT(m_borderRect.isRenderable());
+}
+
 BorderShape BorderShape::shapeWithBorderWidths(const RectEdges<LayoutUnit>& borderWidths) const
 {
-    return BorderShape(m_borderRect.rect(), borderWidths, m_borderRect.radii());
+    return BorderShape(m_borderRect.rect(), borderWidths, m_borderRect.radii(), m_cornerExponents);
+}
+
+bool BorderShape::hasNonRoundCornerShapes() const
+{
+    for (auto e : m_cornerExponents) {
+        if (e != kRoundExponent)
+            return true;
+    }
+    return false;
 }
 
 LayoutRoundedRect BorderShape::deprecatedRoundedRect() const
@@ -246,53 +300,397 @@ static void addRoundedRectToPath(const FloatRoundedRect& roundedRect, Path& path
         path.addRect(roundedRect.rect());
 }
 
-Path BorderShape::pathForOuterShape(float deviceScaleFactor) const
+// ---------------------------------------------------------------------------
+// Contoured-rect path construction (corner-shape rendering).
+//
+// A "contoured rect" is a FloatRoundedRect plus a per-corner superellipse
+// exponent. Exponent semantics (consistent with WebKit's stored value):
+//   * exponent == 2.0       => round (default; uses standard ellipse arc)
+//   * exponent == 1.0       => bevel (straight diagonal chamfer)
+//   * 0 < exponent < 1      => concave (e.g. 0.5 == scoop)
+//   * exponent == 0         => notch (inverted right-angle)
+//   * exponent >= kStraightThreshold => straight (corner stays rectangular)
+//
+// For convex shapes other than round/bevel/straight we approximate the
+// superellipse with two cubic Béziers meeting at the 45° point. This mirrors
+// Chromium's path_builder.cc AddCurvedCorner() implementation.
+// ---------------------------------------------------------------------------
+
+namespace {
+
+struct CornerVertices {
+    FloatPoint start;   // point on the previous straight edge where the curve begins
+    FloatPoint outer;   // the actual rectangle corner (would-be sharp tip)
+    FloatPoint end;     // point on the next straight edge where the curve ends
+    FloatPoint center;  // inner intersection of the two radii (opposite of outer)
+};
+
+static float clampExponent(float exponent)
 {
-    auto pixelSnappedRect = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
-    Path path;
-    addRoundedRectToPath(pixelSnappedRect, path);
-    return path;
+    if (std::isnan(exponent) || exponent < 0.0f)
+        return 0.0f;
+    if (exponent > kStraightThreshold)
+        return kStraightThreshold;
+    return exponent;
 }
 
-Path BorderShape::pathForInnerShape(float deviceScaleFactor) const
+static float halfCornerForExponent(float exponent)
 {
-    auto pixelSnappedRect = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
-    ASSERT(pixelSnappedRect.isRenderable());
+    // The (x,y) coordinate on the unit superellipse at t = 0.5 (45 degrees).
+    return std::pow(0.5f, 1.0f / std::max(exponent, 1e-3f));
+}
 
-    Path path;
-    addRoundedRectToPath(pixelSnappedRect, path);
-    return path;
+// Returns three normalised vectors describing a cubic-Bézier approximation
+// of a half quarter of a superellipse with the supplied (convex) exponent,
+// going from (0,1) clockwise to (halfCorner, halfCorner). Ported from
+// blink::ApproximateSuperellipseHalfCornerAsBezierCurve in path_builder.cc.
+static std::array<FloatPoint, 3> approximateConvexHalfCorner(float exponent)
+{
+    static constexpr std::array<double, 7> p = {
+        1.2430920942724248, 2.010479023614843, 0.32922901179443753,
+        0.2823023142212073, 1.3473704261055421, 2.9149468637949814,
+        0.9106507102917086
+    };
+    const double s = std::log2(std::max(exponent, 1.0f));
+    const double slope = p[0] + (p[6] - p[0]) * 0.5 * (1.0 + std::tanh(p[5] * (s - p[1])));
+    const double base = 1.0 / (1.0 + std::exp(-slope * (0.0 - p[1])));
+    const double logistic = 1.0 / (1.0 + std::exp(-slope * (s - p[1])));
+    const double a = (logistic - base) / (1.0 - base);
+    const double b = p[2] * std::exp(-p[3] * std::pow(s, p[4]));
+    const float halfCorner = halfCornerForExponent(exponent);
+    return {
+        FloatPoint(static_cast<float>(a), 1.0f),
+        FloatPoint(halfCorner - static_cast<float>(b), halfCorner + static_cast<float>(b)),
+        FloatPoint(halfCorner, halfCorner)
+    };
+}
+
+static FloatPoint mapNormalisedPointToCorner(const CornerVertices& v, FloatPoint n)
+{
+    // Local basis: x along (outer - start), y along (start - center).
+    auto v1 = FloatPoint(v.outer.x() - v.start.x(), v.outer.y() - v.start.y());
+    auto v4 = FloatPoint(v.start.x() - v.center.x(), v.start.y() - v.center.y());
+    return FloatPoint(
+        v.center.x() + v1.x() * n.x() + v4.x() * n.y(),
+        v.center.y() + v1.y() * n.x() + v4.y() * n.y());
+}
+
+// Builds the four CornerVertices for a given outer rect + radii.
+// Order: { topLeft, topRight, bottomRight, bottomLeft }, each laid out so
+// `start` is on the edge entering the corner clockwise and `end` is on the
+// edge leaving it. This matches the {TL, TR, BR, BL} traversal order used by
+// the rest of WebKit's painters.
+static std::array<CornerVertices, 4> computeCornerVertices(const FloatRect& rect, const CornerRadii& radii)
+{
+    auto tl = radii.topLeft();
+    auto tr = radii.topRight();
+    auto br = radii.bottomRight();
+    auto bl = radii.bottomLeft();
+
+    auto left = rect.x();
+    auto right = rect.maxX();
+    auto top = rect.y();
+    auto bottom = rect.maxY();
+
+    return {{
+        // top-left
+        {
+            { left, top + tl.height() },
+            { left, top },
+            { left + tl.width(), top },
+            { left + tl.width(), top + tl.height() }
+        },
+        // top-right
+        {
+            { right - tr.width(), top },
+            { right, top },
+            { right, top + tr.height() },
+            { right - tr.width(), top + tr.height() }
+        },
+        // bottom-right
+        {
+            { right, bottom - br.height() },
+            { right, bottom },
+            { right - br.width(), bottom },
+            { right - br.width(), bottom - br.height() }
+        },
+        // bottom-left
+        {
+            { left + bl.width(), bottom },
+            { left, bottom },
+            { left, bottom - bl.height() },
+            { left + bl.width(), bottom - bl.height() }
+        }
+    }};
+}
+
+static bool cornerIsEmpty(const CornerVertices& v)
+{
+    return v.start == v.end;
+}
+
+// Computes an inner corner aligned perpendicular to the outer corner's curve so
+// that the resulting border thickness stays visually uniform along the curve.
+// Ported from blink::ContouredRect::Corner::AlignedToOrigin in chromium's
+// platform/geometry/contoured_rect.cc.
+//
+// For notch (concave 90°) and straight (rectangular) corners the chromium
+// algorithm degenerates (the perpendicular offset reduces to zero in one or
+// both axes), which leaves the inner corner anchored to the outer box's edges
+// instead of the inner box's edges. For those two extremes we take a simpler
+// route and translate the entire corner diagonally inward by `shift`, so the
+// inner notch's adjacent legs land on the inner box's straight edges.
+//
+// When the outer corner is degenerate (zero radii in either direction), the
+// algorithm cannot perpendicular-offset anything meaningful, so we return the
+// already-computed inner corner verbatim. Same when border thickness is zero.
+static CornerVertices alignedInnerCorner(const CornerVertices& outer, const CornerVertices& inner, float exponent, float thicknessStart, float thicknessEnd, FloatSize shift)
+{
+    auto vectorLength = [](FloatPoint a, FloatPoint b) {
+        return std::hypot(a.x() - b.x(), a.y() - b.y());
+    };
+    // Outer is degenerate if either of its two side-vectors is zero-length.
+    if (vectorLength(outer.start, outer.outer) <= 0.0f || vectorLength(outer.outer, outer.end) <= 0.0f)
+        return inner;
+    if (thicknessStart <= 0.0f && thicknessEnd <= 0.0f)
+        return outer;
+
+    // Notch (≈0) and straight (≈∞): translate diagonally so the inner notch's
+    // legs sit on the inner box edges (matches the visual: each leg is the
+    // outer leg perpendicular-offset inward by the matching border width).
+    auto translate = [&](FloatPoint p) {
+        return FloatPoint { p.x() + shift.width(), p.y() + shift.height() };
+    };
+    if (exponent <= kNotchThreshold || exponent >= kStraightThreshold) {
+        return CornerVertices {
+            translate(outer.start),
+            translate(outer.outer),
+            translate(outer.end),
+            translate(outer.center),
+        };
+    }
+
+    auto normalize = [](FloatSize v) {
+        float len = std::hypot(v.width(), v.height());
+        if (len <= 0.0f)
+            return FloatSize { 0.0f, 0.0f };
+        return FloatSize { v.width() / len, v.height() / len };
+    };
+
+    float c = std::clamp(exponent, 0.5f, kRoundExponent);
+    float halfCorner = halfCornerForExponent(c);
+
+    FloatSize hullPre { halfCorner * 2.0f - 0.5f, (1.0f - halfCorner) * 2.0f - 0.5f };
+    FloatSize hull = normalize(hullPre);
+    FloatSize adjusted { hull.width(), -hull.height() };
+
+    FloatSize v1 { outer.outer.x() - outer.start.x(), outer.outer.y() - outer.start.y() };
+    FloatSize v2 { outer.end.x() - outer.outer.x(), outer.end.y() - outer.outer.y() };
+    FloatSize v3 { outer.center.x() - outer.end.x(), outer.center.y() - outer.end.y() };
+    FloatSize v4 { outer.start.x() - outer.center.x(), outer.start.y() - outer.center.y() };
+
+    auto nv1 = normalize(v1);
+    auto nv2 = normalize(v2);
+    auto nv3 = normalize(v3);
+    auto nv4 = normalize(v4);
+
+    auto scale = [](FloatSize v, float s) { return FloatSize { v.width() * s, v.height() * s }; };
+
+    auto o1 = scale(nv1, thicknessStart * adjusted.height());
+    auto o2 = scale(nv2, thicknessStart * adjusted.width());
+    auto o3 = scale(nv3, thicknessEnd * adjusted.width());
+    auto o4 = scale(nv4, thicknessEnd * adjusted.height());
+
+    auto addPoint = [](FloatPoint p, FloatSize a, FloatSize b) {
+        return FloatPoint { p.x() + a.width() + b.width(), p.y() + a.height() + b.height() };
+    };
+
+    return CornerVertices {
+        addPoint(outer.start, o1, o2),
+        addPoint(outer.outer, o2, o3),
+        addPoint(outer.end, o3, o4),
+        addPoint(outer.center, o4, o1),
+    };
+}
+
+static void addCornerToPath(Path& path, const CornerVertices& vIn, float exponent)
+{
+    if (cornerIsEmpty(vIn)) {
+        path.addLineTo(vIn.outer);
+        return;
+    }
+
+    float c = clampExponent(exponent);
+    CornerVertices v = vIn;
+
+    // Concave (exponent < 1): mirror through the center diagonal and use the
+    // equivalent convex exponent. Geometrically this swaps `outer` and `center`.
+    if (c < kBevelExponent && c > 0.0f) {
+        std::swap(v.outer, v.center);
+        c = 1.0f / c;
+    }
+
+    // Connect any preceding straight edge to the curve start.
+    path.addLineTo(v.start);
+
+    if (c >= kStraightThreshold) {
+        // Straight: keep the original rectangular corner.
+        path.addLineTo(v.outer);
+        path.addLineTo(v.end);
+        return;
+    }
+
+    if (c <= 0.0f) {
+        // Notch: inverted right angle reaching the center.
+        path.addLineTo(v.center);
+        path.addLineTo(v.end);
+        return;
+    }
+
+    if (c == kBevelExponent) {
+        // Bevel: straight diagonal across the corner.
+        path.addLineTo(v.end);
+        return;
+    }
+
+    if (c == kRoundExponent) {
+        // Round: standard cubic-Bézier approximation of a quarter ellipse.
+        // Magic constant k = (4/3) * (sqrt(2) - 1).
+        constexpr float k = 0.5522847498307933984022516f;
+        auto v1x = v.outer.x() - v.start.x();
+        auto v1y = v.outer.y() - v.start.y();
+        auto v2x = v.end.x() - v.outer.x();
+        auto v2y = v.end.y() - v.outer.y();
+        FloatPoint c1 { v.start.x() + k * v1x, v.start.y() + k * v1y };
+        FloatPoint c2 { v.end.x() - k * v2x, v.end.y() - k * v2y };
+        path.addBezierCurveTo(c1, c2, v.end);
+        return;
+    }
+
+    // General convex superellipse (1 < c < kStraightThreshold): approximate
+    // with two cubic Béziers meeting at the 45° point (t = 0.5).
+    auto controls = approximateConvexHalfCorner(c);
+    auto cp1a = mapNormalisedPointToCorner(v, controls[0]);
+    auto cp2a = mapNormalisedPointToCorner(v, controls[1]);
+    auto mid  = mapNormalisedPointToCorner(v, controls[2]);
+    // Second half is the same control points transposed across y=x.
+    FloatPoint t1 { controls[1].y(), controls[1].x() };
+    FloatPoint t0 { controls[0].y(), controls[0].x() };
+    auto cp1b = mapNormalisedPointToCorner(v, t1);
+    auto cp2b = mapNormalisedPointToCorner(v, t0);
+
+    path.addBezierCurveTo(cp1a, cp2a, mid);
+    path.addBezierCurveTo(cp1b, cp2b, v.end);
+}
+
+} // namespace
+
+static void addContouredCornersToPath(const std::array<CornerVertices, 4>& corners, const std::array<float, 4>& exponents, Path& path)
+{
+    // Trace the outline clockwise starting just after the TL corner on the top edge.
+    path.moveTo(corners[0].end);
+    addCornerToPath(path, corners[1], exponents[1]); // top-right
+    addCornerToPath(path, corners[2], exponents[2]); // bottom-right
+    addCornerToPath(path, corners[3], exponents[3]); // bottom-left
+    addCornerToPath(path, corners[0], exponents[0]); // top-left
+    path.closeSubpath();
+}
+
+static void addContouredRectToPath(const FloatRoundedRect& roundedRect, const std::array<float, 4>& exponents, Path& path)
+{
+    if (!roundedRect.isRounded()) {
+        path.addRect(roundedRect.rect());
+        return;
+    }
+    auto corners = computeCornerVertices(roundedRect.rect(), roundedRect.radii());
+    addContouredCornersToPath(corners, exponents, path);
 }
 
 void BorderShape::addOuterShapeToPath(Path& path, float deviceScaleFactor) const
 {
     auto pixelSnappedRect = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
-    addRoundedRectToPath(pixelSnappedRect, path);
+    if (hasNonRoundCornerShapes() && pixelSnappedRect.isRounded())
+        addContouredRectToPath(pixelSnappedRect, m_cornerExponents, path);
+    else
+        addRoundedRectToPath(pixelSnappedRect, path);
 }
 
 void BorderShape::addInnerShapeToPath(Path& path, float deviceScaleFactor) const
 {
-    auto pixelSnappedRect = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
-    ASSERT(pixelSnappedRect.isRenderable());
-    addRoundedRectToPath(pixelSnappedRect, path);
+    auto pixelSnappedInner = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
+    ASSERT(pixelSnappedInner.isRenderable());
+
+    // If any corner shape is non-round, the standard concentric inner ellipse
+    // doesn't yield uniform border thickness along chamfered/scooped corners.
+    // Compute each inner corner perpendicular-aligned to the outer corner, like
+    // chromium's ContouredRect::Corner::AlignedToOrigin.
+    auto pixelSnappedOuter = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
+    if (hasNonRoundCornerShapes() && pixelSnappedOuter.isRounded()) {
+        auto outerCorners = computeCornerVertices(pixelSnappedOuter.rect(), pixelSnappedOuter.radii());
+        // The inner rounded rect may have all radii shrunk to zero already (when
+        // border-width >= radius); we still need a valid inner CornerVertices
+        // for the fallback path in alignedInnerCorner() so build it from the
+        // inner rect with its own (possibly-zero) radii.
+        auto innerCornersBase = computeCornerVertices(pixelSnappedInner.rect(), pixelSnappedInner.radii());
+        auto outerSnappedRect = pixelSnappedOuter.rect();
+        auto innerSnappedRect = pixelSnappedInner.rect();
+        // Per-side thicknesses in the snapped coordinate space.
+        float tTop = innerSnappedRect.y() - outerSnappedRect.y();
+        float tRight = outerSnappedRect.maxX() - innerSnappedRect.maxX();
+        float tBottom = outerSnappedRect.maxY() - innerSnappedRect.maxY();
+        float tLeft = innerSnappedRect.x() - outerSnappedRect.x();
+        // Diagonal-inward shift per corner, used by alignedInnerCorner() for
+        // notch / straight shapes (where perpendicular-to-curve is degenerate).
+        std::array<FloatSize, 4> shift = {{
+            { tLeft, tTop },     // TL: shift right+down
+            { -tRight, tTop },   // TR: shift left+down
+            { -tRight, -tBottom }, // BR: shift left+up
+            { tLeft, -tBottom }, // BL: shift right+up
+        }};
+        std::array<CornerVertices, 4> aligned = {
+            alignedInnerCorner(outerCorners[0], innerCornersBase[0], m_cornerExponents[0], tLeft, tTop, shift[0]),    // TL
+            alignedInnerCorner(outerCorners[1], innerCornersBase[1], m_cornerExponents[1], tTop, tRight, shift[1]),   // TR
+            alignedInnerCorner(outerCorners[2], innerCornersBase[2], m_cornerExponents[2], tRight, tBottom, shift[2]), // BR
+            alignedInnerCorner(outerCorners[3], innerCornersBase[3], m_cornerExponents[3], tBottom, tLeft, shift[3]),  // BL
+        };
+        addContouredCornersToPath(aligned, m_cornerExponents, path);
+        return;
+    }
+
+    addRoundedRectToPath(pixelSnappedInner, path);
+}
+
+Path BorderShape::pathForOuterShape(float deviceScaleFactor) const
+{
+    Path path;
+    addOuterShapeToPath(path, deviceScaleFactor);
+    return path;
+}
+
+Path BorderShape::pathForInnerShape(float deviceScaleFactor) const
+{
+    Path path;
+    addInnerShapeToPath(path, deviceScaleFactor);
+    return path;
 }
 
 Path BorderShape::pathForBorderArea(float deviceScaleFactor) const
 {
-    auto pixelSnappedOuterRect = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
-    auto pixelSnappedInnerRect = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
-
-    ASSERT(pixelSnappedInnerRect.isRenderable());
-
     Path path;
-    addRoundedRectToPath(pixelSnappedOuterRect, path);
-    addRoundedRectToPath(pixelSnappedInnerRect, path);
+    addOuterShapeToPath(path, deviceScaleFactor);
+    addInnerShapeToPath(path, deviceScaleFactor);
     return path;
 }
 
 void BorderShape::clipToOuterShape(GraphicsContext& context, float deviceScaleFactor) const
 {
     auto pixelSnappedRect = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
+    if (hasNonRoundCornerShapes() && pixelSnappedRect.isRounded()) {
+        Path path;
+        addContouredRectToPath(pixelSnappedRect, m_cornerExponents, path);
+        context.clipPath(path);
+        return;
+    }
     if (pixelSnappedRect.isRounded())
         context.clipRoundedRect(pixelSnappedRect);
     else
@@ -303,6 +701,12 @@ void BorderShape::clipToInnerShape(GraphicsContext& context, float deviceScaleFa
 {
     auto pixelSnappedRect = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
     ASSERT(pixelSnappedRect.isRenderable());
+    if (hasNonRoundCornerShapes() && pixelSnappedRect.isRounded()) {
+        Path path;
+        addInnerShapeToPath(path, deviceScaleFactor);
+        context.clipPath(path);
+        return;
+    }
     if (pixelSnappedRect.isRounded())
         context.clipRoundedRect(pixelSnappedRect);
     else
@@ -315,6 +719,12 @@ void BorderShape::clipOutOuterShape(GraphicsContext& context, float deviceScaleF
     if (pixelSnappedRect.isEmpty())
         return;
 
+    if (hasNonRoundCornerShapes() && pixelSnappedRect.isRounded()) {
+        Path path;
+        addContouredRectToPath(pixelSnappedRect, m_cornerExponents, path);
+        context.clipOut(path);
+        return;
+    }
     if (pixelSnappedRect.isRounded())
         context.clipOutRoundedRect(pixelSnappedRect);
     else
@@ -327,6 +737,12 @@ void BorderShape::clipOutInnerShape(GraphicsContext& context, float deviceScaleF
     if (pixelSnappedRect.isEmpty())
         return;
 
+    if (hasNonRoundCornerShapes() && pixelSnappedRect.isRounded()) {
+        Path path;
+        addInnerShapeToPath(path, deviceScaleFactor);
+        context.clipOut(path);
+        return;
+    }
     if (pixelSnappedRect.isRounded())
         context.clipOutRoundedRect(pixelSnappedRect);
     else
@@ -336,6 +752,13 @@ void BorderShape::clipOutInnerShape(GraphicsContext& context, float deviceScaleF
 void BorderShape::fillOuterShape(GraphicsContext& context, const Color& color, float deviceScaleFactor) const
 {
     auto pixelSnappedRect = m_borderRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
+    if (hasNonRoundCornerShapes() && pixelSnappedRect.isRounded()) {
+        Path path;
+        addContouredRectToPath(pixelSnappedRect, m_cornerExponents, path);
+        context.setFillColor(color);
+        context.fillPath(path);
+        return;
+    }
     if (pixelSnappedRect.isRounded())
         context.fillRoundedRect(pixelSnappedRect, color);
     else
@@ -346,6 +769,13 @@ void BorderShape::fillInnerShape(GraphicsContext& context, const Color& color, f
 {
     auto pixelSnappedRect = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
     ASSERT(pixelSnappedRect.isRenderable());
+    if (hasNonRoundCornerShapes() && pixelSnappedRect.isRounded()) {
+        Path path;
+        addInnerShapeToPath(path, deviceScaleFactor);
+        context.setFillColor(color);
+        context.fillPath(path);
+        return;
+    }
     if (pixelSnappedRect.isRounded())
         context.fillRoundedRect(pixelSnappedRect, color);
     else
@@ -357,6 +787,17 @@ void BorderShape::fillRectWithInnerHoleShape(GraphicsContext& context, const Lay
     auto pixelSnappedOuterRect = snapRectToDevicePixels(outerRect, deviceScaleFactor);
     auto innerSnappedRoundedRect = m_innerEdgeRect.pixelSnappedRoundedRectForPainting(deviceScaleFactor);
     ASSERT(innerSnappedRoundedRect.isRenderable());
+    if (hasNonRoundCornerShapes() && innerSnappedRoundedRect.isRounded()) {
+        // Fill outerRect with the colour, then punch out the inner contoured shape.
+        Path path;
+        path.addRect(pixelSnappedOuterRect);
+        addInnerShapeToPath(path, deviceScaleFactor);
+        context.setFillRule(WindRule::EvenOdd);
+        context.setFillColor(color);
+        context.fillPath(path);
+        context.setFillRule(WindRule::NonZero);
+        return;
+    }
     context.fillRectWithRoundedHole(pixelSnappedOuterRect, innerSnappedRoundedRect, color);
 }
 

--- a/Source/WebCore/rendering/BorderShape.h
+++ b/Source/WebCore/rendering/BorderShape.h
@@ -32,6 +32,7 @@
 #include "LayoutRoundedRect.h"
 #include "RectEdges.h"
 #include "RenderStyleConstants.h"
+#include <array>
 
 namespace WebCore {
 
@@ -58,6 +59,7 @@ public:
 
     BorderShape(const LayoutRect& borderRect, const RectEdges<LayoutUnit>& borderWidths);
     BorderShape(const LayoutRect& borderRect, const RectEdges<LayoutUnit>& borderWidths, const LayoutRoundedRectRadii&);
+    BorderShape(const LayoutRect& borderRect, const RectEdges<LayoutUnit>& borderWidths, const LayoutRoundedRectRadii&, const std::array<float, 4>& cornerExponents);
 
     BorderShape(const BorderShape&) = default;
 
@@ -92,6 +94,11 @@ public:
     FloatRect snappedInnerRect(float deviceScaleFactor) const;
 
     bool isRounded() const { return m_borderRect.isRounded(); }
+
+    // Per-corner superellipse exponents in order { topLeft, topRight, bottomRight, bottomLeft }.
+    // 2.0 == round, 1.0 == bevel, 0.5 == scoop, 0.0 == notch, infinity == straight.
+    const std::array<float, 4>& cornerExponents() const LIFETIME_BOUND { return m_cornerExponents; }
+    bool hasNonRoundCornerShapes() const;
 
     bool NODELETE outerShapeIsRectangular() const;
     bool NODELETE innerShapeIsRectangular() const;
@@ -128,6 +135,8 @@ private:
     LayoutRoundedRect m_borderRect;
     LayoutRoundedRect m_innerEdgeRect;
     RectEdges<LayoutUnit> m_borderWidths;
+    // Per-corner superellipse exponents { TL, TR, BR, BL }. 2.0 is round (default).
+    std::array<float, 4> m_cornerExponents { 2.0f, 2.0f, 2.0f, 2.0f };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/style/StyleExtractorCustom.h
+++ b/Source/WebCore/style/StyleExtractorCustom.h
@@ -1686,6 +1686,107 @@ inline void extractCoalescingQuadShorthandSerialization(ExtractorState& state, S
     builder.shrink(offsetAfterTop);
 }
 
+// MARK: - Corner / corner-* shorthand extractors
+//
+// Each "corner" output is `<border-radius-corner> <corner-shape>` (or `normal`
+// when the radius is 0px and the shape is round), per drafts.csswg.org/css-borders-4.
+// Pair and quad shorthands emit slash-separated corners with 4->1 / 2->1 collapsing.
+
+inline bool isCornerNormalValue(const CSSValue* radius, const CSSValue* shape)
+{
+    auto* pair = dynamicDowncast<CSSValuePair>(radius);
+    if (!pair)
+        return false;
+    auto isZero = [](const CSSValue& v) {
+        auto* primitive = dynamicDowncast<CSSPrimitiveValue>(v);
+        return primitive && primitive->isLength() && !primitive->resolveAsLengthDeprecated();
+    };
+    if (!isZero(pair->first()) || !isZero(pair->second()))
+        return false;
+    auto* shapeIdent = dynamicDowncast<CSSKeywordValue>(shape);
+    return shapeIdent && shapeIdent->valueID() == CSSValueRound;
+}
+
+inline RefPtr<CSSValue> buildCornerValue(RefPtr<CSSValue> radius, RefPtr<CSSValue> shape)
+{
+    if (!radius || !shape)
+        return nullptr;
+    if (isCornerNormalValue(radius.get(), shape.get()))
+        return CSSKeywordValue::create(CSSValueNormal);
+    return CSSValuePair::create(radius.releaseNonNull(), shape.releaseNonNull());
+}
+
+inline RefPtr<CSSValue> extractCornerSingleShorthand(ExtractorState& state, const StylePropertyShorthand& shorthand)
+{
+    auto longhands = shorthand.properties();
+    auto radius = ExtractorGenerated::extractValue(state, longhands[0]);
+    auto shape = ExtractorGenerated::extractValue(state, longhands[1]);
+    return buildCornerValue(WTF::move(radius), WTF::move(shape));
+}
+
+inline void extractCornerSingleShorthandSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const StylePropertyShorthand& shorthand)
+{
+    if (auto value = extractCornerSingleShorthand(state, shorthand))
+        builder.append(value->cssText(context));
+}
+
+inline RefPtr<CSSValue> extractCornerPairShorthand(ExtractorState& state, const StylePropertyShorthand& shorthand)
+{
+    auto longhands = shorthand.properties();
+    ASSERT(longhands.size() == 4);
+    auto first = buildCornerValue(ExtractorGenerated::extractValue(state, longhands[0]), ExtractorGenerated::extractValue(state, longhands[1]));
+    auto second = buildCornerValue(ExtractorGenerated::extractValue(state, longhands[2]), ExtractorGenerated::extractValue(state, longhands[3]));
+    if (!first || !second)
+        return nullptr;
+
+    CSSValueListBuilder list;
+    bool collapse = compareCSSValuePtr(first, second);
+    list.append(first.releaseNonNull());
+    if (!collapse)
+        list.append(second.releaseNonNull());
+    return CSSValueList::createSlashSeparated(WTF::move(list));
+}
+
+inline void extractCornerPairShorthandSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const StylePropertyShorthand& shorthand)
+{
+    if (auto value = extractCornerPairShorthand(state, shorthand))
+        builder.append(value->cssText(context));
+}
+
+inline RefPtr<CSSValue> extractCornerQuadShorthand(ExtractorState& state, const StylePropertyShorthand& shorthand)
+{
+    auto longhands = shorthand.properties();
+    ASSERT(longhands.size() == 8);
+    std::array<RefPtr<CSSValue>, 4> corners;
+    for (size_t i = 0; i < 4; ++i) {
+        corners[i] = buildCornerValue(ExtractorGenerated::extractValue(state, longhands[i * 2]), ExtractorGenerated::extractValue(state, longhands[i * 2 + 1]));
+        if (!corners[i])
+            return nullptr;
+    }
+
+    // Mirror Chromium logic: collapse 4 -> 3 -> 2 -> 1.
+    // corners are [TL, TR, BR, BL].
+    bool showBL = !compareCSSValuePtr(corners[1], corners[3]);
+    bool showBR = showBL || !compareCSSValuePtr(corners[0], corners[2]);
+    bool showTR = showBR || !compareCSSValuePtr(corners[0], corners[1]);
+
+    CSSValueListBuilder list;
+    list.append(corners[0].releaseNonNull());
+    if (showTR)
+        list.append(corners[1].releaseNonNull());
+    if (showBR)
+        list.append(corners[2].releaseNonNull());
+    if (showBL)
+        list.append(corners[3].releaseNonNull());
+    return CSSValueList::createSlashSeparated(WTF::move(list));
+}
+
+inline void extractCornerQuadShorthandSerialization(ExtractorState& state, StringBuilder& builder, const CSS::SerializationContext& context, const StylePropertyShorthand& shorthand)
+{
+    if (auto value = extractCornerQuadShorthand(state, shorthand))
+        builder.append(value->cssText(context));
+}
+
 inline RefPtr<CSSValue> extractBorderShorthand(ExtractorState& state, std::span<const CSSPropertyID> sections)
 {
     auto value = ExtractorGenerated::extractValue(state, sections[0]);

--- a/Source/WebCore/style/values/borders/StyleCornerShapeValue.cpp
+++ b/Source/WebCore/style/values/borders/StyleCornerShapeValue.cpp
@@ -51,8 +51,11 @@ auto CSSValueConversion<CornerShapeValue>::operator()(BuilderState& state, const
             return CSS::Keyword::Bevel { };
         case CSSValueNotch:
             return CSS::Keyword::Notch { };
+        case CSSValueSquare:
+            return CSS::Keyword::Square { };
         case CSSValueStraight:
-            return CSS::Keyword::Straight { };
+            // Outdated WebKit spelling of `square`; accept and canonicalise.
+            return CSS::Keyword::Square { };
         case CSSValueSquircle:
             return CSS::Keyword::Squircle { };
         default:
@@ -72,58 +75,56 @@ auto CSSValueConversion<CornerShapeValue>::operator()(BuilderState& state, const
     if (RefPtr keywordValue = dynamicDowncast<CSSKeywordValue>(superellipseDescriptor)) {
         switch (keywordValue->valueID()) {
         case CSSValueInfinity:
-            return { SuperellipseFunction { Number<CSS::Nonnegative>(std::numeric_limits<double>::infinity()) } };
+            return { SuperellipseFunction { Number<CSS::All>(std::numeric_limits<double>::infinity()) } };
+        case CSSValueNegativeInfinity:
+            return { SuperellipseFunction { Number<CSS::All>(-std::numeric_limits<double>::infinity()) } };
         default:
             state.setCurrentPropertyInvalidAtComputedValueTime();
-            return { SuperellipseFunction { Number<CSS::Nonnegative>(std::numeric_limits<double>::infinity()) } };
+            return { SuperellipseFunction { Number<CSS::All>(std::numeric_limits<double>::infinity()) } };
         }
     }
 
-    return { SuperellipseFunction { toStyleFromCSSValue<Number<CSS::Nonnegative>>(state, superellipseDescriptor) } };
+    // The function parameter IS the spec `superellipse parameter` (logarithmic);
+    // we store it directly. The curve exponent is `pow(2, parameter)` (see
+    // CornerShapeValue::exponent()).
+    return { SuperellipseFunction { toStyleFromCSSValue<Number<CSS::All>>(state, superellipseDescriptor) } };
 }
 
 // MARK: - Blending
 
 // https://drafts.csswg.org/css-borders-4/#corner-shape-interpolation
 
-static Number<CSS::Nonnegative> convertExponentToInterpolationValue(const CornerShapeValue& cornerShape)
+// Maps a stored superellipse parameter (-∞..+∞) to a normalised interpolation
+// value in [0,1], per https://drafts.csswg.org/css-borders-4/#superellipse-interpolation.
+// Equivalent to interpValue = pow(0.5, pow(2, -parameter)).
+static Number<CSS::Nonnegative> convertParameterToInterpolationValue(const CornerShapeValue& cornerShape)
 {
-    auto exponent = cornerShape.superellipse->value;
-
-    // 1. If exponent is 0, return 0.
-    if (exponent == 0.0)
+    auto parameter = cornerShape.superellipse->value;
+    if (parameter == -std::numeric_limits<double>::infinity())
         return 0.0;
-
-    // 2. If exponent is ∞, return 1.
-    if (exponent == std::numeric_limits<double>::infinity())
+    if (parameter == std::numeric_limits<double>::infinity())
         return 1.0;
-
-    // 3. Return 1/(2^(1/exponent)).
-    return 1.0 / std::pow(2.0, 1.0 / exponent);
+    return std::pow(0.5, std::pow(2.0, -parameter));
 }
 
-static CornerShapeValue convertInterpolationValueToExponent(Number<CSS::Nonnegative> interpolationValue)
+static CornerShapeValue convertInterpolationValueToParameter(Number<CSS::Nonnegative> interpolationValue)
 {
-    // 1. If interpolationValue is 0, return 0.
     if (interpolationValue.value == 0.0)
-        return { SuperellipseFunction { 0.0 } };
-
-    // 2. If interpolationValue is 1, return ∞.
+        return { SuperellipseFunction { -std::numeric_limits<double>::infinity() } };
     if (interpolationValue.value == 1.0)
         return { SuperellipseFunction { std::numeric_limits<double>::infinity() } };
-
-    // 3. Return ln(0.5)/ln(interpolationValue).
-    return { SuperellipseFunction { std::log(0.5) / std::log(interpolationValue.value) } };
+    // Inverse of pow(0.5, pow(2, -s)): s = log2(log(0.5)/log(interpolationValue)).
+    return { SuperellipseFunction { std::log2(std::log(0.5) / std::log(interpolationValue.value)) } };
 }
 
 auto Blending<CornerShapeValue>::blend(const CornerShapeValue& a, const CornerShapeValue& b, const BlendingContext& context) -> CornerShapeValue
 {
-    auto aInterpolationValue = convertExponentToInterpolationValue(a);
-    auto bInterpolationValue = convertExponentToInterpolationValue(b);
+    auto aInterpolationValue = convertParameterToInterpolationValue(a);
+    auto bInterpolationValue = convertParameterToInterpolationValue(b);
 
     auto interpolatedValue = Style::blend(aInterpolationValue, bInterpolationValue, context);
 
-    return convertInterpolationValueToExponent(interpolatedValue);
+    return convertInterpolationValueToParameter(interpolatedValue);
 }
 
 } // namespace Style

--- a/Source/WebCore/style/values/borders/StyleCornerShapeValue.h
+++ b/Source/WebCore/style/values/borders/StyleCornerShapeValue.h
@@ -25,6 +25,8 @@
 #pragma once
 
 #include <WebCore/StylePrimitiveNumericTypes.h>
+#include <cmath>
+#include <limits>
 
 namespace WebCore {
 
@@ -33,20 +35,41 @@ class RenderStyle;
 
 namespace Style {
 
-// NOTE: the keyword value "infinity" is represented as the standard double value `std::numeric_limits<double>::infinity()`.
-using SuperellipseFunction = FunctionNotation<CSSValueSuperellipse, Number<CSS::Nonnegative>>;
+// NOTE: the stored `superellipse.value` is the spec `superellipse parameter`
+// (https://drafts.csswg.org/css-borders-4/#superellipse-parameter), which is
+// logarithmic. The visible curve exponent is `2 ^ superellipse.value`. Keyword
+// shapes map to these spec parameters:
+//   round     => superellipse(1)    [exponent 2]
+//   bevel     => superellipse(0)    [exponent 1]
+//   scoop     => superellipse(-1)   [exponent 0.5]
+//   squircle  => superellipse(2)    [exponent 4]
+//   square    => superellipse(+inf) [exponent +inf] (also accepted as `straight`)
+//   notch     => superellipse(-inf) [exponent 0]
+using SuperellipseFunction = FunctionNotation<CSSValueSuperellipse, Number<CSS::All>>;
 
 // https://drafts.csswg.org/css-borders-4/#typedef-corner-shape-value
 struct CornerShapeValue {
     SuperellipseFunction superellipse;
 
-    constexpr CornerShapeValue(CSS::Keyword::Round) : superellipse { 2.0 } { }
-    constexpr CornerShapeValue(CSS::Keyword::Scoop) : superellipse { 0.5 } { }
-    constexpr CornerShapeValue(CSS::Keyword::Bevel) : superellipse { 1.0 } { }
-    constexpr CornerShapeValue(CSS::Keyword::Notch) : superellipse { 0.0 } { }
+    constexpr CornerShapeValue(CSS::Keyword::Round) : superellipse { 1.0 } { }
+    constexpr CornerShapeValue(CSS::Keyword::Scoop) : superellipse { -1.0 } { }
+    constexpr CornerShapeValue(CSS::Keyword::Bevel) : superellipse { 0.0 } { }
+    constexpr CornerShapeValue(CSS::Keyword::Notch) : superellipse { -std::numeric_limits<double>::infinity() } { }
+    constexpr CornerShapeValue(CSS::Keyword::Square) : superellipse { std::numeric_limits<double>::infinity() } { }
     constexpr CornerShapeValue(CSS::Keyword::Straight) : superellipse { std::numeric_limits<double>::infinity() } { }
-    constexpr CornerShapeValue(CSS::Keyword::Squircle) : superellipse { 4.0 } { }
+    constexpr CornerShapeValue(CSS::Keyword::Squircle) : superellipse { 2.0 } { }
     constexpr CornerShapeValue(SuperellipseFunction value) : superellipse { value } { }
+
+    // Convenience: returns the actual curve exponent (2^parameter).
+    constexpr double exponent() const
+    {
+        auto s = superellipse->value;
+        if (s == std::numeric_limits<double>::infinity())
+            return std::numeric_limits<double>::infinity();
+        if (s == -std::numeric_limits<double>::infinity())
+            return 0.0;
+        return std::pow(2.0, s);
+    }
 
     template<typename F> decltype(auto) switchOn(F&& functor) const
     {
@@ -58,8 +81,8 @@ struct CornerShapeValue {
             return functor(CSS::Keyword::Bevel { });
         if (*this == CornerShapeValue(CSS::Keyword::Notch { }))
             return functor(CSS::Keyword::Notch { });
-        if (*this == CornerShapeValue(CSS::Keyword::Straight { }))
-            return functor(CSS::Keyword::Straight { });
+        if (*this == CornerShapeValue(CSS::Keyword::Square { }))
+            return functor(CSS::Keyword::Square { });
         if (*this == CornerShapeValue(CSS::Keyword::Squircle { }))
             return functor(CSS::Keyword::Squircle { });
         return functor(superellipse);


### PR DESCRIPTION
WIP — pushing to see what EWS thinks. Ports https://chromium-review.googlesource.com/c/chromium/src/+/7747994 (CSS corner and corner-* shorthands) to WebKit AND implements actual corner-shape rendering (webkit.org/b/277912).<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/44522c54d22754f87fc41daba02842c50da7da99

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163975 "18 style errors") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37459 "Hash 44522c54 for PR 65464 does not build (failure)") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30678 "Hash 44522c54 for PR 65464 does not build (failure)") | [❌ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173004 "Hash 44522c54 for PR 65464 does not build (failure)") | [❌ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121226 "Hash 44522c54 for PR 65464 does not build (failure)") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165844 "Passed tests") | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37792 "Hash 44522c54 for PR 65464 does not build (failure)") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37459 "Hash 44522c54 for PR 65464 does not build (failure)") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/5/builds/173004 "Hash 44522c54 for PR 65464 does not build (failure)") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/121226 "Hash 44522c54 for PR 65464 does not build (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166934 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/37792 "Hash 44522c54 for PR 65464 does not build (failure)") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/30678 "Hash 44522c54 for PR 65464 does not build (failure)") | [❌ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/5/builds/173004 "Hash 44522c54 for PR 65464 does not build (failure)") | 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/37792 "Hash 44522c54 for PR 65464 does not build (failure)") | [❌ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/156/builds/37459 "Hash 44522c54 for PR 65464 does not build (failure)") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20768 "Hash 44522c54 for PR 65464 does not build (failure)") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/156126 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/37792 "Hash 44522c54 for PR 65464 does not build (failure)") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/30678 "Hash 44522c54 for PR 65464 does not build (failure)") | [❌ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175529 "Hash 44522c54 for PR 65464 does not build (failure)") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/24867 "Built successfully and passed tests") | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28351 "Failed to build and analyze WebKit") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/30678 "Hash 44522c54 for PR 65464 does not build (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/2/builds/175529 "Hash 44522c54 for PR 65464 does not build (failure)") | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37129 "Hash 44522c54 for PR 65464 does not build (failure)") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/156/builds/37459 "Hash 44522c54 for PR 65464 does not build (failure)") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/2/builds/175529 "Hash 44522c54 for PR 65464 does not build (failure)") | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37914 "Hash 44522c54 for PR 65464 does not build (failure)") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/30678 "Hash 44522c54 for PR 65464 does not build (failure)") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/100082 "The change is no longer eligible for processing.") | 
| | [❌ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/160/builds/37914 "Hash 44522c54 for PR 65464 does not build (failure)") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/30678 "Hash 44522c54 for PR 65464 does not build (failure)") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/196378 "Built successfully") | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36723 "Hash 44522c54 for PR 65464 does not build (failure)") | [❌ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109770 "Failed to build and analyze WebKit") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51296 "Passed tests") | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36122 "Hash 44522c54 for PR 65464 does not build (failure)") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/30678 "Hash 44522c54 for PR 65464 does not build (failure)") | | 
| | [❌ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36372 "Hash 44522c54 for PR 65464 does not build (failure)") | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36269 "Hash 44522c54 for PR 65464 does not build (failure)") | | | 
<!--EWS-Status-Bubble-End-->