### PR TITLE
REGRESSION(305199@main): Crash in `SourceBufferPrivate::removeCodedFramesInternal` https://bugs.webkit.org/show_bug.cgi?id=308678 rdar://170833664

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -247,6 +247,7 @@ fast/shapes/shape-outside-floats/shape-outside-imagedata-overflow.html [ Skip ]
 [ Debug ] fast/files/blob-stream-chunks.html [ Skip ]
 [ Debug ] security/decode-buffer-size.html [ Skip ]
 [ Debug ] security/text-decode-long-strings.html [ Skip ]
+[ Debug ] media/media-source/media-source-evict-invalid-time-crash.html [ Skip ]
 
 # Only iOS supports QuickLook
 quicklook [ Skip ]

--- a/LayoutTests/media/media-source/media-source-evict-invalid-time-crash-expected.txt
+++ b/LayoutTests/media/media-source/media-source-evict-invalid-time-crash-expected.txt
@@ -1,0 +1,19 @@
+This tests that the eviction algorithm does not crash when the intersection of track buffer ranges becomes empty during memory pressure eviction.
+RUN(video.src = URL.createObjectURL(source))
+RUN(video.disableRemotePlayback = true)
+EVENT(sourceopen)
+RUN(sourceBuffer = source.addSourceBuffer("video/mock; codecs=mock"))
+RUN(initSegment = makeAInit(500, [makeATrack(1, 'mock', TRACK_KIND.VIDEO), makeATrack(2, 'mock', TRACK_KIND.AUDIO)]))
+RUN(sourceBuffer.appendBuffer(initSegment))
+EVENT(updateend)
+RUN(sourceBuffer.appendBuffer(makeSyncSamples(1, 200, 400)))
+EVENT(updateend)
+RUN(sourceBuffer.appendBuffer(makeSyncSamples(2, 250, 450)))
+EVENT(updateend)
+RUN(video.currentTime = 200)
+RUN(internals.beginSimulatedMemoryPressure())
+EVENT(bufferedchange)
+RUN(internals.endSimulatedMemoryPressure())
+PASS: No crash from eviction with invalidTime.
+END OF TEST
+

--- a/LayoutTests/media/media-source/media-source-evict-invalid-time-crash.html
+++ b/LayoutTests/media/media-source/media-source-evict-invalid-time-crash.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ ManagedMediaSourceEnabled=true MediaSourceEnabled=true ] -->
+<html>
+<head>
+    <title>media-source-evict-invalid-time-crash</title>
+    <script src="mock-media-source.js"></script>
+    <script src="../../media/video-test.js"></script>
+    <script src="../../media/utilities.js"></script>
+    <script>
+    var source;
+    var sourceBuffer;
+    var initSegment;
+
+    if (window.internals)
+        internals.initializeMockMediaSource();
+
+    function makeSyncSamples(trackID, start, end) {
+        var samples = [];
+        for (var pts = start; pts < end; pts++)
+            samples.push(makeASample(pts, pts, 1, 1, trackID, SAMPLE_FLAG.SYNC));
+        return concatenateSamples(samples);
+    }
+
+    window.addEventListener('load', async event => {
+        findMediaElement();
+
+        source = new ManagedMediaSource();
+
+        run('video.src = URL.createObjectURL(source)');
+        run('video.disableRemotePlayback = true');
+        await waitFor(source, 'sourceopen');
+
+        run('sourceBuffer = source.addSourceBuffer("video/mock; codecs=mock")');
+        run("initSegment = makeAInit(500, [makeATrack(1, 'mock', TRACK_KIND.VIDEO), makeATrack(2, 'mock', TRACK_KIND.AUDIO)])");
+        run('sourceBuffer.appendBuffer(initSegment)');
+        await waitFor(sourceBuffer, 'updateend');
+
+        run('sourceBuffer.appendBuffer(makeSyncSamples(1, 200, 400))');
+        await waitFor(sourceBuffer, 'updateend');
+
+        run('sourceBuffer.appendBuffer(makeSyncSamples(2, 250, 450))');
+        await waitFor(sourceBuffer, 'updateend');
+
+        run('video.currentTime = 200');
+        run('internals.beginSimulatedMemoryPressure()');
+        await waitFor(sourceBuffer, 'bufferedchange');
+
+        run('internals.endSimulatedMemoryPressure()');
+        consoleWrite('PASS: No crash from eviction with invalidTime.');
+        endTest();
+    });
+    </script>
+</head>
+<body>
+    This tests that the eviction algorithm does not crash when the intersection
+    of track buffer ranges becomes empty during memory pressure eviction.
+    <video controls></video>
+</body>
+</html>

--- a/LayoutTests/platform/glib/TestExpectations
+++ b/LayoutTests/platform/glib/TestExpectations
@@ -2255,6 +2255,8 @@ fast/table/table-display-types-vertical.html [ Failure ]
 
 media/audioSession [ Skip ]
 
+media/media-source/media-source-evict-invalid-time-crash.html [ Timeout ]
+
 webkit.org/b/292839 media/media-fullscreen-not-in-document.html [ Timeout ]
 
 webkit.org/b/292841 fullscreen/exit-full-screen-video-crash.html [ Timeout ]

--- a/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
+++ b/Source/WebCore/platform/graphics/SourceBufferPrivate.cpp
@@ -1526,6 +1526,10 @@ bool SourceBufferPrivate::evictFrames(uint64_t newDataSize, const MediaTime& cur
 
         do {
             auto rangeStartBeforeCurrentTime = minimumBufferedTime();
+            if (!rangeStartBeforeCurrentTime.isValid()) {
+                ASSERT_NOT_REACHED();
+                break;
+            }
             auto rangeEndBeforeCurrentTime = std::min(rangeStartBeforeCurrentTime + timeChunk, maximumRangeEnd);
 
             if (rangeStartBeforeCurrentTime >= rangeEndBeforeCurrentTime)
@@ -1558,6 +1562,10 @@ bool SourceBufferPrivate::evictFrames(uint64_t newDataSize, const MediaTime& cur
             });
 
             auto rangeEndAfterCurrentTime = buffered.maximumBufferedTime();
+            if (!rangeEndAfterCurrentTime.isValid()) {
+                ASSERT_NOT_REACHED();
+                break;
+            }
             auto rangeStartAfterCurrentTime = std::max(minimumRangeStartAfterCurrentTime, rangeEndAfterCurrentTime - timeChunk);
 
             if (rangeStartAfterCurrentTime >= rangeEndAfterCurrentTime)


### PR DESCRIPTION
#### abcb3491801d85ed05fc73906afa4ac9b9fb1f16
<pre>
REGRESSION(305199@main): Crash in `SourceBufferPrivate::removeCodedFramesInternal` <a href="https://bugs.webkit.org/show_bug.cgi?id=308678">https://bugs.webkit.org/show_bug.cgi?id=308678</a> <a href="https://rdar.apple.com/170833664">rdar://170833664</a>

Reviewed by Jer Noble.

Crash data indicates removeCodedFramesInternal can be called with an invalid end time. Since
305199@main, invalidTime comparisons return unordered, causing all comparison guards to evaluate to
false, which allows an invalid MediaTime to be used as a std::map key. We should return early if the
buffered time is invalid to avoid crashing.

Test: media/media-source/media-source-evict-invalid-time-crash.html

* LayoutTests/TestExpectations:
* LayoutTests/media/media-source/media-source-evict-invalid-time-crash-expected.txt: Added.
* LayoutTests/media/media-source/media-source-evict-invalid-time-crash.html: Added.
* Source/WebCore/platform/graphics/SourceBufferPrivate.cpp:
(WebCore::SourceBufferPrivate::removeCodedFramesInternal):

Originally-landed-as: 305413.370@rapid/safari-7624.2.5.110-branch (f23e9cfe0406). <a href="https://rdar.apple.com/176067104">rdar://176067104</a>
Canonical link: <a href="https://commits.webkit.org/305877.664@webkitglib/2.52">https://commits.webkit.org/305877.664@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5a7bbda9079d0097dd2c756a5e911c9f7102d0f6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163978 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/37462 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/30681 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173007 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121229 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165847 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/37795 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/37462 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127386 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121229 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166937 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/37795 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/30681 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107934 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/37795 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/37462 "The change is no longer eligible for processing.") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20771 "Unable to build WebKit without PR, please check manually (failure)") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/37795 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/30681 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175532 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/28354 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/30681 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135695 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/37132 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/37462 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135667 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/37917 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/30681 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/100085 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24954 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/37917 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/30681 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/36726 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/109773 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/36125 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/30681 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/36375 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/36272 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->