### PR TITLE
Cherry-pick 309507@main (a8e8ac33b298). https://bugs.webkit.org/show_bug.cgi?id=310192

### DIFF
--- a/LayoutTests/fast/text-extraction/max-recursion-depth-cap-expected.html
+++ b/LayoutTests/fast/text-extraction/max-recursion-depth-cap-expected.html
@@ -1,0 +1,28 @@
+<!-- webkit-test-runner [ textExtractionEnabled=true ] -->
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<style>
+body { white-space: pre; font: 12px monospace; margin: 0; }
+</style>
+<script src="../../resources/ui-helper.js"></script>
+</head>
+<body>
+<div id="nest"></div>
+<script>
+addEventListener("load", async () => {
+    let parent = document.getElementById("nest");
+    for (let i = 0; i < 300; i++) {
+        const child = document.createElement("div");
+        parent.appendChild(child);
+        parent = child;
+    }
+    parent.textContent = "leaf";
+
+    const result = await UIHelper.requestTextExtraction({ });
+    document.body.textContent = result;
+    document.documentElement.classList.remove("reftest-wait");
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/fast/text-extraction/max-recursion-depth-cap.html
+++ b/LayoutTests/fast/text-extraction/max-recursion-depth-cap.html
@@ -1,0 +1,28 @@
+<!-- webkit-test-runner [ textExtractionEnabled=true ] -->
+<!DOCTYPE html>
+<html class="reftest-wait">
+<head>
+<style>
+body { white-space: pre; font: 12px monospace; margin: 0; }
+</style>
+<script src="../../resources/ui-helper.js"></script>
+</head>
+<body>
+<div id="nest"></div>
+<script>
+addEventListener("load", async () => {
+    let parent = document.getElementById("nest");
+    for (let i = 0; i < 350; i++) {
+        const child = document.createElement("div");
+        parent.appendChild(child);
+        parent = child;
+    }
+    parent.textContent = "leaf";
+
+    const result = await UIHelper.requestTextExtraction({ });
+    document.body.textContent = result;
+    document.documentElement.classList.remove("reftest-wait");
+});
+</script>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/blur-clip-border-radius-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/blur-clip-border-radius-expected.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<style>
+  .clip {
+    position: absolute;
+    width: 300px;
+    height: 300px;
+    overflow: clip;
+    border-radius: 50%;
+    border: 1px solid black;
+    box-sizing: border-box;
+  }
+
+  .outer {
+    top: 20px;
+    left: 20px;
+  }
+
+  .mask {
+    position: absolute;
+    top: 170px;
+    left: 170px;
+    width: 150px;
+    height: 150px;
+    border-top-left-radius: 150px;
+    border-bottom-right-radius: 150px;
+    background-color: gray;
+    border: 1px solid gray;
+  }
+
+  p {
+    margin-top: 350px;
+  }
+</style>
+<p>You should see no red above</p>
+<div class="outer clip"></div>
+<div class="mask"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/blur-clip-border-radius-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/blur-clip-border-radius-ref.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<style>
+  .clip {
+    position: absolute;
+    width: 300px;
+    height: 300px;
+    overflow: clip;
+    border-radius: 50%;
+    border: 1px solid black;
+    box-sizing: border-box;
+  }
+
+  .outer {
+    top: 20px;
+    left: 20px;
+  }
+
+  .mask {
+    position: absolute;
+    top: 170px;
+    left: 170px;
+    width: 150px;
+    height: 150px;
+    border-top-left-radius: 150px;
+    border-bottom-right-radius: 150px;
+    background-color: gray;
+    border: 1px solid gray;
+  }
+
+  p {
+    margin-top: 350px;
+  }
+</style>
+<p>You should see no red above</p>
+<div class="outer clip"></div>
+<div class="mask"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/blur-clip-border-radius.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/blur-clip-border-radius.html
@@ -1,0 +1,58 @@
+<!DOCTYPE html>
+<title>CSS Test: Ancestors with rounded clips should correctly clip a filtered element</title>
+<link rel="help" href="https://drafts.fxtf.org/filter-effects/#funcdef-filter-blur">
+<link rel="help" href="https://drafts.csswg.org/css-overflow-3/#valdef-overflow-clip">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=312584">
+<link rel="match" href="blur-clip-border-radius-ref.html">
+<meta name="fuzzy" content="maxDifference=0-4; totalPixels=0-30">
+<style>
+  .clip {
+    position: absolute;
+    width: 300px;
+    height: 300px;
+    overflow: clip;
+    border-radius: 50%;
+    border: 1px solid black;
+    box-sizing: border-box;
+  }
+
+  .outer {
+    top: 20px;
+    left: 20px;
+  }
+
+  .inner {
+    top: 150px;
+    left: 150px;
+  }
+
+  .filtered {
+    width: 100%;
+    height: 100%;
+    background-color: red;
+    filter: blur(10px);
+  }
+
+  .mask {
+    position: absolute;
+    top: 170px;
+    left: 170px;
+    width: 150px;
+    height: 150px;
+    border-top-left-radius: 150px;
+    border-bottom-right-radius: 150px;
+    background-color: gray;
+    border: 1px solid gray;
+  }
+
+  p {
+    margin-top: 350px;
+  }
+</style>
+<p>You should see no red above</p>
+<div class="outer clip">
+    <div class="inner clip">
+        <div class="filtered"></div>
+    </div>
+</div>
+<div class="mask"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/grayscale-clip-border-radius-expected.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/grayscale-clip-border-radius-expected.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<style>
+  .filtered {
+    width: 200px;
+    height: 200px;
+    border-radius: 20px;
+    background-color: limegreen;
+    filter: grayscale(50%);
+  }
+</style>
+<p>You should see a muted green rounded rectangle.</p>
+<div class="filtered"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/grayscale-clip-border-radius-ref.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/grayscale-clip-border-radius-ref.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<style>
+  .filtered {
+    width: 200px;
+    height: 200px;
+    border-radius: 20px;
+    background-color: limegreen;
+    filter: grayscale(50%);
+  }
+</style>
+<p>You should see a muted green rounded rectangle.</p>
+<div class="filtered"></div>

--- a/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/grayscale-clip-border-radius.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/grayscale-clip-border-radius.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<title>CSS Test: Filtered descendant of an element with border-radius and overflow:hidden should render correctly</title>
+<link rel="help" href="https://drafts.fxtf.org/filter-effects/#funcdef-filter-grayscale">
+<link rel="help" href="https://drafts.csswg.org/css-backgrounds-3/#border-radius">
+<link rel="help" href="https://bugs.webkit.org/show_bug.cgi?id=312584">
+<link rel="match" href="grayscale-clip-border-radius-ref.html">
+<meta name="fuzzy" content="maxDifference=0-40; totalPixels=0-160">
+<style>
+  .container {
+    width: 200px;
+    height: 200px;
+    overflow: hidden;
+    border-radius: 20px;
+  }
+  .filtered {
+    width: 100%;
+    height: 100%;
+    background-color: limegreen;
+    filter: grayscale(50%);
+  }
+</style>
+<p>You should see a muted green rounded rectangle.</p>
+<div class="container">
+    <div class="filtered"></div>
+</div>

--- a/LayoutTests/platform/gtk/TestExpectations
+++ b/LayoutTests/platform/gtk/TestExpectations
@@ -121,6 +121,7 @@ webkit.org/b/254733 inspector/canvas/recording-offscreen-webgl-full.html [ Failu
 webkit.org/b/254733 inspector/canvas/recording-offscreen-webgl-memoryLimit.html [ Failure Pass ]
 webkit.org/b/254733 inspector/canvas/shaderProgram-add-remove-webgl2.html [ Failure ]
 webkit.org/b/254733 inspector/canvas/shaderProgram-add-remove-webgl.html [ Failure ]
+inspector/canvas/setShaderProgramHighlighted.html [ Pass Failure ]
 
 # Crash on EWS bot.
 webrtc/vp8-then-h264-gpu-process-crash.html [ Skip ]

--- a/Source/WebCore/page/text-extraction/TextExtraction.cpp
+++ b/Source/WebCore/page/text-extraction/TextExtraction.cpp
@@ -193,6 +193,8 @@ static inline TextNodesAndText collectText(const SimpleRange& range, IncludeText
 
 using ClientNodeAttributesMap = WeakHashMap<Node, HashMap<String, String>, WeakPtrImplWithEventTargetData>;
 
+static constexpr unsigned maxExtractionRecursionDepth = 255;
+
 struct TraversalContext {
     const Request originalRequest;
     const ClientNodeAttributesMap clientNodeAttributes;
@@ -202,6 +204,8 @@ struct TraversalContext {
     const FrameIdentifier frameIdentifier;
     Vector<WeakPtr<Node, WeakPtrImplWithEventTargetData>> enclosingBlocks;
     WeakHashMap<Node, unsigned, WeakPtrImplWithEventTargetData> enclosingBlockNumberMap;
+    WeakHashSet<Node, WeakPtrImplWithEventTargetData> visitedContainers;
+    unsigned depth { 0 };
     unsigned onlyCollectTextAndLinksCount { 0 };
     bool mergeParagraphs { false };
     bool skipNearlyTransparentContent { false };
@@ -679,8 +683,21 @@ static bool areSameOrigin(Document& document, Document& other)
 
 static inline void extractRecursive(Node& node, Item& parentItem, TraversalContext& context)
 {
+    if (context.depth >= maxExtractionRecursionDepth)
+        return;
+
     if (context.nodesToSkip.contains(node))
         return;
+
+    if (RefPtr container = dynamicDowncast<ContainerNode>(node)) {
+        if (!context.visitedContainers.add(*container).isNewEntry)
+            return;
+    }
+
+    ++context.depth;
+    auto depthScope = makeScopeExit([&] {
+        --context.depth;
+    });
 
     bool isBlock = WebCore::isBlock(node);
     if (isBlock)
@@ -1077,6 +1094,8 @@ Item extractItem(Request&& request, LocalFrame& frame)
             .frameIdentifier = WTF::move(frameID),
             .enclosingBlocks = { },
             .enclosingBlockNumberMap = { },
+            .visitedContainers = { },
+            .depth = 0,
             .onlyCollectTextAndLinksCount = 0,
             .mergeParagraphs = request.mergeParagraphs,
             .skipNearlyTransparentContent = request.skipNearlyTransparentContent,

--- a/Source/WebCore/platform/graphics/GraphicsContextSwitcher.h
+++ b/Source/WebCore/platform/graphics/GraphicsContextSwitcher.h
@@ -27,6 +27,7 @@
 
 #include "DestinationColorSpace.h"
 #include "FloatRect.h"
+#include <wtf/Function.h>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
@@ -46,7 +47,7 @@ public:
 
     virtual bool hasSourceImage() const { return false; }
 
-    virtual void beginClipAndDrawSourceImage(GraphicsContext& destinationContext, const FloatRect& repaintRect, const FloatRect& clipRect) = 0;
+    virtual void beginClipAndDrawSourceImage(GraphicsContext& destinationContext, const FloatRect& repaintRect, const FloatRect& clipRect, NOESCAPE const Function<void(GraphicsContext&)>& applyAdditionalDestinationClip = { }) = 0;
     virtual void endClipAndDrawSourceImage(GraphicsContext& destinationContext, const DestinationColorSpace&) = 0;
 
     virtual void beginDrawSourceImage(GraphicsContext& destinationContext, float opacity = 1.f) = 0;

--- a/Source/WebCore/platform/graphics/ImageBufferContextSwitcher.cpp
+++ b/Source/WebCore/platform/graphics/ImageBufferContextSwitcher.cpp
@@ -63,7 +63,7 @@ GraphicsContext* ImageBufferContextSwitcher::drawingContext(GraphicsContext& con
     return m_sourceImage ? &m_sourceImage->context() : &context;
 }
 
-void ImageBufferContextSwitcher::beginClipAndDrawSourceImage(GraphicsContext& destinationContext, const FloatRect& repaintRect, const FloatRect&)
+void ImageBufferContextSwitcher::beginClipAndDrawSourceImage(GraphicsContext& destinationContext, const FloatRect& repaintRect, const FloatRect&, NOESCAPE const Function<void(GraphicsContext&)>&)
 {
     if (auto* context = drawingContext(destinationContext)) {
         context->save();

--- a/Source/WebCore/platform/graphics/ImageBufferContextSwitcher.h
+++ b/Source/WebCore/platform/graphics/ImageBufferContextSwitcher.h
@@ -42,7 +42,7 @@ private:
 
     bool hasSourceImage() const override { return m_sourceImage; }
 
-    void beginClipAndDrawSourceImage(GraphicsContext& destinationContext, const FloatRect& repaintRect, const FloatRect& clipRect) override;
+    void beginClipAndDrawSourceImage(GraphicsContext& destinationContext, const FloatRect& repaintRect, const FloatRect& clipRect, NOESCAPE const Function<void(GraphicsContext&)>& applyAdditionalDestinationClip) override;
     void endClipAndDrawSourceImage(GraphicsContext& destinationContext, const DestinationColorSpace&) override;
 
     void beginDrawSourceImage(GraphicsContext&, float = 1.f) override { }

--- a/Source/WebCore/platform/graphics/TransparencyLayerContextSwitcher.cpp
+++ b/Source/WebCore/platform/graphics/TransparencyLayerContextSwitcher.cpp
@@ -42,10 +42,16 @@ TransparencyLayerContextSwitcher::TransparencyLayerContextSwitcher(GraphicsConte
         m_filterStyles = m_filter->createFilterStyles(destinationContext, sourceImageRect);
 }
 
-void TransparencyLayerContextSwitcher::beginClipAndDrawSourceImage(GraphicsContext& destinationContext, const FloatRect&, const FloatRect& clipRect)
+void TransparencyLayerContextSwitcher::beginClipAndDrawSourceImage(GraphicsContext& destinationContext, const FloatRect&, const FloatRect& clipRect, NOESCAPE const Function<void(GraphicsContext&)>& applyAdditionalDestinationClip)
 {
-    destinationContext.save();
-    destinationContext.beginTransparencyLayer(1);
+    // Workaround for a CG accelerated-drawing bug rdar://177036180: CGStyle filters fail if there's a
+    // non-rectangular clip, so apply the rounded clip in its own wrapping transparency layer.
+    if (applyAdditionalDestinationClip) {
+        destinationContext.save();
+        applyAdditionalDestinationClip(destinationContext);
+        destinationContext.beginTransparencyLayer(1);
+        m_beganOuterClipLayer = true;
+    }
 
     for (auto& filterStyle : m_filterStyles) {
         destinationContext.save();
@@ -73,6 +79,12 @@ void TransparencyLayerContextSwitcher::endDrawSourceImage(GraphicsContext& desti
     for ([[maybe_unused]] auto& filterStyle : m_filterStyles) {
         destinationContext.endTransparencyLayer();
         destinationContext.restore();
+    }
+
+    if (m_beganOuterClipLayer) {
+        destinationContext.endTransparencyLayer();
+        destinationContext.restore();
+        m_beganOuterClipLayer = false;
     }
 
     destinationContext.endTransparencyLayer();

--- a/Source/WebCore/platform/graphics/TransparencyLayerContextSwitcher.h
+++ b/Source/WebCore/platform/graphics/TransparencyLayerContextSwitcher.h
@@ -37,13 +37,14 @@ public:
     TransparencyLayerContextSwitcher(GraphicsContext& destinationContext, const FloatRect& sourceImageRect, RefPtr<Filter>&&);
 
 private:
-    void beginClipAndDrawSourceImage(GraphicsContext& destinationContext, const FloatRect& repaintRect, const FloatRect& clipRect) override;
+    void beginClipAndDrawSourceImage(GraphicsContext& destinationContext, const FloatRect& repaintRect, const FloatRect& clipRect, NOESCAPE const Function<void(GraphicsContext&)>& applyAdditionalDestinationClip) override;
     void endClipAndDrawSourceImage(GraphicsContext& destinationContext, const DestinationColorSpace& colorSpace) override { endDrawSourceImage(destinationContext, colorSpace); }
 
     void beginDrawSourceImage(GraphicsContext& destinationContext, float opacity = 1.f) override;
     void endDrawSourceImage(GraphicsContext& destinationContext, const DestinationColorSpace&) override;
 
     FilterStyleVector m_filterStyles;
+    bool m_beganOuterClipLayer { false };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -44,7 +44,11 @@
 #include "VideoEncoderPrivateGStreamer.h"
 #endif
 
-namespace {
+namespace WebCore {
+
+GST_DEBUG_CATEGORY_STATIC(webkit_media_gst_registry_scanner_debug);
+#define GST_CAT_DEFAULT webkit_media_gst_registry_scanner_debug
+
 struct VideoDecodingLimits {
     unsigned mediaMaxWidth = 0;
     unsigned mediaMaxHeight = 0;
@@ -56,22 +60,18 @@ struct VideoDecodingLimits {
     {
     }
 };
-}
 
-#ifdef VIDEO_DECODING_LIMIT
-static std::optional<VideoDecodingLimits> videoDecoderLimitsDefaults()
+// Parses a video decoding limit string in format WIDTHxHEIGHT@FRAMERATE.
+static std::optional<VideoDecodingLimits> parseVideoDecodingLimit(const StringView& videoDecodingLimit)
 {
-    // VIDEO_DECODING_LIMIT should be in format: WIDTHxHEIGHT@FRAMERATE.
-    String videoDecodingLimit(String::fromUTF8(VIDEO_DECODING_LIMIT));
-
     if (videoDecodingLimit.isEmpty())
         return { };
 
     Vector<String> entries;
 
-    // Extract frame rate part from the VIDEO_DECODING_LIMIT: WIDTHxHEIGHT@FRAMERATE.
-    videoDecodingLimit.split('@', [&entries](StringView item) {
-        entries.append(item.toString());
+    // Extract frame rate part: WIDTHxHEIGHT@FRAMERATE.
+    videoDecodingLimit.toStringWithoutCopying().split('@', [&entries](StringView item) {
+        entries.append(item.toStringWithoutCopying());
     });
 
     if (entries.size() != 2)
@@ -99,12 +99,39 @@ static std::optional<VideoDecodingLimits> videoDecoderLimitsDefaults()
 
     return { VideoDecodingLimits(width.value(), height.value(), frameRate.value()) };
 }
+
+// Returns the active VideoDecodingLimits, resolved once at first call.
+// WEBKIT_GST_VIDEO_DECODING_LIMIT env var takes precedence over the compile-time VIDEO_DECODING_LIMIT.
+// Format for both: WIDTHxHEIGHT@FRAMERATE (e.g. "1920x1080@30").
+static VideoDecodingLimits* resolveVideoDecodingLimits()
+{
+    static std::optional<VideoDecodingLimits> limits;
+    static std::once_flag onceFlag;
+    std::call_once(onceFlag, [] {
+        if (const char* envLimit = g_getenv("WEBKIT_GST_VIDEO_DECODING_LIMIT")) {
+            GST_DEBUG("WEBKIT_GST_VIDEO_DECODING_LIMIT env var is set: %s", envLimit);
+            limits = parseVideoDecodingLimit(StringView::fromLatin1(envLimit));
+            if (!limits)
+                GST_WARNING("Parsing WEBKIT_GST_VIDEO_DECODING_LIMIT env var failed: %s", envLimit);
+        }
+#ifdef VIDEO_DECODING_LIMIT
+        if (!limits) {
+            GST_DEBUG("VIDEO_DECODING_LIMIT compile-time definition is set: %s", VIDEO_DECODING_LIMIT);
+            limits = parseVideoDecodingLimit(String::fromLatin1(VIDEO_DECODING_LIMIT));
+            if (!limits) {
+                GST_WARNING("Parsing VIDEO_DECODING_LIMIT failed: %s", VIDEO_DECODING_LIMIT);
+                ASSERT_NOT_REACHED();
+                return;
+            }
+        }
 #endif
-
-namespace WebCore {
-
-GST_DEBUG_CATEGORY_STATIC(webkit_media_gst_registry_scanner_debug);
-#define GST_CAT_DEFAULT webkit_media_gst_registry_scanner_debug
+        if (limits) {
+            GST_DEBUG("Video decoding limits: max width=%u, max height=%u, max frame rate=%u",
+                limits->mediaMaxWidth, limits->mediaMaxHeight, limits->mediaMaxFrameRate);
+        }
+    });
+    return limits ? &*limits : nullptr;
+}
 
 // We shouldn't accept media that the player can't actually play.
 // AAC supports up to 96 channels.
@@ -842,22 +869,8 @@ bool GStreamerRegistryScanner::supportsFeatures(const String& features) const
 MediaPlayerEnums::SupportsType GStreamerRegistryScanner::isContentTypeSupported(Configuration configuration, const ContentType& contentType, const Vector<ContentType>& contentTypesRequiringHardwareSupport, CaseSensitiveCodecName caseSensitive) const
 {
     VideoDecodingLimits* videoDecodingLimits = nullptr;
-#ifdef VIDEO_DECODING_LIMIT
-    static std::optional<VideoDecodingLimits> videoDecodingLimitsDefaults;
-    static std::once_flag onceFlag;
-    if (configuration == Configuration::Decoding) {
-        std::call_once(onceFlag, [] {
-            videoDecodingLimitsDefaults = videoDecoderLimitsDefaults();
-            if (!videoDecodingLimitsDefaults) {
-                GST_WARNING("Parsing VIDEO_DECODING_LIMIT failed");
-                ASSERT_NOT_REACHED();
-                return;
-            }
-        });
-        if (videoDecodingLimitsDefaults)
-            videoDecodingLimits = &*videoDecodingLimitsDefaults;
-    }
-#endif
+    if (configuration == Configuration::Decoding)
+        videoDecodingLimits = resolveVideoDecodingLimits();
 
     using SupportsType = MediaPlayerEnums::SupportsType;
 

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp
@@ -1079,6 +1079,20 @@ GStreamerRegistryScanner::RegistryLookupResult GStreamerRegistryScanner::isConfi
             videoConfiguration.bitrate, videoConfiguration.framerate);
 #endif
 
+        if (configuration == Configuration::Decoding) {
+            if (auto* videoDecodingLimits = resolveVideoDecodingLimits()) {
+                if (videoConfiguration.width > videoDecodingLimits->mediaMaxWidth
+                    || videoConfiguration.height > videoDecodingLimits->mediaMaxHeight
+                    || videoConfiguration.framerate > videoDecodingLimits->mediaMaxFrameRate) {
+                    GST_DEBUG("Video configuration %ux%u@%f exceeds decoding limits %ux%u@%u",
+                        videoConfiguration.width, videoConfiguration.height, videoConfiguration.framerate,
+                        videoDecodingLimits->mediaMaxWidth, videoDecodingLimits->mediaMaxHeight,
+                        videoDecodingLimits->mediaMaxFrameRate);
+                    return { false, false, nullptr };
+                }
+            }
+        }
+
 #if ENABLE(WPE_PLATFORM)
         Ref platformScreen = PlatformScreen::singleton();
         auto* scrData = platformScreen->screenData(PlatformScreen::singleton()->primaryScreenDisplayID());

--- a/Source/WebCore/rendering/RenderLayer.cpp
+++ b/Source/WebCore/rendering/RenderLayer.cpp
@@ -3228,7 +3228,6 @@ void RenderLayer::paint(GraphicsContext& context, const LayoutRect& damageRect, 
 
 void RenderLayer::clipToRect(GraphicsContext& context, GraphicsContextStateSaver& stateSaver, RegionContextStateSaver& regionContextStateSaver, const LayerPaintingInfo& paintingInfo, OptionSet<PaintBehavior> paintBehavior, const ClipRect& clipRect, BorderRadiusClippingRule rule)
 {
-    float deviceScaleFactor = renderer().document().deviceScaleFactor();
     bool needsClipping = !clipRect.isInfinite() && clipRect.rect() != paintingInfo.paintDirtyRect;
     if (needsClipping || clipRect.affectedByRadius())
         stateSaver.save();
@@ -3241,27 +3240,33 @@ void RenderLayer::clipToRect(GraphicsContext& context, GraphicsContextStateSaver
         regionContextStateSaver.pushClip(enclosingIntRect(snappedClipRect));
     }
 
-    if (clipRect.affectedByRadius()) {
-        // If the clip rect has been tainted by a border radius, then we have to walk up our layer chain applying the clips from
-        // any layers with overflow. The condition for being able to apply these clips is that the overflow object be in our
-        // containing block chain so we check that also.
-        for (RenderLayer* layer = rule == IncludeSelfForBorderRadius ? this : parent(); layer; layer = layer->parent()) {
-            if (paintBehavior.contains(PaintBehavior::CompositedOverflowScrollContent) && layer->usesCompositedScrolling())
-                break;
-        
-            if (layer->renderer().hasNonVisibleOverflow() && layer->renderer().style().hasBorderRadius() && ancestorLayerIsInContainingBlockChain(*layer)) {
-                auto adjustedClipRect = LayoutRect { LayoutPoint { layer->offsetFromAncestor(paintingInfo.rootLayer, AdjustForColumns) }, layer->rendererBorderBoxRect().size() };
-                adjustedClipRect.move(paintingInfo.subpixelOffset);
-                auto borderShape = BorderShape::shapeForBorderRect(layer->renderer().style(), adjustedClipRect);
-                if (borderShape.innerShapeContains(paintingInfo.paintDirtyRect))
-                    context.clip(snapRectToDevicePixels(intersection(paintingInfo.paintDirtyRect, adjustedClipRect), deviceScaleFactor));
-                else
-                    borderShape.clipToInnerShape(context, deviceScaleFactor);
-            }
-            
-            if (layer == paintingInfo.rootLayer)
-                break;
+    if (clipRect.affectedByRadius())
+        applyAncestorClippingForBorderRadius(context, paintingInfo, paintBehavior, rule);
+}
+
+void RenderLayer::applyAncestorClippingForBorderRadius(GraphicsContext& context, const LayerPaintingInfo& paintingInfo, OptionSet<PaintBehavior> paintBehavior, BorderRadiusClippingRule rule)
+{
+    float deviceScaleFactor = renderer().document().deviceScaleFactor();
+
+    // If the clip rect has been tainted by a border radius, then we have to walk up our layer chain applying the clips from
+    // any layers with overflow. The condition for being able to apply these clips is that the overflow object be in our
+    // containing block chain so we check that also.
+    for (RenderLayer* layer = rule == IncludeSelfForBorderRadius ? this : parent(); layer; layer = layer->parent()) {
+        if (paintBehavior.contains(PaintBehavior::CompositedOverflowScrollContent) && layer->usesCompositedScrolling())
+            break;
+
+        if (layer->renderer().hasNonVisibleOverflow() && layer->renderer().style().border().hasBorderRadius() && ancestorLayerIsInContainingBlockChain(*layer)) {
+            auto adjustedClipRect = LayoutRect { LayoutPoint { layer->offsetFromAncestor(paintingInfo.rootLayer, AdjustForColumns) }, layer->rendererBorderBoxRect().size() };
+            adjustedClipRect.move(paintingInfo.subpixelOffset);
+            auto borderShape = BorderShape::shapeForBorderRect(layer->renderer().style(), adjustedClipRect);
+            if (borderShape.innerShapeContains(paintingInfo.paintDirtyRect))
+                context.clip(snapRectToDevicePixels(intersection(paintingInfo.paintDirtyRect, adjustedClipRect), deviceScaleFactor));
+            else
+                borderShape.clipToInnerShape(context, deviceScaleFactor);
         }
+
+        if (layer == paintingInfo.rootLayer)
+            break;
     }
 }
 
@@ -3651,7 +3656,18 @@ GraphicsContext* RenderLayer::setupFilters(GraphicsContext& destinationContext, 
 
     auto rootRelativeBounds = calculateLayerBounds(paintingInfo.rootLayer, offsetFromRoot, { });
 
-    GraphicsContext* filterContext = paintingFilters->beginFilterEffect(renderer(), destinationContext, enclosingIntRect(rootRelativeBounds), enclosingIntRect(paintingInfo.paintDirtyRect), enclosingIntRect(filterRepaintRect), backgroundRect.rect());
+    // When the filter is applied via a transparency layer directly on the destination context (e.g. CG drop-shadow),
+    // the switcher doesn't consult applyFilters's clipToRect path, so the ancestor border-radius clip would be lost.
+    // Provide a callback that applies that rounded clip on the destination before the transparency layer begins.
+    Function<void(GraphicsContext&)> applyAdditionalDestinationClip;
+    if (backgroundRect.affectedByRadius()) {
+        applyAdditionalDestinationClip = [checkedThis = CheckedPtr { this }, &paintingInfo](GraphicsContext& context) {
+            checkedThis->applyAncestorClippingForBorderRadius(context, paintingInfo, paintingInfo.paintBehavior);
+        };
+    }
+
+    GraphicsContext* filterContext = paintingFilters->beginFilterEffect(renderer(), destinationContext, enclosingIntRect(rootRelativeBounds), enclosingIntRect(paintingInfo.paintDirtyRect), enclosingIntRect(filterRepaintRect),
+        backgroundRect.rect(), applyAdditionalDestinationClip);
     if (!filterContext)
         return nullptr;
 

--- a/Source/WebCore/rendering/RenderLayer.h
+++ b/Source/WebCore/rendering/RenderLayer.h
@@ -1070,6 +1070,7 @@ private:
     LayoutRect clipRectRelativeToAncestor(const RenderLayer* ancestor, LayoutSize offsetFromAncestor, const LayoutRect& constrainingRect, bool temporaryClipRects = false) const;
 
     void clipToRect(GraphicsContext&, GraphicsContextStateSaver&, RegionContextStateSaver&, const LayerPaintingInfo&, OptionSet<PaintBehavior>, const ClipRect&, BorderRadiusClippingRule = IncludeSelfForBorderRadius);
+    void applyAncestorClippingForBorderRadius(GraphicsContext&, const LayerPaintingInfo&, OptionSet<PaintBehavior>, BorderRadiusClippingRule = IncludeSelfForBorderRadius);
 
     bool shouldRepaintAfterLayout() const;
 

--- a/Source/WebCore/rendering/RenderLayerFilters.cpp
+++ b/Source/WebCore/rendering/RenderLayerFilters.cpp
@@ -157,7 +157,7 @@ IntOutsets RenderLayerFilters::calculateOutsets(RenderElement& renderer, const F
     return CSSFilterRenderer::calculateOutsets(renderer, filter, targetBoundingBox);
 }
 
-GraphicsContext* RenderLayerFilters::beginFilterEffect(RenderElement& renderer, GraphicsContext& context, const LayoutRect& filterBoxRect, const LayoutRect& dirtyRect, const LayoutRect& layerRepaintRect, const LayoutRect& clipRect)
+GraphicsContext* RenderLayerFilters::beginFilterEffect(RenderElement& renderer, GraphicsContext& context, const LayoutRect& filterBoxRect, const LayoutRect& dirtyRect, const LayoutRect& layerRepaintRect, const LayoutRect& clipRect, NOESCAPE const Function<void(GraphicsContext&)>& applyAdditionalDestinationClip)
 {
     auto preferredFilterRenderingModes = renderer.page().preferredFilterRenderingModes(context);
     auto outsets = calculateOutsets(renderer, filterBoxRect);
@@ -236,7 +236,7 @@ GraphicsContext* RenderLayerFilters::beginFilterEffect(RenderElement& renderer, 
     if (!m_targetSwitcher)
         return nullptr;
 
-    m_targetSwitcher->beginClipAndDrawSourceImage(context, m_repaintRect, clipRect);
+    m_targetSwitcher->beginClipAndDrawSourceImage(context, m_repaintRect, clipRect, applyAdditionalDestinationClip);
 
     return m_targetSwitcher->drawingContext(context);
 }

--- a/Source/WebCore/rendering/RenderLayerFilters.h
+++ b/Source/WebCore/rendering/RenderLayerFilters.h
@@ -76,7 +76,7 @@ public:
     // Per render
     LayoutRect repaintRect() const { return m_repaintRect; }
 
-    GraphicsContext* beginFilterEffect(RenderElement&, GraphicsContext&, const LayoutRect& filterBoxRect, const LayoutRect& dirtyRect, const LayoutRect& layerRepaintRect, const LayoutRect& clipRect);
+    GraphicsContext* beginFilterEffect(RenderElement&, GraphicsContext&, const LayoutRect& filterBoxRect, const LayoutRect& dirtyRect, const LayoutRect& layerRepaintRect, const LayoutRect& clipRect, NOESCAPE const Function<void(GraphicsContext&)>& applyAdditionalDestinationClip = { });
     void applyFilterEffect(GraphicsContext& destinationContext);
 
 private:


### PR DESCRIPTION
#### ae3eaacd1b2d0ca42cb15da8eddbefbda9288843
<pre>
Cherry-pick 309507@main (a8e8ac33b298). <a href="https://bugs.webkit.org/show_bug.cgi?id=310192">https://bugs.webkit.org/show_bug.cgi?id=310192</a>

    [GStreamer] Respect video decoding limits in MediaCapa:bilites queries
    <a href="https://bugs.webkit.org/show_bug.cgi?id=310192">https://bugs.webkit.org/show_bug.cgi?id=310192</a>

    Reviewed by Xabier Rodriguez-Calvar.

    The video decoding limits were only had into account in
    supportsFeatures() so far. They should also be enforced by the
    GStreamerRegistryScanner in isConfigurationSupported() as well.

    See: <a href="https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1639">https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1639</a>

    This change checks the limits from isConfigurationSupported(), so it&apos;s
    enforced from MediaCapabilities queries.

    Original author: Andrzej Surdej (<a href="https://github.com/asurdej-comcast)">https://github.com/asurdej-comcast)</a>

    * Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp:
    (WebCore::GStreamerRegistryScanner::isConfigurationSupported const): Check the video decoding limits.

    Canonical link: <a href="https://commits.webkit.org/309507@main">https://commits.webkit.org/309507@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.669@webkitglib/2.52">https://commits.webkit.org/305877.669@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### f18d440eaafe7b9b9f4cdb7aa6ab598072b27a1e
<pre>
Cherry-pick 308552@main (de98f6bb5014). <a href="https://bugs.webkit.org/show_bug.cgi?id=308969">https://bugs.webkit.org/show_bug.cgi?id=308969</a>

    [GStreamer] Expose VIDEO_DECODING_LIMIT through an environment variable
    <a href="https://bugs.webkit.org/show_bug.cgi?id=308969">https://bugs.webkit.org/show_bug.cgi?id=308969</a>

    Reviewed by Alicia Boya Garcia and Xabier Rodriguez-Calvar.

    The RDK-E downstream platform would like to have a single unified build
    for many kind of devices. For that reason, the platform compile-time
    VIDEO_DECODING_LIMIT restriction aren&apos;t appropriate anymore, since the
    same build can be used for devices with different runtime limits. A way
    to specify the decoding limit ar runtime would be desirable.

    An environment variable looks like a better way to do it than a runtime
    setting, since the limit is unlikely to change at runtime and likely to
    change per device (with a value consistent on every execution).
    Moreover, having a setting would mean extra changes in the dependent
    packages that embed WebKit, while having en environmente variable would
    be less intrusive and would only mean a change in the (easier to
    maintain) startup scripts.

    This change adds WEBKIT_GST_VIDEO_DECODING_LIMIT env on top of
    VIDEO_DECODING_LIMIT compile time option to limit video decoding
    capabilities. WEBKIT_GST_VIDEO_DECODING_LIMIT can now be set in runtime
    and it takes precedence over compile time definition
    VIDEO_DECODING_LIMIT.

    See: <a href="https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1625">https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1625</a>
         <a href="https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1626">https://github.com/WebPlatformForEmbedded/WPEWebKit/pull/1626</a>

    Original author: Andrzej Surdej &lt;Andrzej_Surdej@comcast.com&gt;

    * Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp:
    (videoDecoderLimitsDefaults): Deleted.

    * Source/WebCore/platform/graphics/gstreamer/GStreamerRegistryScanner.cpp:
    (WebCore::parseVideoDecodingLimit): Use a StringView to prevent extra copies.
    (WebCore::resolveVideoDecodingLimits): Decide the right decoding limits considering the build time option and the environment variable value.
    (WebCore::GStreamerRegistryScanner::isContentTypeSupported const): Parse env var and only require the build ifdefs when strictly needed.
    (videoDecoderLimitsDefaults): Deleted.

    Canonical link: <a href="https://commits.webkit.org/308552@main">https://commits.webkit.org/308552@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.668@webkitglib/2.52">https://commits.webkit.org/305877.668@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 3c9f9621a696c36bf1098993b19980f0f840fd2a
<pre>
Cherry-pick 313243@main (26970a5ac7ec). <a href="https://bugs.webkit.org/show_bug.cgi?id=314772">https://bugs.webkit.org/show_bug.cgi?id=314772</a>

    Web process sometimes crashes with excessive stack depth in TextExtraction::extractRecursive
    <a href="https://bugs.webkit.org/show_bug.cgi?id=314772">https://bugs.webkit.org/show_bug.cgi?id=314772</a>
    <a href="https://rdar.apple.com/177009329">rdar://177009329</a>

    Reviewed by Abrar Rahman Protyasha.

    Add a couple of mitigations to prevent crashes due to excessive stack depth:

    -   Avoid ever re-traversing the same element (which is theoretically possible if layout is
        triggered in the middle of recursive extraction).

    -   Enforce a maximum traversal depth and bail early if the stack grows too deep.

    Test: fast/text-extraction/max-recursion-depth-cap.html

    * LayoutTests/fast/text-extraction/max-recursion-depth-cap-expected.html: Added.
    * LayoutTests/fast/text-extraction/max-recursion-depth-cap.html: Added.
    * Source/WebCore/page/text-extraction/TextExtraction.cpp:
    (WebCore::TextExtraction::extractRecursive):

    Canonical link: <a href="https://commits.webkit.org/313243@main">https://commits.webkit.org/313243@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.667@webkitglib/2.52">https://commits.webkit.org/305877.667@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### f90bc16a71273a5be921341032e48bb5bf5bc91d
<pre>
Cherry-pick 313267@main (b8414eccb3b1). <a href="https://bugs.webkit.org/show_bug.cgi?id=312584">https://bugs.webkit.org/show_bug.cgi?id=312584</a>

    REGRESSION (303819@main): Child with filter:blur() ignores border radius overflow clipping
    <a href="https://bugs.webkit.org/show_bug.cgi?id=312584">https://bugs.webkit.org/show_bug.cgi?id=312584</a>
    <a href="https://rdar.apple.com/175519148">rdar://175519148</a>

    Reviewed by Said Abou-Hallawa.

    When using the TransparencyLayerContextSwitcher path for filters, we need to be able
    to supply a complex clip for items clipped by border-radius on ancestors; this
    requires running the code in `applyAncestorClippingForBorderRadius()` after
    saving the graphics state, before starting the transparency layer, so factor
    the code to allow this by passing a function to GraphicsContextSwitcher.

    The previous attempt to fix this (312531@main) was reverted for causing rendering
    regressions of youtube buttons and on wayfair.com; this turned out to be a Core Graphics
    accelerated rendering bug (<a href="https://rdar.apple.com/177036180">rdar://177036180</a>) which we work around by applying the
    rounded clip in an outer transparency layer. `grayscale-clip-border-radius.html` tests
    this workaround.

    Tests: imported/w3c/web-platform-tests/css/filter-effects/blur-clip-border-radius-ref.html
           imported/w3c/web-platform-tests/css/filter-effects/blur-clip-border-radius.html
           imported/w3c/web-platform-tests/css/filter-effects/grayscale-clip-border-radius-ref.html
           imported/w3c/web-platform-tests/css/filter-effects/grayscale-clip-border-radius.html

    * LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/blur-clip-border-radius-expected.html: Added.
    * LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/blur-clip-border-radius-ref.html: Added.
    * LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/blur-clip-border-radius.html: Added.
    * LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/grayscale-clip-border-radius-expected.html: Added.
    * LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/grayscale-clip-border-radius-ref.html: Added.
    * LayoutTests/imported/w3c/web-platform-tests/css/filter-effects/grayscale-clip-border-radius.html: Added.
    * Source/WebCore/platform/graphics/GraphicsContextSwitcher.h:
    (WebCore::GraphicsContextSwitcher::beginClipAndDrawSourceImage):
    * Source/WebCore/platform/graphics/ImageBufferContextSwitcher.cpp:
    (WebCore::ImageBufferContextSwitcher::beginClipAndDrawSourceImage):
    * Source/WebCore/platform/graphics/ImageBufferContextSwitcher.h:
    * Source/WebCore/platform/graphics/TransparencyLayerContextSwitcher.cpp:
    (WebCore::TransparencyLayerContextSwitcher::beginClipAndDrawSourceImage):
    (WebCore::TransparencyLayerContextSwitcher::endDrawSourceImage):
    * Source/WebCore/platform/graphics/TransparencyLayerContextSwitcher.h:
    * Source/WebCore/rendering/RenderLayer.cpp:
    (WebCore::RenderLayer::clipToRect):
    (WebCore::RenderLayer::applyAncestorClippingForBorderRadius):
    (WebCore::RenderLayer::setupFilters):
    * Source/WebCore/rendering/RenderLayer.h:
    * Source/WebCore/rendering/RenderLayerFilters.cpp:
    (WebCore::RenderLayerFilters::beginFilterEffect):
    * Source/WebCore/rendering/RenderLayerFilters.h:

    Canonical link: <a href="https://commits.webkit.org/313267@main">https://commits.webkit.org/313267@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.666@webkitglib/2.52">https://commits.webkit.org/305877.666@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fc099595af03c93986d6e7d5cb19162038efcbfb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164241 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/37725 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/31072 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173270 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121493 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166110 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/38059 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/37725 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127596 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121493 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167200 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/38059 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/31072 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108144 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/38059 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/37725 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21034 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/38059 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/31072 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175796 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/28617 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/31072 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135909 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/37395 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/37725 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135879 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/38181 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/31072 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/100503 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25009 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/38181 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/31072 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/36991 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/110036 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/36388 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/31072 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/36638 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/36538 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->