### PR TITLE
[Tools][GTK][WPE] generate-bundle test suite: fix issue with newer gtk4 and use podman instead of docker

### DIFF
--- a/Tools/Scripts/generate-bundle
+++ b/Tools/Scripts/generate-bundle
@@ -472,7 +472,7 @@ class BundleCreator(object):
         gtk_binary_version = self._get_pkg_config_var('gtk4', 'gtk_binary_version')
         gtk_module_dir = os.path.join(gtk_lib_dir, 'gtk-4.0', gtk_binary_version, subdir)
         if not os.path.isdir(gtk_module_dir):
-            raise RuntimeError('Can not find the the gtk module dir %s' % gtk_module_dir)
+            return []  # gtk4 ships now the modules statically linked in the lib: https://gitlab.gnome.org/GNOME/gtk/-/merge_requests/8522
         return self._list_files_directory(gtk_module_dir, filter_suffix='.so')
 
     def _get_gstreamer_modules(self):

--- a/Tools/Scripts/test-bundle
+++ b/Tools/Scripts/test-bundle
@@ -33,9 +33,6 @@ sys.path.insert(0, os.path.join(top_level_directory, 'Tools', 'Scripts'))
 sys.path.insert(0, os.path.join(top_level_directory, 'Tools', 'jhbuild'))
 sys.path.insert(0, os.path.join(top_level_directory, 'Tools', 'Scripts', 'webkitpy'))
 
-from webkitpy.port.linux_container_sdk_utils import maybe_enter_webkit_container_sdk
-maybe_enter_webkit_container_sdk()
-
 
 # Executes the command and returns 0 if it was sucessful, otherwise returns a number => 1
 def run_cmd(cmd):
@@ -53,15 +50,18 @@ def run_cmd(cmd):
     return max(sys_retcode, 1)
 
 
-def tests_webdriver_minibroser(platform, bundle_type, bundle_path):
+def tests_webdriver_minibroser(platform, bundle_type, bundle_path, headless):
     if not os.path.isfile(bundle_path):
         raise ValueError(f"Can't find a bundle file at path: {bundle_path}")
+
+    headless_arg = '--headless' if headless else ''
+    xwrap = 'xvfb-run -a ' if headless and platform == 'gtk' else ''
 
     if bundle_type == 'distro-specific':
         # This only works if executing on the same distro than created
         test_script = os.path.join(MYDIR,'webkitpy/binary_bundling/tests/webdriver/test_webdriver_bundle.py')
     elif bundle_type == 'universal':
-        test_script = os.path.join(MYDIR,'webkitpy/binary_bundling/tests/webdriver/run-webdriver-tests-bundle-docker.sh')
+        test_script = os.path.join(MYDIR,'webkitpy/binary_bundling/tests/webdriver/run-webdriver-tests-bundle-podman.sh')
     else:
         raise NotImplementedError(f'Unknown bundle type: {bundle_type}')
 
@@ -70,7 +70,7 @@ def tests_webdriver_minibroser(platform, bundle_type, bundle_path):
 
     # The test runner for the universal bundle handles itself uncompressing the bundle
     if bundle_type == 'universal':
-        retcode = run_cmd(f'{test_script} --platform={platform} {bundle_path}')
+        retcode = run_cmd(f'{xwrap}{test_script} --platform={platform} {headless_arg} {bundle_path}')
         return retcode
 
     # Handle here uncompressing the bundle for the distro-specific tests
@@ -84,7 +84,7 @@ def tests_webdriver_minibroser(platform, bundle_type, bundle_path):
         else:
             raise ValueError("Unsupported file format. Only .tar.xz and .zip are supported.")
 
-        retcode = run_cmd(f'{test_script} --platform={platform} {temp_dir}')
+        retcode = run_cmd(f'{xwrap}{test_script} --platform={platform} {headless_arg} {temp_dir}')
         return retcode
 
 
@@ -92,12 +92,13 @@ def main():
     parser = argparse.ArgumentParser('usage: %prog [options]')
     parser.add_argument('--platform', dest='platform', choices=['gtk', 'wpe'], required=True,
                         help='The WebKit port of the bundle to be tested')
+    parser.add_argument("--no-headless", dest="headless", action="store_false", help="Do not run in headless mode")
     parser.add_argument('--bundle-type', dest='bundle_type', choices=['universal', 'distro-specific'], required=True,
                         help='Select universal if the bundle was created with "--syslibs=bundle-all" or select distro-specific otherwise')
     parser.add_argument('bundle_path', action='store', help='Path to the compressed bundle file')
     options = parser.parse_args()
 
-    return tests_webdriver_minibroser(options.platform, options.bundle_type, options.bundle_path)
+    return tests_webdriver_minibroser(options.platform, options.bundle_type, options.bundle_path, options.headless)
 
 
 if __name__ == '__main__':

--- a/Tools/Scripts/webkitpy/binary_bundling/tests/webdriver/install_deps_podman_start_test.sh
+++ b/Tools/Scripts/webkitpy/binary_bundling/tests/webdriver/install_deps_podman_start_test.sh
@@ -15,6 +15,12 @@ fi
 
 export PYTHONUNBUFFERED=1
 
+HEADLESS=""
+if [ "${1}" = "--headless" ]; then
+    HEADLESS="--headless"
+    shift 1
+fi
+
 # Install needed packages
 case "${CURRENT_DISTRO}" in
     alpine)
@@ -80,8 +86,9 @@ tar xfav /testbundle.tar.xz -C /testbundle
 echo "Starting tests on distro: ${CURRENT_DISTRO}"
 [ -f /etc/os-release ] && cat /etc/os-release
 # run the tests
+CMD="/testdata/test_webdriver_bundle.py ${HEADLESS} --platform=$1 /testbundle"
 if [ "${CURRENT_DISTRO}" = "nixos" ]; then
-    nix-shell -p python3 python3Packages.pip python3Packages.pillow python3Packages.numpy --run "/testdata/test_webdriver_bundle.py --platform=$1 /testbundle"
+    exec nix-shell -p python3 python3Packages.pip python3Packages.pillow python3Packages.numpy --run "${CMD}"
 else
-    /testdata/test_webdriver_bundle.py "--platform=$1" /testbundle
+    exec ${CMD}
 fi

--- a/Tools/Scripts/webkitpy/binary_bundling/tests/webdriver/run-webdriver-tests-bundle-podman.sh
+++ b/Tools/Scripts/webkitpy/binary_bundling/tests/webdriver/run-webdriver-tests-bundle-podman.sh
@@ -2,7 +2,7 @@
 
 function error_help() {
     echo "ERROR: ${@}"
-    echo "Use: ${0} --platform {gtk,wpe} /path/to/MiniBrowser-bundle.tar.xz" 1>&2
+    echo "Use: ${0} --platform {gtk,wpe} [--headless] /path/to/MiniBrowser-bundle.tar.xz" 1>&2
     exit 1
 }
 
@@ -19,17 +19,22 @@ elif [[ "${1}" == "--platform" ]]; then
 else
     error_help "Unexpected parameter: ${1}"
 fi
-
+HEADLESS=""
+if [[ "${2}" == "--headless" ]]; then
+    HEADLESS="--headless"
+    shift 1
+fi
 [[ -f "${2}" ]] || error_help "Bundle file does not exist: ${2}"
 echo "${2}" | grep -qE "\.tar\.xz$" || error_help "Bundle file does not end in .tar.xz: ${2}"
 FBUNDLE="$(readlink -f ${2})"
 
 MYDIR="$(dirname $(readlink -f ${0}))"
 
-TESTINITSCRIPT="install_deps_docker_start_test.sh"
-[[ -n "${DISPLAY}" ]] && DOCKER_DISPLAY_BIND+="-v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=${DISPLAY} "
-[[ -n "${XAUTHORITY}" ]] && DOCKER_DISPLAY_BIND+="-v ${XAUTHORITY}:${XAUTHORITY} -e XAUTHORITY=${XAUTHORITY} "
-[[ -n "${WAYLAND_DISPLAY}" ]] && DOCKER_DISPLAY_BIND+="-v ${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY}:/tmp/${WAYLAND_DISPLAY} -e XDG_RUNTIME_DIR=/tmp -e WAYLAND_DISPLAY=${WAYLAND_DISPLAY} "
+TESTINITSCRIPT="install_deps_podman_start_test.sh"
+PODMAN_DISPLAY_BIND=""
+[[ -n "${DISPLAY}" ]] && PODMAN_DISPLAY_BIND+="-v /tmp/.X11-unix:/tmp/.X11-unix -e DISPLAY=${DISPLAY} "
+[[ -n "${XAUTHORITY}" ]] && PODMAN_DISPLAY_BIND+="-v ${XAUTHORITY}:${XAUTHORITY} -e XAUTHORITY=${XAUTHORITY} "
+[[ -n "${WAYLAND_DISPLAY}" ]] && PODMAN_DISPLAY_BIND+="-v ${XDG_RUNTIME_DIR}/${WAYLAND_DISPLAY}:/tmp/${WAYLAND_DISPLAY} -e XDG_RUNTIME_DIR=/tmp -e WAYLAND_DISPLAY=${WAYLAND_DISPLAY} "
 
 set -eux
 
@@ -39,6 +44,7 @@ DISTROS_TO_TEST=(
     archlinux:latest
     debian:11
     debian:12
+    debian:13
     debian:testing
     fedora:latest
     gentoo/stage3:latest
@@ -48,6 +54,7 @@ DISTROS_TO_TEST=(
     ubuntu:20.04
     ubuntu:22.04
     ubuntu:24.04
+    ubuntu:26.04
     ubuntu:latest
 )
 
@@ -57,14 +64,15 @@ HOSTNAME="$(hostname)"
 I=0
 for DISTRO in ${DISTROS_TO_TEST[@]}; do
     echo "[INFO] Start testing on distro: ${DISTRO}"
-    docker pull "${DISTRO}"
-    docker run --init --rm \
+    IMAGE="docker.io/${DISTRO}"
+    podman pull "${IMAGE}"
+    podman run --init --rm \
                 -v "${MYDIR}:/testdata:ro" \
                 -v "${FBUNDLE}:/testbundle.tar.xz:ro" \
-                ${DOCKER_DISPLAY_BIND} \
+                ${PODMAN_DISPLAY_BIND} \
                 -h "${HOSTNAME}" \
-                "${DISTRO}" \
-                "/testdata/${TESTINITSCRIPT}" "${PORT}"
+                "${IMAGE}" \
+                "/testdata/${TESTINITSCRIPT}" ${HEADLESS} "${PORT}"
     echo "[PASS $((++I))/${#DISTROS_TO_TEST[@]}] Finish testing on distro: ${DISTRO}"
 done
 

--- a/Tools/Scripts/webkitpy/binary_bundling/tests/webdriver/test_webdriver_bundle.py
+++ b/Tools/Scripts/webkitpy/binary_bundling/tests/webdriver/test_webdriver_bundle.py
@@ -48,7 +48,7 @@ def callfunc(obj, method_name, *args, **kwargs):
 
 class WebDriverTests():
 
-    def __init__(self, browser_path, webdriver_path, platform_name, number_retries):
+    def __init__(self, browser_path, webdriver_path, platform_name, number_retries, headless):
         self.started = False
         if platform_name == 'gtk':
             from selenium.webdriver import WebKitGTKOptions as WebKitOptions
@@ -63,7 +63,7 @@ class WebDriverTests():
         options = WebKitOptions()
         options.binary_location = browser_path
         options.add_argument('--automation')
-        if platform_name == 'wpe':
+        if headless and platform_name == 'wpe':
             options.add_argument('--headless')
         service = Service(executable_path=webdriver_path, service_args=['--host=127.0.0.1'])
         self.driver = WebKitDriver(options=options, service=service)
@@ -264,7 +264,7 @@ class WebDriverTests():
         return self.do_test(test_name, html_test_url)
 
 
-def run_all_tests(bundle_dir, platform_name, number_retries):
+def run_all_tests(bundle_dir, platform_name, number_retries, headless):
     assert (platform_name in ['gtk', 'wpe'])
     if not os.path.isdir(bundle_dir):
         raise ValueError(f'{bundle_dir} is not a valid directory')
@@ -274,7 +274,7 @@ def run_all_tests(bundle_dir, platform_name, number_retries):
     for binary_path in [browser_path, webdriver_path]:
         if not (os.path.isfile(binary_path) and os.access(binary_path, os.X_OK)):
             raise ValueError(f'Can not find an executable at: {binary_path}')
-    tester = WebDriverTests(browser_path, webdriver_path, platform_name, number_retries)
+    tester = WebDriverTests(browser_path, webdriver_path, platform_name, number_retries, headless)
     total_tests_failed = 0
     for test in ['test_dynamic_rendering', 'test_video_playback', 'test_css_animations', 'test_webgl_support', 'test_webgl_rainbow']:
         total_tests_failed += tester.do_local_test(test)
@@ -295,9 +295,10 @@ def main():
                         help='The WebKit port to test the bundle')
     parser.add_argument('--number-retries-test', dest='number_retries', default=3, type=int,
                         help='The number of retries per test before marking it as a failure.')
+    parser.add_argument("--headless", dest="headless", action="store_true", help="Run in headless mode")
     parser.add_argument('bundle_dir', help='Directory path where the bundle is uncompressed.')
     options = parser.parse_args()
-    return run_all_tests(options.bundle_dir, options.platform, options.number_retries)
+    return run_all_tests(options.bundle_dir, options.platform, options.number_retries, options.headless)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
#### 3d3ad8be8c5bab198c2387c713df354af09abb46
<pre>
[Tools][GTK][WPE] generate-bundle test suite: fix issue with newer gtk4 and use podman instead of docker
<a href="https://bugs.webkit.org/show_bug.cgi?id=315352">https://bugs.webkit.org/show_bug.cgi?id=315352</a>

Reviewed by Nikolas Zimmermann.

For moving the nightly packaging bots to the new infra using podman instead
of docker is required.
This patch  adds debian:13 and ubuntu:26.04 distros to the test matrix
and adds options to run the tests headless, taking care of launching the
xvfb-run wrapper in the case of GTK.

This also fixes an issue with newer GTK4 (4.22) where the generate-bundle
can&apos;t locate the GTK4 printbackends modules anymore because those are now
built statically inside the main lib.

* Tools/Scripts/generate-bundle:
(BundleCreator._get_gtk_modules):
* Tools/Scripts/test-bundle:
(run_cmd):
(tests_webdriver_minibroser):
(main):
* Tools/Scripts/webkitpy/binary_bundling/tests/webdriver/install_deps_podman_start_test.sh: Renamed from Tools/Scripts/webkitpy/binary_bundling/tests/webdriver/install_deps_docker_start_test.sh.
* Tools/Scripts/webkitpy/binary_bundling/tests/webdriver/run-webdriver-tests-bundle-podman.sh: Renamed from Tools/Scripts/webkitpy/binary_bundling/tests/webdriver/run-webdriver-tests-bundle-docker.sh.
* Tools/Scripts/webkitpy/binary_bundling/tests/webdriver/test_webdriver_bundle.py:
(WebDriverTests.__init__):
(run_all_tests):
(main):

Canonical link: <a href="https://commits.webkit.org/313903@main">https://commits.webkit.org/313903@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/5dacf4940d66f444caf0745ee3ead2ceb1231785

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/163992 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37476 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30695 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173021 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121243 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165861 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37809 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37476 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127397 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89669 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166951 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29683 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147426 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107945 "Passed tests") | 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/163313 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28729 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27354 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20785 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138630 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25143 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175546 "Built successfully") | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26811 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135706 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37146 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31466 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135678 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37931 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146938 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100118 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25041 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30984 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23794 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36740 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36139 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1840 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36389 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36286 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->