### PR TITLE
[WebXR Layers] Incorrect rendering of layers in https://threejs.org/examples/?q=layers%20n#webgpu_xr_native_layers

### DIFF
--- a/Source/WebCore/Modules/webxr/XRCylinderLayer.cpp
+++ b/Source/WebCore/Modules/webxr/XRCylinderLayer.cpp
@@ -124,7 +124,7 @@ void XRCylinderLayer::startFrame(PlatformXR::FrameData& frameData)
 void XRCylinderLayer::recomputePose()
 {
     auto scopeExit = makeScopeExit([&]() {
-        RELEASE_LOG_ERROR(XR, "Failed to invert space transform, using identity transform for layer pose");
+        RELEASE_LOG_ERROR(XR, "Failed to decompose space transform, using identity transform for layer pose");
         m_poseInLocalSpace = PlatformXR::FrameData::Pose { .position = { 0, 0, 0 }, .orientation = { 0, 0, 0, 1 } };
     });
 
@@ -133,10 +133,8 @@ void XRCylinderLayer::recomputePose()
         spaceTransform = m_space->nativeOrigin();
     if (!spaceTransform)
         spaceTransform = TransformationMatrix();
-    else if (!spaceTransform->isInvertible())
-        return;
 
-    auto transformInLocalSpace = m_transform ? *spaceTransform->inverse() * m_transform->rawTransform() : *spaceTransform->inverse();
+    auto transformInLocalSpace = m_transform ? *spaceTransform * m_transform->rawTransform() : *spaceTransform;
     TransformationMatrix::Decomposed4Type decomposed;
     if (!transformInLocalSpace.decompose4(decomposed))
         return;

--- a/Source/WebCore/Modules/webxr/XREquirectLayer.cpp
+++ b/Source/WebCore/Modules/webxr/XREquirectLayer.cpp
@@ -130,7 +130,7 @@ void XREquirectLayer::startFrame(PlatformXR::FrameData& frameData)
 void XREquirectLayer::recomputePose()
 {
     auto scopeExit = makeScopeExit([&]() {
-        RELEASE_LOG_ERROR(XR, "Failed to invert space transform, using identity transform for layer pose");
+        RELEASE_LOG_ERROR(XR, "Failed to decompose space transform, using identity transform for layer pose");
         m_poseInLocalSpace = PlatformXR::FrameData::Pose { .position = { 0, 0, 0 }, .orientation = { 0, 0, 0, 1 } };
     });
 
@@ -139,10 +139,8 @@ void XREquirectLayer::recomputePose()
         spaceTransform = m_space->nativeOrigin();
     if (!spaceTransform)
         spaceTransform = TransformationMatrix();
-    else if (!spaceTransform->isInvertible())
-        return;
 
-    auto transformInLocalSpace = m_transform ? *spaceTransform->inverse() * m_transform->rawTransform() : *spaceTransform->inverse();
+    auto transformInLocalSpace = m_transform ? *spaceTransform * m_transform->rawTransform() : *spaceTransform;
     TransformationMatrix::Decomposed4Type decomposed;
     if (!transformInLocalSpace.decompose4(decomposed))
         return;

--- a/Source/WebCore/Modules/webxr/XRQuadLayer.cpp
+++ b/Source/WebCore/Modules/webxr/XRQuadLayer.cpp
@@ -98,7 +98,7 @@ void XRQuadLayer::startFrame(PlatformXR::FrameData& frameData)
 void XRQuadLayer::recomputePose()
 {
     auto scopeExit = makeScopeExit([&]() {
-        RELEASE_LOG_ERROR(XR, "Failed to invert space transform, using identity transform for layer pose");
+        RELEASE_LOG_ERROR(XR, "Failed to decompose space transform, using identity transform for layer pose");
         m_poseInLocalSpace = PlatformXR::FrameData::Pose { .position = { 0, 0, 0 }, .orientation = { 0, 0, 0, 1 } };
     });
 
@@ -107,10 +107,8 @@ void XRQuadLayer::recomputePose()
         spaceTransform = m_space->nativeOrigin();
     if (!spaceTransform)
         spaceTransform = TransformationMatrix();
-    else if (!spaceTransform->isInvertible())
-        return;
 
-    auto transformInLocalSpace = m_transform ? *spaceTransform->inverse() * m_transform->rawTransform() : *spaceTransform->inverse();
+    auto transformInLocalSpace = m_transform ? *spaceTransform * m_transform->rawTransform() : *spaceTransform;
     TransformationMatrix::Decomposed4Type decomposed;
     if (!transformInLocalSpace.decompose4(decomposed))
         return;


### PR DESCRIPTION
#### b9704aaeaa380b95d093e0e362ba8464236a6df4
<pre>
[WebXR Layers] Incorrect rendering of layers in <a href="https://threejs.org/examples/?q=layers%20n#webgpu_xr_native_layers">https://threejs.org/examples/?q=layers%20n#webgpu_xr_native_layers</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=314634">https://bugs.webkit.org/show_bug.cgi?id=314634</a>

Reviewed by Dan Glastonbury.

XRQuadLayer, XRCylinderLayer and XREquirectLayer were submitting their
poses to the device with an inverted offset along the Y axis when the
layer was anchored to a reference space whose nativeOrigin is not the
identity (most notably &apos;local-floor&apos;, which is the three.js default).

The reference space&apos;s nativeOrigin() returns the transform that maps
from the space&apos;s local coordinates into the session&apos;s local space, i.e.
spaceTransform * pointInSpace = pointInLocalSpace. To express a layer&apos;s
transform in local space we should do:

    layerInLocalSpace = spaceTransform * layerInSpace

recomputePose() was instead doing:

    layerInLocalSpace = inverse(spaceTransform) * layerInSpace

In the threejs specific example the &apos;local-floor&apos; space had the floor at
Y = -HEIGHT in local space. This flipped the sign of the floor offset and
pushed any layer placed at Y = 0 in local-floor up to Y = +HEIGHT in local
space (above the user&apos;s head) instead of the intended Y = -HEIGHT (the
floor). That&apos;s why non-projection layers ended up roughly at the room
ceiling and were invisible in the user&apos;s natural forward gaze.

XRProjectionLayer was unaffected because it does not go through this
code path. Its per-view poses are obtained from xrLocateViews() and
submitted directly.

No new tests as the bug lives in the conversion from m_transform
(reference-space coords) to m_poseInLocalSpace (the value passed to
Device::submitFrame), and the result is never exposed to JavaScript.

* Source/WebCore/Modules/webxr/XRCylinderLayer.cpp:
(WebCore::XRCylinderLayer::recomputePose):
* Source/WebCore/Modules/webxr/XREquirectLayer.cpp:
(WebCore::XREquirectLayer::recomputePose):
* Source/WebCore/Modules/webxr/XRQuadLayer.cpp:
(WebCore::XRQuadLayer::recomputePose):

Canonical link: <a href="https://commits.webkit.org/313843@main">https://commits.webkit.org/313843@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f2da9209c8f625188335bf159c96ce72704d1ae7

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164005 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37489 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30708 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173034 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121256 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165874 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37822 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37489 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127407 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89667 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166964 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29692 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147439 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107955 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28738 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27368 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20798 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138639 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25156 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175559 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28381 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26824 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135716 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37159 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31480 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135688 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36621 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37944 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146951 "Passed tests") | [❌ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100133 "Hash f2da9209 for PR 65476 does not build (failure)") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30994 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23807 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36753 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109800 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36152 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1853 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36402 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36299 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->