### PR TITLE
AX Site Isolation: macOS VoiceOver wraps to the top of the page when trying to navigate past a cross-origin iframe

### DIFF
--- a/LayoutTests/http/tests/site-isolation/accessibility/client/walk-up-from-iframe-content-expected.txt
+++ b/LayoutTests/http/tests/site-isolation/accessibility/client/walk-up-from-iframe-content-expected.txt
@@ -1,0 +1,22 @@
+Tests that walking accessibilityParent from a cross-process iframe descendant reaches the main page's WebArea.
+PASS: iframeHeading != null === true
+
+Found Iframe descendant: AXRole: AXHeading "Iframe Heading 1"
+
+Accessibility-parent chain:
+  1: AXRole: AXHeading
+  2: AXRole: AXWebArea
+  3: AXRole: AXScrollArea
+  4: AXRole: AXGroup
+  5: AXRole: AXGroup
+  6: AXRole: AXWebArea
+  7: AXRole: AXScrollArea
+
+PASS: walk.webAreaCount >= 2 === true
+
+PASS successfullyParsed is true
+
+TEST COMPLETE
+Heading Before Iframe
+
+  Button After Iframe

--- a/LayoutTests/http/tests/site-isolation/accessibility/client/walk-up-from-iframe-content.html
+++ b/LayoutTests/http/tests/site-isolation/accessibility/client/walk-up-from-iframe-content.html
@@ -1,0 +1,95 @@
+<html><!-- webkit-test-runner [ SiteIsolationEnabled=true ] -->
+<head>
+<script src="/js-test-resources/accessibility-helper.js"></script>
+<script src="/js-test-resources/js-test.js"></script>
+</head>
+<body>
+
+<h1 id="heading-before">Heading Before Iframe</h1>
+
+<iframe id="iframe" src="http://localhost:8000/site-isolation/accessibility/resources/iframe-with-headings.html"></iframe>
+
+<button id="button-after">Button After Iframe</button>
+
+<script>
+var output = "Tests that walking accessibilityParent from a cross-process iframe descendant reaches the main page's WebArea.\n";
+
+window.jsTestIsAsync = true;
+accessibilityController.setClientAccessibilityMode(true);
+
+// Walks accessibilityParent until the chain ends or maxHops is exceeded.
+// Records each role visited so the test output documents the cross-process boundary.
+function walkParents(startElement) {
+    var roles = [];
+    var webAreaCount = 0;
+    var current = startElement;
+    var maxHops = 20;
+    while (current && roles.length < maxHops) {
+        var role = current.role || "";
+        if (!role)
+            break;
+
+        roles.push(role);
+        if (role.includes("AXWebArea"))
+            webAreaCount++;
+        current = current.parentElement();
+    }
+    return { roles, webAreaCount };
+}
+
+var iframeHeading, walk;
+async function runTest() {
+    if (!window.accessibilityController)
+        return;
+
+    // Wait for an iframe heading (cross-process content) to be in the AX tree.
+    await waitForElements([
+        (element) => element.role.includes("Heading") && element.title.includes("Iframe Heading"),
+    ]);
+
+    var root = accessibilityController.rootElement;
+    var webArea = root.childAtIndex(0);
+
+    // Find a heading inside the iframe. This necessitates crossing the iframe-process
+    // boundary when walking parent-by-parent.
+    function findIframeHeading(element, depth) {
+        if (!element || depth > 8)
+            return null;
+        if (element.role && element.role.includes("Heading") && element.title && element.title.includes("Iframe Heading"))
+            return element;
+        for (var i = 0; i < element.childrenCount; i++) {
+            var found = findIframeHeading(element.childAtIndex(i), depth + 1);
+            if (found)
+                return found;
+        }
+        return null;
+    }
+
+    iframeHeading = findIframeHeading(webArea, 0);
+    output += expect("iframeHeading != null", "true");
+    if (!iframeHeading) {
+        debug(output);
+        finishJSTest();
+        return;
+    }
+
+    output += `\nFound Iframe descendant: ${iframeHeading.role} "${iframeHeading.title}"\n`;
+
+    walk = walkParents(iframeHeading);
+    output += "\nAccessibility-parent chain:\n";
+    for (var i = 0; i < walk.roles.length; i++)
+        output += `  ${i + 1}: ${walk.roles[i]}\n`;
+
+    // The chain should pass through at least two AXWebArea elements: the iframe's
+    // own AXWebArea (inside the iframe process) and the main page's AXWebArea
+    // (in the main process).
+    output += "\n" + expect("walk.webAreaCount >= 2", "true");
+
+    debug(output);
+    finishJSTest();
+}
+
+document.getElementById("iframe").onload = runTest;
+</script>
+</body>
+</html>

--- a/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
+++ b/Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm
@@ -477,7 +477,17 @@ void WebPage::registerRemoteFrameAccessibilityTokens(pid_t pid, WebCore::Accessi
     RetainPtr elementTokenData = toNSData(elementToken.bytes);
     auto remoteElement = [elementTokenData length] ? adoptNS([[NSAccessibilityRemoteUIElement alloc] initWithRemoteToken:elementTokenData.get()]) : nil;
 
-    createMockAccessibilityElement(pid);
+    // Don't replace m_mockAccessibilityElement here. The AXIsolatedTree's ScrollArea caches a strong
+    // reference to the current mock element as its RemoteParent property at construction time, so
+    // recreating the mock would leave the isolated tree pointing at a stale instance with no remote
+    // parent set, breaking cross-process accessibility-parent traversal from inside this iframe.
+    // Reuse the existing mock element and only update what changed: the presenter PID, the remote
+    // parent, and the frame identifier.
+    if (!m_mockAccessibilityElement)
+        createMockAccessibilityElement(pid);
+    else if ([m_mockAccessibilityElement respondsToSelector:@selector(accessibilitySetPresenterProcessIdentifier:)])
+        [(id)m_mockAccessibilityElement.get() accessibilitySetPresenterProcessIdentifier:pid];
+
     RetainPtr accessibilityRemoteObject = this->accessibilityRemoteObject();
     [accessibilityRemoteObject setRemoteParent:remoteElement.get() token:elementTokenData.get()];
     [accessibilityRemoteObject setFrameIdentifier:frameID];


### PR DESCRIPTION
#### d86c4e68319ab64a1deaafd7052be2d6694b5f0b
<pre>
AX Site Isolation: macOS VoiceOver wraps to the top of the page when trying to navigate past a cross-origin iframe
<a href="https://bugs.webkit.org/show_bug.cgi?id=315356">https://bugs.webkit.org/show_bug.cgi?id=315356</a>
<a href="https://rdar.apple.com/177714038">rdar://177714038</a>

Reviewed by Dominic Mazzoni.

This bug occurred because the root scroll area associated with an remote
iframe had an AXProperty::RemoteParent (a WKAccessibilityWebPageObject)
that itself never had its m_parent set, breaking the accessibility tree
and thus preventing VoiceOver from navigating effectively.

This was possible due to this sequence:

  1. Pre-warmed iframe process is spawned (Safari prewarms some web
     content processes).

  2. platformInitializeAccessibility runs in this iframe process,
     calling createMockAccessibilityElement() (this creates a WKAccessibilityWebPageObject).
     Note that its m_parent is nil at this point.

  3. An accessibility query reaches the iframe process, triggering
     AXIsolatedTree::create. The iframe root scrollarea caches an
     AXProperty::RemoteParent with a pointer to the
     WKAccessibilityWebPageObject from step 2 (whose m_parent is still nil).

  4. The parent web content process creates an AXRemoteFrame representing the
     iframe web content process. It sends bindRemoteAccessibilityFrames(parentPid, parentToken)
     through the UI process.

  5. Iframe&apos;s WebPage::bindRemoteAccessibilityFrames runs as result, and calls
     registerRemoteFrameAccessibilityTokens. Prior to this commit, this
     unconditionally replaced m_mockAccessibilityElement (the WKAccessibilityWebPageObject)
     with a brand new instance, and sets m_parent for the new instance.

  6. The iframe&apos;s root scroll area still has the old
     WKAccessibilityWebPageObject cached in its AXProperty::RemoteFrame
     from step #2, with a nil m_parent.

This bug is intermittent, critically depending on whether there was a
prewarmed process available for the iframe web content. If there was not
a prewarmed process available, AXProperty::RemoteParent is set up from
the start with the WKAccessibilityWebPageObject that used to be
unconditionally created in step 5, and the bug did not manifest.

This commit fixes the issue by changing registerRemoteFrameAccessibilityTokens
to only create a new m_mockAccessibilityElement if one doesn&apos;t already
exist, preventing the iframe scroll area from being associated with a
stale one that has no parent.

Because the bug depends on prewarming behavior, the added layout test
passes with and without this commit. I couldn&apos;t find a good way to
emulate that in our testing environment. Fix manually confirmed in Safari.

* LayoutTests/http/tests/site-isolation/accessibility/client/walk-up-from-iframe-content-expected.txt: Added.
* LayoutTests/http/tests/site-isolation/accessibility/client/walk-up-from-iframe-content.html: Added.
* Source/WebKit/WebProcess/WebPage/mac/WebPageMac.mm:
(WebKit::WebPage::registerRemoteFrameAccessibilityTokens):

Canonical link: <a href="https://commits.webkit.org/313754@main">https://commits.webkit.org/313754@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b01fe35c5b5c62101f17ec01e39a4c20c1b5ee0f

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164010 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37494 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30713 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173039 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/281583b4-76ff-498f-b81c-3b70f59caeed) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37827 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37494 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127410 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121261 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2b65161a-c120-4297-a56c-080b68295b37) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166969 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29698 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147442 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107958 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e3a7bdda-dc41-4c72-bcb3-4b670680ef51) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28744 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27370 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20803 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138645 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25159 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175564 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28386 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26827 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135719 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37164 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31482 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135691 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36573 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37949 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146954 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100138 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/30997 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23810 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36758 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109805 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36157 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1857 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36407 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36304 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->