### PR TITLE
Align outerHTML setter with the HTML standard

### DIFF
--- a/LayoutTests/fast/dom/set-outer-html-special-cases-expected.txt
+++ b/LayoutTests/fast/dom/set-outer-html-special-cases-expected.txt
@@ -4,7 +4,7 @@ On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE
 
 
 PASS document.getElementById('svgElement').innerHTML is "<g></g>"
-PASS document.documentElement.outerHTML = '' threw exception NoModificationAllowedError: Cannot set outerHTML on element because its parent is not an Element.
+PASS document.documentElement.outerHTML = '' threw exception NoModificationAllowedError: Cannot set outerHTML on element because its parent is a Document.
 PASS a.parentNode is null
 PASS a.outerHTML = '' did not throw exception.
 PASS successfullyParsed is true

--- a/LayoutTests/fast/dom/set-outer-html-special-cases.html
+++ b/LayoutTests/fast/dom/set-outer-html-special-cases.html
@@ -12,8 +12,7 @@
         // We should throw a NoModificationAllowedError if the parent is a Document.
         shouldThrowErrorName("document.documentElement.outerHTML = ''", "NoModificationAllowedError");
 
-        // We currently throw an exception when the parent is null, as does Blink. Gecko and the specification
-        // say this should be a no-op though.
+        // Setting outerHTML on an element with no parent is a no-op per the specification.
         a = document.createElement("a");
         shouldBe("a.parentNode", "null");
         shouldNotThrow("a.outerHTML = ''");

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/the-outerhtml-property/outerhtml-documentfragment-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/the-outerhtml-property/outerhtml-documentfragment-expected.txt
@@ -1,0 +1,3 @@
+
+PASS outerHTML replaces element within DocumentFragment parent.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/the-outerhtml-property/outerhtml-documentfragment.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/the-outerhtml-property/outerhtml-documentfragment.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<title>outerHTML: child of DocumentFragment</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#the-outerhtml-property">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+test(() => {
+  const fragment = new DocumentFragment();
+  const div = document.createElement("div");
+  div.textContent = "original";
+  fragment.appendChild(div);
+
+  div.outerHTML = "<span>replaced</span>";
+
+  assert_equals(fragment.childNodes.length, 1, "Fragment should have one child");
+  assert_equals(fragment.firstChild.tagName, "SPAN", "Child should be a SPAN");
+  assert_equals(fragment.firstChild.textContent, "replaced", "Content should be 'replaced'");
+}, "outerHTML replaces element within DocumentFragment parent.");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/the-outerhtml-property/outerhtml-no-parent-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/the-outerhtml-property/outerhtml-no-parent-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Setting outerHTML on element with no parent should be a no-op.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/the-outerhtml-property/outerhtml-no-parent.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/the-outerhtml-property/outerhtml-no-parent.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<title>outerHTML: element with no parent</title>
+<link rel="help" href="https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#the-outerhtml-property">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script>
+test(() => {
+  const el = document.createElement("div");
+  el.textContent = "original";
+  el.outerHTML = "<p>replacement</p>";
+  assert_equals(el.tagName, "DIV");
+  assert_equals(el.textContent, "original");
+}, "Setting outerHTML on element with no parent should be a no-op.");
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/the-outerhtml-property/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/the-outerhtml-property/w3c-import.log
@@ -1,0 +1,18 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/the-outerhtml-property/outerhtml-documentfragment.html
+/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/the-outerhtml-property/outerhtml-no-parent.html

--- a/Source/WebCore/dom/Element.cpp
+++ b/Source/WebCore/dom/Element.cpp
@@ -4527,19 +4527,21 @@ ExceptionOr<void> Element::setOuterHTML(Variant<Ref<TrustedHTML>, String>&& html
     if (stringValueHolder.hasException())
         return stringValueHolder.releaseException();
 
-    // The specification allows setting outerHTML on an Element whose parent is a DocumentFragment and Gecko supports this.
-    // https://w3c.github.io/DOM-Parsing/#dom-element-outerhtml
-    RefPtr parent = parentElement();
-    if (!parent) [[unlikely]] {
-        if (!parentNode())
-            return { };
-        return Exception { ExceptionCode::NoModificationAllowedError, "Cannot set outerHTML on element because its parent is not an Element"_s };
-    }
+    // https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#dom-element-outerhtml
+    RefPtr parent = parentNode();
+    if (!parent)
+        return { };
+    if (is<Document>(*parent))
+        return Exception { ExceptionCode::NoModificationAllowedError, "Cannot set outerHTML on element because its parent is a Document"_s };
+
+    RefPtr contextElement = dynamicDowncast<Element>(parent);
+    if (!contextElement)
+        contextElement = HTMLBodyElement::create(document());
 
     RefPtr previous = previousSibling();
     RefPtr next = nextSibling();
 
-    auto fragment = createFragmentForInnerOuterHTML(*parent, stringValueHolder.releaseReturnValue(), { ParserContentPolicy::AllowScriptingContent }, CustomElementRegistry::registryForElement(*parent));
+    auto fragment = createFragmentForInnerOuterHTML(*contextElement, stringValueHolder.releaseReturnValue(), { ParserContentPolicy::AllowScriptingContent }, CustomElementRegistry::registryForElement(*contextElement));
     if (fragment.hasException())
         return fragment.releaseException();
 


### PR DESCRIPTION
#### 8927dd95e82b71c4a0820358d5734bb7bf038ef3
<pre>
Align outerHTML setter with the HTML standard
<a href="https://bugs.webkit.org/show_bug.cgi?id=315359">https://bugs.webkit.org/show_bug.cgi?id=315359</a>

Reviewed by Ryosuke Niwa.

As it happens this also aligns us with Chromium and Gecko.

Tests: imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/the-outerhtml-property/outerhtml-documentfragment.html
       imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/the-outerhtml-property/outerhtml-no-parent.html

Canonical link: <a href="https://commits.webkit.org/313795@main">https://commits.webkit.org/313795@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b089166108db19ceb416fc62de2817eba8ec1bd0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164129 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37613 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30832 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173158 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bd75cf10-98f2-472a-a6b8-268f7472b4b1) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165998 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37947 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37613 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127507 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121381 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/041b0431-7573-4520-90af-58d276602003) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167088 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29796 "Found 1 new test failure: media/track/track-in-band-chapters.html (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147542 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108055 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4cbee393-a9ff-41a5-b71f-1155718ba86b) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28842 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27467 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20922 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138744 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25259 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175684 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28505 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26927 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135818 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37283 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31581 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135788 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36595 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38069 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147054 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100304 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31092 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23910 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36879 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109924 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36276 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1960 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36526 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36426 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->