### PR TITLE
[GPU Process]: Before decoding FEColorMatrix validate the length of the `values` vector

### DIFF
--- a/LayoutTests/ipc/fecolormatrix-type-values-mismatch-crash-expected.txt
+++ b/LayoutTests/ipc/fecolormatrix-type-values-mismatch-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash.

--- a/LayoutTests/ipc/fecolormatrix-type-values-mismatch-crash.html
+++ b/LayoutTests/ipc/fecolormatrix-type-values-mismatch-crash.html
@@ -1,0 +1,123 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<body>
+    <script>
+        window.testRunner?.dumpAsText();
+        window.testRunner?.waitUntilDone();
+
+        window.setTimeout(async () => {
+            if (!window.IPC)
+                return window.testRunner?.notifyDone();
+
+            const { CoreIPC } = await import('./coreipc.js');
+
+            const streamConnection = CoreIPC.newStreamConnection();
+
+            const renderingBackendIdentifier = Math.floor(Math.random() * 0x1000000);
+            CoreIPC.GPU.GPUConnectionToWebProcess.CreateRenderingBackend(0, {
+                renderingBackendIdentifier: renderingBackendIdentifier,
+                connectionHandle: streamConnection
+            });
+            const remoteRenderingBackend = streamConnection.newInterface("RemoteRenderingBackend", renderingBackendIdentifier);
+            const didInitializeReply = streamConnection.connection.waitForMessage(renderingBackendIdentifier, IPC.messages.RemoteRenderingBackendProxy_DidInitialize.name, 1);
+
+            const imageBufferIdentifier = Math.floor(Math.random() * 0x1000000);
+            const contextIdentifier = Math.floor(Math.random() * 0x1000000);
+            remoteRenderingBackend.CreateImageBuffer({
+                logicalSize: {
+                    width: 32,
+                    height: 82
+                },
+                renderingMode: 1,
+                renderingPurpose: 0,
+                resolutionScale: 10,
+                colorSpace: {
+                    serializableColorSpace: {
+                        alias: {
+                            optionalValue: {
+                                m_cgColorSpace: {
+                                    alias: {
+                                        variantType: 'WebCore::ColorSpace',
+                                        variant: 1
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                pixelFormat: 1,
+                bufferFormat: { pixelFormat: 1, useLosslessCompression: 0 },
+                identifier: imageBufferIdentifier,
+                contextIdentifier: contextIdentifier
+            });
+            const remoteImageBuffer = streamConnection.newInterface("RemoteImageBuffer", imageBufferIdentifier);
+
+            const srgbColorSpace = {serializableColorSpace: {alias: {optionalValue: {m_cgColorSpace: {alias: {variantType: 'WebCore::ColorSpace', variant: 1}}}}}};
+
+            try {
+                remoteImageBuffer.FilteredNativeImage({
+                    filter: {
+                        subclasses: {
+                            variantType: 'WebCore::SVGFilterRenderer',
+                            variant: {
+                                primitiveUnits: 0,
+                                expression: {
+                                    alias: [
+                                        {index: 0, level: 0, geometry: {}},
+                                        {index: 1, level: 0, geometry: {}}
+                                    ]
+                                },
+                                effects: [
+                                    {
+                                        subclasses: {
+                                            variantType: 'WebCore::SourceGraphic',
+                                            variant: {
+                                                operatingColorSpace: srgbColorSpace
+                                            }
+                                        }
+                                    },
+                                    {
+                                        subclasses: {
+                                            variantType: 'WebCore::FEColorMatrix',
+                                            variant: {
+                                                type: 2,    // FECOLORMATRIX_TYPE_SATURATE
+                                                values: [], // Empty â€” should have at least 1 value
+                                                operatingColorSpace: srgbColorSpace
+                                            }
+                                        }
+                                    }
+                                ],
+                                geometry: {
+                                    referenceBox: {
+                                        location: {x: 0, y: 0},
+                                        size: {width: 128, height: 128}
+                                    },
+                                    filterRegion: {
+                                        location: {x: 0, y: 0},
+                                        size: {width: 128, height: 128}
+                                    },
+                                    scale: {width: 1, height: 1}
+                                },
+                                filterRenderingModes: 1,
+                                isShowingDebugOverlay: false,
+                                renderingResourceIdentifierIfExists: {}
+                            }
+                        }
+                    }
+                });
+            } catch(err) {
+                if(!(err instanceof TypeError)) {
+                    console.log("Test failed: expected TypeError, got " + err);
+                }
+            }
+
+            streamConnection.connection.invalidate();
+
+            // Allow some time for the GPUP to receive the FilteredNativeImage message, otherwise we can finish
+            // the test before we detect a possible GPUP crash.
+            setTimeout(()=>{
+                window.testRunner?.notifyDone();
+            }, 500);
+        }, 20);
+    </script>
+    <p>This test passes if WebKit does not crash.</p>
+</body>

--- a/Source/WebCore/platform/graphics/filters/FEColorMatrix.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEColorMatrix.cpp
@@ -41,6 +41,7 @@ namespace WebCore {
 
 Ref<FEColorMatrix> FEColorMatrix::create(ColorMatrixType type, Vector<float>&& values, DestinationColorSpace colorSpace)
 {
+    ASSERT(areValuesValidForType(type, values));
     return adoptRef(*new FEColorMatrix(type, WTF::move(values), colorSpace));
 }
 
@@ -77,6 +78,21 @@ bool FEColorMatrix::setValues(const Vector<float>& values)
         return false;
     m_values = values;
     return true;
+}
+
+bool FEColorMatrix::areValuesValidForType(ColorMatrixType type, const Vector<float>& values)
+{
+    switch (type) {
+    case ColorMatrixType::FECOLORMATRIX_TYPE_MATRIX:
+        return values.size() == 20;
+    case ColorMatrixType::FECOLORMATRIX_TYPE_SATURATE:
+    case ColorMatrixType::FECOLORMATRIX_TYPE_HUEROTATE:
+        return values.size() == 1;
+    case ColorMatrixType::FECOLORMATRIX_TYPE_LUMINANCETOALPHA:
+        return true;
+    case ColorMatrixType::FECOLORMATRIX_TYPE_UNKNOWN:
+        return false;
+    }
 }
 
 void FEColorMatrix::calculateSaturateComponents(std::span<float, 9> components, float value)

--- a/Source/WebCore/platform/graphics/filters/FEColorMatrix.h
+++ b/Source/WebCore/platform/graphics/filters/FEColorMatrix.h
@@ -52,6 +52,7 @@ public:
     const Vector<float>& values() const LIFETIME_BOUND { return m_values; }
     bool setValues(const Vector<float>&);
 
+    WEBCORE_EXPORT static bool areValuesValidForType(ColorMatrixType, const Vector<float>& values);
     static void NODELETE calculateSaturateComponents(std::span<float, 9> components, float value);
     static void NODELETE calculateHueRotateComponents(std::span<float, 9> components, float value);
     static Vector<float> normalizedFloats(const Vector<float>& values);

--- a/Source/WebCore/svg/SVGFEColorMatrixElement.cpp
+++ b/Source/WebCore/svg/SVGFEColorMatrixElement.cpp
@@ -51,16 +51,6 @@ Ref<SVGFEColorMatrixElement> SVGFEColorMatrixElement::create(const QualifiedName
     return adoptRef(*new SVGFEColorMatrixElement(tagName, document));
 }
 
-bool SVGFEColorMatrixElement::isInvalidValuesLength() const
-{
-    auto filterType = type();
-    auto size = values().size();
-
-    return (filterType == ColorMatrixType::FECOLORMATRIX_TYPE_MATRIX    && size != 20)
-        || (filterType == ColorMatrixType::FECOLORMATRIX_TYPE_HUEROTATE && size != 1)
-        || (filterType == ColorMatrixType::FECOLORMATRIX_TYPE_SATURATE  && size != 1);
-}
-
 void SVGFEColorMatrixElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     switch (name.nodeName()) {
@@ -107,7 +97,7 @@ void SVGFEColorMatrixElement::svgAttributeChanged(const QualifiedName& attrName)
     case AttributeNames::typeAttr:
     case AttributeNames::valuesAttr: {
         InstanceInvalidationGuard guard(*this);
-        if (isInvalidValuesLength())
+        if (!FEColorMatrix::areValuesValidForType(type(), values()))
             markFilterEffectForRebuild();
         else
             primitiveAttributeChanged(attrName);
@@ -144,11 +134,11 @@ RefPtr<FilterEffect> SVGFEColorMatrixElement::createFilterEffect(const FilterEff
             break;
         }
     } else {
-        if (isInvalidValuesLength())
-            return nullptr;
-
         filterValues = values();
         filterValues.shrinkToFit();
+
+        if (!FEColorMatrix::areValuesValidForType(type(), filterValues))
+            return nullptr;
     }
 
     return FEColorMatrix::create(filterType, WTF::move(filterValues));

--- a/Source/WebCore/svg/SVGFEColorMatrixElement.h
+++ b/Source/WebCore/svg/SVGFEColorMatrixElement.h
@@ -83,8 +83,6 @@ public:
 private:
     SVGFEColorMatrixElement(const QualifiedName&, Document&);
 
-    bool isInvalidValuesLength() const;
-
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -2409,7 +2409,7 @@ header: <WebCore/SwitchPart.h>
 
 [RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::FEColorMatrix {
     WebCore::ColorMatrixType type();
-    Vector<float> values();
+    [Validator='WebCore::FEColorMatrix::areValuesValidForType(*type, *values)'] Vector<float> values();
 
     WebCore::DestinationColorSpace operatingColorSpace();
 };


### PR DESCRIPTION
#### b5b06c0fc266fbe80ac09bd769f0557e0a6fc8f0
<pre>
[GPU Process]: Before decoding FEColorMatrix validate the length of the `values` vector
<a href="https://bugs.webkit.org/show_bug.cgi?id=309868">https://bugs.webkit.org/show_bug.cgi?id=309868</a>
<a href="https://rdar.apple.com/172397794">rdar://172397794</a>

Reviewed by Kimmo Kinnunen.

SVGFEColorMatrixElement checks the length of `values` attribute before creating
the FEColorMatrix. Similarly the IPC should check the length of decoded `values`
before creating the FEColorMatrix. In both cases the `type` attribute should be
used to decide whether the length of `values` is valid or not.

Test: ipc/fecolormatrix-type-values-mismatch-crash.html

* LayoutTests/ipc/fecolormatrix-type-values-mismatch-crash-expected.txt: Added.
* LayoutTests/ipc/fecolormatrix-type-values-mismatch-crash.html: Added.
* Source/WebCore/platform/graphics/filters/FEColorMatrix.cpp:
(WebCore::FEColorMatrix::create):
(WebCore::FEColorMatrix::areValuesValidForType):
* Source/WebCore/platform/graphics/filters/FEColorMatrix.h:
* Source/WebCore/svg/SVGFEColorMatrixElement.cpp:
(WebCore::SVGFEColorMatrixElement::svgAttributeChanged):
(WebCore::SVGFEColorMatrixElement::createFilterEffect const):
(WebCore::SVGFEColorMatrixElement::isInvalidValuesLength const): Deleted.
* Source/WebCore/svg/SVGFEColorMatrixElement.h:
* Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

Originally-landed-as: 305413.505@rapid/safari-7624.2.5.110-branch (ec665bbbbe8b). <a href="https://rdar.apple.com/176062410">rdar://176062410</a>
Canonical link: <a href="https://commits.webkit.org/315306@main">https://commits.webkit.org/315306@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/aebeb477e3a4f1ef032a65ba1e84903257d722b8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168223 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41779 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35618 "") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177551 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125924 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170089 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42155 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41736 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130908 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92019 "1 flakes 4 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171182 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33374 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151178 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111420 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32360 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31064 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26247 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142346 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30582 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180151 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32874 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35223 "Found 2 new test failures: fast/speechsynthesis/speech-synthesis-speak.html ipc/fecolormatrix-type-values-mismatch-crash.html (failure)") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139346 "Found 1 new test failure: ipc/fecolormatrix-type-values-mismatch-crash.html (failure)") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41792 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150654 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139209 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37587 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42480 "Built successfully") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27546 "Unexpected infrastructure issue, retrying build") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/105854 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34493 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114240 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40984 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5637 "") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40381 "Built successfully") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40632 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40526 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->