### PR TITLE
Race condition in JSXPathResult::visitAdditionalChildren during GC

### DIFF
--- a/Source/WebCore/bindings/js/JSXPathResultCustom.cpp
+++ b/Source/WebCore/bindings/js/JSXPathResultCustom.cpp
@@ -27,21 +27,12 @@
 #include "config.h"
 #include "JSXPathResult.h"
 
-#include "JSNodeCustom.h"
-#include "WebCoreOpaqueRootInlines.h"
-#include "XPathValue.h"
-
 namespace WebCore {
 
 template<typename Visitor>
 void JSXPathResult::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
-    auto& value = wrapped().value();
-    if (value.isNodeSet()) {
-        // FIXME: This looks like it might race, but I'm not sure.
-        for (auto& node : value.toNodeSet())
-            addWebCoreOpaqueRoot(visitor, node.get());
-    }
+    wrapped().visitAdditionalChildrenInGCThread(visitor);
 }
 
 DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSXPathResult);

--- a/Source/WebCore/xml/XPathResult.cpp
+++ b/Source/WebCore/xml/XPathResult.cpp
@@ -29,7 +29,10 @@
 
 #include "Document.h"
 #include "ExceptionOr.h"
+#include "WebCoreOpaqueRootInlines.h"
 #include "XPathEvaluator.h"
+#include <JavaScriptCore/SlotVisitorMacros.h>
+#include <wtf/Locker.h>
 
 namespace WebCore {
 
@@ -49,14 +52,31 @@ XPathResult::XPathResult(Document& document, const XPath::Value& value)
         [&](const XPath::NodeSet& nodeSet) {
             m_resultType = UNORDERED_NODE_ITERATOR_TYPE;
             m_nodeSetPosition = 0;
-            m_nodeSet = nodeSet;
+            {
+                Locker locker { m_nodeSetLock };
+                m_nodeSet = nodeSet;
+            }
             m_document = document;
             m_domTreeVersion = document.domTreeVersion();
         }
     );
 }
 
-XPathResult::~XPathResult() = default;
+XPathResult::~XPathResult()
+{
+#if ASSERT_ENABLED
+    if (!m_value.isNodeSet())
+        return;
+
+    auto& valueNodeSet = m_value.toNodeSet();
+    ASSERT(valueNodeSet.size() == m_nodeSet.size());
+    HashSet<const Node*> set;
+    for (auto& node : m_nodeSet)
+        set.add(node.ptr());
+    for (auto& node : valueNodeSet)
+        ASSERT(set.contains(node.ptr()));
+#endif
+}
 
 ExceptionOr<void> XPathResult::convertTo(unsigned short type)
 {
@@ -86,7 +106,10 @@ ExceptionOr<void> XPathResult::convertTo(unsigned short type)
     case ORDERED_NODE_ITERATOR_TYPE:
         if (!m_value.isNodeSet())
             return Exception { ExceptionCode::TypeError };
-        m_nodeSet.sort();
+        {
+            Locker locker { m_nodeSetLock };
+            m_nodeSet.sort();
+        }
         m_resultType = type;
         break;
     case ORDERED_NODE_SNAPSHOT_TYPE:
@@ -162,6 +185,7 @@ ExceptionOr<Node*> XPathResult::iterateNext()
     if (invalidIteratorState())
         return Exception { ExceptionCode::InvalidStateError };
 
+    Locker locker { m_nodeSetLock };
     if (m_nodeSetPosition >= m_nodeSet.size())
         return nullptr;
 
@@ -179,5 +203,15 @@ ExceptionOr<Node*> XPathResult::snapshotItem(unsigned index)
 
     return nodes[index];
 }
+
+template<typename Visitor>
+void XPathResult::visitAdditionalChildrenInGCThread(Visitor& visitor)
+{
+    Locker locker { m_nodeSetLock };
+    for (auto& node : m_nodeSet)
+        addWebCoreOpaqueRoot(visitor, node.get());
+}
+
+DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(XPathResult);
 
 } // namespace WebCore

--- a/Source/WebCore/xml/XPathResult.h
+++ b/Source/WebCore/xml/XPathResult.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <WebCore/XPathValue.h>
+#include <wtf/Lock.h>
 
 namespace WebCore {
 
@@ -66,12 +67,16 @@ public:
 
     const XPath::Value& value() const LIFETIME_BOUND { return m_value; }
 
+    template<typename Visitor>
+    void visitAdditionalChildrenInGCThread(Visitor&);
+
 private:
     XPathResult(Document&, const XPath::Value&);
 
     XPath::Value m_value;
     unsigned m_nodeSetPosition { 0 };
-    XPath::NodeSet m_nodeSet; // FIXME: why duplicate the node set stored in m_value?
+    Lock m_nodeSetLock;
+    XPath::NodeSet m_nodeSet WTF_GUARDED_BY_LOCK(m_nodeSetLock);
     unsigned short m_resultType;
     RefPtr<Document> m_document;
     uint64_t m_domTreeVersion { 0 };


### PR DESCRIPTION
#### e8db86ea1203dcc4109eece64cfe0434d21cf13a
<pre>
Race condition in JSXPathResult::visitAdditionalChildren during GC
<a href="https://bugs.webkit.org/show_bug.cgi?id=309776">https://bugs.webkit.org/show_bug.cgi?id=309776</a>
&lt;<a href="https://rdar.apple.com/172263146">rdar://172263146</a>&gt;

Reviewed by Chris Dumez.

This PR fixes a race condition in JSXPathResult::visitAdditionalChildren
which results in a use-after-free. The issue is that this function
iterates over XPathNodeList&apos;s internal vector but XPathNodeList&apos;s member
functions such as XPathNodeList::firstNode could mutate the vector via
XPathNodeList::sort, letting a GC thread to do a use-after-free.

Fixed the bug by guarding the access to m_nodeSet with a lock.

No new tests since there is no reliable reproduction.

* Source/WebCore/bindings/js/JSXPathResultCustom.cpp:
(WebCore::JSXPathResult::visitAdditionalChildren):
* Source/WebCore/xml/XPathResult.cpp:
(WebCore::XPathResult::XPathResult):
(WebCore::XPathResult::~XPathResult):
(WebCore::XPathResult::convertTo):
(WebCore::XPathResult::visitAdditionalChildren):
* Source/WebCore/xml/XPathResult.h:

Originally-landed-as: 305413.475@rapid/safari-7624.2.5.110-branch (97ed68c66545). <a href="https://rdar.apple.com/176062693">rdar://176062693</a>
Canonical link: <a href="https://commits.webkit.org/313820@main">https://commits.webkit.org/313820@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8ea58ce7dd8a720c29182a89c7aa6830cfd6e263

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164259 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37743 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31307 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Running apply-patch; Checked out pull request; Compiled WebKit (warnings); Compiled WebKit (warnings)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173288 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121511 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166128 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38077 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37743 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127609 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89793 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167218 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29907 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147635 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108156 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28954 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27578 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21052 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138856 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25352 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175814 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28635 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27020 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135921 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37413 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31694 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135891 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38199 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147147 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100528 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25004 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31204 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24003 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37009 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110054 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36406 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2058 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36656 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36556 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->