### PR TITLE
Content extensions should block plugin loads from embed and object elements

### DIFF
--- a/LayoutTests/http/tests/contentextensions/block-embed-element-expected.txt
+++ b/LayoutTests/http/tests/contentextensions/block-embed-element-expected.txt
@@ -1,0 +1,3 @@
+CONSOLE MESSAGE: Content blocker prevented frame displaying http://127.0.0.1:8000/contentextensions/block-embed-element.html from loading a resource from http://127.0.0.1:8000/contentextensions/resources/should-load.html?should-be-blocked
+CONSOLE MESSAGE: Content blocker prevented frame displaying http://127.0.0.1:8000/contentextensions/block-embed-element.html from loading a resource from http://127.0.0.1:8000/media/resources/test.pdf?should-be-blocked
+

--- a/LayoutTests/http/tests/contentextensions/block-embed-element.html
+++ b/LayoutTests/http/tests/contentextensions/block-embed-element.html
@@ -1,0 +1,5 @@
+<script>testRunner?.dumpAsText();</script>
+<body>
+<embed src="http://127.0.0.1:8000/contentextensions/resources/should-load.html?should-be-blocked" type="text/html" width="100" height="100"></embed>
+<embed src="http://127.0.0.1:8000/media/resources/test.pdf?should-be-blocked" type="application/pdf" width="100" height="100"></embed>
+</body>

--- a/LayoutTests/http/tests/contentextensions/block-embed-element.json
+++ b/LayoutTests/http/tests/contentextensions/block-embed-element.json
@@ -1,0 +1,10 @@
+[
+    {
+        "action": {
+            "type": "block"
+        },
+        "trigger": {
+            "url-filter": ".*should-be-blocked"
+        }
+    }
+]

--- a/LayoutTests/http/tests/contentextensions/block-object-element-expected.txt
+++ b/LayoutTests/http/tests/contentextensions/block-object-element-expected.txt
@@ -1,0 +1,3 @@
+CONSOLE MESSAGE: Content blocker prevented frame displaying http://127.0.0.1:8000/contentextensions/block-object-element.html from loading a resource from http://127.0.0.1:8000/contentextensions/resources/should-load.html?should-be-blocked
+CONSOLE MESSAGE: Content blocker prevented frame displaying http://127.0.0.1:8000/contentextensions/block-object-element.html from loading a resource from http://127.0.0.1:8000/media/resources/test.pdf?should-be-blocked
+

--- a/LayoutTests/http/tests/contentextensions/block-object-element.html
+++ b/LayoutTests/http/tests/contentextensions/block-object-element.html
@@ -1,0 +1,5 @@
+<script>testRunner?.dumpAsText();</script>
+<body>
+<object data="http://127.0.0.1:8000/contentextensions/resources/should-load.html?should-be-blocked" type="text/html" width="100" height="100"></object>
+<object data="http://127.0.0.1:8000/media/resources/test.pdf?should-be-blocked" type="application/pdf" width="100" height="100"></object>
+</body>

--- a/LayoutTests/http/tests/contentextensions/block-object-element.json
+++ b/LayoutTests/http/tests/contentextensions/block-object-element.json
@@ -1,0 +1,10 @@
+[
+    {
+        "action": {
+            "type": "block"
+        },
+        "trigger": {
+            "url-filter": ".*should-be-blocked"
+        }
+    }
+]

--- a/Source/WebCore/html/HTMLPlugInElement.cpp
+++ b/Source/WebCore/html/HTMLPlugInElement.cpp
@@ -86,6 +86,12 @@
 #include <JavaScriptCore/TopExceptionScope.h>
 #include <wtf/TZoneMallocInlines.h>
 
+#if ENABLE(CONTENT_EXTENSIONS)
+#include "ContentExtensionsBackend.h"
+#include "ResourceLoadInfo.h"
+#include "UserContentProvider.h"
+#endif
+
 #if PLATFORM(COCOA)
 #include "YouTubePluginReplacement.h"
 #endif
@@ -546,6 +552,20 @@ bool HTMLPlugInElement::canLoadURL(const URL& completeURL) const
         if (contentDocument && !protect(protect(document())->securityOrigin())->isSameOriginDomain(protect(contentDocument->securityOrigin()).get()))
             return false;
     }
+
+#if ENABLE(CONTENT_EXTENSIONS)
+    if (completeURL.isValid()) {
+        RefPtr page = document().page();
+        RefPtr frame = document().frame();
+        RefPtr documentLoader = frame ? frame->loader().documentLoader() : nullptr;
+        RefPtr userContentProvider = frame ? frame->userContentProvider() : nullptr;
+        if (page && documentLoader && userContentProvider) {
+            auto results = userContentProvider->processContentRuleListsForLoad(*page, completeURL, ContentExtensions::ResourceType::Other, *documentLoader);
+            if (results.shouldBlock())
+                return false;
+        }
+    }
+#endif
 
     return !isProhibitedSelfReference(completeURL);
 }


### PR DESCRIPTION
#### 7d28e39dfc1ff46bdf98b4fa898384e4a5051345
<pre>
Content extensions should block plugin loads from embed and object elements
<a href="https://bugs.webkit.org/show_bug.cgi?id=309880">https://bugs.webkit.org/show_bug.cgi?id=309880</a>
<a href="https://rdar.apple.com/169290430">rdar://169290430</a>

Reviewed by Anne van Kesteren.

Plugin content loaded via &lt;embed&gt; and &lt;object&gt; elements was not checked against content extension
rules. Add a content extension check in HTMLPlugInElement::canLoadURL so that blocked URLs are
rejected before the wouldLoadAsPlugIn deferral in updateWidget.

Tests: http/tests/contentextensions/block-embed-element.html
       http/tests/contentextensions/block-object-element.html

* LayoutTests/http/tests/contentextensions/block-embed-element-expected.txt: Added.
* LayoutTests/http/tests/contentextensions/block-embed-element.html: Added.
* LayoutTests/http/tests/contentextensions/block-embed-element.json: Added.
* LayoutTests/http/tests/contentextensions/block-object-element-expected.txt: Added.
* LayoutTests/http/tests/contentextensions/block-object-element.html: Added.
* LayoutTests/http/tests/contentextensions/block-object-element.json: Added.
* Source/WebCore/html/HTMLPlugInElement.cpp:
(WebCore::HTMLPlugInElement::canLoadURL const):

Originally-landed-as: 305413.470@rapid/safari-7624.2.5.110-branch (f896e1bfd583). <a href="https://rdar.apple.com/176062570">rdar://176062570</a>
Canonical link: <a href="https://commits.webkit.org/313757@main">https://commits.webkit.org/313757@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a42f0cd4ce270da38729ca39114dff09e8e28cd3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164020 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37504 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30723 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173049 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165889 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37837 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37504 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127418 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121271 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166979 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29704 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147452 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107966 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28750 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27377 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20813 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138651 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25169 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175574 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28396 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26837 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135727 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37174 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31489 "Found 1 new test failure: http/tests/storageAccess/deny-due-to-no-interaction-under-general-third-party-cookie-blocking-ephemeral.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135699 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36575 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37959 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146964 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100148 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31006 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23820 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36768 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109815 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36167 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1867 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36417 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36314 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->