### PR TITLE
didSameDocumentNavigationForFrame accepts arbitrary URL, enabling address bar spoofing

### DIFF
--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -8683,6 +8683,7 @@ void WebPageProxy::didSameDocumentNavigationForFrameViaJS(IPC::Connection& conne
 
     Ref process = WebProcessProxy::fromConnection(connection);
     MESSAGE_CHECK_URL(process, url);
+    MESSAGE_CHECK(process, url.protocolIsFile() || frame->url().isEmpty() || protocolHostAndPortAreEqual(url, frame->url()));
 
     WEBPAGEPROXY_RELEASE_LOG(Loading, "didSameDocumentNavigationForFrameViaJS: frameID=%" PRIu64 ", isMainFrame=%d, type=%u", frameID.toUInt64(), frame->isMainFrame(), std::to_underlying(navigationType));
 


### PR DESCRIPTION
#### 23b15df9ebc00659c80da09bf7e7297a60f6a479
<pre>
didSameDocumentNavigationForFrame accepts arbitrary URL, enabling address bar spoofing
<a href="https://bugs.webkit.org/show_bug.cgi?id=310073">https://bugs.webkit.org/show_bug.cgi?id=310073</a>
<a href="https://rdar.apple.com/172567659">rdar://172567659</a>

Reviewed by Ryosuke Niwa.

Add a MESSAGE_CHECK to validate that the URL&apos;s protocol/host/port match
the current frame&apos;s URL.

* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::didSameDocumentNavigationForFrameViaJS):

Originally-landed-as: 305413.512@rapid/safari-7624.2.5.110-branch (d1551df53d97). <a href="https://rdar.apple.com/176062692">rdar://176062692</a>
Canonical link: <a href="https://commits.webkit.org/313796@main">https://commits.webkit.org/313796@main</a>
</pre>
