### PR TITLE
Unreviewed, reverting 313672@main (371f7ad0ed89)

### DIFF
--- a/Source/JavaScriptCore/jit/JITWorklistThread.cpp
+++ b/Source/JavaScriptCore/jit/JITWorklistThread.cpp
@@ -33,11 +33,6 @@
 #include "VM.h"
 #include <wtf/TZoneMallocInlines.h>
 
-#if HAVE(QOS_CLASSES)
-#include <wtf/NumberOfCores.h>
-#include <wtf/Threading.h>
-#endif
-
 namespace JSC {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(JITWorklistThread);
@@ -179,15 +174,6 @@ void JITWorklistThread::threadDidStart()
 {
     dataLogLnIf(Options::verboseCompilationQueue(), m_worklist, ": Thread started");
 
-#if HAVE(QOS_CLASSES)
-#if CPU(ARM64)
-    bool isSmall = WTF::numberOfPerformanceProcessorCores() <= static_cast<int>(Options::smallDeviceMaxPerformanceCores());
-#else
-    bool isSmall = WTF::numberOfProcessorCores() <= static_cast<int>(Options::smallDeviceMaxLogicalCores());
-#endif
-    if (isSmall)
-        Thread::setCurrentThreadIsUtility();
-#endif
 }
 
 void JITWorklistThread::threadIsStopping(const AbstractLocker&)

--- a/Source/JavaScriptCore/runtime/OptionsList.h
+++ b/Source/JavaScriptCore/runtime/OptionsList.h
@@ -299,8 +299,6 @@ bool hasCapacityToUseLargeGigacage();
     v(Int32, priorityDeltaOfDFGCompilerThreads, computePriorityDeltaOfWorkerThreads(-1, 0), Normal, nullptr) \
     v(Int32, priorityDeltaOfFTLCompilerThreads, computePriorityDeltaOfWorkerThreads(-2, 0), Normal, nullptr) \
     v(Int32, priorityDeltaOfWasmCompilerThreads, computePriorityDeltaOfWorkerThreads(-1, 0), Normal, nullptr) \
-    v(Unsigned, smallDeviceMaxPerformanceCores, 2, Normal, nullptr) \
-    v(Unsigned, smallDeviceMaxLogicalCores, 6, Normal, nullptr) \
     \
     v(Bool, useProfiler, false, Normal, nullptr) \
     v(Bool, dumpProfilerDataAtExit, false, Normal, nullptr) \

--- a/Source/WTF/wtf/NumberOfCores.cpp
+++ b/Source/WTF/wtf/NumberOfCores.cpp
@@ -104,20 +104,4 @@ int numberOfPhysicalProcessorCores()
 }
 #endif
 
-#if CPU(ARM64) && OS(DARWIN)
-int numberOfPerformanceProcessorCores()
-{
-    static int s_pcores = 0;
-    if (s_pcores > 0)
-        return s_pcores;
-
-    int32_t count = 0;
-    size_t valueSize = sizeof(count);
-    int result = sysctlbyname("hw.perflevel0.physicalcpu", &count, &valueSize, nullptr, 0);
-    RELEASE_ASSERT(result >= 0 && count > 0);
-    s_pcores = count;
-    return s_pcores;
-}
-#endif
-
 }

--- a/Source/WTF/wtf/NumberOfCores.h
+++ b/Source/WTF/wtf/NumberOfCores.h
@@ -32,10 +32,4 @@ WTF_EXPORT_PRIVATE int numberOfProcessorCores();
 WTF_EXPORT_PRIVATE int numberOfPhysicalProcessorCores();
 #endif
 
-#if CPU(ARM64) && OS(DARWIN)
-// Returns the number of performance ("P") cores on Apple silicon, queried via
-// the "hw.perflevel0.physicalcpu" sysctl.
-WTF_EXPORT_PRIVATE int numberOfPerformanceProcessorCores();
-#endif
-
 }

--- a/Source/WTF/wtf/Threading.cpp
+++ b/Source/WTF/wtf/Threading.cpp
@@ -393,17 +393,6 @@ void Thread::setCurrentThreadIsUserInitiated(int relativePriority)
 #endif
 }
 
-void Thread::setCurrentThreadIsUtility(int relativePriority)
-{
-#if HAVE(QOS_CLASSES)
-    ASSERT(relativePriority <= 0);
-    ASSERT(relativePriority >= QOS_MIN_RELATIVE_PRIORITY);
-    pthread_set_qos_class_self_np(adjustedQOSClass(QOS_CLASS_UTILITY), relativePriority);
-#else
-    UNUSED_PARAM(relativePriority);
-#endif
-}
-
 #if HAVE(QOS_CLASSES)
 static Thread::QOS NODELETE toQOS(qos_class_t qosClass)
 {

--- a/Source/WTF/wtf/Threading.h
+++ b/Source/WTF/wtf/Threading.h
@@ -199,7 +199,6 @@ public:
     // relativePriority is a value in the range [-15, 0] where a lower value indicates a lower priority.
     WTF_EXPORT_PRIVATE static void setCurrentThreadIsUserInteractive(int relativePriority = 0);
     WTF_EXPORT_PRIVATE static void setCurrentThreadIsUserInitiated(int relativePriority = 0);
-    WTF_EXPORT_PRIVATE static void setCurrentThreadIsUtility(int relativePriority = 0);
     WTF_EXPORT_PRIVATE static QOS currentThreadQOS();
     WTF_EXPORT_PRIVATE static bool currentThreadIsRealtime();
     bool isRealtime() const { return m_isRealtime; }


### PR DESCRIPTION
#### facb03402d4a5e9be3cf8887b99e446a17c43e2f
<pre>
Unreviewed, reverting 313672@main (371f7ad0ed89)
<a href="https://bugs.webkit.org/show_bug.cgi?id=315366">https://bugs.webkit.org/show_bug.cgi?id=315366</a>
<a href="https://rdar.apple.com/177719169">rdar://177719169</a>

Revert QOS_UTILITY for JIT threads

Reverted change:

    Give JIT helper threads QOS_UTILITY on less powerful devices
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315203">https://bugs.webkit.org/show_bug.cgi?id=315203</a>
    <a href="https://rdar.apple.com/177532305">rdar://177532305</a>
    313672@main (371f7ad0ed89)

Canonical link: <a href="https://commits.webkit.org/313748@main">https://commits.webkit.org/313748@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fbc33dd43585ed80b1260a6b51cdec015b932644

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164028 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37512 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30731 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173057 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37845 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37512 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/127427 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121279 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/166987 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29713 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147458 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107975 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28759 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27385 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20821 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/156179 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138660 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25175 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175582 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/24920 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28404 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26843 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/135744 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37182 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31497 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135707 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36567 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37967 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146970 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100159 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31016 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23826 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/196431 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36776 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109823 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/51351 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36175 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1873 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36425 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36322 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->