### PR TITLE
Dots for photo galleries on lemonde.fr repaint incorrectly with zoom

### DIFF
--- a/LayoutTests/css3/blending/repaint/blend-mode-isolate-stacking-context-expected.txt
+++ b/LayoutTests/css3/blending/repaint/blend-mode-isolate-stacking-context-expected.txt
@@ -11,6 +11,7 @@ Test if switching the property that causes the parent to create a stacking conte
 Test if unsetting a parent's stacking context correctly updates its parent isolation.
 
 (repaint rects
+  (rect 48 54 60 60)
   (rect 48 172 60 60)
   (rect 48 172 60 60)
   (rect 28 290 60 60)

--- a/LayoutTests/fast/repaint/repaint-on-layer-creation-from-transition-expected.txt
+++ b/LayoutTests/fast/repaint/repaint-on-layer-creation-from-transition-expected.txt
@@ -1,0 +1,29 @@
+PASS successfullyParsed is true
+
+TEST COMPLETE
+(repaint rects
+  (rect 78 70 300 300)
+)
+(GraphicsLayer
+  (anchor 0.00 0.00)
+  (bounds 800.00 600.00)
+  (children 1
+    (GraphicsLayer
+      (bounds 800.00 600.00)
+      (contentsOpaque 1)
+      (children 1
+        (GraphicsLayer
+          (position 58.00 50.00)
+          (bounds 340.00 340.00)
+          (drawsContent 1)
+          (repaint rects
+            (rect 20.00 20.00 300.00 300.00)
+            (rect 20.00 20.00 150.00 150.00)
+            (rect 20.00 20.00 150.00 150.00)
+          )
+        )
+      )
+    )
+  )
+)
+

--- a/LayoutTests/fast/repaint/repaint-on-layer-creation-from-transition.html
+++ b/LayoutTests/fast/repaint/repaint-on-layer-creation-from-transition.html
@@ -1,0 +1,60 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style>
+    .container {
+        will-change: transform;
+        background-color: #222;
+        border-radius: 5px;
+        height: 300px;
+        margin: 50px;
+        width: 300px;
+        padding: 20px;
+    }
+
+    .inner {
+        background: white;
+        border-radius: 50%;
+        height: 100%;
+        width: 100%;
+        opacity: 1;
+        transition: opacity 50ms linear;
+    }
+
+    body.changed .inner {
+        height: 50%;
+        width: 50%;
+        opacity: 0.5;
+    }
+</style>
+<script src="../../resources/ui-helper.js"></script>
+<script src="../../resources/js-test.js"></script>
+<script>
+
+jsTestIsAsync = true;
+
+window.addEventListener('load', async () => {
+    await UIHelper.renderingUpdate();
+    window.internals?.startTrackingRepaints();
+
+    const inner = document.querySelector('.inner');
+    const transitionEnded = new Promise(resolve => inner.addEventListener("transitionend", resolve, { once: true }));
+    document.body.classList.add("changed");
+    await transitionEnded;
+
+    document.getElementById('layers').innerText = window.internals.layerTreeAsText(document, internals.LAYER_TREE_INCLUDES_REPAINT_RECTS);
+
+    window.internals?.stopTrackingRepaints();
+    finishJSTest();
+}, false);
+
+</script>
+</head>
+<body>
+    <div class="container">
+        <div class="inner"></div>
+    </div>
+<div id="console"></div>
+<pre id="layers"></pre>
+</body>
+</html>

--- a/LayoutTests/platform/ios/css3/blending/repaint/blend-mode-isolate-stacking-context-expected.txt
+++ b/LayoutTests/platform/ios/css3/blending/repaint/blend-mode-isolate-stacking-context-expected.txt
@@ -11,6 +11,7 @@ Test if switching the property that causes the parent to create a stacking conte
 Test if unsetting a parent's stacking context correctly updates its parent isolation.
 
 (repaint rects
+  (rect 48 56 60 60)
   (rect 48 176 60 60)
   (rect 48 176 60 60)
   (rect 28 296 60 60)

--- a/Source/WebCore/rendering/RenderElement.cpp
+++ b/Source/WebCore/rendering/RenderElement.cpp
@@ -505,13 +505,7 @@ bool RenderElement::repaintBeforeStyleChange(Style::Difference diff, const Rende
         if (auto* modelObject = dynamicDowncast<RenderLayerModelObject>(*this)) {
             // If we don't have a layer yet, but we are going to get one because of transform or opacity, then we need to repaint the old position of the object.
             bool hasLayer = modelObject->hasLayer();
-            bool willHaveLayer = newStyle.affectsTransform()
-                || !newStyle.opacity().isOpaque()
-#if HAVE(CORE_MATERIAL)
-                || newStyle.appleVisualEffect() != AppleVisualEffect::None
-#endif
-                || !newStyle.filter().isNone()
-                || !newStyle.backdropFilter().isNone();
+            bool willHaveLayer = !newStyle.usedZIndex().isAuto();
             if (!hasLayer && willHaveLayer)
                 return RequiredRepaint::RendererOnly;
         }

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -4021,7 +4021,7 @@ void RenderLayerBacking::setContentsNeedDisplay(GraphicsLayer::ShouldClipToLayer
 void RenderLayerBacking::setContentsNeedDisplayInRect(const LayoutRect& r, GraphicsLayer::ShouldClipToLayer shouldClip)
 {
     ASSERT(!paintsIntoCompositedAncestor());
-    
+
     // Use the repaint as a trigger to re-evaluate direct compositing (which is never used on the root layer).
     if (!m_owningLayer.isRenderViewLayer())
         m_owningLayer.setNeedsCompositingConfigurationUpdate();

--- a/Source/WebCore/rendering/RenderLayerCompositor.cpp
+++ b/Source/WebCore/rendering/RenderLayerCompositor.cpp
@@ -3817,8 +3817,7 @@ bool RenderLayerCompositor::requiresCompositingForAnimation(RenderLayerModelObje
         if (styleable->hasRunningAcceleratedAnimations())
             return true;
         if (auto* effectsStack = styleable->keyframeEffectStack()) {
-            return (effectsStack->isCurrentlyAffectingProperty(CSSPropertyOpacity)
-                && (usesCompositing() || (m_compositingTriggers & ChromeClient::AnimatedOpacityTrigger)))
+            return (effectsStack->isCurrentlyAffectingProperty(CSSPropertyOpacity) && (usesCompositing() || (m_compositingTriggers & ChromeClient::AnimatedOpacityTrigger)))
                 || effectsStack->isCurrentlyAffectingProperty(CSSPropertyFilter)
                 || effectsStack->isCurrentlyAffectingProperty(CSSPropertyBackdropFilter)
                 || effectsStack->isCurrentlyAffectingProperty(CSSPropertyWebkitBackdropFilter)


### PR DESCRIPTION
#### 5885f16b5d2d0c379977942d53870104406e488f
<pre>
Dots for photo galleries on lemonde.fr repaint incorrectly with zoom
<a href="https://bugs.webkit.org/show_bug.cgi?id=315370">https://bugs.webkit.org/show_bug.cgi?id=315370</a>
<a href="https://rdar.apple.com/176665892">rdar://176665892</a>

Reviewed by Alan Baradlay.

The content in question triggered an opacity animation from opacity 1, with a simultaneous
size change, so the renderer changed from having no RenderLayer to having a layer by
virtue of an opacity transition.

The &quot;gaining a layer&quot; repaint branch in `RenderElement::repaintBeforeStyleChange()`
failed to do a repaint in this case, because it didn&apos;t take into account the fact
that animated opacity will create a layer. Fix by simply checking for non-auto
used z-index, because StyleAdjuster has already set this based on all the properties
that might create layers, including filters, backdrop-filter and animations.

Zoom isn&apos;t specifically a requirement for the bug, but triggered it in some scenarios;
likewise with the border-radius that&apos;s needed in the test case. I also verified that
the fix also works when compositing for opacity animations is disabled.

Test: fast/repaint/repaint-on-layer-creation-from-transition.html

* LayoutTests/css3/blending/repaint/blend-mode-isolate-stacking-context-expected.txt:
* LayoutTests/fast/repaint/repaint-on-layer-creation-from-transition-expected.txt: Added.
* LayoutTests/fast/repaint/repaint-on-layer-creation-from-transition.html: Added.
* LayoutTests/platform/ios/css3/blending/repaint/blend-mode-isolate-stacking-context-expected.txt:
* Source/WebCore/rendering/RenderElement.cpp:
(WebCore::RenderElement::repaintBeforeStyleChange):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::setContentsNeedDisplayInRect): Just whitespace
* Source/WebCore/rendering/RenderLayerCompositor.cpp:
(WebCore::RenderLayerCompositor::requiresCompositingForAnimation const): Just formatting

Canonical link: <a href="https://commits.webkit.org/314039@main">https://commits.webkit.org/314039@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/295d67a642c0710f33cdbc08f758a455ca488c63

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164746 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38230 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31801 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173781 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121998 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/a3d170a6-4a29-4cb8-9e77-b06ebdda3701) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166615 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38564 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38232 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128032 "Passed tests") | [⏳ 🧪 win-tests](https://ews-build.webkit.org/#/builders/Win-Tests-EWS "Waiting to run tests") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/66aba24a-7df7-4310-85de-d76c05906360) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167705 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30334 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148073 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108578 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/541ab7ab-ee10-4acb-aca2-138496e60ae5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29380 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28005 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21540 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139284 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25789 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176304 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29129 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27458 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136351 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38299 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32129 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136314 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36767 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38989 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147584 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101194 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31586 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24440 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37497 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110542 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36895 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2506 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37143 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37043 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->