### PR TITLE
Add runtime toggle for appearance defaults

### DIFF
--- a/Source/WebCore/platform/graphics/cg/UTIRegistry.mm
+++ b/Source/WebCore/platform/graphics/cg/UTIRegistry.mm
@@ -197,6 +197,7 @@ static Vector<String> allowableDefaultSupportedImageTypes()
     allowableDefaultSupportedImageTypes.append("public.radiance"_s);
     allowableDefaultSupportedImageTypes.append("com.ilm.openexr-image"_s);
     allowableDefaultSupportedImageTypes.append("com.truevision.tga-image"_s);
+    allowableDefaultSupportedImageTypes.append("org.khronos.ktx"_s);
     return allowableDefaultSupportedImageTypes;
 }
 

--- a/Source/WebCore/rendering/RenderLayerBacking.cpp
+++ b/Source/WebCore/rendering/RenderLayerBacking.cpp
@@ -1341,9 +1341,18 @@ bool RenderLayerBacking::updateConfiguration(const RenderLayer* compositingAnces
     }
 #if ENABLE(MODEL_ELEMENT)
     else if (is<RenderModel>(renderer())) {
+        auto modelBackgroundColor = rendererBackgroundColor();
+#if ENABLE(GPU_PROCESS_MODEL)
+        // Model expects opaque colors but if dynamic-range-limit: standard is used, we don't make the IOSurface
+        // of the model opaque, rather we make it transparent and composite it with the user's chosen background
+        // color. Otherwise during tonemapping to standard dynamic range the background becomes too dark.
+        // Set the graphics layer's background color as a fallback for the transparent IOSurface case.
+        modelBackgroundColor = modelBackgroundColor.isValid() ? modelBackgroundColor.opaqueColor() : Color::black;
+        m_graphicsLayer->setBackgroundColor(modelBackgroundColor);
+#endif
         RefPtr element = downcast<HTMLModelElement>(renderer().element());
 
-        element->configureGraphicsLayer(*m_graphicsLayer, rendererBackgroundColor());
+        element->configureGraphicsLayer(*m_graphicsLayer, modelBackgroundColor);
         element->sizeMayHaveChanged();
 
         layerConfigChanged = true;

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift
@@ -48,7 +48,113 @@ final class Renderer {
     private var effectiveCameraDistance: Float = Renderer.cameraDistance
     private var fovY: Float = 60 * .pi / 180
     private var clearColor: MTLClearColor = .init(red: 1, green: 1, blue: 1, alpha: 1)
+    var tonemapEnabled: Bool = false
+    var rasterSampleCount: Int = 1
     let memoryOwner: task_id_token_t
+
+    private struct ColorAdjustTilePipelineKey: Hashable {
+        let pixelFormat: MTLPixelFormat
+        let rasterSampleCount: Int
+    }
+
+    private var colorAdjustTilePipelineStates: [ColorAdjustTilePipelineKey: any MTLRenderPipelineState] = [:]
+
+    private static let colorAdjustTileShaderSource = """
+        #include <metal_stdlib>
+        using namespace metal;
+
+        // Mirrors RealityCoreRenderer's TonemapParameters / kDefaultTonemapParams
+        // from RealityCoreRenderer/Shaders/TonemapShared.h and Tonemap.h.
+        struct TonemapSegment {
+            float offsX, offsY, scaleX, scaleY, lnA, B;
+        };
+
+        struct TonemapParameters {
+            float whitePoint;
+            float oneOverWhitePoint;
+            float x0, x1, y0, y1;
+            float exposure;
+            float pivotFactor;
+            float contrast;
+            float oneOverPivotFactor;
+            float oneOverContrast;
+            TonemapSegment segments[3];
+            float oneOverExposure;
+            float edrScalar;
+        };
+
+        constant TonemapParameters kDefaultTonemapParams = {
+            .whitePoint = 2.01402664,
+            .oneOverWhitePoint = 0.496517748,
+            .x0 = 0.0278579127,
+            .x1 = 0.17054522,
+            .y0 = 0.0420799,
+            .y1 = 0.3294559,
+            .exposure = 1.0,
+            .pivotFactor = 1.0,
+            .contrast = 1.0,
+            .oneOverPivotFactor = 1.0,
+            .oneOverContrast = 1.0,
+            .segments = {
+                { 0.0,          0.0,        1.0,  0.778939604,  1.60599995,  1.33333337 },
+                { 0.00696447864, 0.0,       1.0,  0.778939604,  0.700136005, 1.0        },
+                { 3.0,          1.16840935, -1.0, -0.778939604, -4.90600586, 4.86833191 }
+            },
+            .oneOverExposure = 1.0,
+            .edrScalar = 1.0,
+        };
+
+        // Mirrors computeFilmic() in RealityCoreRenderer/Shaders/Tonemap.metal.
+        static half3 computeFilmic(half3 clr, constant TonemapParameters &params) {
+            if (params.contrast != 1.0f) {
+                clr = pow(clr, params.contrast) * params.pivotFactor;
+            }
+
+            half3 xs = clr * (half)params.oneOverWhitePoint;
+            int3 indices = (int3)((half3)params.x0 < xs) + (int3)((half3)params.x1 < xs);
+
+            half3 offsXs  = half3(params.segments[indices.r].offsX,  params.segments[indices.g].offsX,  params.segments[indices.b].offsX);
+            half3 scaleXs = half3(params.segments[indices.r].scaleX, params.segments[indices.g].scaleX, params.segments[indices.b].scaleX);
+            half3 lnAs    = half3(params.segments[indices.r].lnA,    params.segments[indices.g].lnA,    params.segments[indices.b].lnA);
+            half3 Bs      = half3(params.segments[indices.r].B,      params.segments[indices.g].B,      params.segments[indices.b].B);
+            half3 scaleYs = half3(params.segments[indices.r].scaleY, params.segments[indices.g].scaleY, params.segments[indices.b].scaleY);
+            half3 offsYs  = half3(params.segments[indices.r].offsY,  params.segments[indices.g].offsY,  params.segments[indices.b].offsY);
+
+            half3 x0s = (xs - offsXs) * scaleXs;
+            bool3 mask = (x0s > 0);
+            half3 y0s = select(half3(0, 0, 0), exp(lnAs + Bs * log(x0s)), mask);
+            return y0s * scaleYs + offsYs;
+        }
+
+        // Mirrors tonemap() in RealityCoreRenderer/Shaders/Tonemap.metal.
+        static half3 tonemap(half3 color, constant TonemapParameters &params) {
+            color *= params.exposure;
+            return computeFilmic(color, params) * params.edrScalar;
+        }
+
+        struct ImplicitFragmentInPlace {
+            half4 color [[color(0)]];
+        };
+
+        // Mirrors resolveColorInPlace() in RealityCoreRenderer/Shaders/ColorResolve.metal.
+        kernel void colorAdjustTile(imageblock<ImplicitFragmentInPlace, imageblock_layout_implicit> ib,
+                                    ushort2 localThreadId [[thread_position_in_threadgroup]]) {
+            half4 color = 0;
+            ushort numColors = ib.get_num_colors(localThreadId);
+            for (ushort c = 0; c < numColors; ++c) {
+                ImplicitFragmentInPlace f = ib.read(localThreadId, c, imageblock_data_rate::color);
+                color += f.color * popcount(ib.get_color_coverage_mask(localThreadId, c));
+            }
+            color /= (half)ib.get_num_samples();
+
+            color.rgb = tonemap(color.rgb, kDefaultTonemapParams);
+            color.rgb *= 1.5032214035h;
+
+            ImplicitFragmentInPlace out;
+            out.color = color;
+            ib.write(out, localThreadId, 0xF);
+        }
+        """
 
     init(device: any MTLDevice, memoryOwner: task_id_token_t) throws {
         guard let commandQueue = device.makeCommandQueue() else {
@@ -108,7 +214,11 @@ final class Renderer {
         renderer.cameras[0].position = cameraPosition
         renderer.cameras[0].rotation = cameraRotation
         renderer.cameras[0].projection = projection
-        renderer.output.clearColor = clearColor
+        if tonemapEnabled {
+            renderer.output.clearColor = MTLClearColor(red: 0.0, green: 0.0, blue: 0.0, alpha: 0.0)
+        } else {
+            renderer.output.clearColor = clearColor
+        }
         renderer.output.color = .init(texture: texture)
         try renderer.setMeshInstances(meshInstances, at: 0)
 
@@ -125,12 +235,41 @@ final class Renderer {
             indices: &span,
             configuration: .init(cameraPosition: renderer.cameras[0].position)
         )
+        let tilePipelineState: (any MTLRenderPipelineState)? =
+            tonemapEnabled ? nil : try colorAdjustTilePipelineState(for: texture.pixelFormat, rasterSampleCount: rasterSampleCount)
         renderer.render(using: commandBuffer) { state in
             for index in indices {
                 state.render(meshInstancesArrayIndex: 0, meshInstanceIndex: index)
             }
+            if let tilePipelineState {
+                let encoder = state.encoder
+                encoder.setRenderPipelineState(tilePipelineState)
+                encoder.dispatchThreadsPerTile(MTLSize(width: encoder.tileWidth, height: encoder.tileHeight, depth: 1))
+            }
+            state.reset()
         }
         commandBuffer.commit()
+    }
+
+    private func colorAdjustTilePipelineState(for pixelFormat: MTLPixelFormat, rasterSampleCount: Int) throws -> any MTLRenderPipelineState
+    {
+        let key = ColorAdjustTilePipelineKey(pixelFormat: pixelFormat, rasterSampleCount: rasterSampleCount)
+        if let cached = colorAdjustTilePipelineStates[key] {
+            return cached
+        }
+        let library = try device.makeLibrary(source: Self.colorAdjustTileShaderSource, options: nil)
+        guard let tileFunction = library.makeFunction(name: "colorAdjustTile") else {
+            fatalError("Failed to find colorAdjustTile tile function")
+        }
+        let descriptor = MTLTileRenderPipelineDescriptor()
+        descriptor.label = "Color Adjust Tile Pipeline"
+        descriptor.tileFunction = tileFunction
+        descriptor.colorAttachments[0].pixelFormat = pixelFormat
+        descriptor.rasterSampleCount = rasterSampleCount
+        descriptor.threadgroupSizeMatchesTileSize = true
+        let (pipelineState, _) = try device.makeRenderPipelineState(tileDescriptor: descriptor, options: [])
+        colorAdjustTilePipelineStates[key] = pipelineState
+        return pipelineState
     }
 
     func setFOV(_ fovYRadians: Float) {

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h
@@ -482,6 +482,8 @@ NS_SWIFT_SENDABLE
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithDevice:(id<MTLDevice>)device memoryOwner:(task_id_token_t)memoryOwner NS_DESIGNATED_INITIALIZER;
 
+@property (nonatomic) BOOL standardDynamicRange;
+
 - (void)makeStandaloneResourcesWithCompletionHandler:(void (^)(void))completionHandler;
 - (void)createMaterialCompiler;
 - (void)makeRendererResourcesWithCompletionHandler:(void (^)(void))completionHandler;
@@ -831,6 +833,7 @@ typedef struct WebModelCreateMeshDescriptor {
     WebModel::ImageAsset&& diffuseTexture;
     WebModel::ImageAsset&& specularTexture;
     const WebCore::ProcessIdentity* processIdentity;
+    bool standardDynamicRange { false };
 } WebModelCreateMeshDescriptor;
 
 #endif

--- a/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.cpp
+++ b/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.cpp
@@ -43,13 +43,14 @@ namespace WebKit {
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(RemoteMesh);
 
-RemoteMesh::RemoteMesh(GPUConnectionToWebProcess& gpuConnectionToWebProcess, RemoteGPU& gpu, WebKit::Mesh& mesh, ModelObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, WebModelIdentifier identifier)
+RemoteMesh::RemoteMesh(GPUConnectionToWebProcess& gpuConnectionToWebProcess, RemoteGPU& gpu, WebKit::Mesh& mesh, ModelObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, WebModelIdentifier identifier, bool standardDynamicRange)
     : m_backing(mesh)
     , m_objectHeap(objectHeap)
     , m_streamConnection(WTF::move(streamConnection))
     , m_identifier(identifier)
     , m_gpuConnectionToWebProcess(gpuConnectionToWebProcess)
     , m_gpu(gpu)
+    , m_standardDynamicRange(standardDynamicRange)
 {
     protect(m_streamConnection)->startReceivingMessages(*this, Messages::RemoteMesh::messageReceiverName(), m_identifier.toUInt64());
 }
@@ -149,7 +150,7 @@ void RemoteMesh::updateRenderBuffers(unsigned width, unsigned height, Completion
         return;
     }
 
-    auto renderBuffers = RemoteGPU::createRenderBuffers(width, height, gpuProcessConnection->webProcessIdentity());
+    auto renderBuffers = RemoteGPU::createRenderBuffers(width, height, gpuProcessConnection->webProcessIdentity(), m_standardDynamicRange);
     WebModel::ResizeMeshDescriptor descriptor { width, height, WTF::move(renderBuffers) };
     m_backing->updateRenderBuffers(WTF::move(descriptor));
     completionHandler(m_backing->ioSurfaceHandles());

--- a/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.h
+++ b/Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.h
@@ -61,9 +61,9 @@ class ObjectHeap;
 class RemoteMesh final : public IPC::StreamMessageReceiver {
     WTF_MAKE_TZONE_ALLOCATED(RemoteMesh);
 public:
-    static Ref<RemoteMesh> create(GPUConnectionToWebProcess& gpuConnectionToWebProcess, RemoteGPU& gpu, WebKit::Mesh& mesh, ModelObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, WebModelIdentifier identifier)
+    static Ref<RemoteMesh> create(GPUConnectionToWebProcess& gpuConnectionToWebProcess, RemoteGPU& gpu, WebKit::Mesh& mesh, ModelObjectHeap& objectHeap, Ref<IPC::StreamServerConnection>&& streamConnection, WebModelIdentifier identifier, bool standardDynamicRange = false)
     {
-        return adoptRef(*new RemoteMesh(gpuConnectionToWebProcess, gpu, mesh, objectHeap, WTF::move(streamConnection), identifier));
+        return adoptRef(*new RemoteMesh(gpuConnectionToWebProcess, gpu, mesh, objectHeap, WTF::move(streamConnection), identifier, standardDynamicRange));
     }
 
     virtual ~RemoteMesh();
@@ -75,7 +75,7 @@ public:
 private:
     friend class ModelObjectHeap;
 
-    RemoteMesh(GPUConnectionToWebProcess&, RemoteGPU&, WebKit::Mesh&, ModelObjectHeap&, Ref<IPC::StreamServerConnection>&&, WebModelIdentifier);
+    RemoteMesh(GPUConnectionToWebProcess&, RemoteGPU&, WebKit::Mesh&, ModelObjectHeap&, Ref<IPC::StreamServerConnection>&&, WebModelIdentifier, bool standardDynamicRange);
 
     RemoteMesh(const RemoteMesh&) = delete;
     RemoteMesh(RemoteMesh&&) = delete;
@@ -111,6 +111,7 @@ private:
     const WebModelIdentifier m_identifier;
     ThreadSafeWeakPtr<GPUConnectionToWebProcess> m_gpuConnectionToWebProcess;
     WeakRef<RemoteGPU> m_gpu;
+    const bool m_standardDynamicRange { false };
 };
 
 } // namespace WebKit

--- a/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
@@ -497,6 +497,8 @@ extension WKBridgeUSDConfiguration {
         }
     }
 
+    var standardDynamicRange: Bool = false
+
     func makeStandaloneResources() async {
         do {
             appRenderer.pendingStandaloneResources = try await LowLevelRenderContextStandalone.Resources(device: self.device)
@@ -518,16 +520,19 @@ extension WKBridgeUSDConfiguration {
 
     func makeRendererResources() async {
         do {
+            let colorPixelFormat: MTLPixelFormat = standardDynamicRange ? .bgra8Unorm : .rgba16Float
+            let sampleCount: Int = 4
             appRenderer.pendingRendererResources = try await LowLevelRenderer.Resources(
                 configuration: .init(
-                    output: .init(colorPixelFormat: .rgba16Float),
-                    rasterSampleCount: 4,
-                    enableTonemap: false,
+                    output: .init(colorPixelFormat: colorPixelFormat),
+                    rasterSampleCount: sampleCount,
+                    enableTonemap: standardDynamicRange,
                     enableColorMatch: false,
                     alphaPremultiply: false
                 ),
                 renderContext: self.renderContext
             )
+            appRenderer.rasterSampleCount = sampleCount
         } catch {
             fatalError("Exception creating renderer resources \(error)")
         }
@@ -539,6 +544,7 @@ extension WKBridgeUSDConfiguration {
             // swift-format-ignore: NeverForceUnwrap
             try appRenderer.createRenderer(resources: appRenderer.pendingRendererResources!)
             appRenderer.pendingRendererResources = nil
+            appRenderer.tonemapEnabled = standardDynamicRange
         } catch {
             fatalError("Exception creating renderer \(error)")
         }
@@ -2412,6 +2418,8 @@ private func makeFallBackTextureResource(
 extension WKBridgeUSDConfiguration {
     init(device: any MTLDevice, memoryOwner: task_id_token_t) {
     }
+
+    var standardDynamicRange: Bool = false
 
     func makeStandaloneResources() async {
     }

--- a/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.h
+++ b/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.h
@@ -80,6 +80,7 @@ private:
     WebMesh(const WebModelCreateMeshDescriptor&);
 
     RetainPtr<NSMutableArray> m_textures;
+    const bool m_standardDynamicRange { false };
 
 #if ENABLE(GPU_PROCESS_MODEL)
     RetainPtr<WKBridgeReceiver> m_receiver;

--- a/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm
+++ b/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm
@@ -867,9 +867,9 @@ static WKBridgeMaterialGraph *convert(const MaterialGraph& material)
 
 namespace WebKit {
 
-static RetainPtr<NSMutableArray> createMetalTextures(id<MTLDevice> device, const Vector<RetainPtr<IOSurfaceRef>>& ioSurfaces, unsigned width, unsigned height)
+static RetainPtr<NSMutableArray> createMetalTextures(id<MTLDevice> device, const Vector<RetainPtr<IOSurfaceRef>>& ioSurfaces, unsigned width, unsigned height, MTLPixelFormat pixelFormat)
 {
-    MTLTextureDescriptor *textureDescriptor = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:MTLPixelFormatRGBA16Float width:width height:height mipmapped:NO];
+    MTLTextureDescriptor *textureDescriptor = [MTLTextureDescriptor texture2DDescriptorWithPixelFormat:pixelFormat width:width height:height mipmapped:NO];
     RetainPtr textures = adoptNS([[NSMutableArray alloc] init]);
     for (auto& ioSurface : ioSurfaces)
         [textures addObject:[device newTextureWithDescriptor:textureDescriptor iosurface:ioSurface.get() plane:0]];
@@ -878,16 +878,23 @@ static RetainPtr<NSMutableArray> createMetalTextures(id<MTLDevice> device, const
 
 WTF_MAKE_TZONE_ALLOCATED_IMPL(WebMesh);
 
+static MTLPixelFormat pixelFormatForDynamicRange(bool standardRange)
+{
+    return standardRange ? MTLPixelFormatBGRA8Unorm : MTLPixelFormatRGBA16Float;
+}
+
 WebMesh::WebMesh(const WebModelCreateMeshDescriptor& descriptor)
+    : m_standardDynamicRange(descriptor.standardDynamicRange)
 {
     id<MTLDevice> device = MTLCreateSystemDefaultDevice();
-    m_textures = createMetalTextures(device, descriptor.ioSurfaces, descriptor.width, descriptor.height);
+    m_textures = createMetalTextures(device, descriptor.ioSurfaces, descriptor.width, descriptor.height, pixelFormatForDynamicRange(m_standardDynamicRange));
 
 #if ENABLE(GPU_PROCESS_MODEL)
     WKBridgeUSDConfiguration *configuration = [WebKit::allocWKBridgeUSDConfigurationInstance() initWithDevice:device memoryOwner:descriptor.processIdentity ? descriptor.processIdentity->taskIdToken() : 0];
     WKBridgeImageAsset *diffuseAsset = WebModel::convert(descriptor.diffuseTexture);
     WKBridgeImageAsset *specularAsset = WebModel::convert(descriptor.specularTexture);
     if (configuration) {
+        configuration.standardDynamicRange = m_standardDynamicRange;
         BinarySemaphore standaloneResourcesCompletion;
         [configuration makeStandaloneResourcesWithCompletionHandler:[&standaloneResourcesCompletion] mutable {
             standaloneResourcesCompletion.signal();
@@ -1065,7 +1072,7 @@ void WebMesh::updateRenderBuffers(const WebModel::ResizeMeshDescriptor& descript
     auto ioSurfaces = descriptor.renderBuffers.map([](auto& buffer) -> RetainPtr<IOSurfaceRef> {
         return buffer->surface();
     });
-    m_textures = createMetalTextures(MTLCreateSystemDefaultDevice(), ioSurfaces, descriptor.width, descriptor.height);
+    m_textures = createMetalTextures(MTLCreateSystemDefaultDevice(), ioSurfaces, descriptor.width, descriptor.height, pixelFormatForDynamicRange(m_standardDynamicRange));
 #else
     UNUSED_PARAM(descriptor);
 #endif

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp
@@ -272,10 +272,10 @@ void RemoteGPU::paintNativeImageToImageBuffer(WebCore::NativeImage& nativeImage,
 
 
 #if ENABLE(GPU_PROCESS_MODEL)
-Vector<UniqueRef<WebCore::IOSurface>> RemoteGPU::createRenderBuffers(unsigned width, unsigned height, const WebCore::ProcessIdentity& processIdentity)
+Vector<UniqueRef<WebCore::IOSurface>> RemoteGPU::createRenderBuffers(unsigned width, unsigned height, const WebCore::ProcessIdentity& processIdentity, bool standardDynamicRange)
 {
-    const auto colorFormat = WebCore::IOSurface::Format::RGBA16F;
-    const auto colorSpace = WebCore::DestinationColorSpace::ExtendedLinearDisplayP3();
+    const auto colorFormat = standardDynamicRange ? WebCore::IOSurface::Format::BGRA : WebCore::IOSurface::Format::RGBA16F;
+    const auto colorSpace = standardDynamicRange ? WebCore::DestinationColorSpace::LinearDisplayP3() : WebCore::DestinationColorSpace::ExtendedLinearDisplayP3();
 
     Vector<UniqueRef<WebCore::IOSurface>> ioSurfaces;
 
@@ -292,9 +292,9 @@ Vector<UniqueRef<WebCore::IOSurface>> RemoteGPU::createRenderBuffers(unsigned wi
 #endif
 
 #if ENABLE(GPU_PROCESS_MODEL)
-static RefPtr<WebKit::Mesh> createModelBackingInternal(unsigned width, unsigned height, WebModel::ImageAsset&& diffuseTexture, WebModel::ImageAsset&& specularTexture, const WebCore::ProcessIdentity& processIdentity, CompletionHandler<void(Vector<MachSendRight>&&)>&& callback)
+static RefPtr<WebKit::Mesh> createModelBackingInternal(unsigned width, unsigned height, WebModel::ImageAsset&& diffuseTexture, WebModel::ImageAsset&& specularTexture, const WebCore::ProcessIdentity& processIdentity, bool standardDynamicRange, CompletionHandler<void(Vector<MachSendRight>&&)>&& callback)
 {
-    auto ioSurfaceVector = RemoteGPU::createRenderBuffers(width, height, processIdentity);
+    auto ioSurfaceVector = RemoteGPU::createRenderBuffers(width, height, processIdentity, standardDynamicRange);
     Vector<RetainPtr<IOSurfaceRef>> ioSurfaces;
     for (auto& ioSurface : ioSurfaceVector)
         ioSurfaces.append(ioSurface->surface());
@@ -305,7 +305,8 @@ static RefPtr<WebKit::Mesh> createModelBackingInternal(unsigned width, unsigned 
         .ioSurfaces = WTF::move(ioSurfaces),
         .diffuseTexture = WTF::move(diffuseTexture),
         .specularTexture = WTF::move(specularTexture),
-        .processIdentity = &processIdentity
+        .processIdentity = &processIdentity,
+        .standardDynamicRange = standardDynamicRange
     };
 
     auto mesh = WebKit::MeshImpl::create(WebMesh::create(backingDescriptor), WTF::move(ioSurfaceVector));
@@ -314,7 +315,7 @@ static RefPtr<WebKit::Mesh> createModelBackingInternal(unsigned width, unsigned 
 }
 #endif
 
-void RemoteGPU::createModelBacking(unsigned width, unsigned height, WebModel::ImageAsset&& diffuseTexture, WebModel::ImageAsset&& specularTexture, WebModelIdentifier identifier, CompletionHandler<void(Vector<MachSendRight>&&)>&& callback)
+void RemoteGPU::createModelBacking(unsigned width, unsigned height, WebModel::ImageAsset&& diffuseTexture, WebModel::ImageAsset&& specularTexture, WebModelIdentifier identifier, bool standardDynamicRange, CompletionHandler<void(Vector<MachSendRight>&&)>&& callback)
 {
 #if ENABLE(GPU_PROCESS_MODEL)
     assertIsCurrent(workQueue());
@@ -347,8 +348,8 @@ void RemoteGPU::createModelBacking(unsigned width, unsigned height, WebModel::Im
     auto gpuProcessConnection = m_gpuConnectionToWebProcess.get();
     MESSAGE_CHECK(gpuProcessConnection);
 
-    auto mesh = createModelBackingInternal(width, height, WTF::move(diffuseTexture), WTF::move(specularTexture), gpuProcessConnection->webProcessIdentity(), WTF::move(callback));
-    auto remoteMesh = RemoteMesh::create(*m_gpuConnectionToWebProcess.get(), *this, *mesh, objectHeap, protect(*m_streamConnection), identifier);
+    auto mesh = createModelBackingInternal(width, height, WTF::move(diffuseTexture), WTF::move(specularTexture), gpuProcessConnection->webProcessIdentity(), standardDynamicRange, WTF::move(callback));
+    auto remoteMesh = RemoteMesh::create(*m_gpuConnectionToWebProcess.get(), *this, *mesh, objectHeap, protect(*m_streamConnection), identifier, standardDynamicRange);
     objectHeap->addObject(identifier, remoteMesh);
 #else
     UNUSED_PARAM(width);
@@ -356,6 +357,7 @@ void RemoteGPU::createModelBacking(unsigned width, unsigned height, WebModel::Im
     UNUSED_PARAM(diffuseTexture);
     UNUSED_PARAM(specularTexture);
     UNUSED_PARAM(identifier);
+    UNUSED_PARAM(standardDynamicRange);
     UNUSED_PARAM(callback);
 #endif
 }

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h
@@ -99,7 +99,7 @@ public:
     void paintNativeImageToImageBuffer(WebCore::NativeImage&, WebCore::RenderingResourceIdentifier);
     RefPtr<GPUConnectionToWebProcess> gpuConnectionToWebProcess() const;
 
-    static Vector<UniqueRef<WebCore::IOSurface>> createRenderBuffers(unsigned width, unsigned height, const WebCore::ProcessIdentity&);
+    static Vector<UniqueRef<WebCore::IOSurface>> createRenderBuffers(unsigned width, unsigned height, const WebCore::ProcessIdentity&, bool standardDynamicRange = false);
     IPC::StreamConnectionWorkQueue& workQueue() const { return m_workQueue; }
 
 private:
@@ -129,7 +129,7 @@ private:
 
 
     void requestAdapter(const WebGPU::RequestAdapterOptions&, WebGPUIdentifier, CompletionHandler<void(std::optional<RemoteGPURequestAdapterResponse>&&)>&&);
-    void NODELETE createModelBacking(unsigned width, unsigned height, WebModel::ImageAsset&& diffuseTexture, WebModel::ImageAsset&& specularTexture, WebKit::WebModelIdentifier, CompletionHandler<void(Vector<MachSendRight>&&)>&&);
+    void NODELETE createModelBacking(unsigned width, unsigned height, WebModel::ImageAsset&& diffuseTexture, WebModel::ImageAsset&& specularTexture, WebKit::WebModelIdentifier, bool standardDynamicRange, CompletionHandler<void(Vector<MachSendRight>&&)>&&);
 
     void createPresentationContext(const WebGPU::PresentationContextDescriptor&, WebGPUIdentifier);
 

--- a/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.messages.in
+++ b/Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.messages.in
@@ -35,7 +35,7 @@ messages -> RemoteGPU Stream {
 
     void IsValid(WebKit::WebGPUIdentifier identifier) -> (bool isValid, bool exists) Synchronous
 #if ENABLE(GPU_PROCESS_MODEL)
-    void CreateModelBacking(unsigned width, unsigned height, struct WebModel::ImageAsset diffuseAsset, struct WebModel::ImageAsset specularAsset, WebKit::WebModelIdentifier identifier) -> (Vector<MachSendRight> renderBuffers) Synchronous NotStreamEncodable NotStreamEncodableReply
+    void CreateModelBacking(unsigned width, unsigned height, struct WebModel::ImageAsset diffuseAsset, struct WebModel::ImageAsset specularAsset, WebKit::WebModelIdentifier identifier, bool standardDynamicRange) -> (Vector<MachSendRight> renderBuffers) Synchronous NotStreamEncodable NotStreamEncodableReply
 #endif
 }
 

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp
@@ -220,12 +220,12 @@ void RemoteGPUProxy::requestAdapter(const WebCore::WebGPU::RequestAdapterOptions
     callback(WebGPU::RemoteAdapterProxy::create(WTF::move(response->name), WTF::move(resultSupportedFeatures), WTF::move(resultSupportedLimits), response->isFallbackAdapter, options.xrCompatible, *this, m_convertToBackingContext, identifier));
 }
 
-RefPtr<WebKit::Mesh> RemoteGPUProxy::createModelBacking(unsigned width, unsigned height, WebModel::ImageAsset&& diffuseTexture, WebModel::ImageAsset&& specularTexture, CompletionHandler<void(Vector<MachSendRight>&&)>&& callback)
+RefPtr<WebKit::Mesh> RemoteGPUProxy::createModelBacking(unsigned width, unsigned height, WebModel::ImageAsset&& diffuseTexture, WebModel::ImageAsset&& specularTexture, bool standardDynamicRange, CompletionHandler<void(Vector<MachSendRight>&&)>&& callback)
 {
 #if ENABLE(GPU_PROCESS_MODEL)
     auto identifier = WebModelIdentifier::generate();
 
-    auto sendResult = sendSync(Messages::RemoteGPU::CreateModelBacking(width, height, WTF::move(diffuseTexture), WTF::move(specularTexture), identifier));
+    auto sendResult = sendSync(Messages::RemoteGPU::CreateModelBacking(width, height, WTF::move(diffuseTexture), WTF::move(specularTexture), identifier, standardDynamicRange));
     if (!sendResult.succeeded()) {
         callback({ });
         return nullptr;
@@ -242,6 +242,7 @@ RefPtr<WebKit::Mesh> RemoteGPUProxy::createModelBacking(unsigned width, unsigned
 #else
     UNUSED_PARAM(width);
     UNUSED_PARAM(height);
+    UNUSED_PARAM(standardDynamicRange);
     UNUSED_PARAM(callback);
     return nullptr;
 #endif

--- a/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
+++ b/Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h
@@ -77,7 +77,7 @@ public:
 
     void paintToCanvas(WebCore::NativeImage&, const WebCore::IntSize&, WebCore::GraphicsContext&) final;
     WebGPUIdentifier backing() const { return m_backing; }
-    RefPtr<WebKit::Mesh> NODELETE createModelBacking(unsigned width, unsigned height, WebModel::ImageAsset&& diffuseTexture, WebModel::ImageAsset&& specularTexture, CompletionHandler<void(Vector<MachSendRight>&&)>&&);
+    RefPtr<WebKit::Mesh> NODELETE createModelBacking(unsigned width, unsigned height, WebModel::ImageAsset&& diffuseTexture, WebModel::ImageAsset&& specularTexture, bool standardDynamicRange, CompletionHandler<void(Vector<MachSendRight>&&)>&&);
 
 private:
     friend class WebGPU::DowncastConvertToBackingContext;

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.h
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.h
@@ -135,6 +135,8 @@ private:
     float computeContentsHeadroom();
     void updateContentsHeadroom();
     void updateScreenHeadroom(float currentEDRHeadroom, bool suppressEDR);
+    void updateScreenHeadroomFromPage();
+    void dynamicRangeLimitDidChange();
 #endif
 
     WeakPtr<WebCore::ModelPlayerClient> m_client;
@@ -176,9 +178,13 @@ private:
 #if HAVE(SUPPORT_HDR_DISPLAY) && ENABLE(PIXEL_FORMAT_RGBA16F)
     using ScreenPropertiesChangedObserver = Observer<void(WebCore::PlatformDisplayID)>;
     RefPtr<ScreenPropertiesChangedObserver> m_screenPropertiesChangedObserver;
+    RefPtr<WebCore::Model> m_cachedModelSource;
+    WebCore::LayoutSize m_lastLayoutSize;
     float m_currentEDRHeadroom { 1.f };
+    float m_lastSentContentsHeadroom { -1.f };
     bool m_suppressEDR { false };
     WebCore::PlatformDynamicRangeLimit m_dynamicRangeLimit { WebCore::PlatformDynamicRangeLimit::initialValue() };
+    bool m_usingStandardDynamicRange { false };
 #endif
 };
 

--- a/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
+++ b/Source/WebKit/WebProcess/Model/WebModelPlayer.mm
@@ -52,6 +52,7 @@
 #import <WebCore/PlatformCALayerDelegatedContents.h>
 #import <WebCore/PlatformScreen.h>
 #import <WebCore/ScreenProperties.h>
+#import <wtf/BlockPtr.h>
 #import <wtf/RetainPtr.h>
 #import <wtf/cocoa/SpanCocoa.h>
 #import <wtf/threads/BinarySemaphore.h>
@@ -109,6 +110,7 @@ public:
     void setContentsFormat(WebCore::ContentsFormat contentsFormat)
     {
         m_contentsFormat = contentsFormat;
+        setOpaque(m_contentsFormat == WebCore::ContentsFormat::RGBA16F);
     }
     void setOpaque(bool opaque)
     {
@@ -143,6 +145,8 @@ WebModelPlayer::WebModelPlayer(WebCore::Page& page, WebCore::ModelPlayerClient& 
 , m_page(page)
 {
 #if HAVE(SUPPORT_HDR_DISPLAY) && ENABLE(PIXEL_FORMAT_RGBA16F)
+    updateScreenHeadroomFromPage();
+
     if (RefPtr document = page.localTopDocument()) {
         m_screenPropertiesChangedObserver = ScreenPropertiesChangedObserver::create([weakThis = ThreadSafeWeakPtr { *this }](WebCore::PlatformDisplayID displayID) {
             RefPtr protectedThis = weakThis.get();
@@ -182,6 +186,13 @@ static std::optional<WebCore::SharedMemoryHandle> loadData(RetainPtr<CFStringRef
     return WebCore::SharedMemoryHandle::createCopy(WTF::span(data.get()), WebCore::SharedMemoryProtection::ReadOnly);
 }
 
+#if HAVE(SUPPORT_HDR_DISPLAY) && ENABLE(PIXEL_FORMAT_RGBA16F)
+static WebCore::ContentsFormat contentsFormatForDynamicRange(bool isStandard)
+{
+    return isStandard ? WebCore::ContentsFormat::RGBA8 : WebCore::ContentsFormat::RGBA16F;
+}
+#endif
+
 // MARK: - ModelPlayer overrides.
 
 void WebModelPlayer::load(WebCore::Model& modelSource, WebCore::LayoutSize size)
@@ -210,12 +221,27 @@ void WebModelPlayer::load(WebCore::Model& modelSource, WebCore::LayoutSize size)
     size.scale(document->deviceScaleFactor());
     m_currentPixelSize = WebCore::IntSize(size.width().toUnsigned(), size.height().toUnsigned());
 
+#if HAVE(SUPPORT_HDR_DISPLAY) && ENABLE(PIXEL_FORMAT_RGBA16F)
+    m_cachedModelSource = &modelSource;
+    m_lastLayoutSize = cssSize;
+#endif
+
     WEBMODEL_WEB_MODEL_PLAYER_DECLARE_DIFFUSE_AND_SPECULAR_TEXTURES
 
-    m_currentModel = static_cast<RemoteGPUProxy&>(gpu->backing()).createModelBacking(m_currentPixelSize.width(), m_currentPixelSize.height(), WTF::move(diffuseTexture), WTF::move(specularTexture), [protectedThis = protect(*this)] (Vector<MachSendRight>&& surfaceHandles) {
+#if HAVE(SUPPORT_HDR_DISPLAY) && ENABLE(PIXEL_FORMAT_RGBA16F)
+    bool standardDynamicRange = m_dynamicRangeLimit == WebCore::PlatformDynamicRangeLimit::standard();
+    m_usingStandardDynamicRange = standardDynamicRange;
+#else
+    bool standardDynamicRange = false;
+#endif
+
+    m_lastSentContentsHeadroom = -1.f;
+    m_currentModel = static_cast<RemoteGPUProxy&>(gpu->backing()).createModelBacking(m_currentPixelSize.width(), m_currentPixelSize.height(), WTF::move(diffuseTexture), WTF::move(specularTexture), standardDynamicRange, [protectedThis = protect(*this)] (Vector<MachSendRight>&& surfaceHandles) {
         if (surfaceHandles.size()) {
             protectedThis->m_displayBuffers = WTF::move(surfaceHandles);
-            protectedThis->updateContentsHeadroom();
+            protectedThis->m_renderTextureIndex = 0;
+            protectedThis->m_displayTextureIndex = 0;
+            protectedThis->updateScreenHeadroomFromPage();
         }
     });
     if (!m_currentModel)
@@ -323,6 +349,9 @@ void WebModelPlayer::sizeDidChange(WebCore::LayoutSize size)
         return;
 
     m_currentPixelSize = newPixelSize;
+#if HAVE(SUPPORT_HDR_DISPLAY) && ENABLE(PIXEL_FORMAT_RGBA16F)
+    m_lastLayoutSize = cssSize;
+#endif
 
     currentModel->sizeDidChange(newPixelSize.width(), newPixelSize.height(), [protectedThis = protect(*this)](Vector<MachSendRight>&& newBuffers) {
         if (newBuffers.isEmpty())
@@ -479,6 +508,10 @@ WebCore::GraphicsLayerContentsDisplayDelegate* WebModelPlayer::contentsDisplayDe
         RefPtr modelDisplayDelegate = ModelDisplayBufferDisplayDelegate::create(*this);
         m_contentsDisplayDelegate = modelDisplayDelegate;
         modelDisplayDelegate->setDisplayBuffer(*buffer);
+#if HAVE(SUPPORT_HDR_DISPLAY) && ENABLE(PIXEL_FORMAT_RGBA16F)
+        if (m_dynamicRangeLimit == WebCore::PlatformDynamicRangeLimit::standard())
+            modelDisplayDelegate->setContentsFormat(WebCore::ContentsFormat::RGBA8);
+#endif
     }
 
     return m_contentsDisplayDelegate.get();
@@ -592,8 +625,18 @@ bool WebModelPlayer::render()
                 return;
 
             protectedThis->m_displayTextureIndex = textureIndex;
-            if (auto* machSendRight = protectedThis->displayBuffer(); machSendRight && protectedThis->contentsDisplayDelegate())
-                protect(protectedThis->m_contentsDisplayDelegate)->setDisplayBuffer(*machSendRight);
+            if (auto* machSendRight = protectedThis->displayBuffer(); machSendRight && protectedThis->contentsDisplayDelegate()) {
+                Ref delegate = *protectedThis->m_contentsDisplayDelegate;
+#if HAVE(SUPPORT_HDR_DISPLAY) && ENABLE(PIXEL_FORMAT_RGBA16F)
+                // Apply the contents format together with the new display buffer so the
+                // layer's format always matches the IOSurface being shown. This is what
+                // completes the deferred format swap when the model is reloaded due to
+                // a dynamic-range-limit change.
+                delegate->setContentsFormat(contentsFormatForDynamicRange(protectedThis->m_usingStandardDynamicRange));
+#endif
+                delegate->setDisplayBuffer(*machSendRight);
+                protectedThis->updateScreenHeadroomFromPage();
+            }
 
             protectedThis->scheduleDisplayUpdate();
         });
@@ -748,6 +791,9 @@ void WebModelPlayer::visibilityStateDidChange()
         m_isUpdateScheduled = false;
         m_isUpdating = false;
         m_displayTextureIndex = 0;
+#if HAVE(SUPPORT_HDR_DISPLAY) && ENABLE(PIXEL_FORMAT_RGBA16F)
+        m_cachedModelSource = nullptr;
+#endif
     }
 }
 
@@ -841,16 +887,28 @@ float WebModelPlayer::computeContentsHeadroom()
 void WebModelPlayer::updateContentsHeadroom()
 {
     constexpr auto visionProHeadroom = 2.f;
-    auto headroom = computeContentsHeadroom();
-    if (RefPtr model = m_currentModel)
-        model->updateContentsHeadroom(std::min(visionProHeadroom, headroom));
+    auto contentsHeadroom = std::min(visionProHeadroom, computeContentsHeadroom());
+    if (fabs(contentsHeadroom - m_lastSentContentsHeadroom) < 0.01f)
+        return;
+    if (RefPtr model = m_currentModel; model && m_didFinishLoading) {
+        m_lastSentContentsHeadroom = contentsHeadroom;
+        model->updateContentsHeadroom(contentsHeadroom);
+    }
+}
+
+void WebModelPlayer::updateScreenHeadroomFromPage()
+{
+    RefPtr page = m_page.get();
+    if (!page)
+        return;
+
+    auto platformScreen = WebCore::PlatformScreen::singleton();
+    if (auto data = platformScreen->screenData(page->displayID()))
+        updateScreenHeadroom(data->currentEDRHeadroom, data->suppressEDR);
 }
 
 void WebModelPlayer::updateScreenHeadroom(float currentEDRHeadroom, bool suppressEDR)
 {
-    if (m_suppressEDR == suppressEDR && m_currentEDRHeadroom == currentEDRHeadroom)
-        return;
-
     m_currentEDRHeadroom = currentEDRHeadroom;
     m_suppressEDR = suppressEDR;
     updateContentsHeadroom();
@@ -868,7 +926,9 @@ void WebModelPlayer::setDynamicRangeLimit(WebCore::PlatformDynamicRangeLimit dyn
     m_currentEDRHeadroom = currentEDRHeadroom;
     m_suppressEDR = suppressEDR;
 
+    dynamicRangeLimitDidChange();
     updateContentsHeadroom();
+    startUpdateLoopIfNeeded();
 }
 
 std::optional<double> WebModelPlayer::getEffectiveDynamicRangeLimitValue() const
@@ -876,6 +936,26 @@ std::optional<double> WebModelPlayer::getEffectiveDynamicRangeLimitValue() const
     auto limitValue = m_dynamicRangeLimit.value();
     auto suppressValue = m_suppressEDR ? WebCore::PlatformDynamicRangeLimit::constrained().value() : WebCore::PlatformDynamicRangeLimit::noLimit().value();
     return std::min(limitValue, suppressValue);
+}
+
+void WebModelPlayer::dynamicRangeLimitDidChange()
+{
+    if (!m_cachedModelSource)
+        return;
+
+    bool newIsStandard = m_dynamicRangeLimit == WebCore::PlatformDynamicRangeLimit::standard();
+    if (newIsStandard == m_usingStandardDynamicRange)
+        return;
+
+    auto animationState = currentAnimationState();
+    if (!animationState)
+        return;
+    auto transformStateOpt = currentTransformState();
+    std::unique_ptr<WebCore::ModelPlayerTransformState> transformState;
+    if (transformStateOpt)
+        transformState = WTF::move(*transformStateOpt);
+
+    reload(*m_cachedModelSource, m_lastLayoutSize, *animationState, WTF::move(transformState));
 }
 #endif
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ScrollbarTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ScrollbarTests.mm
@@ -49,7 +49,7 @@
 
 @implementation ContainerView
 
-- (void)setCustomCornerRadius:(WebCore::CornerRadii)cornerRadii
+- (void)setCustomCornerRadius:(::WebCore::CornerRadii)cornerRadii
 {
     _topLeftRadius = cornerRadii.topLeft().width();
     _topRightRadius = cornerRadii.topRight().width();


### PR DESCRIPTION
#### a291a6917b7efdaa9af4c917532f4b87f8735d2e
<pre>
Add runtime toggle for appearance defaults
<a href="https://bugs.webkit.org/show_bug.cgi?id=315363">https://bugs.webkit.org/show_bug.cgi?id=315363</a>
<a href="https://rdar.apple.com/177719743">rdar://177719743</a>

Reviewed by Etienne Segonzac.

Add runtime switch for changing default dynamic-range-limit for model.

Fixes a number of bugs where switching from standard to high didn&apos;t update
the appearance of the model immedietly and a page reload was required. But
CSS can set this property at any time so the feature was not functioning as
expected.

Also update tonemapping appearance to more closely match RealityCoreRenderer&apos;s
tone mapping policy while ensuring 1.0 matches page white.

* Source/WebCore/platform/graphics/cg/UTIRegistry.mm:
(WebCore::allowableDefaultSupportedImageTypes):
* Source/WebCore/rendering/RenderLayerBacking.cpp:
(WebCore::RenderLayerBacking::updateConfiguration):
* Source/WebKit/GPUProcess/graphics/Model/ModelRenderer.swift:
(Renderer.tonemapEnabled):
(Renderer.rasterSampleCount):
(ColorAdjustTilePipelineKey.colorAdjustTilePipelineStates):
(ImplicitFragmentInPlace.colorAdjustTilePipelineState(for:rasterSampleCount:)):
(Renderer.createMaterialCompiler(_:)): Deleted.
(Renderer.createRenderer(_:)): Deleted.
(Renderer.newCommandBuffer): Deleted.
(Renderer.setFOV(_:)): Deleted.
(Renderer.setBackgroundColor(_:)):
(Renderer.setCameraTransformForModelTransform(_:)): Deleted.
* Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h:
* Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.cpp:
(WebKit::RemoteMesh::RemoteMesh):
(WebKit::RemoteMesh::updateRenderBuffers):
* Source/WebKit/GPUProcess/graphics/Model/RemoteMesh.h:
* Source/WebKit/GPUProcess/graphics/Model/USDModel.swift:
(WKBridgeUSDConfiguration.standardDynamicRange):
(WKBridgeUSDConfiguration.makeRendererResources):
(WKBridgeUSDConfiguration.createRenderer):
* Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.h:
* Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm:
(WebKit::createMetalTextures):
(WebKit::pixelFormatForDynamicRange):
(WebKit::WebMesh::WebMesh):
(WebKit::WebMesh::updateRenderBuffers):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.cpp:
(WebKit::RemoteGPU::createRenderBuffers):
(WebKit::createModelBackingInternal):
(WebKit::RemoteGPU::createModelBacking):
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.h:
* Source/WebKit/GPUProcess/graphics/WebGPU/RemoteGPU.messages.in:
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.cpp:
(WebKit::RemoteGPUProxy::createModelBacking):
* Source/WebKit/WebProcess/GPU/graphics/WebGPU/RemoteGPUProxy.h:
* Source/WebKit/WebProcess/Model/WebModelPlayer.h:
* Source/WebKit/WebProcess/Model/WebModelPlayer.mm:
(WebKit::m_page):
(WebKit::contentsFormatForDynamicRange):
(WebKit::WebModelPlayer::load):
(WebKit::WebModelPlayer::sizeDidChange):
(WebKit::WebModelPlayer::contentsDisplayDelegate):
(WebKit::WebModelPlayer::render):
(WebKit::WebModelPlayer::visibilityStateDidChange):
(WebKit::WebModelPlayer::updateContentsHeadroom):
(WebKit::WebModelPlayer::updateScreenHeadroomFromPage):
(WebKit::WebModelPlayer::updateScreenHeadroom):
(WebKit::WebModelPlayer::setDynamicRangeLimit):
(WebKit::WebModelPlayer::dynamicRangeLimitDidChange):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/ScrollbarTests.mm:
(-[ContainerView setCustomCornerRadius:]):

Canonical link: <a href="https://commits.webkit.org/314750@main">https://commits.webkit.org/314750@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2656b3c0fffe13efdc05d623f441a8e5908c29eb

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167065 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40556 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34136 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176113 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124323 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6848118f-497a-45a9-a3df-cac165b6a665) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168931 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40989 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40565 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129928 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91530 "2 flakes 3 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c3599475-d11f-439e-885c-4a8ac887eebc) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170024 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32328 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150108 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110453 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f961e3a6-0171-4cdc-8030-363a6bd5c523) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31303 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30010 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/24852 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141278 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27805 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178651 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31549 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29512 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138296 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40627 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34159 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138207 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37216 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41314 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149603 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104263 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33477 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26468 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39825 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112898 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39220 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4570 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39466 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39364 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->