### PR TITLE
Web Inspector: hovering over a node in a preview for a collection should highlight it

### DIFF
--- a/Source/WebInspectorUI/UserInterface/Models/ObjectPreview.js
+++ b/Source/WebInspectorUI/UserInterface/Models/ObjectPreview.js
@@ -70,4 +70,9 @@ WI.ObjectPreview = class ObjectPreview
     {
         return this._size !== undefined && (this._subtype === "array" || this._subtype === "set" || this._subtype === "map" || this._subtype === "weakmap" || this._subtype === "weakset");
     }
+
+    isWeakCollection()
+    {
+        return this._subtype === "weakmap" || this._subtype === "weakset";
+    }
 };

--- a/Source/WebInspectorUI/UserInterface/Views/ObjectPreviewView.js
+++ b/Source/WebInspectorUI/UserInterface/Views/ObjectPreviewView.js
@@ -166,11 +166,11 @@ WI.ObjectPreviewView = class ObjectPreviewView extends WI.Object
             var keyPreviewLossless = true;
             var entry = preview.collectionEntryPreviews[i];
             if (entry.keyPreview) {
-                keyPreviewLossless = this._appendPreview(element, entry.keyPreview);
+                keyPreviewLossless = this._appendCollectionEntryNodePreview(element, entry.keyPreview, preview, i, true);
                 element.append(" => ");
             }
 
-            var valuePreviewLossless = this._appendPreview(element, entry.valuePreview);
+            var valuePreviewLossless = this._appendCollectionEntryNodePreview(element, entry.valuePreview, preview, i, false);
 
             if (!keyPreviewLossless || !valuePreviewLossless)
                 lossless = false;
@@ -190,6 +190,24 @@ WI.ObjectPreviewView = class ObjectPreviewView extends WI.Object
         element.append(isIterator ? "]" : "}");
 
         return lossless;
+    }
+
+    _appendCollectionEntryNodePreview(element, entryPreview, collectionPreview, entryIndex, isKey)
+    {
+        if (entryPreview.subtype === "node" && collectionPreview === this._preview && this._object && !this._preview.isWeakCollection()) {
+            let options = {
+                remoteObjectAccessor: (callback) => {
+                    this._object.getCollectionEntries((entries) => {
+                        let remoteObject = isKey ? entries[0].key : entries[0].value;
+                        WI.consoleManager.releaseRemoteObjectWithConsoleClear(remoteObject);
+                        callback(remoteObject);
+                    }, {fetchStart: entryIndex, fetchCount: 1});
+                },
+            };
+            element.appendChild(WI.FormattedValue.createElementForNodePreview(entryPreview, options));
+            return false;
+        }
+        return this._appendPreview(element, entryPreview);
     }
 
     _appendPropertyPreviews(element, preview)


### PR DESCRIPTION
#### 20b0d2d5de071e54fb873a539241cae9eeac9b11
<pre>
Web Inspector: hovering over a node in a preview for a collection should highlight it
<a href="https://bugs.webkit.org/show_bug.cgi?id=143206">https://bugs.webkit.org/show_bug.cgi?id=143206</a>
<a href="https://rdar.apple.com/20341722">rdar://20341722</a>

Reviewed by Devin Rousso.

Hovering over a DOM node in a collection preview (Set, Map) didn&apos;t
highlight it on the page (works fine for arrays).

Arrays render through `_appendPropertyPreviews`, which already handled
node entries with a `remoteObjectAccessor`. Collection entries went
through `_appendValuePreview` instead, which only provided an accessor
when rendering the top level object, never for individual entry sub
previews. Without an accessor, `createElementForNodePreview` has no way
to resolve the node, so it skips attaching the hover listeners entirely.

The fix adds `_appendCollectionEntryNodePreview`, which handles node
entries directly by calling `getCollectionEntries({fetchStart:
entryIndex, fetchCount: 1})` to fetch the live `RemoteObject` for that
specific entry and pass it as the accessor. Non-node entries fall
through to `_appendPreview` as before. WeakMap and WeakSet are excluded
because `fetchStart` has no effect on them, so positional lookup is
not reliable.

* Source/WebInspectorUI/UserInterface/Views/ObjectPreviewView.js:
(WI.ObjectPreviewView.prototype._appendEntryPreviews):
(WI.ObjectPreviewView.prototype._appendCollectionEntryNodePreview):

Canonical link: <a href="https://commits.webkit.org/314589@main">https://commits.webkit.org/314589@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8231659d800608be41fd7f760eec2e6e44ebc78a

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166265 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39755 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33336 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175313 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123520 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40181 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39759 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129232 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91023 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169224 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31619 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149388 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109757 "Passed tests") | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30597 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 4 new passes 2 flakes") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29288 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23453 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140565 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27085 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177845 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30747 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28791 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137584 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39824 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33433 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137509 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37118 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40512 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148881 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/103152 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32806 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25748 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39023 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112097 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38420 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3834 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38665 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38563 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->