### PR TITLE
AX: Make AXIntersectionWithSelectionRange return element-relative range instead of document-root-relative range.

### DIFF
--- a/Source/WebCore/accessibility/AXCoreObject.h
+++ b/Source/WebCore/accessibility/AXCoreObject.h
@@ -1247,6 +1247,16 @@ public:
 #endif
 #if PLATFORM(MAC)
     virtual AXTextMarkerRange selectedTextMarkerRange() const = 0;
+
+    // The intersection of the global selection with this object's text range,
+    // expressed as an AXTextMarkerRange whose endpoints are anchored to this
+    // object with element-local character offsets (so the result's
+    // characterRange() and the underlying markers' characterOffset are
+    // 0-based within this object's text content). Returns std::nullopt if
+    // the selection does not intersect this object's range. Works in both
+    // isolated-tree and non-isolated-tree modes via virtual dispatch on the
+    // underlying range accessors.
+    std::optional<AXTextMarkerRange> intersectionWithSelectionRange() const;
 #endif
 
     virtual IntRect boundsForRange(const SimpleRange&) const = 0;

--- a/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
+++ b/Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm
@@ -501,6 +501,61 @@ AXCoreObject::AccessibilityChildrenVector AXCoreObject::crossFrameSortedDescenda
     return results;
 }
 
+// Walk from the AX tree root to `marker`, counting characters. Works on
+// either the main thread (via SimpleRange) or the secondary AX thread (via
+// the isolated tree's character walk).
+static unsigned offsetFromRootForMarker(const AXTextMarker& marker)
+{
+    if (!marker.isValid())
+        return 0;
+    if (!isMainThread())
+        return marker.offsetFromRoot();
+    return makeNSRange(AXTextMarkerRange { marker, marker }.simpleRange()).location;
+}
+
+std::optional<AXTextMarkerRange> AXCoreObject::intersectionWithSelectionRange() const
+{
+    auto objectRange = textMarkerRange();
+    if (!objectRange)
+        return std::nullopt;
+    auto selectionRange = selectedTextMarkerRange();
+    if (!selectionRange)
+        return std::nullopt;
+    auto intersection = objectRange.intersectionWith(selectionRange);
+    if (!intersection.has_value())
+        return std::nullopt;
+
+    // If the intersection's endpoints are already anchored to this object,
+    // their characterOffsets are already in element-local coordinates and
+    // no root walks are needed.
+    if (intersection->start().objectID() == objectID()
+        && intersection->end().objectID() == objectID()
+        && intersection->start().treeID() == treeID()
+        && intersection->end().treeID() == treeID())
+        return intersection;
+
+    // The AX text marker APIs that surface a marker as an integer (e.g.
+    // AXIndexForTextMarker / offsetFromRoot) report the offset relative to
+    // the AX tree root, not relative to this object. To return an
+    // AXTextMarkerRange whose endpoints are expressed in element-local
+    // character offsets — which is what callers of
+    // AXIntersectionWithSelectionRange expect from an attribute named
+    // "intersection ... range [for this element]" — convert the intersection
+    // endpoints to offsets within this object's range and rebuild the range
+    // anchored to this object.
+    unsigned objectStartFromRoot = offsetFromRootForMarker(objectRange.start());
+    unsigned intersectionStartFromRoot = offsetFromRootForMarker(intersection->start());
+    unsigned intersectionEndFromRoot = intersection->isCollapsed()
+        ? intersectionStartFromRoot
+        : offsetFromRootForMarker(intersection->end());
+
+    if (intersectionStartFromRoot < objectStartFromRoot
+        || intersectionEndFromRoot < intersectionStartFromRoot)
+        return std::nullopt;
+
+    return { { treeID(), objectID(), intersectionStartFromRoot - objectStartFromRoot, intersectionEndFromRoot - objectStartFromRoot } };
+}
+
 namespace Accessibility {
 
 PlatformRoleMap createPlatformRoleMap()

--- a/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
+++ b/Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm
@@ -1509,9 +1509,7 @@ static id handleElementBusyAttribute(WebAccessibilityObjectWrapper*, AXCoreObjec
 
 static id handleIntersectionWithSelectionRangeAttribute(WebAccessibilityObjectWrapper *, AXCoreObject& backingObject)
 {
-    auto objectRange = backingObject.textMarkerRange();
-    auto selectionRange = backingObject.selectedTextMarkerRange();
-    auto intersection = selectionRange.intersectionWith(objectRange);
+    auto intersection = backingObject.intersectionWithSelectionRange();
     if (!intersection.has_value())
         return nil;
 


### PR DESCRIPTION
#### f1034b08fe31d6e3faf7bd7602e403b736e566db
<pre>
AX: Make AXIntersectionWithSelectionRange return element-relative range instead of document-root-relative range.
<a href="https://bugs.webkit.org/show_bug.cgi?id=315357">https://bugs.webkit.org/show_bug.cgi?id=315357</a>
&lt;<a href="https://rdar.apple.com/problem/177714583">rdar://problem/177714583</a>&gt;

Reviewed by NOBODY (OOPS!).

The AXIntersectionWithSelectionRange attribute is documented to return
the intersection of the global selection with this object&apos;s text range.
Its value was previously expressed as document-root offsets rather than
offsets local to the receiver, so VoiceOver cursor landed
at the wrong position when interacting with a web static text element
that had an AX selection caret inside it. For example: in a Mail
message paragraph &quot;This week&apos;s top stories include:&quot;, moving the caret
between &apos;w&apos; and &apos;e&apos; of &quot;week&quot; and then drilling into the paragraph
positioned the client cursor at root-relative offset 90 instead of the
element-local offset 6, producing a &quot;reached boundary&quot; sound and
stranding the cursor at the element&apos;s end.

The root cause was in handleIntersectionWithSelectionRangeAttribute:
it computed the intersection inline and returned the result of
AXTextMarkerRange::intersectionWith directly. That method&apos;s fast path
anchors the result markers to the selection range&apos;s start objectID —
typically a parent container, not the receiver — so the wire-format
wrapping (platformData() on macOS 26.4+, NSValue/NSRange via
characterRange() otherwise) preserved that anchoring and the receiver
was effectively ignored.

This patch fixes the producer. The wire format is unchanged and no
client-side code change is required for the attribute to start
returning element-local data.

AXCoreObject::intersectionWithSelectionRange() is a new method on the
core object that composes the existing virtual textMarkerRange() and
selectedTextMarkerRange() accessors, runs intersectionWith with
objectRange as the receiver so the result anchor leans toward this
object (the fast path of intersectionWith anchors to the receiver&apos;s
start objectID), then converts the intersection endpoints to
element-local character offsets and returns an AXTextMarkerRange
anchored to this object. Conversion uses a small helper,
offsetFromRootForMarker, that mirrors handleIndexForTextMarkerAttribute&apos;s
existing main-thread / isolated-tree dispatch (SimpleRange location on
the main thread, AXTextMarker::offsetFromRoot() on the secondary AX
thread). The method works in both ITM-on and ITM-off configurations
via virtual dispatch on the underlying range accessors.

handleIntersectionWithSelectionRangeAttribute now delegates to the new
core method. The HAVE-branched return form is preserved unchanged: on
macOS 26.4+ it returns intersection-&gt;platformData(), otherwise it
returns [NSValue valueWithRange:intersection-&gt;characterRange()]. Only
the values inside that form change from root-relative to element-local.

The new method has an O(1) fast path of its own: when the intersection
returned by AXTextMarkerRange::intersectionWith is already anchored to
this object, the markers&apos; characterOffsets are already in this
object&apos;s coordinate space, so the range can be returned directly
without any root walks. The collapsed-range case (a caret selection,
which is the dominant use case) reuses the start offset for the end
instead of walking from root twice.

This change does not touch handleIndexForTextMarkerAttribute /
AXIndexForTextMarker. That attribute keeps its existing
document-root-relative semantics, including the <a href="https://rdar.apple.com/144892240">rdar://144892240</a>
contract for markers pointing into runless objects (e.g. the start of
an empty &lt;input&gt;) where the local offset is not a meaningful character
index in the document. Migration of AT-side consumers that
currently route through AXIndexForTextMarker to compute element-local
positions — and any associated introduction of an opt-in element-local
attribute — is left to a follow-up so that the contract change is
explicit and per-caller reviewable.

* Source/WebCore/accessibility/AXCoreObject.h:
* Source/WebCore/accessibility/cocoa/AXCoreObjectCocoa.mm:
(WebCore::offsetFromRootForMarker):
(WebCore::AXCoreObject::intersectionWithSelectionRange const):
* Source/WebCore/accessibility/mac/WebAccessibilityObjectWrapperMac.mm:
(handleIntersectionWithSelectionRangeAttribute):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f1034b08fe31d6e3faf7bd7602e403b736e566db

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164058 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37542 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30761 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173087 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121309 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/dff00238-f89a-4cc5-8e26-ab56fdbb2f44) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165927 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37875 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37542 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127451 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89686 "layout-tests (failure)") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/1e62800f-8d2c-4270-b473-67d8c10387f3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167017 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29736 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147481 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107999 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bb049478-5d17-4b08-adcd-7f9747194797) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28782 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27409 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20851 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138683 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25198 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175613 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28434 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26866 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135763 "Passed tests") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37212 "Failed to compile WebKit") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31523 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135733 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37997 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146993 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100194 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31035 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23849 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36806 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109853 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36205 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1899 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36455 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36352 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->