### PR TITLE
[export-w3c-test-changes]

### DIFF
--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
@@ -459,7 +459,7 @@ nothing to commit, working tree clean
                 self.executable, 'checkout', '-B', re.compile(r'.+'),
                 cwd=self.path,
                 generator=lambda *args, **kwargs:
-                    mocks.ProcessCompletion(returncode=0) if self.checkout(args[3], source=args[4] if len(args) > 4 else None, create=False, force=True) else mocks.ProcessCompletion(returncode=1)
+                    mocks.ProcessCompletion(returncode=0) if self.checkout(args[3], source=args[4] if len(args) > 4 else None, create=True, force=True) else mocks.ProcessCompletion(returncode=1)
             ), mocks.Subprocess.Route(
                 self.executable, 'checkout', re.compile(r'.+'),
                 cwd=self.path,
@@ -948,9 +948,19 @@ nothing to commit, working tree clean
         if create:
             if commit:
                 if force:
-                    self.head = commit
-                    self.detached = something not in self.commits.keys()
-                    return True
+                    if source == something:
+                        # checkout -B branch (no start-point): reset to current HEAD
+                        del self.commits[something]
+                        # Fall through to create branch from current HEAD
+                    else:
+                        # checkout -B branch start-point: reset branch to start-point
+                        self.head = commit
+                        self.detached = False
+                        return True
+                else:
+                    return False
+            elif source != something:
+                # Source was explicitly provided but doesn't exist: fail
                 return False
             self.commits[something] = [Commit.from_json(Commit.Encoder().default(self.head))]
             # Copy one more to create a bridge commit

--- a/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
+++ b/Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py
@@ -61,6 +61,7 @@ class Git(mocks.Subprocess):
         self.remote = remote or 'git@example.org:mock/{}'.format(os.path.basename(path))
         self.detached = detached or False
         self.is_worktree = is_worktree
+        self.push_error = None
 
         self.tags = tags or {}
 
@@ -633,6 +634,14 @@ nothing to commit, working tree clean
                 self.executable, 'add', re.compile(r'.+'),
                 cwd=self.path,
                 generator=lambda *args, **kwargs: self.add(args[2]),
+            ), mocks.Subprocess.Route(
+                self.executable, 'show-ref', '--verify', '--quiet', re.compile(r'.+'),
+                cwd=self.path,
+                generator=lambda *args, **kwargs: self.show_ref_verify(args[4]),
+            ), mocks.Subprocess.Route(
+                self.executable, 'push', '--porcelain', re.compile(r'.+'), re.compile(r'.+'),
+                cwd=self.path,
+                generator=lambda *args, **kwargs: self.push_porcelain(args[3], args[4], force='-f' in args),
             ), mocks.Subprocess.Route(
                 self.executable, 'push', '-f', re.compile(r'.+'), re.compile(r'.+'),
                 cwd=self.path,
@@ -1325,6 +1334,30 @@ nothing to commit, working tree clean
             self.remotes[remote_branch] = self.commits[branch][:]
         elif remote_branch in self.remotes:
             del self.remotes[remote_branch]
+        return mocks.ProcessCompletion(returncode=0)
+
+    def show_ref_verify(self, ref):
+        branch = ref.replace('refs/heads/', '')
+        if branch in self.commits:
+            return mocks.ProcessCompletion(returncode=0)
+        return mocks.ProcessCompletion(returncode=1)
+
+    def push_porcelain(self, remote, refspec, force=False):
+        if self.push_error is not None:
+            return mocks.ProcessCompletion(returncode=self.push_error)
+
+        local_branch = refspec.split(':')[0]
+        remote_ref = refspec.split(':')[-1] if ':' in refspec else local_branch
+        remote_branch = '{}/{}'.format(remote, remote_ref)
+
+        if not force and remote_branch in self.remotes:
+            return mocks.ProcessCompletion(
+                returncode=1,
+                stdout='!\trefs/heads/{ref}:refs/heads/{ref}\t[rejected] (non-fast-forward)\n'.format(ref=remote_ref),
+            )
+
+        if local_branch in self.commits:
+            self.remotes[remote_branch] = self.commits[local_branch][:]
         return mocks.ProcessCompletion(returncode=0)
 
     def _fetch_with_refspec(self, refspecs):

--- a/Tools/Scripts/webkitpy/w3c/test_exporter.py
+++ b/Tools/Scripts/webkitpy/w3c/test_exporter.py
@@ -26,22 +26,19 @@
 
 import argparse
 import logging
-import os
 import sys
 import subprocess
 
 from webkitcorepy import string_utils, run
-from webkitbugspy import Tracker, bugzilla
+from webkitbugspy import bugzilla
 from webkitscmpy import local
 
 from webkitpy.common.host import Host
-from webkitpy.common.net.bugzilla import Bugzilla
 from webkitpy.common.webkit_finder import WebKitFinder
 from webkitpy.w3c.wpt_linter import WPTLinter
 from webkitpy.w3c.common import WPT_GH_ORG, WPT_GH_REPO_NAME, WPT_GH_URL, WPTPaths
 from webkitpy.common.memoized import memoized
 
-from urllib.error import HTTPError
 
 _log = logging.getLogger(__name__)
 
@@ -53,46 +50,28 @@ EXCLUDED_FILE_SUFFIXES = ['-expected.txt', '-expected.html', '-expected.xht', '-
 
 
 class WebPlatformTestExporter(object):
-    def __init__(self, host, options, bugzillaClass=Bugzilla, WPTLinterClass=WPTLinter, WKRepository=None):
+    def __init__(self, host, options):
         self._host = host
         self._filesystem = host.filesystem
         self._options = options
-        self._linter = WPTLinterClass
 
         self._host.initialize_scm()
 
-        self._bugzilla = bugzillaClass()
-        self._bug_id = options.bug_id
-        self._bug = None
-
-        issue = None
         repo_path = WebKitFinder(self._filesystem).webkit_base()
-        self._repository = WKRepository or local.Git(repo_path)
+        self._repository = local.Git(repo_path)
 
-        if not self._bug_id:
-            if options.attachment_id:
-                self._bug_id = self._bugzilla.bug_id_for_attachment_id(options.attachment_id)  # FIXME: Dependency on webkitpy.bugzilla should be removed when patch workflow is disabled
-            elif options.git_commit:
-                commit = self._repository.find(options.git_commit)
-                issue = next((issue for issue in commit.issues if isinstance(issue.tracker, bugzilla.Tracker)), None)
-                if not issue:
-                    raise ValueError('Unable to find associated bug. Please provide a bug id using `--bug`.')
-                self._bug_id = issue.id
-                self._options.git_commit = commit.hash
+        if not options.git_commit:
+            raise ValueError('A git commit must be provided using `--git-commit`.')
 
-        if not self._bug_id:
-            raise ValueError('Unable to find associated bug. Please provide a bug id using `--bug`.')
-        elif Tracker.instance() and (isinstance(self._bug_id, int) or string_utils.decode(self._bug_id).isnumeric()):
-            issue = Tracker.instance().issue(int(self._bug_id))
-        else:
-            issue = Tracker.from_string(self._bug_id)
-        if issue:
-            self._bug_id = issue.id
-            self._bug = issue
+        commit = self._repository.find(options.git_commit)
+        issue = next((issue for issue in commit.issues if isinstance(issue.tracker, bugzilla.Tracker)), None)
+        if not issue:
+            raise ValueError('Unable to find associated bug from commit.')
+        self._bug_id = issue.id
+        self._bug = issue
+        self._options.git_commit = commit.hash
 
-        self._commit_message = options.message
-        if not self._commit_message:
-            self._commit_message = f'WebKit export of {issue.link}' if issue else 'Export made from a WebKit repository'
+        self._commit_message = options.message or f'WebKit export of {issue.link}'
 
     @property
     def username(self):
@@ -128,10 +107,7 @@ class WebPlatformTestExporter(object):
     @property
     @memoized
     def _branch_name(self):
-        if not self._bug_id:
-            commit = self._repository.find(self._options.git_commit)
-            commit_hash = commit.hash[:7] if commit else '0'
-        return f"wpt-export-for-webkit-{(str(self._bug_id) if self._bug_id else commit_hash)}"
+        return f"wpt-export-for-webkit-{self._bug_id}"
 
     @property
     @memoized
@@ -223,7 +199,7 @@ class WebPlatformTestExporter(object):
         self._remote = self._init_wpt_remote()
         if not self._remote:
             return 1
-        self._linter = self._linter(repository_directory)
+        self._linter = WPTLinter(repository_directory)
         return True
 
     def clean(self):
@@ -245,7 +221,7 @@ class WebPlatformTestExporter(object):
         try:
             output = self._run_wpt_git(['apply', '--index', patch, '-3'], stderr=subprocess.STDOUT)
             if output.returncode:
-                _log.error(f'Failed to apply patch!')
+                _log.error('Failed to apply patch!')
                 _log.error(f"{output.stdout.decode('utf-8', 'replace')}")
                 return False
         except Exception as e:
@@ -346,7 +322,7 @@ class WebPlatformTestExporter(object):
             return 1
 
         if not self._get_wpt_repository():
-            _log.error(f'Could not find WPT repository')
+            _log.error('Could not find WPT repository')
             return 1
 
         _log.info('Fetching web-platform-tests repository')
@@ -403,10 +379,10 @@ class WebPlatformTestExporter(object):
 
 def parse_args(args):
     description = f"""Script to generate a pull request to W3C web-platform-tests repository
-    'Tools/Scripts/export-w3c-test-changes -c -g HEAD -b XYZ' will do the following:
+    'Tools/Scripts/export-w3c-test-changes -c -g HEAD' will do the following:
     - Clone web-platform-tests repository if not done already and set it up for pushing branches. By default, the repository will be cloned into the parent directory of your WebKit checkout (e.g. ~/WebKit/../wpt).
-    - Gather WebKit bug id XYZ bug and changes to apply to web-platform-tests repository based on the HEAD commit
-    - Create a remote branch named webkit-XYZ on https://github.com/USERNAME/{WPT_GH_REPO_NAME}.git repository based on the locally applied patch.
+    - Gather the bug and changes to apply to web-platform-tests repository based on the HEAD commit
+    - Create a remote branch on https://github.com/USERNAME/{WPT_GH_REPO_NAME}.git repository based on the locally applied patch.
        * {WPT_GH_URL}.git should have already been cloned to https://github.com/USERNAME/{WPT_GH_REPO_NAME}.git.
     - Make the related pull request on {WPT_GH_URL}.git repository.
     - Clean the local Git repository
@@ -420,8 +396,6 @@ def parse_args(args):
     parser = argparse.ArgumentParser(prog='export-w3c-test-changes ...', description=description, formatter_class=argparse.RawDescriptionHelpFormatter)
 
     parser.add_argument('-g', '--git-commit', dest='git_commit', default=None, help='Git commit to apply')
-    parser.add_argument('-b', '--bug', dest='bug_id', default=None, help='Bug ID or URL to search for patch')
-    parser.add_argument('-a', '--attachment', dest='attachment_id', default=None, help='Attachment ID to search for patch')
     parser.add_argument('-bn', '--branch-name', dest='public_branch_name', default=None, help='Branch name to push to')
     parser.add_argument('-m', '--message', dest='message', default=None, help='Commit message')
     parser.add_argument('-r', '--remote', dest='repository_remote', default=None, help='repository origin to use to push')

--- a/Tools/Scripts/webkitpy/w3c/test_exporter.py
+++ b/Tools/Scripts/webkitpy/w3c/test_exporter.py
@@ -32,6 +32,7 @@ import subprocess
 from webkitcorepy import string_utils, run
 from webkitbugspy import bugzilla
 from webkitscmpy import local
+from webkitscmpy.program.pull_request import PullRequest as PullRequestProgram
 
 from webkitpy.common.host import Host
 from webkitpy.common.webkit_finder import WebKitFinder
@@ -209,14 +210,9 @@ class WebPlatformTestExporter(object):
 
     def create_branch_with_patch(self, patch):
         _log.info('Applying patch to web-platform-tests branch ' + self._branch_name)
-        try:
-            self._run_wpt_git(['checkout', '-b', self._branch_name])
-        except Exception as e:
-            _log.warning(e)
-            _log.info('Retrying to create the branch')
-            if self._run_wpt_git(['show-ref', '--quiet', '--verify', f'refs/heads/{self._branch_name}']):
-                self._run_wpt_git(['branch', '-D', self._branch_name])
-            self._run_wpt_git(['checkout', '-b', self._branch_name])
+        if self._run_wpt_git(['checkout', '-B', self._branch_name]).returncode:
+            _log.error(f'Failed to create branch {self._branch_name}')
+            return False
 
         try:
             output = self._run_wpt_git(['apply', '--index', patch, '-3'], stderr=subprocess.STDOUT)
@@ -292,9 +288,18 @@ class WebPlatformTestExporter(object):
         return pr
 
     def create_wpt_pull_request(self, remote_branch_name, title, body):
-        _log.info(f"\nCreating pull-request for '{remote_branch_name}'...")
+        existing_pr = PullRequestProgram.find_existing_pull_request(self._wpt_repo, self._remote, branch=self._public_branch_name)
 
-        # FIXME: If the pull request/branch exists, we should give the option to overwrite or rebase - https://bugs.webkit.org/show_bug.cgi?id=295350
+        if existing_pr and existing_pr.opened:
+            _log.info(f"\nUpdating pull-request for '{remote_branch_name}'...")
+            pr = self._remote.pull_requests.update(pull_request=existing_pr, title=title, body=body)
+            if not pr:
+                _log.error(f"Failed to update pull-request for '{self._wpt_repo.branch}'\n")
+                return None
+            print(f"Updated '{pr}'!")
+            return pr
+
+        _log.info(f"\nCreating pull-request for '{remote_branch_name}'...")
         pr = self._remote.pull_requests.create(
             title=title,
             body=body,
@@ -303,7 +308,6 @@ class WebPlatformTestExporter(object):
         if not pr:
             _log.error(f"Failed to create pull-request for '{self._wpt_repo.branch}'\n")
             return None
-
         print(f"Created '{pr}'!")
         return pr
 
@@ -390,7 +394,6 @@ def parse_args(args):
     - As a dry run, one can start by running the script without -c. This will only create the branch on the user public GitHub repository.
     - By default, the script will create an https remote URL that will require a password-based authentication to GitHub. If you are using an SSH key, please use the --remote-url option.
     FIXME:
-    - The script is not yet able to update an existing pull request.
     - Need a way to monitor the progress of the pull request so that status of all pending pull requests can be done at import time.
     """
     parser = argparse.ArgumentParser(prog='export-w3c-test-changes ...', description=description, formatter_class=argparse.RawDescriptionHelpFormatter)

--- a/Tools/Scripts/webkitpy/w3c/test_exporter.py
+++ b/Tools/Scripts/webkitpy/w3c/test_exporter.py
@@ -29,7 +29,7 @@ import logging
 import sys
 import subprocess
 
-from webkitcorepy import string_utils, run
+from webkitcorepy import arguments, string_utils, run
 from webkitbugspy import bugzilla
 from webkitscmpy import local
 from webkitscmpy.program.pull_request import PullRequest as PullRequestProgram
@@ -210,7 +210,15 @@ class WebPlatformTestExporter(object):
 
     def create_branch_with_patch(self, patch):
         _log.info('Applying patch to web-platform-tests branch ' + self._branch_name)
-        if self._run_wpt_git(['checkout', '-B', self._branch_name]).returncode:
+        branch_exists = not self._run_wpt_git(['show-ref', '--verify', '--quiet', f'refs/heads/{self._branch_name}']).returncode
+        if branch_exists:
+            if not self._options.delete_existing:
+                _log.error(f'Local branch {self._branch_name} already exists. Use --delete-existing to overwrite.')
+                return False
+            if self._run_wpt_git(['checkout', '-B', self._branch_name]).returncode:
+                _log.error(f'Failed to create branch {self._branch_name}')
+                return False
+        elif self._run_wpt_git(['checkout', '-b', self._branch_name]).returncode:
             _log.error(f'Failed to create branch {self._branch_name}')
             return False
 
@@ -256,9 +264,24 @@ class WebPlatformTestExporter(object):
 
     def push_to_wpt_fork(self):
         _log.info(f'Pushing branch {self._branch_name} to {self._wpt_fork_remote}...')
-        if self._run_wpt_git(['push', self._wpt_fork_remote, self._branch_name + ':' + self._public_branch_name, '-f']).returncode:
-            _log.error('Failed to push to WPT fork')
-            return 1
+        refspec = self._branch_name + ':' + self._public_branch_name
+        result = self._run_wpt_git(['push', '--porcelain', self._wpt_fork_remote, refspec], capture_output=True)
+        if result.returncode:
+            if result.returncode >= 128:
+                _log.error('Failed to push to WPT fork')
+                return None
+            stdout = result.stdout or b''
+            if any(line.startswith(b'!') for line in stdout.splitlines()):
+                if not self._options.delete_existing:
+                    _log.error(f'Remote branch {self._public_branch_name} already exists. Use --delete-existing to overwrite.')
+                    return None
+                retry = self._run_wpt_git(['push', '--porcelain', self._wpt_fork_remote, refspec, '-f'], capture_output=True)
+                if retry.returncode:
+                    _log.error('Failed to push to WPT fork')
+                    return None
+            else:
+                _log.error('Failed to push to WPT fork')
+                return None
         _log.info(f'Branch available at {self._wpt_fork_branch_github_url}')
         return True
 
@@ -410,6 +433,12 @@ def parse_args(args):
     parser.add_argument('--no-clean', action='store_false', dest='clean', help='Do not clean up.')
     parser.add_argument('--clean-on-failure', action='store_true', dest='clean_on_failure', help='Do not clean up on failure.')
     parser.add_argument('--dry-run', action='store_true', dest='dry_run', default=False, help='Create local branch and commit but do not push to remote.')
+    parser.add_argument(
+        '--delete-existing', '--no-delete-existing',
+        dest='delete_existing', default=False,
+        action=arguments.NoAction,
+        help='Allow overwriting an existing local branch or force-pushing to an existing remote branch.',
+    )
 
     options, args = parser.parse_known_args(args)
 

--- a/Tools/Scripts/webkitpy/w3c/test_exporter_unittest.py
+++ b/Tools/Scripts/webkitpy/w3c/test_exporter_unittest.py
@@ -168,7 +168,7 @@ class TestExporterTest(testing.PathTestCase):
             host.filesystem.write_binary_file(f'{self.path}/wpt', '')
 
             host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
-            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '--delete-existing', '-d', self.path])
             exporter = WebPlatformTestExporter(host, options)
             exporter.do_export()
 
@@ -222,7 +222,7 @@ class TestExporterTest(testing.PathTestCase):
             host.filesystem.write_binary_file(f'{self.path}/wpt', '')
 
             host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
-            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '--delete-existing', '-d', self.path])
             exporter = WebPlatformTestExporter(host, options)
             exporter.do_export()
 
@@ -297,7 +297,7 @@ class TestExporterTest(testing.PathTestCase):
             host.filesystem.write_binary_file(f'{self.path}/wpt', '')
 
             host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
-            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '--delete-existing', '-d', self.path])
             exporter = WebPlatformTestExporter(host, options)
             exporter.do_export()
 
@@ -379,7 +379,7 @@ class TestExporterTest(testing.PathTestCase):
             host.filesystem.write_binary_file(f'{self.path}/wpt', '')
 
             host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
-            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '--delete-existing', '-d', self.path])
             exporter = WebPlatformTestExporter(host, options)
             exporter.do_export()
 
@@ -465,6 +465,365 @@ class TestExporterTest(testing.PathTestCase):
             self.assertEqual(issue.related_links, ['https://github.com/web-platform-tests/wpt/pull/43'])
 
             # A new PR should have been created (total: original closed + new open)
+            self.assertEqual(len(wpt_remote.pull_requests), 2)
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            "Created 'PR 43 | WebKit export of https://bugs.example.com/show_bug.cgi?id=1'!\n",
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+        log = captured.root.log.getvalue().splitlines()
+        self.assertEqual(
+            [line for line in log if 'Mock process' not in line], [
+                f'Using the WPT repository found at `{self.path}`',
+                'Fetching web-platform-tests repository',
+                'Cleaning web-platform-tests master branch',
+                'Applying patch to web-platform-tests branch wpt-export-for-webkit-1',
+                'Pushing branch wpt-export-for-webkit-1 to username...',
+                'Branch available at https://github.com/username/wpt/tree/wpt-export-for-webkit-1',
+                '',
+                "Creating pull-request for 'username:wpt-export-for-webkit-1'...",
+                'Removing local branch wpt-export-for-webkit-1',
+                'WPT Pull Request: https://github.com/web-platform-tests/wpt/pull/43'],
+        )
+
+    def test_export_local_branch_exists_errors_without_flag(self):
+        with OutputCapture(level=logging.INFO) as captured, bmocks.Bugzilla(self.BUGZILLA_URL.split('://')[1], issues=bmocks.ISSUES, environment=wkmocks.Environment(
+            BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+            BUGS_EXAMPLE_COM_PASSWORD='password',
+        )), mocks.remote.GitHub(remote='github.com/web-platform-tests/wpt', labels={
+            'webkit-export': dict(color='00000', description=''),
+        }) as wpt_remote, mocks.local.Git(
+            self.path,
+            remote='https://{}'.format(wpt_remote.remote)
+        ) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ):
+            # Pre-create the local branch
+            git_mock.checkout('wpt-export-for-webkit-1', create=True)
+            git_mock.checkout(git_mock.default_branch)
+
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
+            host = TestExporterTest.MyMockHost()
+            host.filesystem.maybe_make_directory(self.path)
+            host.filesystem.write_binary_file(f'{self.path}/resources/testharness.js', '')
+            host.filesystem.write_binary_file(f'{self.path}/wpt', '')
+
+            host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
+            # NOTE: No --delete-existing flag
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+            exporter = WebPlatformTestExporter(host, options)
+            result = exporter.do_export()
+
+            self.assertEqual(result, 1)
+
+            # No bug comment should have been posted (only pre-existing mock comments)
+            issue = Tracker.from_string('{}/show_bug.cgi?id=1'.format(self.BUGZILLA_URL))
+            self.assertEqual(len(issue.comments), 2)
+
+        self.assertEqual(captured.stdout.getvalue(), '')
+        log = captured.root.log.getvalue()
+        self.assertIn('already exists', log)
+
+    def test_export_remote_branch_exists_errors_without_flag(self):
+        with OutputCapture(level=logging.INFO) as captured, bmocks.Bugzilla(self.BUGZILLA_URL.split('://')[1], issues=bmocks.ISSUES, environment=wkmocks.Environment(
+            BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+            BUGS_EXAMPLE_COM_PASSWORD='password',
+        )), mocks.remote.GitHub(remote='github.com/web-platform-tests/wpt', labels={
+            'webkit-export': dict(color='00000', description=''),
+        }) as wpt_remote, mocks.local.Git(
+            self.path,
+            remote='https://{}'.format(wpt_remote.remote)
+        ) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ):
+            # Pre-populate the remote branch
+            git_mock.remotes['username/wpt-export-for-webkit-1'] = git_mock.commits[git_mock.default_branch][:]
+
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
+            host = TestExporterTest.MyMockHost()
+            host.filesystem.maybe_make_directory(self.path)
+            host.filesystem.write_binary_file(f'{self.path}/resources/testharness.js', '')
+            host.filesystem.write_binary_file(f'{self.path}/wpt', '')
+
+            host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
+            # NOTE: No --delete-existing flag
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+            exporter = WebPlatformTestExporter(host, options)
+            result = exporter.do_export()
+
+            self.assertEqual(result, 1)
+
+            # No bug comment should have been posted (only pre-existing mock comments)
+            issue = Tracker.from_string('{}/show_bug.cgi?id=1'.format(self.BUGZILLA_URL))
+            self.assertEqual(len(issue.comments), 2)
+
+        self.assertEqual(captured.stdout.getvalue(), '')
+        log = captured.root.log.getvalue()
+        self.assertIn('already exists', log)
+
+    def test_export_push_fatal_error(self):
+        with OutputCapture(level=logging.INFO) as captured, bmocks.Bugzilla(self.BUGZILLA_URL.split('://')[1], issues=bmocks.ISSUES, environment=wkmocks.Environment(
+            BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+            BUGS_EXAMPLE_COM_PASSWORD='password',
+        )), mocks.remote.GitHub(remote='github.com/web-platform-tests/wpt', labels={
+            'webkit-export': dict(color='00000', description=''),
+        }) as wpt_remote, mocks.local.Git(
+            self.path,
+            remote='https://{}'.format(wpt_remote.remote)
+        ) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ):
+            git_mock.push_error = 128
+
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
+            host = TestExporterTest.MyMockHost()
+            host.filesystem.maybe_make_directory(self.path)
+            host.filesystem.write_binary_file(f'{self.path}/resources/testharness.js', '')
+            host.filesystem.write_binary_file(f'{self.path}/wpt', '')
+
+            host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+            exporter = WebPlatformTestExporter(host, options)
+            result = exporter.do_export()
+
+            self.assertEqual(result, 1)
+
+            issue = Tracker.from_string('{}/show_bug.cgi?id=1'.format(self.BUGZILLA_URL))
+            self.assertEqual(len(issue.comments), 2)
+
+        self.assertEqual(captured.stdout.getvalue(), '')
+        log = captured.root.log.getvalue()
+        self.assertIn('Failed to push to WPT fork', log)
+
+    def test_export_push_non_rejected_error(self):
+        with OutputCapture(level=logging.INFO) as captured, bmocks.Bugzilla(self.BUGZILLA_URL.split('://')[1], issues=bmocks.ISSUES, environment=wkmocks.Environment(
+            BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+            BUGS_EXAMPLE_COM_PASSWORD='password',
+        )), mocks.remote.GitHub(remote='github.com/web-platform-tests/wpt', labels={
+            'webkit-export': dict(color='00000', description=''),
+        }) as wpt_remote, mocks.local.Git(
+            self.path,
+            remote='https://{}'.format(wpt_remote.remote)
+        ) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ):
+            git_mock.push_error = 2
+
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
+            host = TestExporterTest.MyMockHost()
+            host.filesystem.maybe_make_directory(self.path)
+            host.filesystem.write_binary_file(f'{self.path}/resources/testharness.js', '')
+            host.filesystem.write_binary_file(f'{self.path}/wpt', '')
+
+            host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+            exporter = WebPlatformTestExporter(host, options)
+            result = exporter.do_export()
+
+            self.assertEqual(result, 1)
+
+            issue = Tracker.from_string('{}/show_bug.cgi?id=1'.format(self.BUGZILLA_URL))
+            self.assertEqual(len(issue.comments), 2)
+
+        self.assertEqual(captured.stdout.getvalue(), '')
+        log = captured.root.log.getvalue()
+        self.assertIn('Failed to push to WPT fork', log)
+
+    def test_export_open_pr_errors_without_flag(self):
+        with OutputCapture(level=logging.INFO) as captured, bmocks.Bugzilla(self.BUGZILLA_URL.split('://')[1], issues=bmocks.ISSUES, environment=wkmocks.Environment(
+            BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+            BUGS_EXAMPLE_COM_PASSWORD='password',
+        )), mocks.remote.GitHub(remote='github.com/web-platform-tests/wpt', labels={
+            'webkit-export': dict(color='00000', description=''),
+        }) as wpt_remote, mocks.local.Git(
+            self.path,
+            remote='https://{}'.format(wpt_remote.remote)
+        ) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ):
+            # Remote branch must exist for the push to be rejected as non-fast-forward
+            git_mock.remotes['username/wpt-export-for-webkit-1'] = git_mock.commits[git_mock.default_branch][:]
+            wpt_remote.pull_requests.append({
+                'number': 42,
+                'state': 'open',
+                'title': 'Old title',
+                'body': 'Old body',
+                'user': {'login': 'USER'},
+                'head': {'ref': 'wpt-export-for-webkit-1', 'sha': 'abc123', 'label': 'USER:wpt-export-for-webkit-1'},
+                'base': {'ref': 'master', 'label': 'web-platform-tests:master', 'user': {'login': 'web-platform-tests'}},
+                'draft': False,
+                '_links': {'issue': {'href': 'https://api.github.com/repos/web-platform-tests/wpt/issues/42'}},
+                'reviews': [],
+            })
+            wpt_remote.issues[42] = dict(
+                creator=wpt_remote.users.create(username='USER'),
+                timestamp=0,
+                assignee=None,
+                comments=[],
+                title='Old title',
+                opened=True,
+                description='Old body',
+            )
+
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
+            host = TestExporterTest.MyMockHost()
+            host.filesystem.maybe_make_directory(self.path)
+            host.filesystem.write_binary_file(f'{self.path}/resources/testharness.js', '')
+            host.filesystem.write_binary_file(f'{self.path}/wpt', '')
+
+            host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+            exporter = WebPlatformTestExporter(host, options)
+            result = exporter.do_export()
+
+            self.assertEqual(result, 1)
+
+            issue = Tracker.from_string('{}/show_bug.cgi?id=1'.format(self.BUGZILLA_URL))
+            self.assertEqual(len(issue.comments), 2)
+
+        self.assertEqual(captured.stdout.getvalue(), '')
+        log = captured.root.log.getvalue()
+        self.assertIn('already exists', log)
+
+    def test_export_local_and_open_pr_errors_without_flag(self):
+        with OutputCapture(level=logging.INFO) as captured, bmocks.Bugzilla(self.BUGZILLA_URL.split('://')[1], issues=bmocks.ISSUES, environment=wkmocks.Environment(
+            BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+            BUGS_EXAMPLE_COM_PASSWORD='password',
+        )), mocks.remote.GitHub(remote='github.com/web-platform-tests/wpt', labels={
+            'webkit-export': dict(color='00000', description=''),
+        }) as wpt_remote, mocks.local.Git(
+            self.path,
+            remote='https://{}'.format(wpt_remote.remote)
+        ) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ):
+            # Pre-create the local branch
+            git_mock.checkout('wpt-export-for-webkit-1', create=True)
+            git_mock.checkout(git_mock.default_branch)
+
+            # Remote branch must exist for the push to be rejected as non-fast-forward
+            git_mock.remotes['username/wpt-export-for-webkit-1'] = git_mock.commits[git_mock.default_branch][:]
+            wpt_remote.pull_requests.append({
+                'number': 42,
+                'state': 'open',
+                'title': 'Old title',
+                'body': 'Old body',
+                'user': {'login': 'USER'},
+                'head': {'ref': 'wpt-export-for-webkit-1', 'sha': 'abc123', 'label': 'USER:wpt-export-for-webkit-1'},
+                'base': {'ref': 'master', 'label': 'web-platform-tests:master', 'user': {'login': 'web-platform-tests'}},
+                'draft': False,
+                '_links': {'issue': {'href': 'https://api.github.com/repos/web-platform-tests/wpt/issues/42'}},
+                'reviews': [],
+            })
+            wpt_remote.issues[42] = dict(
+                creator=wpt_remote.users.create(username='USER'),
+                timestamp=0,
+                assignee=None,
+                comments=[],
+                title='Old title',
+                opened=True,
+                description='Old body',
+            )
+
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
+            host = TestExporterTest.MyMockHost()
+            host.filesystem.maybe_make_directory(self.path)
+            host.filesystem.write_binary_file(f'{self.path}/resources/testharness.js', '')
+            host.filesystem.write_binary_file(f'{self.path}/wpt', '')
+
+            host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+            exporter = WebPlatformTestExporter(host, options)
+            result = exporter.do_export()
+
+            self.assertEqual(result, 1)
+
+            issue = Tracker.from_string('{}/show_bug.cgi?id=1'.format(self.BUGZILLA_URL))
+            self.assertEqual(len(issue.comments), 2)
+
+        self.assertEqual(captured.stdout.getvalue(), '')
+        log = captured.root.log.getvalue()
+        self.assertIn('already exists', log)
+
+    def test_export_closed_pr_succeeds_without_flag(self):
+        with OutputCapture(level=logging.INFO) as captured, bmocks.Bugzilla(self.BUGZILLA_URL.split('://')[1], issues=bmocks.ISSUES, environment=wkmocks.Environment(
+            BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+            BUGS_EXAMPLE_COM_PASSWORD='password',
+        )), mocks.remote.GitHub(remote='github.com/web-platform-tests/wpt', labels={
+            'webkit-export': dict(color='00000', description=''),
+        }) as wpt_remote, mocks.local.Git(
+            self.path,
+            remote='https://{}'.format(wpt_remote.remote)
+        ) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ):
+            # Closed PR — branch may have been deleted
+            wpt_remote.pull_requests.append({
+                'number': 42,
+                'state': 'closed',
+                'title': 'Old title',
+                'body': 'Old body',
+                'user': {'login': 'USER'},
+                'head': {'ref': 'wpt-export-for-webkit-1', 'sha': 'abc123', 'label': 'USER:wpt-export-for-webkit-1'},
+                'base': {'ref': 'master', 'label': 'web-platform-tests:master', 'user': {'login': 'web-platform-tests'}},
+                'draft': False,
+                '_links': {'issue': {'href': 'https://api.github.com/repos/web-platform-tests/wpt/issues/42'}},
+                'reviews': [],
+            })
+            wpt_remote.issues[42] = dict(
+                creator=wpt_remote.users.create(username='USER'),
+                timestamp=0,
+                assignee=None,
+                comments=[],
+                title='Old title',
+                opened=False,
+                description='Old body',
+            )
+
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
+            host = TestExporterTest.MyMockHost()
+            host.filesystem.maybe_make_directory(self.path)
+            host.filesystem.write_binary_file(f'{self.path}/resources/testharness.js', '')
+            host.filesystem.write_binary_file(f'{self.path}/wpt', '')
+
+            host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+            exporter = WebPlatformTestExporter(host, options)
+            exporter.do_export()
+
+            issue = Tracker.from_string('{}/show_bug.cgi?id=1'.format(self.BUGZILLA_URL))
+            self.assertEqual(issue.comments[-1].content, 'Submitted web-platform-tests pull request: https://github.com/web-platform-tests/wpt/pull/43')
+            self.assertEqual(issue.related_links, ['https://github.com/web-platform-tests/wpt/pull/43'])
+
             self.assertEqual(len(wpt_remote.pull_requests), 2)
 
         self.assertEqual(

--- a/Tools/Scripts/webkitpy/w3c/test_exporter_unittest.py
+++ b/Tools/Scripts/webkitpy/w3c/test_exporter_unittest.py
@@ -141,6 +141,352 @@ class TestExporterTest(testing.PathTestCase):
                 WebPlatformTestExporter(host, options)
             self.assertIn('Unable to find associated bug', str(context.exception))
 
+    def test_export_local_branch_exists(self):
+        with OutputCapture(level=logging.INFO) as captured, bmocks.Bugzilla(self.BUGZILLA_URL.split('://')[1], issues=bmocks.ISSUES, environment=wkmocks.Environment(
+            BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+            BUGS_EXAMPLE_COM_PASSWORD='password',
+        )), mocks.remote.GitHub(remote='github.com/web-platform-tests/wpt', labels={
+            'webkit-export': dict(color='00000', description=''),
+        }) as wpt_remote, mocks.local.Git(
+            self.path,
+            remote='https://{}'.format(wpt_remote.remote)
+        ) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ) as mock_linter_class:
+            # Pre-create the local branch before export
+            git_mock.checkout('wpt-export-for-webkit-1', create=True)
+            git_mock.checkout(git_mock.default_branch)
+
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
+            host = TestExporterTest.MyMockHost()
+            host.filesystem.maybe_make_directory(self.path)
+            host.filesystem.write_binary_file(f'{self.path}/resources/testharness.js', '')
+            host.filesystem.write_binary_file(f'{self.path}/wpt', '')
+
+            host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+            exporter = WebPlatformTestExporter(host, options)
+            exporter.do_export()
+
+            issue = Tracker.from_string('{}/show_bug.cgi?id=1'.format(self.BUGZILLA_URL))
+            self.assertEqual(issue.comments[-1].content, 'Submitted web-platform-tests pull request: https://github.com/web-platform-tests/wpt/pull/1')
+            self.assertEqual(issue.related_links, ['https://github.com/web-platform-tests/wpt/pull/1'])
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            "Created 'PR 1 | WebKit export of https://bugs.example.com/show_bug.cgi?id=1'!\n",
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+        log = captured.root.log.getvalue().splitlines()
+        self.assertEqual(
+            [line for line in log if 'Mock process' not in line], [
+                f'Using the WPT repository found at `{self.path}`',
+                'Fetching web-platform-tests repository',
+                'Cleaning web-platform-tests master branch',
+                'Applying patch to web-platform-tests branch wpt-export-for-webkit-1',
+                'Pushing branch wpt-export-for-webkit-1 to username...',
+                'Branch available at https://github.com/username/wpt/tree/wpt-export-for-webkit-1',
+                '',
+                "Creating pull-request for 'username:wpt-export-for-webkit-1'...",
+                'Removing local branch wpt-export-for-webkit-1',
+                'WPT Pull Request: https://github.com/web-platform-tests/wpt/pull/1'],
+        )
+
+    def test_export_remote_branch_exists_no_pr(self):
+        with OutputCapture(level=logging.INFO) as captured, bmocks.Bugzilla(self.BUGZILLA_URL.split('://')[1], issues=bmocks.ISSUES, environment=wkmocks.Environment(
+            BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+            BUGS_EXAMPLE_COM_PASSWORD='password',
+        )), mocks.remote.GitHub(remote='github.com/web-platform-tests/wpt', labels={
+            'webkit-export': dict(color='00000', description=''),
+        }) as wpt_remote, mocks.local.Git(
+            self.path,
+            remote='https://{}'.format(wpt_remote.remote)
+        ) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ) as mock_linter_class:
+            # Pre-populate the remote branch (simulating a previous push) but no PR
+            git_mock.remotes['username/wpt-export-for-webkit-1'] = git_mock.commits[git_mock.default_branch][:]
+
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
+            host = TestExporterTest.MyMockHost()
+            host.filesystem.maybe_make_directory(self.path)
+            host.filesystem.write_binary_file(f'{self.path}/resources/testharness.js', '')
+            host.filesystem.write_binary_file(f'{self.path}/wpt', '')
+
+            host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+            exporter = WebPlatformTestExporter(host, options)
+            exporter.do_export()
+
+            issue = Tracker.from_string('{}/show_bug.cgi?id=1'.format(self.BUGZILLA_URL))
+            self.assertEqual(issue.comments[-1].content, 'Submitted web-platform-tests pull request: https://github.com/web-platform-tests/wpt/pull/1')
+            self.assertEqual(issue.related_links, ['https://github.com/web-platform-tests/wpt/pull/1'])
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            "Created 'PR 1 | WebKit export of https://bugs.example.com/show_bug.cgi?id=1'!\n",
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+        log = captured.root.log.getvalue().splitlines()
+        self.assertEqual(
+            [line for line in log if 'Mock process' not in line], [
+                f'Using the WPT repository found at `{self.path}`',
+                'Fetching web-platform-tests repository',
+                'Cleaning web-platform-tests master branch',
+                'Applying patch to web-platform-tests branch wpt-export-for-webkit-1',
+                'Pushing branch wpt-export-for-webkit-1 to username...',
+                'Branch available at https://github.com/username/wpt/tree/wpt-export-for-webkit-1',
+                '',
+                "Creating pull-request for 'username:wpt-export-for-webkit-1'...",
+                'Removing local branch wpt-export-for-webkit-1',
+                'WPT Pull Request: https://github.com/web-platform-tests/wpt/pull/1'],
+        )
+
+    def test_export_updates_existing_open_pr(self):
+        with OutputCapture(level=logging.INFO) as captured, bmocks.Bugzilla(self.BUGZILLA_URL.split('://')[1], issues=bmocks.ISSUES, environment=wkmocks.Environment(
+            BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+            BUGS_EXAMPLE_COM_PASSWORD='password',
+        )), mocks.remote.GitHub(remote='github.com/web-platform-tests/wpt', labels={
+            'webkit-export': dict(color='00000', description=''),
+        }) as wpt_remote, mocks.local.Git(
+            self.path,
+            remote='https://{}'.format(wpt_remote.remote)
+        ) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ) as mock_linter_class:
+            # Remote branch must exist for the push to be rejected as non-fast-forward
+            git_mock.remotes['username/wpt-export-for-webkit-1'] = git_mock.commits[git_mock.default_branch][:]
+            wpt_remote.pull_requests.append({
+                'number': 42,
+                'state': 'open',
+                'title': 'Old title',
+                'body': 'Old body',
+                'user': {'login': 'USER'},
+                'head': {'ref': 'wpt-export-for-webkit-1', 'sha': 'abc123', 'label': 'USER:wpt-export-for-webkit-1'},
+                'base': {'ref': 'master', 'label': 'web-platform-tests:master', 'user': {'login': 'web-platform-tests'}},
+                'draft': False,
+                '_links': {'issue': {'href': 'https://api.github.com/repos/web-platform-tests/wpt/issues/42'}},
+                'reviews': [],
+            })
+            wpt_remote.issues[42] = dict(
+                creator=wpt_remote.users.create(username='USER'),
+                timestamp=0,
+                assignee=None,
+                comments=[],
+                title='Old title',
+                opened=True,
+                description='Old body',
+            )
+
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
+            host = TestExporterTest.MyMockHost()
+            host.filesystem.maybe_make_directory(self.path)
+            host.filesystem.write_binary_file(f'{self.path}/resources/testharness.js', '')
+            host.filesystem.write_binary_file(f'{self.path}/wpt', '')
+
+            host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+            exporter = WebPlatformTestExporter(host, options)
+            exporter.do_export()
+
+            issue = Tracker.from_string('{}/show_bug.cgi?id=1'.format(self.BUGZILLA_URL))
+            self.assertEqual(issue.comments[-1].content, 'Submitted web-platform-tests pull request: https://github.com/web-platform-tests/wpt/pull/42')
+            self.assertEqual(issue.related_links, ['https://github.com/web-platform-tests/wpt/pull/42'])
+
+            # No new PR should have been created
+            self.assertEqual(len(wpt_remote.pull_requests), 1)
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            "Updated 'PR 42 | WebKit export of https://bugs.example.com/show_bug.cgi?id=1'!\n",
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+        log = captured.root.log.getvalue().splitlines()
+        self.assertEqual(
+            [line for line in log if 'Mock process' not in line], [
+                f'Using the WPT repository found at `{self.path}`',
+                'Fetching web-platform-tests repository',
+                'Cleaning web-platform-tests master branch',
+                'Applying patch to web-platform-tests branch wpt-export-for-webkit-1',
+                'Pushing branch wpt-export-for-webkit-1 to username...',
+                'Branch available at https://github.com/username/wpt/tree/wpt-export-for-webkit-1',
+                '',
+                "Updating pull-request for 'username:wpt-export-for-webkit-1'...",
+                'Removing local branch wpt-export-for-webkit-1',
+                'WPT Pull Request: https://github.com/web-platform-tests/wpt/pull/42'],
+        )
+
+    def test_export_local_and_remote_exist_with_open_pr(self):
+        with OutputCapture(level=logging.INFO) as captured, bmocks.Bugzilla(self.BUGZILLA_URL.split('://')[1], issues=bmocks.ISSUES, environment=wkmocks.Environment(
+            BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+            BUGS_EXAMPLE_COM_PASSWORD='password',
+        )), mocks.remote.GitHub(remote='github.com/web-platform-tests/wpt', labels={
+            'webkit-export': dict(color='00000', description=''),
+        }) as wpt_remote, mocks.local.Git(
+            self.path,
+            remote='https://{}'.format(wpt_remote.remote)
+        ) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ) as mock_linter_class:
+            # Pre-create the local branch
+            git_mock.checkout('wpt-export-for-webkit-1', create=True)
+            git_mock.checkout(git_mock.default_branch)
+
+            # Remote branch must exist for the push to be rejected as non-fast-forward
+            git_mock.remotes['username/wpt-export-for-webkit-1'] = git_mock.commits[git_mock.default_branch][:]
+            wpt_remote.pull_requests.append({
+                'number': 42,
+                'state': 'open',
+                'title': 'Old title',
+                'body': 'Old body',
+                'user': {'login': 'USER'},
+                'head': {'ref': 'wpt-export-for-webkit-1', 'sha': 'abc123', 'label': 'USER:wpt-export-for-webkit-1'},
+                'base': {'ref': 'master', 'label': 'web-platform-tests:master', 'user': {'login': 'web-platform-tests'}},
+                'draft': False,
+                '_links': {'issue': {'href': 'https://api.github.com/repos/web-platform-tests/wpt/issues/42'}},
+                'reviews': [],
+            })
+            wpt_remote.issues[42] = dict(
+                creator=wpt_remote.users.create(username='USER'),
+                timestamp=0,
+                assignee=None,
+                comments=[],
+                title='Old title',
+                opened=True,
+                description='Old body',
+            )
+
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
+            host = TestExporterTest.MyMockHost()
+            host.filesystem.maybe_make_directory(self.path)
+            host.filesystem.write_binary_file(f'{self.path}/resources/testharness.js', '')
+            host.filesystem.write_binary_file(f'{self.path}/wpt', '')
+
+            host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+            exporter = WebPlatformTestExporter(host, options)
+            exporter.do_export()
+
+            issue = Tracker.from_string('{}/show_bug.cgi?id=1'.format(self.BUGZILLA_URL))
+            self.assertEqual(issue.comments[-1].content, 'Submitted web-platform-tests pull request: https://github.com/web-platform-tests/wpt/pull/42')
+            self.assertEqual(issue.related_links, ['https://github.com/web-platform-tests/wpt/pull/42'])
+
+            # No new PR should have been created
+            self.assertEqual(len(wpt_remote.pull_requests), 1)
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            "Updated 'PR 42 | WebKit export of https://bugs.example.com/show_bug.cgi?id=1'!\n",
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+        log = captured.root.log.getvalue().splitlines()
+        self.assertEqual(
+            [line for line in log if 'Mock process' not in line], [
+                f'Using the WPT repository found at `{self.path}`',
+                'Fetching web-platform-tests repository',
+                'Cleaning web-platform-tests master branch',
+                'Applying patch to web-platform-tests branch wpt-export-for-webkit-1',
+                'Pushing branch wpt-export-for-webkit-1 to username...',
+                'Branch available at https://github.com/username/wpt/tree/wpt-export-for-webkit-1',
+                '',
+                "Updating pull-request for 'username:wpt-export-for-webkit-1'...",
+                'Removing local branch wpt-export-for-webkit-1',
+                'WPT Pull Request: https://github.com/web-platform-tests/wpt/pull/42'],
+        )
+
+    def test_export_creates_new_pr_when_existing_is_closed(self):
+        with OutputCapture(level=logging.INFO) as captured, bmocks.Bugzilla(self.BUGZILLA_URL.split('://')[1], issues=bmocks.ISSUES, environment=wkmocks.Environment(
+            BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
+            BUGS_EXAMPLE_COM_PASSWORD='password',
+        )), mocks.remote.GitHub(remote='github.com/web-platform-tests/wpt', labels={
+            'webkit-export': dict(color='00000', description=''),
+        }) as wpt_remote, mocks.local.Git(
+            self.path,
+            remote='https://{}'.format(wpt_remote.remote)
+        ) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ) as mock_linter_class:
+            # Pre-populate a closed PR for the same branch
+            wpt_remote.pull_requests.append({
+                'number': 42,
+                'state': 'closed',
+                'title': 'Old title',
+                'body': 'Old body',
+                'user': {'login': 'USER'},
+                'head': {'ref': 'wpt-export-for-webkit-1', 'sha': 'abc123', 'label': 'USER:wpt-export-for-webkit-1'},
+                'base': {'ref': 'master', 'label': 'web-platform-tests:master', 'user': {'login': 'web-platform-tests'}},
+                'draft': False,
+                '_links': {'issue': {'href': 'https://api.github.com/repos/web-platform-tests/wpt/issues/42'}},
+                'reviews': [],
+            })
+            wpt_remote.issues[42] = dict(
+                creator=wpt_remote.users.create(username='USER'),
+                timestamp=0,
+                assignee=None,
+                comments=[],
+                title='Old title',
+                opened=False,
+                description='Old body',
+            )
+
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
+            host = TestExporterTest.MyMockHost()
+            host.filesystem.maybe_make_directory(self.path)
+            host.filesystem.write_binary_file(f'{self.path}/resources/testharness.js', '')
+            host.filesystem.write_binary_file(f'{self.path}/wpt', '')
+
+            host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+            exporter = WebPlatformTestExporter(host, options)
+            exporter.do_export()
+
+            issue = Tracker.from_string('{}/show_bug.cgi?id=1'.format(self.BUGZILLA_URL))
+            self.assertEqual(issue.comments[-1].content, 'Submitted web-platform-tests pull request: https://github.com/web-platform-tests/wpt/pull/43')
+            self.assertEqual(issue.related_links, ['https://github.com/web-platform-tests/wpt/pull/43'])
+
+            # A new PR should have been created (total: original closed + new open)
+            self.assertEqual(len(wpt_remote.pull_requests), 2)
+
+        self.assertEqual(
+            captured.stdout.getvalue(),
+            "Created 'PR 43 | WebKit export of https://bugs.example.com/show_bug.cgi?id=1'!\n",
+        )
+        self.assertEqual(captured.stderr.getvalue(), '')
+        log = captured.root.log.getvalue().splitlines()
+        self.assertEqual(
+            [line for line in log if 'Mock process' not in line], [
+                f'Using the WPT repository found at `{self.path}`',
+                'Fetching web-platform-tests repository',
+                'Cleaning web-platform-tests master branch',
+                'Applying patch to web-platform-tests branch wpt-export-for-webkit-1',
+                'Pushing branch wpt-export-for-webkit-1 to username...',
+                'Branch available at https://github.com/username/wpt/tree/wpt-export-for-webkit-1',
+                '',
+                "Creating pull-request for 'username:wpt-export-for-webkit-1'...",
+                'Removing local branch wpt-export-for-webkit-1',
+                'WPT Pull Request: https://github.com/web-platform-tests/wpt/pull/43'],
+        )
+
     def test_export_with_specific_branch(self):
         with OutputCapture(level=logging.INFO) as captured, bmocks.Bugzilla(self.BUGZILLA_URL.split('://')[1], issues=bmocks.ISSUES, environment=wkmocks.Environment(
             BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',

--- a/Tools/Scripts/webkitpy/w3c/test_exporter_unittest.py
+++ b/Tools/Scripts/webkitpy/w3c/test_exporter_unittest.py
@@ -42,20 +42,6 @@ class TestExporterTest(testing.PathTestCase):
         super().setUp()
         os.mkdir(os.path.join(self.path, '.git'))
 
-    class MockBugzilla(object):
-        def __init__(self):
-            self.calls = []
-
-        def fetch_bug_dictionary(self, id):
-            self.calls.append('fetch bug ' + id)
-            return {"title": "my bug title"}
-
-        def post_comment_to_bug(self, id, comment, see_also=None):
-            if see_also:
-                self.calls.append("Append %s to see also list" % ", ".join(see_also))
-            self.calls.append('post comment to bug ' + id + ' : ' + comment)
-            return True
-
     class MockGit(object):
         mock_format_patch_result = b'my patch containing some diffs'
 
@@ -85,17 +71,22 @@ class TestExporterTest(testing.PathTestCase):
         }) as wpt_remote, mocks.local.Git(
             self.path,
             remote='https://{}'.format(wpt_remote.remote)
-        ), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)]), patch(
+        ) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
             'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
         ) as mock_linter_class:
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
             host = TestExporterTest.MyMockHost()
             host.filesystem.maybe_make_directory(self.path)
             host.filesystem.write_binary_file(f'{self.path}/resources/testharness.js', '')
             host.filesystem.write_binary_file(f'{self.path}/wpt', '')
 
             host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
-            options = parse_args(['test_exporter.py', '-g', '1@main', '-b', '1', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
-            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, mock_linter_class, 1)
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+            exporter = WebPlatformTestExporter(host, options)
             exporter.do_export()
 
             issue = Tracker.from_string('{}/show_bug.cgi?id=1'.format(self.BUGZILLA_URL))
@@ -107,7 +98,7 @@ class TestExporterTest(testing.PathTestCase):
 
         self.assertEqual(
             captured.stdout.getvalue(),
-            f"Created 'PR 1 | WebKit export of https://bugs.example.com/show_bug.cgi?id=1'!\n",
+            "Created 'PR 1 | WebKit export of https://bugs.example.com/show_bug.cgi?id=1'!\n",
         )
         self.assertEqual(captured.stderr.getvalue(), '')
         log = captured.root.log.getvalue().splitlines()
@@ -125,6 +116,31 @@ class TestExporterTest(testing.PathTestCase):
                 'WPT Pull Request: https://github.com/web-platform-tests/wpt/pull/1'],
         )
 
+    def test_export_no_git_commit(self):
+        with mocks.local.Git(self.path), patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ):
+            host = TestExporterTest.MyMockHost()
+            host.filesystem.maybe_make_directory(self.path)
+            options = parse_args(['test_exporter.py', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+            with self.assertRaises(ValueError) as context:
+                WebPlatformTestExporter(host, options)
+            self.assertIn('--git-commit', str(context.exception))
+
+    def test_export_no_bugzilla_issue_in_commit(self):
+        with mocks.local.Git(self.path) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ):
+            git_mock.head.message = 'Commit with no bug reference\n'
+            host = TestExporterTest.MyMockHost()
+            host.filesystem.maybe_make_directory(self.path)
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+            with self.assertRaises(ValueError) as context:
+                WebPlatformTestExporter(host, options)
+            self.assertIn('Unable to find associated bug', str(context.exception))
+
     def test_export_with_specific_branch(self):
         with OutputCapture(level=logging.INFO) as captured, bmocks.Bugzilla(self.BUGZILLA_URL.split('://')[1], issues=bmocks.ISSUES, environment=wkmocks.Environment(
             BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
@@ -134,16 +150,21 @@ class TestExporterTest(testing.PathTestCase):
         }) as wpt_remote, mocks.local.Git(
             self.path,
             remote='https://{}'.format(wpt_remote.remote)
-        ), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)]), patch(
+        ) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
             'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
         ) as mock_linter_class:
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
             host = TestExporterTest.MyMockHost()
             host.filesystem.maybe_make_directory(self.path)
             host.filesystem.write_binary_file(f'{self.path}/resources/testharness.js', '')
             host.filesystem.write_binary_file(f'{self.path}/wpt', '')
             host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
-            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-b', '1', '-c', '-n', 'USER', '-t', 'TOKEN', '-bn', 'wpt-export-branch', '-d', self.path])
-            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, mock_linter_class, 1)
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-bn', 'wpt-export-branch', '-d', self.path])
+            exporter = WebPlatformTestExporter(host, options)
             exporter.do_export()
             issue = Tracker.from_string('{}/show_bug.cgi?id=1'.format(self.BUGZILLA_URL))
             self.assertEqual(issue.comments[-1].content, 'Submitted web-platform-tests pull request: https://github.com/web-platform-tests/wpt/pull/1')
@@ -154,7 +175,7 @@ class TestExporterTest(testing.PathTestCase):
 
         self.assertEqual(
             captured.stdout.getvalue(),
-            f"Created 'PR 1 | WebKit export of https://bugs.example.com/show_bug.cgi?id=1'!\n",
+            "Created 'PR 1 | WebKit export of https://bugs.example.com/show_bug.cgi?id=1'!\n",
         )
         self.assertEqual(captured.stderr.getvalue(), '')
         log = captured.root.log.getvalue().splitlines()
@@ -181,16 +202,21 @@ class TestExporterTest(testing.PathTestCase):
         }) as wpt_remote, mocks.local.Git(
             self.path,
             remote='https://{}'.format(wpt_remote.remote)
-        ), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)]), patch(
+        ) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
             'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
         ) as mock_linter_class:
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
             host = TestExporterTest.MyMockHost()
             host.filesystem.maybe_make_directory(self.path)
             host.filesystem.write_binary_file(f'{self.path}/resources/testharness.js', '')
             host.filesystem.write_binary_file(f'{self.path}/wpt', '')
             host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
-            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-b', '1', '-c', '-n', 'USER', '-t', 'TOKEN', '--no-clean', '-d', self.path])
-            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, mock_linter_class, 1)
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '--no-clean', '-d', self.path])
+            exporter = WebPlatformTestExporter(host, options)
             exporter.do_export()
             issue = Tracker.from_string('{}/show_bug.cgi?id=1'.format(self.BUGZILLA_URL))
             self.assertEqual(issue.comments[-1].content, 'Submitted web-platform-tests pull request: https://github.com/web-platform-tests/wpt/pull/1')
@@ -201,7 +227,7 @@ class TestExporterTest(testing.PathTestCase):
 
         self.assertEqual(
             captured.stdout.getvalue(),
-            f"Created 'PR 1 | WebKit export of https://bugs.example.com/show_bug.cgi?id=1'!\n",
+            "Created 'PR 1 | WebKit export of https://bugs.example.com/show_bug.cgi?id=1'!\n",
         )
         self.assertEqual(captured.stderr.getvalue(), '')
         log = captured.root.log.getvalue().splitlines()
@@ -220,7 +246,7 @@ class TestExporterTest(testing.PathTestCase):
         )
 
     def test_export_interactive_mode(self):
-        with OutputCapture(level=logging.INFO) as captured, bmocks.Bugzilla(self.BUGZILLA_URL.split('://')[1], issues=bmocks.ISSUES, environment=wkmocks.Environment(
+        with OutputCapture(level=logging.INFO), bmocks.Bugzilla(self.BUGZILLA_URL.split('://')[1], issues=bmocks.ISSUES, environment=wkmocks.Environment(
             BUGS_EXAMPLE_COM_USERNAME='tcontributor@example.com',
             BUGS_EXAMPLE_COM_PASSWORD='password',
         )), mocks.remote.GitHub(remote='github.com/web-platform-tests/wpt', labels={
@@ -228,30 +254,40 @@ class TestExporterTest(testing.PathTestCase):
         }) as wpt_remote, mocks.local.Git(
             self.path,
             remote='https://{}'.format(wpt_remote.remote)
-        ), patch('webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)]), patch(
+        ) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
             'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
-        ) as mock_linter_class:
+        ):
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
             host = TestExporterTest.MyMockHost()
             host.filesystem.maybe_make_directory(self.path)
             host.web.responses.append({'status_code': 200, 'body': '{"login": "USER"}'})
-            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-b', '1', '-c', '-n', 'USER', '-t', 'TOKEN', '--interactive', '-d', self.path])
-            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, mock_linter_class, 1)
+            options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '--interactive', '-d', self.path])
+            exporter = WebPlatformTestExporter(host, options)
             exporter.do_export()
 
     def test_export_invalid_token(self):
         host = TestExporterTest.MyMockHost()
         host.filesystem.maybe_make_directory(self.path)
         host.web.responses.append({'status_code': 401})
-        options = parse_args(['test_exporter.py', '-g', 'HEAD', '-b', '1', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
-        with OutputCapture(level=logging.INFO) as captured, mocks.remote.GitHub(remote='github.com/web-platform-tests/wpt', labels={
+        options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+        with OutputCapture(level=logging.INFO), mocks.remote.GitHub(remote='github.com/web-platform-tests/wpt', labels={
             'webkit-export': dict(color='00000', description=''),
         }) as wpt_remote, mocks.local.Git(
             self.path,
             remote='https://{}'.format(wpt_remote.remote)
-        ), self.assertRaises(Exception) as context, patch('webkitpy.w3c.test_exporter.WPTLinter',
-            autospec=True, spec_set=True,
-        ) as mock_linter_class:
-            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, mock_linter_class, 1)
+        ) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), self.assertRaises(Exception) as context, patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ):
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
+            exporter = WebPlatformTestExporter(host, options)
             exporter.do_export()
             self.assertIn('OAuth token is not valid', str(context.exception))
 
@@ -259,43 +295,58 @@ class TestExporterTest(testing.PathTestCase):
         host = TestExporterTest.MyMockHost()
         host.filesystem.maybe_make_directory(self.path)
         host.web.responses.append({'status_code': 200, 'body': '{"login": "DIFF_USER"}'})
-        options = parse_args(['test_exporter.py', '-g', 'HEAD', '-b', '1', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
-        with OutputCapture(level=logging.INFO) as captured, mocks.remote.GitHub(remote='github.com/web-platform-tests/wpt', labels={
+        options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+        with OutputCapture(level=logging.INFO), mocks.remote.GitHub(remote='github.com/web-platform-tests/wpt', labels={
             'webkit-export': dict(color='00000', description=''),
         }) as wpt_remote, mocks.local.Git(
             self.path,
             remote='https://{}'.format(wpt_remote.remote)
-        ), self.assertRaises(Exception) as context, patch('webkitpy.w3c.test_exporter.WPTLinter',
-            autospec=True, spec_set=True,
-        ) as mock_linter_class:
-            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, mock_linter_class, 1)
+        ) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), self.assertRaises(Exception) as context, patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ):
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
+            exporter = WebPlatformTestExporter(host, options)
             exporter.do_export()
             self.assertIn('OAuth token does not match the provided username', str(context.exception))
 
     def test_has_wpt_changes(self):
         host = TestExporterTest.MyMockHost()
         host.filesystem.maybe_make_directory(self.path)
-        options = parse_args(['test_exporter.py', '-g', 'HEAD', '-b', '1', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
-        with mocks.local.Git(self.path), patch('webkitpy.w3c.test_exporter.WPTLinter',
-            autospec=True, spec_set=True,
-        ) as mock_linter_class:
-            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, mock_linter_class, 1)
+        options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+        with mocks.local.Git(self.path) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ):
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
+            exporter = WebPlatformTestExporter(host, options)
             self.assertTrue(exporter.has_wpt_changes())
 
     def test_has_no_wpt_changes_for_no_diff(self):
         host = TestExporterTest.MyMockHost()
         host.filesystem.maybe_make_directory(self.path)
         host._mockSCM.mock_format_patch_result = None
-        options = parse_args(['test_exporter.py', '-g', 'HEAD', '-b', '1', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+        options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
         with mocks.remote.GitHub(remote='github.com/web-platform-tests/wpt', labels={
             'webkit-export': dict(color='00000', description=''),
         }) as wpt_remote, mocks.local.Git(
             self.path,
             remote='https://{}'.format(wpt_remote.remote)
-        ), patch('webkitpy.w3c.test_exporter.WPTLinter',
-            autospec=True, spec_set=True,
-        ) as mock_linter_class:
-            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, mock_linter_class, 1)
+        ) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ):
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
+            exporter = WebPlatformTestExporter(host, options)
             self.assertFalse(exporter.has_wpt_changes())
 
     def test_ignore_changes_to_expected_file(self):
@@ -319,11 +370,16 @@ diff --git a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/headers/heade
 
 +change to any.sharedworker
 """
-        options = parse_args(['test_exporter.py', '-g', 'HEAD', '-b', '1', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
-        with mocks.local.Git(self.path), patch('webkitpy.w3c.test_exporter.WPTLinter',
-            autospec=True, spec_set=True,
-        ) as mock_linter_class:
-            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, mock_linter_class, 1)
+        options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+        with mocks.local.Git(self.path) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ):
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
+            exporter = WebPlatformTestExporter(host, options)
         self.assertFalse(exporter.has_wpt_changes())
 
     def test_ignore_changes_to_expected_mismatch_file(self):
@@ -335,11 +391,16 @@ diff --git a/LayoutTests/imported/w3c/web-platform-tests/css/css-counter-styles/
 
 +change to expected-mismatch
 """
-        options = parse_args(['test_exporter.py', '-g', 'HEAD', '-b', '1', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
-        with mocks.local.Git(self.path), patch('webkitpy.w3c.test_exporter.WPTLinter',
-            autospec=True, spec_set=True,
-        ) as mock_linter_class:
-            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, mock_linter_class, 1)
+        options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+        with mocks.local.Git(self.path) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ):
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
+            exporter = WebPlatformTestExporter(host, options)
         self.assertFalse(exporter.has_wpt_changes())
 
     def test_ignore_changes_to_w3c_import_log(self):
@@ -351,9 +412,14 @@ diff --git a/LayoutTests/imported/w3c/web-platform-tests/fetch/api/headers/w3c-i
 
 +change to w3c import
 """
-        options = parse_args(['test_exporter.py', '-g', 'HEAD', '-b', '1', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
-        with mocks.local.Git(self.path), patch('webkitpy.w3c.test_exporter.WPTLinter',
-            autospec=True, spec_set=True,
-        ) as mock_linter_class:
-            exporter = WebPlatformTestExporter(host, options, TestExporterTest.MockBugzilla, mock_linter_class, 1)
+        options = parse_args(['test_exporter.py', '-g', 'HEAD', '-c', '-n', 'USER', '-t', 'TOKEN', '-d', self.path])
+        with mocks.local.Git(self.path) as git_mock, patch(
+            'webkitpy.common.webkit_finder.WebKitFinder.webkit_base', return_value=self.path,
+        ), patch(
+            'webkitbugspy.Tracker._trackers', [bugzilla.Tracker(self.BUGZILLA_URL)],
+        ), patch(
+            'webkitpy.w3c.test_exporter.WPTLinter', autospec=True, spec_set=True,
+        ):
+            git_mock.head.message = f'Test\n{self.BUGZILLA_URL}/show_bug.cgi?id=1\n'
+            exporter = WebPlatformTestExporter(host, options)
         self.assertFalse(exporter.has_wpt_changes())


### PR DESCRIPTION
#### 64c03e67100c
<pre>
[export-w3c-test-changes] Support --delete-existing/--no-delete-existing
<a href="https://bugs.webkit.org/show_bug.cgi?id=295350">https://bugs.webkit.org/show_bug.cgi?id=295350</a>
<a href="https://rdar.apple.com/155454170">rdar://155454170</a>

Reviewed by NOBODY (OOPS!).

Add a --delete-existing/--no-delete-existing flag, similar to the one
git-webkit already supports, to control whether the exporter may
overwrite existing local branches or force-push to existing remote
branches. Unlike git-webkit, which defaults to rebasing an existing
branch, the exporter defaults to --no-delete-existing and refuses to
proceed when it finds pre-existing state.

As part of this, stop unconditionally force-pushing: push without
-f first, parse the --porcelain output to detect a non-fast-forward
rejection, and only force-push if --delete-existing was given.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py:
(Git): Add push_error property for injecting push failures in tests.
Add show-ref --verify --quiet and push --porcelain routes, along with
show_ref_verify and push_porcelain methods.
* Tools/Scripts/webkitpy/w3c/test_exporter.py:
(WebPlatformTestExporter.create_branch_with_patch): Check whether the
local branch exists with show-ref --verify --quiet; refuse to proceed
without --delete-existing. Use checkout -b when creating, -B when
overwriting.
(WebPlatformTestExporter.push_to_wpt_fork): Replace unconditional
push -f with push --porcelain; parse output to distinguish
non-fast-forward rejections from fatal errors, and only force-push on
rejection when --delete-existing is set.
(parse_args): Add --delete-existing/--no-delete-existing via
arguments.NoAction.
* Tools/Scripts/webkitpy/w3c/test_exporter_unittest.py:
(TestExporterTest.test_export_local_branch_exists): Pass
--delete-existing.
(TestExporterTest.test_export_remote_branch_exists_no_pr): Ditto.
(TestExporterTest.test_export_updates_existing_open_pr): Ditto.
(TestExporterTest.test_export_local_and_remote_exist_with_open_pr):
Ditto.
(TestExporterTest.test_export_creates_new_pr_when_existing_is_closed):
Ditto.
(TestExporterTest.test_export_local_branch_exists_errors_without_flag):
(TestExporterTest.test_export_remote_branch_exists_errors_without_flag):
(TestExporterTest.test_export_push_fatal_error):
(TestExporterTest.test_export_push_non_rejected_error):
(TestExporterTest.test_export_open_pr_errors_without_flag):
(TestExporterTest.test_export_local_and_open_pr_errors_without_flag):
(TestExporterTest.test_export_closed_pr_succeeds_without_flag):
</pre>
----------------------------------------------------------------------
#### 4ab0cbdc3d3d
<pre>
[export-w3c-test-changes] Fix behaviour with an already-existing branch
<a href="https://bugs.webkit.org/show_bug.cgi?id=307376">https://bugs.webkit.org/show_bug.cgi?id=307376</a>
<a href="https://rdar.apple.com/170508778">rdar://170508778</a>

Reviewed by NOBODY (OOPS!).

The old code wrapped `checkout -b` in a try/except, but
_run_wpt_git never raises on failure (no check=True), so the retry
path that deleted and recreated the branch was unreachable. Replace
with `checkout -B` which creates the branch or resets it if it already
exists.

When pushing to a fork where the remote branch already exists, look
for an existing open pull request and update it instead of creating a
duplicate.

* Tools/Scripts/libraries/webkitscmpy/webkitscmpy/mocks/local/git.py:
Fix `checkout -B` mock to pass create=True and correctly handle the
reset-existing-branch semantics (delete-then-recreate versus
reset-to-start-point).
* Tools/Scripts/webkitpy/w3c/test_exporter.py:
(WebPlatformTestExporter.create_branch_with_patch): Use `checkout -B`
instead of `checkout -b` with exception-based retry.
(WebPlatformTestExporter.create_wpt_pull_request): Check for an
existing open PR via find_existing_pull_request and update it rather
than creating a new one. If the existing PR is closed, create a new PR.
(parse_args): Remove stale FIXME about not supporting PR updates.
* Tools/Scripts/webkitpy/w3c/test_exporter_unittest.py:
(TestExporterTest.test_export_local_branch_exists):
(TestExporterTest.test_export_remote_branch_exists_no_pr):
(TestExporterTest.test_export_updates_existing_open_pr):
(TestExporterTest.test_export_local_and_remote_exist_with_open_pr):
(TestExporterTest.test_export_creates_new_pr_when_existing_is_closed):
</pre>
----------------------------------------------------------------------
#### f4e904cf7170
<pre>
[export-w3c-test-changes] Remove support for exporting Bugzilla attachments
<a href="https://bugs.webkit.org/show_bug.cgi?id=297919">https://bugs.webkit.org/show_bug.cgi?id=297919</a>
<a href="https://rdar.apple.com/159206512">rdar://159206512</a>

Reviewed by NOBODY (OOPS!).

The Bugzilla attachment and bug-id paths are practically unused, and
make related improvements harder because they lack the full context of
a git commit. Remove them so that the exporter always derives the bug
from the git commit. Simplify the constructor by removing the
dependency-injection parameters that only existed to support the
removed paths.

Drive-by: remove the WPTLinterClass parameter from
WebPlatformTestExporter, the last dependency-injection paramter, since
the tests already patch the module-level name.

* Tools/Scripts/webkitpy/tool/steps/wptchangeexport.py:
(WPTChangeExport.run): Require git_commit instead of bug_id, and
build args without --bug.
* Tools/Scripts/webkitpy/w3c/test_exporter.py:
(WebPlatformTestExporter.__init__): Remove bugzillaClass,
WPTLinterClass, and WKRepository parameters. Remove bug_id and
attachment_id handling; always derive the bug from the git commit.
(WebPlatformTestExporter._branch_name): Simplify now that bug_id is
always set.
(WebPlatformTestExporter._get_wpt_repository): Use WPTLinter directly
instead of indirecting through self._linter class reference.
(WebPlatformTestExporter.create_branch_with_patch):
(WebPlatformTestExporter.do_export):
(parse_args): Remove -b/--bug and -a/--attachment arguments. Update
usage description.
* Tools/Scripts/webkitpy/w3c/test_exporter_unittest.py:
(TestExporterTest.setUp):
(TestExporterTest.test_export):
(TestExporterTest.test_export_with_specific_branch):
(TestExporterTest.test_export_no_clean):
(TestExporterTest.test_export_interactive_mode):
(TestExporterTest.test_export_invalid_token):
(TestExporterTest.test_export_wrong_token):
(TestExporterTest.test_has_wpt_changes):
(TestExporterTest.test_has_no_wpt_changes_for_no_diff):
(TestExporterTest.MockBugzilla): Removed.
(TestExporterTest.MockBugzilla.__init__): Deleted.
(TestExporterTest.MockBugzilla.fetch_bug_dictionary): Deleted.
(TestExporterTest.MockBugzilla.post_comment_to_bug): Deleted.
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/64c03e67100c2b3e30593fa57ea82a3b8f737a97

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164046 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37530 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30749 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173075 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/21f308f6-40de-4a39-a3c4-04e5083f8ab4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165915 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37863 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37530 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127439 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121294 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ff535baa-c4a9-4527-be06-e3f2ea0ea4ba) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167005 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/29726 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147472 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107987 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b225af89-f2ab-4a3f-bc08-0d93b5b2d271) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/163367 "Passed tests") | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/28772 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27400 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20839 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/138673 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25189 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175601 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26857 "Passed tests") | [❌ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135752 "Found 1 new test failure: accessibility/aria-owns-deep-chain-no-timeout.html (failure)") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/163443 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37200 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31512 "Passed tests") | [❌ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135722 "Found 1 new API test failure: TestWTF:WTF_ParkingLot.UnparkOneFiftyThenFiftyAllFast (failure)") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37985 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146984 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100182 "Built successfully") | | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/31028 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23840 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36794 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36193 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1889 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36443 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36340 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->