### PR TITLE
[libpas] Readd dummy field in pas_root.h

### DIFF
--- a/Source/bmalloc/libpas/src/libpas/pas_root.h
+++ b/Source/bmalloc/libpas/src/libpas/pas_root.h
@@ -81,6 +81,7 @@ struct pas_root {
     uintptr_t* compact_heap_reservation_base;
     size_t* compact_heap_reservation_size;
     size_t* compact_heap_reservation_guard_size;
+    size_t compact_heap_reservation_available_size; /* Unused */
     size_t* compact_heap_reservation_bump;
     pas_enumerable_range_list* enumerable_page_malloc_page_list;
     pas_enumerable_range_list* large_heap_physical_page_sharing_cache_page_list;


### PR DESCRIPTION
#### fb1d83206facadd84b6e426952fec1924ba9a3ef
<pre>
[libpas] Readd dummy field in pas_root.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=315382">https://bugs.webkit.org/show_bug.cgi?id=315382</a>
<a href="https://rdar.apple.com/177736059">rdar://177736059</a>

Reviewed by NOBODY (OOPS!).

This maintains ABI stability until we can create a proper version-field
for pas_root itself (rather than one scoped to just the PGM).
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/fb1d83206facadd84b6e426952fec1924ba9a3ef

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164053 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37537 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30756 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173082 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121304 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/27b23b69-e44f-474a-8359-696b3c18efff) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37870 "Built successfully") | [❌ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37537 "Failed to compile WebKit") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127446 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89684 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e5b98516-b036-4723-9faf-3995c1880082) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167012 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29733 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147476 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107994 "Passed tests") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5996d176-a5e9-4013-b9ab-72fec0b8f899) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28779 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27404 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20846 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/156204 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138680 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25193 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175608 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/24945 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26861 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135758 "Passed tests") | | 
| | [❌ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37207 "Failed to compile WebKit") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31518 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135728 "Passed tests") | | 
| | [❌ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/37992 "Failed to compile WebKit") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146988 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100189 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31033 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23844 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/196456 "Built successfully") | | 
| | [❌ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36801 "Failed to compile WebKit") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51360 "Passed tests") | | 
| | [❌ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36200 "Failed to compile WebKit") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1894 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36450 "Built successfully") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36347 "Failed to compile WebKit") | | | | 
<!--EWS-Status-Bubble-End-->