### PR TITLE
[GFC] Close updateScrollInfoAfterLayout transaction on GFC early-return

### DIFF
--- a/LayoutTests/fast/grid/grid-overflow-after-style-change-crash-expected.txt
+++ b/LayoutTests/fast/grid/grid-overflow-after-style-change-crash-expected.txt
@@ -1,0 +1,1 @@
+PASS if no crash.

--- a/LayoutTests/fast/grid/grid-overflow-after-style-change-crash.html
+++ b/LayoutTests/fast/grid/grid-overflow-after-style-change-crash.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
+<style>
+.grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-template-rows: 1fr;
+}
+.item {
+    grid-row: 1 / 2;
+    grid-column: 1 / 2;
+}
+.scroller {
+    width: 100px;
+    height: 100px;
+    overflow: scroll;
+    will-change: scroll-position;
+    visibility: hidden;
+}
+.content {
+    width: 200px;
+    height: 200px;
+}
+</style>
+<div class="grid">
+    <div class="item">
+        <div class="scroller">
+            <div class="content"></div>
+        </div>
+    </div>
+</div>
+<div>PASS if no crash.</div>
+<script>
+    window.testRunner?.dumpAsText();
+    document.body.offsetHeight;
+    document.querySelector('.scroller').style.visibility = 'visible';
+</script>

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -471,8 +471,10 @@ void RenderGrid::layoutGrid(RelayoutChildren relayoutChildren)
 
         resetLogicalHeightBeforeLayoutIfNeeded();
 
-        if (layoutUsingGridFormattingContext())
+        if (layoutUsingGridFormattingContext()) {
+            endAndCommitUpdateScrollInfoAfterLayoutTransaction();
             return;
+        }
 
         // Fieldsets need to find their legend and position it inside the border of the object.
         // The legend then gets skipped during normal layout. The same is true for ruby text.


### PR DESCRIPTION
#### 13d9bbd57202d4cffc86e0bd50bc71635e17cf91
<pre>
[GFC] Close updateScrollInfoAfterLayout transaction on GFC early-return
<a href="https://bugs.webkit.org/show_bug.cgi?id=315377">https://bugs.webkit.org/show_bug.cgi?id=315377</a>
&lt;<a href="https://rdar.apple.com/177732995">rdar://177732995</a>&gt;

Reviewed by Sammy Gill.

RenderGrid::layoutGrid opens an updateScrollInfoAfterLayout transaction via
beginUpdateScrollInfoAfterLayoutTransaction(), but the modern Grid Formatting
Context (GFC) fast path early-returns before reaching the matching
endAndCommitUpdateScrollInfoAfterLayoutTransaction() on the legacy path.

Mirror the legacy path by calling endAndCommitUpdateScrollInfoAfterLayoutTransaction()
on the GFC fast path before returning, so the transaction is always balanced
and deferred blocks are flushed at layout completion.

* LayoutTests/fast/grid/grid-overflow-after-style-change-crash-expected.txt: Added.
* LayoutTests/fast/grid/grid-overflow-after-style-change-crash.html: Added.
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::layoutGrid):

Canonical link: <a href="https://commits.webkit.org/313801@main">https://commits.webkit.org/313801@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b67d4079eef2e64ec946b4c6938adda3a44ca35b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164056 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37540 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30759 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173085 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121307 "Built successfully") | ⏳ 🛠 ios-apple 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165925 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37873 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37540 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127447 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89685 "layout-tests (failure)") | ⏳ 🛠 mac-apple 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167015 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29735 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147479 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/107995 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28781 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27407 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20849 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138682 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25196 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175611 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28432 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26864 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135759 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37210 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31521 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135729 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38025 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/146991 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100192 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24992 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31056 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23847 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36804 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109851 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36203 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1897 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36453 "Built successfully") | | | | 
| | [❌ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36382 "Hash b67d4079 for PR 65505 does not build (failure)") | | | | 
<!--EWS-Status-Bubble-End-->