### PR TITLE
[CMake, iOS] Match Xcode for WebKit swiftmodule staging and overlay cxx-interop

### DIFF
--- a/Source/WebKit/PlatformIOS.cmake
+++ b/Source/WebKit/PlatformIOS.cmake
@@ -1056,31 +1056,42 @@ else ()
     set(_webkit_swift_triple "${_webkit_swift_arch}-apple-ios")
 endif ()
 set(_webkit_fw_swiftmodule_dir "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebKit.framework/Modules/WebKit.swiftmodule")
-set(WebKit_POST_BUILD_COMMAND
-    ${CMAKE_COMMAND} -E make_directory "${_webkit_fw_swiftmodule_dir}"
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        "${_webkit_swift_output}/WebKit.swiftmodule"
-        "${_webkit_swiftmodule_dir}/${_webkit_swift_triple}.swiftmodule"
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        "${_webkit_swift_output}/WebKit.swiftmodule"
-        "${_webkit_fw_swiftmodule_dir}/${_webkit_swift_triple}.swiftmodule"
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        "${_webkit_swift_output}/WebKit.swiftdoc"
-        "${_webkit_swiftmodule_dir}/${_webkit_swift_triple}.swiftdoc"
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        "${_webkit_swift_output}/WebKit.swiftdoc"
-        "${_webkit_fw_swiftmodule_dir}/${_webkit_swift_triple}.swiftdoc"
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        "${_webkit_swift_output}/WebKit.abi.json"
-        "${_webkit_swiftmodule_dir}/${_webkit_swift_triple}.abi.json"
-    COMMAND ${CMAKE_COMMAND} -E copy_if_different
-        "${_webkit_swift_output}/WebKit.abi.json"
-        "${_webkit_fw_swiftmodule_dir}/${_webkit_swift_triple}.abi.json"
-    COMMAND sh -c "[ -f '${_webkit_swift_output}/WebKit.swiftinterface' ] && ${CMAKE_COMMAND} -E copy_if_different '${_webkit_swift_output}/WebKit.swiftinterface' '${_webkit_swiftmodule_dir}/${_webkit_swift_triple}.swiftinterface' || true"
-    COMMAND sh -c "[ -f '${_webkit_swift_output}/WebKit.swiftinterface' ] && ${CMAKE_COMMAND} -E copy_if_different '${_webkit_swift_output}/WebKit.swiftinterface' '${_webkit_fw_swiftmodule_dir}/${_webkit_swift_triple}.swiftinterface' || true"
-    COMMAND sh -c "[ -f '${_webkit_swift_output}/WebKit.private.swiftinterface' ] && ${CMAKE_COMMAND} -E copy_if_different '${_webkit_swift_output}/WebKit.private.swiftinterface' '${_webkit_swiftmodule_dir}/${_webkit_swift_triple}.private.swiftinterface' || true"
-    COMMAND sh -c "[ -f '${_webkit_swift_output}/WebKit.private.swiftinterface' ] && ${CMAKE_COMMAND} -E copy_if_different '${_webkit_swift_output}/WebKit.private.swiftinterface' '${_webkit_fw_swiftmodule_dir}/${_webkit_swift_triple}.private.swiftinterface' || true"
+
+# Stage WebKit's Swift module via a tracked add_custom_command so ninja replays
+# the copies whenever the staged files go missing. POST_BUILD on the dylib link
+# rule only fires on relink, leaving incremental builds with an empty Modules/.
+set(_webkit_swiftmodule_required_exts swiftmodule swiftdoc abi.json)
+set(_webkit_swiftmodule_optional_exts swiftinterface private.swiftinterface)
+set(_webkit_swiftmodule_dests "${_webkit_swiftmodule_dir}" "${_webkit_fw_swiftmodule_dir}")
+
+set(_webkit_staged_swiftmodule_artifacts "")
+set(_webkit_stage_swiftmodule_commands "")
+foreach (_dest IN LISTS _webkit_swiftmodule_dests)
+    foreach (_ext IN LISTS _webkit_swiftmodule_required_exts)
+        list(APPEND _webkit_staged_swiftmodule_artifacts
+            "${_dest}/${_webkit_swift_triple}.${_ext}"
+        )
+        list(APPEND _webkit_stage_swiftmodule_commands
+            COMMAND ${CMAKE_COMMAND} -E copy_if_different
+                "${_webkit_swift_output}/WebKit.${_ext}"
+                "${_dest}/${_webkit_swift_triple}.${_ext}"
+        )
+    endforeach ()
+    foreach (_ext IN LISTS _webkit_swiftmodule_optional_exts)
+        list(APPEND _webkit_stage_swiftmodule_commands
+            COMMAND sh -c "[ -f '${_webkit_swift_output}/WebKit.${_ext}' ] && ${CMAKE_COMMAND} -E copy_if_different '${_webkit_swift_output}/WebKit.${_ext}' '${_dest}/${_webkit_swift_triple}.${_ext}' || true"
+        )
+    endforeach ()
+endforeach ()
+add_custom_command(
+    OUTPUT ${_webkit_staged_swiftmodule_artifacts}
+    DEPENDS WebKit
+    COMMAND ${CMAKE_COMMAND} -E make_directory "${_webkit_fw_swiftmodule_dir}"
+    ${_webkit_stage_swiftmodule_commands}
+    COMMENT "Staging WebKit.swiftmodule into WebKit.framework/Modules/"
+    VERBATIM
 )
+add_custom_target(WebKit_StageSwiftModule DEPENDS ${_webkit_staged_swiftmodule_artifacts})
 
 make_directory("${CMAKE_BINARY_DIR}/WebKit/Modules/WebKit.swiftcrossimport")
 file(WRITE "${CMAKE_BINARY_DIR}/WebKit/Modules/WebKit.swiftcrossimport/SwiftUI.swiftoverlay"
@@ -1735,10 +1746,8 @@ target_compile_options(_WebKit_SwiftUI PRIVATE
     "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xfrontend -experimental-spi-only-imports>"
     "$<$<COMPILE_LANGUAGE:Swift>:-DENABLE_SWIFTUI>"
     "$<$<COMPILE_LANGUAGE:Swift>:SHELL:@${_swiftui_resp}>"
-    "$<$<COMPILE_LANGUAGE:Swift>:-cxx-interoperability-mode=default>"
     "$<$<COMPILE_LANGUAGE:Swift>:-F${CMAKE_LIBRARY_OUTPUT_DIRECTORY}>"
     "$<$<COMPILE_LANGUAGE:Swift>:-F${CMAKE_OSX_SYSROOT}/System/Cryptexes/OS/System/Library/Frameworks>"
-    "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -std=c++2b>"
     "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -DHAVE_CONFIG_H=1>"
     "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -DJS_EXPORT_PRIVATE=>"
     "$<$<COMPILE_LANGUAGE:Swift>:SHELL:-Xcc -DPAL_EXPORT=>"
@@ -1793,7 +1802,7 @@ target_link_options(_WebKit_SwiftUI PRIVATE
     "-framework" "WebKit"
 )
 
-add_dependencies(_WebKit_SwiftUI WebKit)
+add_dependencies(_WebKit_SwiftUI WebKit WebKit_StageSwiftModule)
 
 set(_swiftui_module_output "${CMAKE_BINARY_DIR}/Source/WebKit")
 set(_swiftui_arch "${CMAKE_OSX_ARCHITECTURES}")


### PR DESCRIPTION
#### 3f64c90c2d2afb2e43edbcfe27af956cc8807e33
<pre>
[CMake, iOS] Match Xcode for WebKit swiftmodule staging and overlay cxx-interop
<a href="https://bugs.webkit.org/show_bug.cgi?id=315390">https://bugs.webkit.org/show_bug.cgi?id=315390</a>
<a href="https://rdar.apple.com/problem/177745516">rdar://problem/177745516</a>

Reviewed by Geoffrey Garen.

Two related cmake/Xcode drift bugs in the iOS Swift overlay path:

* WebKit.swiftmodule was staged into WebKit.framework/Modules/ via a
POST_BUILD command on the dylib link rule. Ninja only fires POST_BUILD
when the link itself fires, so an incremental build that finds the
dylib up-to-date never replays the staging. If the framework&apos;s
Modules/ goes missing for any reason, _WebKit_SwiftUI silently falls
through to the SDK&apos;s WebKit module and fails with bogus errors like
&quot;&apos;ImmersiveEnvironment&apos; is not a member type of class &apos;WebKit.WebPage&apos;&quot;.
Replace POST_BUILD with an add_custom_command(OUTPUT ...) so ninja
tracks the staged files and replays the copy whenever they go missing.

* Drop -cxx-interoperability-mode=default from _WebKit_SwiftUI to match Xcode.

* Source/WebKit/PlatformIOS.cmake:

Canonical link: <a href="https://commits.webkit.org/313766@main">https://commits.webkit.org/313766@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/cc1474654ff8b820ef3212d81a2a598612b6c7ea

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164080 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37564 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30783 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173109 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3cb6c921-6128-4556-b865-93a8711f05d9) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37897 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37564 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/127471 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121331 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/798b6c8b-cd52-43c0-b73d-261c8f4c9b27) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167039 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29756 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147501 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108019 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28802 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27429 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20873 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138703 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175635 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28456 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26886 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/135783 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37234 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31543 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135753 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38019 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147013 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100222 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24972 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31052 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23869 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36830 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/109875 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36227 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1919 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36477 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36375 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->