### PR TITLE
Closing an already-transferred MessagePort shouldn't break channel

### DIFF
--- a/LayoutTests/fast/events/message-port-close-after-transfer-expected.txt
+++ b/LayoutTests/fast/events/message-port-close-after-transfer-expected.txt
@@ -1,0 +1,11 @@
+Tests that calling close() on a MessagePort after it has been transferred to another context is a no-op for the channel - the new owner must still receive messages.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS echoData is "echo:hello"
+PASS echoData is "echo:hello again"
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/fast/events/message-port-close-after-transfer.html
+++ b/LayoutTests/fast/events/message-port-close-after-transfer.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+<head>
+<script src="../../resources/js-test.js"></script>
+</head>
+<body>
+
+<iframe id="echoIframe" srcdoc='<script>
+window.onmessage = (e) => {
+    if (e.data === "port-transfer") {
+        const port = e.ports[0];
+        port.onmessage = (evt) => port.postMessage("echo:" + evt.data);
+        window.parent.postMessage("port-transfer-ack", "*");
+    }
+};
+</script>'></iframe>
+
+<script>
+description("Tests that calling close() on a MessagePort after it has been transferred to another context is a no-op for the channel - the new owner must still receive messages.");
+jsTestIsAsync = true;
+
+let echoData;
+const channel = new MessageChannel();
+
+// Send channel.port1 to the iframe when it's ready:
+document.getElementById("echoIframe").onload = () => {
+    document.getElementById("echoIframe").contentWindow.postMessage("port-transfer", "*", [channel.port1]);
+};
+
+// channel.port2 stays in this document and listens for the iframe's echo.
+const {promise: firstEchoReceived, resolve} = Promise.withResolvers();
+let messageCount = 0;
+channel.port2.onmessage = (evt) => {
+    echoData = evt.data;
+    if (messageCount == 0) {
+        messageCount = 1;
+        shouldBeEqualToString("echoData", "echo:hello");
+        resolve();
+    } else if (messageCount == 1) {
+        shouldBeEqualToString("echoData", "echo:hello again");
+        finishJSTest();
+    }
+};
+
+window.addEventListener("message", async (evt) => {
+    if (evt.data !== "port-transfer-ack")
+        return;
+
+    // channel.port1 was disentangled in this document and is entangled in the iframe.
+    channel.port2.postMessage("hello");
+    await firstEchoReceived;
+
+    // Calling close() on the disentangled wrapper should not disrupt communication.
+    channel.port1.close();
+
+    // Send a message on channel.port2, which should reach the iframe:
+    channel.port2.postMessage("hello again");
+});
+</script>
+
+</body>
+</html>

--- a/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
+++ b/Source/WebCore/Modules/webaudio/AudioWorkletNode.cpp
@@ -119,7 +119,7 @@ ExceptionOr<Ref<AudioWorkletNode>> AudioWorkletNode::create(JSC::JSGlobalObject&
     if (node->numberOfOutputs() > 0)
         context.sourceNodeWillBeginPlayback(node);
 
-    context.audioWorklet().createProcessor(name, processorMessagePort.disentangle(), serializedOptions.releaseNonNull(), node);
+    context.audioWorklet().createProcessor(name, processorMessagePort.lenientDisentangle(), serializedOptions.releaseNonNull(), node);
 
     {
         // The node should be manually added to the automatic pull node list, even without a connect() call.

--- a/Source/WebCore/dom/MessagePort.cpp
+++ b/Source/WebCore/dom/MessagePort.cpp
@@ -111,10 +111,9 @@ void MessagePort::notifyAllConnectionsClosed()
     for (auto& [contextIdentifier, weakPort] : entries) {
         ScriptExecutionContext::ensureOnContextThread(contextIdentifier, [weakPort = WTF::move(weakPort)](auto&) {
             RefPtr port = weakPort.get();
-            if (!port || port->m_isDetached)
+            if (!port || port->isDetached())
                 return;
-            port->m_isDetached = true;
-            port->m_entangled = false;
+            port->m_state = State::Disentangled;
             port->removeAllEventListeners();
         });
     }
@@ -162,7 +161,7 @@ MessagePort::~MessagePort()
         }
     }
 
-    if (m_entangled)
+    if (!isDetached())
         close();
 
     if (RefPtr context = scriptExecutionContext())
@@ -183,7 +182,7 @@ ExceptionOr<void> MessagePort::postMessage(JSC::JSGlobalObject& globalObject, JS
     if (messageData.hasException())
         return messageData.releaseException();
 
-    if (!isEntangled())
+    if (isDetached())
         return { };
     ASSERT(scriptExecutionContext());
 
@@ -208,7 +207,7 @@ ExceptionOr<void> MessagePort::postMessage(JSC::JSGlobalObject& globalObject, JS
     if (RefPtr partner = m_localPartner) {
         partner->m_localQueue.append(WTF::move(message));
         ++partner->m_newLocalMessages;
-        if (partner->started()) {
+        if (partner->isStarted()) {
             queueTaskKeepingObjectAlive(*partner, TaskSource::PostedMessageQueue, [](auto& port) mutable {
                 port.dispatchMessages();
             });
@@ -227,8 +226,13 @@ ExceptionOr<void> MessagePort::postMessage(JSC::JSGlobalObject& globalObject, JS
 
 TransferredMessagePort MessagePort::disentangle()
 {
-    ASSERT(m_entangled);
-    m_entangled = false;
+    ASSERT(!isDetached());
+    return lenientDisentangle();
+}
+
+TransferredMessagePort MessagePort::lenientDisentangle()
+{
+    m_state = State::Disentangled;
 
     Ref context = *scriptExecutionContext();
     if (RefPtr localSibling = m_localPartner) {
@@ -269,15 +273,11 @@ void MessagePort::messageAvailable()
 
 void MessagePort::start()
 {
-    // Do nothing if we've been cloned or closed.
-    if (!isEntangled())
+    if (m_state != State::NotStartedYet)
         return;
 
     ASSERT(scriptExecutionContext());
-    if (m_started)
-        return;
-
-    m_started = true;
+    m_state = State::Started;
 
     if (m_localPartner.get() && m_localQueue.isEmpty())
         return;
@@ -287,9 +287,9 @@ void MessagePort::start()
 
 void MessagePort::close()
 {
-    if (m_isDetached)
+    if (isDetached())
         return;
-    m_isDetached = true;
+    m_state = State::Disentangled;
 
     m_localQueue.clear();
     m_newLocalMessages = 0;
@@ -315,12 +315,12 @@ void MessagePort::contextDestroyed()
 
 void MessagePort::dispatchMessages()
 {
+    ASSERT(m_state != State::NotStartedYet);
+
     // Messages for contexts that are not fully active get dispatched too, but JSAbstractEventListener::handleEvent() doesn't call handlers for these.
     // The HTML5 spec specifies that any messages sent to a document that is not fully active should be dropped, so this behavior is OK.
-    ASSERT(started());
-
     RefPtr context = scriptExecutionContext();
-    if (!context || context->activeDOMObjectsAreSuspended() || !isEntangled())
+    if (!context || context->activeDOMObjectsAreSuspended() || isDetached())
         return;
 
     LOG(MessagePorts, "Dispatching messages on MessagePort %s (%p)", m_identifier.logString().utf8().data(), this);
@@ -384,7 +384,7 @@ void MessagePort::dispatchMessages()
 void MessagePort::drainOneLocalMessage()
 {
     RefPtr context = scriptExecutionContext();
-    if (!context || !context->globalObject() || context->activeDOMObjectsAreSuspended() || !isEntangled())
+    if (!context || !context->globalObject() || context->activeDOMObjectsAreSuspended() || isDetached())
         return;
 
     ASSERT(context->isContextThread());
@@ -417,7 +417,7 @@ void MessagePort::drainOneLocalMessage()
 
 void MessagePort::dispatchEvent(Event& event)
 {
-    if (!isEntangled())
+    if (isDetached())
         return;
 
     if (RefPtr globalScope = dynamicDowncast<WorkerGlobalScope>(scriptExecutionContext())) {
@@ -432,14 +432,14 @@ void MessagePort::dispatchEvent(Event& event)
 bool MessagePort::virtualHasPendingActivity() const
 {
     // If the ScriptExecutionContext has been shut down on this object close()'ed, we can GC.
-    if (!scriptExecutionContext() || m_isDetached)
+    if (!scriptExecutionContext() || isDetached())
         return false;
 
     // If this MessagePort has no message event handler then there is no point in keeping it alive.
     if (!m_hasMessageEventListener)
         return false;
 
-    return m_entangled;
+    return true;
 }
 
 MessagePort* MessagePort::locallyEntangledPort() const
@@ -457,7 +457,7 @@ ExceptionOr<Vector<TransferredMessagePort>> MessagePort::disentanglePorts(Vector
     // Walk the incoming array - if there are any duplicate ports, or null ports or cloned ports, throw an error (per section 8.3.3 of the HTML5 spec).
     HashSet<Ref<MessagePort>> portSet;
     for (auto& port : ports) {
-        if (!port->m_entangled || !portSet.add(port).isNewEntry)
+        if (port->isDetached() || !portSet.add(port).isNewEntry)
             return Exception { ExceptionCode::DataCloneError };
     }
 

--- a/Source/WebCore/dom/MessagePort.h
+++ b/Source/WebCore/dom/MessagePort.h
@@ -85,8 +85,8 @@ public:
     WEBCORE_EXPORT static void notifyAllConnectionsClosed();
 
     WEBCORE_EXPORT void messageAvailable();
-    bool started() const { return m_started; }
-    bool isDetached() const { return m_isDetached; }
+    bool isStarted() const { return m_state == State::Started; }
+    bool isDetached() const { return m_state == State::Disentangled; }
 
     void dispatchMessages();
 
@@ -107,6 +107,9 @@ public:
     void dispatchEvent(Event&) final;
 
     TransferredMessagePort disentangle();
+    // FIXME: remove lenientDisentangle() after fixing its call sites - it only exists to
+    // avoid tripping an assert when trying to disentangle an already closed port
+    TransferredMessagePort lenientDisentangle();
     static Ref<MessagePort> entangle(ScriptExecutionContext&, TransferredMessagePort&&);
 
     // Short-circuits message delivery for same-context ports. Should only be used for
@@ -126,12 +129,12 @@ private:
     void stop() final { close(); }
     bool virtualHasPendingActivity() const final;
 
-    // A port starts out its life entangled, and remains entangled until it is detached or is cloned.
-    bool isEntangled() const { return !m_isDetached && m_entangled; }
-
-    bool m_started { false };
-    bool m_isDetached { false };
-    bool m_entangled { true };
+    // A port starts out its life entangled, and remains entangled until it is closed or transferred.
+    // The spec implies an intermediate "detached, still entangled" state while the port is
+    // in flight, but we don't do this - the original port is disentangled immediately when sent,
+    // and the channel is re-attached later, upon reception, to the new port. See https://github.com/whatwg/html/issues/12490
+    enum class State : uint8_t { NotStartedYet, Started, Disentangled };
+    State m_state { State::NotStartedYet };
     bool m_hasMessageEventListener { false };
 
     MessagePortIdentifier m_identifier;

--- a/Source/WebCore/dom/ScriptExecutionContext.cpp
+++ b/Source/WebCore/dom/ScriptExecutionContext.cpp
@@ -281,13 +281,13 @@ void ScriptExecutionContext::dispatchMessagePortEvents()
 
     if (dispatchAll) {
         m_messagePorts.forEach([](auto& messagePort) {
-            if (messagePort.started())
+            if (messagePort.isStarted())
                 messagePort.dispatchMessages();
         });
     } else {
         for (auto& portIdentifier : portsToDispatch) {
             m_messagePorts.forEach([&portIdentifier](auto& messagePort) {
-                if (messagePort.identifier() == portIdentifier && messagePort.started())
+                if (messagePort.identifier() == portIdentifier && messagePort.isStarted())
                     messagePort.dispatchMessages();
             });
         }

--- a/Source/WebCore/workers/shared/SharedWorker.cpp
+++ b/Source/WebCore/workers/shared/SharedWorker.cpp
@@ -107,7 +107,7 @@ ExceptionOr<Ref<SharedWorker>> SharedWorker::create(Document& document, Variant<
     }
 
     auto channel = MessageChannel::create(document);
-    auto transferredPort = protect(channel->port2())->disentangle();
+    auto transferredPort = protect(channel->port2())->lenientDisentangle();
 
     ClientOrigin clientOrigin { document.topOrigin().data(), document.securityOrigin().data() };
     SharedWorkerKey key { clientOrigin, url, options.name };


### PR DESCRIPTION
#### 3e80e65d4fd85e1dbce0584210c99c0807063491
<pre>
Closing an already-transferred MessagePort shouldn&apos;t break channel
<a href="https://bugs.webkit.org/show_bug.cgi?id=315394">https://bugs.webkit.org/show_bug.cgi?id=315394</a>
<a href="https://rdar.apple.com/177749843">rdar://177749843</a>

Reviewed by Brady Eidson.

MessagePort::close() was improperly guarded if
MessagePort::disentangle() happened before it, causing it to tear down
a channel it no longer owns.

To fix this, MessagePort::State was introduced to replace the valid
combinations of (m_started, m_isDetached, m_entangled). There are now
only three states:

- NotStartedYet : entangled, waiting for start() to begin handling
  received messages
- Started : entangled and start()&apos;d
- Disentangled : not entangled, port was closed or shipped away

There is no longer a distinction between &quot;disentangled&quot; and
&quot;detached&quot; - both were collapsed into State::Disentangled. This matches
our implementation: we disentangle shipped ports eagerly on
postMessage() rather than deferring it to the receiver side, so
a &quot;detached but not yet disentangled&quot; intermediate state is not
possible.

lenientDisentangle() was introduced for code that leans on the
&quot;detached but not disentangled&quot; state - it skips the assert on
disentangle() so that it may succeed even if the port has already been
closed. This edge case happens when SharedWorker::create() or
AudioWorkletNode::create() run on a closed context.

Test: fast/events/message-port-close-after-transfer.html
Canonical link: <a href="https://commits.webkit.org/316652@main">https://commits.webkit.org/316652@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4d154bebe93203bc2d5f1047485d405562193866

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/172260 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/46178 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/39606 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/181711 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/129816 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9b95e4ab-9edf-49d0-82f6-383fe8054726) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/174125 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/47471 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/45820 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/133979 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/94516 "1 flakes 21 failures") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fb83e631-471a-4dea-802c-aa067a35b730) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/175218 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/37412 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/154521 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/114450 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/95fb35db-27f3-4baa-884e-c1a4672faa26) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/36046 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/34312 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/30317 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/146476 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/34032 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/184245 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/36931 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/38514 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/142742 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/45850 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/154104 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/142624 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/38681 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/46528 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/30874 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/111242 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/37697 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/118279 "Built successfully") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/45045 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/8973 "") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/44445 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/44677 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/44504 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->