### PR TITLE
[SwiftBrowser] Web content should be inspectable

### DIFF
--- a/Tools/SwiftBrowser/Resources/SwiftBrowser.entitlements
+++ b/Tools/SwiftBrowser/Resources/SwiftBrowser.entitlements
@@ -25,6 +25,7 @@
 		<string>com.apple.PIPAgent</string>
 		<string>com.apple.Safari.SafeBrowsing.Service</string>
 		<string>com.apple.WebKit.NetworkingDaemon</string>
+		<string>com.apple.webinspector</string>
 	</array>
 	<key>com.apple.security.temporary-exception.sbpl</key>
 	<array>

--- a/Tools/SwiftBrowser/Source/ViewModel/BrowserViewModel.swift
+++ b/Tools/SwiftBrowser/Source/ViewModel/BrowserViewModel.swift
@@ -66,6 +66,7 @@ final class BrowserViewModel {
         configuration.deviceSensorAuthorization = WebPage.DeviceSensorAuthorization(decisionHandler: Self.decideSensorAuthorization(permission:frame:origin:))
 
         self.page = WebPage(configuration: configuration, navigationDecider: self.navigationDecider, dialogPresenter: self.dialogPresenter)
+        self.page.isInspectable = true
 
         self.navigationDecider.owner = self
         self.dialogPresenter.owner = self


### PR DESCRIPTION
#### 3fd28c13a8aabdeb489f5c890691a0f8d1a5b982
<pre>
[SwiftBrowser] Web content should be inspectable
<a href="https://bugs.webkit.org/show_bug.cgi?id=315399">https://bugs.webkit.org/show_bug.cgi?id=315399</a>
<a href="https://rdar.apple.com/177752422">rdar://177752422</a>

Reviewed by Wenson Hsieh.

Web content presented in SwiftBrowser is currently not inspectable by
developer tools. This is a tooling gap and makes some web development
tricky. We plug this gap by setting `WebPage.isInspectable` and the
associated `com.apple.webinspector` mach lookup exceptionentitlement.

* Tools/SwiftBrowser/Resources/SwiftBrowser.entitlements:
* Tools/SwiftBrowser/Source/ViewModel/BrowserViewModel.swift:

Canonical link: <a href="https://commits.webkit.org/313784@main">https://commits.webkit.org/313784@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/d2ff2b711a799a397db5c125d50e8d4732886331

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164090 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37574 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30793 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173119 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/be8688a7-e738-40c4-a6e8-e35febcf7455) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165959 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37907 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37574 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127479 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121341 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6db0adc9-fd52-4585-aac9-abb03fcd91a1) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167049 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29766 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147511 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108027 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0f6bdc9b-b656-4ca3-ba36-4856c6b97c02) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28812 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27438 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20883 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138713 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25228 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175645 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26896 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135791 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37244 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31552 "Found 1 new test failure: http/tests/storageAccess/deny-due-to-no-interaction-under-general-third-party-cookie-blocking-ephemeral.https.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135761 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38030 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147023 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100240 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24983 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31063 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23879 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36840 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36237 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1929 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36487 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36387 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->