### PR TITLE
Apply swift-format over SwiftBrowser/BrowserViewModel.swift

### DIFF
--- a/Tools/SwiftBrowser/Source/ViewModel/BrowserViewModel.swift
+++ b/Tools/SwiftBrowser/Source/ViewModel/BrowserViewModel.swift
@@ -49,9 +49,25 @@ struct OpenRequest: Equatable {
 final class BrowserViewModel {
     private static let logger = Logger(subsystem: Bundle.main.bundleIdentifier!, category: String(describing: BrowserViewModel.self))
 
-    private static func decideSensorAuthorization(permission: WebPage.DeviceSensorAuthorization.Permission, frame: WebPage.FrameInfo, origin: WKSecurityOrigin) async -> WKPermissionDecision {
-        let mediaCaptureAuthorization = WKPermissionDecision(rawValue: UserDefaults.standard.integer(forKey: AppStorageKeys.mediaCaptureAuthorization))!
-        let orientationAndMotionAuthorization = WKPermissionDecision(rawValue: UserDefaults.standard.integer(forKey: AppStorageKeys.orientationAndMotionAuthorization))!
+    private static func decideSensorAuthorization(
+        permission: WebPage.DeviceSensorAuthorization.Permission,
+        frame: WebPage.FrameInfo,
+        origin: WKSecurityOrigin
+    ) async -> WKPermissionDecision {
+        guard
+            let mediaCaptureAuthorization = WKPermissionDecision(
+                rawValue: UserDefaults.standard.integer(forKey: AppStorageKeys.mediaCaptureAuthorization)
+            )
+        else {
+            preconditionFailure()
+        }
+        guard
+            let orientationAndMotionAuthorization = WKPermissionDecision(
+                rawValue: UserDefaults.standard.integer(forKey: AppStorageKeys.orientationAndMotionAuthorization)
+            )
+        else {
+            preconditionFailure()
+        }
 
         return switch permission {
         case .deviceOrientationAndMotion: orientationAndMotionAuthorization
@@ -63,7 +79,9 @@ final class BrowserViewModel {
 
     init() {
         var configuration = WebPage.Configuration()
-        configuration.deviceSensorAuthorization = WebPage.DeviceSensorAuthorization(decisionHandler: Self.decideSensorAuthorization(permission:frame:origin:))
+        configuration.deviceSensorAuthorization = WebPage.DeviceSensorAuthorization(
+            decisionHandler: Self.decideSensorAuthorization(permission:frame:origin:)
+        )
 
         self.page = WebPage(configuration: configuration, navigationDecider: self.navigationDecider, dialogPresenter: self.dialogPresenter)
         self.page.isInspectable = true
@@ -162,26 +180,28 @@ final class BrowserViewModel {
 
     func didExportPDF(result: Result<URL, any Error>) {
         switch result {
-        case let .success(url):
+        case .success(let url):
             Self.logger.info("Exported PDF to \(url)")
 
-        case let .failure(error):
+        case .failure(let error):
             Self.logger.error("Failed to export PDF: \(error)")
         }
     }
 
     func didImportFiles(result: Result<[URL], any Error>) {
-        precondition(currentFilePicker != nil)
-
-        switch result {
-        case let .success(urls):
-            currentFilePicker!.completion(.selected(urls))
-
-        case .failure:
-            currentFilePicker!.completion(.cancel)
+        guard let currentFilePicker else {
+            preconditionFailure()
         }
 
-        currentFilePicker = nil
+        switch result {
+        case .success(let urls):
+            currentFilePicker.completion(.selected(urls))
+
+        case .failure:
+            currentFilePicker.completion(.cancel)
+        }
+
+        self.currentFilePicker = nil
     }
 
     func setCameraCaptureState(_ state: WKMediaCaptureState) {


### PR DESCRIPTION
#### 1cd968cdd081a251c7266f03c80670176eab1119
<pre>
Apply swift-format over SwiftBrowser/BrowserViewModel.swift
<a href="https://bugs.webkit.org/show_bug.cgi?id=315401">https://bugs.webkit.org/show_bug.cgi?id=315401</a>
<a href="https://rdar.apple.com/177752918">rdar://177752918</a>

Reviewed by Richard Robinson.

Just a mechanical application of `swift format --in-place`.

* Tools/SwiftBrowser/Source/ViewModel/BrowserViewModel.swift:
(BrowserViewModel.didExportPDF(_:any:)):
(BrowserViewModel.didImportFiles(_:any:)):
(BrowserViewModel.decideSensorAuthorization(_:frame:origin:)): Deleted.

Canonical link: <a href="https://commits.webkit.org/313798@main">https://commits.webkit.org/313798@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/8436e4a9310d8f13bc12427d0d31529df7753d49

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164141 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37625 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30844 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173170 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121393 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/735fc094-d349-48d1-9a17-eaadba7daf81) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166010 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37959 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37625 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127518 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89709 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b231beae-89e5-4d73-9989-b17ef9036fb2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167100 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29809 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147554 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108066 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/12dfa476-c294-45bd-a63e-57072d0b87a5) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28855 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27480 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20934 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138758 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25271 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175696 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26939 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135829 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37295 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31594 "Found 1 new test failure: http/tests/ssl/applepay/ApplePayButton.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135799 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38081 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147066 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100333 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24990 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31105 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23922 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36891 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36288 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1973 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36538 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36438 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->