### PR TITLE
[GFC] Extract sizeColumnTracks helper from performGridSizingAlgorithm

### DIFF
--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp
@@ -427,18 +427,18 @@ static LayoutUnit NODELETE oppositeAxisConstraintForTrackSizing(Vector<LayoutUni
     return totalAvailableSpaceFromSpannedTracks;
 }
 
-// https://www.w3.org/TR/css-grid-1/#algo-grid-sizing
-UsedTrackSizes GridLayout::performGridSizingAlgorithm(const GridLayoutState& layoutState, const PlacedGridItems& placedGridItems,
-    const TrackSizingFunctionsList& columnTrackSizingFunctionsList, const TrackSizingFunctionsList& rowTrackSizingFunctionsList) const
+// 1. https://www.w3.org/TR/css-grid-1/#algo-grid-sizing — step 1.
+// First, the track sizing algorithm is used to resolve the sizes of the grid columns.
+// If calculating the layout of a grid item in this step depends on the available space in the block axis,
+// assume the available space that it would have if any row with a definite max track sizing function had
+// that size and all other rows were infinite. If both the grid container and all tracks have definite sizes,
+// also apply align-content to find the final effective size of any gaps spanned by such items; otherwise
+// ignore the effects of track alignment in this estimation.
+TrackSizes GridLayout::sizeColumnTracks(const PlacedGridItems& placedGridItems, const TrackSizingFunctionsList& columnTrackSizingFunctionsList,
+    const TrackSizingFunctionsList& rowTrackSizingFunctionsList, const GridLayoutState& layoutState) const
 {
     auto& layoutConstraints = layoutState.gridLayoutConstraints;
 
-    // 1. First, the track sizing algorithm is used to resolve the sizes of the grid columns.
-    // If calculating the layout of a grid item in this step depends on the available space in the block axis,
-    // assume the available space that it would have if any row with a definite max track sizing function had
-    // that size and all other rows were infinite. If both the grid container and all tracks have definite sizes,
-    // also apply align-content to find the final effective size of any gaps spanned by such items; otherwise
-    // ignore the effects of track alignment in this estimation.
     auto columnFreeSpaceScenario = layoutConstraints.inlineAxis.scenario();
     std::optional<LayoutUnit> inlineAxisAvailableSpace = columnFreeSpaceScenario == AxisConstraint::FreeSpaceScenario::Definite
         ? std::optional(layoutConstraints.inlineAxis.availableSpace())
@@ -451,10 +451,22 @@ UsedTrackSizes GridLayout::performGridSizingAlgorithm(const GridLayoutState& lay
             { gridItem.columnStartLine(), gridItem.columnEndLine() }, oppositeAxisConstraintForTrackSizing(rowSizesForFirstColumnSizing, rowSpan) };
     });
 
-    auto& formattingContext = this->formattingContext();
-    auto columnSizes = TrackSizingAlgorithm::sizeTracks(columnTrackSizingItems, columnTrackSizingFunctionsList,
-        layoutConstraints.inlineAxis, GridLayoutUtils::inlineAxisGridItemSizingFunctions(formattingContext.integrationUtils()),
+    return TrackSizingAlgorithm::sizeTracks(columnTrackSizingItems, columnTrackSizingFunctionsList,
+        layoutConstraints.inlineAxis, GridLayoutUtils::inlineAxisGridItemSizingFunctions(formattingContext().integrationUtils()),
         layoutState.usedColumnGap, layoutState.usedJustifyContent);
+}
+
+// https://www.w3.org/TR/css-grid-1/#algo-grid-sizing
+UsedTrackSizes GridLayout::performGridSizingAlgorithm(const GridLayoutState& layoutState, const PlacedGridItems& placedGridItems,
+    const TrackSizingFunctionsList& columnTrackSizingFunctionsList, const TrackSizingFunctionsList& rowTrackSizingFunctionsList) const
+{
+    auto& layoutConstraints = layoutState.gridLayoutConstraints;
+
+    // 1. First, the track sizing algorithm is used to resolve the sizes of the grid columns.
+    // If both the grid container and all tracks have definite sizes, also apply align-content
+    // to find the final effective size of any gaps spanned by such items; otherwise ignore
+    // the effects of track alignment in this estimation.
+    auto columnSizes = sizeColumnTracks(placedGridItems, columnTrackSizingFunctionsList, rowTrackSizingFunctionsList, layoutState);
 
     // 2. Next, the track sizing algorithm resolves the sizes of the grid rows.
     // To find the inline-axis available space for any items whose block-axis size contributions
@@ -465,6 +477,7 @@ UsedTrackSizes GridLayout::performGridSizingAlgorithm(const GridLayoutState& lay
             { gridItem.rowStartLine(), gridItem.rowEndLine() }, oppositeAxisConstraintForTrackSizing(columnSizes, columnSpan) };
     });
 
+    auto& formattingContext = this->formattingContext();
     auto rowSizes = TrackSizingAlgorithm::sizeTracks(rowTrackSizingItems, rowTrackSizingFunctionsList,
         layoutConstraints.blockAxis, GridLayoutUtils::blockAxisGridItemSizingFunctions(formattingContext),
         layoutState.usedRowGap, layoutState.usedAlignContent);

--- a/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
+++ b/Source/WebCore/layout/formattingContexts/grid/GridLayout.h
@@ -72,6 +72,7 @@ private:
     static TrackSizingFunctionsList trackSizingFunctions(size_t totalTracksCount, const Vector<Style::GridTrackSize>& gridTemplateTrackSizes, const Style::GridTrackSizes& gridAutoTrackSizes);
 
     UsedTrackSizes performGridSizingAlgorithm(const GridLayoutState&, const PlacedGridItems&, const TrackSizingFunctionsList&, const TrackSizingFunctionsList&) const;
+    TrackSizes sizeColumnTracks(const PlacedGridItems&, const TrackSizingFunctionsList& columnTrackSizingFunctions, const TrackSizingFunctionsList& rowTrackSizingFunctions, const GridLayoutState&) const;
 
     std::pair<UsedInlineSizes, UsedBlockSizes> layoutGridItems(const PlacedGridItems&, const GridAreaSizes&,
         const TrackSizingFunctionsList& columnTrackSizingFunctions, const TrackSizingFunctionsList& rowTrackSizingFunctions) const;


### PR DESCRIPTION
#### b9416ebab754177b6c3d38ddf70fb2877968f550
<pre>
[GFC] Extract sizeColumnTracks helper from performGridSizingAlgorithm
<a href="https://bugs.webkit.org/show_bug.cgi?id=315405">https://bugs.webkit.org/show_bug.cgi?id=315405</a>
&lt;<a href="https://rdar.apple.com/177753728">rdar://177753728</a>&gt;

Reviewed by Sammy Gill.

We should extract the column-sizing logic out of performGridSizingAlgorithm into
a reusable sizeColumnTracks helper to prepare for a perf optimization.

This will let us perform intrinsic-width computation without running row
sizing and item layout. No behavior change.

* Source/WebCore/layout/formattingContexts/grid/GridLayout.cpp:
(WebCore::Layout::GridLayout::sizeColumnTracks const):
(WebCore::Layout::GridLayout::performGridSizingAlgorithm const):
* Source/WebCore/layout/formattingContexts/grid/GridLayout.h:

Canonical link: <a href="https://commits.webkit.org/313914@main">https://commits.webkit.org/313914@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/086274bec579ce3a918623efee813e42bd5a23e4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164097 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37581 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30800 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173126 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121348 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/92359abb-635f-4d00-a992-f069acd0e565) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/165966 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37914 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37581 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127483 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89694 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/98368b61-528d-4a1e-a594-6c56d3cae247) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167056 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29770 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147515 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108031 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/47c3e14c-97de-459a-a526-dc67af750665) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28816 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27441 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20890 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138717 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25232 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175652 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28473 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26900 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135795 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37251 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31890 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135765 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38037 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147027 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100249 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25047 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31067 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23883 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36847 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109892 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36244 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1933 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36494 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36394 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->