### PR TITLE
Some models appear washed out

### DIFF
--- a/Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift
@@ -490,15 +490,18 @@ extension WKBridgeConstantContainer {
     let constant: WKBridgeConstant
     let constantValues: [WKBridgeValueString]
     let name: String
+    let colorSpaceName: String?
 
     init(
         constant: WKBridgeConstant,
         constantValues: [WKBridgeValueString],
-        name: String
+        name: String,
+        colorSpaceName: String?
     ) {
         self.constant = constant
         self.constantValues = constantValues
         self.name = name
+        self.colorSpaceName = colorSpaceName
     }
 }
 

--- a/Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h
+++ b/Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h
@@ -321,9 +321,10 @@ typedef NS_ENUM(NSInteger, WKBridgeNodeType) {
 @property (nonatomic, readonly) WKBridgeConstant constant;
 @property (nonatomic, readonly, strong) NSArray<WKBridgeValueString *> *constantValues;
 @property (nonatomic, readonly) NSString *name;
+@property (nonatomic, readonly, nullable) NSString *colorSpaceName;
 
 - (instancetype)init NS_UNAVAILABLE;
-- (instancetype)initWithConstant:(WKBridgeConstant)constant constantValues:(NSArray<WKBridgeValueString *> *)constantValues name:(NSString *)name NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithConstant:(WKBridgeConstant)constant constantValues:(NSArray<WKBridgeValueString *> *)constantValues name:(NSString *)name colorSpaceName:(nullable NSString *)colorSpaceName NS_DESIGNATED_INITIALIZER;
 
 @end
 
@@ -707,6 +708,7 @@ struct ConstantContainer {
     Constant constant;
     Vector<Variant<String, double>> constantValues;
     String name;
+    std::optional<String> colorSpaceName;
 };
 
 struct InputOutput {

--- a/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
+++ b/Source/WebKit/GPUProcess/graphics/Model/USDModel.swift
@@ -1330,16 +1330,30 @@ private func constantValues(_ constant: _Proto_ShaderGraphValue) -> ([WKBridgeVa
     }
 }
 
+private func colorSpaceName(for value: _Proto_ShaderGraphValue) -> String? {
+    switch value {
+    case .cgColor3(let color): color.colorSpace?.name as String?
+    case .cgColor4(let color): color.colorSpace?.name as String?
+    default: nil
+    }
+}
+
 private func toWKBridgeConstantContainer(
-    _ node: _Proto_ShaderNodeGraph.Node
+    _ node: _Proto_ShaderNodeGraph.Node,
+    colorOverride: WKBridgeConstant? = nil
 ) -> WKBridgeConstantContainer {
     // Extract constant value if this is a constant node
     switch node.data {
     case .constant(let value):
         let (values, defaultType) = constantValues(value)
-        return WKBridgeConstantContainer(constant: defaultType, constantValues: values, name: node.name)
+        return WKBridgeConstantContainer(
+            constant: colorOverride ?? defaultType,
+            constantValues: values,
+            name: node.name,
+            colorSpaceName: colorSpaceName(for: value)
+        )
     case .definition, .graph:
-        return WKBridgeConstantContainer(constant: .asset, constantValues: [], name: node.name)
+        return WKBridgeConstantContainer(constant: .asset, constantValues: [], name: node.name, colorSpaceName: nil)
     default: fatalError("toWKBridgeConstantContainer - unknown _Proto_ShaderNodeGraph.Node.data type")
     }
 }
@@ -1388,7 +1402,7 @@ private func createInputOutput(
 ) -> WKBridgeInputOutput {
     let defaultValueContainer: WKBridgeConstantContainer? = defaultValue.map {
         let (values, constantType) = constantValues($0)
-        return WKBridgeConstantContainer(constant: constantType, constantValues: values, name: "")
+        return WKBridgeConstantContainer(constant: constantType, constantValues: values, name: "", colorSpaceName: colorSpaceName(for: $0))
     }
 
     let actualType = toWKBridgeDataType(type)
@@ -1422,11 +1436,11 @@ private func toWebOutputs(_ outputs: [_Proto_ShaderGraphNodeDefinition.Output]) 
     }
 }
 
-private func toWebNode(_ e: _Proto_ShaderNodeGraph.Node) -> WKBridgeNode {
+private func toWebNode(_ e: _Proto_ShaderNodeGraph.Node, colorOverride: WKBridgeConstant? = nil) -> WKBridgeNode {
     WKBridgeNode(
         bridgeNodeType: toWKBridgeNodeType(e),
         builtin: toWKBridgeBuiltin(e),
-        constant: toWKBridgeConstantContainer(e)
+        constant: toWKBridgeConstantContainer(e, colorOverride: colorOverride)
     )
 }
 
@@ -1479,12 +1493,12 @@ private func toWebMaterialGraph(_ material: _Proto_ShaderNodeGraph?) -> WKBridge
             arguments: WKBridgeNode(
                 bridgeNodeType: .arguments,
                 builtin: WKBridgeBuiltin(definition: "", name: "arguments"),
-                constant: WKBridgeConstantContainer(constant: .asset, constantValues: [], name: "")
+                constant: WKBridgeConstantContainer(constant: .asset, constantValues: [], name: "", colorSpaceName: nil)
             ),
             results: WKBridgeNode(
                 bridgeNodeType: .results,
                 builtin: WKBridgeBuiltin(definition: "", name: "results"),
-                constant: WKBridgeConstantContainer(constant: .asset, constantValues: [], name: "")
+                constant: WKBridgeConstantContainer(constant: .asset, constantValues: [], name: "", colorSpaceName: nil)
             ),
             inputs: [],
             outputs: [],
@@ -1494,8 +1508,33 @@ private func toWebMaterialGraph(_ material: _Proto_ShaderNodeGraph?) -> WKBridge
         )
     }
 
+    // Detect color3f/color4f constants by checking the input port types they connect to.
+    // The proto layer collapses color3f/color3h → float3 and color4f/color4h → float4, losing
+    // the color type. Recover it by inspecting the destination port's declared _Proto_ShaderDataType.
+    var colorTypeOverrides: [String: WKBridgeConstant] = [:]
+    let library = _Proto_ShaderNodeGraphLibrary.shared
+    let outgoingEdges = Dictionary(grouping: material.edges, by: \.outputNode)
+    for (nodeName, node) in material.nodes {
+        guard case .constant(let value) = node.data else { continue }
+        guard let edges = outgoingEdges[nodeName] else { continue }
+        for edge in edges {
+            guard let destNode = material.nodes[edge.inputNode],
+                case .definition(let def) = destNode.data,
+                let definition = library.definition(named: def.name),
+                let input = definition.inputs.first(where: { $0.name == edge.inputPort })
+            else { continue }
+            switch input.type {
+            case .cgColor3:
+                if case .float3 = value { colorTypeOverrides[nodeName] = .color3f }
+            case .cgColor4:
+                if case .float4 = value { colorTypeOverrides[nodeName] = .color4f }
+            default: break
+            }
+        }
+    }
+
     // Convert nodes dictionary to array
-    let nodes = material.nodes.values.map { toWebNode($0) }
+    let nodes = material.nodes.values.map { toWebNode($0, colorOverride: colorTypeOverrides[$0.name]) }
 
     // Convert edges
     let edges = toWebEdges(material.edges)
@@ -1659,8 +1698,34 @@ private func fromWKBridgeDataType(_ dataType: WKBridgeDataType) -> ShaderGraph.D
     }
 }
 
+private func makeCGColor3(colorSpace: CGColorSpace, _ a: CGFloat, _ b: CGFloat, _ c: CGFloat) -> CGColor {
+    // rdar://177971578 - CG should provide an API for not requiring unsafe
+    guard let cs = unsafe CGColor(colorSpace: colorSpace, components: [a, b, c, 1.0]) else {
+        fatalError("\(a) \(b) \(c) could not form a CGColor with colorSpace \(colorSpace)")
+    }
+    return cs
+}
+
+private func makeCGColor4(colorSpace: CGColorSpace, _ a: CGFloat, _ b: CGFloat, _ c: CGFloat, _ d: CGFloat) -> CGColor {
+    // rdar://177971578 - CG should provide an API for not requiring unsafe
+    guard let cs = unsafe CGColor(colorSpace: colorSpace, components: [a, b, c, d]) else {
+        fatalError("\(a) \(b) \(c) \(d) could not form a CGColor with colorSpace \(colorSpace)")
+    }
+    return cs
+}
+
 private func fromWKBridgeConstant(_ constant: WKBridgeConstantContainer) -> ShaderGraph.Value {
     let values = constant.constantValues
+    // Resolve the color space from the transmitted name, falling back to extendedLinearSRGB.
+    // USD color3f/color4f values are in linear sRGB, so extendedLinearSRGB is the correct fallback.
+    // swift-format-ignore: NeverForceUnwrap
+    guard
+        let colorSpace =
+            (constant.colorSpaceName.flatMap { CGColorSpace(name: $0 as CFString) }
+                ?? CGColorSpace(name: CGColorSpace.extendedLinearSRGB))
+    else {
+        fatalError("extendedLinearSRGB could not be constructed, should never occur")
+    }
 
     switch constant.constant {
     case .bool:
@@ -1851,64 +1916,65 @@ private func fromWKBridgeConstant(_ constant: WKBridgeConstantContainer) -> Shad
         guard values.count >= 3 else {
             fatalError("fromWKBridgeConstant: expected 3 values for color3 constant '\(constant.name)', got \(values.count)")
         }
-        // Use extendedLinearSRGB to preserve values outside [0,1] (e.g. negative bias, scale > 1).
-        // CGColor(red:green:blue:alpha:) clamps to device RGB [0,1] which corrupts shader constants.
-        let components3: [CGFloat] = [
-            CGFloat(values[0].number.floatValue),
-            CGFloat(values[1].number.floatValue),
-            CGFloat(values[2].number.floatValue),
-            1.0,
-        ]
-        return .cgColor3(CGColor(red: components3[0], green: components3[1], blue: components3[2], alpha: 1.0))
+        return .cgColor3(
+            makeCGColor3(
+                colorSpace: colorSpace,
+                CGFloat(values[0].number.floatValue),
+                CGFloat(values[1].number.floatValue),
+                CGFloat(values[2].number.floatValue)
+            )
+        )
     case .cgColor4:
         guard values.count >= 4 else {
             fatalError("fromWKBridgeConstant: expected 4 values for color4 constant '\(constant.name)', got \(values.count)")
         }
-        // Use extendedLinearSRGB to preserve values outside [0,1] (e.g. negative bias, scale > 1).
-        // CGColor(red:green:blue:alpha:) clamps to device RGB [0,1] which corrupts shader constants.
-        let components4: [CGFloat] = [
-            CGFloat(values[0].number.floatValue),
-            CGFloat(values[1].number.floatValue),
-            CGFloat(values[2].number.floatValue),
-            CGFloat(values[3].number.floatValue),
-        ]
-        return .cgColor4(CGColor(red: components4[0], green: components4[1], blue: components4[2], alpha: components4[3]))
+        return .cgColor4(
+            makeCGColor4(
+                colorSpace: colorSpace,
+                CGFloat(values[0].number.floatValue),
+                CGFloat(values[1].number.floatValue),
+                CGFloat(values[2].number.floatValue),
+                CGFloat(values[3].number.floatValue)
+            )
+        )
     case .color4f:
-        // USD/MaterialX color4f or color4h — encoded as 4 raw floats without CGColor clamping.
-        // Decoded as cgColor4 via extendedLinearSRGB to preserve color semantics for MaterialX.
+        // USD/MaterialX color4f — encoded as 4 raw floats without CGColor clamping.
         guard values.count >= 4 else {
             fatalError("fromWKBridgeConstant: expected 4 values for color4f constant '\(constant.name)', got \(values.count)")
         }
-        let components4f: [CGFloat] = [
-            CGFloat(values[0].number.floatValue),
-            CGFloat(values[1].number.floatValue),
-            CGFloat(values[2].number.floatValue),
-            CGFloat(values[3].number.floatValue),
-        ]
-        return .cgColor4(CGColor(red: components4f[0], green: components4f[1], blue: components4f[2], alpha: components4f[3]))
+        return .cgColor4(
+            makeCGColor4(
+                colorSpace: colorSpace,
+                CGFloat(values[0].number.floatValue),
+                CGFloat(values[1].number.floatValue),
+                CGFloat(values[2].number.floatValue),
+                CGFloat(values[3].number.floatValue)
+            )
+        )
     case .color3f:
         // USD/MaterialX color3f — encoded as 3 raw floats without CGColor clamping.
         guard values.count >= 3 else {
             fatalError("fromWKBridgeConstant: expected 3 values for color3f constant '\(constant.name)', got \(values.count)")
         }
-        let components3f: [CGFloat] = [
-            CGFloat(values[0].number.floatValue),
-            CGFloat(values[1].number.floatValue),
-            CGFloat(values[2].number.floatValue),
-            1.0,
-        ]
-        return .cgColor3(CGColor(red: components3f[0], green: components3f[1], blue: components3f[2], alpha: 1.0))
+        return .cgColor3(
+            makeCGColor3(
+                colorSpace: colorSpace,
+                CGFloat(values[0].number.floatValue),
+                CGFloat(values[1].number.floatValue),
+                CGFloat(values[2].number.floatValue)
+            )
+        )
     case .color3h:
         // USD/MaterialX color3h — half-precision; represented as cgColor3 in ShaderGraph.Value.
         guard values.count >= 3 else {
             fatalError("fromWKBridgeConstant: expected 3 values for color3h constant '\(constant.name)', got \(values.count)")
         }
         return .cgColor3(
-            CGColor(
-                red: CGFloat(values[0].number.floatValue),
-                green: CGFloat(values[1].number.floatValue),
-                blue: CGFloat(values[2].number.floatValue),
-                alpha: 1.0
+            makeCGColor3(
+                colorSpace: colorSpace,
+                CGFloat(values[0].number.floatValue),
+                CGFloat(values[1].number.floatValue),
+                CGFloat(values[2].number.floatValue)
             )
         )
     case .color4h:
@@ -1917,11 +1983,12 @@ private func fromWKBridgeConstant(_ constant: WKBridgeConstantContainer) -> Shad
             fatalError("fromWKBridgeConstant: expected 4 values for color4h constant '\(constant.name)', got \(values.count)")
         }
         return .cgColor4(
-            CGColor(
-                red: CGFloat(values[0].number.floatValue),
-                green: CGFloat(values[1].number.floatValue),
-                blue: CGFloat(values[2].number.floatValue),
-                alpha: CGFloat(values[3].number.floatValue)
+            makeCGColor4(
+                colorSpace: colorSpace,
+                CGFloat(values[0].number.floatValue),
+                CGFloat(values[1].number.floatValue),
+                CGFloat(values[2].number.floatValue),
+                CGFloat(values[3].number.floatValue)
             )
         )
     @unknown default:

--- a/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm
+++ b/Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm
@@ -758,7 +758,8 @@ static NSArray<WKBridgeValueString *> *convert(const Vector<Variant<String, doub
 
 static WKBridgeConstantContainer *convert(const ConstantContainer& constant)
 {
-    return [WebKit::allocWKBridgeConstantContainerInstance() initWithConstant:convert(constant.constant) constantValues:convert(constant.constantValues) name:constant.name.createNSString().get()];
+    NSString *colorSpaceName = constant.colorSpaceName ? constant.colorSpaceName->createNSString().get() : nil;
+    return [WebKit::allocWKBridgeConstantContainerInstance() initWithConstant:convert(constant.constant) constantValues:convert(constant.constantValues) name:constant.name.createNSString().get() colorSpaceName:colorSpaceName];
 }
 
 static NSArray<WKBridgeInputOutput *> *convert(const Vector<InputOutput>& inputOutputs)

--- a/Source/WebKit/Shared/Model.serialization.in
+++ b/Source/WebKit/Shared/Model.serialization.in
@@ -313,6 +313,7 @@ header: <WebKit/ModelTypes.h>
     WebModel::Constant constant;
     Vector<Variant<String, double>> constantValues;
     String name;
+    std::optional<String> colorSpaceName;
 };
 
 header: <WebKit/ModelTypes.h>

--- a/Source/WebKit/WebProcess/Model/ModelInlineConverters.h
+++ b/Source/WebKit/WebProcess/Model/ModelInlineConverters.h
@@ -712,7 +712,8 @@ static WebModel::ConstantContainer convert(WKBridgeConstantContainer *container)
     return WebModel::ConstantContainer {
         .constant = convert(container.constant),
         .constantValues = convert(container.constantValues),
-        .name = String(container.name)
+        .name = String(container.name),
+        .colorSpaceName = container.colorSpaceName ? std::optional<String>(String(container.colorSpaceName)) : std::nullopt
     };
 }
 


### PR DESCRIPTION
#### dc32cc79255f7890c9727d02a5b13479f47464f4
<pre>
Some models appear washed out
<a href="https://bugs.webkit.org/show_bug.cgi?id=315407">https://bugs.webkit.org/show_bug.cgi?id=315407</a>
<a href="https://rdar.apple.com/177549833">rdar://177549833</a>

Reviewed by Richard Robinson.

Colors must have their color space passed over IPC to
correctly reconstruct them.

* Source/WebKit/GPUProcess/graphics/Model/ModelBridge.swift:
* Source/WebKit/GPUProcess/graphics/Model/ModelTypes.h:
* Source/WebKit/GPUProcess/graphics/Model/USDModel.swift:
(colorSpaceName(for:)):
(toWebNode(_:colorOverride:)):
(toWebMaterialGraph(_:)):
(makeCGColor3(_:_:_:_:)):
(makeCGColor4(_:_:_:_:_:)):
(fromWKBridgeConstant(_:)):
(toWebNode(_:)): Deleted.
* Source/WebKit/GPUProcess/graphics/Model/WebKitMesh.mm:
(WebModel::convert):
* Source/WebKit/Shared/Model.serialization.in:
* Source/WebKit/WebProcess/Model/ModelInlineConverters.h:
(WebKit::convert):

Canonical link: <a href="https://commits.webkit.org/313920@main">https://commits.webkit.org/313920@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/7960e03c86899d3b22f2f0cb8a84fe6ce89a2f98

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164532 "2 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38016 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31587 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173562 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4bd9e961-7d80-40fb-9557-e7a94a34c26a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38350 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38018 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127848 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121784 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2cc50c3e-8a9d-46e4-93ae-b5d6171e6fd5) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167491 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30148 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147883 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108393 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b68f143d-1f3b-4f51-b5ad-72bd4a83b7a0) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29195 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/27819 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21325 "Built successfully") | | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/139098 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176088 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/28911 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27267 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136165 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38085 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31941 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136130 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36665 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38775 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147394 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100927 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31408 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24250 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37283 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110327 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36681 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2311 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36929 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36829 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->