### PR TITLE
[Site Isolation] Web Inspector: disable instrumentation for the old process on didCommitProvisionalPage

### DIFF
--- a/LayoutTests/platform/mac-wk2/TestExpectations
+++ b/LayoutTests/platform/mac-wk2/TestExpectations
@@ -2338,10 +2338,6 @@ webkit.org/b/315354 media/video-concurrent-visible-playback.html [ Pass Failure 
 
 webkit.org/b/315398 [ Release ] http/tests/site-isolation/accessibility/client/simple-iframe.html [ Timeout ]
 
-# webkit.org/b/314902 REGRESSION(313207@main): [macOS Debug] ASSERTION FAILED: !m_messageReceiverMapCount
-[ Debug ] http/tests/site-isolation/inspector/target/target.html [ Skip ]
-[ Debug ] http/tests/site-isolation/inspector/target/target-cross-origin-page-navigation.html [ Skip ]
-
 # webkit.org/b/315593 [macOS Release] imported/w3c/web-platform-tests/fetch/api/crashtests/huge-fetch.any.sharedworker.html  is a flaky crash
 [ Release ] imported/w3c/web-platform-tests/fetch/api/crashtests/huge-fetch.any.serviceworker.html [ Skip ]
 [ Release ] imported/w3c/web-platform-tests/fetch/api/crashtests/huge-fetch.any.sharedworker.html [ Skip ]

--- a/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.cpp
+++ b/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.cpp
@@ -165,19 +165,20 @@ ProxyingNetworkAgent::~ProxyingNetworkAgent()
 
 void ProxyingNetworkAgent::removeAllRegisteredReceivers()
 {
-    // Iterate by ProcessIdentifier so we reach swapped-out processes that
-    // forEachWebContentProcess() no longer enumerates. We rely on the
-    // inspected WebPageProxy keeping its WebProcessProxy alive until after
-    // WebPageInspectorController tears down; cross-origin iframe processes
-    // are kept alive by their own page state. processForIdentifier() returning
-    // null would mean the proxy was already destructed, in which case
-    // m_messageReceiverMapCount would leak here -- ~AuxiliaryProcessProxy does
-    // not invalidate its receiver map.
+    // Use the pinned WebProcessProxy refs rather than WebProcessProxy::processForIdentifier(),
+    // which can return null when the process has been destructed but its receiver map entry
+    // has not yet been torn down. The pin guarantees the process (and its receiver map) is
+    // still alive here so removeMessageReceiver() can decrement m_messageReceiverMapCount.
     for (auto& [key, _] : std::exchange(m_instrumentedProcessPageCounts, { })) {
         auto [processID, pageID] = key;
-        if (RefPtr webProcess = WebKit::WebProcessProxy::processForIdentifier(processID))
-            webProcess->removeMessageReceiver(Messages::ProxyingNetworkAgent::messageReceiverName(), pageID);
+        auto it = m_pinnedInstrumentedProcesses.find(processID);
+        ASSERT(it != m_pinnedInstrumentedProcesses.end());
+        if (it == m_pinnedInstrumentedProcesses.end())
+            continue;
+        Ref webProcess = it->value;
+        webProcess->removeMessageReceiver(Messages::ProxyingNetworkAgent::messageReceiverName(), pageID);
     }
+    m_pinnedInstrumentedProcesses.clear();
 }
 
 void ProxyingNetworkAgent::didCreateFrontendAndBackend()
@@ -197,13 +198,17 @@ void ProxyingNetworkAgent::enableInstrumentationForProcess(WebKit::WebProcessPro
     if (++result.iterator->value > 1)
         return;
 
+    m_pinnedInstrumentedProcesses.ensure(webProcess.coreProcessIdentifier(), [&] {
+        return Ref { webProcess };
+    });
     webProcess.addMessageReceiver(Messages::ProxyingNetworkAgent::messageReceiverName(), pageID, *this);
     webProcess.send(Messages::WebInspectorBackend::EnableNetworkInstrumentation { }, pageID);
 }
 
 void ProxyingNetworkAgent::disableInstrumentationForProcess(WebKit::WebProcessProxy& webProcess, WebCore::PageIdentifier pageID)
 {
-    auto key = std::make_pair(webProcess.coreProcessIdentifier(), pageID);
+    auto processID = webProcess.coreProcessIdentifier();
+    auto key = std::make_pair(processID, pageID);
     auto it = m_instrumentedProcessPageCounts.find(key);
     if (it == m_instrumentedProcessPageCounts.end())
         return;
@@ -214,6 +219,17 @@ void ProxyingNetworkAgent::disableInstrumentationForProcess(WebKit::WebProcessPr
     m_instrumentedProcessPageCounts.remove(it);
     webProcess.send(Messages::WebInspectorBackend::DisableNetworkInstrumentation { }, pageID);
     webProcess.removeMessageReceiver(Messages::ProxyingNetworkAgent::messageReceiverName(), pageID);
+
+    // Drop the pin once this process has no remaining page registrations.
+    bool processStillHasRegistrations = false;
+    for (auto& entry : m_instrumentedProcessPageCounts) {
+        if (entry.key.first == processID) {
+            processStillHasRegistrations = true;
+            break;
+        }
+    }
+    if (!processStillHasRegistrations)
+        m_pinnedInstrumentedProcesses.remove(processID);
 }
 
 CommandResult<void> ProxyingNetworkAgent::enable()
@@ -250,11 +266,16 @@ CommandResult<void> ProxyingNetworkAgent::disable()
     // Iterate the registration map, not forEachWebContentProcess(): under
     // Site Isolation a process may have swapped out while still holding our
     // message receiver, in which case forEachWebContentProcess() would no
-    // longer enumerate it.
+    // longer enumerate it. The pinned process refs (see m_pinnedInstrumentedProcesses)
+    // keep the WebProcessProxy alive long enough for the send + remove below.
     for (auto& [key, _] : m_instrumentedProcessPageCounts) {
         auto [processID, pageID] = key;
-        if (RefPtr webProcess = WebKit::WebProcessProxy::processForIdentifier(processID))
-            webProcess->send(Messages::WebInspectorBackend::DisableNetworkInstrumentation { }, pageID);
+        auto it = m_pinnedInstrumentedProcesses.find(processID);
+        ASSERT(it != m_pinnedInstrumentedProcesses.end());
+        if (it == m_pinnedInstrumentedProcesses.end())
+            continue;
+        Ref webProcess = it->value;
+        webProcess->send(Messages::WebInspectorBackend::DisableNetworkInstrumentation { }, pageID);
     }
     removeAllRegisteredReceivers();
 

--- a/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.h
+++ b/Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.h
@@ -116,6 +116,13 @@ private:
 
     bool m_enabled { false };
     HashMap<std::pair<WebCore::ProcessIdentifier, WebCore::PageIdentifier>, unsigned> m_instrumentedProcessPageCounts;
+
+    // Pin each instrumented WebProcessProxy alive while we hold an IPC message
+    // receiver registration on it. Without this, the process can be destructed
+    // before ~ProxyingNetworkAgent runs, leaving the receiver registered against
+    // a map that has already gone away. The receiver's m_messageReceiverMapCount
+    // then stays nonzero and ~MessageReceiver fires its debug ASSERT.
+    HashMap<WebCore::ProcessIdentifier, Ref<WebKit::WebProcessProxy>> m_pinnedInstrumentedProcesses;
 };
 
 } // namespace Inspector

--- a/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
+++ b/Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp
@@ -342,6 +342,13 @@ void WebPageInspectorController::didCommitProvisionalPage(std::optional<WebCore:
             pageAgent->disableInstrumentationForProcess(*oldProcess, oldWebPageID);
         pageAgent->enableInstrumentationForProcess(newProcess, newWebPageID);
     }
+
+    RefPtr networkAgent = m_networkAgent;
+    if (networkAgent && networkAgent->isEnabled()) {
+        if (oldProcess)
+            networkAgent->disableInstrumentationForProcess(*oldProcess, oldWebPageID);
+        networkAgent->enableInstrumentationForProcess(newProcess, newWebPageID);
+    }
 }
 
 void WebPageInspectorController::didCreateFrame(WebFrameProxy& frame)


### PR DESCRIPTION
#### bafdda395eebfb3bf97f2759eadcae9c85347b15
<pre>
[Site Isolation] Web Inspector: disable instrumentation for the old process on didCommitProvisionalPage
<a href="https://bugs.webkit.org/show_bug.cgi?id=315312">https://bugs.webkit.org/show_bug.cgi?id=315312</a>
<a href="https://rdar.apple.com/177178776">rdar://177178776</a>

Reviewed by Sihui Liu.

REGRESSION(313207@main): [macOS Debug] ASSERTION FAILED:
!m_messageReceiverMapCount in http/tests/ssl/applepay/ApplePayButton.html.

Two complementary fixes:

(1) Pair add/remove on full-page cross-origin navigation.

313741@main fixed one half of ProxyingNetworkAgent&apos;s receiver leak --
the disable() walk now reaches stale processes via the registration map.
CI reports the assertion still flakes, and inspecting the
process-swap hooks shows why: didCommitProvisionalFrame disables
instrumentation on the old process when an iframe swaps, but
didCommitProvisionalPage (the full-page cross-origin navigation hook)
does not. So a top-level cross-origin nav under inspection leaves
m_instrumentedProcessPageCounts referencing the swapped-out process and
its IPC receiver registration intact. When that process eventually goes
away or the inspector tears down, MessageReceiver&apos;s destructor asserts.

Mirror the didCommitProvisionalFrame pattern in didCommitProvisionalPage:
look up the old WebProcessProxy by ProcessIdentifier, call
disableInstrumentationForProcess for (oldProcess, oldWebPageID) so the
addMessageReceiver registration is paired by a removeMessageReceiver,
and enableInstrumentationForProcess for the new (process, pageID).

(2) Pin the instrumented WebProcessProxy alive while we hold a receiver
registration on it. This design is already proven to work by ProxyingPageAgent.

The disable() walk and the ~ProxyingNetworkAgent backstop both used
WebProcessProxy::processForIdentifier() to find the proxy to call
removeMessageReceiver on. That lookup returns null once the
WebProcessProxy has been destructed -- but the IPC receiver map entry
isn&apos;t torn down until later, so the receiver&apos;s m_messageReceiverMapCount
stays nonzero and ~MessageReceiver fires the ASSERT. This was first
caught locally on http/tests/storageAccess/deny-due-to-no-interaction-...
ephemeral.https.html via the new ProxyingPageAgent added in #61177, but
ProxyingNetworkAgent has the identical pattern and same latent UAF.

Add a parallel HashMap&lt;ProcessIdentifier, Ref&lt;WebProcessProxy&gt;&gt; on both
agents. enableInstrumentationForProcess populates it; cleanup paths drop
the pin once the last (process, pageID) registration for that process
goes away. With the pin, disable() and ~ProxyingNetworkAgent /
~ProxyingPageAgent can use the pinned ref directly and never hit a null
processForIdentifier() lookup.

* Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.cpp:
(Inspector::ProxyingNetworkAgent::removeAllRegisteredReceivers):
(Inspector::ProxyingNetworkAgent::enableInstrumentationForProcess):
(Inspector::ProxyingNetworkAgent::disableInstrumentationForProcess):
(Inspector::ProxyingNetworkAgent::disable):
* Source/WebKit/UIProcess/Inspector/Agents/ProxyingNetworkAgent.h:
* Source/WebKit/UIProcess/Inspector/WebPageInspectorController.cpp:
(WebKit::WebPageInspectorController::didCommitProvisionalPage):

Canonical link: <a href="https://commits.webkit.org/314195@main">https://commits.webkit.org/314195@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/67f7e8cef2c9a8c6cd14962a3895cb09ef155caf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165351 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38842 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32422 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174395 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122608 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/74c1c3e6-2fe0-4e2f-bcfa-a667a82d8bc2) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39179 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38846 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128495 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90435 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/17af5418-89c6-4453-893d-1377736fab5d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168310 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30805 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148560 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109020 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b9d6d743-3d78-4b61-9fc9-13fc75dbb937) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29853 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28476 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22469 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139748 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26258 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176917 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29818 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27963 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136819 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38911 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32614 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136755 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36872 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39600 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148054 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101944 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32026 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24921 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38110 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111184 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37507 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2999 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37754 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37651 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->