### PR TITLE
Fix fragment parsing of xmlns="" inheritance and annotation-xml encoding

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/the-innerhtml-property/annotation-xml-fragment-parsing-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/the-innerhtml-property/annotation-xml-fragment-parsing-expected.txt
@@ -1,0 +1,5 @@
+
+
+PASS HTML parsing doesn't apply in <annotation-xml> without encoding attribute
+PASS HTML parsing does apply in <annotation-xml encoding="application/xhtml+xml">
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/the-innerhtml-property/annotation-xml-fragment-parsing.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/the-innerhtml-property/annotation-xml-fragment-parsing.html
@@ -1,0 +1,42 @@
+<!DOCTYPE HTML>
+<title>mathml:annotation-xml and fragment parsing</title>
+<link rel="help" href="https://issues.chromium.org/513859894">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<math>
+  <annotation-xml id="noenc"></annotation-xml>
+  <annotation-xml id="enchtml" encoding="application/xhtml+xml"></annotation-xml>
+</math>
+
+<script>
+  "use strict";
+
+  const noenc = document.getElementById("noenc");
+  const enchtml = document.getElementById("enchtml");
+
+  const HTML_NS = "http://www.w3.org/1999/xhtml";
+  const MATH_NS = "http://www.w3.org/1998/Math/MathML";
+
+  test(() => {
+    noenc.innerHTML = "<style><img></style>";
+    assert_equals(noenc.namespaceURI, MATH_NS, "<annotation-xml> namespace");
+    assert_equals(noenc.childNodes.length, 2, "<annotation-xml> child count");
+    assert_equals(noenc.firstChild.namespaceURI, MATH_NS, "<annotation-xml> first child namespace");
+    assert_equals(noenc.firstChild.localName, "style", "<annotation-xml> first child localName");
+    assert_equals(noenc.firstChild.childNodes.length, 0, "<annotation-xml> first child child count");
+    assert_equals(noenc.firstChild.nextSibling.namespaceURI, HTML_NS, "<annotation-xml> second child namespace");
+    assert_equals(noenc.firstChild.nextSibling.localName, "img", "<annotation-xml> second child localName");
+    assert_equals(noenc.firstChild.nextSibling.childNodes.length, 0, "<annotation-xml> second child child count");
+  }, `HTML parsing doesn't apply in <annotation-xml> without encoding attribute`);
+
+  test(() => {
+    enchtml.innerHTML = "<style><img></style>";
+    assert_equals(enchtml.namespaceURI, MATH_NS, "<annotation-xml> namespace");
+    assert_equals(enchtml.childNodes.length, 1, "<annotation-xml> child count");
+    assert_equals(enchtml.firstChild.namespaceURI, HTML_NS, "<annotation-xml> child namespace");
+    assert_equals(enchtml.firstChild.childNodes.length, 1, "<annotation-xml> child's child count");
+    assert_equals(enchtml.firstChild.childNodes[0].nodeType, Node.TEXT_NODE, "<annotation-xml> grandchild node type");
+  }, `HTML parsing does apply in <annotation-xml encoding="application/xhtml+xml">`);
+
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/the-innerhtml-property/innerhtml-and-xml-namespaces-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/the-innerhtml-property/innerhtml-and-xml-namespaces-expected.txt
@@ -1,0 +1,16 @@
+
+PASS prerequisites
+PASS default namespace applies to children of namespaced element
+PASS default namespace applies to children of default-namespaced element
+PASS default namespace applies to children of non-namespaced element
+PASS default namespace applies to children of namespaced element with new default namespace
+PASS namespace prefix applies to children of namespaced element
+PASS default namespace prefix applies to descendants of namespaced element
+PASS unsetting default namespace works inside parse of fragment (on element)
+PASS unsetting default namespace works inside parse of fragment (on child of element)
+PASS default namespace applied to sibling of namespace-resetting element in parse of fragment.
+PASS default namespace applied to sibling of namespace-resetting template element in parse of fragment.
+PASS nested default namespace reset works inside parse of fragment
+PASS declaring namespace with prefix inside of fragment parsed by innerHTML
+PASS declaring default namespace inside of fragment parsed by innerHTML
+

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/the-innerhtml-property/innerhtml-and-xml-namespaces.svg
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/the-innerhtml-property/innerhtml-and-xml-namespaces.svg
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     xmlns:h="http://www.w3.org/1999/xhtml"
+     width="800px" height="1000px">
+  <title>innerHTML setter and XML namespaces</title>
+  <metadata>
+    <h:link rel="help" href="https://html.spec.whatwg.org/multipage/dynamic-markup-insertion.html#the-innerhtml-property"/>
+  </metadata>
+  <h:script src="/resources/testharness.js"/>
+  <h:script src="/resources/testharnessreport.js"/>
+
+  <foreignObject>
+    <h:body>
+      <h:div/>
+      <g/>
+      <element xmlns=""/>
+      <element xmlns="https://example.org/ns"/>
+
+      <h:script><![CDATA[
+      "use strict";
+
+      const SVG_NS = "http://www.w3.org/2000/svg";
+      const XHTML_NS = "http://www.w3.org/1999/xhtml";
+
+      const body = document.querySelector("body");
+      const prefixedContainer = body.firstElementChild;
+      const unprefixedContainer = prefixedContainer.nextElementSibling;
+      const noDefaultNsContainer = unprefixedContainer.nextElementSibling;
+      const newDefaultNsContainer = noDefaultNsContainer.nextElementSibling;
+
+      test(() => {
+        assert_equals(prefixedContainer.namespaceURI, XHTML_NS);
+        assert_true(prefixedContainer.isDefaultNamespace(SVG_NS));
+        assert_equals(unprefixedContainer.namespaceURI, SVG_NS);
+        assert_true(unprefixedContainer.isDefaultNamespace(SVG_NS));
+        assert_equals(noDefaultNsContainer.namespaceURI, null);
+        assert_true(noDefaultNsContainer.isDefaultNamespace(""));
+        assert_equals(newDefaultNsContainer.namespaceURI, "https://example.org/ns");
+        assert_true(newDefaultNsContainer.isDefaultNamespace("https://example.org/ns"));
+      }, "prerequisites");
+
+      test(() => {
+        prefixedContainer.innerHTML = "<e></e>";
+        assert_equals(prefixedContainer.firstChild.namespaceURI, SVG_NS);
+      }, "default namespace applies to children of namespaced element");
+
+      test(() => {
+        unprefixedContainer.innerHTML = "<e></e>";
+        assert_equals(unprefixedContainer.firstChild.namespaceURI, SVG_NS);
+      }, "default namespace applies to children of default-namespaced element");
+
+      test(() => {
+        noDefaultNsContainer.innerHTML = "<e></e>";
+        assert_equals(noDefaultNsContainer.firstChild.namespaceURI, null);
+      }, "default namespace applies to children of non-namespaced element");
+
+      test(() => {
+        newDefaultNsContainer.innerHTML = "<e></e>";
+        assert_equals(newDefaultNsContainer.firstChild.namespaceURI, "https://example.org/ns");
+      }, "default namespace applies to children of namespaced element with new default namespace");
+
+      test(() => {
+        prefixedContainer.innerHTML = "<e><h:span></h:span></e>";
+        assert_equals(prefixedContainer.firstChild.firstChild.namespaceURI, XHTML_NS);
+      }, "namespace prefix applies to children of namespaced element");
+
+      test(() => {
+        prefixedContainer.innerHTML = "<e><h:span><f></f></h:span></e>";
+        assert_equals(prefixedContainer.firstChild.firstChild.firstChild.namespaceURI, SVG_NS);
+      }, "default namespace prefix applies to descendants of namespaced element");
+
+      test(() => {
+        prefixedContainer.innerHTML = "<e><f xmlns=''><g></g></f></e>";
+        assert_equals(prefixedContainer.firstChild.firstChild.namespaceURI, null);
+      }, "unsetting default namespace works inside parse of fragment (on element)");
+
+      test(() => {
+        prefixedContainer.innerHTML = "<e><f xmlns=''><g></g></f></e>";
+        assert_equals(prefixedContainer.firstChild.firstChild.firstChild.namespaceURI, null);
+      }, "unsetting default namespace works inside parse of fragment (on child of element)");
+
+      test(() => {
+        prefixedContainer.innerHTML = "<e><f xmlns=''><g></g></f><h/></e>";
+        assert_equals(prefixedContainer.firstChild.firstChild.firstChild.namespaceURI, null);
+        assert_equals(prefixedContainer.firstChild.lastChild.namespaceURI, SVG_NS);
+      }, "default namespace applied to sibling of namespace-resetting element in parse of fragment.");
+
+      test(() => {
+        prefixedContainer.innerHTML = "<e><h:template xmlns=''><g></g></h:template><h/></e>";
+        assert_equals(prefixedContainer.firstChild.firstChild.content.firstChild.namespaceURI, null);
+        assert_equals(prefixedContainer.firstChild.lastChild.namespaceURI, SVG_NS);
+      }, "default namespace applied to sibling of namespace-resetting template element in parse of fragment.");
+
+      test(() => {
+        prefixedContainer.innerHTML = "<e><f xmlns=''><g xmlns=''></g><h/></f><i></i></e>";
+        assert_equals(prefixedContainer.firstChild.namespaceURI, SVG_NS);
+        assert_equals(prefixedContainer.firstChild.firstChild.namespaceURI, null);
+        assert_equals(prefixedContainer.firstChild.firstChild.firstChild.namespaceURI, null);
+        assert_equals(prefixedContainer.firstChild.firstChild.lastChild.namespaceURI, null);
+        assert_equals(prefixedContainer.firstChild.lastChild.namespaceURI, SVG_NS);
+      }, "nested default namespace reset works inside parse of fragment");
+
+      test(() => {
+        prefixedContainer.innerHTML = "<e><h:f xmlns:h='https://example.com/new-h'><g><h:d></h:d></g></h:f></e>";
+        assert_equals(prefixedContainer.firstChild.firstChild.namespaceURI, "https://example.com/new-h");
+        assert_equals(prefixedContainer.firstChild.firstChild.firstChild.namespaceURI, SVG_NS);
+        assert_equals(prefixedContainer.firstChild.firstChild.firstChild.firstChild.namespaceURI, "https://example.com/new-h");
+      }, "declaring namespace with prefix inside of fragment parsed by innerHTML");
+
+      test(() => {
+        prefixedContainer.innerHTML = "<e><f xmlns='https://example.com/new-default'><h:g><d></d></h:g></f></e>";
+        assert_equals(prefixedContainer.firstChild.firstChild.namespaceURI, "https://example.com/new-default");
+        assert_equals(prefixedContainer.firstChild.firstChild.firstChild.namespaceURI, XHTML_NS);
+        assert_equals(prefixedContainer.firstChild.firstChild.firstChild.firstChild.namespaceURI, "https://example.com/new-default");
+      }, "declaring default namespace inside of fragment parsed by innerHTML");
+
+      ]]></h:script>
+    </h:body>
+  </foreignObject>
+</svg>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/the-innerhtml-property/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/the-innerhtml-property/w3c-import.log
@@ -1,0 +1,18 @@
+The tests in this directory were imported from the W3C repository.
+Do NOT modify these tests directly in WebKit.
+Instead, create a pull request on the WPT github:
+	https://github.com/web-platform-tests/wpt
+
+Then run the Tools/Scripts/import-w3c-tests in WebKit to reimport
+
+Do NOT modify or remove this file.
+
+------------------------------------------------------------------------
+Properties requiring vendor prefixes:
+None
+Property values requiring vendor prefixes:
+None
+------------------------------------------------------------------------
+List of files:
+/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/the-innerhtml-property/annotation-xml-fragment-parsing.html
+/LayoutTests/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/the-innerhtml-property/innerhtml-and-xml-namespaces.svg

--- a/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/the-innerhtml-property/annotation-xml-fragment-parsing-expected.txt
+++ b/LayoutTests/platform/glib/imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/the-innerhtml-property/annotation-xml-fragment-parsing-expected.txt
@@ -1,0 +1,4 @@
+
+PASS HTML parsing doesn't apply in <annotation-xml> without encoding attribute
+PASS HTML parsing does apply in <annotation-xml encoding="application/xhtml+xml">
+

--- a/Source/WTF/wtf/RefPtr.h
+++ b/Source/WTF/wtf/RefPtr.h
@@ -356,7 +356,7 @@ inline RefPtr<match_constness_t<Source, Target>> downcast(RefPtr<Source, PtrTrai
     return unsafeRefPtrDowncast<match_constness_t<Source, Target>>(WTF::move(source));
 }
 
-template<typename Target, typename Source, typename TargetPtrTraits = RawPtrTraits<Target>, typename TargetRefDerefTraits = DefaultRefDerefTraits<Target>,
+template<typename Target, typename Source, typename TargetPtrTraits = RawPtrTraits<match_constness_t<Source, Target>>, typename TargetRefDerefTraits = DefaultRefDerefTraits<match_constness_t<Source, Target>>,
     typename SourcePtrTraits, typename SourceRefDerefTraits>
 inline RefPtr<match_constness_t<Source, Target>, TargetPtrTraits, TargetRefDerefTraits> dynamicDowncast(RefPtr<Source, SourcePtrTraits, SourceRefDerefTraits> source)
 {

--- a/Source/WebCore/html/parser/HTMLElementStack.cpp
+++ b/Source/WebCore/html/parser/HTMLElementStack.cpp
@@ -278,13 +278,13 @@ bool HTMLElementStack::isMathMLTextIntegrationPoint(HTMLStackItem& item)
 bool HTMLElementStack::isHTMLIntegrationPoint(HTMLStackItem& item)
 {
     if (item.elementName() == MathML::annotation_xml) {
-        const Attribute* encodingAttr = item.findAttribute(MathMLNames::encodingAttr);
-        if (encodingAttr) {
-            const String& encoding = encodingAttr->value();
-            return equalLettersIgnoringASCIICase(encoding, "text/html"_s)
-                || equalLettersIgnoringASCIICase(encoding, "application/xhtml+xml"_s);
-        }
-        return false;
+        // Read encoding off the element directly: m_attributes is unset for fragment-context items.
+        RefPtr element = item.elementOrNull();
+        if (!element)
+            return false;
+        auto& encoding = element->attributeWithoutSynchronization(MathMLNames::encodingAttr);
+        return equalLettersIgnoringASCIICase(encoding, "text/html"_s)
+            || equalLettersIgnoringASCIICase(encoding, "application/xhtml+xml"_s);
     }
     return item.elementName() == SVG::foreignObject
         || item.elementName() == SVG::desc

--- a/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
+++ b/Source/WebCore/xml/parser/XMLDocumentParserLibxml2.cpp
@@ -40,6 +40,7 @@
 #include "DocumentResourceLoader.h"
 #include "DocumentSecurityOrigin.h"
 #include "DocumentType.h"
+#include "ElementInlines.h"
 #include "EventLoop.h"
 #include "FrameConsoleClient.h"
 #include "FrameDestructionObserverInlines.h"
@@ -54,18 +55,19 @@
 #include "MIMETypeRegistry.h"
 #include "NameValidation.h"
 #include "NodeDocument.h"
+#include "NodeInlines.h"
 #include "OriginAccessPatterns.h"
 #include "Page.h"
 #include "PendingScript.h"
 #include "ProcessingInstruction.h"
 #include "ResourceError.h"
 #include "ResourceResponse.h"
-#include "SVGElement.h"
 #include "ScriptElement.h"
 #include "ScriptSourceCode.h"
 #include "Settings.h"
 #include "SharedBuffer.h"
 #include "StyleScope.h"
+#include "TemplateContentDocumentFragment.h"
 #include "TextResourceDecoder.h"
 #include "ThrowOnDynamicMarkupInsertionCountIncrementer.h"
 #include "TransformSource.h"
@@ -759,9 +761,8 @@ struct _xmlSAX2Namespace {
 };
 typedef struct _xmlSAX2Namespace xmlSAX2Namespace;
 
-static inline bool handleNamespaceAttributes(Vector<Attribute>& prefixedAttributes, const xmlChar** libxmlNamespaces, int numNamespaces, bool& shouldUseNullCustomElementRegistry)
+static inline bool handleNamespaceAttributes(Vector<Attribute>& prefixedAttributes, std::span<xmlSAX2Namespace> namespaces, bool& shouldUseNullCustomElementRegistry)
 {
-    auto namespaces = unsafeMakeSpan(reinterpret_cast<xmlSAX2Namespace*>(libxmlNamespaces), numNamespaces);
     for (auto& xmlNamespace : namespaces) {
         AtomString namespaceQName = xmlnsAtom();
         AtomString namespaceURI = toAtomString(xmlNamespace.uri);
@@ -833,14 +834,35 @@ void XMLDocumentParser::startElementNs(const xmlChar* xmlLocalName, const xmlCha
     AtomString prefix = toAtomString(xmlPrefix);
     RefPtr currentNode = *m_currentNode;
     RefPtr document = currentNode->document();
+    auto namespaces = unsafeMakeSpan(reinterpret_cast<xmlSAX2Namespace*>(libxmlNamespaces), numNamespaces);
 
     if (m_parsingFragment && uri.isNull()) {
-        if (!prefix.isNull())
-            uri = m_prefixToNamespaceMap.get(prefix);
-        else if (is<SVGElement>(currentNode.get()) || localName == SVGNames::svgTag->localName())
-            uri = SVGNames::svgNamespaceURI;
-        else
-            uri = m_defaultNamespaceURI;
+        uri = [&] -> AtomString {
+            if (!prefix.isNull())
+                return m_prefixToNamespaceMap.get(prefix);
+
+            // libxml2 reports null URI both for "no namespace" and explicit xmlns=""; preserve the latter.
+            for (auto& xmlNamespace : namespaces) {
+                if (!xmlNamespace.prefix)
+                    return nullAtom();
+            }
+
+            RefPtr<const Node> ancestorNode = currentNode;
+            while (ancestorNode) {
+                if (RefPtr ancestor = dynamicDowncast<Element>(ancestorNode)) {
+                    if (!ancestor->namespaceURI().isNull() && ancestor->prefix().isNull())
+                        return ancestor->namespaceURI();
+                    auto& xmlnsValue = ancestor->attributeWithoutSynchronization(XMLNSNames::xmlnsAttr);
+                    if (!xmlnsValue.isNull())
+                        return xmlnsValue.isEmpty() ? nullAtom() : xmlnsValue;
+                    ancestorNode = ancestor->parentNode();
+                } else if (RefPtr templateContent = dynamicDowncast<TemplateContentDocumentFragment>(ancestorNode))
+                    ancestorNode = templateContent->host();
+                else
+                    break;
+            }
+            return m_defaultNamespaceURI;
+        }();
     }
 
     bool isFirstElement = !m_sawFirstElement;
@@ -867,7 +889,7 @@ void XMLDocumentParser::startElementNs(const xmlChar* xmlLocalName, const xmlCha
 
     Vector<Attribute> prefixedAttributes;
     bool shouldUseNullCustomElementRegistry = false;
-    bool handledAttributes = handleNamespaceAttributes(prefixedAttributes, libxmlNamespaces, numNamespaces, shouldUseNullCustomElementRegistry);
+    bool handledAttributes = handleNamespaceAttributes(prefixedAttributes, namespaces, shouldUseNullCustomElementRegistry);
     bool success = handledAttributes ? handleElementAttributes(prefixedAttributes, libxmlAttributes, numAttributes, shouldUseNullCustomElementRegistry) : false;
 
     RefPtr registry = shouldUseNullCustomElementRegistry ? nullptr : CustomElementRegistry::registryForNodeOrTreeScope(*currentNode, protect(currentNode->treeScope()));


### PR DESCRIPTION
#### b9e630270a1d655f2fdc0cc7121cfe04d961d849
<pre>
Fix fragment parsing of xmlns=&quot;&quot; inheritance and annotation-xml encoding
<a href="https://bugs.webkit.org/show_bug.cgi?id=315418">https://bugs.webkit.org/show_bug.cgi?id=315418</a>

Reviewed by Ryosuke Niwa.

1. XML fragment parsing didn&apos;t distinguish &quot;no namespace info&quot; from an
   explicit xmlns=&quot;&quot; (libxml2 reports a null URI for both), and didn&apos;t
   walk the parsed-fragment ancestors (or cross template-content
   boundaries) to honor an inherited default namespace. Also allows us
   to drop the SVGElement / localName == &quot;svg&quot; workarounds.

2. HTMLElementStack::isHTMLIntegrationPoint read encoding from the
   stack item&apos;s saved attributes, which are empty for fragment-context
   items built via HTMLStackItem(Element&amp;). So &lt;annotation-xml
   encoding=&quot;application/xhtml+xml&quot;&gt; as fragment context never matched.
   Read it off the element via attributeWithoutSynchronization. (This
   is the only element where this matters so this is better than making
   HTMLStackItem itself more involved.)

3. RefPtr&apos;s dynamicDowncast propagates const via match_constness_t for
   the value type but used plain Target for the trait defaults, making
   RefPtr&lt;const T&gt; not work. (Which we need to work as host() returns a
   const T.)

Tests: imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/the-innerhtml-property/annotation-xml-fragment-parsing.html
       imported/w3c/web-platform-tests/html/webappapis/dynamic-markup-insertion/the-innerhtml-property/innerhtml-and-xml-namespaces.svg

Canonical link: <a href="https://commits.webkit.org/313803@main">https://commits.webkit.org/313803@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bd2bef4a30e6f6423a184e01370735c81a358add

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164180 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37664 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/30883 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173209 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121432 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/55f7adc0-2ab4-4f1a-b29a-92be847558b4) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166049 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37998 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37664 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/127549 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/89733 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9dd91a2f-2dae-4ccd-b6f9-4442a612b2fd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167139 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29845 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/147589 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108097 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0309ce03-6110-4ea9-9b00-7ffe57292abe) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28891 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27515 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20973 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/156331 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/138794 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/25306 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175735 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/25072 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28556 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/26974 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/135859 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37334 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31630 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/135829 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36599 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38120 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/147101 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100411 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31141 "Passed tests") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/23957 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/196583 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36930 "Build is in progress. Recent messages:OS: Tahoe (26.4.1), Xcode: 26.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109975 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51568 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36327 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/2009 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36577 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36477 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->