### PR TITLE
Unreviewed, just making JSC::OrderedHashTable => JSC::JSOrderedHashTable

### DIFF
--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -1265,6 +1265,8 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/JSObject.h
     runtime/JSObjectInlines.h
     runtime/JSONObject.h
+    runtime/JSOrderedHashTable.h
+    runtime/JSOrderedHashTableHelper.h
     runtime/JSPromise.h
     runtime/JSPromiseConstructor.h
     runtime/JSPropertyNameEnumerator.h
@@ -1339,8 +1341,6 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     runtime/OperationsInlines.h
     runtime/Options.h
     runtime/OptionsList.h
-    runtime/OrderedHashTable.h
-    runtime/OrderedHashTableHelper.h
     runtime/PageCount.h
     runtime/ParseInt.h
     runtime/PinballCompletion.h

--- a/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -2359,11 +2359,11 @@
 		FFA2E02D2EA16F37006661A3 /* BinaryTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FFA2E0212EA16F37006661A3 /* BinaryTests.cpp */; };
 		FFA2E02E2EA16F37006661A3 /* MemoryTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FFA2E0232EA16F37006661A3 /* MemoryTests.cpp */; };
 		FFA2E02F2EA16F37006661A3 /* UnaryTests.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FFA2E0262EA16F37006661A3 /* UnaryTests.cpp */; };
-		FFB951142C043CA800349750 /* OrderedHashTableHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = FFB951132C043CA800349750 /* OrderedHashTableHelper.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FFB951142C043CA800349750 /* JSOrderedHashTableHelper.h in Headers */ = {isa = PBXBuildFile; fileRef = FFB951132C043CA800349750 /* JSOrderedHashTableHelper.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FFB963922E38302B0069A70F /* WasmBreakpointManager.h in Headers */ = {isa = PBXBuildFile; fileRef = FFB9638F2E38302B0069A70F /* WasmBreakpointManager.h */; };
 		FFBD27052F6B133900DE6C3D /* ExecutionHandlerVMLifecycleTest.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FFBD27042F6B133900DE6C3D /* ExecutionHandlerVMLifecycleTest.cpp */; };
 		FFBF548A2F189712008F124F /* WasmGDBPacketParser.h in Headers */ = {isa = PBXBuildFile; fileRef = FFBF54872F189712008F124F /* WasmGDBPacketParser.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		FFCC9A412BDD7C4700C75345 /* OrderedHashTable.h in Headers */ = {isa = PBXBuildFile; fileRef = FFCC9A402BDD7C4700C75345 /* OrderedHashTable.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FFCC9A412BDD7C4700C75345 /* JSOrderedHashTable.h in Headers */ = {isa = PBXBuildFile; fileRef = FFCC9A402BDD7C4700C75345 /* JSOrderedHashTable.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FFD49E6E2E276CA10083E383 /* WasmDebugServer.h in Headers */ = {isa = PBXBuildFile; fileRef = FFD49E5A2E276CA10083E383 /* WasmDebugServer.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		FFD49E6F2E276CA10083E383 /* WasmQueryHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = FFD49E602E276CA10083E383 /* WasmQueryHandler.h */; };
 		FFD49E722E276CA10083E383 /* WasmExecutionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = FFD49E5C2E276CA10083E383 /* WasmExecutionHandler.h */; };
@@ -6528,7 +6528,7 @@
 		FF1344652EB3F2A600940C00 /* ExtGCTests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ExtGCTests.cpp; sourceTree = "<group>"; };
 		FF18EBC42EA5C73E00185CFA /* TestUtilities.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = TestUtilities.cpp; sourceTree = "<group>"; };
 		FF1D8E862CE7C9BF00E211DD /* VerifierSlotVisitorScope.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VerifierSlotVisitorScope.h; sourceTree = "<group>"; };
-		FF27D0E42BE2AEDB00397A8C /* OrderedHashTable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = OrderedHashTable.cpp; sourceTree = "<group>"; };
+		FF27D0E42BE2AEDB00397A8C /* JSOrderedHashTable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = JSOrderedHashTable.cpp; sourceTree = "<group>"; };
 		FF31EC8B2D947F0500D9CB81 /* DFGCloneHelper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = DFGCloneHelper.h; path = dfg/DFGCloneHelper.h; sourceTree = "<group>"; };
 		FF31EC8C2D947F0500D9CB81 /* DFGCloneHelper.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; name = DFGCloneHelper.cpp; path = dfg/DFGCloneHelper.cpp; sourceTree = "<group>"; };
 		FF3394A92CB4941B004AFF6A /* RegExpSubstringGlobalAtomCache.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = RegExpSubstringGlobalAtomCache.h; sourceTree = "<group>"; };
@@ -6572,14 +6572,14 @@
 		FFA2E0252EA16F37006661A3 /* TestUtilities.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TestUtilities.h; sourceTree = "<group>"; };
 		FFA2E0262EA16F37006661A3 /* UnaryTests.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = UnaryTests.cpp; sourceTree = "<group>"; };
 		FFB77C2828FF561B00F3C55B /* WaiterListManager.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = WaiterListManager.cpp; sourceTree = "<group>"; };
-		FFB951132C043CA800349750 /* OrderedHashTableHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OrderedHashTableHelper.h; sourceTree = "<group>"; };
+		FFB951132C043CA800349750 /* JSOrderedHashTableHelper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSOrderedHashTableHelper.h; sourceTree = "<group>"; };
 		FFB9638F2E38302B0069A70F /* WasmBreakpointManager.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmBreakpointManager.h; sourceTree = "<group>"; };
 		FFB963902E38302B0069A70F /* WasmBreakpointManager.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WasmBreakpointManager.cpp; sourceTree = "<group>"; };
 		FFBD27032F6B133900DE6C3D /* ExecutionHandlerVMLifecycleTest.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ExecutionHandlerVMLifecycleTest.h; sourceTree = "<group>"; };
 		FFBD27042F6B133900DE6C3D /* ExecutionHandlerVMLifecycleTest.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = ExecutionHandlerVMLifecycleTest.cpp; sourceTree = "<group>"; };
 		FFBF54872F189712008F124F /* WasmGDBPacketParser.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmGDBPacketParser.h; sourceTree = "<group>"; };
 		FFBF54882F189712008F124F /* WasmGDBPacketParser.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WasmGDBPacketParser.cpp; sourceTree = "<group>"; };
-		FFCC9A402BDD7C4700C75345 /* OrderedHashTable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = OrderedHashTable.h; sourceTree = "<group>"; };
+		FFCC9A402BDD7C4700C75345 /* JSOrderedHashTable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JSOrderedHashTable.h; sourceTree = "<group>"; };
 		FFD49E5A2E276CA10083E383 /* WasmDebugServer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmDebugServer.h; sourceTree = "<group>"; };
 		FFD49E5B2E276CA10083E383 /* WasmDebugServer.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = WasmDebugServer.cpp; sourceTree = "<group>"; };
 		FFD49E5C2E276CA10083E383 /* WasmExecutionHandler.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WasmExecutionHandler.h; sourceTree = "<group>"; };
@@ -9142,6 +9142,9 @@
 				A7F9935E0FD7325100A0B2D0 /* JSONObject.cpp */,
 				A7F9935D0FD7325100A0B2D0 /* JSONObject.h */,
 				276B38782A71D11700252F4E /* JSONObjectInlines.h */,
+				FF27D0E42BE2AEDB00397A8C /* JSOrderedHashTable.cpp */,
+				FFCC9A402BDD7C4700C75345 /* JSOrderedHashTable.h */,
+				FFB951132C043CA800349750 /* JSOrderedHashTableHelper.h */,
 				230F325B2F3D10AF00E9D286 /* JSPIContext.cpp */,
 				23D7A3E02F3D0F4C00A27B88 /* JSPIContext.h */,
 				23D7A3E12F3D0F4C00A27B88 /* JSPIContextInlines.h */,
@@ -9342,9 +9345,6 @@
 				0FE228EA1436AB2300196C48 /* Options.cpp */,
 				0FE228EB1436AB2300196C48 /* Options.h */,
 				FE3842312324D51B009DD445 /* OptionsList.h */,
-				FF27D0E42BE2AEDB00397A8C /* OrderedHashTable.cpp */,
-				FFCC9A402BDD7C4700C75345 /* OrderedHashTable.h */,
-				FFB951132C043CA800349750 /* OrderedHashTableHelper.h */,
 				E389D851291226BC0085C3DC /* PageCount.cpp */,
 				E389D852291226BC0085C3DC /* PageCount.h */,
 				37C738D11EDB5672003F2B0B /* ParseInt.h */,
@@ -12216,6 +12216,8 @@
 				E32FEA2C27448F3700FF41C1 /* JSONAtomStringCacheInlines.h in Headers */,
 				A7F9935F0FD7325100A0B2D0 /* JSONObject.h in Headers */,
 				276B387B2A71D11800252F4E /* JSONObjectInlines.h in Headers */,
+				FFCC9A412BDD7C4700C75345 /* JSOrderedHashTable.h in Headers */,
+				FFB951142C043CA800349750 /* JSOrderedHashTableHelper.h in Headers */,
 				23D7A3E22F3D0F4C00A27B88 /* JSPIContext.h in Headers */,
 				23D7A3E32F3D0F4C00A27B88 /* JSPIContextInlines.h in Headers */,
 				7C184E1B17BEDBD3007CB63A /* JSPromise.h in Headers */,
@@ -12457,8 +12459,6 @@
 				BC18C44A0E16F5CD00B34460 /* OperationsInlines.h in Headers */,
 				0FE228ED1436AB2700196C48 /* Options.h in Headers */,
 				FE3842332324D51B009DD445 /* OptionsList.h in Headers */,
-				FFCC9A412BDD7C4700C75345 /* OrderedHashTable.h in Headers */,
-				FFB951142C043CA800349750 /* OrderedHashTableHelper.h in Headers */,
 				FE37C52A2A9C3EA9003EE733 /* OSCheck.h in Headers */,
 				E356987222841187008CDCCB /* PackedCellPtr.h in Headers */,
 				E389D854291226BC0085C3DC /* PageCount.h in Headers */,

--- a/Source/JavaScriptCore/Sources.txt
+++ b/Source/JavaScriptCore/Sources.txt
@@ -956,6 +956,7 @@ runtime/JSModuleRecord.cpp
 runtime/JSNativeStdFunction.cpp
 runtime/JSONObject.cpp
 runtime/JSObject.cpp
+runtime/JSOrderedHashTable.cpp
 runtime/JSPIContext.cpp
 runtime/JSPromise.cpp
 runtime/JSPromiseCombinatorsContext.cpp
@@ -1031,7 +1032,6 @@ runtime/ObjectInitializationScope.cpp
 runtime/ObjectPrototype.cpp
 runtime/Operations.cpp
 runtime/Options.cpp
-runtime/OrderedHashTable.cpp
 runtime/PageCount.cpp
 runtime/PinballCompletion.cpp
 runtime/PinballHandlerContext.cpp

--- a/Source/JavaScriptCore/runtime/AbstractModuleRecord.cpp
+++ b/Source/JavaScriptCore/runtime/AbstractModuleRecord.cpp
@@ -942,7 +942,7 @@ JSModuleNamespaceObject* AbstractModuleRecord::getModuleNamespace(JSGlobalObject
 }
 
 // https://tc39.es/proposal-defer-import-eval/#sec-GatherAsynchronousTransitiveDependencies
-void AbstractModuleRecord::gatherAsynchronousTransitiveDependencies(WTF::OrderedHashSet<AbstractModuleRecord*>& result, UncheckedKeyHashSet<AbstractModuleRecord*>& seen)
+void AbstractModuleRecord::gatherAsynchronousTransitiveDependencies(OrderedHashSet<AbstractModuleRecord*>& result, UncheckedKeyHashSet<AbstractModuleRecord*>& seen)
 {
     // The spec text is recursive; we use an explicit work list to avoid native stack overflow on
     // deep graphs. Children are pushed in reverse to preserve the spec's pre-order discovery order.
@@ -1197,7 +1197,7 @@ unsigned AbstractModuleRecord::innerModuleEvaluation(JSGlobalObject* globalObjec
     stack.append(module);
     // https://tc39.es/proposal-defer-import-eval/#sec-innermoduleevaluation
     // 10. Let evaluationList be a new empty List.
-    WTF::OrderedHashSet<AbstractModuleRecord*> evaluationList;
+    OrderedHashSet<AbstractModuleRecord*> evaluationList;
     // 11. For each ModuleRequest Record request of module.[[RequestedModules]], do
     for (const ModuleRequest& request : module->requestedModules()) {
         // 11.a. Let requiredModule be GetImportedModule(module, request).

--- a/Source/JavaScriptCore/runtime/AbstractModuleRecord.h
+++ b/Source/JavaScriptCore/runtime/AbstractModuleRecord.h
@@ -106,9 +106,9 @@ public:
         Identifier localName;
     };
 
-    using OrderedIdentifierSet = WTF::OrderedHashSet<RefPtr<UniquedStringImpl>, IdentifierRepHash>;
-    using ImportEntries = WTF::OrderedHashMap<RefPtr<UniquedStringImpl>, ImportEntry, IdentifierRepHash, HashTraits<RefPtr<UniquedStringImpl>>>;
-    using ExportEntries = WTF::OrderedHashMap<RefPtr<UniquedStringImpl>, ExportEntry, IdentifierRepHash, HashTraits<RefPtr<UniquedStringImpl>>>;
+    using OrderedIdentifierSet = OrderedHashSet<RefPtr<UniquedStringImpl>, IdentifierRepHash>;
+    using ImportEntries = OrderedHashMap<RefPtr<UniquedStringImpl>, ImportEntry, IdentifierRepHash, HashTraits<RefPtr<UniquedStringImpl>>>;
+    using ExportEntries = OrderedHashMap<RefPtr<UniquedStringImpl>, ExportEntry, IdentifierRepHash, HashTraits<RefPtr<UniquedStringImpl>>>;
 
     struct ModuleRequest {
         Identifier m_specifier;
@@ -202,7 +202,7 @@ public:
 
     JSModuleNamespaceObject* getModuleNamespace(JSGlobalObject*, ModulePhase = ModulePhase::Evaluation);
 
-    void gatherAsynchronousTransitiveDependencies(WTF::OrderedHashSet<AbstractModuleRecord*>& result, UncheckedKeyHashSet<AbstractModuleRecord*>& seen);
+    void gatherAsynchronousTransitiveDependencies(OrderedHashSet<AbstractModuleRecord*>& result, UncheckedKeyHashSet<AbstractModuleRecord*>& seen);
     bool readyForSyncExecution();
     void evaluateSync(JSGlobalObject*);
 

--- a/Source/JavaScriptCore/runtime/JSCJSValue.h
+++ b/Source/JavaScriptCore/runtime/JSCJSValue.h
@@ -109,7 +109,7 @@ extern JS_EXPORT_PRIVATE const ASCIILiteral SymbolCoercionError;
 extern JS_EXPORT_PRIVATE std::atomic<unsigned> activeJSGlobalObjectSignpostIntervalCount;
 
 class JSValue {
-    friend struct OrderedHashTableTraits;
+    friend struct JSOrderedHashTableTraits;
     friend struct EncodedJSValueHashTraits;
     friend struct EncodedJSValueWithRepresentationHashTraits;
     friend class AssemblyHelpers;
@@ -525,7 +525,7 @@ private:
 };
 
 #if USE(JSVALUE32_64)
-struct OrderedHashTableTraits {
+struct JSOrderedHashTableTraits {
     ALWAYS_INLINE static void set(JSValue* value, uint32_t number)
     {
         value->u.asBits.tag = JSValue::Int32Tag;
@@ -543,7 +543,7 @@ struct OrderedHashTableTraits {
     }
 };
 #else
-struct OrderedHashTableTraits {
+struct JSOrderedHashTableTraits {
     ALWAYS_INLINE static void set(JSValue* value, uint32_t number)
     {
         value->u.asInt64 = JSValue::NumberTag | number;

--- a/Source/JavaScriptCore/runtime/JSMap.h
+++ b/Source/JavaScriptCore/runtime/JSMap.h
@@ -25,12 +25,12 @@
 
 #pragma once
 
-#include <JavaScriptCore/OrderedHashTable.h>
+#include <JavaScriptCore/JSOrderedHashTable.h>
 
 namespace JSC {
 
-class JSMap final : public OrderedHashMap {
-    using Base = OrderedHashMap;
+class JSMap final : public JSOrderedHashMap {
+    using Base = JSOrderedHashMap;
 public:
 
     DECLARE_EXPORT_INFO;

--- a/Source/JavaScriptCore/runtime/JSMicrotask.cpp
+++ b/Source/JavaScriptCore/runtime/JSMicrotask.cpp
@@ -1308,7 +1308,7 @@ static void dynamicImportLoadSettled(JSGlobalObject* globalObject, VM& vm, Throw
     // all settle, hand back the deferred namespace.
     //
     // Let evaluationList be GatherAsynchronousTransitiveDependencies(module).
-    WTF::OrderedHashSet<AbstractModuleRecord*> evaluationList;
+    OrderedHashSet<AbstractModuleRecord*> evaluationList;
     UncheckedKeyHashSet<AbstractModuleRecord*> seen;
     module->gatherAsynchronousTransitiveDependencies(evaluationList, seen);
 

--- a/Source/JavaScriptCore/runtime/JSModuleNamespaceObject.h
+++ b/Source/JavaScriptCore/runtime/JSModuleNamespaceObject.h
@@ -82,7 +82,7 @@ private:
         WriteBarrier<AbstractModuleRecord> moduleRecord;
     };
 
-    using ExportMap = WTF::OrderedHashMap<RefPtr<UniquedStringImpl>, ExportEntry, IdentifierRepHash, HashTraits<RefPtr<UniquedStringImpl>>>;
+    using ExportMap = OrderedHashMap<RefPtr<UniquedStringImpl>, ExportEntry, IdentifierRepHash, HashTraits<RefPtr<UniquedStringImpl>>>;
 
     ExportMap m_exports;
     WriteBarrier<AbstractModuleRecord> m_moduleRecord;

--- a/Source/JavaScriptCore/runtime/JSOrderedHashTable.cpp
+++ b/Source/JavaScriptCore/runtime/JSOrderedHashTable.cpp
@@ -24,7 +24,7 @@
  */
 
 #include "config.h"
-#include "OrderedHashTable.h"
+#include "JSOrderedHashTable.h"
 
 #include "ButterflyInlinesLight.h"
 
@@ -32,18 +32,18 @@ namespace JSC {
 
 template<typename Traits>
 template<typename Visitor>
-void OrderedHashTable<Traits>::visitChildrenImpl(JSCell* cell, Visitor& visitor)
+void JSOrderedHashTable<Traits>::visitChildrenImpl(JSCell* cell, Visitor& visitor)
 {
-    OrderedHashTable<Traits>* thisObject = uncheckedDowncast<OrderedHashTable<Traits>>(cell);
+    JSOrderedHashTable<Traits>* thisObject = uncheckedDowncast<JSOrderedHashTable<Traits>>(cell);
     ASSERT_GC_OBJECT_INHERITS(thisObject, info());
     Base::visitChildren(thisObject, visitor);
 
     visitor.append(thisObject->m_storage);
 }
 
-DEFINE_VISIT_CHILDREN_WITH_MODIFIER(template<typename Traits>, OrderedHashTable<Traits>);
+DEFINE_VISIT_CHILDREN_WITH_MODIFIER(template<typename Traits>, JSOrderedHashTable<Traits>);
 
-template class OrderedHashTable<MapTraits>;
-template class OrderedHashTable<SetTraits>;
+template class JSOrderedHashTable<MapTraits>;
+template class JSOrderedHashTable<SetTraits>;
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/JSOrderedHashTable.h
+++ b/Source/JavaScriptCore/runtime/JSOrderedHashTable.h
@@ -25,28 +25,28 @@
 
 #pragma once
 
-#include <JavaScriptCore/OrderedHashTableHelper.h>
+#include <JavaScriptCore/JSOrderedHashTableHelper.h>
 
 namespace JSC {
 
 template<typename Traits>
-class OrderedHashTable : public JSNonFinalObject {
+class JSOrderedHashTable : public JSNonFinalObject {
     using Base = JSNonFinalObject;
 
 public:
-    using HashTable = OrderedHashTable<Traits>;
-    using Helper = OrderedHashTableHelper<Traits>;
+    using HashTable = JSOrderedHashTable<Traits>;
+    using Helper = JSOrderedHashTableHelper<Traits>;
     using Storage = JSCellButterfly;
     using TableIndex = typename Helper::TableIndex;
 
     DECLARE_VISIT_CHILDREN;
 
-    OrderedHashTable(VM& vm, Structure* structure)
+    JSOrderedHashTable(VM& vm, Structure* structure)
         : Base(vm, structure)
     {
     }
 
-    static ptrdiff_t offsetOfStorage() { return OBJECT_OFFSETOF(OrderedHashTable, m_storage); }
+    static ptrdiff_t offsetOfStorage() { return OBJECT_OFFSETOF(JSOrderedHashTable, m_storage); }
 
     void finishCreation(VM& vm) { Base::finishCreation(vm); }
     void finishCreation(JSGlobalObject* globalObject, VM& vm, HashTable* base)
@@ -164,11 +164,11 @@ public:
     WriteBarrier<Storage> m_storage;
 };
 
-class OrderedHashMap : public OrderedHashTable<MapTraits> {
-    using Base = OrderedHashTable<MapTraits>;
+class JSOrderedHashMap : public JSOrderedHashTable<MapTraits> {
+    using Base = JSOrderedHashTable<MapTraits>;
 
 public:
-    OrderedHashMap(VM& vm, Structure* structure)
+    JSOrderedHashMap(VM& vm, Structure* structure)
         : Base(vm, structure)
     {
     }
@@ -245,11 +245,11 @@ public:
     static Symbol* createDeletedValue(VM& vm) { return Symbol::create(vm); }
 };
 
-class OrderedHashSet : public OrderedHashTable<SetTraits> {
-    using Base = OrderedHashTable<SetTraits>;
+class JSOrderedHashSet : public JSOrderedHashTable<SetTraits> {
+    using Base = JSOrderedHashTable<SetTraits>;
 
 public:
-    OrderedHashSet(VM& vm, Structure* structure)
+    JSOrderedHashSet(VM& vm, Structure* structure)
         : Base(vm, structure)
     {
     }

--- a/Source/JavaScriptCore/runtime/JSOrderedHashTableHelper.h
+++ b/Source/JavaScriptCore/runtime/JSOrderedHashTableHelper.h
@@ -48,7 +48,7 @@ struct SetTraits {
 };
 
 template<typename Traits>
-class OrderedHashTable;
+class JSOrderedHashTable;
 
 // ################ NonObsolete Table ################
 //
@@ -106,11 +106,11 @@ class OrderedHashTable;
 // Note that all elements in the JSCellButterfly are in JSValue type. However, only the key and value in the DataTable are real JSValues.
 // The others are used as unsigned integers wrapped by JSValue.
 template<typename Traits>
-class OrderedHashTableHelper {
+class JSOrderedHashTableHelper {
 public:
     using Storage = JSCellButterfly;
-    using Helper = OrderedHashTableHelper<Traits>;
-    using HashTable = OrderedHashTable<Traits>;
+    using Helper = JSOrderedHashTableHelper<Traits>;
+    using HashTable = JSOrderedHashTable<Traits>;
     using TableSize = uint32_t;
     using Entry = TableSize;
     using TableIndex = TableSize;
@@ -125,14 +125,14 @@ public:
 
     static_assert(EntrySize == MapTraits::EntrySize || EntrySize == SetTraits::EntrySize);
 
-    OrderedHashTableHelper() = delete;
+    JSOrderedHashTableHelper() = delete;
 
     ALWAYS_INLINE static TableSize toNumber(JSValue number) { return static_cast<TableSize>(number.asInt32()); }
     ALWAYS_INLINE static constexpr TableSize asNumber(Storage& storage, TableIndex index) { return toNumber(get(storage, index)); }
     ALWAYS_INLINE static JSValue toJSValue(Entry entry)
     {
         JSValue value = JSValue();
-        OrderedHashTableTraits::set(&value, entry);
+        JSOrderedHashTableTraits::set(&value, entry);
         return value;
     }
 
@@ -144,7 +144,7 @@ public:
     ALWAYS_INLINE static JSValue* slot(Storage& storage, TableIndex index) { return storage.toButterfly()->contiguous().atUnsafe(index).slot(); }
 
     ALWAYS_INLINE static void set(Storage& storage, TableIndex index, JSValue value) { return storage.toButterfly()->contiguous().atUnsafe(index).setWithoutWriteBarrier(value); }
-    ALWAYS_INLINE static void set(Storage& storage, TableIndex index, TableSize number) { OrderedHashTableTraits::set(slot(storage, index), number); }
+    ALWAYS_INLINE static void set(Storage& storage, TableIndex index, TableSize number) { JSOrderedHashTableTraits::set(slot(storage, index), number); }
     ALWAYS_INLINE static void setWithWriteBarrier(VM& vm, Storage& storage, TableIndex index, JSValue value) { storage.toButterfly()->contiguous().atUnsafe(index).set(vm, &storage, value); }
 
     /* -------------------------------- AliveEntryCount, DeletedEntryCount, Capacity, and IterationEntry -------------------------------- */
@@ -162,9 +162,9 @@ public:
     ALWAYS_INLINE static constexpr TableSize capacity(Storage& storage) { return asNumber(storage, capacityIndex()); }
     ALWAYS_INLINE static constexpr TableSize iterationEntry(Storage& storage) { return asNumber(storage, iterationEntryIndex()); }
 
-    ALWAYS_INLINE static constexpr void incrementAliveEntryCount(Storage& storage) { OrderedHashTableTraits::increment(slot(storage, aliveEntryCountIndex())); }
-    ALWAYS_INLINE static constexpr void decrementAliveEntryCount(Storage& storage) { OrderedHashTableTraits::decrement(slot(storage, aliveEntryCountIndex())); }
-    ALWAYS_INLINE static constexpr void incrementDeletedEntryCount(Storage& storage) { OrderedHashTableTraits::increment(slot(storage, deletedEntryCountIndex())); }
+    ALWAYS_INLINE static constexpr void incrementAliveEntryCount(Storage& storage) { JSOrderedHashTableTraits::increment(slot(storage, aliveEntryCountIndex())); }
+    ALWAYS_INLINE static constexpr void decrementAliveEntryCount(Storage& storage) { JSOrderedHashTableTraits::decrement(slot(storage, aliveEntryCountIndex())); }
+    ALWAYS_INLINE static constexpr void incrementDeletedEntryCount(Storage& storage) { JSOrderedHashTableTraits::increment(slot(storage, deletedEntryCountIndex())); }
 
     /* -------------------------------- Hash table -------------------------------- */
     ALWAYS_INLINE static constexpr TableSize bucketCount(TableSize capacity) { return capacity; }
@@ -192,7 +192,7 @@ public:
         set(storage, newChainStartKeyIndex + ChainOffset, prevChainStartKeyIndex);
     }
 
-    /* -------------------------------- OrderedHashTable -------------------------------- */
+    /* -------------------------------- JSOrderedHashTable -------------------------------- */
     ALWAYS_INLINE static constexpr TableSize tableSize(TableSize capacity)
     {
         TableSize result = 4 /* AliveEntryCount, DeletedEntryCount, Capacity, and IterationEntry */

--- a/Source/JavaScriptCore/runtime/JSSet.h
+++ b/Source/JavaScriptCore/runtime/JSSet.h
@@ -25,12 +25,12 @@
 
 #pragma once
 
-#include <JavaScriptCore/OrderedHashTable.h>
+#include <JavaScriptCore/JSOrderedHashTable.h>
 
 namespace JSC {
 
-class JSSet final : public OrderedHashSet {
-    using Base = OrderedHashSet;
+class JSSet final : public JSOrderedHashSet {
+    using Base = JSOrderedHashSet;
 public:
 
     DECLARE_EXPORT_INFO;

--- a/Source/JavaScriptCore/runtime/VM.cpp
+++ b/Source/JavaScriptCore/runtime/VM.cpp
@@ -380,8 +380,8 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     evalCodeBlockStructure.setWithoutWriteBarrier(EvalCodeBlock::createStructure(*this, nullptr, jsNull()));
     functionCodeBlockStructure.setWithoutWriteBarrier(FunctionCodeBlock::createStructure(*this, nullptr, jsNull()));
     bigIntStructure.setWithoutWriteBarrier(JSBigInt::createStructure(*this, nullptr, jsNull()));
-    m_orderedHashTableDeletedValue.setWithoutWriteBarrier(OrderedHashMap::createDeletedValue(*this));
-    m_orderedHashTableSentinel.setWithoutWriteBarrier(OrderedHashMap::createSentinel(*this));
+    m_orderedHashTableDeletedValue.setWithoutWriteBarrier(JSOrderedHashMap::createDeletedValue(*this));
+    m_orderedHashTableSentinel.setWithoutWriteBarrier(JSOrderedHashMap::createSentinel(*this));
     m_sortScratchSentinel.setWithoutWriteBarrier(JSCellButterfly::create(*this, CopyOnWriteArrayWithContiguous, 0));
 
     // Eagerly initialize constant cells since the concurrent compiler can access them.

--- a/Source/WTF/wtf/OrderedHashMap.h
+++ b/Source/WTF/wtf/OrderedHashMap.h
@@ -527,3 +527,5 @@ bool equalIgnoringOrder(const OrderedHashMap<T, U, V, W, X, M>& a, const Ordered
 }
 
 } // namespace WTF
+
+using WTF::OrderedHashMap;

--- a/Source/WTF/wtf/OrderedHashSet.h
+++ b/Source/WTF/wtf/OrderedHashSet.h
@@ -201,3 +201,6 @@ bool equalIgnoringOrder(const OrderedHashSet<T, U, V, M>& a, const OrderedHashSe
 }
 
 } // namespace WTF
+
+
+using WTF::OrderedHashSet;

--- a/Source/WebCore/Modules/geolocation/Geolocation.h
+++ b/Source/WebCore/Modules/geolocation/Geolocation.h
@@ -115,7 +115,7 @@ private:
         bool NODELETE isEmpty() const;
         void getNotifiersVector(GeoNotifierVector&) const;
     private:
-        typedef WTF::OrderedHashMap<int, Ref<GeoNotifier>> IdToNotifierMap;
+        typedef OrderedHashMap<int, Ref<GeoNotifier>> IdToNotifierMap;
         typedef HashMap<Ref<GeoNotifier>, int> NotifierToIdMap;
         IdToNotifierMap m_idToNotifierMap;
         NotifierToIdMap m_notifierToIdMap;

--- a/Source/WebCore/Modules/webaudio/AudioParamMap.h
+++ b/Source/WebCore/Modules/webaudio/AudioParamMap.h
@@ -48,12 +48,12 @@ public:
     void initializeMapLike(DOMMapAdapter&);
     void add(const String&, Ref<AudioParam>&&);
 
-    const WTF::OrderedHashMap<String, Ref<AudioParam>>& map() const LIFETIME_BOUND { return m_map; }
+    const OrderedHashMap<String, Ref<AudioParam>>& map() const LIFETIME_BOUND { return m_map; }
 
 private:
     AudioParamMap();
 
-    WTF::OrderedHashMap<String, Ref<AudioParam>> m_map;
+    OrderedHashMap<String, Ref<AudioParam>> m_map;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/css/CSSCounterStyleRegistry.cpp
+++ b/Source/WebCore/css/CSSCounterStyleRegistry.cpp
@@ -63,11 +63,11 @@ void CSSCounterStyleRegistry::resolveReferencesIfNeeded()
 
 void CSSCounterStyleRegistry::resolveExtendsReference(CSSRegisteredCounterStyle& counterStyle, CounterStyleMap* map)
 {
-    WTF::OrderedHashSet<CSSRegisteredCounterStyle*> countersInChain;
+    OrderedHashSet<CSSRegisteredCounterStyle*> countersInChain;
     resolveExtendsReference(counterStyle, countersInChain, map);
 }
 
-void CSSCounterStyleRegistry::resolveExtendsReference(CSSRegisteredCounterStyle& counter, WTF::OrderedHashSet<CSSRegisteredCounterStyle*>& countersInChain, CounterStyleMap* map)
+void CSSCounterStyleRegistry::resolveExtendsReference(CSSRegisteredCounterStyle& counter, OrderedHashSet<CSSRegisteredCounterStyle*>& countersInChain, CounterStyleMap* map)
 {
     ASSERT(counter.isExtendsSystem() && counter.isExtendsUnresolved());
     if (!(counter.isExtendsSystem() && counter.isExtendsUnresolved()))

--- a/Source/WebCore/css/CSSCounterStyleRegistry.h
+++ b/Source/WebCore/css/CSSCounterStyleRegistry.h
@@ -69,7 +69,7 @@ private:
     // If no map is passed on, user-agent counter styles map will be used
     static void resolveFallbackReference(CSSRegisteredCounterStyle&, CounterStyleMap* = nullptr);
     static void resolveExtendsReference(CSSRegisteredCounterStyle&, CounterStyleMap* = nullptr);
-    static void resolveExtendsReference(CSSRegisteredCounterStyle&, WTF::OrderedHashSet<CSSRegisteredCounterStyle*>&, CounterStyleMap* = nullptr);
+    static void resolveExtendsReference(CSSRegisteredCounterStyle&, OrderedHashSet<CSSRegisteredCounterStyle*>&, CounterStyleMap* = nullptr);
 
     static Ref<CSSRegisteredCounterStyle> counterStyle(const AtomString&, CounterStyleMap* = nullptr);
 

--- a/Source/WebCore/platform/graphics/FontFeatureValues.h
+++ b/Source/WebCore/platform/graphics/FontFeatureValues.h
@@ -47,7 +47,7 @@ class FontFeatureValues : public RefCounted<FontFeatureValues> {
 public:
     // Insertion-ordered per CSS OM spec: serialization must reproduce the
     // order in which `@<variant>` tags were declared in the stylesheet.
-    using Tags = WTF::OrderedHashMap<String, Vector<unsigned>>;
+    using Tags = OrderedHashMap<String, Vector<unsigned>>;
     static Ref<FontFeatureValues> create() { return adoptRef(*new FontFeatureValues()); }
     virtual ~FontFeatureValues() = default;
 

--- a/Source/WebCore/style/PropertyCascade.h
+++ b/Source/WebCore/style/PropertyCascade.h
@@ -109,7 +109,7 @@ public:
     const Property& functionResultProperty() const LIFETIME_BOUND;
 
     std::span<const CSSPropertyID> logicalGroupPropertyIDs() const LIFETIME_BOUND;
-    const WTF::OrderedHashMap<AtomString, Property>& customProperties() const LIFETIME_BOUND { return m_customProperties; }
+    const OrderedHashMap<AtomString, Property>& customProperties() const LIFETIME_BOUND { return m_customProperties; }
 
     ValueOrReference<HashSet<AnimatableCSSProperty>> overriddenAnimatedProperties() const;
 
@@ -186,7 +186,7 @@ private:
     CSSPropertyID m_lowestSeenLogicalGroupProperty { lastLogicalGroupProperty };
     CSSPropertyID m_highestSeenLogicalGroupProperty { firstLogicalGroupProperty };
 
-    WTF::OrderedHashMap<AtomString, Property> m_customProperties;
+    OrderedHashMap<AtomString, Property> m_customProperties;
 };
 
 inline bool PropertyCascade::hasNormalProperty(CSSPropertyID id) const

--- a/Tools/TestWebKitAPI/Tests/WTF/OrderedHashMap.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/OrderedHashMap.cpp
@@ -40,7 +40,7 @@ namespace TestWebKitAPI {
 
 TEST(WTF_OrderedHashMap, EmptyMap)
 {
-    WTF::OrderedHashMap<int, int> map;
+    OrderedHashMap<int, int> map;
     EXPECT_TRUE(map.isEmpty());
     EXPECT_EQ(0u, map.size());
     EXPECT_TRUE(map.begin() == map.end());
@@ -48,7 +48,7 @@ TEST(WTF_OrderedHashMap, EmptyMap)
 
 TEST(WTF_OrderedHashMap, BasicAddAndFind)
 {
-    WTF::OrderedHashMap<int, int> map;
+    OrderedHashMap<int, int> map;
     auto result = map.add(1, 100);
     EXPECT_TRUE(result.isNewEntry);
     EXPECT_EQ(1, result.iterator->key);
@@ -63,7 +63,7 @@ TEST(WTF_OrderedHashMap, BasicAddAndFind)
 
 TEST(WTF_OrderedHashMap, Set)
 {
-    WTF::OrderedHashMap<int, int> map;
+    OrderedHashMap<int, int> map;
     map.set(1, 100);
     EXPECT_EQ(100, map.get(1));
 
@@ -74,7 +74,7 @@ TEST(WTF_OrderedHashMap, Set)
 
 TEST(WTF_OrderedHashMap, Ensure)
 {
-    WTF::OrderedHashMap<int, int> map;
+    OrderedHashMap<int, int> map;
     auto result1 = map.ensure(1, [] {
         return 100;
     });
@@ -90,7 +90,7 @@ TEST(WTF_OrderedHashMap, Ensure)
 
 TEST(WTF_OrderedHashMap, Contains)
 {
-    WTF::OrderedHashMap<int, int> map;
+    OrderedHashMap<int, int> map;
     map.add(1, 100);
     map.add(2, 200);
 
@@ -101,7 +101,7 @@ TEST(WTF_OrderedHashMap, Contains)
 
 TEST(WTF_OrderedHashMap, Get)
 {
-    WTF::OrderedHashMap<int, int> map;
+    OrderedHashMap<int, int> map;
     map.add(1, 100);
     EXPECT_EQ(100, map.get(1));
     EXPECT_EQ(0, map.get(999)); // Default for missing key
@@ -109,7 +109,7 @@ TEST(WTF_OrderedHashMap, Get)
 
 TEST(WTF_OrderedHashMap, GetOptional)
 {
-    WTF::OrderedHashMap<int, int> map;
+    OrderedHashMap<int, int> map;
     map.add(1, 100);
     auto result = map.getOptional(1);
     EXPECT_TRUE(result.has_value());
@@ -121,7 +121,7 @@ TEST(WTF_OrderedHashMap, GetOptional)
 
 TEST(WTF_OrderedHashMap, InsertionOrderPreserved)
 {
-    WTF::OrderedHashMap<int, int> map;
+    OrderedHashMap<int, int> map;
     map.add(3, 300);
     map.add(1, 100);
     map.add(4, 400);
@@ -143,7 +143,7 @@ TEST(WTF_OrderedHashMap, InsertionOrderPreserved)
 
 TEST(WTF_OrderedHashMap, InsertionOrderPreservedAfterDeletion)
 {
-    WTF::OrderedHashMap<int, int> map;
+    OrderedHashMap<int, int> map;
     map.add(1, 100);
     map.add(2, 200);
     map.add(3, 300);
@@ -165,7 +165,7 @@ TEST(WTF_OrderedHashMap, InsertionOrderPreservedAfterDeletion)
 
 TEST(WTF_OrderedHashMap, SetDoesNotChangeOrder)
 {
-    WTF::OrderedHashMap<int, int> map;
+    OrderedHashMap<int, int> map;
     map.add(1, 100);
     map.add(2, 200);
     map.add(3, 300);
@@ -185,7 +185,7 @@ TEST(WTF_OrderedHashMap, SetDoesNotChangeOrder)
 
 TEST(WTF_OrderedHashMap, RemoveByKey)
 {
-    WTF::OrderedHashMap<int, int> map;
+    OrderedHashMap<int, int> map;
     map.add(1, 100);
     map.add(2, 200);
 
@@ -197,7 +197,7 @@ TEST(WTF_OrderedHashMap, RemoveByKey)
 
 TEST(WTF_OrderedHashMap, RemoveByIterator)
 {
-    WTF::OrderedHashMap<int, int> map;
+    OrderedHashMap<int, int> map;
     map.add(1, 100);
     map.add(2, 200);
 
@@ -209,7 +209,7 @@ TEST(WTF_OrderedHashMap, RemoveByIterator)
 
 TEST(WTF_OrderedHashMap, Take)
 {
-    WTF::OrderedHashMap<int, int> map;
+    OrderedHashMap<int, int> map;
     map.add(1, 100);
     map.add(2, 200);
 
@@ -224,7 +224,7 @@ TEST(WTF_OrderedHashMap, Take)
 
 TEST(WTF_OrderedHashMap, TakeOptional)
 {
-    WTF::OrderedHashMap<int, int> map;
+    OrderedHashMap<int, int> map;
     map.add(1, 100);
 
     auto result = map.takeOptional(1);
@@ -238,7 +238,7 @@ TEST(WTF_OrderedHashMap, TakeOptional)
 
 TEST(WTF_OrderedHashMap, TakeFirst)
 {
-    WTF::OrderedHashMap<int, int> map;
+    OrderedHashMap<int, int> map;
     map.add(3, 300);
     map.add(1, 100);
     map.add(2, 200);
@@ -250,7 +250,7 @@ TEST(WTF_OrderedHashMap, TakeFirst)
 
 TEST(WTF_OrderedHashMap, Clear)
 {
-    WTF::OrderedHashMap<int, int> map;
+    OrderedHashMap<int, int> map;
     map.add(1, 100);
     map.add(2, 200);
     map.clear();
@@ -262,11 +262,11 @@ TEST(WTF_OrderedHashMap, Clear)
 
 TEST(WTF_OrderedHashMap, Swap)
 {
-    WTF::OrderedHashMap<int, int> map1;
+    OrderedHashMap<int, int> map1;
     map1.add(1, 100);
     map1.add(2, 200);
 
-    WTF::OrderedHashMap<int, int> map2;
+    OrderedHashMap<int, int> map2;
     map2.add(3, 300);
 
     map1.swap(map2);
@@ -280,12 +280,12 @@ TEST(WTF_OrderedHashMap, Swap)
 
 TEST(WTF_OrderedHashMap, CopyConstruction)
 {
-    WTF::OrderedHashMap<int, int> map1;
+    OrderedHashMap<int, int> map1;
     map1.add(1, 100);
     map1.add(2, 200);
     map1.add(3, 300);
 
-    WTF::OrderedHashMap<int, int> map2(map1);
+    OrderedHashMap<int, int> map2(map1);
 
     EXPECT_EQ(3u, map2.size());
 
@@ -301,11 +301,11 @@ TEST(WTF_OrderedHashMap, CopyConstruction)
 
 TEST(WTF_OrderedHashMap, MoveConstruction)
 {
-    WTF::OrderedHashMap<int, int> map1;
+    OrderedHashMap<int, int> map1;
     map1.add(1, 100);
     map1.add(2, 200);
 
-    WTF::OrderedHashMap<int, int> map2(WTF::move(map1));
+    OrderedHashMap<int, int> map2(WTF::move(map1));
 
     EXPECT_EQ(2u, map2.size());
     EXPECT_TRUE(map2.contains(1));
@@ -315,11 +315,11 @@ TEST(WTF_OrderedHashMap, MoveConstruction)
 
 TEST(WTF_OrderedHashMap, CopyAssignment)
 {
-    WTF::OrderedHashMap<int, int> map1;
+    OrderedHashMap<int, int> map1;
     map1.add(1, 100);
     map1.add(2, 200);
 
-    WTF::OrderedHashMap<int, int> map2;
+    OrderedHashMap<int, int> map2;
     map2.add(9, 900);
     map2 = map1;
 
@@ -331,10 +331,10 @@ TEST(WTF_OrderedHashMap, CopyAssignment)
 
 TEST(WTF_OrderedHashMap, MoveAssignment)
 {
-    WTF::OrderedHashMap<int, int> map1;
+    OrderedHashMap<int, int> map1;
     map1.add(1, 100);
 
-    WTF::OrderedHashMap<int, int> map2;
+    OrderedHashMap<int, int> map2;
     map2.add(9, 900);
     map2 = WTF::move(map1);
 
@@ -345,7 +345,7 @@ TEST(WTF_OrderedHashMap, MoveAssignment)
 
 TEST(WTF_OrderedHashMap, KeysIteration)
 {
-    WTF::OrderedHashMap<int, int> map;
+    OrderedHashMap<int, int> map;
     map.add(3, 300);
     map.add(1, 100);
     map.add(2, 200);
@@ -362,7 +362,7 @@ TEST(WTF_OrderedHashMap, KeysIteration)
 
 TEST(WTF_OrderedHashMap, ValuesIteration)
 {
-    WTF::OrderedHashMap<int, int> map;
+    OrderedHashMap<int, int> map;
     map.add(3, 300);
     map.add(1, 100);
     map.add(2, 200);
@@ -379,7 +379,7 @@ TEST(WTF_OrderedHashMap, ValuesIteration)
 
 TEST(WTF_OrderedHashMap, RehashPreservesOrder)
 {
-    WTF::OrderedHashMap<int, int> map;
+    OrderedHashMap<int, int> map;
     // Insert enough entries to trigger rehashing
     Vector<int> expectedOrder;
     for (int i = 0; i < 100; ++i) {
@@ -396,7 +396,7 @@ TEST(WTF_OrderedHashMap, RehashPreservesOrder)
 
 TEST(WTF_OrderedHashMap, DeleteAndReinsert)
 {
-    WTF::OrderedHashMap<int, int> map;
+    OrderedHashMap<int, int> map;
     map.add(1, 100);
     map.add(2, 200);
     map.add(3, 300);
@@ -417,7 +417,7 @@ TEST(WTF_OrderedHashMap, DeleteAndReinsert)
 
 TEST(WTF_OrderedHashMap, ManyDeletesAndInserts)
 {
-    WTF::OrderedHashMap<int, int> map;
+    OrderedHashMap<int, int> map;
     for (int i = 0; i < 50; ++i)
         map.add(i, i);
 
@@ -438,7 +438,7 @@ TEST(WTF_OrderedHashMap, ManyDeletesAndInserts)
 
 TEST(WTF_OrderedHashMap, StringKeys)
 {
-    WTF::OrderedHashMap<String, int> map;
+    OrderedHashMap<String, int> map;
     map.add("banana"_s, 2);
     map.add("apple"_s, 1);
     map.add("cherry"_s, 3);
@@ -455,7 +455,7 @@ TEST(WTF_OrderedHashMap, StringKeys)
 
 TEST(WTF_OrderedHashMap, InitializerList)
 {
-    WTF::OrderedHashMap<int, int> map {
+    OrderedHashMap<int, int> map {
         { 3, 300 },
         { 1, 100 },
         { 2, 200 }
@@ -474,7 +474,7 @@ TEST(WTF_OrderedHashMap, InitializerList)
 
 TEST(WTF_OrderedHashMap, ReserveCapacity)
 {
-    WTF::OrderedHashMap<int, int> map;
+    OrderedHashMap<int, int> map;
     map.reserveInitialCapacity(100);
 
     for (int i = 0; i < 100; ++i)
@@ -492,7 +492,7 @@ TEST(WTF_OrderedHashMap, ReserveCapacity)
 
 TEST(WTF_OrderedHashMap, ConstIteration)
 {
-    WTF::OrderedHashMap<int, int> map;
+    OrderedHashMap<int, int> map;
     map.add(1, 100);
     map.add(2, 200);
 
@@ -508,7 +508,7 @@ TEST(WTF_OrderedHashMap, ConstIteration)
 
 TEST(WTF_OrderedHashMap, FindReturnsCorrectIterator)
 {
-    WTF::OrderedHashMap<int, int> map;
+    OrderedHashMap<int, int> map;
     map.add(1, 100);
     map.add(2, 200);
     map.add(3, 300);
@@ -524,13 +524,13 @@ TEST(WTF_OrderedHashMap, FindReturnsCorrectIterator)
 
 TEST(WTF_OrderedHashMap, IteratorComparison)
 {
-    WTF::OrderedHashMap<int, int> map;
+    OrderedHashMap<int, int> map;
     map.add(1, 100);
 
     EXPECT_TRUE(map.begin() != map.end());
     EXPECT_FALSE(map.begin() == map.end());
 
-    WTF::OrderedHashMap<int, int>::const_iterator constBegin = map.begin();
+    OrderedHashMap<int, int>::const_iterator constBegin = map.begin();
     EXPECT_TRUE(constBegin == map.begin());
     EXPECT_TRUE(constBegin != map.end());
 }
@@ -540,7 +540,7 @@ TEST(WTF_OrderedHashMap, CompactInPlacePreservesOrderAndCapacity)
     // Fills the initial entries array (capacity=6, bucketCount=8), deletes most,
     // then adds to trigger rehashForAdd on a table that cannot shrink below
     // initialBucketCount — forcing the compactInPlace branch.
-    WTF::OrderedHashMap<int, int> map;
+    OrderedHashMap<int, int> map;
     for (int i = 0; i < 6; ++i)
         map.add(i, i * 10);
     unsigned initialCapacity = map.capacity();
@@ -579,7 +579,7 @@ TEST(WTF_OrderedHashMap, CompactInPlacePreservesOrderAndCapacity)
 
 TEST(WTF_OrderedHashMap, CompactInPlaceOnLargerTable)
 {
-    WTF::OrderedHashMap<int, int> map;
+    OrderedHashMap<int, int> map;
     map.reserveInitialCapacity(12);
     unsigned reservedCapacity = map.capacity();
     EXPECT_GE(reservedCapacity, 12u);
@@ -617,7 +617,7 @@ TEST(WTF_OrderedHashMap, CompactInPlaceOnLargerTable)
 TEST(WTF_OrderedHashMap, CompactInPlaceWithStringValues)
 {
     // Non-trivial value type exercises move/destroy paths inside compactInPlace.
-    WTF::OrderedHashMap<int, String> map;
+    OrderedHashMap<int, String> map;
     for (int i = 0; i < 6; ++i)
         map.add(i, makeString("v"_s, i));
     unsigned initialCapacity = map.capacity();
@@ -655,7 +655,7 @@ TEST(WTF_OrderedHashMap, RemoveIfAcrossShrinkThreshold)
     // Fill past initialBucketCount so shrinkIfNeeded() can actually rehash, then
     // removeIf enough entries to cross the 1/4 shrink threshold. Prior to the fix
     // that deferred shrink, this would rehash mid-iteration and skip entries.
-    WTF::OrderedHashMap<int, int> map;
+    OrderedHashMap<int, int> map;
     for (int i = 0; i < 64; ++i)
         map.add(i, i * 10);
     EXPECT_EQ(64u, map.size());
@@ -688,7 +688,7 @@ TEST(WTF_OrderedHashMap, RemoveIfAcrossShrinkThreshold)
 
 TEST(WTF_OrderedHashMap, MoveOnlyValue)
 {
-    WTF::OrderedHashMap<int, MoveOnly> map;
+    OrderedHashMap<int, MoveOnly> map;
     auto addResult = map.add(1, MoveOnly(100));
     EXPECT_TRUE(addResult.isNewEntry);
     EXPECT_EQ(100u, addResult.iterator->value.value());
@@ -723,7 +723,7 @@ TEST(WTF_OrderedHashMap, MoveOnlyValueRehash)
 {
     // Force enough additions to trigger rehash with move-only values, exercising
     // the move construction in the rehash path.
-    WTF::OrderedHashMap<int, MoveOnly> map;
+    OrderedHashMap<int, MoveOnly> map;
     for (unsigned i = 0; i < 64; ++i)
         map.add(i, MoveOnly(i * 7));
     EXPECT_EQ(64u, map.size());
@@ -733,7 +733,7 @@ TEST(WTF_OrderedHashMap, MoveOnlyValueRehash)
 
 TEST(WTF_OrderedHashMap, HashTranslatorFindContainsGet)
 {
-    WTF::OrderedHashMap<String, unsigned> map;
+    OrderedHashMap<String, unsigned> map;
     map.add("alpha"_s, 1u);
     map.add("beta"_s, 2u);
     map.add("gamma"_s, 3u);
@@ -883,12 +883,12 @@ TEST(WTF_OrderedHashMap, EqualIgnoringOrder)
     // order-sensitive vs order-insensitive choice is explicit at the call
     // site. equalIgnoringOrder compares contents, matching HashMap::operator==
     // semantics.
-    WTF::OrderedHashMap<String, unsigned> a;
+    OrderedHashMap<String, unsigned> a;
     a.add("alpha"_s, 1);
     a.add("beta"_s, 2);
     a.add("gamma"_s, 3);
 
-    WTF::OrderedHashMap<String, unsigned> b;
+    OrderedHashMap<String, unsigned> b;
     b.add("gamma"_s, 3);
     b.add("alpha"_s, 1);
     b.add("beta"_s, 2);
@@ -904,11 +904,11 @@ TEST(WTF_OrderedHashMap, EqualIgnoringOrder)
 
 TEST(WTF_OrderedHashMap, EqualIgnoringOrderDifferentSize)
 {
-    WTF::OrderedHashMap<String, unsigned> a;
+    OrderedHashMap<String, unsigned> a;
     a.add("alpha"_s, 1);
     a.add("beta"_s, 2);
 
-    WTF::OrderedHashMap<String, unsigned> b;
+    OrderedHashMap<String, unsigned> b;
     b.add("alpha"_s, 1);
 
     EXPECT_FALSE(equalIgnoringOrder(a, b));
@@ -917,11 +917,11 @@ TEST(WTF_OrderedHashMap, EqualIgnoringOrderDifferentSize)
 
 TEST(WTF_OrderedHashMap, EqualIgnoringOrderDifferentValues)
 {
-    WTF::OrderedHashMap<String, unsigned> a;
+    OrderedHashMap<String, unsigned> a;
     a.add("alpha"_s, 1);
     a.add("beta"_s, 2);
 
-    WTF::OrderedHashMap<String, unsigned> b;
+    OrderedHashMap<String, unsigned> b;
     b.add("alpha"_s, 1);
     b.add("beta"_s, 99);
 
@@ -931,8 +931,8 @@ TEST(WTF_OrderedHashMap, EqualIgnoringOrderDifferentValues)
 
 TEST(WTF_OrderedHashMap, EqualIgnoringOrderEmpty)
 {
-    WTF::OrderedHashMap<String, unsigned> a;
-    WTF::OrderedHashMap<String, unsigned> b;
+    OrderedHashMap<String, unsigned> a;
+    OrderedHashMap<String, unsigned> b;
     EXPECT_TRUE(equalIgnoringOrder(a, b));
 
     a.add("key"_s, 0);

--- a/Tools/TestWebKitAPI/Tests/WTF/OrderedHashSet.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/OrderedHashSet.cpp
@@ -35,7 +35,7 @@ namespace TestWebKitAPI {
 
 TEST(WTF_OrderedHashSet, EmptySet)
 {
-    WTF::OrderedHashSet<int> set;
+    OrderedHashSet<int> set;
     EXPECT_TRUE(set.isEmpty());
     EXPECT_EQ(0u, set.size());
     EXPECT_TRUE(set.begin() == set.end());
@@ -43,7 +43,7 @@ TEST(WTF_OrderedHashSet, EmptySet)
 
 TEST(WTF_OrderedHashSet, BasicAddAndContains)
 {
-    WTF::OrderedHashSet<int> set;
+    OrderedHashSet<int> set;
     auto result = set.add(1);
     EXPECT_TRUE(result.isNewEntry);
     EXPECT_EQ(1u, set.size());
@@ -58,7 +58,7 @@ TEST(WTF_OrderedHashSet, BasicAddAndContains)
 
 TEST(WTF_OrderedHashSet, InsertionOrderPreserved)
 {
-    WTF::OrderedHashSet<int> set;
+    OrderedHashSet<int> set;
     set.add(5);
     set.add(3);
     set.add(1);
@@ -79,7 +79,7 @@ TEST(WTF_OrderedHashSet, InsertionOrderPreserved)
 
 TEST(WTF_OrderedHashSet, InsertionOrderPreservedAfterDeletion)
 {
-    WTF::OrderedHashSet<int> set;
+    OrderedHashSet<int> set;
     set.add(1);
     set.add(2);
     set.add(3);
@@ -101,7 +101,7 @@ TEST(WTF_OrderedHashSet, InsertionOrderPreservedAfterDeletion)
 
 TEST(WTF_OrderedHashSet, Remove)
 {
-    WTF::OrderedHashSet<int> set;
+    OrderedHashSet<int> set;
     set.add(1);
     set.add(2);
     set.add(3);
@@ -114,7 +114,7 @@ TEST(WTF_OrderedHashSet, Remove)
 
 TEST(WTF_OrderedHashSet, RemoveByIterator)
 {
-    WTF::OrderedHashSet<int> set;
+    OrderedHashSet<int> set;
     set.add(1);
     set.add(2);
     set.add(3);
@@ -127,7 +127,7 @@ TEST(WTF_OrderedHashSet, RemoveByIterator)
 
 TEST(WTF_OrderedHashSet, Take)
 {
-    WTF::OrderedHashSet<int> set;
+    OrderedHashSet<int> set;
     set.add(1);
     set.add(2);
     set.add(3);
@@ -143,7 +143,7 @@ TEST(WTF_OrderedHashSet, Take)
 
 TEST(WTF_OrderedHashSet, TakeAny)
 {
-    WTF::OrderedHashSet<int> set;
+    OrderedHashSet<int> set;
     set.add(5);
     set.add(3);
     set.add(1);
@@ -155,7 +155,7 @@ TEST(WTF_OrderedHashSet, TakeAny)
 
 TEST(WTF_OrderedHashSet, Clear)
 {
-    WTF::OrderedHashSet<int> set;
+    OrderedHashSet<int> set;
     set.add(1);
     set.add(2);
     set.clear();
@@ -167,11 +167,11 @@ TEST(WTF_OrderedHashSet, Clear)
 
 TEST(WTF_OrderedHashSet, Swap)
 {
-    WTF::OrderedHashSet<int> set1;
+    OrderedHashSet<int> set1;
     set1.add(1);
     set1.add(2);
 
-    WTF::OrderedHashSet<int> set2;
+    OrderedHashSet<int> set2;
     set2.add(3);
 
     set1.swap(set2);
@@ -185,12 +185,12 @@ TEST(WTF_OrderedHashSet, Swap)
 
 TEST(WTF_OrderedHashSet, CopyConstruction)
 {
-    WTF::OrderedHashSet<int> set1;
+    OrderedHashSet<int> set1;
     set1.add(3);
     set1.add(1);
     set1.add(2);
 
-    WTF::OrderedHashSet<int> set2(set1);
+    OrderedHashSet<int> set2(set1);
 
     EXPECT_EQ(3u, set2.size());
 
@@ -205,11 +205,11 @@ TEST(WTF_OrderedHashSet, CopyConstruction)
 
 TEST(WTF_OrderedHashSet, MoveConstruction)
 {
-    WTF::OrderedHashSet<int> set1;
+    OrderedHashSet<int> set1;
     set1.add(1);
     set1.add(2);
 
-    WTF::OrderedHashSet<int> set2(WTF::move(set1));
+    OrderedHashSet<int> set2(WTF::move(set1));
 
     EXPECT_EQ(2u, set2.size());
     EXPECT_TRUE(set2.contains(1));
@@ -219,11 +219,11 @@ TEST(WTF_OrderedHashSet, MoveConstruction)
 
 TEST(WTF_OrderedHashSet, CopyAssignment)
 {
-    WTF::OrderedHashSet<int> set1;
+    OrderedHashSet<int> set1;
     set1.add(1);
     set1.add(2);
 
-    WTF::OrderedHashSet<int> set2;
+    OrderedHashSet<int> set2;
     set2.add(9);
     set2 = set1;
 
@@ -235,10 +235,10 @@ TEST(WTF_OrderedHashSet, CopyAssignment)
 
 TEST(WTF_OrderedHashSet, MoveAssignment)
 {
-    WTF::OrderedHashSet<int> set1;
+    OrderedHashSet<int> set1;
     set1.add(1);
 
-    WTF::OrderedHashSet<int> set2;
+    OrderedHashSet<int> set2;
     set2.add(9);
     set2 = WTF::move(set1);
 
@@ -249,7 +249,7 @@ TEST(WTF_OrderedHashSet, MoveAssignment)
 
 TEST(WTF_OrderedHashSet, RehashPreservesOrder)
 {
-    WTF::OrderedHashSet<int> set;
+    OrderedHashSet<int> set;
     Vector<int> expectedOrder;
     for (int i = 0; i < 100; ++i) {
         set.add(i);
@@ -265,7 +265,7 @@ TEST(WTF_OrderedHashSet, RehashPreservesOrder)
 
 TEST(WTF_OrderedHashSet, DeleteAndReinsert)
 {
-    WTF::OrderedHashSet<int> set;
+    OrderedHashSet<int> set;
     set.add(1);
     set.add(2);
     set.add(3);
@@ -285,7 +285,7 @@ TEST(WTF_OrderedHashSet, DeleteAndReinsert)
 
 TEST(WTF_OrderedHashSet, ManyDeletesAndInserts)
 {
-    WTF::OrderedHashSet<int> set;
+    OrderedHashSet<int> set;
     for (int i = 0; i < 50; ++i)
         set.add(i);
 
@@ -304,7 +304,7 @@ TEST(WTF_OrderedHashSet, ManyDeletesAndInserts)
 
 TEST(WTF_OrderedHashSet, StringValues)
 {
-    WTF::OrderedHashSet<String> set;
+    OrderedHashSet<String> set;
     set.add("banana"_s);
     set.add("apple"_s);
     set.add("cherry"_s);
@@ -321,7 +321,7 @@ TEST(WTF_OrderedHashSet, StringValues)
 
 TEST(WTF_OrderedHashSet, InitializerList)
 {
-    WTF::OrderedHashSet<int> set { 5, 3, 1, 4, 2 };
+    OrderedHashSet<int> set { 5, 3, 1, 4, 2 };
 
     EXPECT_EQ(5u, set.size());
 
@@ -338,7 +338,7 @@ TEST(WTF_OrderedHashSet, InitializerList)
 
 TEST(WTF_OrderedHashSet, AddAll)
 {
-    WTF::OrderedHashSet<int> set;
+    OrderedHashSet<int> set;
     set.add(1);
 
     Vector<int> toAdd { 2, 3, 4 };
@@ -358,7 +358,7 @@ TEST(WTF_OrderedHashSet, AddAll)
 
 TEST(WTF_OrderedHashSet, Find)
 {
-    WTF::OrderedHashSet<int> set;
+    OrderedHashSet<int> set;
     set.add(1);
     set.add(2);
     set.add(3);
@@ -373,7 +373,7 @@ TEST(WTF_OrderedHashSet, Find)
 
 TEST(WTF_OrderedHashSet, ReserveCapacity)
 {
-    WTF::OrderedHashSet<int> set;
+    OrderedHashSet<int> set;
     set.reserveInitialCapacity(100);
 
     for (int i = 0; i < 100; ++i)
@@ -391,7 +391,7 @@ TEST(WTF_OrderedHashSet, ReserveCapacity)
 
 TEST(WTF_OrderedHashSet, StressTest)
 {
-    WTF::OrderedHashSet<int> set;
+    OrderedHashSet<int> set;
     // Insert 1000 elements
     for (int i = 0; i < 1000; ++i)
         set.add(i);
@@ -423,7 +423,7 @@ TEST(WTF_OrderedHashSet, CompactInPlacePreservesOrderAndCapacity)
     // With initialBucketCount=8, entriesCapacity starts at 6 and the table
     // does not shrink below initialBucketCount, so compactInPlace is the only
     // rehash path triggered here.
-    WTF::OrderedHashSet<int> set;
+    OrderedHashSet<int> set;
     for (int i = 0; i < 6; ++i)
         set.add(i);
     unsigned initialCapacity = set.capacity();
@@ -460,7 +460,7 @@ TEST(WTF_OrderedHashSet, CompactInPlaceOnLargerTable)
 {
     // Force a larger table so we can verify compactInPlace works beyond the
     // initial capacity without triggering a grow or shrink rehash.
-    WTF::OrderedHashSet<int> set;
+    OrderedHashSet<int> set;
     set.reserveInitialCapacity(12);
     unsigned reservedCapacity = set.capacity();
     EXPECT_GE(reservedCapacity, 12u);
@@ -494,7 +494,7 @@ TEST(WTF_OrderedHashSet, CompactInPlaceOnLargerTable)
 TEST(WTF_OrderedHashSet, CompactInPlaceWithStrings)
 {
     // Non-trivial value type exercises move/destroy paths inside compactInPlace.
-    WTF::OrderedHashSet<String> set;
+    OrderedHashSet<String> set;
     set.add("zero"_s);
     set.add("one"_s);
     set.add("two"_s);
@@ -531,7 +531,7 @@ TEST(WTF_OrderedHashSet, CompactInPlaceRepeatedCycles)
 {
     // Many cycles of "delete most, refill to capacity" keep hitting the compactInPlace
     // branch. Verify the table remains consistent across all of them.
-    WTF::OrderedHashSet<int> set;
+    OrderedHashSet<int> set;
     set.reserveInitialCapacity(12);
     unsigned capacity = set.capacity();
 
@@ -568,7 +568,7 @@ TEST(WTF_OrderedHashSet, RemoveIfAcrossShrinkThreshold)
     // Fill past initialBucketCount so shrinkIfNeeded() can actually rehash, then
     // removeIf enough entries to cross the 1/4 shrink threshold. Prior to the fix
     // that deferred shrink, this would rehash mid-iteration and skip entries.
-    WTF::OrderedHashSet<int> set;
+    OrderedHashSet<int> set;
     for (int i = 0; i < 64; ++i)
         set.add(i);
     EXPECT_EQ(64u, set.size());
@@ -594,7 +594,7 @@ TEST(WTF_OrderedHashSet, RemoveIfAcrossShrinkThreshold)
 
 TEST(WTF_OrderedHashSet, MoveOnlyValue)
 {
-    WTF::OrderedHashSet<MoveOnly> set;
+    OrderedHashSet<MoveOnly> set;
     auto addResult = set.add(MoveOnly(1));
     EXPECT_TRUE(addResult.isNewEntry);
     EXPECT_EQ(1u, addResult.iterator->value());
@@ -624,7 +624,7 @@ TEST(WTF_OrderedHashSet, MoveOnlyValue)
 
 TEST(WTF_OrderedHashSet, MoveOnlyValueRehash)
 {
-    WTF::OrderedHashSet<MoveOnly> set;
+    OrderedHashSet<MoveOnly> set;
     for (unsigned i = 0; i < 64; ++i)
         set.add(MoveOnly(i));
     EXPECT_EQ(64u, set.size());
@@ -634,7 +634,7 @@ TEST(WTF_OrderedHashSet, MoveOnlyValueRehash)
 
 TEST(WTF_OrderedHashSet, HashTranslatorFindContains)
 {
-    WTF::OrderedHashSet<String> set;
+    OrderedHashSet<String> set;
     set.add("alpha"_s);
     set.add("beta"_s);
     set.add("gamma"_s);
@@ -849,16 +849,16 @@ TEST(WTF_OrderedHashSet, HashTranslatorAddTriggersRehashAndCompact)
 
 TEST(WTF_OrderedHashSet, EqualIgnoringOrder)
 {
-    // WTF::OrderedHashSet intentionally does not define operator==, so that the
+    // OrderedHashSet intentionally does not define operator==, so that the
     // order-sensitive vs order-insensitive choice is explicit at the call
     // site. equalIgnoringOrder compares contents, matching HashSet::operator==
     // semantics.
-    WTF::OrderedHashSet<String> a;
+    OrderedHashSet<String> a;
     a.add("alpha"_s);
     a.add("beta"_s);
     a.add("gamma"_s);
 
-    WTF::OrderedHashSet<String> b;
+    OrderedHashSet<String> b;
     b.add("gamma"_s);
     b.add("alpha"_s);
     b.add("beta"_s);
@@ -873,11 +873,11 @@ TEST(WTF_OrderedHashSet, EqualIgnoringOrder)
 
 TEST(WTF_OrderedHashSet, EqualIgnoringOrderDifferentSize)
 {
-    WTF::OrderedHashSet<String> a;
+    OrderedHashSet<String> a;
     a.add("alpha"_s);
     a.add("beta"_s);
 
-    WTF::OrderedHashSet<String> b;
+    OrderedHashSet<String> b;
     b.add("alpha"_s);
 
     EXPECT_FALSE(equalIgnoringOrder(a, b));
@@ -886,11 +886,11 @@ TEST(WTF_OrderedHashSet, EqualIgnoringOrderDifferentSize)
 
 TEST(WTF_OrderedHashSet, EqualIgnoringOrderDifferentElements)
 {
-    WTF::OrderedHashSet<String> a;
+    OrderedHashSet<String> a;
     a.add("alpha"_s);
     a.add("beta"_s);
 
-    WTF::OrderedHashSet<String> b;
+    OrderedHashSet<String> b;
     b.add("alpha"_s);
     b.add("delta"_s);
 
@@ -900,8 +900,8 @@ TEST(WTF_OrderedHashSet, EqualIgnoringOrderDifferentElements)
 
 TEST(WTF_OrderedHashSet, EqualIgnoringOrderEmpty)
 {
-    WTF::OrderedHashSet<String> a;
-    WTF::OrderedHashSet<String> b;
+    OrderedHashSet<String> a;
+    OrderedHashSet<String> b;
     EXPECT_TRUE(equalIgnoringOrder(a, b));
 
     a.add("key"_s);


### PR DESCRIPTION
#### 54982d6c532d3c0b412975518c318ae714c33870
<pre>
Unreviewed, just making JSC::OrderedHashTable =&gt; JSC::JSOrderedHashTable
<a href="https://bugs.webkit.org/show_bug.cgi?id=315420">https://bugs.webkit.org/show_bug.cgi?id=315420</a>
<a href="https://rdar.apple.com/177776997">rdar://177776997</a>

Tests: Tools/TestWebKitAPI/Tests/WTF/OrderedHashMap.cpp
       Tools/TestWebKitAPI/Tests/WTF/OrderedHashSet.cpp

* Source/JavaScriptCore/CMakeLists.txt:
* Source/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj:
* Source/JavaScriptCore/Sources.txt:
* Source/JavaScriptCore/runtime/AbstractModuleRecord.cpp:
(JSC::AbstractModuleRecord::gatherAsynchronousTransitiveDependencies):
(JSC::AbstractModuleRecord::innerModuleEvaluation):
* Source/JavaScriptCore/runtime/AbstractModuleRecord.h:
* Source/JavaScriptCore/runtime/JSCJSValue.h:
(JSC::OrderedHashTableTraits::set): Deleted.
(JSC::OrderedHashTableTraits::increment): Deleted.
(JSC::OrderedHashTableTraits::decrement): Deleted.
* Source/JavaScriptCore/runtime/JSMap.h:
* Source/JavaScriptCore/runtime/JSMicrotask.cpp:
(JSC::dynamicImportLoadSettled):
* Source/JavaScriptCore/runtime/JSModuleNamespaceObject.h:
* Source/JavaScriptCore/runtime/JSOrderedHashTable.cpp: Renamed from Source/JavaScriptCore/runtime/OrderedHashTable.cpp.
(JSC::JSOrderedHashTable&lt;Traits&gt;::visitChildrenImpl):
* Source/JavaScriptCore/runtime/JSOrderedHashTable.h: Renamed from Source/JavaScriptCore/runtime/OrderedHashTable.h.
(JSC::JSOrderedHashTable::JSOrderedHashTable):
(JSC::JSOrderedHashTable::offsetOfStorage):
(JSC::JSOrderedHashTable::finishCreation):
(JSC::JSOrderedHashTable::getKeySlot):
(JSC::JSOrderedHashTable::has):
(JSC::JSOrderedHashTable::add):
(JSC::JSOrderedHashTable::addNormalized):
(JSC::JSOrderedHashTable::remove):
(JSC::JSOrderedHashTable::removeNormalized):
(JSC::JSOrderedHashTable::size):
(JSC::JSOrderedHashTable::clear):
(JSC::JSOrderedHashTable::materializeIfNeeded):
(JSC::JSOrderedHashTable::tryGetStorage):
(JSC::JSOrderedHashTable::storage):
(JSC::JSOrderedHashTable::storageOrSentinel):
(JSC::JSOrderedHashTable::storageRef):
(JSC::JSOrderedHashMap::JSOrderedHashMap):
(JSC::JSOrderedHashMap::getImpl):
(JSC::JSOrderedHashMap::get):
(JSC::JSOrderedHashMap::getOrInsert):
(JSC::JSOrderedHashMap::createSentinel):
(JSC::JSOrderedHashMap::createDeletedValue):
(JSC::JSOrderedHashSet::JSOrderedHashSet):
* Source/JavaScriptCore/runtime/JSOrderedHashTableHelper.h: Renamed from Source/JavaScriptCore/runtime/OrderedHashTableHelper.h.
(JSC::JSOrderedHashTableHelper::toNumber):
(JSC::JSOrderedHashTableHelper::asNumber):
(JSC::JSOrderedHashTableHelper::toJSValue):
(JSC::JSOrderedHashTableHelper::isDeleted):
(JSC::JSOrderedHashTableHelper::isValidTableIndex):
(JSC::JSOrderedHashTableHelper::invalidTableIndex):
(JSC::JSOrderedHashTableHelper::get):
(JSC::JSOrderedHashTableHelper::slot):
(JSC::JSOrderedHashTableHelper::set):
(JSC::JSOrderedHashTableHelper::setWithWriteBarrier):
(JSC::JSOrderedHashTableHelper::aliveEntryCountIndex):
(JSC::JSOrderedHashTableHelper::deletedEntryCountIndex):
(JSC::JSOrderedHashTableHelper::capacityIndex):
(JSC::JSOrderedHashTableHelper::iterationEntryIndex):
(JSC::JSOrderedHashTableHelper::offsetInStorageForIndex):
(JSC::JSOrderedHashTableHelper::offsetOfAliveEntryCount):
(JSC::JSOrderedHashTableHelper::aliveEntryCount):
(JSC::JSOrderedHashTableHelper::deletedEntryCount):
(JSC::JSOrderedHashTableHelper::usedCapacity):
(JSC::JSOrderedHashTableHelper::capacity):
(JSC::JSOrderedHashTableHelper::iterationEntry):
(JSC::JSOrderedHashTableHelper::incrementAliveEntryCount):
(JSC::JSOrderedHashTableHelper::decrementAliveEntryCount):
(JSC::JSOrderedHashTableHelper::incrementDeletedEntryCount):
(JSC::JSOrderedHashTableHelper::bucketCount):
(JSC::JSOrderedHashTableHelper::hashTableStartIndex):
(JSC::JSOrderedHashTableHelper::hashTableEndIndex):
(JSC::JSOrderedHashTableHelper::bucketIndex):
(JSC::JSOrderedHashTableHelper::dataTableSize):
(JSC::JSOrderedHashTableHelper::dataTableStartIndex):
(JSC::JSOrderedHashTableHelper::dataTableEndIndex):
(JSC::JSOrderedHashTableHelper::entryDataStartIndex):
(JSC::JSOrderedHashTableHelper::setKeyOrValueData):
(JSC::JSOrderedHashTableHelper::deleteData):
(JSC::JSOrderedHashTableHelper::addToChain):
(JSC::JSOrderedHashTableHelper::tableSize):
(JSC::JSOrderedHashTableHelper::tableSizeSlow):
(JSC::JSOrderedHashTableHelper::isObsolete):
(JSC::JSOrderedHashTableHelper::nextTable):
(JSC::JSOrderedHashTableHelper::setNextTable):
(JSC::JSOrderedHashTableHelper::deletedEntriesStartIndex):
(JSC::JSOrderedHashTableHelper::isCleared):
(JSC::JSOrderedHashTableHelper::setClearedTableSentinel):
(JSC::JSOrderedHashTableHelper::tryCreate):
(JSC::JSOrderedHashTableHelper::copyImpl):
(JSC::JSOrderedHashTableHelper::copy):
(JSC::JSOrderedHashTableHelper::rehash):
(JSC::JSOrderedHashTableHelper::clear):
(JSC::JSOrderedHashTableHelper::find):
(JSC::JSOrderedHashTableHelper::expandIfNeeded):
(JSC::JSOrderedHashTableHelper::addImpl):
(JSC::JSOrderedHashTableHelper::add):
(JSC::JSOrderedHashTableHelper::addNormalized):
(JSC::JSOrderedHashTableHelper::shrinkIfNeeded):
(JSC::JSOrderedHashTableHelper::removeImpl):
(JSC::JSOrderedHashTableHelper::remove):
(JSC::JSOrderedHashTableHelper::removeNormalized):
(JSC::JSOrderedHashTableHelper::transit):
(JSC::JSOrderedHashTableHelper::transitAndNext):
(JSC::JSOrderedHashTableHelper::getKey):
(JSC::JSOrderedHashTableHelper::getValue):
(JSC::JSOrderedHashTableHelper::nextAndUpdateIterationEntry):
(JSC::JSOrderedHashTableHelper::getIterationEntry):
(JSC::JSOrderedHashTableHelper::getIterationEntryKey):
(JSC::JSOrderedHashTableHelper::getIterationEntryValue):
* Source/JavaScriptCore/runtime/JSSet.h:
* Source/JavaScriptCore/runtime/VM.cpp:
(JSC::VM::VM):
* Source/WTF/wtf/OrderedHashMap.h:
* Source/WTF/wtf/OrderedHashSet.h:
* Source/WebCore/Modules/geolocation/Geolocation.h:
* Source/WebCore/Modules/webaudio/AudioParamMap.h:
* Source/WebCore/css/CSSCounterStyleRegistry.cpp:
(WebCore::CSSCounterStyleRegistry::resolveExtendsReference):
* Source/WebCore/css/CSSCounterStyleRegistry.h:
* Source/WebCore/platform/graphics/FontFeatureValues.h:
* Source/WebCore/style/PropertyCascade.h:
* Tools/TestWebKitAPI/Tests/WTF/OrderedHashMap.cpp:
(TestWebKitAPI::TEST(WTF_OrderedHashMap, EmptyMap)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, BasicAddAndFind)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, Set)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, Ensure)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, Contains)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, Get)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, GetOptional)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, InsertionOrderPreserved)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, InsertionOrderPreservedAfterDeletion)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, SetDoesNotChangeOrder)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, RemoveByKey)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, RemoveByIterator)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, Take)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, TakeOptional)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, TakeFirst)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, Clear)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, Swap)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, CopyConstruction)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, MoveConstruction)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, CopyAssignment)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, MoveAssignment)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, KeysIteration)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, ValuesIteration)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, RehashPreservesOrder)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, DeleteAndReinsert)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, ManyDeletesAndInserts)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, StringKeys)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, InitializerList)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, ReserveCapacity)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, ConstIteration)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, FindReturnsCorrectIterator)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, IteratorComparison)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, CompactInPlacePreservesOrderAndCapacity)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, CompactInPlaceOnLargerTable)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, CompactInPlaceWithStringValues)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, RemoveIfAcrossShrinkThreshold)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, MoveOnlyValue)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, MoveOnlyValueRehash)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, HashTranslatorFindContainsGet)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, EqualIgnoringOrder)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, EqualIgnoringOrderDifferentSize)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, EqualIgnoringOrderDifferentValues)):
(TestWebKitAPI::TEST(WTF_OrderedHashMap, EqualIgnoringOrderEmpty)):
* Tools/TestWebKitAPI/Tests/WTF/OrderedHashSet.cpp:
(TestWebKitAPI::TEST(WTF_OrderedHashSet, EmptySet)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, BasicAddAndContains)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, InsertionOrderPreserved)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, InsertionOrderPreservedAfterDeletion)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, Remove)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, RemoveByIterator)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, Take)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, TakeAny)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, Clear)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, Swap)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, CopyConstruction)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, MoveConstruction)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, CopyAssignment)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, MoveAssignment)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, RehashPreservesOrder)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, DeleteAndReinsert)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, ManyDeletesAndInserts)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, StringValues)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, InitializerList)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, AddAll)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, Find)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, ReserveCapacity)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, StressTest)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, CompactInPlacePreservesOrderAndCapacity)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, CompactInPlaceOnLargerTable)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, CompactInPlaceWithStrings)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, CompactInPlaceRepeatedCycles)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, RemoveIfAcrossShrinkThreshold)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, MoveOnlyValue)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, MoveOnlyValueRehash)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, HashTranslatorFindContains)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, EqualIgnoringOrder)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, EqualIgnoringOrderDifferentSize)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, EqualIgnoringOrderDifferentElements)):
(TestWebKitAPI::TEST(WTF_OrderedHashSet, EqualIgnoringOrderEmpty)):

Canonical link: <a href="https://commits.webkit.org/313786@main">https://commits.webkit.org/313786@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8b3c52d13932136bcea0343daf6cab4e7bde0cf

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164131 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37615 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30834 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173160 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/432944f7-1040-43a1-b160-2bc8c80df389) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166000 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37949 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37615 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127511 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121383 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5c2d2066-87c6-4008-bec3-2f65d2a0a625) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167090 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29803 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147547 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108059 "Passed tests") | | [❌ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c4652b54-1153-410b-bbdf-d2b704d77a9c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28849 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27471 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20924 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/156282 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138751 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25264 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175686 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/25023 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28507 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26932 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135822 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37285 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31585 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135792 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38071 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147059 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100309 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24985 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31099 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23915 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/196534 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36881 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109926 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51455 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36278 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1965 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36528 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36428 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->