### PR TITLE
Google Docs: Typing in "Hindi - InScript" can result in an unexpected beep

### DIFF
--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -4394,7 +4394,7 @@ bool EventHandler::internalKeyEvent(const PlatformKeyboardEvent& initialKeyEvent
     keypress->setTarget(element.copyRef());
     if (keypress->isComposing() || shouldAvoidDispatchingKeyPressEvent()) {
         frame->editor().handleKeyboardEvent(keypress);
-        return keydownResult;
+        return keydownResult || keypress->defaultPrevented() || keypress->defaultHandled();
     }
     if (keydownResult)
         keypress->preventDefault();

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/WKWebViewMacEditingTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/WKWebViewMacEditingTests.mm
@@ -230,6 +230,40 @@
 
 @end
 
+// Borderless windows return canBecomeKeyWindow=NO by default, which makes
+// [NSApp sendEvent:] silently drop the keydown re-send that
+// WebViewImpl::doneWithKeyEvent issues on eventWasHandled=false. This subclass
+// (a) forces canBecomeKeyWindow=YES so re-sent keydowns reach the firstResponder,
+// and (b) counts -noResponderFor:keyDown:: when an unhandled keydown propagates
+// up the responder chain past the webView and bottoms out at the window, AppKit's
+// default -noResponderFor: would call NSBeep — our override suppresses the beep
+// and counts so tests can assert the IPC reply correctly reports handled.
+@interface KeyableBorderlessWindow : NSWindow
+@property (nonatomic, readonly) NSUInteger unhandledKeyDownCount;
+@end
+
+@implementation KeyableBorderlessWindow {
+    NSUInteger _unhandledKeyDownCount;
+}
+
+- (BOOL)canBecomeKeyWindow
+{
+    return YES;
+}
+
+- (NSUInteger)unhandledKeyDownCount
+{
+    return _unhandledKeyDownCount;
+}
+
+- (void)noResponderFor:(SEL)selector
+{
+    if (selector == @selector(keyDown:))
+        ++_unhandledKeyDownCount;
+}
+
+@end
+
 @interface WKWebView (MacEditingTests)
 - (std::pair<NSRect, NSRange>)_firstRectForCharacterRange:(NSRange)characterRange;
 @end
@@ -580,6 +614,58 @@ TEST(WKWebViewMacEditingTests, HindiInScriptViramaConjunctEmitsSuffixFromKeyboar
     Util::runFor(1_s);
 
     EXPECT_STREQ(@"\u0915\u094D\u092F\u093E".UTF8String, [webView stringByEvaluatingJavaScript:@"document.body.textContent"].UTF8String);
+}
+
+TEST(WKWebViewMacEditingTests, HindiInScriptViramaConjunctReportsKeystrokeHandled)
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    for (_WKFeature *feature in WKPreferences._features) {
+        NSString *key = feature.key;
+        if ([key isEqualToString:@"InputMethodUsesCorrectKeyEventOrder"])
+            [[configuration preferences] _setEnabled:YES forFeature:feature];
+    }
+
+    RetainPtr webView = adoptNS([[TestWebViewWithMockTextInputContext alloc] initWithFrame:NSMakeRect(0, 0, 400, 400) configuration:configuration.get()]);
+    [webView removeFromSuperview];
+    RetainPtr window = adoptNS([[KeyableBorderlessWindow alloc] initWithContentRect:NSMakeRect(100, 100, 800, 600) styleMask:NSWindowStyleMaskBorderless backing:NSBackingStoreBuffered defer:YES]);
+    [[window contentView] addSubview:webView.get()];
+    [window makeKeyAndOrderFront:nil];
+    [window makeFirstResponder:webView.get()];
+
+    // The Hindi InScript "/" keystroke goes through the partial-prefix path: the input method commits
+    // the marked virama via insertText:"\u094D" and the layout pass appends insertText:"\u092F".
+    // We need to prevent NSEvent from bubbling up to [NSApp sendEvent:] which beeps.
+    [webView _web_superInputContext].actions = [@[
+        [[[MockTextInputContextAction alloc] initWithInsertText:@"\u0915" replacementRange:NSMakeRange(NSNotFound, 0)] autorelease],
+        [[[MockTextInputContextAction alloc] initWithMarkedText:@"\u094D" selectedRange:NSMakeRange(0, 1) replacementRange:NSMakeRange(NSNotFound, 0)] autorelease],
+        [[[MockTextInputContextAction alloc] initWithInsertText:@"\u094D" replacementRange:NSMakeRange(NSNotFound, 0)] autorelease],
+        [[[MockTextInputContextAction alloc] initWithInsertText:@"\u093E" replacementRange:NSMakeRange(NSNotFound, 0)] autorelease],
+    ].mutableCopy autorelease];
+    [webView _web_superInputContext].layoutActions = [@[
+        [[[MockTextInputContextAction alloc] initWithInsertText:@"\u0915" replacementRange:NSMakeRange(NSNotFound, 0)] autorelease],
+        [[[MockTextInputContextAction alloc] initWithInsertText:@"\u092F" replacementRange:NSMakeRange(NSNotFound, 0)] autorelease],
+        [[[MockTextInputContextAction alloc] initWithInsertText:@"\u093E" replacementRange:NSMakeRange(NSNotFound, 0)] autorelease],
+    ].mutableCopy autorelease];
+
+    [webView synchronouslyLoadHTMLString:@"<body contenteditable></body>"];
+    [webView stringByEvaluatingJavaScript:@"document.body.focus()"];
+    [webView waitForNextPresentationUpdate];
+
+    [webView sendKey:@"\u0915" code:0x28 isDown:YES modifiers:0];
+    [webView sendKey:@"\u0915" code:0x28 isDown:NO modifiers:0];
+    Util::runFor(1_s);
+    [webView sendKey:@"\u094D" code:0x02 isDown:YES modifiers:0];
+    [webView sendKey:@"\u094D" code:0x02 isDown:NO modifiers:0];
+    Util::runFor(1_s);
+    [webView sendKey:@"\u094D\u092F" code:0x2C isDown:YES modifiers:0];
+    [webView sendKey:@"\u094D\u092F" code:0x2C isDown:NO modifiers:0];
+    Util::runFor(1_s);
+    [webView sendKey:@"\u093E" code:0x0E isDown:YES modifiers:0];
+    [webView sendKey:@"\u093E" code:0x0E isDown:NO modifiers:0];
+    Util::runFor(1_s);
+
+    EXPECT_STREQ(@"\u0915\u094D\u092F\u093E".UTF8String, [webView stringByEvaluatingJavaScript:@"document.body.textContent"].UTF8String);
+    EXPECT_EQ(0u, [window unhandledKeyDownCount]);
 }
 
 TEST(WKWebViewMacEditingTests, ModelessInputMethodStagingReportsPostKeystrokeCursorAndContent)


### PR DESCRIPTION
#### abcaf42866b178759f81eff6c290522c6e678520
<pre>
Google Docs: Typing in &quot;Hindi - InScript&quot; can result in an unexpected beep
<a href="https://bugs.webkit.org/show_bug.cgi?id=315421">https://bugs.webkit.org/show_bug.cgi?id=315421</a>
<a href="https://rdar.apple.com/177643899">rdar://177643899</a>

Reviewed by Wenson Hsieh.

The bug was caused by the missing check for defaultPrevented and defaultHandled for keypress event
when we take an early exit.

Test: TestWebKitAPI.WKWebViewMacEditingTests.HindiInScriptViramaConjunctReportsKeystrokeHandled

* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::internalKeyEvent):
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/mac/WKWebViewMacEditingTests.mm:
(-[KeyableBorderlessWindow canBecomeKeyWindow]):
(-[KeyableBorderlessWindow unhandledKeyDownCount]):
(-[KeyableBorderlessWindow noResponderFor:]):
(TestWebKitAPI::TEST(WKWebViewMacEditingTests, HindiInScriptViramaConjunctReportsKeystrokeHandled)):

Canonical link: <a href="https://commits.webkit.org/313813@main">https://commits.webkit.org/313813@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ca36bcdc959780285fb764e6af24fdc9c186898b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164153 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37637 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30856 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173182 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121405 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8dce81bf-b566-41ad-9b9c-7d3b092fe08e) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166022 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37971 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37637 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127527 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89713 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d8a7b5e2-4d90-4750-b02c-875fa781a658) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167112 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29820 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147565 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108075 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ea61b578-d831-4d33-bea5-ff77dc50586f) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28866 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27492 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20946 "Built successfully") | | 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138769 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; 4 api tests failed or timed out") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25282 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175708 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28529 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26950 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135837 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37307 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31606 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135807 "Passed tests") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38093 "Build is in progress. Recent messages:OS: Tahoe (26.4.1), Xcode: 26.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147077 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100352 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24999 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31115 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23933 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36903 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109948 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36300 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1985 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36550 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36450 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->