### PR TITLE
WebAssemblyCompileOptions::tryCreate should throw on OOM

### DIFF
--- a/JSTests/wasm/stress/wasm-imported-string-oom-exception.js
+++ b/JSTests/wasm/stress/wasm-imported-string-oom-exception.js
@@ -1,0 +1,15 @@
+//@ requireOptions("--useConcurrentJIT=0")
+//@ skip if $memoryLimited or $addressBits <= 32
+
+function main() {
+    const wasmCode = new Uint8Array([0x00, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00]);
+
+    const options = {
+        importedStringConstants: 'a'.repeat(0x7ffffffe) + '\u1234',
+        builtins: []
+    };
+
+    new WebAssembly.Module(wasmCode, options);
+}
+
+try { main(); } catch(e) { }

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyCompileOptions.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyCompileOptions.cpp
@@ -48,6 +48,7 @@ std::optional<WebAssemblyCompileOptions> WebAssemblyCompileOptions::tryCreate(JS
     RETURN_IF_EXCEPTION(scope, std::nullopt);
     if (importedStringConstantsValue.isString()) {
         auto importedStringConstants = asString(importedStringConstantsValue)->value(globalObject);
+        RETURN_IF_EXCEPTION(scope, std::nullopt);
         options.m_importedStringConstants = makeString(StringView(importedStringConstants));
     } else if (!importedStringConstantsValue.isUndefined()) {
         auto error = createTypeError(globalObject, "importedStringConstants option value must be a string"_s);


### PR DESCRIPTION
#### d8b63073f0c5e0cdd1949ce3d246c183e3a13932
<pre>
WebAssemblyCompileOptions::tryCreate should throw on OOM
<a href="https://bugs.webkit.org/show_bug.cgi?id=310576">https://bugs.webkit.org/show_bug.cgi?id=310576</a>
<a href="https://rdar.apple.com/173135164">rdar://173135164</a>

Reviewed by Yusuke Suzuki, Yijia Huang, and Dan Hecht.

When importing string constants, WebAssemblyCompileOptions::tryCreate
may run out of memory when trying to convert a big enough rope to a
string, in which case it should throw an out of memory exception,
which is not currently done.

Test: JSTests/wasm/stress/wasm-imported-string-oom-exception.js

* JSTests/wasm/stress/wasm-imported-string-oom-exception.js: Added.
(main):
(catch):
* Source/JavaScriptCore/wasm/js/WebAssemblyCompileOptions.cpp:
(JSC::WebAssemblyCompileOptions::tryCreate):

Originally-landed-as: 305413.610@rapid/safari-7624.2.5.110-branch (5a151853d699). <a href="https://rdar.apple.com/176062426">rdar://176062426</a>
Canonical link: <a href="https://commits.webkit.org/313797@main">https://commits.webkit.org/313797@main</a>
</pre>
