### PR TITLE
WebView on macOS fights with other views for NSCursor control

### DIFF
--- a/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
+++ b/Source/WebKit/UIProcess/mac/PageClientImplMac.mm
@@ -371,6 +371,15 @@ void PageClientImpl::setCursor(const WebCore::Cursor& cursor)
     if (window.get().windowNumber != [NSWindow windowNumberAtPoint:mouseLocationInScreen belowWindowWithWindowNumber:0])
         return;
 
+    // The web process may have decided this cursor before the mouse moved off the web view onto
+    // a sibling view in the same window. Without this guard, the late-arriving IPC would
+    // override the sibling's cursor.
+    auto mouseLocationInWindow = [window convertPointFromScreen:mouseLocationInScreen];
+    RetainPtr contentView = [window contentView];
+    RetainPtr hitView = [contentView hitTest:[[contentView superview] convertPoint:mouseLocationInWindow fromView:nil]];
+    if (![hitView isDescendantOf:view])
+        return;
+
     RetainPtr platformCursor = cursor.platformCursor();
     if ([NSCursor currentCursor] == platformCursor.get())
         return;


### PR DESCRIPTION
#### 2a69be73858f1d556fc285c6f9810867b43365f4
<pre>
WebView on macOS fights with other views for NSCursor control
<a href="https://bugs.webkit.org/show_bug.cgi?id=315425">https://bugs.webkit.org/show_bug.cgi?id=315425</a>
<a href="https://rdar.apple.com/177373957">rdar://177373957</a>

Reviewed by Aditya Keerthi.

Consider a SwiftUI view like this:

```swift
struct ContentView: View {
    @State private var page = WebPage()

    var body: some View {
        ZStack {
            WebView(page)

            Button {
            } label: {
                Text(&quot;CLICK ME&quot;)
                    .frame(width: 100, height: 100)
            }
            .frame(width: 100, height: 100)
            .pointerStyle(.default)
        }
        .toolbar {
            Button(&quot;Click me&quot;) {

            }
        }
    }
}
```

which contains a WebView with a button atop it, and a toolbar above the WebView.

When the user moves the mouse from the WebView to either the button or the toolbar, the cursor sometimes
changes from the I-beam cursor to the arrow cursor, however this commonly does not actually happen; instead,
the cursor unexpectedly stays the I-beam cursor.

This is because after the mouse moves to the new view, and the new view requests whatever cursor it wants,
a delayed IPC message may arrive in WebKit resulting in `PageClientImpl::setCursor` getting called, which
then incorrectly sets the cursor to whatever WebKit had it set as.

Fix by performing a hit-test in that method and returning early in the case the web view is not the hit view.

This also incidentally fixes a small correctness bug in the `imageAnalysisOverlayViewHasCursorAtPoint` check,
since it was originally using screen coordinates as window coordinates.

Note that even with this fix, the developer still needs to use

```
.pointerStyle(.default)
```

on the non-web view view, since the system doesn&apos;t request the cursor become the default cursor by default, and
therefore just would stay as-is otherwise.

* Source/WebKit/UIProcess/mac/PageClientImplMac.mm:
(WebKit::PageClientImpl::setCursor):

Canonical link: <a href="https://commits.webkit.org/313907@main">https://commits.webkit.org/313907@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96481e53bed4e8db7411926bfe3d0f456489fc05

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164493 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37977 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31548 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173523 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121745 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e93a2d37-b846-4318-8026-62a02f34d23a) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38311 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37979 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127811 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/89976 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2ffef30b-cba7-44a1-a56b-db44bb1f9599) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167452 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30117 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147851 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108356 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d820f613-5346-438a-b086-0b4a75606df8) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29164 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/27789 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21286 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139066 "Passed tests") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176049 "Built successfully") | | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/28872 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/27235 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136132 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38046 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31911 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136097 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36657 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38736 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147362 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100888 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31383 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24218 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37244 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/110288 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36642 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2279 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36890 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36790 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->