### PR TITLE
Can no longer "Close and return to ..." after opening a new window in Safari

### DIFF
--- a/Source/WebKit/UIProcess/WebBackForwardList.cpp
+++ b/Source/WebKit/UIProcess/WebBackForwardList.cpp
@@ -681,7 +681,10 @@ std::pair<RefPtr<WebBackForwardListItem>, size_t> WebBackForwardList::itemStarti
 
     if (direction == NavigationDirection::Backward) {
         // If going backwards, skip over next item with user iteraction since this is the one the user
-        // thinks they're on.
+        // thinks they're on. But if the user-gesture item is at the start of history, there is nothing
+        // to skip to — the item itself must be the destination.
+        if (!itemIndex)
+            return item;
         --itemIndex;
         item = itemAtIndexWithoutSkipping(itemIndex);
         if (!item.first)

--- a/Source/WebKit/UIProcess/WebBackForwardList.swift
+++ b/Source/WebKit/UIProcess/WebBackForwardList.swift
@@ -810,7 +810,11 @@ final class WebBackForwardList {
 
         if direction == Direction.backward {
             // If going backwards, skip over next item with user iteraction since this is the one the user
-            // thinks they're on.
+            // thinks they're on. But if the user-gesture item is at the start of history, there is nothing
+            // to skip to — the item itself must be the destination.
+            if itemIndex == 0 {
+                return item
+            }
             itemIndex -= 1
             let (thisItem, thisItemIndex) = itemAtIndexWithoutSkipping(index: itemIndex)
             guard let thisItem else {

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/RestoreSessionStateWithoutNavigation.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/RestoreSessionStateWithoutNavigation.mm
@@ -132,9 +132,11 @@ TEST(WebKit, RestoreSessionStateWithoutNavigationPreservesWasCreatedByJSWithoutU
     [view _evaluateJavaScriptWithoutUserGesture:@"history.pushState(null, document.title, location.pathname + '#b');" completionHandler:nil];
     Util::run(&didNavigate);
 
-    EXPECT_EQ([view backForwardList].backList.count, 2U);
+    // The back-list filter collapses the JS-without-user-gesture chain past the user-gesture
+    // lifeline at idx 0, so backList only exposes the lifeline. currentItem retains its flag
+    // and is the observable witness that the flag is preserved.
+    EXPECT_EQ([view backForwardList].backList.count, 1U);
     EXPECT_FALSE([view backForwardList].backList[0]._wasCreatedByJSWithoutUserInteraction);
-    EXPECT_TRUE([view backForwardList].backList[1]._wasCreatedByJSWithoutUserInteraction);
     EXPECT_TRUE([view backForwardList].currentItem._wasCreatedByJSWithoutUserInteraction);
 
     // Restore session state into a new web view.
@@ -142,9 +144,8 @@ TEST(WebKit, RestoreSessionStateWithoutNavigationPreservesWasCreatedByJSWithoutU
     RetainPtr sessionState = adoptNS([[_WKSessionState alloc] initWithData:[view _sessionStateData]]);
     [restoredView _restoreSessionState:sessionState.get() andNavigate:NO];
 
-    EXPECT_EQ([restoredView backForwardList].backList.count, 2U);
+    EXPECT_EQ([restoredView backForwardList].backList.count, 1U);
     EXPECT_FALSE([restoredView backForwardList].backList[0]._wasCreatedByJSWithoutUserInteraction);
-    EXPECT_TRUE([restoredView backForwardList].backList[1]._wasCreatedByJSWithoutUserInteraction);
     EXPECT_TRUE([restoredView backForwardList].currentItem._wasCreatedByJSWithoutUserInteraction);
 }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKBackForwardListTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKBackForwardListTests.mm
@@ -914,6 +914,41 @@ TEST(WKBackForwardList, BackForwardNavigationSkipsClientSideRedirectWithCOOP)
     EXPECT_STREQ([webView URL].absoluteString.UTF8String, server.request("/source.html"_s).URL.absoluteString.UTF8String);
 }
 
+TEST(WKBackForwardList, BackForwardNavigationLandsOnInitialItemPastJSChain)
+{
+    RetainPtr webView = adoptNS([[WKWebView alloc] init]);
+
+    RetainPtr navigationDelegate = adoptNS([WKBackForwardNavigationDelegate new]);
+    webView.get().navigationDelegate = navigationDelegate.get();
+
+    RetainPtr url1 = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+
+    [webView loadRequest:[NSURLRequest requestWithURL:url1.get()]];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    // url1 is the only user-gesture entry in history. Push two JS-without-gesture entries on top
+    // so the back chain extends all the way to the start of history. The filter must land on
+    // url1 rather than falling back to the first item in the chain.
+    [webView _evaluateJavaScriptWithoutUserGesture:@"history.pushState(null, document.title, location.pathname + '#a');" completionHandler:nil];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    [webView _evaluateJavaScriptWithoutUserGesture:@"history.pushState(null, document.title, location.pathname + '#b');" completionHandler:nil];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+
+    EXPECT_TRUE(webView.get().backForwardList.currentItem._wasCreatedByJSWithoutUserInteraction);
+
+    // Raw bf list: url1 - url1#a (no user gesture) - url1#b (no user gesture)*
+    // Filtered back list should contain only url1.
+    EXPECT_EQ([webView backForwardList].backList.count, 1U);
+    EXPECT_EQ([webView backForwardList].forwardList.count, 0U);
+    EXPECT_STREQ([webView backForwardList].backItem.URL.absoluteString.UTF8String, [url1 absoluteString].UTF8String);
+
+    [webView goBack];
+    [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
+    EXPECT_STREQ([webView URL].absoluteString.UTF8String, [url1 absoluteString].UTF8String);
+    EXPECT_EQ([webView backForwardList].backList.count, 0U);
+}
+
 static void runBackForwardNavigationDoesNotSkipItemsWithUserGestureTest(Function<void(WKWebView *, ASCIILiteral fragment)>&& navigate)
 {
     RetainPtr webView = adoptNS([[WKWebView alloc] init]);
@@ -1531,7 +1566,9 @@ TEST(WKBackForwardList, ForwardSkipIteratesThroughLeadingConsecutiveJSItems)
     [navigationDelegate waitForDidFinishNavigationOrDidSameDocumentNavigation];
 
     EXPECT_STREQ([webView URL].absoluteString.UTF8String, [url2 absoluteString].UTF8String);
-    EXPECT_EQ([webView backForwardList].backList.count, 3U);
+    // The back list collapses past the JS chain to the user-gesture lifeline at idx 0:
+    // [url1, url1#b]. url1#a is skipped because it's part of the JS chain anchored on url1.
+    EXPECT_EQ([webView backForwardList].backList.count, 2U);
     EXPECT_EQ([webView backForwardList].forwardList.count, 0U);
 }
 


### PR DESCRIPTION
#### 96d6f336d4e2eee88e3448fac2ec63bb6a72be91
<pre>
Can no longer &quot;Close and return to ...&quot; after opening a new window in Safari
<a href="https://rdar.apple.com/177655022">rdar://177655022</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=315433">https://bugs.webkit.org/show_bug.cgi?id=315433</a>

Reviewed by Simon Fraser.

When a website opens a new tab in Safari (window.open(), target=&quot;_blank&quot;, etc), Safari inserts a placeholder
&quot;parent-tab://&quot; entry into the start of the back/forward list of the new tab.

This enables the feature in Safari where the back button is enabled, and it provides a &quot;Close and return to...&quot;
item which - when activated - causes Safari to close the new tab and refocus the originating window.

During the &quot;filter some items from the API representation of the back/forward list&quot; work that&apos;s been going on,
we inadvertently filtered this item out in a common case. This left the back button disabled for most new
windows, and breaking this convenience.

This PR implements a small tweak to the filtering algorithm to let this item peek through.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKBackForwardListTests.mm

* Source/WebKit/UIProcess/WebBackForwardList.cpp:
(WebKit::WebBackForwardList::itemStartingAtIndexSkippingItemsAddedByJSWithoutUserGesture const):
* Source/WebKit/UIProcess/WebBackForwardList.swift:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKBackForwardListTests.mm:
(TEST(WKBackForwardList, BackForwardNavigationLandsOnInitialItemPastJSChain)):

Canonical link: <a href="https://commits.webkit.org/313800@main">https://commits.webkit.org/313800@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/4251f2587952e1cea95ff5b1404d7f5b16ab7da8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164159 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37643 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30862 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173188 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121411 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/11b31db5-753a-4807-a55a-72cab46d96cd) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166028 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37977 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37643 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127532 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89716 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/15db0e15-c25d-430d-b1e4-acb43e2c0c1e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167118 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29824 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147570 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108080 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e8f01f73-f293-4616-8ae3-9eb213098d21) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28870 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27496 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20952 "Built successfully") | | 
| | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138773 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Running apply-patch; Checked out pull request; 5 api tests failed or timed out; 5 api tests failed or timed out") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25287 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175714 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28535 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26955 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135842 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37313 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31610 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135812 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; run-api-tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36598 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38099 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147082 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100369 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31120 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23938 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36909 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109954 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36306 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1990 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36556 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36456 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->