### PR TITLE
[CMake] WebInspectorUI rebuilds when you touch any JavaScriptCore .cpp file

### DIFF
--- a/Source/WebInspectorUI/CMakeLists.txt
+++ b/Source/WebInspectorUI/CMakeLists.txt
@@ -46,9 +46,8 @@ WEBKIT_INCLUDE_CONFIG_FILES_IF_EXISTS()
 # expected in DerivedSources/WebInspectorUI/UserInterface/Protocol/.
 add_custom_command(
     OUTPUT ${WebInspectorUI_DERIVED_SOURCES_DIR}/UserInterface/Protocol/InspectorBackendCommands.js
-    DEPENDS JavaScriptCore
-            ${JavaScriptCore_DERIVED_SOURCES_DIR}/inspector/InspectorBackendCommands.js
-    COMMAND ${CMAKE_COMMAND} -E copy ${JavaScriptCore_DERIVED_SOURCES_DIR}/inspector/InspectorBackendCommands.js ${WebInspectorUI_DERIVED_SOURCES_DIR}/UserInterface/Protocol/InspectorBackendCommands.js
+    DEPENDS ${JavaScriptCore_DERIVED_SOURCES_DIR}/inspector/InspectorBackendCommands.js
+    COMMAND ${CMAKE_COMMAND} -E copy_if_different ${JavaScriptCore_DERIVED_SOURCES_DIR}/inspector/InspectorBackendCommands.js ${WebInspectorUI_DERIVED_SOURCES_DIR}/UserInterface/Protocol/InspectorBackendCommands.js
     VERBATIM
 )
 


### PR DESCRIPTION
#### 749560aa559c3bf2c97f9bdf41ad8fddd0b8b24f
<pre>
[CMake] WebInspectorUI rebuilds when you touch any JavaScriptCore .cpp file
<a href="https://bugs.webkit.org/show_bug.cgi?id=315434">https://bugs.webkit.org/show_bug.cgi?id=315434</a>
&lt;<a href="https://rdar.apple.com/problem/177794004">rdar://problem/177794004</a>&gt;

Reviewed by David Kilzer.

Touching any JSC/WTF/bmalloc .cpp file re-runs copy-user-interface-resources.pl
(~1.3s). 313182@main made this worse on Mac by adding a copy_directory step (~0.4s).

`ninja -d explain` shows the chain:

    JavaScriptCore.framework/Versions/A/JavaScriptCore is dirty
    -&gt; WebInspectorUI/DerivedSources/.../InspectorBackendCommands.js is dirty
    -&gt; inspector-resources.stamp is dirty

* Source/WebInspectorUI/CMakeLists.txt: Don&apos;t depend on JavaScriptCore because
we only actually depend on InspectorBackendCommands.js, which we already declare.

Also, when we copy, only copy-if-different. A byte-identical .js file has
no effect on WebInspector behavior. (I&apos;m not sure if this case can happen
anymore, now that we&apos;ve dropped the over-zealous dependency. But it&apos;s good
hygiene.)

Canonical link: <a href="https://commits.webkit.org/313812@main">https://commits.webkit.org/313812@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bec4a29c90435fc17a191cd7bb25a668f60da5a0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164158 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37642 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30861 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173187 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121410 "Build is in progress. Recent messages:Printed configuration; Running apply-patch; Checked out pull request; Compiled WebKit") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e1be0747-93ee-4c33-9f86-d5f5f9d90671) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37976 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37642 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127531 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89714 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f761ba37-afbc-4812-b23d-8d201bff22d4) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167117 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29823 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; Ignored 2 pre-existing failure based on results-db; Uploaded test results") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147568 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108079 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c3afb7d6-b3fc-4820-9319-325c8c190bd1) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28869 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27495 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20951 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138772 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25285 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175713 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28534 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26953 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135841 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37312 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31609 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135811 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38098 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147080 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100368 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/24998 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31119 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23936 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 13 flakes") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36908 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109953 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36305 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1988 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36555 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36455 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->