### PR TITLE
[AppKit Gestures] Can never get context menu with a right click (non-text)

### DIFF
--- a/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
+++ b/Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm
@@ -166,6 +166,11 @@ static bool representsDraggableElement(const WebKit::InteractionInformationAtPos
     return info.isLink || info.isImage || info.isAttachment || info.isDHTMLDraggable || info.isColorInput || info.prefersDraggingOverTextSelection;
 }
 
+static bool representsSelectableElement(const WebKit::InteractionInformationAtPosition& info)
+{
+    return info.selectability == WebKit::InteractionInformationAtPosition::Selectability::Selectable;
+}
+
 @interface WKAppKitGestureController () <NSGestureRecognizerDelegatePrivate, WKDeferringGestureRecognizerDelegate>
 @end
 
@@ -177,7 +182,10 @@ static bool representsDraggableElement(const WebKit::InteractionInformationAtPos
     RetainPtr<NSPressGestureRecognizer> _mouseTrackingGestureRecognizer;
     RetainPtr<NSPressGestureRecognizer> _singleClickGestureRecognizer;
     RetainPtr<NSClickGestureRecognizer> _doubleClickGestureRecognizer;
+
+    //  Auxiliary gesture recognizers to support context menus.
     RetainPtr<NSPressGestureRecognizer> _secondaryClickGestureRecognizer;
+    RetainPtr<WKDeferringGestureRecognizer> _secondaryClickDeferringGestureRecognizer;
 
     // Auxiliary gesture recognizers to support drag-and-drop.
     RetainPtr<NSGestureRecognizer> _textSelectionDragGesture;
@@ -238,7 +246,10 @@ static bool representsDraggableElement(const WebKit::InteractionInformationAtPos
     [self setUpMouseTrackingGestureRecognizer];
     [self setUpSingleClickGestureRecognizer];
     [self setUpDoubleClickGestureRecognizer];
+
     [self setUpSecondaryClickGestureRecognizer];
+    [self setUpSecondaryClickDeferringGestureRecognizer];
+
     [self setUpDragPressGestureRecognizer];
     [self setUpDragDeferringGestureRecognizer];
 }
@@ -283,8 +294,17 @@ static bool representsDraggableElement(const WebKit::InteractionInformationAtPos
 {
     _secondaryClickGestureRecognizer = adoptNS([[NSPressGestureRecognizer alloc] initWithTarget:self action:@selector(secondaryClickGestureRecognized:)]);
     [self configureForSecondaryClick:_secondaryClickGestureRecognizer.get()];
+    [_secondaryClickGestureRecognizer setCancelPastAllowableMovement:YES];
     [_secondaryClickGestureRecognizer setDelegate:self];
     [_secondaryClickGestureRecognizer setName:@"WKSecondaryClickGesture"];
+}
+
+- (void)setUpSecondaryClickDeferringGestureRecognizer
+{
+    _secondaryClickDeferringGestureRecognizer = adoptNS([[WKDeferringGestureRecognizer alloc] initWithDeferringGestureDelegate:self]);
+    [self configureForSecondaryClickDeferral:_secondaryClickDeferringGestureRecognizer];
+    [_secondaryClickDeferringGestureRecognizer setDelegate:self];
+    [_secondaryClickDeferringGestureRecognizer setName:@"WKSecondaryClickDeferringGesture"];
 }
 
 - (void)setUpDragPressGestureRecognizer
@@ -317,7 +337,10 @@ static bool representsDraggableElement(const WebKit::InteractionInformationAtPos
     [webView addGestureRecognizer:_mouseTrackingGestureRecognizer.get()];
     [webView addGestureRecognizer:_singleClickGestureRecognizer.get()];
     [webView addGestureRecognizer:_doubleClickGestureRecognizer.get()];
+
     [webView addGestureRecognizer:_secondaryClickGestureRecognizer.get()];
+    [webView addGestureRecognizer:_secondaryClickDeferringGestureRecognizer.get()];
+
     [webView addGestureRecognizer:_dragPressGestureRecognizer.get()];
     [webView addGestureRecognizer:_dragDeferringGestureRecognizer.get()];
 }
@@ -330,6 +353,8 @@ static bool representsDraggableElement(const WebKit::InteractionInformationAtPos
     [self enableGestureIfNeeded:_doubleClickGestureRecognizer.get()];
     [self enableGestureIfNeeded:_secondaryClickGestureRecognizer.get()];
     [self enableGestureIfNeeded:_dragPressGestureRecognizer.get()];
+
+    // The deferring gesture recognizers are intentionally not enabled.
 }
 
 - (void)enableGestureIfNeeded:(NSGestureRecognizer *)gesture
@@ -385,24 +410,22 @@ static bool representsDraggableElement(const WebKit::InteractionInformationAtPos
 
     WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(page->logIdentifier(), "%@", gesture);
 
-    RetainPtr panGesture = dynamic_objc_cast<NSPanGestureRecognizer>(gesture);
-    if (!panGesture || _panGestureRecognizer != panGesture)
-        return;
+    RELEASE_ASSERT(_panGestureRecognizer == gesture);
 
     if (viewImpl->ignoresAllEvents()) {
         WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(page->logIdentifier(), "Ignored gesture");
         return;
     }
 
-    if ([panGesture state] == NSGestureRecognizerStateBegan)
+    if ([gesture state] == NSGestureRecognizerStateBegan)
         viewImpl->dismissContentRelativeChildWindowsWithAnimation(false);
 
 #if ENABLE(TOP_BANNER_VIEW_OVERLAYS)
-    viewImpl->updateBannerViewForPanGesture([panGesture state]);
+    viewImpl->updateBannerViewForPanGesture([gesture state]);
 #endif
 
-    [self sendWheelEventForGesture:panGesture.get()];
-    [self startMomentumIfNeededForGesture:panGesture.get()];
+    [self sendWheelEventForGesture:_panGestureRecognizer];
+    [self startMomentumIfNeededForGesture:_panGestureRecognizer];
 }
 
 - (void)singleClickGestureRecognized:(NSGestureRecognizer *)gesture
@@ -421,8 +444,7 @@ static bool representsDraggableElement(const WebKit::InteractionInformationAtPos
 
     WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(page->logIdentifier(), "%@", gesture);
 
-    if (_singleClickGestureRecognizer != gesture)
-        return;
+    RELEASE_ASSERT(_singleClickGestureRecognizer == gesture);
 
     // Clicks aren't delivered to NSButton's built-in click gesture
     // recognizer when a parent view's GR recognizes first, so we
@@ -469,9 +491,7 @@ static bool representsDraggableElement(const WebKit::InteractionInformationAtPos
 
     WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(page->logIdentifier(), "%@", gesture);
 
-    RetainPtr clickGesture = dynamic_objc_cast<NSClickGestureRecognizer>(gesture);
-    if (!clickGesture || _doubleClickGestureRecognizer != clickGesture)
-        return;
+    RELEASE_ASSERT(_doubleClickGestureRecognizer == gesture);
 
     viewImpl->dismissContentRelativeChildWindowsWithAnimation(false);
 
@@ -495,7 +515,14 @@ static bool representsDraggableElement(const WebKit::InteractionInformationAtPos
 
     WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(page->logIdentifier(), "%@", gesture);
 
-    if (_secondaryClickGestureRecognizer != gesture)
+    RELEASE_ASSERT(_secondaryClickGestureRecognizer == gesture);
+
+    if (gesture.state == NSGestureRecognizerStateBegan) {
+        [self _handleClickCancelled];
+        return;
+    }
+
+    if (gesture.state != NSGestureRecognizerStateEnded)
         return;
 
 ALLOW_NEW_API_WITHOUT_GUARDS_BEGIN
@@ -543,8 +570,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
         return;
     }
 
-    if (_mouseTrackingGestureRecognizer != gesture)
-        return;
+    RELEASE_ASSERT(_mouseTrackingGestureRecognizer == gesture);
 
     if (viewImpl->ignoresAllEvents())
         return;
@@ -630,7 +656,7 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
 
     for (NSGestureRecognizer *textSelectionGesture in [[webView textSelectionManager] gesturesForFailureRequirements]) {
         if (gestureRecognizer == textSelectionGesture)
-            return deferringGestureRecognizer == _dragDeferringGestureRecognizer;
+            return YES;
     }
 
     return NO;
@@ -646,39 +672,48 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     if (!webView)
         return NO;
 
-    if (deferringGestureRecognizer == _dragDeferringGestureRecognizer) {
-        NSPoint locationInView = [webView convertPoint:[event locationInWindow] fromView:nil];
-        if (viewImpl->isTextSelectedAtPoint(locationInView)) {
-            WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(RefPtr { _page.get() }->logIdentifier(), "Drag deferral: not deferring; text already selected at %@", NSStringFromPoint(locationInView));
-            return NO;
-        }
-
-        WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(RefPtr { _page.get() }->logIdentifier(), "Drag deferral: deferring; awaiting position info at %@", NSStringFromPoint(locationInView));
-
-        WebKit::InteractionInformationRequest request { WebCore::IntPoint { locationInView } };
-        [self doAfterPositionInformationUpdate:[weakSelf = WeakObjCPtr<WKAppKitGestureController>(self), weakDeferring = WeakObjCPtr<WKDeferringGestureRecognizer>(deferringGestureRecognizer)](const auto& info) {
-            RetainPtr strongSelf = weakSelf.get();
-            RetainPtr strongDeferring = weakDeferring.get();
-            if (!strongSelf || !strongDeferring)
-                return;
-
-            auto deferralState = [strongDeferring state];
-            if (deferralState != NSGestureRecognizerStatePossible) {
-                WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(RefPtr { strongSelf->_page.get() }->logIdentifier(),
-                    "Drag deferral: position info arrived after deferring gesture exited Possible (state=%ld); skipping resolution", static_cast<long>(deferralState));
-                return;
-            }
-            bool isDraggable = representsDraggableElement(info);
-            WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(RefPtr { strongSelf->_page.get() }->logIdentifier(),
-                "Drag deferral resolved: isDraggable=%d (link=%d image=%d attachment=%d dhtml=%d color=%d prefersDrag=%d)",
-                isDraggable, info.isLink, info.isImage, info.isAttachment, info.isDHTMLDraggable, info.isColorInput, info.prefersDraggingOverTextSelection);
-            [strongDeferring endDeferralShouldPreventGestures:isDraggable];
-        } forRequest:request];
-
-        return YES;
+    NSPoint locationInView = [webView convertPoint:[event locationInWindow] fromView:nil];
+    if (viewImpl->isTextSelectedAtPoint(locationInView)) {
+        WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(RefPtr { _page.get() }->logIdentifier(), "deferral: not deferring; text already selected at %@", NSStringFromPoint(locationInView));
+        return NO;
     }
 
-    return NO;
+    WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(RefPtr { _page.get() }->logIdentifier(), "deferral: deferring; awaiting position info at %@", NSStringFromPoint(locationInView));
+
+    WebKit::InteractionInformationRequest request { WebCore::IntPoint { locationInView } };
+    [self doAfterPositionInformationUpdate:[weakSelf = WeakObjCPtr<WKAppKitGestureController>(self), weakDeferring = WeakObjCPtr<WKDeferringGestureRecognizer>(deferringGestureRecognizer)](const auto &info) {
+        RetainPtr strongSelf = weakSelf.get();
+        RetainPtr strongDeferring = weakDeferring.get();
+        if (!strongSelf || !strongDeferring)
+            return;
+
+        auto deferralState = [strongDeferring state];
+        if (deferralState != NSGestureRecognizerStatePossible) {
+            WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(RefPtr { strongSelf->_page.get() }->logIdentifier(),
+                "deferral: position info arrived after deferring gesture exited Possible (state=%ld); skipping resolution", static_cast<long>(deferralState));
+            return;
+        }
+
+        auto shouldPreventGestures = [&] {
+            if (strongDeferring == strongSelf->_dragDeferringGestureRecognizer) {
+                auto isDraggable = representsDraggableElement(info);
+                WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(RefPtr { strongSelf->_page.get() }->logIdentifier(), "deferral resolved: isDraggable=%d (link=%d image=%d attachment=%d dhtml=%d color=%d prefersDrag=%d)", isDraggable, info.isLink, info.isImage, info.isAttachment, info.isDHTMLDraggable, info.isColorInput, info.prefersDraggingOverTextSelection);
+                return isDraggable;
+            }
+
+            if (strongDeferring == strongSelf->_secondaryClickDeferringGestureRecognizer) {
+                bool isSelectable = representsSelectableElement(info);
+                WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(RefPtr { strongSelf->_page.get() }->logIdentifier(), "Resolved deferral: isSelectable=%d", isSelectable);
+                return !isSelectable;
+            }
+
+            RELEASE_ASSERT_NOT_REACHED();
+        }();
+
+        [strongDeferring endDeferralShouldPreventGestures:shouldPreventGestures];
+    } forRequest:request];
+
+    return YES;
 }
 
 - (void)deferringGestureRecognizer:(WKDeferringGestureRecognizer *)deferringGestureRecognizer didEndActionWithEvent:(NSEvent *)event
@@ -686,13 +721,11 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     if (deferringGestureRecognizer.state != NSGestureRecognizerStatePossible)
         return;
 
-    if (deferringGestureRecognizer == _dragDeferringGestureRecognizer) {
-        WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(RefPtr { _page.get() }->logIdentifier(), "Drag deferral: press ended before position info arrived; unblocking text selection");
-        if (auto abandonedRequest = std::exchange(_lastOutstandingPositionInformationRequest, std::nullopt)) {
-            for (auto& slot : _pendingPositionInformationHandlers) {
-                if (slot && slot->request.isValidForRequest(*abandonedRequest))
-                    slot.reset();
-            }
+    WK_APPKIT_GESTURE_CONTROLLER_RELEASE_LOG(RefPtr { _page.get() }->logIdentifier(), "deferral: press ended before position info arrived; unblocking text selection");
+    if (auto abandonedRequest = std::exchange(_lastOutstandingPositionInformationRequest, std::nullopt)) {
+        for (auto& slot : _pendingPositionInformationHandlers) {
+            if (slot && slot->request.isValidForRequest(*abandonedRequest))
+                slot.reset();
         }
     }
 
@@ -799,6 +832,20 @@ ALLOW_NEW_API_WITHOUT_GUARDS_END
     _hasValidPositionInformation = _positionInformation.canBeValid;
 
     [self _invokeAndRemovePendingHandlersValidForCurrentPositionInformation];
+}
+
+- (BOOL)_secondaryClickShouldBeginAtLocation:(NSPoint)locationInViewCoordinates
+{
+    WebKit::InteractionInformationRequest request { WebCore::IntPoint { locationInViewCoordinates } };
+
+    bool requestIsValid = _hasValidPositionInformation && _positionInformation.request.isValidForRequest(request);
+    bool isSelectable = representsSelectableElement(_positionInformation);
+    bool shouldBegin = requestIsValid && isSelectable;
+
+    if (!requestIsValid)
+        [self _invalidateCurrentPositionInformation];
+
+    return shouldBegin;
 }
 
 - (BOOL)_dragPressShouldBeginAtLocation:(NSPoint)locationInViewCoordinates
@@ -1319,8 +1366,8 @@ static inline bool isSamePair(NSGestureRecognizer *a, NSGestureRecognizer *b, NS
     if (!webView)
         return NO;
 
-    if (gestureRecognizer == _dragDeferringGestureRecognizer)
-        return [_dragDeferringGestureRecognizer shouldDeferGestureRecognizer:otherGestureRecognizer];
+    if ([gestureRecognizer isKindOfClass:WKDeferringGestureRecognizer.class])
+        return [(WKDeferringGestureRecognizer *)gestureRecognizer shouldDeferGestureRecognizer:otherGestureRecognizer];
 
     // Fail any gestures from the text selection manager if the secondary click GR handles them.
     for (NSGestureRecognizer *gestureForFailureRequirements in [[webView textSelectionManager] gesturesForFailureRequirements]) {
@@ -1353,24 +1400,22 @@ static inline bool isSamePair(NSGestureRecognizer *a, NSGestureRecognizer *b, NS
     if (!webView)
         return NO;
 
-    if (gestureRecognizer == _doubleClickGestureRecognizer) {
-        if (!viewImpl->allowsMagnification())
-            return NO;
-    }
+    NSPoint locationInViewCoordinates = [gestureRecognizer locationInView:webView];
 
-    if (gestureRecognizer == _secondaryClickGestureRecognizer) {
-        // FIXME: Implement logic for determining if the clicked node is not text.
-        return NO;
-    }
+    if (gestureRecognizer == _doubleClickGestureRecognizer)
+        return viewImpl->allowsMagnification();
 
-    if (gestureRecognizer == _singleClickGestureRecognizer || gestureRecognizer == _mouseTrackingGestureRecognizer || gestureRecognizer == _dragPressGestureRecognizer) {
-        NSPoint locationInViewCoordinates = [gestureRecognizer locationInView:webView];
+    if (gestureRecognizer == _secondaryClickGestureRecognizer)
+        return [self _secondaryClickShouldBeginAtLocation:locationInViewCoordinates];
 
-        if (gestureRecognizer == _dragPressGestureRecognizer)
-            return [self _dragPressShouldBeginAtLocation:locationInViewCoordinates];
+    if (gestureRecognizer == _dragPressGestureRecognizer)
+        return [self _dragPressShouldBeginAtLocation:locationInViewCoordinates];
 
+    if (gestureRecognizer == _singleClickGestureRecognizer)
         return !viewImpl->isTextSelectedAtPoint(locationInViewCoordinates);
-    }
+
+    if (gestureRecognizer == _mouseTrackingGestureRecognizer)
+        return !viewImpl->isTextSelectedAtPoint(locationInViewCoordinates);
 
     return YES;
 }
@@ -1401,6 +1446,12 @@ static inline bool isSamePair(NSGestureRecognizer *a, NSGestureRecognizer *b, NS
         return YES;
 
     if ([self _isScrollOrZoomGestureRecognizer:preventedGestureRecognizer])
+        return NO;
+
+    // Don't let other click gestures prevent the secondary click GR; it must be allowed to fire its
+    // press timer (0.72s) without being short-circuited by gestures that recognize earlier
+    // (e.g. single click and mouse-tracking, which both transition to Began at mouse-down).
+    if (preventedGestureRecognizer == _secondaryClickGestureRecognizer)
         return NO;
 
     // Don't let our click gestures prevent text selection manager gestures;

--- a/Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptMessages.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptMessages.swift
@@ -104,11 +104,11 @@ extension JavaScriptMessages {
             case .selection(let selection):
                 [
                     "selection": selection.encoded(),
-                    "elementID": NSNull(),
+                    "elementID": nil,
                 ]
             case .element(let id):
                 [
-                    "selection": NSNull(),
+                    "selection": nil,
                     "elementID": id,
                 ]
             }

--- a/Tools/TestWebKitAPI/Helpers/cocoa/WebPage+JavaScriptExpression.swift
+++ b/Tools/TestWebKitAPI/Helpers/cocoa/WebPage+JavaScriptExpression.swift
@@ -24,6 +24,7 @@
 #if ENABLE_SWIFTUI
 
 public import WebKit
+public import struct Swift.String
 
 extension WebPage {
     /// A type that can encode itself to a JavaScript JSON value representation.

--- a/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift
@@ -179,27 +179,10 @@ struct AppKitGesturesTests {
             return
         }
 
-        let future = Future()
-
-        let implementation: @convention(block) (NSMenu.Type, NSMenu, _NSViewMenuContext, NSView, (@convention(block) () -> Void)?) -> Void =
-            { _, menu, context, view, completion in
-                completion?()
-
-                #expect(view is WKWebView)
-
-                future.signal()
-            }
-
-        await withSwizzledObjectiveCClassMethod(
-            class: NSMenu.self,
-            replacing: #selector(NSMenu._popUpContextMenu(_:with:for:) as (NSMenu, _NSViewMenuContext, NSView) async -> Void),
-            with: implementation
-        ) {
+        await withSwizzledContextMenu {
             await recap.play { composer in
                 composer._wk_click(at: crazyBoundsInScreenCoordinates.center, for: .seconds(0.1))
             }
-
-            await future.wait()
         }
 
         await page.waitForNextPresentationUpdate()
@@ -207,6 +190,34 @@ struct AppKitGesturesTests {
         let newSelection = try await page.callJavaScript(JavaScriptMessages.GetSelection())
 
         #expect(newSelection == crazySelection)
+    }
+
+    @Test(arguments: [true, false])
+    func clickingAndHoldingOnEmptyContentOpensContextMenu(contentEditable: Bool) async throws {
+        try await loadHTML(contentEditable: contentEditable)
+
+        let middleOfWindow = convertToCoreGraphicsScreenCoordinates(pointInWindowCoordinates: window.frame.center, window: window)
+
+        // Recap requires this test to be ran within an app host.
+        guard NSApp.isActive else {
+            return
+        }
+
+        await withSwizzledContextMenu {
+            await recap.play { composer in
+                composer._wk_click(at: middleOfWindow, for: .seconds(1))
+            }
+        }
+
+        await page.waitForNextPresentationUpdate()
+
+        let newSelection = try await page.callJavaScript(JavaScriptMessages.GetSelection())
+
+        if contentEditable {
+            #expect(newSelection == .none)
+        } else {
+            #expect(newSelection == .collapsed(.init(in: "div", at: Self.text.count)))
+        }
     }
 
     @Test(arguments: [true, false], [true, false])
@@ -248,7 +259,7 @@ struct AppKitGesturesTests {
     )
     func tripleClickingInPDFSelectsLine() async throws {
         let pdfURL = try #require(Bundle.testResources.url(forResource: "test", withExtension: "pdf"))
-        try await page.load(URLRequest(url: pdfURL)).wait()
+        try await page.load(pdfURL).wait()
         await page.waitForNextPresentationUpdate()
 
         // Recap requires this test to be ran within an app host.
@@ -256,19 +267,10 @@ struct AppKitGesturesTests {
             return
         }
 
-        let pointInDOMCoords = try #require(
-            DOMRect(decodedRepresentation: [
-                "x": 100.0,
-                "y": 100.0,
-                "width": 0.0,
-                "height": 0.0,
-            ])
-        )
         let clickPoint = convertToCoreGraphicsScreenCoordinates(
-            rectInViewportCoordinates: pointInDOMCoords,
+            pointInWindowCoordinates: .init(x: 100, y: 350),
             window: window
         )
-        .origin
 
         await recap.play { composer in
             composer._wk_click(at: clickPoint, for: .seconds(0.1))
@@ -442,7 +444,7 @@ struct AppKitGesturesTests {
             return NSDraggingSession()
         }
 
-        try await withSwizzledObjectiveCInstanceMethod(
+        await withSwizzledObjectiveCInstanceMethod(
             replacing: NSView.self,
             name: #selector(NSView.beginDraggingSession(items:gesture:source:)),
             with: implementation
@@ -462,7 +464,7 @@ struct AppKitGesturesTests {
         await page.waitForNextPresentationUpdate()
 
         let selection = try await page.callJavaScript(JavaScriptMessages.GetSelection())
-        #expect(selection == JavaScriptSelection.none)
+        #expect(selection == .none)
     }
 
     @Test(
@@ -557,7 +559,7 @@ struct AppKitGesturesTests {
             return NSDraggingSession()
         }
 
-        try await withSwizzledObjectiveCInstanceMethod(
+        await withSwizzledObjectiveCInstanceMethod(
             replacing: NSView.self,
             name: #selector(NSView.beginDraggingSession(items:gesture:source:)),
             with: implementation
@@ -591,6 +593,22 @@ struct AppKitGesturesTests {
 // MARK: Helpers
 
 @MainActor
+private func convertToCoreGraphicsScreenCoordinates(pointInWindowCoordinates: CGPoint, window: NSWindow) -> CGPoint {
+    guard let screen = window.screen else {
+        preconditionFailure()
+    }
+
+    let inAppKitScreenCoordinates = window.convertPoint(toScreen: pointInWindowCoordinates)
+
+    let inCoreGraphicsScreenCoordinates = CGPoint(
+        x: inAppKitScreenCoordinates.x,
+        y: screen.frame.maxY - inAppKitScreenCoordinates.y
+    )
+
+    return inCoreGraphicsScreenCoordinates
+}
+
+@MainActor
 private func convertToCoreGraphicsScreenCoordinates(rectInViewportCoordinates: DOMRect, window: NSWindow) -> CGRect {
     guard let contentViewController = window.contentViewController else {
         preconditionFailure()
@@ -619,6 +637,29 @@ private func convertToCoreGraphicsScreenCoordinates(rectInViewportCoordinates: D
     )
 
     return inCoreGraphicsScreenCoordinates
+}
+
+nonisolated(nonsending) private func withSwizzledContextMenu(perform body: () async -> Void) async {
+    typealias CompletionHandler = @convention(block) () -> Void
+    typealias ObjCImplementation = @convention(block) (NSMenu.Type, NSMenu, _NSViewMenuContext, NSView, CompletionHandler?) -> Void
+
+    let future = Future()
+
+    let implementation: ObjCImplementation = { _, _, _, _, completion in
+        completion?()
+
+        future.signal()
+    }
+
+    await withSwizzledObjectiveCClassMethod(
+        class: NSMenu.self,
+        replacing: #selector(NSMenu._popUpContextMenu(_:with:for:) as (NSMenu, _NSViewMenuContext, NSView) async -> Void),
+        with: implementation
+    ) {
+        await body()
+
+        await future.wait()
+    }
 }
 
 extension AppKitGesturesTests {


### PR DESCRIPTION
#### 4723be8cda9e9cd7103444192e83290129b0828a
<pre>
[AppKit Gestures] Can never get context menu with a right click (non-text)
<a href="https://bugs.webkit.org/show_bug.cgi?id=315437">https://bugs.webkit.org/show_bug.cgi?id=315437</a>
<a href="https://rdar.apple.com/170741007">rdar://170741007</a>

Reviewed by Tim Horton.

Right-clicking on non-text content in `WKWebView` (an image, a link, the page background, etc.)
never produced a context menu. `gestureRecognizerShouldBegin:` for `_secondaryClickGestureRecognizer`
carried a FIXME and returned NO unconditionally, so the secondary-click gesture never started
on non-text content. (Right-clicks on selected text worked, but only via the text-selection
manager&apos;s own gestures.)

Mirror the existing drag-deferral flow that already gates drag-and-drop
on a position-info fetch.

Tests: Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptMessages.swift
       Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift

* Source/WebKit/UIProcess/mac/WKAppKitGestureController.mm:
(representsSelectableElement):
(-[WKAppKitGestureController setUpGestureRecognizers]):
(-[WKAppKitGestureController setUpSecondaryClickGestureRecognizer]):
(-[WKAppKitGestureController setUpSecondaryClickDeferringGestureRecognizer]):
(-[WKAppKitGestureController addGesturesToWebView]):
(-[WKAppKitGestureController enableGesturesIfNeeded]):

- Add a second `WKDeferringGestureRecognizer`, `_secondaryClickDeferringGestureRecognizer`,
configured via the new `configureForSecondaryClickDeferral:`. Like `configureForDragDeferral:`,
it defers text-selection gestures while position info is fetched.

- Set `cancelPastAllowableMovement` on the secondary-click GR so a press-and-drag cancels the
gesture rather than spuriously triggering a context menu.

(-[WKAppKitGestureController panGestureRecognized:]):
(-[WKAppKitGestureController singleClickGestureRecognized:]):
(-[WKAppKitGestureController doubleClickGestureRecognized:]):
(-[WKAppKitGestureController mouseTrackingGestureRecognized:]):

While here, tighten the gesture-handler entry points. The `...Recognized:` methods are wired to
specific recognizers via `initWithTarget:action:`, so the existing `if (... != gesture) return;`
guards were either dead code or evidence of a bug — replace them with `RELEASE_ASSERT`.

(-[WKAppKitGestureController secondaryClickGestureRecognized:]):

- Treat `Began` as a click cancellation (the in-flight potential click would otherwise leak when
  the press recognizer fires) and only pop the menu on `Ended`.

(-[WKAppKitGestureController deferringGestureRecognizer:shouldDeferOtherGestureRecognizer:]):
(-[WKAppKitGestureController deferringGestureRecognizer:shouldDeferGesturesForEventThatWillBeginAction:]):
(-[WKAppKitGestureController deferringGestureRecognizer:didEndActionWithEvent:]):

- Generalize the deferring delegate callbacks to handle either deferring GR. The position-info
resolution callback picks its predicate by identity: representsDraggableElement` for the drag GR,
and `representsSelectableElement` (new helper, defined symmetrically and returning true iff `info.selectability == Selectable`)
for the secondary-click GR. The secondary-click branch ends the deferral with
`shouldPreventGestures = !isSelectable`, so text-selection wins on selectable text and the
secondary click wins everywhere else.

(-[WKAppKitGestureController gestureRecognizer:shouldBeRequiredToFailByGestureRecognizer:]):

- Generalize to dispatch on `WKDeferringGestureRecognizer` class membership instead of
`_dragDeferringGestureRecognizer` identity, so the new deferring GR is handled the same way.

(-[WKAppKitGestureController gestureRecognizerShouldBegin:]):
(-[WKAppKitGestureController _secondaryClickShouldBeginAtLocation:]):

- Flatten `gestureRecognizerShouldBegin:` to early-return per recognizer.

- Replace the FIXME with `_secondaryClickShouldBeginAtLocation:`, which consults the cached position
info (or invalidates it and fails fast if stale) and returns YES only for selectable elements. Together
with the deferring GR, this means the secondary click owns non-selectable points and text-selection
still owns selectable ones.

(-[WKAppKitGestureController _gestureRecognizer:canPreventGestureRecognizer:]):

- Stop letting other click GRs prevent `_secondaryClickGestureRecognizer` in `_gestureRecognizer:canPreventGestureRecognizer:`.
The single-click and mouse-tracking GRs both transition to `Began` immediately on mouse-down, which
would otherwise short-circuit the 0.72s press timer before it can fire.

* Tools/TestWebKitAPI/Helpers/cocoa/JavaScriptMessages.swift:
(Storage.encoded):
* Tools/TestWebKitAPI/Tests/WebKit/WebPage/AppKitGesturesTests.swift:
(AppKitGesturesTests.clickingOnSelectedWordOpensContextMenu(_:)):
(AppKitGesturesTests.clickingAndHoldingOnEmptyContentOpensContextMenu(_:)):
(AppKitGesturesTests.tripleClickingInPDFSelectsLine):
(AppKitGesturesTests.pressDragOnLinkInitiatesDragAndDrop):
(AppKitGesturesTests.pressDragOnExistingSelectionDoesNotExtendSelection):
(convertToCoreGraphicsScreenCoordinates(_:window:)):
(withSwizzledContextMenu(perform:)):

- New `AppKitGesturesTests.clickingAndHoldingOnEmptyContentOpensContextMenu`
  exercises the long-press → context-menu path on empty content (both
  with and without `contenteditable`).
- `clickingOnSelectedWordOpensContextMenu` is refactored to use a
  shared `withSwizzledContextMenu(perform:)` helper that swizzles
  `NSMenu._popUpContextMenu(_:with:for:)` and waits for it to be
  invoked, replacing the inline swizzling.
- A new
  `convertToCoreGraphicsScreenCoordinates(pointInWindowCoordinates:window:)`
  helper supports tests that have a window-space point rather than a
  DOM rect; `tripleClickingInPDFSelectsLine` switches to it.
- `JavaScriptMessages.Storage.encoded` uses `nil` directly instead of
  `NSNull()` (the dictionary value type is already `Any?`).

Canonical link: <a href="https://commits.webkit.org/313984@main">https://commits.webkit.org/313984@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90e4c4b246c784794b784392b5b086634277ac3c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164169 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37653 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30872 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173198 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121421 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fb98020e-ed94-4e5d-a717-802f1a6c6bff) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166038 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37987 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37653 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127539 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89723 "layout-tests (failure)") | [❌ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e542f77a-0208-4d46-8aa3-45457529a4de) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167128 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29832 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147576 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108087 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6e544cb9-f78b-4652-ad28-42ed14edbf57) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28878 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27505 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20962 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138781 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25293 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175724 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28545 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Checked out pull request; Found 33168 issues") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26961 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135849 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37323 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31620 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135819 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36709 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38109 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147088 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100391 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31128 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23944 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36919 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109964 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36316 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/1996 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36566 "Built successfully") | | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36466 "Build is in progress. Recent messages:OS: Tahoe (26.4.1), Xcode: 26.4.1; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | | | | 
<!--EWS-Status-Bubble-End-->