### PR TITLE
Back button not enabled on sciencedirect.com to support Safari's "Close and return to ..." feature for new windows

### DIFF
--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -1348,15 +1348,14 @@ void FrameLoader::loadInSameDocument(URL url, RefPtr<SerializedScriptValue> stat
         // we have already saved away the scroll and doc state for the long slow load,
         // but it's not an obvious case.
 
-        if (historyHandling == NavigationHistoryBehavior::Replace)
-            history().updateBackForwardListForReplaceState(nullptr, url.string());
-        else
-            history().updateBackForwardListForFragmentScroll();
+        auto wasCreatedByJSWithoutUserInteraction = HistoryController::WasCreatedByJSWithoutUserInteraction::No;
+        if (!document->hasRecentUserInteractionForNavigationFromJS() && !documentLoader()->triggeringAction().isRequestFromClientOrUserInput())
+            wasCreatedByJSWithoutUserInteraction = HistoryController::WasCreatedByJSWithoutUserInteraction::Yes;
 
-        if (!document->hasRecentUserInteractionForNavigationFromJS() && !documentLoader()->triggeringAction().isRequestFromClientOrUserInput()) {
-            if (RefPtr currentItem = history().currentItem())
-                currentItem->setWasCreatedByJSWithoutUserInteraction(true);
-        }
+        if (historyHandling == NavigationHistoryBehavior::Replace)
+            history().updateBackForwardListForReplaceState(nullptr, url.string(), wasCreatedByJSWithoutUserInteraction);
+        else
+            history().updateBackForwardListForFragmentScroll(wasCreatedByJSWithoutUserInteraction);
     }
 
     bool hashChange = equalIgnoringFragmentIdentifier(url, oldURL) && !equalRespectingNullity(url.fragmentIdentifier(), oldURL.fragmentIdentifier());

--- a/Source/WebCore/loader/HistoryController.cpp
+++ b/Source/WebCore/loader/HistoryController.cpp
@@ -205,10 +205,10 @@ void HistoryController::restoreScrollPositionAndViewState()
 #endif
 }
 
-void HistoryController::updateBackForwardListForFragmentScroll()
+void HistoryController::updateBackForwardListForFragmentScroll(WasCreatedByJSWithoutUserInteraction wasCreatedByJSWithoutUserInteraction)
 {
     m_frame->navigationScheduler().adjustPendingHistoryNavigationForNewBackForwardEntry();
-    updateBackForwardListClippedAtTarget(false);
+    updateBackForwardListClippedAtTarget(false, wasCreatedByJSWithoutUserInteraction);
 }
 
 void HistoryController::saveDocumentState()
@@ -568,17 +568,18 @@ void HistoryController::updateForStandardLoad(HistoryUpdateType updateType)
     RefPtr documentLoader = frameLoader->documentLoader();
     if (!frameLoader->documentLoader()->isClientRedirect()) {
         if (!historyURL.isEmpty()) {
-            if (updateType != UpdateAllExceptBackForwardList)
-                updateBackForwardListClippedAtTarget(true);
-
+            auto wasCreatedByJSWithoutUserInteraction = WasCreatedByJSWithoutUserInteraction::No;
 #if PLATFORM(COCOA)
-            if (linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::AllBackForwardItemsWithoutUserGestureInvisibleToUI)) {
-                if (m_currentItem && m_frame->isMainFrame() && !documentLoader->triggeringAction().processingUserGesture() && !documentLoader->isRequestFromClientOrUserInput()) {
-                    if (RefPtr document = m_frame->document(); document && !document->hasRecentUserInteractionForNavigationFromJS())
-                        m_currentItem->setWasCreatedByJSWithoutUserInteraction(true);
-                }
+            if (linkedOnOrAfterSDKWithBehavior(SDKAlignedBehavior::AllBackForwardItemsWithoutUserGestureInvisibleToUI)
+                && m_frame->isMainFrame()
+                && !documentLoader->triggeringAction().processingUserGesture()
+                && !documentLoader->isRequestFromClientOrUserInput()) {
+                if (RefPtr document = m_frame->document(); document && !document->hasRecentUserInteractionForNavigationFromJS())
+                    wasCreatedByJSWithoutUserInteraction = WasCreatedByJSWithoutUserInteraction::Yes;
             }
 #endif
+            if (updateType != UpdateAllExceptBackForwardList)
+                updateBackForwardListClippedAtTarget(true, wasCreatedByJSWithoutUserInteraction);
 
             if (canRecordHistory) {
                 protect(frameLoader->client())->updateGlobalHistory();
@@ -1010,11 +1011,11 @@ bool HistoryController::itemsAreClones(HistoryItem& item1, HistoryItem* item2)
         && item1.itemSequenceNumber() == item2->itemSequenceNumber();
 }
 
-void HistoryController::updateBackForwardListClippedAtTarget(bool doClip)
+void HistoryController::updateBackForwardListClippedAtTarget(bool doClip, WasCreatedByJSWithoutUserInteraction wasCreatedByJSWithoutUserInteraction)
 {
-    // In the case of saving state about a page with frames, we store a tree of items that mirrors the frame tree.  
-    // The item that was the target of the user's navigation is designated as the "targetItem".  
-    // When this function is called with doClip=true we're able to create the whole tree except for the target's children, 
+    // In the case of saving state about a page with frames, we store a tree of items that mirrors the frame tree.
+    // The item that was the target of the user's navigation is designated as the "targetItem".
+    // When this function is called with doClip=true we're able to create the whole tree except for the target's children,
     // which will be loaded in the future. That part of the tree will be filled out as the child loads are committed.
     Ref frame = m_frame.get();
     RefPtr page = frame->page();
@@ -1027,6 +1028,9 @@ void HistoryController::updateBackForwardListClippedAtTarget(bool doClip)
     RefPtr item = protect(frame->loader().client())->createHistoryItemTree(doClip, BackForwardItemIdentifier::generate());
     if (!item)
         return;
+
+    if (wasCreatedByJSWithoutUserInteraction)
+        item->setWasCreatedByJSWithoutUserInteraction(true);
     LOG(History, "HistoryController %p updateBackForwardListClippedAtTarget: Adding backforward item %p in frame %p (main frame %d) %s", this, item.get(), m_frame.ptr(), m_frame->isMainFrame(), m_frame->loader().documentLoader()->url().string().utf8().data());
     protect(page->backForward())->addItem(item.releaseNonNull());
 }
@@ -1104,7 +1108,7 @@ void HistoryController::pushState(RefPtr<SerializedScriptValue>&& stateObject, c
     protect(frame->loader().client())->updateGlobalHistory();
 }
 
-void HistoryController::updateBackForwardListForReplaceState(RefPtr<SerializedScriptValue>&& stateObject, const String& urlString)
+void HistoryController::updateBackForwardListForReplaceState(RefPtr<SerializedScriptValue>&& stateObject, const String& urlString, WasCreatedByJSWithoutUserInteraction wasCreatedByJSWithoutUserInteraction)
 {
     RefPtr currentItem = m_currentItem;
     if (!currentItem)
@@ -1117,6 +1121,8 @@ void HistoryController::updateBackForwardListForReplaceState(RefPtr<SerializedSc
     currentItem->setStateObject(WTF::move(stateObject));
     currentItem->setFormData(nullptr);
     currentItem->setFormContentType(String());
+    if (wasCreatedByJSWithoutUserInteraction)
+        currentItem->setWasCreatedByJSWithoutUserInteraction(true);
     currentItem->notifyChanged();
 }
 

--- a/Source/WebCore/loader/HistoryController.h
+++ b/Source/WebCore/loader/HistoryController.h
@@ -51,6 +51,7 @@ class HistoryController final : public CanMakeWeakPtr<HistoryController>  {
     WTF_DEPRECATED_MAKE_FAST_ALLOCATED_WITH_HEAP_IDENTIFIER(HistoryController, Loader);
 public:
     enum HistoryUpdateType { UpdateAll, UpdateAllExceptBackForwardList };
+    enum WasCreatedByJSWithoutUserInteraction : bool { No, Yes };
 
     explicit HistoryController(LocalFrame&);
     ~HistoryController();
@@ -61,8 +62,8 @@ public:
     WEBCORE_EXPORT void saveScrollPositionAndViewStateToItem(HistoryItem*);
     WEBCORE_EXPORT void restoreScrollPositionAndViewState();
 
-    void updateBackForwardListForFragmentScroll();
-    void updateBackForwardListForReplaceState(RefPtr<SerializedScriptValue>&&, const String&);
+    void updateBackForwardListForFragmentScroll(WasCreatedByJSWithoutUserInteraction = WasCreatedByJSWithoutUserInteraction::No);
+    void updateBackForwardListForReplaceState(RefPtr<SerializedScriptValue>&&, const String&, WasCreatedByJSWithoutUserInteraction = WasCreatedByJSWithoutUserInteraction::No);
 
     void saveDocumentState();
     WEBCORE_EXPORT void saveDocumentAndScrollState();
@@ -121,7 +122,7 @@ private:
     void recursiveUpdateForCommit();
     void recursiveUpdateForSameDocumentNavigation();
     static bool NODELETE itemsAreClones(HistoryItem&, HistoryItem*);
-    void updateBackForwardListClippedAtTarget(bool doClip);
+    void updateBackForwardListClippedAtTarget(bool doClip, WasCreatedByJSWithoutUserInteraction = WasCreatedByJSWithoutUserInteraction::No);
     void updateCurrentItem();
     bool isFrameLoadComplete() const { return m_frameLoadComplete; }
 

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKBackForwardListTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKBackForwardListTests.mm
@@ -1941,3 +1941,60 @@ TEST(WKBackForwardList, BackButtonWorksAfterUserClickFromJSCreatedPage)
 
     EXPECT_STREQ([popupWebView URL].absoluteString.UTF8String, server.request("/pageA"_s).URL.absoluteString.UTF8String);
 }
+
+@interface ItemAddedRecordingDelegate : NSObject <WKNavigationDelegatePrivate>
+@end
+
+@implementation ItemAddedRecordingDelegate {
+@public
+    NSUInteger _itemAddedCount;
+    BOOL _lastAddedItemFlag;
+    BOOL _didNavigate;
+}
+
+- (void)webView:(WKWebView *)webView didFinishNavigation:(WKNavigation *)navigation
+{
+    _didNavigate = YES;
+}
+
+- (void)_webView:(WKWebView *)webView navigation:(WKNavigation *)navigation didSameDocumentNavigation:(_WKSameDocumentNavigationType)navigationType
+{
+    if (navigationType == _WKSameDocumentNavigationTypeSessionStatePush || navigationType == _WKSameDocumentNavigationTypeSessionStatePop)
+        _didNavigate = YES;
+}
+
+- (void)_webView:(WKWebView *)webView backForwardListItemAdded:(WKBackForwardListItem *)itemAdded removed:(NSArray<WKBackForwardListItem *> *)itemsRemoved
+{
+    ++_itemAddedCount;
+    _lastAddedItemFlag = itemAdded._wasCreatedByJSWithoutUserInteraction;
+}
+
+@end
+
+TEST(WKBackForwardList, ItemAddedDelegateObservesUserGestureFlagAtCallbackTime)
+{
+    // Before this change, we first added a HistoryItem to the session history and then updated it
+    // as being "made by JS without user gesture" as a separate step.
+    // After this change, items with that flag should be created with that flag and not updated later.
+    //
+    // The separate update was visible to API clients which was unintended, so this test makes sure
+    // the updating doesn't happen.
+    RetainPtr delegate = adoptNS([ItemAddedRecordingDelegate new]);
+    RetainPtr webView = adoptNS([WKWebView new]);
+    [webView setNavigationDelegate:delegate.get()];
+
+    RetainPtr url = [NSBundle.test_resourcesBundle URLForResource:@"simple" withExtension:@"html"];
+    [webView loadRequest:[NSURLRequest requestWithURL:url.get()]];
+    TestWebKitAPI::Util::run(&delegate.get()->_didNavigate);
+
+    // The initial load fired one callback for the first item (flag=NO). Reset to track the next.
+    delegate.get()->_itemAddedCount = 0;
+    delegate.get()->_lastAddedItemFlag = NO;
+    delegate.get()->_didNavigate = NO;
+
+    [webView _evaluateJavaScriptWithoutUserGesture:@"location.hash = '#a';" completionHandler:nil];
+    TestWebKitAPI::Util::run(&delegate.get()->_didNavigate);
+
+    EXPECT_EQ(delegate.get()->_itemAddedCount, 1U);
+    EXPECT_TRUE(delegate.get()->_lastAddedItemFlag);
+}


### PR DESCRIPTION
#### 523b810325c4ddb180cca01c35a0f8981a9eed77
<pre>
Back button not enabled on sciencedirect.com to support Safari&apos;s &quot;Close and return to ...&quot; feature for new windows
<a href="https://rdar.apple.com/177792841">rdar://177792841</a>
<a href="https://bugs.webkit.org/show_bug.cgi?id=315440">https://bugs.webkit.org/show_bug.cgi?id=315440</a>

Reviewed by Richard Robinson.

Before this change, we add new history items to the back/forward list in one step, then flag them as
&quot;created by JS without user interaction&quot; in a separate step.

The first step performs a delegate callback to notify the app that the bf-list changed.
The app then runs some code based on the bf-list change.

Then the second step updates the items flag, which can change the presentation of the bf-list,
notably by making it shorter by hiding some items.

But the app saw the &quot;incorrect&quot; list already, and already ran code, which might&apos;ve been destructive.

This patch sets the flag upon initial creation of the history item which removes this interstitial gap.

This allows the app to make its decisions based on an always accurate presentation of the bf-list.

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKBackForwardListTests.mm

* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::FrameLoader::loadInSameDocument):
* Source/WebCore/loader/HistoryController.cpp:
(WebCore::HistoryController::updateBackForwardListForFragmentScroll):
(WebCore::HistoryController::updateForStandardLoad):
(WebCore::HistoryController::updateBackForwardListClippedAtTarget):
(WebCore::HistoryController::updateBackForwardListForReplaceState):
* Source/WebCore/loader/HistoryController.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKBackForwardListTests.mm:
(-[ItemAddedRecordingDelegate webView:didFinishNavigation:]):
(-[ItemAddedRecordingDelegate _webView:navigation:didSameDocumentNavigation:]):
(-[ItemAddedRecordingDelegate _webView:backForwardListItemAdded:removed:]):
(TEST(WKBackForwardList, ItemAddedDelegateObservesUserGestureFlagAtCallbackTime)):

Canonical link: <a href="https://commits.webkit.org/313814@main">https://commits.webkit.org/313814@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6b7554a3c74530226dbfea221c708870b618d7c3

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164211 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37695 "Built successfully") | [❌ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30914 "Hash 6b7554a3 for PR 65548 does not build (failure)") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173240 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121463 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/34d8bfe5-dba1-4a5d-a334-621c6acd7522) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166080 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38029 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit (warnings)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37695 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/127572 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89756 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/29b97a5d-c7aa-4843-853d-c0bf08c0febd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167170 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29869 "Passed tests") | [❌ 🧪 api-mac](https://ews-build.webkit.org/#/builders/168/builds/30914 "Hash 6b7554a3 for PR 65548 does not build (failure)") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108120 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d9459cf1-17ef-489e-b36a-5576a9cf3c0c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28916 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/27541 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21004 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138818 "Passed tests") | [❌ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/168/builds/30914 "Hash 6b7554a3 for PR 65548 does not build (failure)") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175766 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28587 "Built successfully") | [❌ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/168/builds/30914 "Hash 6b7554a3 for PR 65548 does not build (failure)") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135883 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37365 "Built successfully") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31656 "Build is in progress. Recent messages:OS: Tahoe (26.5), Xcode: 26.5; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; 10 flakes 5 failures; Uploaded test results") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135853 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36605 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38151 "Built successfully") | [❌ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/168/builds/30914 "Hash 6b7554a3 for PR 65548 does not build (failure)") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100461 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31164 "Passed tests") | [❌ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/168/builds/30914 "Hash 6b7554a3 for PR 65548 does not build (failure)") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36961 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110006 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36358 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/168/builds/30914 "Hash 6b7554a3 for PR 65548 does not build (failure)") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36608 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36508 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->