### PR TITLE
IntersectionObserver should not notify targets in detached documents

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/target-in-detached-document-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/target-in-detached-document-expected.txt
@@ -1,4 +1,5 @@
 
 PASS IntersectionObserver in a single document using the implicit root.
-FAIL First rAF. assert_equals: No initial notification while in detached document. expected 0 but got 1
+PASS First rAF.
+PASS Adopt target.
 

--- a/Source/WebCore/page/IntersectionObserver.cpp
+++ b/Source/WebCore/page/IntersectionObserver.cpp
@@ -681,6 +681,19 @@ auto IntersectionObserver::updateObservations(const Frame& hostFrame) -> NeedNot
     auto needNotify = NeedNotify::No;
 
     for (auto& target : observationTargets()) {
+        // For implicit-root observers, a target whose owning Document is not fully
+        // active (e.g. created via document.implementation.createHTMLDocument) cannot
+        // produce an intersection. Skip without advancing the registration state, so a
+        // later adopt into a fully-active document is treated as the first observation.
+        // Drop the first-observation keep-alive so a permanently detached target/document
+        // can be collected (intersection-observer/no-document-leak.html).
+        if (!root() && !target.document().isFullyActive()) {
+            m_targetsWaitingForFirstObservation.removeFirstMatching([&](auto& pendingTarget) {
+                return pendingTarget.ptr() == &target;
+            });
+            continue;
+        }
+
         auto& targetRegistrations = target.intersectionObserverDataIfExists()->registrations;
         auto index = targetRegistrations.findIf([&](auto& registration) {
             return registration.observer.get() == this;


### PR DESCRIPTION
#### b49b5a000685f86c8d7d16eaeda6fbc0a1d0e0c8
<pre>
IntersectionObserver should not notify targets in detached documents
<a href="https://bugs.webkit.org/show_bug.cgi?id=300729">https://bugs.webkit.org/show_bug.cgi?id=300729</a>
<a href="https://rdar.apple.com/162699098">rdar://162699098</a>

Reviewed by Chris Dumez.

HTML&apos;s &quot;update the rendering&quot; steps build the docs list from &quot;all
fully active Document objects&quot; [1], so the intersection observer
update step (Step 19) [1] never runs for a detached document. A
target whose owning Document is not fully active therefore cannot
legitimately produce an intersection.

WebKit still queued an initial zero-rect, not-intersecting entry for
such targets, so target-in-detached-document.html saw one notification
before the target was adopted into a fully-active document where the
specification expect none.

Fix it by skipping such targets in updateObservations without
advancing previousThresholdIndex, so a later adoptNode is treated as
the first observation.

This skip is gated on implicit root observers, &quot;Update the rendering&quot;
[1] (Step 19) invoke &quot;run the update intersection observations
steps&quot; [2] which iterates &quot;all IntersectionObservers whose root is
in the DOM tree of document … this includes implicit root
observers&quot;. The explicit-root [3] case is left alone and continues
to be tested by explicit-root-different-document.html.

Drop the skipped target from m_targetsWaitingForFirstObservation so a
permanently detached target/document can be collected
(i.e., intersection-observer/no-document-leak.html).

[1] <a href="https://html.spec.whatwg.org/#update-the-rendering">https://html.spec.whatwg.org/#update-the-rendering</a>
[2] <a href="https://w3c.github.io/IntersectionObserver/#run-the-update-intersection-observations-steps">https://w3c.github.io/IntersectionObserver/#run-the-update-intersection-observations-steps</a>
[3] <a href="https://w3c.github.io/IntersectionObserver/#intersectionobserver-explicit-root-observer">https://w3c.github.io/IntersectionObserver/#intersectionobserver-explicit-root-observer</a>

* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/target-in-detached-document-expected.txt: Progression
* Source/WebCore/page/IntersectionObserver.cpp:
(WebCore::IntersectionObserver::updateObservations):

Canonical link: <a href="https://commits.webkit.org/313834@main">https://commits.webkit.org/313834@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c84a26e4f6c8305f7a5d5d4da73274bb0f5b4c17

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164182 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37666 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30885 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173211 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121434 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/218bb26b-c42a-4c85-9a10-805221f35550) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166051 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38000 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37666 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127548 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89734 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/425587c6-af02-42e4-ad6c-c5941bae4943) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167141 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29843 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147590 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108096 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3c104ab9-1952-44b6-8b97-538301c635a2) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28889 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27516 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20975 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138792 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25307 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175737 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28558 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26975 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135858 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 10 flakes 8 failures; Uploaded test results; 1 flakes 2 failures; Compiled WebKit; 2 failures; Passed layout tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37336 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31631 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135828 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36617 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38122 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147102 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100416 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31139 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23958 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; 8 flakes 1 failures; Uploaded test results; 12 flakes") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36932 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109977 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36329 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2018 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36579 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36479 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->