### PR TITLE
Use OrderedHashSet instead of ListHashSet in Pasteboard

### DIFF
--- a/Source/WebCore/platform/Pasteboard.h
+++ b/Source/WebCore/platform/Pasteboard.h
@@ -32,8 +32,8 @@
 #include <WebCore/PasteboardItemInfo.h>
 #include <WebCore/SharedBuffer.h>
 #include <wtf/HashMap.h>
-#include <wtf/ListHashSet.h>
 #include <wtf/Noncopyable.h>
+#include <wtf/OrderedHashSet.h>
 #include <wtf/Platform.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/URL.h>
@@ -360,7 +360,7 @@ private:
 #if PLATFORM(COCOA)
     Vector<String> readFilePaths();
     Vector<String> readPlatformValuesAsStrings(const String& domType, int64_t changeCount, const String& pasteboardName);
-    static void addHTMLClipboardTypesForCocoaType(ListHashSet<String>& resultTypes, const String& cocoaType);
+    static void addHTMLClipboardTypesForCocoaType(OrderedHashSet<String>& resultTypes, const String& cocoaType);
     String readStringForPlatformType(const String&);
     Vector<String> readTypesWithSecurityCheck();
     RefPtr<SharedBuffer> readBufferForTypeWithSecurityCheck(const String&);

--- a/Source/WebCore/platform/cocoa/PasteboardCocoa.mm
+++ b/Source/WebCore/platform/cocoa/PasteboardCocoa.mm
@@ -32,7 +32,7 @@
 #import "SharedBuffer.h"
 #import <ImageIO/ImageIO.h>
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
-#import <wtf/ListHashSet.h>
+#import <wtf/OrderedHashSet.h>
 #import <wtf/text/StringHash.h>
 
 #if PLATFORM(IOS_FAMILY)
@@ -197,7 +197,7 @@ Vector<String> Pasteboard::typesForLegacyUnsafeBindings()
     if (cocoaTypes.isEmpty())
         return cocoaTypes;
 
-    ListHashSet<String> result;
+    OrderedHashSet<String> result;
     for (auto& cocoaType : cocoaTypes)
         addHTMLClipboardTypesForCocoaType(result, cocoaType);
 

--- a/Source/WebCore/platform/glib/PasteboardGLib.cpp
+++ b/Source/WebCore/platform/glib/PasteboardGLib.cpp
@@ -377,7 +377,7 @@ bool Pasteboard::hasData()
 Vector<String> Pasteboard::typesSafeForBindings(const String& origin)
 {
     if (m_selectionData) {
-        ListHashSet<String> types;
+        OrderedHashSet<String> types;
         if (auto& buffer = m_selectionData->customData()) {
             auto customData = PasteboardCustomData::fromSharedBuffer(*buffer);
             if (customData.origin() == origin) {

--- a/Source/WebCore/platform/ios/PasteboardIOS.mm
+++ b/Source/WebCore/platform/ios/PasteboardIOS.mm
@@ -548,7 +548,7 @@ Vector<String> Pasteboard::readPlatformValuesAsStrings(const String& domType, in
     return values;
 }
 
-void Pasteboard::addHTMLClipboardTypesForCocoaType(ListHashSet<String>& resultTypes, const String& cocoaType)
+void Pasteboard::addHTMLClipboardTypesForCocoaType(OrderedHashSet<String>& resultTypes, const String& cocoaType)
 {
     RetainPtr nsType = cocoaType.createNSString();
     // UTI may not do these right, so make sure we get the right, predictable result.

--- a/Source/WebCore/platform/ios/PlatformPasteboardIOS.mm
+++ b/Source/WebCore/platform/ios/PlatformPasteboardIOS.mm
@@ -43,7 +43,7 @@
 #import <UniformTypeIdentifiers/UniformTypeIdentifiers.h>
 #import <WebCore/AttributedString.h>
 #import <pal/spi/ios/UIKitSPI.h>
-#import <wtf/ListHashSet.h>
+#import <wtf/OrderedHashSet.h>
 #import <wtf/URL.h>
 #import <wtf/cocoa/NSURLExtras.h>
 #import <wtf/cocoa/RuntimeApplicationChecksCocoa.h>
@@ -181,7 +181,7 @@ static const char *safeTypeForDOMToReadAndWriteForPlatformType(NSString *platfor
 
 static Vector<String> webSafeTypes(NSArray<NSString *> *platformTypes, PlatformPasteboard::IncludeImageTypes includeImageTypes, Function<bool()>&& shouldAvoidExposingURLType)
 {
-    ListHashSet<String> domPasteboardTypes;
+    OrderedHashSet<String> domPasteboardTypes;
     for (NSString *type in platformTypes) {
         if ([type isEqualToString:@(PasteboardCustomData::cocoaType().characters())])
             continue;
@@ -584,7 +584,7 @@ static const char customTypesKeyForTeamData[] = "com.apple.WebKit.drag-and-drop-
 
 Vector<String> PlatformPasteboard::typesSafeForDOMToReadAndWrite(const String& origin) const
 {
-    ListHashSet<String> domPasteboardTypes;
+    OrderedHashSet<String> domPasteboardTypes;
 #if PASTEBOARD_SUPPORTS_PRESENTATION_STYLE_AND_TEAM_DATA
     for (NSItemProvider *provider in [m_pasteboard itemProviders]) {
         if (!provider.teamData.length)

--- a/Source/WebCore/platform/mac/PasteboardMac.mm
+++ b/Source/WebCore/platform/mac/PasteboardMac.mm
@@ -666,7 +666,7 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     return String();
 }
 
-void Pasteboard::addHTMLClipboardTypesForCocoaType(ListHashSet<String>& resultTypes, const String& cocoaType)
+void Pasteboard::addHTMLClipboardTypesForCocoaType(OrderedHashSet<String>& resultTypes, const String& cocoaType)
 {
     if (cocoaType == "NeXT plain ascii pasteboard type"_s)
         return; // Skip this ancient type that gets auto-supplied by some system conversion.

--- a/Source/WebCore/platform/mac/PlatformPasteboardMac.mm
+++ b/Source/WebCore/platform/mac/PlatformPasteboardMac.mm
@@ -38,7 +38,7 @@
 #import <pal/spi/cocoa/FoundationSPI.h>
 #import <pal/spi/mac/NSPasteboardSPI.h>
 #import <wtf/HashCountedSet.h>
-#import <wtf/ListHashSet.h>
+#import <wtf/OrderedHashSet.h>
 #import <wtf/URL.h>
 #import <wtf/cocoa/TypeCastsCocoa.h>
 #import <wtf/cocoa/VectorCocoa.h>
@@ -266,7 +266,7 @@ static ASCIILiteral safeTypeForDOMToReadAndWriteForPlatformType(NSString *platfo
 
 Vector<String> PlatformPasteboard::typesSafeForDOMToReadAndWrite(const String& origin) const
 {
-    ListHashSet<String> domPasteboardTypes;
+    OrderedHashSet<String> domPasteboardTypes;
     if (RetainPtr serializedCustomData = [m_pasteboard dataForType:RetainPtr { @(PasteboardCustomData::cocoaType().characters()) }.get()]) {
         auto data = PasteboardCustomData::fromSharedBuffer(SharedBuffer::create(serializedCustomData.get()).get());
         if (data.origin() == origin) {
@@ -598,7 +598,7 @@ std::optional<PasteboardItemInfo> PlatformPasteboard::informationForItemAtIndex(
     PasteboardItemInfo info;
     RetainPtr<NSArray<NSPasteboardType>> platformTypes = [item types];
     auto containsFileURL = [platformTypes containsObject:NSPasteboardTypeFileURL] ? ContainsFileURL::Yes : ContainsFileURL::No;
-    ListHashSet<String> webSafeTypes;
+    OrderedHashSet<String> webSafeTypes;
     info.platformTypesByFidelity.reserveInitialCapacity(platformTypes.get().count);
     for (NSPasteboardType type in platformTypes.get()) {
         info.platformTypesByFidelity.append(type);

--- a/Source/WebCore/platform/win/PasteboardWin.cpp
+++ b/Source/WebCore/platform/win/PasteboardWin.cpp
@@ -243,7 +243,7 @@ bool Pasteboard::hasData()
     return !m_dragDataMap.isEmpty();
 }
 
-static void addMimeTypesForFormat(ListHashSet<String>& results, const FORMATETC& format)
+static void addMIMETypesForFormat(OrderedHashSet<String>& results, const FORMATETC& format)
 {
     if (format.cfFormat == urlFormat()->cfFormat || format.cfFormat == urlWFormat()->cfFormat)
         results.add("text/uri-list"_s);
@@ -272,7 +272,7 @@ std::optional<PasteboardCustomData> Pasteboard::readPasteboardCustomData()
 
 Vector<String> Pasteboard::typesSafeForBindings(const String& origin)
 {
-    ListHashSet<String> domPasteboardTypes;
+    OrderedHashSet<String> domPasteboardTypes;
 
     std::optional<PasteboardCustomData> customData = readPasteboardCustomData();
 
@@ -290,7 +290,7 @@ Vector<String> Pasteboard::typesSafeForBindings(const String& origin)
 
 Vector<String> Pasteboard::typesForLegacyUnsafeBindings()
 {
-    ListHashSet<String> results;
+    OrderedHashSet<String> results;
 
     if (!m_dataObject && m_dragDataMap.isEmpty())
         return Vector<String>();
@@ -308,12 +308,12 @@ Vector<String> Pasteboard::typesForLegacyUnsafeBindings()
 
         // IEnumFORMATETC::Next returns S_FALSE if there are no more items.
         while (itr->Next(1, &data, 0) == S_OK)
-            addMimeTypesForFormat(results, data);
+            addMIMETypesForFormat(results, data);
     } else {
         for (DragDataMap::const_iterator it = m_dragDataMap.begin(); it != m_dragDataMap.end(); ++it) {
             FORMATETC data;
             data.cfFormat = (*it).key;
-            addMimeTypesForFormat(results, data);
+            addMIMETypesForFormat(results, data);
         }
     }
 


### PR DESCRIPTION
#### 44c372da8d63ebca486e4eb715b139c1606d6d03
<pre>
Use OrderedHashSet instead of ListHashSet in Pasteboard
<a href="https://bugs.webkit.org/show_bug.cgi?id=315442">https://bugs.webkit.org/show_bug.cgi?id=315442</a>
<a href="https://rdar.apple.com/177805590">rdar://177805590</a>

Reviewed by Ryosuke Niwa.

* Source/WebCore/platform/Pasteboard.h:
* Source/WebCore/platform/cocoa/PasteboardCocoa.mm:
(WebCore::Pasteboard::typesForLegacyUnsafeBindings):
* Source/WebCore/platform/glib/PasteboardGLib.cpp:
(WebCore::Pasteboard::typesSafeForBindings):
* Source/WebCore/platform/ios/PasteboardIOS.mm:
(WebCore::Pasteboard::addHTMLClipboardTypesForCocoaType):
* Source/WebCore/platform/ios/PlatformPasteboardIOS.mm:
(WebCore::webSafeTypes):
(WebCore::PlatformPasteboard::typesSafeForDOMToReadAndWrite const):
* Source/WebCore/platform/mac/PasteboardMac.mm:
(WebCore::Pasteboard::addHTMLClipboardTypesForCocoaType):
* Source/WebCore/platform/mac/PlatformPasteboardMac.mm:
(WebCore::PlatformPasteboard::typesSafeForDOMToReadAndWrite const):
(WebCore::PlatformPasteboard::informationForItemAtIndex):
* Source/WebCore/platform/win/PasteboardWin.cpp:
(WebCore::addMimeTypesForFormat):
(WebCore::Pasteboard::typesSafeForBindings):
(WebCore::Pasteboard::typesForLegacyUnsafeBindings):

Canonical link: <a href="https://commits.webkit.org/313809@main">https://commits.webkit.org/313809@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c7bb46b07df18421127cf29e26ece743898f575e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164173 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37657 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30876 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173202 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121425 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4616e55a-6ebd-4991-ae0a-b7f8e0323aa0) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166042 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37991 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37657 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127542 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89729 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/78532dd6-8abe-4843-9f65-1f0749c6a887) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167132 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29837 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147581 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108090 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6583db7c-cc3c-44d7-a5f9-05c0e33ab592) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28883 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27509 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20966 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138786 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25298 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175728 "Built successfully") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28549 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Checked out pull request; Found 33168 issues") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26966 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135852 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37327 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31624 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135822 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36602 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38113 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147093 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100401 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31133 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23949 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36923 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109968 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36320 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2001 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36570 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36470 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->