### PR TITLE
[CMake] List WebCore.framework bundle resources explicitly to bring back true null build

### DIFF
--- a/Source/WebCore/PlatformMac.cmake
+++ b/Source/WebCore/PlatformMac.cmake
@@ -5,8 +5,30 @@ include(PlatformCocoa.cmake)
 file(COPY "${WEBCORE_DIR}/en.lproj"
      DESTINATION "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebCore.framework/Versions/A/Resources")
 
-# Copy the proper resources over, mirroring Xcode.
-file(GLOB WebCore_BUNDLE_RESOURCES CONFIGURE_DEPENDS "${WEBCORE_DIR}/Resources/*")
+# Copy the proper resources over, mirroring Xcode's Resources build phase.
+# Listed explicitly (rather than globbed) so null builds stay clean.
+set(WebCore_BUNDLE_RESOURCES
+    ${WEBCORE_DIR}/Resources/ContentFilterBlockedPage.html
+    ${WEBCORE_DIR}/Resources/ListButtonArrow.png
+    ${WEBCORE_DIR}/Resources/ListButtonArrow@2x.png
+    ${WEBCORE_DIR}/Resources/copyCursor.png
+    ${WEBCORE_DIR}/Resources/deleteButtonPressed.tiff
+    ${WEBCORE_DIR}/Resources/linearSRGB.icc
+    ${WEBCORE_DIR}/Resources/missingImage.png
+    ${WEBCORE_DIR}/Resources/missingImage@2x.png
+    ${WEBCORE_DIR}/Resources/missingImage@3x.png
+    ${WEBCORE_DIR}/Resources/modelDefaultDiffuseData
+    ${WEBCORE_DIR}/Resources/modelDefaultSpecularData
+    ${WEBCORE_DIR}/Resources/moveCursor.png
+    ${WEBCORE_DIR}/Resources/northEastSouthWestResizeCursor.png
+    ${WEBCORE_DIR}/Resources/northSouthResizeCursor.png
+    ${WEBCORE_DIR}/Resources/northWestSouthEastResizeCursor.png
+    ${WEBCORE_DIR}/Resources/nullPlugin.png
+    ${WEBCORE_DIR}/Resources/nullPlugin@2x.png
+    ${WEBCORE_DIR}/Resources/panIcon.png
+    ${WEBCORE_DIR}/Resources/textAreaResizeCorner.png
+    ${WEBCORE_DIR}/Resources/textAreaResizeCorner@2x.png
+)
 WEBKIT_COPY_FILES(WebCore_CopyBundleResources
     DESTINATION "${CMAKE_LIBRARY_OUTPUT_DIRECTORY}/WebCore.framework/Versions/A/Resources"
     FILES ${WebCore_BUNDLE_RESOURCES}


### PR DESCRIPTION
#### fb4a998a6e6c9144357a0db8eea5f682c99791ca
<pre>
[CMake] List WebCore.framework bundle resources explicitly to bring back true null build
<a href="https://bugs.webkit.org/show_bug.cgi?id=315443">https://bugs.webkit.org/show_bug.cgi?id=315443</a>
<a href="https://rdar.apple.com/177806988">rdar://177806988</a>

Reviewed by Pascoe.

The CONFIGURE_DEPENDS glob added in 313697@main re-runs every build and
dirties the build graph, breaking null builds. Replace it with an
explicit file list, mirroring how Xcode&apos;s Resources build phase already
enumerates each file.

* Source/WebCore/PlatformMac.cmake:

Canonical link: <a href="https://commits.webkit.org/313805@main">https://commits.webkit.org/313805@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/05b49c81b7b70861f7626e98bbf3abf87c0bbf9d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164176 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37660 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30879 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173205 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121428 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4a06cc5b-0856-45ba-a90e-4970b5e9ec73) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166045 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/37994 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37660 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127544 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89730 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/4328662d-e670-46c4-8791-6f735d0c5da3) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167135 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29839 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147584 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108092 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/8ff02e55-6662-4082-9708-eb1b690878bc) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28885 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27511 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20969 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138788 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25301 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175731 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28552 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26969 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135854 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37330 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31626 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135824 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36601 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38116 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147096 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100404 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31134 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23952 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36926 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109971 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36323 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/2004 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36573 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36473 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->