### PR TITLE
IntersectionObserver does not compute intersections for SVG element roots

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/svg-intersection-with-fractional-bounds-2-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/svg-intersection-with-fractional-bounds-2-expected.txt
@@ -1,8 +1,8 @@
 
 PASS IntersectionObserver observing an SVG <rect> with fractional bounds element
-FAIL Initial Observation assert_approx_equals: entries[0].boundingClientRect.right expected 0.004 +/- 0.0001 but got 0
-FAIL Changing target y position to -2 (-0.002 in root coordinates) assert_equals: entries.length expected 2 but got 1
-FAIL Changing target y position to -1 (-0.001 in root coordinates) assert_equals: entries.length expected 3 but got 1
-FAIL Changing target y position to -4 (-0.004 in root coordinates) assert_equals: entries.length expected 4 but got 1
-FAIL Changing target y position to 0 assert_equals: entries.length expected 5 but got 1
+PASS Initial Observation
+PASS Changing target y position to -2 (-0.002 in root coordinates)
+PASS Changing target y position to -1 (-0.001 in root coordinates)
+PASS Changing target y position to -4 (-0.004 in root coordinates)
+PASS Changing target y position to 0
 

--- a/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/svg-viewbox-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/intersection-observer/svg-viewbox-expected.txt
@@ -1,5 +1,5 @@
 
 PASS IntersectionObserver observing an SVG <rect> element with changing 'transform'
-FAIL First rAF. assert_approx_equals: entries[0].boundingClientRect.right expected 10 +/- 0 but got 0
-FAIL change target's y property to -64) assert_equals: entries.length expected 2 but got 1
+PASS First rAF.
+PASS change target's y property to -64)
 

--- a/Source/WebCore/page/IntersectionObserver.cpp
+++ b/Source/WebCore/page/IntersectionObserver.cpp
@@ -45,6 +45,7 @@
 #include "IntersectionObserverEntry.h"
 #include "JSNodeCustom.h"
 #include "LegacyRenderSVGModelObject.h"
+#include "LegacyRenderSVGRoot.h"
 #include "LocalDOMWindow.h"
 #include "Logging.h"
 #include "Performance.h"
@@ -54,7 +55,9 @@
 #include "RenderLineBreak.h"
 #include "RenderObjectInlines.h"
 #include "RenderSVGModelObject.h"
+#include "RenderSVGRoot.h"
 #include "RenderView.h"
+#include "SVGRenderSupport.h"
 #include "StyleKeyword+Logging.h"
 #include "StylePrimitiveNumericTypes+Conversions.h"
 #include "StylePrimitiveNumericTypes+Evaluation.h"
@@ -501,7 +504,7 @@ auto IntersectionObserver::computeIntersectionState(const IntersectionObserverRe
 
     // This is only set for explicit roots.
     // FIXME: remove one remaining place that needs this to work with implicit root.
-    CheckedPtr<RenderBlock> rootRenderer;
+    CheckedPtr<RenderBox> rootRenderer;
 
     CheckedPtr<RenderElement> targetRenderer;
     IntersectionObservationState intersectionState;
@@ -527,8 +530,26 @@ auto IntersectionObserver::computeIntersectionState(const IntersectionObserverRe
             if (!root()->renderer())
                 return;
 
-            rootRenderer = dynamicDowncast<RenderBlock>(root()->renderer());
-            if (!rootRenderer || !rootRenderer->isContainingBlockAncestorFor(*targetRenderer))
+            // Use RenderBox here rather than RenderBlock so explicit SVG roots
+            // (LegacyRenderSVGRoot and RenderSVGRoot are RenderReplaced) are accepted.
+            rootRenderer = dynamicDowncast<RenderBox>(root()->renderer());
+            if (!rootRenderer)
+                return;
+
+            auto isRootAncestorOfTarget = [&] {
+                // containingBlock() skips the SVG boundary (the SVG root is a
+                // RenderReplaced), so resolve an explicit SVG root via the target's SVG tree root.
+                if (CheckedPtr legacySVGRoot = dynamicDowncast<LegacyRenderSVGRoot>(rootRenderer))
+                    return SVGRenderSupport::findTreeRootObject(*targetRenderer) == legacySVGRoot;
+                if (CheckedPtr svgRoot = dynamicDowncast<RenderSVGRoot>(rootRenderer))
+                    return lineageOfType<RenderSVGRoot>(*targetRenderer).first() == svgRoot;
+
+                // isContainingBlockAncestorFor is only available on RenderBlock.
+                CheckedPtr rootBlock = dynamicDowncast<RenderBlock>(rootRenderer);
+                return rootBlock && rootBlock->isContainingBlockAncestorFor(*targetRenderer);
+            };
+
+            if (!isRootAncestorOfTarget())
                 return;
 
             intersectionState.canComputeIntersection = true;


### PR DESCRIPTION
#### df9d73be75356c5200568fb53708f15c7997d211
<pre>
IntersectionObserver does not compute intersections for SVG element roots
<a href="https://bugs.webkit.org/show_bug.cgi?id=315445">https://bugs.webkit.org/show_bug.cgi?id=315445</a>
<a href="https://rdar.apple.com/177807041">rdar://177807041</a>

Reviewed by Simon Fraser.

IntersectionObserver::computeIntersectionState() bailed out when an
explicit root was an SVG element: the rootRenderer downcast was
RenderBlock, but both LegacyRenderSVGRoot and RenderSVGRoot derive
from RenderReplaced, so the cast returned null and
canComputeIntersection stayed false. Every entry was queued with
zero rects, and once previousThresholdIndex pinned to 0 against the
zero geometry no later setAttribute() change could shift the
threshold, so subsequent observations were dropped.

Relax the cast to RenderBox (which both SVG roots and RenderBlock
derive from) and resolve the root-ancestor check by root type:

- When the explicit root is an SVG element, resolve via the target&apos;s
  SVG tree root, since containingBlock() skips SVG boundaries (the SVG
  root is a RenderReplaced; see the note in
  RenderObject::propagateFragmentedFlowState). Legacy SVG uses
  SVGRenderSupport::findTreeRootObject; LBSE uses lineageOfType&lt;RenderSVGRoot&gt;.
- Otherwise walk containingBlock() to the root, as before.

NOTE: This patch fixes both Legacy and Layer Based SVG engines.

* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/svg-intersection-with-fractional-bounds-2-expected.txt: Progressions
* LayoutTests/imported/w3c/web-platform-tests/intersection-observer/svg-viewbox-expected.txt: Ditto
* Source/WebCore/page/IntersectionObserver.cpp:
(WebCore::IntersectionObserver::computeIntersectionState const):

Canonical link: <a href="https://commits.webkit.org/314837@main">https://commits.webkit.org/314837@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/052dd136a5b47931b3789169dfe89397b7eeed77

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167265 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40760 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34352 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176314 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/124946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/becc4144-8e19-4643-8d79-272de57b127a) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169131 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41193 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40773 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130112 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/124946 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d0f52d8a-076b-42ad-b899-0e5f308ddd7e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170224 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32513 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150287 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110629 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/292ff712-0b24-490c-804b-a0f75ddd8f18) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31495 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30195 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25052 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141478 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27979 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178855 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31754 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29697 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138499 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40834 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34348 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138389 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37278 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41522 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104525 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33638 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26649 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40026 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113107 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39423 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4747 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39673 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39568 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->