### PR TITLE
[JSC] Fix `Math.sumPrecise` for `-Number.MAX_VALUE`

### DIFF
--- a/JSTests/stress/math-sum-precise.js
+++ b/JSTests/stress/math-sum-precise.js
@@ -45,6 +45,9 @@ for (var i = 0; i < testLoopCount; i++) {
     shouldBe(Math.sumPrecise([-Infinity]), -Infinity);
     shouldBe(Math.sumPrecise([-Infinity, -Infinity]), -Infinity);
 
+    shouldBe(Math.sumPrecise([Number.MAX_VALUE]), Number.MAX_VALUE);
+    shouldBe(Math.sumPrecise([-Number.MAX_VALUE]), -Number.MAX_VALUE);
+
     shouldBe(Math.sumPrecise([]), -0);
     shouldBe(Math.sumPrecise([-0]), -0);
     shouldBe(Math.sumPrecise([-0, -0]), -0);

--- a/Source/WTF/wtf/PreciseSum.cpp
+++ b/Source/WTF/wtf/PreciseSum.cpp
@@ -549,17 +549,24 @@ double XsumSmall::compute()
         ivalue = -ivalue;
         if ((ivalue & 3) == 3)
             shouldRoundAwayFromZero = true;
-        if (!lower) {
-            while (j > 0) {
-                j -= 1;
-                if (m_smallAccumulator.chunk[j]) {
-                    lower = 1;
-                    break;
+        else if ((ivalue & 3) <= 1 || !(ivalue & 4)) {
+            // this is not required,
+            // but removing the branch would change the logic
+            // leave it as it is
+            shouldRoundAwayFromZero = false;
+        } else {
+            if (!lower) {
+                while (j > 0) {
+                    j -= 1;
+                    if (m_smallAccumulator.chunk[j]) {
+                        lower = 1;
+                        break;
+                    }
                 }
             }
+            if (!lower)
+                shouldRoundAwayFromZero = true;
         }
-        if (!lower)
-            shouldRoundAwayFromZero = true;
     }
 
     if (shouldRoundAwayFromZero) {

--- a/Tools/TestWebKitAPI/Tests/WTF/PreciseSum.cpp
+++ b/Tools/TestWebKitAPI/Tests/WTF/PreciseSum.cpp
@@ -32,8 +32,9 @@ namespace TestWebKitAPI {
 
 static constexpr double Infinity = std::numeric_limits<double>::infinity();
 static constexpr double NaN = std::numeric_limits<double>::quiet_NaN();
+static constexpr double MAX_VALUE = std::numeric_limits<double>::max();
 
-static const std::array<std::pair<std::vector<double>, double>, 38> TEST_CASES = { {
+static const std::array<std::pair<std::vector<double>, double>, 40> TEST_CASES = { {
     { { 1, 2, 3 }, 6 },
     { { 1e308 }, 1e308 },
     { { 1e308, -1e308 }, 0 },
@@ -69,6 +70,8 @@ static const std::array<std::pair<std::vector<double>, double>, 38> TEST_CASES =
     { { Infinity, Infinity }, Infinity },
     { { -Infinity }, -Infinity },
     { { -Infinity, -Infinity }, -Infinity },
+    { { MAX_VALUE }, MAX_VALUE },
+    { { -MAX_VALUE }, -MAX_VALUE },
 
     { { }, -0 },
     { { 0 }, 0 },


### PR DESCRIPTION
#### bf3b6d2113f59a8c0817367ff1e74d589334b030
<pre>
[JSC] Fix `Math.sumPrecise` for `-Number.MAX_VALUE`
<a href="https://bugs.webkit.org/show_bug.cgi?id=315450">https://bugs.webkit.org/show_bug.cgi?id=315450</a>

Reviewed by NOBODY (OOPS!).

Currently, `Math.sumPrecise([-Number.MAX_VALUE])` returns `-infinity`.
This patch fixes the bug.

Test: Tools/TestWebKitAPI/Tests/WTF/PreciseSum.cpp

* JSTests/stress/math-sum-precise.js:
* Source/WTF/wtf/PreciseSum.cpp:
(WTF::Xsum::XsumSmall::compute):
* Tools/TestWebKitAPI/Tests/WTF/PreciseSum.cpp:
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/bf3b6d2113f59a8c0817367ff1e74d589334b030

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164187 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37671 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30890 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173216 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121439 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166056 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38005 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37671 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127554 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89738 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167146 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29850 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Skipped layout-tests; 3 new passes 8 flakes 3 failures; Uploaded test results; Ignored 2 pre-existing failure based on results-db") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147594 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108102 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28897 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27521 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20980 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/156338 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC (warnings); Passed JSC tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138799 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25311 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175742 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/25079 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28563 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26979 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135864 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37341 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31636 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135834 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38127 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147106 "Passed tests") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/100422 "The change is no longer eligible for processing.") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31145 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23962 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/196590 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36937 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/109982 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51575 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36334 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2016 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36584 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36484 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->