### PR TITLE
Missing validation for incoming file paths from web content process when attachment elements are enabled

### DIFF
--- a/Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm
+++ b/Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm
@@ -84,6 +84,24 @@ static bool shouldTranscodeHEICImagesForPage(std::optional<WebPageProxyIdentifie
     return protect(page->preferences())->needsSiteSpecificQuirks() && Quirks::shouldTranscodeHeicImagesForURL(URL { page->currentURL() });
 }
 
+#if ENABLE(ATTACHMENT_ELEMENT)
+
+static void addAllowedAttachmentFilePaths(const IPC::Connection& connection, std::optional<WebPageProxyIdentifier> pageID, const Vector<String>& paths)
+{
+    if (!pageID)
+        return;
+
+    RefPtr page = WebProcessProxy::webPage(*pageID);
+    if (!page)
+        return;
+
+    for (auto& path : paths)
+        WebProcessProxy::fromConnection(connection)->addAllowedAttachmentFilePath(path);
+}
+
+#endif // ENABLE(ATTACHMENT_ELEMENT)
+
+
 void WebPasteboardProxy::grantAccessToCurrentTypes(WebProcessProxy& process, const String& pasteboardName)
 {
     grantAccess(process, pasteboardName, PasteboardAccessType::Types);
@@ -252,6 +270,9 @@ void WebPasteboardProxy::getPasteboardPathnamesForType(IPC::Connection& connecti
                     return SandboxExtension::Handle { };
                 return valueOrDefault(SandboxExtension::createHandle(filename, SandboxExtension::Type::ReadOnly));
             });
+#if ENABLE(ATTACHMENT_ELEMENT)
+            addAllowedAttachmentFilePaths(connection, pageID, pathnames);
+#endif
             completionHandler(WTF::move(pathnames), WTF::move(sandboxExtensions));
             return;
         }
@@ -643,12 +664,22 @@ void WebPasteboardProxy::allPasteboardItemInfo(IPC::Connection& connection, cons
 
 #if PLATFORM(IOS_FAMILY)
         if (!allInfo || !process) {
+#if ENABLE(ATTACHMENT_ELEMENT)
+            if (allInfo) {
+                for (auto& info : *allInfo)
+                    addAllowedAttachmentFilePaths(connection, pageID, info.pathsForFileUpload);
+            }
+#endif
             completionHandler(WTF::move(allInfo));
             return;
         }
 
         auto transcodingInfo = findHEICPathsForTranscoding(*allInfo, pageID);
         if (transcodingInfo.isEmpty()) {
+#if ENABLE(ATTACHMENT_ELEMENT)
+            for (auto& info : *allInfo)
+                addAllowedAttachmentFilePaths(connection, pageID, info.pathsForFileUpload);
+#endif
             completionHandler(WTF::move(allInfo));
             return;
         }
@@ -656,12 +687,12 @@ void WebPasteboardProxy::allPasteboardItemInfo(IPC::Connection& connection, cons
         auto pathsToTranscode = extractPathsToTranscode(transcodingInfo);
         auto [transcodingUTI, transcodingExtension] = heicTranscodingParameters();
 
-        sharedImageTranscodingQueueSingleton().dispatch([process = WTF::move(process), allInfo = WTF::move(*allInfo), pathsToTranscode = crossThreadCopy(WTF::move(pathsToTranscode)), transcodingInfo = WTF::move(transcodingInfo), transcodingUTI = crossThreadCopy(WTF::move(transcodingUTI)), transcodingExtension = crossThreadCopy(WTF::move(transcodingExtension)), completionHandler = WTF::move(completionHandler)] mutable {
+        sharedImageTranscodingQueueSingleton().dispatch([protectedConnection = Ref { connection }, pageID, process = WTF::move(process), allInfo = WTF::move(*allInfo), pathsToTranscode = crossThreadCopy(WTF::move(pathsToTranscode)), transcodingInfo = WTF::move(transcodingInfo), transcodingUTI = crossThreadCopy(WTF::move(transcodingUTI)), transcodingExtension = crossThreadCopy(WTF::move(transcodingExtension)), completionHandler = WTF::move(completionHandler)] mutable {
             ASSERT(!RunLoop::isMain());
 
             auto transcodedPaths = transcodeImages(pathsToTranscode, transcodingUTI, transcodingExtension);
 
-            RunLoop::mainSingleton().dispatch([process = WTF::move(process), allInfo = WTF::move(allInfo), transcodedPaths = crossThreadCopy(WTF::move(transcodedPaths)), transcodingInfo = WTF::move(transcodingInfo), completionHandler = WTF::move(completionHandler)] mutable {
+            RunLoop::mainSingleton().dispatch([protectedConnection = WTF::move(protectedConnection), pageID, process = WTF::move(process), allInfo = WTF::move(allInfo), transcodedPaths = crossThreadCopy(WTF::move(transcodedPaths)), transcodingInfo = WTF::move(transcodingInfo), completionHandler = WTF::move(completionHandler)] mutable {
                 for (size_t i = 0; i < transcodingInfo.size(); ++i) {
                     if (!transcodedPaths[i].isEmpty())
                         allInfo[transcodingInfo[i].infoIndex].pathsForFileUpload[transcodingInfo[i].pathIndex] = transcodedPaths[i];
@@ -669,10 +700,21 @@ void WebPasteboardProxy::allPasteboardItemInfo(IPC::Connection& connection, cons
 
                 notifyNetworkProcessOfTranscodedFiles(process, transcodedPaths);
 
+#if ENABLE(ATTACHMENT_ELEMENT)
+                for (auto& info : allInfo)
+                    addAllowedAttachmentFilePaths(protectedConnection.get(), pageID, info.pathsForFileUpload);
+#endif
+
                 completionHandler(WTF::move(allInfo));
             });
         });
 #else
+#if ENABLE(ATTACHMENT_ELEMENT)
+        if (allInfo) {
+            for (auto& info : *allInfo)
+                addAllowedAttachmentFilePaths(connection, pageID, info.pathsForFileUpload);
+        }
+#endif
         completionHandler(WTF::move(allInfo));
 #endif
     });
@@ -693,12 +735,19 @@ void WebPasteboardProxy::informationForItemAtIndex(IPC::Connection& connection, 
 
 #if PLATFORM(IOS_FAMILY)
         if (!info || !process) {
+#if ENABLE(ATTACHMENT_ELEMENT)
+            if (info)
+                addAllowedAttachmentFilePaths(connection, pageID, info->pathsForFileUpload);
+#endif
             completionHandler(WTF::move(info));
             return;
         }
 
         auto transcodingInfo = findHEICPathsForTranscoding(*info, pageID);
         if (transcodingInfo.isEmpty()) {
+#if ENABLE(ATTACHMENT_ELEMENT)
+            addAllowedAttachmentFilePaths(connection, pageID, info->pathsForFileUpload);
+#endif
             completionHandler(WTF::move(info));
             return;
         }
@@ -706,12 +755,12 @@ void WebPasteboardProxy::informationForItemAtIndex(IPC::Connection& connection, 
         auto pathsToTranscode = extractPathsToTranscode(transcodingInfo);
         auto [transcodingUTI, transcodingExtension] = heicTranscodingParameters();
 
-        sharedImageTranscodingQueueSingleton().dispatch([process = WTF::move(process), info = WTF::move(*info), pathsToTranscode = crossThreadCopy(WTF::move(pathsToTranscode)), transcodingInfo = WTF::move(transcodingInfo), transcodingUTI = crossThreadCopy(WTF::move(transcodingUTI)), transcodingExtension = crossThreadCopy(WTF::move(transcodingExtension)), completionHandler = WTF::move(completionHandler)] mutable {
+        sharedImageTranscodingQueueSingleton().dispatch([protectedConnection = Ref { connection }, pageID, process = WTF::move(process), info = WTF::move(*info), pathsToTranscode = crossThreadCopy(WTF::move(pathsToTranscode)), transcodingInfo = WTF::move(transcodingInfo), transcodingUTI = crossThreadCopy(WTF::move(transcodingUTI)), transcodingExtension = crossThreadCopy(WTF::move(transcodingExtension)), completionHandler = WTF::move(completionHandler)] mutable {
             ASSERT(!RunLoop::isMain());
 
             auto transcodedPaths = transcodeImages(pathsToTranscode, transcodingUTI, transcodingExtension);
 
-            RunLoop::mainSingleton().dispatch([process = WTF::move(process), info = WTF::move(info), transcodedPaths = crossThreadCopy(WTF::move(transcodedPaths)), transcodingInfo = WTF::move(transcodingInfo), completionHandler = WTF::move(completionHandler)] mutable {
+            RunLoop::mainSingleton().dispatch([protectedConnection = WTF::move(protectedConnection), pageID, process = WTF::move(process), info = WTF::move(info), transcodedPaths = crossThreadCopy(WTF::move(transcodedPaths)), transcodingInfo = WTF::move(transcodingInfo), completionHandler = WTF::move(completionHandler)] mutable {
                 for (size_t i = 0; i < transcodingInfo.size(); ++i) {
                     if (!transcodedPaths[i].isEmpty())
                         info.pathsForFileUpload[transcodingInfo[i].pathIndex] = transcodedPaths[i];
@@ -719,10 +768,18 @@ void WebPasteboardProxy::informationForItemAtIndex(IPC::Connection& connection, 
 
                 notifyNetworkProcessOfTranscodedFiles(process, transcodedPaths);
 
+#if ENABLE(ATTACHMENT_ELEMENT)
+                addAllowedAttachmentFilePaths(protectedConnection.get(), pageID, info.pathsForFileUpload);
+#endif
+
                 completionHandler(WTF::move(info));
             });
         });
 #else
+#if ENABLE(ATTACHMENT_ELEMENT)
+        if (info)
+            addAllowedAttachmentFilePaths(connection, pageID, info->pathsForFileUpload);
+#endif
         completionHandler(WTF::move(info));
 #endif
     });

--- a/Source/WebKit/UIProcess/WebPageProxy.cpp
+++ b/Source/WebKit/UIProcess/WebPageProxy.cpp
@@ -4174,6 +4174,11 @@ void WebPageProxy::performDragOperation(DragData& dragData, const String& dragSt
         if (!protectedThis->m_mainFrame)
             return;
 
+#if ENABLE(ATTACHMENT_ELEMENT)
+        for (auto& filename : dragData.fileNames())
+            protect(protectedThis->legacyMainFrameProcess())->addAllowedAttachmentFilePath(filename);
+#endif
+
         DragData dragDataCopy(dragData);
 
         protectedThis->sendWithAsyncReplyToProcessContainingFrame(protectedThis->m_mainFrame->frameID(), Messages::WebPage::PerformDragOperation(protectedThis->m_mainFrame->frameID(), WTF::move(dragData), WTF::move(sandboxExtensionHandle), WTF::move(sandboxExtensionsForUpload)), [protectedThis, frameID = protectedThis->m_mainFrame->frameID(), dragDataCopy = WTF::move(dragDataCopy), dragStorageName] (DragOperationResult dragOperationResult) mutable {
@@ -16817,6 +16822,7 @@ void WebPageProxy::registerAttachmentIdentifierFromFilePath(IPC::Connection& con
 {
     MESSAGE_CHECK_BASE(protect(preferences())->attachmentElementEnabled(), connection);
     MESSAGE_CHECK_BASE(IdentifierToAttachmentMap::isValidKey(identifier), connection);
+    MESSAGE_CHECK_BASE(WebProcessProxy::fromConnection(connection)->isAllowedAttachmentFilePath(filePath), connection);
 
     if (attachmentForIdentifier(identifier))
         return;
@@ -16842,6 +16848,7 @@ void WebPageProxy::registerAttachmentsFromSerializedData(IPC::Connection& connec
     MESSAGE_CHECK_BASE(protect(preferences())->attachmentElementEnabled(), connection);
 
     for (auto& serializedData : data) {
+        MESSAGE_CHECK_BASE(IdentifierToAttachmentMap::isValidKey(serializedData.identifier), connection);
         auto identifier = WTF::move(serializedData.identifier);
         if (!attachmentForIdentifier(identifier)) {
             Ref attachment = ensureAttachment(identifier);

--- a/Source/WebKit/UIProcess/WebProcessProxy.cpp
+++ b/Source/WebKit/UIProcess/WebProcessProxy.cpp
@@ -1513,6 +1513,19 @@ void WebProcessProxy::setIgnoreInvalidMessageForTesting()
 }
 #endif
 
+#if ENABLE(ATTACHMENT_ELEMENT)
+void WebProcessProxy::addAllowedAttachmentFilePath(const String& filePath)
+{
+    if (!filePath.isEmpty())
+        m_allowedAttachmentFilePaths.add(filePath);
+}
+
+bool WebProcessProxy::isAllowedAttachmentFilePath(const String& filePath) const
+{
+    return m_allowedAttachmentFilePaths.contains(filePath);
+}
+#endif
+
 void WebProcessProxy::didFinishLaunching(ProcessLauncher* launcher, IPC::Connection::Identifier&& connectionIdentifier)
 {
     WEBPROCESSPROXY_RELEASE_LOG(Process, "didFinishLaunching:");

--- a/Source/WebKit/UIProcess/WebProcessProxy.h
+++ b/Source/WebKit/UIProcess/WebProcessProxy.h
@@ -514,6 +514,11 @@ public:
     bool ignoreInvalidMessageForTesting() const { return m_ignoreInvalidMessageForTesting; }
     void setIgnoreInvalidMessageForTesting();
 #endif
+
+#if ENABLE(ATTACHMENT_ELEMENT)
+    void addAllowedAttachmentFilePath(const String&);
+    bool isAllowedAttachmentFilePath(const String&) const;
+#endif
     
     bool allowTestOnlyIPC() const { return m_allowTestOnlyIPC; }
     void setAllowTestOnlyIPC(bool allowTestOnlyIPC) { m_allowTestOnlyIPC = allowTestOnlyIPC; }
@@ -908,6 +913,10 @@ private:
 
 #if ENABLE(IPC_TESTING_API)
     bool m_ignoreInvalidMessageForTesting { false };
+#endif
+
+#if ENABLE(ATTACHMENT_ELEMENT)
+    HashSet<String> m_allowedAttachmentFilePaths;
 #endif
     
     bool m_allowTestOnlyIPC { false };

--- a/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKAttachmentTests.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKAttachmentTests.mm
@@ -45,6 +45,7 @@
 #import <WebKit/WKWebViewPrivateForTesting.h>
 #import <WebKit/WebArchive.h>
 #import <WebKit/WebKitPrivate.h>
+#import <WebKit/_WKFeature.h>
 #import <WebKit/_WKUserStyleSheet.h>
 #import <ranges>
 #import <wtf/RetainPtr.h>
@@ -2745,6 +2746,63 @@ TEST(WKAttachmentTestsIOS, PasteRichTextCopiedFromNotes)
 }
 
 #endif // PLATFORM(IOS_FAMILY)
+
+#if PLATFORM(MAC) && ENABLE(IPC_TESTING_API)
+
+TEST(WKAttachmentTestsMac, RegisterAttachmentIdentifierFromFilePathWithUnauthorizedPathTerminatesProcess)
+{
+    RetainPtr configuration = adoptNS([[WKWebViewConfiguration alloc] init]);
+    [configuration _setAttachmentElementEnabled:YES];
+
+    WKPreferencesSetCustomPasteboardDataEnabled((__bridge WKPreferencesRef)[configuration preferences], YES);
+    for (_WKFeature *feature in [WKPreferences _features]) {
+        if ([feature.key isEqualToString:@"IPCTestingAPIEnabled"])
+            [[configuration preferences] _setEnabled:YES forFeature:feature];
+        if ([feature.key isEqualToString:@"IgnoreInvalidMessageWhenIPCTestingAPIEnabled"])
+            [[configuration preferences] _setEnabled:NO forFeature:feature];
+    }
+
+    RetainPtr webView = adoptNS([[TestWKWebView alloc] initWithFrame:NSMakeRect(0, 0, 500, 500) configuration:configuration.get()]);
+    [webView synchronouslyLoadHTMLString:attachmentEditingTestMarkup];
+
+    RetainPtr navigationDelegate = adoptNS([TestNavigationDelegate new]);
+    [webView setNavigationDelegate:navigationDelegate.get()];
+
+    [webView evaluateJavaScript:
+        @"IPC.sendMessage('UI', IPC.webPageProxyID, IPC.messages.WebPageProxy_RegisterAttachmentIdentifierFromFilePath.name, ["
+        "    {type: 'String', value: 'fake-identifier'},"
+        "    {type: 'String', value: 'application/octet-stream'},"
+        "    {type: 'String', value: '/etc/passwd'}"
+        "])"
+    completionHandler:nil];
+
+    [navigationDelegate waitForWebContentProcessDidTerminate];
+}
+
+TEST(WKAttachmentTestsMac, PastedFileURLsUseAuthorizedPaths)
+{
+    NSPasteboard *pasteboard = [NSPasteboard generalPasteboard];
+    [pasteboard clearContents];
+    [pasteboard declareTypes:@[NSFilenamesPboardType] owner:nil];
+    [pasteboard setPropertyList:@[testPDFFileURL().path, testImageFileURL().path] forType:NSFilenamesPboardType];
+
+    RetainPtr<NSArray<_WKAttachment *>> insertedAttachments;
+    RetainPtr webView = webViewForTestingAttachments();
+    {
+        ObserveAttachmentUpdatesForScope observer(webView.get());
+        [webView _synchronouslyExecuteEditCommand:@"Paste" argument:nil];
+        insertedAttachments = [observer.observer() inserted];
+        EXPECT_EQ(2U, [insertedAttachments count]);
+    }
+
+    [webView expectElementCount:1 querySelector:@"ATTACHMENT"];
+    [webView expectElementCount:1 querySelector:@"IMG"];
+
+    for (_WKAttachment *attachment in insertedAttachments.get())
+        EXPECT_GT(attachment.info.data.length, 0U);
+}
+
+#endif // PLATFORM(MAC) && ENABLE(IPC_TESTING_API)
 
 } // namespace TestWebKitAPI
 


### PR DESCRIPTION
#### c6cd4e07e9afcb0f5a8dc696182822e21fafd913
<pre>
Missing validation for incoming file paths from web content process when attachment elements are enabled
<a href="https://bugs.webkit.org/show_bug.cgi?id=309698">https://bugs.webkit.org/show_bug.cgi?id=309698</a>
<a href="https://rdar.apple.com/170082216">rdar://170082216</a>

Reviewed by Abrar Rahman Protyasha, Richard Robinson, and Charlie Wolfe.

Maintain an allowlist of file paths (`m_allowedAttachmentFilePaths`) in `WebProcessProxy` that
tracks paths legitimately provided to the web process via pasteboard and drag-drop operations.
Validate incoming paths in `RegisterAttachmentIdentifierFromFilePath` against this allowlist using
`MESSAGE_CHECK`, terminating the web process for unauthorized paths.

Tests:  WKAttachmentTestsMac.RegisterAttachmentIdentifierFromFilePathWithUnauthorizedPathTerminatesProcess
        WKAttachmentTestsMac.PastedFileURLsUseAuthorizedPaths

Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKAttachmentTests.mm
* Source/WebKit/UIProcess/Cocoa/WebPasteboardProxyCocoa.mm:
(WebKit::addAllowedAttachmentFilePaths):
(WebKit::WebPasteboardProxy::getPasteboardPathnamesForType):
(WebKit::WebPasteboardProxy::allPasteboardItemInfo):
(WebKit::WebPasteboardProxy::informationForItemAtIndex):
* Source/WebKit/UIProcess/WebPageProxy.cpp:
(WebKit::WebPageProxy::performDragOperation):
(WebKit::WebPageProxy::registerAttachmentIdentifierFromFilePath):
(WebKit::WebPageProxy::registerAttachmentsFromSerializedData):
* Source/WebKit/UIProcess/WebProcessProxy.cpp:
(WebKit::WebProcessProxy::addAllowedAttachmentFilePath):
(WebKit::WebProcessProxy::isAllowedAttachmentFilePath const):
* Source/WebKit/UIProcess/WebProcessProxy.h:
* Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKAttachmentTests.mm:
(TestWebKitAPI::TEST(WKAttachmentTestsMac, RegisterAttachmentIdentifierFromFilePathWithUnauthorizedPathTerminatesProcess)):
(TestWebKitAPI::TEST(WKAttachmentTestsMac, PastedFileURLsUseAuthorizedPaths)):

Canonical link: <a href="https://commits.webkit.org/315269@main">https://commits.webkit.org/315269@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/38774d57d60c71450352dcb1a35893845ddcb852

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168533 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/42090 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35679 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177863 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126234 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170399 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42466 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/42052 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131186 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/92264 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171492 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33643 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151457 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111697 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/32629 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/31334 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26558 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/142615 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180462 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33185 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30861 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139628 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42102 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35498 "Found 1 new test failure: fast/speechsynthesis/speech-synthesis-utterance-gc.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139486 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37562 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42790 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106451 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34767 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27834 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41294 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114550 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40691 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5917 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40942 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40836 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->