### PR TITLE
[JSC] Add a `gcSafeMemcpy` fast path for cloning large Maps and Sets

### DIFF
--- a/JSTests/microbenchmarks/map-clone-large.js
+++ b/JSTests/microbenchmarks/map-clone-large.js
@@ -1,0 +1,11 @@
+function test(map) {
+    return new Map(map);
+}
+noInline(test);
+
+var map = new Map();
+for (var j = 0; j < 1000; ++j)
+    map.set(j, j);
+
+for (var i = 0; i < testLoopCount; ++i)
+    test(map);

--- a/JSTests/microbenchmarks/map-clone.js
+++ b/JSTests/microbenchmarks/map-clone.js
@@ -1,0 +1,11 @@
+function test(map) {
+    return new Map(map);
+}
+noInline(test);
+
+var map = new Map();
+for (var j = 0; j < 100; ++j)
+    map.set(j, j);
+
+for (var i = 0; i < testLoopCount; ++i)
+    test(map);

--- a/JSTests/microbenchmarks/set-clone-large.js
+++ b/JSTests/microbenchmarks/set-clone-large.js
@@ -1,0 +1,11 @@
+function test(set) {
+    return new Set(set);
+}
+noInline(test);
+
+var set = new Set();
+for (var j = 0; j < 1000; ++j)
+    set.add(j);
+
+for (var i = 0; i < testLoopCount; ++i)
+    test(set);

--- a/JSTests/microbenchmarks/set-clone.js
+++ b/JSTests/microbenchmarks/set-clone.js
@@ -1,0 +1,11 @@
+function test(set) {
+    return new Set(set);
+}
+noInline(test);
+
+var set = new Set();
+for (var j = 0; j < 100; ++j)
+    set.add(j);
+
+for (var i = 0; i < testLoopCount; ++i)
+    test(set);

--- a/JSTests/stress/map-set-clone-large-table.js
+++ b/JSTests/stress/map-set-clone-large-table.js
@@ -1,0 +1,96 @@
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error('bad value: ' + actual + ' expected: ' + expected);
+}
+
+// 600 entries grow the backing table to capacity 2048, which is large enough for the bulk table copy.
+const count = 600;
+
+// Set cloning via new Set(set).
+{
+    const source = new Set();
+    for (let i = 0; i < count; ++i)
+        source.add(i);
+
+    const clone = new Set(source);
+    shouldBe(clone.size, count);
+    let expected = 0;
+    for (const value of clone)
+        shouldBe(value, expected++);
+    shouldBe(expected, count);
+
+    // The clone is independent from the source.
+    clone.add(count);
+    clone.delete(0);
+    shouldBe(source.size, count);
+    shouldBe(source.has(0), true);
+    shouldBe(source.has(count), false);
+
+    // The clone keeps working as a Set (lookup, add, delete, rehash, GC).
+    gc();
+    for (let i = 0; i < count; ++i)
+        shouldBe(clone.has(i), i !== 0);
+    for (let i = 0; i < 2000; ++i)
+        clone.add('extra' + i);
+    shouldBe(clone.size, count + 2000);
+    for (let i = 0; i < 2000; ++i)
+        shouldBe(clone.delete('extra' + i), true);
+    gc();
+    shouldBe(clone.size, count);
+
+    // Cloning a table with deleted entries takes the entry-by-entry path.
+    source.delete(1);
+    source.delete(599);
+    const compacted = new Set(source);
+    shouldBe(compacted.size, count - 2);
+    shouldBe(compacted.has(1), false);
+    shouldBe(compacted.has(599), false);
+    shouldBe(compacted.has(2), true);
+}
+
+// Set cloning via Set.prototype.union with an empty-ish other set.
+{
+    const source = new Set();
+    for (let i = 0; i < count; ++i)
+        source.add('key' + i);
+
+    const result = source.union(new Set([ 'key0' ]));
+    shouldBe(result.size, count);
+    let index = 0;
+    for (const value of result)
+        shouldBe(value, 'key' + index++);
+    gc();
+    shouldBe(result.has('key599'), true);
+}
+
+// Map cloning via new Map(map).
+{
+    const source = new Map();
+    for (let i = 0; i < count; ++i)
+        source.set('k' + i, i * 2);
+
+    const clone = new Map(source);
+    shouldBe(clone.size, count);
+    let expected = 0;
+    for (const [key, value] of clone) {
+        shouldBe(key, 'k' + expected);
+        shouldBe(value, expected * 2);
+        ++expected;
+    }
+    shouldBe(expected, count);
+
+    clone.set('k0', -1);
+    clone.delete('k1');
+    shouldBe(source.get('k0'), 0);
+    shouldBe(source.has('k1'), true);
+
+    gc();
+    for (let i = 2; i < count; ++i)
+        shouldBe(clone.get('k' + i), i * 2);
+
+    source.delete('k0');
+    const compacted = new Map(source);
+    shouldBe(compacted.size, count - 1);
+    shouldBe(compacted.has('k0'), false);
+    shouldBe(compacted.get('k599'), 1198);
+}

--- a/Source/JavaScriptCore/runtime/JSOrderedHashTableHelper.h
+++ b/Source/JavaScriptCore/runtime/JSOrderedHashTableHelper.h
@@ -25,6 +25,7 @@
 
 #pragma once
 
+#include <JavaScriptCore/GCMemoryOperations.h>
 #include <JavaScriptCore/HashMapHelper.h>
 #include <JavaScriptCore/JSCellButterfly.h>
 #include <JavaScriptCore/JSObject.h>
@@ -122,6 +123,7 @@ public:
 
     static constexpr uint8_t InitialCapacity = 8;
     static constexpr TableSize LargeCapacity = 2 << 15;
+    static constexpr TableSize MemcpyCopyMinimumCapacity = 1024;
 
     static_assert(EntrySize == MapTraits::EntrySize || EntrySize == SetTraits::EntrySize);
 
@@ -312,7 +314,21 @@ public:
     }
     ALWAYS_INLINE static Storage* copy(JSGlobalObject* globalObject, Storage& base)
     {
-        return copyImpl<>(globalObject, base, capacity(base));
+        VM& vm = getVM(globalObject);
+        auto scope = DECLARE_THROW_SCOPE(vm);
+        ASSERT(!isObsolete(base));
+
+        TableSize capacity = Helper::capacity(base);
+        if (!deletedEntryCount(base) && capacity >= MemcpyCopyMinimumCapacity) {
+            Storage* result = tryCreate(globalObject, 0, 0, capacity);
+            RETURN_IF_EXCEPTION(scope, nullptr);
+            TableSize usedLength = dataTableStartIndex(capacity) + aliveEntryCount(base) * EntrySize;
+            gcSafeMemcpy(slot(*result, 0), slot(base, 0), usedLength * sizeof(JSValue));
+            vm.writeBarrier(result);
+            return result;
+        }
+
+        RELEASE_AND_RETURN(scope, copyImpl<>(globalObject, base, capacity));
     }
 
     ALWAYS_INLINE static Storage* rehash(JSGlobalObject* globalObject, Storage& base, TableSize newCapacity)


### PR DESCRIPTION
#### 253bd0c20582bdfa537c4056546c64785a1380dc
<pre>
[JSC] Add a `gcSafeMemcpy` fast path for cloning large Maps and Sets
<a href="https://bugs.webkit.org/show_bug.cgi?id=315452">https://bugs.webkit.org/show_bug.cgi?id=315452</a>

Reviewed by Yusuke Suzuki.

OrderedHashTableHelper::copy(), used by JSSet::clone() / JSMap::clone() (e.g. `new Set(set)`,
`new Map(map)`, and the Set.prototype set methods), re-hashes and re-inserts every alive entry
one by one. For large tables this is slow because every insertion scatters writes across the
whole table.

When the base table has no deleted entry, a copy with the same capacity is bit-identical to
the base: every entry keeps its index, so the bucket chains stay valid. So this change adds a
fast path which copies the table memory at once with gcSafeMemcpy() in that case. The data
table slots after the used entries are empty in both tables, so it is enough to copy the
header, the hash table, and the used part of the data table.

The fast path is taken only for tables with capacity &gt;= 1024: empirically it beats the
entry-by-entry copy there and the gap grows with the table size (about 2x for 1000 entries),
while for smaller tables both approaches are within a few percent of each other.

                          ToT                        Patched

    set-clone-large    21.7035+-0.0747     ^     10.3831+-0.1370    ^ definitely 2.0903x faster
    map-clone-large    24.7747+-0.2633     ^     12.4437+-0.1895    ^ definitely 1.9909x faster
    set-clone           6.3262+-0.3274           6.3180+-0.2851
    map-clone           7.3885+-0.1931           7.2759+-0.1067       might be 1.0155x faster

Tests: JSTests/microbenchmarks/map-clone-large.js
       JSTests/microbenchmarks/map-clone.js
       JSTests/microbenchmarks/set-clone-large.js
       JSTests/microbenchmarks/set-clone.js
       JSTests/stress/map-set-clone-large-table.js

* JSTests/microbenchmarks/map-clone-large.js: Added.
(test):
* JSTests/microbenchmarks/map-clone.js: Added.
(test):
* JSTests/microbenchmarks/set-clone-large.js: Added.
* JSTests/microbenchmarks/set-clone.js: Added.
* JSTests/stress/map-set-clone-large-table.js: Added.
(shouldBe):
(shouldBe.compacted.has):
* Source/JavaScriptCore/runtime/JSOrderedHashTableHelper.h:
(JSC::JSOrderedHashTableHelper::copy):

Canonical link: <a href="https://commits.webkit.org/313952@main">https://commits.webkit.org/313952@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0f50a63389d769722ab782082789db3acbaae4b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164612 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38096 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31667 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173647 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121864 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38430 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38098 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127911 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90032 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167571 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30211 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147947 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108455 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29258 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27883 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21405 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/156763 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139162 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25663 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176170 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/25504 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28991 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27332 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136228 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38165 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32007 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136192 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36690 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38855 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147458 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101009 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31466 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24314 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/197015 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37363 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110407 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51748 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36761 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2377 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37009 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36909 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->