### PR TITLE
[WTF] `Thread::suspend()` hangs when the suspend-resume signal handler runs on an alternate signal stack

### DIFF
--- a/Source/WTF/wtf/PlatformRegisters.h
+++ b/Source/WTF/wtf/PlatformRegisters.h
@@ -89,6 +89,58 @@ inline PlatformRegisters& registersFromUContext(ucontext_t* ucontext)
 #endif
 }
 
+inline void* stackPointerFromRegisters(const PlatformRegisters& regs)
+{
+#if OS(HAIKU)
+#if CPU(X86_64)
+    return reinterpret_cast<void*>(regs.machineContext.rsp);
+#else
+    return nullptr;
+#endif
+#elif OS(FREEBSD)
+#if CPU(X86_64)
+    return reinterpret_cast<void*>(regs.machineContext.mc_rsp);
+#elif CPU(ARM)
+    return reinterpret_cast<void*>(regs.machineContext.__gregs[_REG_SP]);
+#elif CPU(ARM64)
+    return reinterpret_cast<void*>(regs.machineContext.mc_gpregs.gp_sp);
+#else
+    return nullptr;
+#endif
+#elif OS(QNX)
+#if CPU(X86_64)
+    return reinterpret_cast<void*>(regs.machineContext.cpu.rsp);
+#elif CPU(ARM64)
+    return reinterpret_cast<void*>(regs.machineContext.cpu.gpr[AARCH64_REG_SP]);
+#else
+    return nullptr;
+#endif
+#elif OS(NETBSD)
+#if CPU(X86_64)
+    return reinterpret_cast<void*>(regs.machineContext.__gregs[_REG_RSP]);
+#elif CPU(ARM) || CPU(ARM64)
+    return reinterpret_cast<void*>(regs.machineContext.__gregs[_REG_SP]);
+#else
+    return nullptr;
+#endif
+#elif OS(FUCHSIA) || OS(LINUX) || OS(HURD)
+#if CPU(X86_64)
+    return reinterpret_cast<void*>(regs.machineContext.gregs[REG_RSP]);
+#elif CPU(ARM)
+    return reinterpret_cast<void*>(regs.machineContext.arm_sp);
+#elif CPU(ARM64)
+    return reinterpret_cast<void*>(regs.machineContext.sp);
+#elif CPU(RISCV64)
+    return reinterpret_cast<void*>(regs.machineContext.__gregs[REG_SP]);
+#else
+    return nullptr;
+#endif
+#else
+    UNUSED_PARAM(regs);
+    return nullptr;
+#endif
+}
+
 #else
 
 struct PlatformRegisters {

--- a/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
+++ b/Source/WTF/wtf/posix/ThreadingPOSIX.cpp
@@ -130,7 +130,15 @@ void Thread::signalHandlerSuspendResume(int, siginfo_t*, void* ucontext)
         return;
     }
 
+#if HAVE(MACHINE_CONTEXT)
+    PlatformRegisters& platformRegisters = registersFromUContext(static_cast<ucontext_t*>(ucontext));
+    void* approximateStackPointer = stackPointerFromRegisters(platformRegisters);
+    if (!approximateStackPointer)
+        approximateStackPointer = currentStackPointer();
+#else
+    UNUSED_PARAM(ucontext);
     void* approximateStackPointer = currentStackPointer();
+#endif
     if (!thread->m_stack.contains(approximateStackPointer)) {
         // This happens if we use an alternative signal stack.
         // 1. A user-defined signal handler is invoked with an alternative signal stack.
@@ -144,10 +152,8 @@ void Thread::signalHandlerSuspendResume(int, siginfo_t*, void* ucontext)
     }
 
 #if HAVE(MACHINE_CONTEXT)
-    ucontext_t* userContext = static_cast<ucontext_t*>(ucontext);
-    thread->m_platformRegisters = &registersFromUContext(userContext);
+    thread->m_platformRegisters = &platformRegisters;
 #else
-    UNUSED_PARAM(ucontext);
     PlatformRegisters platformRegisters { approximateStackPointer };
     thread->m_platformRegisters = &platformRegisters;
 #endif


### PR DESCRIPTION
#### b3b47b015002d1ebb65ee1f821c36737984db9b0
<pre>
[WTF] `Thread::suspend()` hangs when the suspend-resume signal handler runs on an alternate signal stack
<a href="https://bugs.webkit.org/show_bug.cgi?id=315453">https://bugs.webkit.org/show_bug.cgi?id=315453</a>

Reviewed by NOBODY (OOPS!).

On non-Darwin POSIX platforms, Thread::suspend() sends sigThreadSuspendResume to the
target thread and retries until the signal handler publishes a register snapshot. The
handler decides whether the interrupted thread is on its normal stack by checking
currentStackPointer() -- the stack pointer of the handler&apos;s own frame -- against
thread-&gt;m_stack.

That only works as long as the handler runs on the interrupted thread&apos;s normal stack.
If something adds SA_ONSTACK to our sigaction and installs a sigaltstack, the handler
runs on the alternate signal stack, the containment check fails on every retry, and
Thread::suspend() spins forever. This is not hypothetical: Go&apos;s cgo runtime
(runtime.initsig -&gt; setsigstack) forces SA_ONSTACK onto every pre-existing signal
handler when a Go c-shared library is dlopen&apos;ed into the process, and sanitizer
runtimes install alternate signal stacks unconditionally. The result is a livelock of
the suspending thread (e.g. the GC requesting a stop-the-world). This was originally
hit by JSC embedders on Linux loading Go-based addons (oven-sh/bun#31158).

Instead, check the stack pointer the thread was actually interrupted at, taken from the
kernel-saved ucontext via registersFromUContext(). This is the same register set we
record into m_platformRegisters and that conservative scanning later consumes, so the
checked value now matches the recorded one. The existing back-off still works: if the
signal genuinely interrupted code running on an alternate stack (a nested signal
handler), the ucontext stack pointer points into that stack and we retry as before.

Add stackPointerFromRegisters() next to registersFromUContext() in PlatformRegisters.h,
covering the same platforms as JSC&apos;s MachineContext. Configurations without a known
stack pointer field fall back to currentStackPointer(), preserving the previous
behavior there.

* Source/WTF/wtf/PlatformRegisters.h:
(WTF::stackPointerFromRegisters):
* Source/WTF/wtf/posix/ThreadingPOSIX.cpp:
(WTF::Thread::signalHandlerSuspendResume):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3b47b015002d1ebb65ee1f821c36737984db9b0

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164659 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38143 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31714 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173694 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121911 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38477 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38145 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127957 "Passed tests") | [✅ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/90061 "Passed tests") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167618 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30256 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147994 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108501 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29302 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27926 "Passed tests") | [❌ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21452 "Hash b3b47b01 for PR 65562 does not build (failure)") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/156810 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139206 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25710 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176217 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/25551 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29041 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27379 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136275 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38212 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32050 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136237 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38902 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147505 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101068 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31506 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24361 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/197062 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37410 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110454 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51768 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36808 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2424 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37056 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36956 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->