### PR TITLE
Unreviewed, Fix malformed `//@` directives in `JSTests` that were silently ignored

### DIFF
--- a/JSTests/stress/create-many-realms.js
+++ b/JSTests/stress/create-many-realms.js
@@ -1,4 +1,4 @@
- //@ runDefault("--collectContinuously=1", "--collectContinuouslyPeriodMS=20", "--useGenerationalGC=0", "--useStochasticMutatorScheduler=0", "--useDFGJIT=0", "--useFTLJIT=0", "--maxPerThreadStackUsage=1000000")
+//@ runDefault("--collectContinuously=1", "--collectContinuouslyPeriodMS=20", "--useGenerationalGC=0", "--useStochasticMutatorScheduler=0", "--useDFGJIT=0", "--useFTLJIT=0", "--maxPerThreadStackUsage=1000000")
 
 function foo(count) {
     const x = createGlobalObject();

--- a/JSTests/stress/decouple-calllinkinfo-from-access-case.js
+++ b/JSTests/stress/decouple-calllinkinfo-from-access-case.js
@@ -1,4 +1,4 @@
-// runDefault("--validateOptions=true", "--thresholdForJITSoon=10", "--thresholdForJITAfterWarmUp=10", "--thresholdForOptimizeAfterWarmUp=100", "--thresholdForOptimizeAfterLongWarmUp=100", "--thresholdForOptimizeSoon=100", "--thresholdForFTLOptimizeAfterWarmUp=1000", "--thresholdForFTLOptimizeSoon=1000", "--validateBCE=true")
+//@ runDefault("--validateOptions=true", "--thresholdForJITSoon=10", "--thresholdForJITAfterWarmUp=10", "--thresholdForOptimizeAfterWarmUp=100", "--thresholdForOptimizeAfterLongWarmUp=100", "--thresholdForOptimizeSoon=100", "--thresholdForFTLOptimizeAfterWarmUp=1000", "--thresholdForFTLOptimizeSoon=1000", "--validateBCE=true")
 
 const ProxyConstructor = Proxy;
 const getPrototypeOf = Object.getPrototypeOf;

--- a/JSTests/stress/osr-exit-scratch-buffer-gc.js
+++ b/JSTests/stress/osr-exit-scratch-buffer-gc.js
@@ -1,5 +1,5 @@
 //@ memoryHog!
-// @requireOptions("--useConcurrentJIT=0", "--useZombieMode=1", "--slowPathAllocsBetweenGCs=16")
+//@ requireOptions("--useConcurrentJIT=0", "--useZombieMode=1", "--slowPathAllocsBetweenGCs=16")
 
 function opt(s) {
     const o = {};

--- a/JSTests/wasm/gc/struct-write-barrier.js
+++ b/JSTests/wasm/gc/struct-write-barrier.js
@@ -1,4 +1,4 @@
-// requireOptions("--collectContinuously=1")
+//@ requireOptions("--collectContinuously=1")
 
 import * as assert from "../assert.js";
 import { instantiate } from "./wast-wrapper.js";


### PR DESCRIPTION
#### 707fe4bc83e3d6e211785b274eca385dcb646587
<pre>
Unreviewed, Fix malformed `//@` directives in `JSTests` that were silently ignored
<a href="https://bugs.webkit.org/show_bug.cgi?id=315454">https://bugs.webkit.org/show_bug.cgi?id=315454</a>

run-jsc-stress-tests only recognizes directive lines that start exactly
with &quot;//@&quot;. A few tests have malformed directives (a leading space, a
space between &quot;//&quot; and &quot;@&quot;, or a missing &quot;@&quot;), so the harness silently
treats them as plain comments and the intended options are never
applied.

* JSTests/stress/create-many-realms.js:
* JSTests/stress/decouple-calllinkinfo-from-access-case.js:
* JSTests/stress/osr-exit-scratch-buffer-gc.js:
* JSTests/wasm/gc/struct-write-barrier.js:

Canonical link: <a href="https://commits.webkit.org/313810@main">https://commits.webkit.org/313810@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/eff8c71f4f8f3e0084b97e633ff368a62f7d2d0b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164192 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37676 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30895 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173221 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121444 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38010 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37676 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127558 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89742 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167151 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29852 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147600 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108106 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28899 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27526 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/20985 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/156343 "Built successfully and passed tests") | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138801 "Found 1 new API test failure: TestWebKitAPI.DownloadProgress.PublishProgressOnPartialDownload (failure)") | | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175747 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled WebKit") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/25084 "Built successfully and passed tests") | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26985 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135868 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37346 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31641 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135838 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36604 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38132 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147112 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100432 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31151 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23968 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/196595 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36942 "Built successfully") | | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51595 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36339 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2023 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36589 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36489 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->