### PR TITLE
[JSC] Implement `String#search` in C++

### DIFF
--- a/JSTests/microbenchmarks/regexp-search-digit-cached.js
+++ b/JSTests/microbenchmarks/regexp-search-digit-cached.js
@@ -1,0 +1,14 @@
+// Hot-path microbenchmark for String.prototype.search with a cached primordial
+// RegExp argument. The DFG StringSearch node is converted to RegExpSearch in
+// fixup, guarded by a CheckStructure on the primordial RegExp structure.
+
+function search(string, regexp)
+{
+    return string.search(regexp);
+}
+noInline(search);
+
+var string = "abc1def2ghi3jkl4mno5";
+var regexp = /[0-9]/;
+for (var i = 0; i < 1e6; ++i)
+    search(string, regexp);

--- a/JSTests/microbenchmarks/regexp-search-digit-literal.js
+++ b/JSTests/microbenchmarks/regexp-search-digit-literal.js
@@ -1,0 +1,13 @@
+// Hot-path microbenchmark for String.prototype.search with a RegExp literal
+// allocated on every call. Stresses the primordial-RegExp fast path together
+// with regex allocation.
+
+function search(string)
+{
+    return string.search(/[0-9]/);
+}
+noInline(search);
+
+var string = "abc1def2ghi3jkl4mno5";
+for (var i = 0; i < 1e6; ++i)
+    search(string);

--- a/JSTests/microbenchmarks/string-search-digit-short.js
+++ b/JSTests/microbenchmarks/string-search-digit-short.js
@@ -1,0 +1,14 @@
+// Hot-path microbenchmark for String.prototype.search with a short literal
+// string regexp source. This exercises the DFG StringSearch fast path for the
+// common case where the regexp arg is a string and gets coerced via
+// RegExp construction.
+
+function search(string, regexp)
+{
+    return string.search(regexp);
+}
+noInline(search);
+
+var string = "abc1def2ghi3jkl4mno5";
+for (var i = 0; i < 1e7; ++i)
+    search(string, "[0-9]");

--- a/JSTests/stress/string-prototype-search-edge-cases.js
+++ b/JSTests/stress/string-prototype-search-edge-cases.js
@@ -1,0 +1,160 @@
+// Edge case coverage for the C++ implementation of String.prototype.search.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("expected " + expected + " but got " + actual);
+}
+
+function shouldThrow(func, errorType) {
+    var threw = false;
+    try {
+        func();
+    } catch (e) {
+        threw = e instanceof errorType;
+    }
+    if (!threw)
+        throw new Error("expected to throw " + errorType.name);
+}
+
+// Basic behavior.
+shouldBe("abc".search(/b/), 1);
+shouldBe("abc".search(/x/), -1);
+shouldBe("abc".search(/a/), 0);
+shouldBe("".search(/x/), -1);
+shouldBe("".search(/(?:)/), 0);
+shouldBe("abc".search(new RegExp("c")), 2);
+
+// No argument / undefined / null arguments.
+shouldBe("abc".search(), 0); // RegExpCreate(undefined) -> /(?:)/
+shouldBe("abc".search(undefined), 0);
+shouldBe("abcnull".search(null), 3); // pattern is the string "null"
+
+// Primitive patterns are coerced through RegExpCreate.
+shouldBe("a1b2".search("[0-9]"), 1);
+shouldBe("a.c".search("."), 0); // "." is a regexp wildcard
+shouldBe("abc123".search(123), 3);
+shouldBe("abctrue".search(true), 3);
+
+// |this| coercion.
+shouldBe(String.prototype.search.call(12345, /3/), 2);
+shouldBe(String.prototype.search.call(true, /ru/), 1);
+shouldThrow(() => String.prototype.search.call(null, /a/), TypeError);
+shouldThrow(() => String.prototype.search.call(undefined, /a/), TypeError);
+shouldThrow(() => "abc".search.call(undefined), TypeError);
+
+// |this| with a custom toString.
+shouldBe(String.prototype.search.call({ toString() { return "xyz"; } }, /y/), 1);
+
+// Global flag and lastIndex are ignored: search always starts from index 0 and
+// restores lastIndex.
+{
+    var re = /b/g;
+    re.lastIndex = 2;
+    shouldBe("abcabc".search(re), 1);
+    shouldBe(re.lastIndex, 2);
+}
+{
+    var re = /b/y;
+    shouldBe("ba".search(re), 0);
+    shouldBe("ab".search(re), -1);
+    shouldBe(re.lastIndex, 0);
+}
+
+// Non-writable lastIndex: resetting to 0 throws only when it is not already 0.
+{
+    var re = /b/;
+    re.lastIndex = 3;
+    Object.defineProperty(re, "lastIndex", { writable: false });
+    shouldThrow(() => "abc".search(re), TypeError);
+
+    var reZero = /b/;
+    Object.defineProperty(reZero, "lastIndex", { writable: false });
+    shouldBe("abc".search(reZero), 1);
+}
+
+// Custom @@search on a plain object.
+shouldBe("abc".search({ [Symbol.search]() { return 42; } }), 42);
+
+// @@search receives the original |this| value, not a string.
+{
+    var receivedArg;
+    var searcher = { [Symbol.search](arg) { receivedArg = arg; return 7; } };
+    var thisObject = { toString() { return "should-not-be-called-by-search"; } };
+    shouldBe(String.prototype.search.call(thisObject, searcher), 7);
+    shouldBe(receivedArg, thisObject);
+}
+
+// undefined / null @@search on an object falls back to RegExpCreate(ToString(object)).
+shouldBe("xbcx".search({ [Symbol.search]: undefined, toString() { return "b"; } }), 1);
+shouldBe("xbcx".search({ [Symbol.search]: null, toString() { return "c"; } }), 2);
+
+// Non-callable @@search throws.
+shouldThrow(() => "abc".search({ [Symbol.search]: 1 }), TypeError);
+shouldThrow(() => "abc".search({ [Symbol.search]: "x" }), TypeError);
+
+// Throwing @@search getter propagates.
+shouldThrow(() => "abc".search({ get [Symbol.search]() { throw new TypeError("getter"); } }), TypeError);
+
+// RegExp subclasses without overrides behave like plain regexps.
+{
+    class MyRegExp extends RegExp { }
+    shouldBe("a1b2".search(new MyRegExp("[0-9]")), 1);
+}
+
+// RegExp subclasses overriding @@search are observed.
+{
+    class MyRegExp2 extends RegExp {
+        [Symbol.search](str) { return "custom:" + str; }
+    }
+    shouldBe("a1b2".search(new MyRegExp2("[0-9]")), "custom:a1b2");
+}
+
+// RegExp subclasses overriding exec are observed through RegExp.prototype[@@search].
+{
+    class MyRegExp3 extends RegExp {
+        exec() { return { index: 99 }; }
+    }
+    shouldBe("a1b2".search(new MyRegExp3("[0-9]")), 99);
+}
+
+// A fake regexp-like object with only @@search.
+{
+    var fake = {
+        [Symbol.search](str) { return str.length; }
+    };
+    shouldBe("hello".search(fake), 5);
+}
+
+// Unicode handling: the result is a code unit index.
+shouldBe("\u{20BB7}a".search(/a/), 2);
+shouldBe("\u{20BB7}a".search(/\u{20BB7}/u), 0);
+shouldBe("あいう".search(/う/), 2);
+
+// Rope strings.
+{
+    var left = "a".repeat(10);
+    var right = "1" + "b".repeat(10);
+    shouldBe((left + right).search(/[0-9]/), 10);
+}
+
+// Captures and legacy RegExp statics still work through search.
+{
+    "abc1def".search(/([0-9])/);
+    shouldBe(RegExp.$1, "1");
+    shouldBe(RegExp.lastMatch, "1");
+}
+
+// Function properties.
+shouldBe(String.prototype.search.length, 1);
+shouldBe(String.prototype.search.name, "search");
+shouldBe(typeof RegExp.prototype[Symbol.search], "function");
+
+// Property attributes stay the same as before (writable, non-enumerable, configurable).
+{
+    var descriptor = Object.getOwnPropertyDescriptor(String.prototype, "search");
+    shouldBe(descriptor.writable, true);
+    shouldBe(descriptor.enumerable, false);
+    shouldBe(descriptor.configurable, true);
+}
+
+print("PASSED");

--- a/JSTests/stress/string-prototype-search-strength-reduction.js
+++ b/JSTests/stress/string-prototype-search-strength-reduction.js
@@ -1,0 +1,92 @@
+// Exercises the DFG path where a StringSearch node is converted to RegExpSearch
+// in fixup and then further strength-reduced for known-flag literal RegExp
+// arguments.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("expected " + expected + " but got " + actual);
+}
+
+// Non-global literal: StringSearch -> RegExpSearch (strength-reduced for the literal).
+function searchLiteral(str) {
+    return str.search(/[0-9]/);
+}
+noInline(searchLiteral);
+for (var i = 0; i < 1e5; ++i)
+    shouldBe(searchLiteral("a1b2c3"), 1);
+shouldBe(searchLiteral("nope"), -1);
+
+// Global literal: search ignores the global flag and always starts from index 0.
+function searchGlobalLiteral(str) {
+    return str.search(/[0-9]/g);
+}
+noInline(searchGlobalLiteral);
+for (var i = 0; i < 1e5; ++i)
+    shouldBe(searchGlobalLiteral("a1b2c3"), 1);
+shouldBe(searchGlobalLiteral("nope"), -1);
+
+// Sticky literal: @@search resets lastIndex to 0, so sticky only matches at the start.
+function searchStickyLiteral(str) {
+    return str.search(/[0-9]/y);
+}
+noInline(searchStickyLiteral);
+for (var i = 0; i < 1e5; ++i)
+    shouldBe(searchStickyLiteral("1abc"), 0);
+shouldBe(searchStickyLiteral("a1bc"), -1);
+
+// Unicode literal exercising surrogate handling.
+function searchUnicode(str) {
+    return str.search(/\u{1F600}/u);
+}
+noInline(searchUnicode);
+for (var i = 0; i < 1e5; ++i)
+    shouldBe(searchUnicode("a\u{1F600}b"), 1);
+
+// Cached RegExp parameter: StringSearch -> RegExpSearch (no strength reduction
+// since the regexp is not a constant).
+function searchCached(str, re) {
+    return str.search(re);
+}
+noInline(searchCached);
+var cached = /[0-9]/;
+for (var i = 0; i < 1e5; ++i)
+    shouldBe(searchCached("a1b2c3", cached), 1);
+
+// Cached global RegExp with non-zero lastIndex: search always starts from 0 and
+// must leave lastIndex untouched on the fast path.
+var cachedGlobal = /[0-9]/g;
+cachedGlobal.lastIndex = 5;
+for (var i = 0; i < 1e5; ++i) {
+    shouldBe(searchCached("a1b2c3", cachedGlobal), 1);
+    shouldBe(cachedGlobal.lastIndex, 5);
+}
+
+// String pattern: StringSearch with StringUse on child2.
+function searchStringPattern(str, pat) {
+    return str.search(pat);
+}
+noInline(searchStringPattern);
+for (var i = 0; i < 1e5; ++i)
+    shouldBe(searchStringPattern("a1b2c3", "[0-9]"), 1);
+
+// Mixed: function that sees both global and non-global regexps.
+function searchPoly(str, re) {
+    return str.search(re);
+}
+noInline(searchPoly);
+var g = /[0-9]/g;
+var ng = /[0-9]/;
+for (var i = 0; i < 1e5; ++i) {
+    shouldBe(searchPoly("a1b2c3", g), 1);
+    shouldBe(searchPoly("a1b2c3", ng), 1);
+}
+
+// Legacy properties recorded after a search.
+{
+    "abc1def".search(/[0-9]/);
+    shouldBe(RegExp.lastMatch, "1");
+    shouldBe(RegExp.leftContext, "abc");
+    shouldBe(RegExp.rightContext, "def");
+}
+
+print("PASSED");

--- a/JSTests/stress/string-prototype-search-watchpoint-invalidation.js
+++ b/JSTests/stress/string-prototype-search-watchpoint-invalidation.js
@@ -1,0 +1,189 @@
+// Verifies that String.prototype.search honors dynamic mutations of @@search-related
+// state after DFG/FTL code has been compiled. Each test warms up the fast path,
+// then invalidates one watchpoint or the per-instance state and confirms the
+// override is observed.
+
+function shouldBe(actual, expected) {
+    if (actual !== expected)
+        throw new Error("expected " + expected + " but got " + actual);
+}
+
+// 1. Per-instance @@search override after JIT compilation with a primordial RegExp.
+(function () {
+    function search(str, re) { return str.search(re); }
+    noInline(search);
+    var re = /[0-9]/;
+    for (var i = 0; i < 1e4; ++i)
+        shouldBe(search("a1b2c3", re), 1);
+    re[Symbol.search] = function (s) { return "override:" + s; };
+    shouldBe(search("a1b2c3", re), "override:a1b2c3");
+})();
+
+// 2. RegExp.prototype[@@search] replaced after JIT compilation.
+(function () {
+    function search(str, re) { return str.search(re); }
+    noInline(search);
+    var re = /[0-9]/;
+    for (var i = 0; i < 1e4; ++i)
+        shouldBe(search("a1b2c3", re), 1);
+    var saved = RegExp.prototype[Symbol.search];
+    RegExp.prototype[Symbol.search] = function (s) { return "proto:" + s; };
+    try {
+        shouldBe(search("a1b2c3", re), "proto:a1b2c3");
+    } finally {
+        RegExp.prototype[Symbol.search] = saved;
+    }
+})();
+
+// 3. RegExp.prototype.exec replaced after JIT compilation.
+(function () {
+    function search(str, re) { return str.search(re); }
+    noInline(search);
+    var re = /[0-9]/;
+    for (var i = 0; i < 1e4; ++i)
+        shouldBe(search("a1b2c3", re), 1);
+    var saved = RegExp.prototype.exec;
+    var execCount = 0;
+    RegExp.prototype.exec = function (s) {
+        execCount++;
+        return saved.call(this, s);
+    };
+    try {
+        shouldBe(search("a1b2c3", re), 1);
+        if (execCount === 0)
+            throw new Error("custom RegExp.prototype.exec must be observed");
+    } finally {
+        RegExp.prototype.exec = saved;
+    }
+})();
+
+// 4. String.prototype[@@search] defined after JIT compilation with a string regexp.
+(function () {
+    function search(str, pat) { return str.search(pat); }
+    noInline(search);
+    for (var i = 0; i < 1e4; ++i)
+        shouldBe(search("abc1def2", "[0-9]"), 3);
+    // Per current spec ("2. If regexp is not Object"), a primitive pattern argument
+    // does NOT trigger a GetMethod(@@search) lookup, so a user-installed
+    // String.prototype[@@search] is not observed for a primitive string pattern.
+    Object.defineProperty(String.prototype, Symbol.search, {
+        configurable: true,
+        value: function () { return "string-proto"; }
+    });
+    try {
+        shouldBe(search("abc1def2", "[0-9]"), 3);
+        // But a String *object* DOES go through @@search.
+        shouldBe("abc1def2".search(new String("[0-9]")), "string-proto");
+    } finally {
+        delete String.prototype[Symbol.search];
+    }
+})();
+
+// 5. Non-numeric lastIndex after JIT compilation. @@search never coerces lastIndex,
+//    so valueOf must not be observed and the result stays correct.
+(function () {
+    function search(str, re) { return str.search(re); }
+    noInline(search);
+    var re = /[0-9]/g;
+    for (var i = 0; i < 1e4; ++i)
+        shouldBe(search("a1b2c3", re), 1);
+    var valueOfCount = 0;
+    re.lastIndex = { valueOf() { valueOfCount++; return 0; } };
+    shouldBe(search("a1b2c3", re), 1);
+    shouldBe(valueOfCount, 0);
+})();
+
+// 6. Non-writable lastIndex after JIT compilation.
+(function () {
+    function search(str, re) { return str.search(re); }
+    noInline(search);
+    var re = /[0-9]/g;
+    for (var i = 0; i < 1e4; ++i)
+        shouldBe(search("a1b2c3", re), 1);
+    // With lastIndex frozen at 0 and a non-global regexp, @@search performs no
+    // lastIndex writes and succeeds.
+    var frozenZero = /[0-9]/;
+    Object.defineProperty(frozenZero, "lastIndex", { writable: false });
+    shouldBe(search("a1b2c3", frozenZero), 1);
+    // The original regexp keeps using the fast path.
+    shouldBe(search("a1b2c3", re), 1);
+})();
+
+// 7. Reflect.setPrototypeOf to a non-RegExp prototype after JIT compilation.
+(function () {
+    function search(str, re) { return str.search(re); }
+    noInline(search);
+    var re = /[0-9]/;
+    for (var i = 0; i < 1e4; ++i)
+        shouldBe(search("a1b2c3", re), 1);
+    var weird = /[0-9]/;
+    Object.setPrototypeOf(weird, {
+        [Symbol.search](s) { return "weird:" + s; }
+    });
+    shouldBe(search("a1b2c3", weird), "weird:a1b2c3");
+    // The fast path must keep working for normal regexps after seeing one weird instance.
+    shouldBe(search("a1b2c3", re), 1);
+})();
+
+// 8. ToString(this) mutates the regexp instance between the fast-path check and
+//    the search engine. Per spec, RegExp.prototype[@@search] dispatches to
+//    RegExpExec(rx, S) *after* S = ToString(string), so the user-installed exec
+//    must be observed.
+(function () {
+    var re = /a/;
+    var receiver = {
+        toString() {
+            re.exec = function () { return { index: 42 }; };
+            return "abc";
+        }
+    };
+    shouldBe(String.prototype.search.call(receiver, re), 42);
+})();
+(function () {
+    // Mutating RegExp.prototype.exec inside ToString fires regExpPrimordialPropertiesWatchpointSet.
+    var re = /a/;
+    var saved = RegExp.prototype.exec;
+    var receiver = {
+        toString() {
+            RegExp.prototype.exec = function () { return { index: 42 }; };
+            return "abc";
+        }
+    };
+    try {
+        shouldBe(String.prototype.search.call(receiver, re), 42);
+    } finally {
+        RegExp.prototype.exec = saved;
+    }
+})();
+(function () {
+    // Mutating lastIndex to a non-number inside ToString.
+    var re = /b/;
+    var receiver = {
+        toString() {
+            re.lastIndex = { valueOf() { return 0; } };
+            return "abc";
+        }
+    };
+    shouldBe(String.prototype.search.call(receiver, re), 1);
+})();
+(function () {
+    // Making lastIndex non-writable (and non-zero) inside ToString: the generic
+    // @@search path must throw when resetting lastIndex to 0.
+    var re = /b/;
+    re.lastIndex = 3;
+    var receiver = {
+        toString() {
+            Object.defineProperty(re, "lastIndex", { writable: false });
+            return "abc";
+        }
+    };
+    var threw = false;
+    try {
+        String.prototype.search.call(receiver, re);
+    } catch (e) {
+        threw = e instanceof TypeError;
+    }
+    shouldBe(threw, true);
+})();
+
+print("PASSED");

--- a/Source/JavaScriptCore/builtins/StringPrototype.js
+++ b/Source/JavaScriptCore/builtins/StringPrototype.js
@@ -46,21 +46,4 @@ function matchAll(arg)
     return regExp.@@matchAll(string);
 }
 
-function search(regexp)
-{
-    "use strict";
-
-    if (@isUndefinedOrNull(this))
-        @throwTypeError("String.prototype.search requires that |this| not be null or undefined");
-
-    if (@isObject(regexp)) {
-        var searcher = regexp.@@search;
-        if (!@isUndefinedOrNull(searcher))
-            return searcher.@call(regexp, this);
-    }
-
-    var thisString = @toString(this);
-    var createdRegExp = @regExpCreate(regexp, @undefined);
-    return createdRegExp.@@search(thisString);
-}
 

--- a/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
+++ b/Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h
@@ -2711,6 +2711,7 @@ bool AbstractInterpreter<AbstractStateType>::executeEffects(unsigned clobberLimi
         break;
 
     case StringMatch:
+    case StringSearch:
         clobberWorld();
         makeHeapTopForNode(node);
         break;

--- a/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp
@@ -375,7 +375,8 @@ private:
             break;
         }
 
-        case StringMatch: {
+        case StringMatch:
+        case StringSearch: {
             node->child1()->mergeFlags(NodeBytecodeUsesAsValue);
             node->child2()->mergeFlags(NodeBytecodeUsesAsValue);
             break;

--- a/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
+++ b/Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp
@@ -3374,6 +3374,30 @@ auto ByteCodeParser::handleIntrinsicCall(Node* callee, Operand resultOperand, Ca
             return CallOptimizationResult::Inlined;
         }
 
+        case StringPrototypeSearchIntrinsic: {
+            if (argumentCountIncludingThis < 2)
+                return CallOptimizationResult::DidNothing;
+
+            if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadType))
+                return CallOptimizationResult::DidNothing;
+
+            if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadConstantValue))
+                return CallOptimizationResult::DidNothing;
+
+            if (m_inlineStackTop->m_exitProfile.hasExitSite(m_currentIndex, BadCache))
+                return CallOptimizationResult::DidNothing;
+
+            if (!m_graph.isWatchingStringSymbolSearchWatchpoint(currentCodeOrigin()))
+                return CallOptimizationResult::DidNothing;
+
+            insertChecks();
+            Node* thisValue = get(virtualRegisterForArgumentIncludingThis(0, registerOffset));
+            Node* regexp = get(virtualRegisterForArgumentIncludingThis(1, registerOffset));
+            Node* result = addToGraph(StringSearch, thisValue, regexp);
+            setResult(result);
+            return CallOptimizationResult::Inlined;
+        }
+
         case StringPrototypeStartsWithIntrinsic:
         case StringPrototypeEndsWithIntrinsic: {
             if (argumentCountIncludingThis < 2)

--- a/Source/JavaScriptCore/dfg/DFGClobberize.h
+++ b/Source/JavaScriptCore/dfg/DFGClobberize.h
@@ -2336,6 +2336,7 @@ void clobberize(Graph& graph, Node* node, const ReadFunctor& read, const WriteFu
 
     case StringSplit:
     case StringMatch:
+    case StringSearch:
         clobberTop();
         return;
 

--- a/Source/JavaScriptCore/dfg/DFGCloneHelper.h
+++ b/Source/JavaScriptCore/dfg/DFGCloneHelper.h
@@ -357,6 +357,7 @@ BasicBlock* CloneHelper::cloneBlock(BasicBlock* const block, const CustomizeSucc
     CLONE_STATUS(StringSlice, Common) \
     CLONE_STATUS(StringSplit, Common) \
     CLONE_STATUS(StringMatch, Common) \
+    CLONE_STATUS(StringSearch, Common) \
     CLONE_STATUS(StringSubstring, Common) \
     CLONE_STATUS(StringSubstr, Common) \
     CLONE_STATUS(StrCat, Common) \

--- a/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
+++ b/Source/JavaScriptCore/dfg/DFGDoesGC.cpp
@@ -505,6 +505,7 @@ bool doesGC(Graph& graph, Node* node)
     case StringEndsWith:
     case StringSplit:
     case StringMatch:
+    case StringSearch:
     case ResolvePromiseFirstResolving:
     case RejectPromiseFirstResolving:
     case FulfillPromiseFirstResolving:

--- a/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGFixupPhase.cpp
@@ -1182,7 +1182,7 @@ private:
         case StringMatch: {
             if (node->child2()->shouldSpeculateRegExpObject()) {
                 if (m_graph.isWatchingRegExpPrimordialPropertiesWatchpoint(node)) {
-                    addStringMatchPrimordialChecks(node->child2().node());
+                    addStringMatchAndSearchPrimordialChecks(node->child2().node());
 
                     JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);
                     Node* globalObjectNode = m_insertionSet.insertNode(
@@ -1190,6 +1190,32 @@ private:
                         OpInfo(m_graph.freeze(globalObject)));
 
                     node->convertToRegExpMatchFast(globalObjectNode);
+
+                    fixEdge<KnownCellUse>(node->child1());
+                    fixEdge<RegExpObjectUse>(node->child2());
+                    fixEdge<StringUse>(node->child3());
+                    break;
+                }
+                fixEdge<StringUse>(node->child1());
+                fixEdge<RegExpObjectUse>(node->child2());
+                break;
+            }
+            fixEdge<StringUse>(node->child1());
+            fixEdge<StringUse>(node->child2());
+            break;
+        }
+
+        case StringSearch: {
+            if (node->child2()->shouldSpeculateRegExpObject()) {
+                if (m_graph.isWatchingRegExpPrimordialPropertiesWatchpoint(node)) {
+                    addStringMatchAndSearchPrimordialChecks(node->child2().node());
+
+                    JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);
+                    Node* globalObjectNode = m_insertionSet.insertNode(
+                        m_indexInBlock, SpecObjectOther, JSConstant, node->origin,
+                        OpInfo(m_graph.freeze(globalObject)));
+
+                    node->convertToRegExpSearch(globalObjectNode);
 
                     fixEdge<KnownCellUse>(node->child1());
                     fixEdge<RegExpObjectUse>(node->child2());
@@ -4597,7 +4623,7 @@ private:
         emitPrimordialCheckFor(globalObject->regExpProtoSymbolReplaceFunction(), vm().propertyNames->replaceSymbol.impl());
     }
 
-    void addStringMatchPrimordialChecks(Node* regExp)
+    void addStringMatchAndSearchPrimordialChecks(Node* regExp)
     {
         Node* node = m_currentNode;
         JSGlobalObject* globalObject = m_graph.globalObjectFor(node->origin.semantic);

--- a/Source/JavaScriptCore/dfg/DFGGraph.h
+++ b/Source/JavaScriptCore/dfg/DFGGraph.h
@@ -1006,6 +1006,13 @@ public:
         return isWatchingGlobalObjectWatchpoint(globalObject, set, LinkerIR::Type::StringSymbolMatchWatchpointSet);
     }
 
+    bool isWatchingStringSymbolSearchWatchpoint(const CodeOrigin& semanticOrigin)
+    {
+        JSGlobalObject* globalObject = globalObjectFor(semanticOrigin);
+        InlineWatchpointSet& set = globalObject->stringSymbolSearchWatchpointSet();
+        return isWatchingGlobalObjectWatchpoint(globalObject, set, LinkerIR::Type::StringSymbolSearchWatchpointSet);
+    }
+
     bool isWatchingStringSymbolReplaceWatchpoint(const CodeOrigin& semanticOrigin)
     {
         JSGlobalObject* globalObject = globalObjectFor(semanticOrigin);

--- a/Source/JavaScriptCore/dfg/DFGJITCode.cpp
+++ b/Source/JavaScriptCore/dfg/DFGJITCode.cpp
@@ -54,6 +54,7 @@ JITData::JITData(unsigned propertyCacheSize, unsigned poolSize, const JITCode& j
         case LinkerIR::Type::StringToStringWatchpointSet:
         case LinkerIR::Type::StringValueOfWatchpointSet:
         case LinkerIR::Type::StringSymbolMatchWatchpointSet:
+        case LinkerIR::Type::StringSymbolSearchWatchpointSet:
         case LinkerIR::Type::StringSymbolReplaceWatchpointSet:
         case LinkerIR::Type::StringSymbolSplitWatchpointSet:
         case LinkerIR::Type::StringSymbolToPrimitiveWatchpointSet:
@@ -178,6 +179,11 @@ bool JITData::tryInitialize(VM& vm, CodeBlock* codeBlock, const JITCode& jitCode
         case LinkerIR::Type::StringSymbolMatchWatchpointSet: {
             auto& watchpoint = m_watchpoints[indexOfWatchpoints++];
             success &= attemptToWatch(codeBlock, m_globalObject->stringSymbolMatchWatchpointSet(), watchpoint);
+            break;
+        }
+        case LinkerIR::Type::StringSymbolSearchWatchpointSet: {
+            auto& watchpoint = m_watchpoints[indexOfWatchpoints++];
+            success &= attemptToWatch(codeBlock, m_globalObject->stringSymbolSearchWatchpointSet(), watchpoint);
             break;
         }
         case LinkerIR::Type::StringSymbolReplaceWatchpointSet: {

--- a/Source/JavaScriptCore/dfg/DFGJITCode.h
+++ b/Source/JavaScriptCore/dfg/DFGJITCode.h
@@ -102,6 +102,7 @@ public:
         StringToStringWatchpointSet,
         StringValueOfWatchpointSet,
         StringSymbolMatchWatchpointSet,
+        StringSymbolSearchWatchpointSet,
         StringSymbolReplaceWatchpointSet,
         StringSymbolSplitWatchpointSet,
         StringSymbolToPrimitiveWatchpointSet,

--- a/Source/JavaScriptCore/dfg/DFGNode.cpp
+++ b/Source/JavaScriptCore/dfg/DFGNode.cpp
@@ -376,6 +376,15 @@ void Node::convertToRegExpMatchFast(Node* globalObjectNode)
     children = AdjacencyList(AdjacencyList::Fixed, Edge(globalObjectNode), regExpEdge, stringEdge);
 }
 
+void Node::convertToRegExpSearch(Node* globalObjectNode)
+{
+    ASSERT(op() == StringSearch);
+    Edge stringEdge = child1();
+    Edge regExpEdge = child2();
+    setOpAndDefaultFlags(RegExpSearch);
+    children = AdjacencyList(AdjacencyList::Fixed, Edge(globalObjectNode), regExpEdge, stringEdge);
+}
+
 void Node::convertToDefineDataProperty(Graph& graph, Edge base, Edge property, Edge value, Edge attributes)
 {
     ASSERT(op() == ObjectDefinePropertyFromFields);

--- a/Source/JavaScriptCore/dfg/DFGNode.h
+++ b/Source/JavaScriptCore/dfg/DFGNode.h
@@ -963,6 +963,7 @@ public:
     void NODELETE convertToRegExpExecNonGlobalOrStickyWithoutChecks(FrozenValue* regExp);
     void NODELETE convertToRegExpMatchFastGlobalWithoutChecks(FrozenValue* regExp);
     void NODELETE convertToRegExpMatchFast(Node* globalObjectNode);
+    void NODELETE convertToRegExpSearch(Node* globalObjectNode);
     void NODELETE convertToRegExpTestInline(FrozenValue* globalObject, FrozenValue* regExp);
 
     enum DescriptorSlot : unsigned {

--- a/Source/JavaScriptCore/dfg/DFGNodeType.h
+++ b/Source/JavaScriptCore/dfg/DFGNodeType.h
@@ -373,6 +373,7 @@ namespace JSC { namespace DFG {
     macro(StringEndsWith, NodeResultBoolean) \
     macro(StringSplit, NodeResultJS | NodeMustGenerate) \
     macro(StringMatch, NodeResultJS | NodeMustGenerate) \
+    macro(StringSearch, NodeResultJS | NodeMustGenerate) \
     \
     /* Optimizations for string access */ \
     macro(StringAt, NodeResultJS) \

--- a/Source/JavaScriptCore/dfg/DFGOperations.cpp
+++ b/Source/JavaScriptCore/dfg/DFGOperations.cpp
@@ -4154,6 +4154,44 @@ JSC_DEFINE_JIT_OPERATION(operationStringMatchRegExp, EncodedJSValue, (JSGlobalOb
     OPERATION_RETURN(scope, JSValue::encode(stringMatchSlow(globalObject, thisString, regexp)));
 }
 
+JSC_DEFINE_JIT_OPERATION(operationStringSearch, EncodedJSValue, (JSGlobalObject* globalObject, JSString* thisString, JSString* regexpString))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    OPERATION_RETURN(scope, JSValue::encode(stringSearchSlow(globalObject, thisString, regexpString)));
+}
+
+JSC_DEFINE_JIT_OPERATION(operationStringSearchRegExp, EncodedJSValue, (JSGlobalObject* globalObject, JSString* thisString, RegExpObject* regexp))
+{
+    VM& vm = globalObject->vm();
+    CallFrame* callFrame = DECLARE_CALL_FRAME(vm);
+    JITOperationPrologueCallFrameTracer tracer(vm, callFrame);
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (regexp->isSymbolSearchFastAndNonObservable()) [[likely]]
+        OPERATION_RETURN(scope, JSValue::encode(regExpSearchFast(globalObject, regexp, thisString)));
+
+    JSValue searcher = regexp->get(globalObject, vm.propertyNames->searchSymbol);
+    OPERATION_RETURN_IF_EXCEPTION(scope, encodedJSValue());
+    if (!searcher.isUndefinedOrNull()) {
+        auto callData = JSC::getCallData(searcher);
+        if (callData.type == CallData::Type::None) [[unlikely]] {
+            throwTypeError(globalObject, scope, "@@search method is not callable"_s);
+            OPERATION_RETURN(scope, encodedJSValue());
+        }
+        std::array<EncodedJSValue, 1> args { {
+            JSValue::encode(thisString),
+        } };
+        JSValue result = call(globalObject, searcher, callData, regexp, ArgList { args.data(), args.size() });
+        OPERATION_RETURN_IF_EXCEPTION(scope, encodedJSValue());
+        OPERATION_RETURN(scope, JSValue::encode(result));
+    }
+    OPERATION_RETURN(scope, JSValue::encode(stringSearchSlow(globalObject, thisString, regexp)));
+}
+
 JSC_DEFINE_JIT_OPERATION(operationStringProtoFuncReplaceGeneric, JSCell*, (JSGlobalObject* globalObject, EncodedJSValue thisValue, EncodedJSValue searchValue, EncodedJSValue replaceValue))
 {
     VM& vm = globalObject->vm();

--- a/Source/JavaScriptCore/dfg/DFGOperations.h
+++ b/Source/JavaScriptCore/dfg/DFGOperations.h
@@ -325,6 +325,8 @@ JSC_DECLARE_JIT_OPERATION(operationStringSplit, JSCell*, (JSGlobalObject*, JSStr
 JSC_DECLARE_JIT_OPERATION(operationStringSplitRegExp, EncodedJSValue, (JSGlobalObject*, JSString*, RegExpObject*, EncodedJSValue));
 JSC_DECLARE_JIT_OPERATION(operationStringMatch, EncodedJSValue, (JSGlobalObject*, JSString*, JSString*));
 JSC_DECLARE_JIT_OPERATION(operationStringMatchRegExp, EncodedJSValue, (JSGlobalObject*, JSString*, RegExpObject*));
+JSC_DECLARE_JIT_OPERATION(operationStringSearch, EncodedJSValue, (JSGlobalObject*, JSString*, JSString*));
+JSC_DECLARE_JIT_OPERATION(operationStringSearchRegExp, EncodedJSValue, (JSGlobalObject*, JSString*, RegExpObject*));
 
 JSC_DECLARE_JIT_OPERATION(operationStringProtoFuncReplaceGeneric, JSCell*, (JSGlobalObject*, EncodedJSValue thisValue, EncodedJSValue searchValue, EncodedJSValue replaceValue));
 JSC_DECLARE_JIT_OPERATION(operationStringProtoFuncReplaceAllGeneric, JSCell*, (JSGlobalObject*, EncodedJSValue thisValue, EncodedJSValue searchValue, EncodedJSValue replaceValue));

--- a/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
+++ b/Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp
@@ -1228,6 +1228,11 @@ private:
             break;
         }
 
+        case StringSearch: {
+            setPrediction(SpecInt32Only);
+            break;
+        }
+
         case StringLocaleCompare: {
             setPrediction(SpecInt32Only);
             break;

--- a/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
+++ b/Source/JavaScriptCore/dfg/DFGSafeToExecute.h
@@ -647,6 +647,7 @@ bool safeToExecute(AbstractStateType& state, Graph& graph, Node* node, bool igno
     case RegExpMatchFastGlobal:
     case RegExpSearch:
     case StringMatch:
+    case StringSearch:
     case Call:
     case DirectCall:
     case TailCallInlinedCaller:

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp
@@ -18174,6 +18174,36 @@ void SpeculativeJIT::compileStringMatch(Node* node)
     jsValueResult(resultRegs, node);
 }
 
+void SpeculativeJIT::compileStringSearch(Node* node)
+{
+    SpeculateCellOperand base(this, node->child1());
+    SpeculateCellOperand argument(this, node->child2());
+
+    GPRReg baseGPR = base.gpr();
+    GPRReg argumentGPR = argument.gpr();
+
+    speculateString(node->child1(), baseGPR);
+
+    if (node->child2().useKind() == RegExpObjectUse) {
+        speculateRegExpObject(node->child2(), argumentGPR);
+
+        flushRegisters();
+        JSValueRegsFlushedCallResult result(this);
+        JSValueRegs resultRegs = result.regs();
+        callOperation(operationStringSearchRegExp, resultRegs, LinkableConstant::globalObject(*this, node), baseGPR, argumentGPR);
+        jsValueResult(resultRegs, node);
+        return;
+    }
+
+    speculateString(node->child2(), argumentGPR);
+
+    flushRegisters();
+    JSValueRegsFlushedCallResult result(this);
+    JSValueRegs resultRegs = result.regs();
+    callOperation(operationStringSearch, resultRegs, LinkableConstant::globalObject(*this, node), baseGPR, argumentGPR);
+    jsValueResult(resultRegs, node);
+}
+
 void SpeculativeJIT::compileStringLastIndexOf(Node* node)
 {
     std::optional<char16_t> character;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h
@@ -1814,6 +1814,7 @@ public:
 #endif
     void compileStringSplit(Node*);
     void compileStringMatch(Node*);
+    void compileStringSearch(Node*);
     void compileDateNow(Node*);
     void compileDateGet(Node*);
     void compileDateSet(Node*);

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp
@@ -3188,6 +3188,11 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case StringSearch: {
+        compileStringSearch(node);
+        break;
+    }
+
     case StringLastIndexOf: {
         compileStringLastIndexOf(node);
         break;

--- a/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
+++ b/Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp
@@ -3794,6 +3794,11 @@ void SpeculativeJIT::compile(Node* node)
         break;
     }
 
+    case StringSearch: {
+        compileStringSearch(node);
+        break;
+    }
+
     case StringLastIndexOf: {
         compileStringLastIndexOf(node);
         break;

--- a/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
+++ b/Source/JavaScriptCore/ftl/FTLCapabilities.cpp
@@ -181,6 +181,7 @@ inline CapabilityLevel canCompile(DFG::Node* node)
     case StringEndsWith:
     case StringSplit:
     case StringMatch:
+    case StringSearch:
     case AllocatePropertyStorage:
     case ReallocatePropertyStorage:
     case NukeStructureAndSetButterfly:

--- a/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
+++ b/Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp
@@ -1412,6 +1412,9 @@ private:
         case StringMatch:
             compileStringMatch();
             break;
+        case StringSearch:
+            compileStringSearch();
+            break;
         case GetByOffset:
         case GetGetterSetterByOffset:
             compileGetByOffset();
@@ -12403,6 +12406,19 @@ IGNORE_CLANG_WARNINGS_END
         }
         LValue regexp = lowString(m_node->child2());
         setJSValue(vmCall(Int64, operationStringMatch, weakPointer(globalObject), base, regexp));
+    }
+
+    void compileStringSearch()
+    {
+        LValue base = lowString(m_node->child1());
+        auto* globalObject = m_graph.globalObjectFor(m_origin.semantic);
+        if (m_node->child2().useKind() == RegExpObjectUse) {
+            LValue regexp = lowRegExpObject(m_node->child2());
+            setJSValue(vmCall(Int64, operationStringSearchRegExp, weakPointer(globalObject), base, regexp));
+            return;
+        }
+        LValue argument = lowString(m_node->child2());
+        setJSValue(vmCall(Int64, operationStringSearch, weakPointer(globalObject), base, argument));
     }
 
     void compileStringLastIndexOf()

--- a/Source/JavaScriptCore/runtime/Intrinsic.h
+++ b/Source/JavaScriptCore/runtime/Intrinsic.h
@@ -136,6 +136,7 @@ namespace JSC {
     macro(StringPrototypeLocaleCompareIntrinsic) \
     macro(StringPrototypeValueOfIntrinsic) \
     macro(StringPrototypeMatchIntrinsic) \
+    macro(StringPrototypeSearchIntrinsic) \
     macro(StringPrototypeReplaceIntrinsic) \
     macro(StringPrototypeReplaceAllIntrinsic) \
     macro(StringPrototypeSplitIntrinsic) \

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.cpp
@@ -2276,6 +2276,7 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     installObjectPropertyChangeAdaptiveWatchpoint(setupAdaptiveWatchpoint(this, m_regExpPrototype.get(), vm.propertyNames->unicodeSets), m_regExpPrimordialPropertiesWatchpointSet);
     installObjectPropertyChangeAdaptiveWatchpoint(setupAdaptiveWatchpoint(this, m_regExpPrototype.get(), vm.propertyNames->replaceSymbol), m_regExpPrimordialPropertiesWatchpointSet);
     installObjectPropertyChangeAdaptiveWatchpoint(setupAdaptiveWatchpoint(this, m_regExpPrototype.get(), vm.propertyNames->matchSymbol), m_regExpPrimordialPropertiesWatchpointSet);
+    installObjectPropertyChangeAdaptiveWatchpoint(setupAdaptiveWatchpoint(this, m_regExpPrototype.get(), vm.propertyNames->searchSymbol), m_regExpPrimordialPropertiesWatchpointSet);
     installObjectPropertyChangeAdaptiveWatchpoint(setupAdaptiveWatchpoint(this, m_regExpPrototype.get(), vm.propertyNames->splitSymbol), m_regExpPrimordialPropertiesWatchpointSet);
     installObjectPropertyChangeAdaptiveWatchpoint(setupAdaptiveWatchpoint(this, jsSetPrototype(), vm.propertyNames->has), m_setPrimordialPropertiesWatchpointSet);
     installObjectPropertyChangeAdaptiveWatchpoint(setupAdaptiveWatchpoint(this, jsSetPrototype(), vm.propertyNames->keys), m_setPrimordialPropertiesWatchpointSet);
@@ -2287,6 +2288,8 @@ capitalName ## Constructor* lowerName ## Constructor = featureFlag ? capitalName
     // Detect property absence.
     installObjectAdaptiveStructureWatchpoint(setupAbsenceAdaptiveWatchpoint(this, m_stringPrototype.get(), vm.propertyNames->matchSymbol, objectPrototype()), m_stringSymbolMatchWatchpointSet);
     installObjectAdaptiveStructureWatchpoint(setupAbsenceAdaptiveWatchpoint(this, m_objectPrototype.get(), vm.propertyNames->matchSymbol, nullptr), m_stringSymbolMatchWatchpointSet);
+    installObjectAdaptiveStructureWatchpoint(setupAbsenceAdaptiveWatchpoint(this, m_stringPrototype.get(), vm.propertyNames->searchSymbol, objectPrototype()), m_stringSymbolSearchWatchpointSet);
+    installObjectAdaptiveStructureWatchpoint(setupAbsenceAdaptiveWatchpoint(this, m_objectPrototype.get(), vm.propertyNames->searchSymbol, nullptr), m_stringSymbolSearchWatchpointSet);
     installObjectAdaptiveStructureWatchpoint(setupAbsenceAdaptiveWatchpoint(this, m_stringPrototype.get(), vm.propertyNames->replaceSymbol, objectPrototype()), m_stringSymbolReplaceWatchpointSet);
     installObjectAdaptiveStructureWatchpoint(setupAbsenceAdaptiveWatchpoint(this, m_objectPrototype.get(), vm.propertyNames->replaceSymbol, nullptr), m_stringSymbolReplaceWatchpointSet);
     installObjectAdaptiveStructureWatchpoint(setupAbsenceAdaptiveWatchpoint(this, m_stringPrototype.get(), vm.propertyNames->splitSymbol, objectPrototype()), m_stringSymbolSplitWatchpointSet);

--- a/Source/JavaScriptCore/runtime/JSGlobalObject.h
+++ b/Source/JavaScriptCore/runtime/JSGlobalObject.h
@@ -519,6 +519,7 @@ public:
     InlineWatchpointSet m_setIteratorProtocolWatchpointSet { IsWatched };
     InlineWatchpointSet m_stringIteratorProtocolWatchpointSet { IsWatched };
     InlineWatchpointSet m_stringSymbolMatchWatchpointSet { IsWatched };
+    InlineWatchpointSet m_stringSymbolSearchWatchpointSet { IsWatched };
     InlineWatchpointSet m_stringSymbolReplaceWatchpointSet { IsWatched };
     InlineWatchpointSet m_stringSymbolSplitWatchpointSet { IsWatched };
     InlineWatchpointSet m_stringSymbolToPrimitiveWatchpointSet { IsWatched };
@@ -597,6 +598,7 @@ public:
     InlineWatchpointSet& setIteratorProtocolWatchpointSet() LIFETIME_BOUND { return m_setIteratorProtocolWatchpointSet; }
     InlineWatchpointSet& stringIteratorProtocolWatchpointSet() LIFETIME_BOUND { return m_stringIteratorProtocolWatchpointSet; }
     InlineWatchpointSet& stringSymbolMatchWatchpointSet() LIFETIME_BOUND { return m_stringSymbolMatchWatchpointSet; }
+    InlineWatchpointSet& stringSymbolSearchWatchpointSet() LIFETIME_BOUND { return m_stringSymbolSearchWatchpointSet; }
     InlineWatchpointSet& stringSymbolReplaceWatchpointSet() LIFETIME_BOUND { return m_stringSymbolReplaceWatchpointSet; }
     InlineWatchpointSet& stringSymbolSplitWatchpointSet() LIFETIME_BOUND { return m_stringSymbolSplitWatchpointSet; }
     InlineWatchpointSet& stringSymbolToPrimitiveWatchpointSet() LIFETIME_BOUND { return m_stringSymbolToPrimitiveWatchpointSet; }

--- a/Source/JavaScriptCore/runtime/RegExpObject.h
+++ b/Source/JavaScriptCore/runtime/RegExpObject.h
@@ -112,6 +112,7 @@ public:
     JSValue matchGlobal(JSGlobalObject*, JSString*);
 
     bool isSymbolMatchFastAndNonObservable();
+    bool isSymbolSearchFastAndNonObservable();
     bool isSymbolReplaceFastAndNonObservable();
     bool isSymbolSplitFastAndNonObservable();
 

--- a/Source/JavaScriptCore/runtime/RegExpObjectInlines.h
+++ b/Source/JavaScriptCore/runtime/RegExpObjectInlines.h
@@ -62,6 +62,40 @@ ALWAYS_INLINE bool RegExpObject::isSymbolMatchFastAndNonObservable()
     return true;
 }
 
+ALWAYS_INLINE bool RegExpObject::isSymbolSearchFastAndNonObservable()
+{
+    JSGlobalObject* globalObject = this->realm();
+    if (!globalObject->regExpPrimordialPropertiesWatchpointSet().isStillValid())
+        return false;
+
+    if (!globalObject->stringSymbolSearchWatchpointSet().isStillValid())
+        return false;
+
+    // RegExp.prototype[@@search] sets lastIndex to 0 and restores it afterwards. The fast
+    // path skips both writes, which is only unobservable when lastIndex is a plain writable
+    // number; a non-writable lastIndex must throw in the generic path.
+    if (!lastIndexIsWritable())
+        return false;
+
+    if (!getLastIndex().isNumber())
+        return false;
+
+    Structure* structure = this->structure();
+    if (structure == globalObject->regExpStructure()) [[likely]]
+        return true;
+
+    if (structure->hasPolyProto())
+        return false;
+
+    if (structure->storedPrototype() != globalObject->regExpPrototype())
+        return false;
+
+    if (hasCustomProperties())
+        return false;
+
+    return true;
+}
+
 ALWAYS_INLINE bool RegExpObject::isSymbolReplaceFastAndNonObservable()
 {
     JSGlobalObject* globalObject = this->realm();

--- a/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/RegExpPrototype.cpp
@@ -464,6 +464,63 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoGetterSource, (JSGlobalObject* globalObject,
     return JSValue::encode(jsString(vm, regexp->regExp()->escapedPattern()));
 }
 
+JSValue regExpSearchFast(JSGlobalObject* globalObject, RegExpObject* regExpObject, JSString* string)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    auto strView = string->view(globalObject);
+    RETURN_IF_EXCEPTION(scope, { });
+    scope.release();
+    MatchResult result = globalObject->regExpGlobalData().performMatch(globalObject, regExpObject->regExp(), string, strView, 0);
+    return result ? jsNumber(result.start) : jsNumber(-1);
+}
+
+JSValue regExpSearchGeneric(JSGlobalObject* globalObject, JSObject* thisObject, JSString* str)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (regExpExecWatchpointIsValid(vm, thisObject)) [[likely]] {
+        auto* regExp = dynamicDowncast<RegExpObject>(thisObject);
+        if (!regExp) [[unlikely]] {
+            throwTypeError(globalObject, scope, "Builtin RegExp exec can only be called on a RegExp object"_s);
+            return { };
+        }
+        if (regExp->lastIndexIsWritable() && regExp->getLastIndex().isNumber()) [[likely]]
+            RELEASE_AND_RETURN(scope, regExpSearchFast(globalObject, regExp, str));
+    }
+
+    auto previousLastIndex = thisObject->get(globalObject, vm.propertyNames->lastIndex);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    bool isPreviousLastIndexZero = sameValue(globalObject, previousLastIndex, jsNumber(0));
+    RETURN_IF_EXCEPTION(scope, { });
+    if (!isPreviousLastIndexZero) {
+        PutPropertySlot slot(thisObject, true);
+        thisObject->methodTable()->put(thisObject, globalObject, vm.propertyNames->lastIndex, jsNumber(0), slot);
+        RETURN_IF_EXCEPTION(scope, { });
+    }
+
+    JSValue match = regExpExec(globalObject, thisObject, str);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    auto currentLastIndex = thisObject->get(globalObject, vm.propertyNames->lastIndex);
+    RETURN_IF_EXCEPTION(scope, { });
+    bool isCurrentAndPreviousLastIndexSame = sameValue(globalObject, currentLastIndex, previousLastIndex);
+    RETURN_IF_EXCEPTION(scope, { });
+    if (!isCurrentAndPreviousLastIndexSame) {
+        PutPropertySlot slot(thisObject, true);
+        thisObject->methodTable()->put(thisObject, globalObject, vm.propertyNames->lastIndex, previousLastIndex, slot);
+        RETURN_IF_EXCEPTION(scope, { });
+    }
+
+    if (match.isNull())
+        return jsNumber(-1);
+
+    RELEASE_AND_RETURN(scope, match.get(globalObject, vm.propertyNames->index));
+}
+
 JSC_DEFINE_HOST_FUNCTION(regExpProtoFuncSearch, (JSGlobalObject* globalObject, CallFrame* callFrame))
 {
     VM& vm = globalObject->vm();
@@ -477,47 +534,7 @@ JSC_DEFINE_HOST_FUNCTION(regExpProtoFuncSearch, (JSGlobalObject* globalObject, C
     JSString* str = callFrame->argument(0).toString(globalObject);
     RETURN_IF_EXCEPTION(scope, { });
 
-    if (regExpExecWatchpointIsValid(vm, thisObject)) [[likely]] {
-        auto* regExp = dynamicDowncast<RegExpObject>(thisValue);
-        if (!regExp) [[unlikely]]
-            return throwVMTypeError(globalObject, scope, "Builtin RegExp exec can only be called on a RegExp object"_s);
-        if (regExp->lastIndexIsWritable() && regExp->getLastIndex().isNumber()) [[likely]] {
-            auto strView = str->view(globalObject);
-            RETURN_IF_EXCEPTION(scope, { });
-            scope.release();
-            MatchResult result = globalObject->regExpGlobalData().performMatch(globalObject, regExp->regExp(), str, strView, 0);
-            return JSValue::encode(result ? jsNumber(result.start) : jsNumber(-1));
-        }
-    }
-
-    auto previsouLastIndex = thisObject->get(globalObject, vm.propertyNames->lastIndex);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    bool isPreviousLastIndexZero = sameValue(globalObject, previsouLastIndex, jsNumber(0));
-    RETURN_IF_EXCEPTION(scope, { });
-    if (!isPreviousLastIndexZero) {
-        PutPropertySlot slot(thisObject, true);
-        thisObject->methodTable()->put(thisObject, globalObject, vm.propertyNames->lastIndex, jsNumber(0), slot);
-        RETURN_IF_EXCEPTION(scope, { });
-    }
-
-    JSValue match = regExpExec(globalObject, thisValue, str);
-    RETURN_IF_EXCEPTION(scope, { });
-
-    auto currentLastIndex = thisObject->get(globalObject, vm.propertyNames->lastIndex);
-    RETURN_IF_EXCEPTION(scope, { });
-    bool isCurrentAndPreviousLastIndexSame = sameValue(globalObject, currentLastIndex, previsouLastIndex);
-    RETURN_IF_EXCEPTION(scope, { });
-    if (!isCurrentAndPreviousLastIndexSame) {
-        PutPropertySlot slot(thisObject, true);
-        thisObject->methodTable()->put(thisObject, globalObject, vm.propertyNames->lastIndex, previsouLastIndex, slot);
-        RETURN_IF_EXCEPTION(scope, { });
-    }
-
-    if (match.isNull())
-        return JSValue::encode(jsNumber(-1));
-
-    RELEASE_AND_RETURN(scope, JSValue::encode(match.get(globalObject, vm.propertyNames->index)));
+    RELEASE_AND_RETURN(scope, JSValue::encode(regExpSearchGeneric(globalObject, thisObject, str)));
 }
 
 static inline uint64_t NODELETE advanceStringIndex(StringView str, unsigned strSize, uint64_t index, bool isUnicode)

--- a/Source/JavaScriptCore/runtime/RegExpPrototype.h
+++ b/Source/JavaScriptCore/runtime/RegExpPrototype.h
@@ -60,6 +60,8 @@ class RegExpObject;
 class JSString;
 
 JSValue regExpMatchFast(JSGlobalObject*, RegExpObject*, JSString* inputString);
+JSValue regExpSearchFast(JSGlobalObject*, RegExpObject*, JSString* inputString);
+JSValue regExpSearchGeneric(JSGlobalObject*, JSObject* thisObject, JSString* inputString);
 JSCell* regExpSplitFast(JSGlobalObject*, RegExpObject*, JSString* inputString, unsigned limit);
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/StringPrototype.cpp
+++ b/Source/JavaScriptCore/runtime/StringPrototype.cpp
@@ -114,7 +114,6 @@ const ClassInfo StringPrototype::s_info = { "String"_s, &StringObject::s_info, &
 /* Source for StringConstructor.lut.h
 @begin stringPrototypeTable
     matchAll      JSBuiltin                      DontEnum|Function 1
-    search        JSBuiltin                      DontEnum|Function 1
     anchor        stringProtoFuncAnchor          DontEnum|Function 1
     big           stringProtoFuncBig             DontEnum|Function 0
     bold          stringProtoFuncBold            DontEnum|Function 0
@@ -169,6 +168,7 @@ void StringPrototype::finishCreation(VM& vm, JSGlobalObject* globalObject)
     JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("endsWith"_s, stringProtoFuncEndsWith, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, StringPrototypeEndsWithIntrinsic);
     JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("includes"_s, stringProtoFuncIncludes, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, StringPrototypeIncludesIntrinsic);
     JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("match"_s, stringProtoFuncMatch, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, StringPrototypeMatchIntrinsic);
+    JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("search"_s, stringProtoFuncSearch, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, StringPrototypeSearchIntrinsic);
     JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION("split"_s, stringProtoFuncSplit, static_cast<unsigned>(PropertyAttribute::DontEnum), 2, ImplementationVisibility::Public, StringPrototypeSplitIntrinsic);
     JSC_NATIVE_FUNCTION_WITHOUT_TRANSITION("normalize"_s, stringProtoFuncNormalize, static_cast<unsigned>(PropertyAttribute::DontEnum), 0, ImplementationVisibility::Public);
     JSC_NATIVE_INTRINSIC_FUNCTION_WITHOUT_TRANSITION(vm.propertyNames->builtinNames().charCodeAtPrivateName(), stringProtoFuncCharCodeAt, static_cast<unsigned>(PropertyAttribute::DontEnum), 1, ImplementationVisibility::Public, CharCodeAtIntrinsic);
@@ -1380,6 +1380,78 @@ JSC_DEFINE_HOST_FUNCTION(stringProtoFuncMatch, (JSGlobalObject* globalObject, Ca
     RETURN_IF_EXCEPTION(scope, { });
 
     RELEASE_AND_RETURN(scope, JSValue::encode(stringMatchSlow(globalObject, thisString, regexpValue)));
+}
+
+JSValue stringSearchSlow(JSGlobalObject* globalObject, JSString* thisString, JSValue regexpValue)
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSObject* createdRegExp = regExpCreate(globalObject, JSValue(), regexpValue, jsUndefined());
+    RETURN_IF_EXCEPTION(scope, { });
+
+    if (auto* regExpObject = dynamicDowncast<RegExpObject>(createdRegExp); regExpObject && regExpObject->isSymbolSearchFastAndNonObservable()) [[likely]]
+        RELEASE_AND_RETURN(scope, regExpSearchFast(globalObject, regExpObject, thisString));
+
+    JSValue searcher = createdRegExp->get(globalObject, vm.propertyNames->searchSymbol);
+    RETURN_IF_EXCEPTION(scope, { });
+    auto callData = JSC::getCallData(searcher);
+    if (callData.type == CallData::Type::None) [[unlikely]] {
+        auto description = errorDescriptionForValue(globalObject, searcher);
+        RETURN_IF_EXCEPTION(scope, { });
+        throwTypeError(globalObject, scope, makeString(description, " is not a function"_s));
+        return { };
+    }
+    std::array<EncodedJSValue, 1> args { {
+        JSValue::encode(thisString),
+    } };
+    RELEASE_AND_RETURN(scope, call(globalObject, searcher, callData, createdRegExp, ArgList { args.data(), args.size() }));
+}
+
+JSC_DEFINE_HOST_FUNCTION(stringProtoFuncSearch, (JSGlobalObject* globalObject, CallFrame* callFrame))
+{
+    VM& vm = globalObject->vm();
+    auto scope = DECLARE_THROW_SCOPE(vm);
+
+    JSValue thisValue = callFrame->thisValue();
+    if (!checkObjectCoercible(thisValue)) [[unlikely]]
+        return throwVMTypeError(globalObject, scope, "String.prototype.search requires that |this| not be null or undefined"_s);
+
+    JSValue regexpValue = callFrame->argument(0);
+
+    if (regexpValue.isObject()) {
+        if (auto* regExpObject = dynamicDowncast<RegExpObject>(regexpValue); regExpObject && regExpObject->isSymbolSearchFastAndNonObservable()) [[likely]] {
+            JSString* thisString = thisValue.toString(globalObject);
+            RETURN_IF_EXCEPTION(scope, { });
+            if (regExpObject->isSymbolSearchFastAndNonObservable()) [[likely]]
+                RELEASE_AND_RETURN(scope, JSValue::encode(regExpSearchFast(globalObject, regExpObject, thisString)));
+            // ToString(this) may have run user code that invalidated the fast path. The searcher
+            // observed by GetMethod was still the primordial RegExp.prototype[@@search], so
+            // continue with its generic implementation.
+            RELEASE_AND_RETURN(scope, JSValue::encode(regExpSearchGeneric(globalObject, regExpObject, thisString)));
+        }
+
+        JSValue searcher = asObject(regexpValue)->get(globalObject, vm.propertyNames->searchSymbol);
+        RETURN_IF_EXCEPTION(scope, { });
+
+        if (!searcher.isUndefinedOrNull()) {
+            auto callData = JSC::getCallData(searcher);
+            if (callData.type == CallData::Type::None) [[unlikely]] {
+                auto description = errorDescriptionForValue(globalObject, searcher);
+                RETURN_IF_EXCEPTION(scope, { });
+                return throwVMTypeError(globalObject, scope, makeString(description, " is not a function"_s));
+            }
+            std::array<EncodedJSValue, 1> args { {
+                JSValue::encode(thisValue),
+            } };
+            RELEASE_AND_RETURN(scope, JSValue::encode(call(globalObject, searcher, callData, regexpValue, ArgList { args.data(), args.size() })));
+        }
+    }
+
+    JSString* thisString = thisValue.toString(globalObject);
+    RETURN_IF_EXCEPTION(scope, { });
+
+    RELEASE_AND_RETURN(scope, JSValue::encode(stringSearchSlow(globalObject, thisString, regexpValue)));
 }
 
 JSC_DEFINE_HOST_FUNCTION(stringProtoFuncSubstr, (JSGlobalObject* globalObject, CallFrame* callFrame))

--- a/Source/JavaScriptCore/runtime/StringPrototype.h
+++ b/Source/JavaScriptCore/runtime/StringPrototype.h
@@ -62,6 +62,8 @@ JSString* replaceUsingRegExpSearch(VM&, JSGlobalObject*, JSString*, JSValue sear
 JSC_DECLARE_HOST_FUNCTION(stringProtoFuncRepeatCharacter);
 JSC_DECLARE_HOST_FUNCTION(stringProtoFuncMatch);
 JSValue stringMatchSlow(JSGlobalObject*, JSString* thisString, JSValue regexpValue);
+JSC_DECLARE_HOST_FUNCTION(stringProtoFuncSearch);
+JSValue stringSearchSlow(JSGlobalObject*, JSString* thisString, JSValue regexpValue);
 JSC_DECLARE_HOST_FUNCTION(stringProtoFuncSplit);
 JSCell* stringSplitFast(JSGlobalObject*, JSString* thisString, JSString* separatorString, unsigned limit);
 JSC_DECLARE_HOST_FUNCTION(stringProtoFuncSubstring);


### PR DESCRIPTION
#### c800622bab898f312ace1cc2fdab14a9eb7fbe3b
<pre>
[JSC] Implement `String#search` in C++
<a href="https://bugs.webkit.org/show_bug.cgi?id=315456">https://bugs.webkit.org/show_bug.cgi?id=315456</a>

Reviewed by Yusuke Suzuki.

Move String.prototype.search from a JS builtin to a C++ host function and add
a StringSearch DFG node, mirroring the String#match work in 313363@main.

Notes:

* StringSearch is converted to RegExpSearch in fixup (reusing the StringMatch
  primordial checks), so the existing RegExpSearch strength reductions apply
  to str.search(re) as well.
* searchSymbol is added to regExpPrimordialPropertiesWatchpointSet, and the new
  stringSymbolSearchWatchpointSet watches @@search absence on String.prototype
  and Object.prototype.
* isSymbolSearchFastAndNonObservable additionally requires lastIndexIsWritable()
  since @@search resets and restores lastIndex.
* regExpProtoFuncSearch is split into regExpSearchFast / regExpSearchGeneric,
  shared by stringProtoFuncSearch and the DFG operations.

                                                  TipOfTree                  Patched

regexp-prototype-search-short-string            5.4420+-0.3191     ^      2.1768+-0.0847        ^ definitely 2.5001x faster
regexp-prototype-search-complex-pattern         7.0782+-0.6621     ^      2.2992+-0.2105        ^ definitely 3.0786x faster
regexp-prototype-search-basic                   6.7999+-0.3401     ^      2.3138+-0.2230        ^ definitely 2.9389x faster
regexp-prototype-search-anchor                  7.2162+-0.6817     ^      2.3149+-0.1519        ^ definitely 3.1172x faster
regexp-search-digit-literal                     9.1569+-0.2871            8.6720+-0.2132          might be 1.0559x faster

Tests: JSTests/microbenchmarks/regexp-search-digit-cached.js
       JSTests/microbenchmarks/regexp-search-digit-literal.js
       JSTests/microbenchmarks/string-search-digit-short.js
       JSTests/stress/string-prototype-search-edge-cases.js
       JSTests/stress/string-prototype-search-strength-reduction.js
       JSTests/stress/string-prototype-search-watchpoint-invalidation.js

* JSTests/microbenchmarks/regexp-search-digit-cached.js: Added.
(search):
* JSTests/microbenchmarks/regexp-search-digit-literal.js: Added.
(search):
* JSTests/microbenchmarks/string-search-digit-short.js: Added.
(search):
* JSTests/stress/string-prototype-search-edge-cases.js: Added.
(shouldBe):
(shouldThrow):
(shouldBe.String.prototype.search.call.toString):
(toString):
(shouldBe.string_appeared_here.search.Symbol.search):
(Symbol.search):
(shouldBe.string_appeared_here.search.toString):
(shouldThrow.string_appeared_here.search.get Symbol):
(throw.new.TypeError.MyRegExp):
(throw.new.TypeError):
(shouldBe.MyRegExp2.prototype.Symbol.search):
(shouldBe.MyRegExp2):
(shouldBe.MyRegExp3.prototype.exec):
(shouldBe.MyRegExp3):
(shouldBe.string_appeared_here.search):
* JSTests/stress/string-prototype-search-strength-reduction.js: Added.
(shouldBe):
(searchLiteral):
(searchGlobalLiteral):
(searchStickyLiteral):
(searchUnicode):
(searchCached):
(searchStringPattern):
(searchPoly):
(shouldBe.searchPoly):
* JSTests/stress/string-prototype-search-watchpoint-invalidation.js: Added.
(shouldBe):
(search):
(re.Symbol.search):
(RegExp.prototype.Symbol.search):
(RegExp.prototype.exec):
(value):
(re.lastIndex.valueOf):
(Symbol.search):
(receiver.toString.re.exec):
(receiver.toString):
(receiver.toString.RegExp.prototype.exec):
(catch):
* Source/JavaScriptCore/builtins/StringPrototype.js:
(search): Deleted.
* Source/JavaScriptCore/dfg/DFGAbstractInterpreterInlines.h:
(JSC::DFG::AbstractInterpreter&lt;AbstractStateType&gt;::executeEffects):
* Source/JavaScriptCore/dfg/DFGBackwardsPropagationPhase.cpp:
(JSC::DFG::BackwardsPropagationPhase::propagate):
* Source/JavaScriptCore/dfg/DFGByteCodeParser.cpp:
(JSC::DFG::ByteCodeParser::handleIntrinsicCall):
* Source/JavaScriptCore/dfg/DFGClobberize.h:
(JSC::DFG::clobberize):
* Source/JavaScriptCore/dfg/DFGCloneHelper.h:
* Source/JavaScriptCore/dfg/DFGDoesGC.cpp:
(JSC::DFG::doesGC):
* Source/JavaScriptCore/dfg/DFGFixupPhase.cpp:
(JSC::DFG::FixupPhase::fixupNode):
(JSC::DFG::FixupPhase::addStringMatchAndSearchPrimordialChecks):
(JSC::DFG::FixupPhase::addStringMatchPrimordialChecks): Deleted.
* Source/JavaScriptCore/dfg/DFGGraph.h:
* Source/JavaScriptCore/dfg/DFGJITCode.cpp:
(JSC::DFG::JITData::JITData):
(JSC::DFG::JITData::tryInitialize):
* Source/JavaScriptCore/dfg/DFGJITCode.h:
* Source/JavaScriptCore/dfg/DFGNode.cpp:
(JSC::DFG::Node::convertToRegExpSearch):
* Source/JavaScriptCore/dfg/DFGNode.h:
* Source/JavaScriptCore/dfg/DFGNodeType.h:
* Source/JavaScriptCore/dfg/DFGOperations.cpp:
(JSC::DFG::JSC_DEFINE_JIT_OPERATION):
* Source/JavaScriptCore/dfg/DFGOperations.h:
* Source/JavaScriptCore/dfg/DFGPredictionPropagationPhase.cpp:
* Source/JavaScriptCore/dfg/DFGSafeToExecute.h:
(JSC::DFG::safeToExecute):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.cpp:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT.h:
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT32_64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/dfg/DFGSpeculativeJIT64.cpp:
(JSC::DFG::SpeculativeJIT::compile):
* Source/JavaScriptCore/ftl/FTLCapabilities.cpp:
(JSC::FTL::canCompile):
* Source/JavaScriptCore/ftl/FTLLowerDFGToB3.cpp:
(JSC::FTL::DFG::LowerDFGToB3::compileNode):
(JSC::FTL::DFG::LowerDFGToB3::compileStringSearch):
* Source/JavaScriptCore/runtime/Intrinsic.h:
* Source/JavaScriptCore/runtime/JSGlobalObject.cpp:
(JSC::JSGlobalObject::init):
* Source/JavaScriptCore/runtime/JSGlobalObject.h:
* Source/JavaScriptCore/runtime/RegExpObject.h:
* Source/JavaScriptCore/runtime/RegExpObjectInlines.h:
(JSC::RegExpObject::isSymbolSearchFastAndNonObservable):
* Source/JavaScriptCore/runtime/RegExpPrototype.cpp:
(JSC::regExpSearchFast):
(JSC::regExpSearchGeneric):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/RegExpPrototype.h:
* Source/JavaScriptCore/runtime/StringPrototype.cpp:
(JSC::StringPrototype::finishCreation):
(JSC::stringSearchSlow):
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/runtime/StringPrototype.h:

Canonical link: <a href="https://commits.webkit.org/314261@main">https://commits.webkit.org/314261@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b5c33a20f097b6035ef29c5a7d730198e0cf770d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165606 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/39096 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32677 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174648 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122861 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/39432 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/39100 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128702 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90630 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/168565 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/31028 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148787 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/109226 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/30065 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28699 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/22733 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157763 "Built successfully and passed tests") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/139958 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/26485 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/177172 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/26499 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/30084 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/28191 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137027 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/39165 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32843 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136961 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36906 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39853 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/148281 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/102333 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/32244 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/25148 "Passed tests") | [  ~~🛠 jsc-armv7~~](https://ews-build.webkit.org/#/builders/35/builds/198875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/38364 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/111437 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/35/builds/198875 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37760 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/3229 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38006 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37904 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->