### PR TITLE
[GStreamer] WebKitGLVideoSink finalized from wrong thread

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
@@ -56,7 +56,12 @@ GST_DEBUG_CATEGORY_STATIC(webkit_gl_video_sink_debug);
 struct _WebKitGLVideoSinkPrivate {
     ~_WebKitGLVideoSinkPrivate()
     {
-        ASSERT(isMainThread());
+        // Here we are either in the main thread or in a thread created by the gst_async_call_pool.
+        // The latter case happens when the player has been destructed while the sink was in an
+        // ASYNC state change. The last reference of the sink would then be held by the
+        // gst_object_call_async() call made from gstbin's bin_push_state_continue. After the async task
+        // completed there would be no reference left and the sink would be finalized, from a thread
+        // managed by the thread pool.
         webKitVideoSinkDisconnectSignalHandlers(appSink.get(), signalIdentifiers);
         GST_DEBUG_OBJECT(appSink.get(), "WebKitGLVideoSink finalized.");
     }


### PR DESCRIPTION
#### a3972609ade72ae334bc84cfe946e56bf4d32b55
<pre>
[GStreamer] WebKitGLVideoSink finalized from wrong thread
<a href="https://bugs.webkit.org/show_bug.cgi?id=308119">https://bugs.webkit.org/show_bug.cgi?id=308119</a>

Reviewed by Xabier Rodriguez-Calvar.

Remove the ASSERT(isMainThread()) from ~_WebKitGLVideoSinkPrivate() because it is invalid, the sink
can be finalized from a non-main thread when the player it belongs to has been destructed while the
pipeline was in an ASYNC state change.

* Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp:
(_WebKitGLVideoSinkPrivate::~_WebKitGLVideoSinkPrivate):

Canonical link: <a href="https://commits.webkit.org/313828@main">https://commits.webkit.org/313828@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6158a06b5f082a462952a577efa7d3c72e60a171

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164207 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37691 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/30910 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173236 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121459 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166076 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38025 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37691 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127568 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89752 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167166 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29865 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147613 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108116 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28912 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27536 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21000 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138814 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25330 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175762 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28583 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/26998 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135879 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37361 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31651 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135849 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36613 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38147 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147125 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100453 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31160 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23981 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36957 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110002 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36354 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2036 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36604 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36504 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->