### PR TITLE
[GStreamer] Possible pipeline leak when the owning media element id is updated

### DIFF
--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -654,11 +654,15 @@ static HashMap<String, GRefPtr<GstElement>>& activePipelinesMap()
     return activePipelines.get();
 }
 
-void registerActivePipeline(const GRefPtr<GstElement>& pipeline)
+void registerActivePipeline(const GRefPtr<GstElement>& pipeline, const String& pipelineName)
 {
-    auto name = GMallocString::unsafeAdoptFromUTF8(gst_object_get_name(GST_OBJECT_CAST(pipeline.get())));
+    String key = pipelineName;
+    if (key.isEmpty()) {
+        auto name = GMallocString::unsafeAdoptFromUTF8(gst_object_get_name(GST_OBJECT_CAST(pipeline.get())));
+        key = name.span();
+    }
     Locker locker { s_activePipelinesMapLock };
-    activePipelinesMap().add(name.span(), GRefPtr<GstElement>(pipeline));
+    activePipelinesMap().add(key, GRefPtr<GstElement>(pipeline));
 }
 
 void unregisterPipeline(const GRefPtr<GstElement>& pipeline)
@@ -666,6 +670,12 @@ void unregisterPipeline(const GRefPtr<GstElement>& pipeline)
     auto name = GMallocString::unsafeAdoptFromUTF8(gst_object_get_name(GST_OBJECT_CAST(pipeline.get())));
     Locker locker { s_activePipelinesMapLock };
     activePipelinesMap().remove(name.span());
+}
+
+void unregisterPipeline(const String& pipelineName)
+{
+    Locker locker { s_activePipelinesMapLock };
+    activePipelinesMap().remove(pipelineName);
 }
 
 void WebCoreLogObserver::didLogMessage(const WTFLogChannel& channel, WTFLogLevel level, std::optional<WTFLogLocation> location, Vector<JSONLogValue>&& values)

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -341,8 +341,9 @@ GRefPtr<GstBuffer> wrapSpanData(const std::span<const uint8_t>&);
 
 std::optional<unsigned> gstGetAutoplugSelectResult(ASCIILiteral);
 
-void registerActivePipeline(const GRefPtr<GstElement>&);
+void registerActivePipeline(const GRefPtr<GstElement>&, const String& = emptyString());
 void unregisterPipeline(const GRefPtr<GstElement>&);
+void unregisterPipeline(const String&);
 
 class WebCoreLogObserver : public Logger::Observer {
     WTF_MAKE_TZONE_ALLOCATED(WebCoreLogObserver);

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -263,16 +263,18 @@ void MediaPlayerPrivateGStreamer::tearDown(bool clearMediaPlayer)
     // The change to GST_STATE_NULL state is always synchronous. So after this gets executed we don't need to worry
     // about handlers running in the GStreamer thread.
     if (m_pipeline) {
-        unregisterPipeline(m_pipeline);
+        unregisterPipeline(m_originalPipelineName);
         gst_element_set_state(m_pipeline.get(), GST_STATE_NULL);
-
-        m_source = nullptr;
 
         auto bus = adoptGRef(gst_pipeline_get_bus(GST_PIPELINE(m_pipeline.get())));
         gst_bus_disable_sync_message_emission(bus.get());
         disconnectSimpleBusMessageCallback(m_pipeline.get());
         g_signal_handlers_disconnect_matched(m_pipeline.get(), G_SIGNAL_MATCH_DATA, 0, 0, nullptr, nullptr, this);
 
+        m_source = nullptr;
+        m_videoSink = nullptr;
+        m_audioSink = nullptr;
+        m_textSink = nullptr;
         m_pipeline = nullptr;
     }
 
@@ -1385,8 +1387,9 @@ void MediaPlayerPrivateGStreamer::elementIdChanged(const String& elementId) cons
     auto currentName = String(objectName.span());
     auto tokens = currentName.split('-');
     auto newName = makeString(tokens[0], '-', elementId, '-', tokens.last());
-    GST_DEBUG_OBJECT(m_pipeline.get(), "Renaming to %s", newName.utf8().data());
-    gst_object_set_name(GST_OBJECT_CAST(m_pipeline.get()), newName.utf8().data());
+    auto nameCString = newName.utf8();
+    GST_DEBUG_OBJECT(m_pipeline.get(), "Renaming to %s", nameCString.data());
+    gst_object_set_name(GST_OBJECT_CAST(m_pipeline.get()), nameCString.data());
 }
 
 void MediaPlayerPrivateGStreamer::handleTextSample(GRefPtr<GstSample>&& sample, TrackID streamId)
@@ -3476,7 +3479,9 @@ void MediaPlayerPrivateGStreamer::createGSTPlayBin(const URL& url)
 
     static Atomic<uint32_t> pipelineId;
 
-    m_pipeline = makeGStreamerElement(playbinName, makeString(type, '-', elementId, '-', pipelineId.exchangeAdd(1)));
+    // Keep track of the original pipeline name because the MediaElement might be renamed, leading to the pipeline being renamed as well.
+    m_originalPipelineName = makeString(type, '-', elementId, '-', pipelineId.exchangeAdd(1));
+    m_pipeline = makeGStreamerElement(playbinName, m_originalPipelineName);
     if (!m_pipeline) {
         GST_WARNING("%s not found, make sure to install gst-plugins-base", playbinName.characters());
         loadingFailed(MediaPlayer::NetworkState::FormatError, MediaPlayer::ReadyState::HaveNothing, true);
@@ -3487,7 +3492,7 @@ void MediaPlayerPrivateGStreamer::createGSTPlayBin(const URL& url)
     auto identifier = makeString(LOGIDENTIFIER.objectIdentifier);
     GST_INFO_OBJECT(m_pipeline.get(), "WebCore logs identifier for this pipeline is: %s", identifier.convertToASCIIUppercase().ascii().data());
 #endif
-    registerActivePipeline(m_pipeline);
+    registerActivePipeline(m_pipeline, m_originalPipelineName);
 
     if (isMediaStream) {
         auto clock = adoptGRef(gst_system_clock_obtain());

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -419,6 +419,8 @@ protected:
     GRefPtr<GstElement> m_pipeline;
     IntSize m_size;
 
+    String m_originalPipelineName;
+
     MediaPlayer::ReadyState m_readyState { MediaPlayer::ReadyState::HaveNothing };
     mutable MediaPlayer::NetworkState m_networkState { MediaPlayer::NetworkState::Empty };
 


### PR DESCRIPTION
#### cb7ccd0d2919c3322793bcc9f32125ef9499d9cb
<pre>
[GStreamer] Possible pipeline leak when the owning media element id is updated
<a href="https://bugs.webkit.org/show_bug.cgi?id=315459">https://bugs.webkit.org/show_bug.cgi?id=315459</a>

Reviewed by Xabier Rodriguez-Calvar.

Keep track of the initial player pipeline name and use it for storage in the global pipelines
hashmap.

Driving-by, clean-up some more GstElement smart pointers during tear-down and avoid one string copy
when logging media element id updates.

* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
(WebCore::registerActivePipeline):
(WebCore::unregisterPipeline):
* Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
(WebCore::MediaPlayerPrivateGStreamer::tearDown):
(WebCore::MediaPlayerPrivateGStreamer::elementIdChanged const):
(WebCore::MediaPlayerPrivateGStreamer::createGSTPlayBin):
* Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:

Canonical link: <a href="https://commits.webkit.org/313830@main">https://commits.webkit.org/313830@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c30568d3e7717953bd1e63bc3a3616eee9b53f0e

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164289 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37773 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31344 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173318 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121541 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166158 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38107 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37773 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/127642 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89820 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167248 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/29939 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147674 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108189 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28986 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27610 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21082 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138888 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25390 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175844 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/28665 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27058 "Passed tests") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/135954 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37444 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31728 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/135924 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36615 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38230 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147185 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100580 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31237 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24041 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37039 "Built successfully") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/110084 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36436 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2098 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36686 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36586 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->