### PR TITLE
<picture> <source> candidates are speculatively preloaded even when the inner <img> has loading="lazy"

### DIFF
--- a/LayoutTests/http/tests/preload/picture-source-loading-lazy-expected.txt
+++ b/LayoutTests/http/tests/preload/picture-source-loading-lazy-expected.txt
@@ -1,0 +1,20 @@
+The speculative preload scanner must not preload <source> candidates inside a <picture> whose <img> has loading=lazy.
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS internals.isPreloaded('/resources/square20.jpg?0&control&preload'); is true
+PASS internals.isPreloaded('/resources/square20.jpg?0'); is false
+PASS internals.isPreloaded('/resources/square20.jpg?1&jxl'); is false
+PASS internals.isPreloaded('/resources/square20.jpg?1&webp'); is false
+PASS internals.isPreloaded('/resources/square20.jpg?1'); is false
+PASS internals.isPreloaded('/resources/square20.jpg?2&100w'); is false
+PASS internals.isPreloaded('/resources/square20.jpg?2&800w'); is false
+PASS internals.isPreloaded('/resources/square20.jpg?2&1000w'); is false
+PASS internals.isPreloaded('/resources/square20.jpg?2'); is false
+PASS internals.isPreloaded('/resources/square20.jpg?3&eager&preload'); is true
+PASS internals.isPreloaded('/resources/square20.jpg?3'); is false
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/preload/picture-source-loading-lazy.html
+++ b/LayoutTests/http/tests/preload/picture-source-loading-lazy.html
@@ -1,0 +1,64 @@
+<html>
+<head>
+    <script>
+        if (window.testRunner && window.internals) {
+            testRunner.dumpAsText();
+            internals.clearMemoryCache();
+            internals.settings.setLazyImageLoadingEnabled(true);
+        }
+    </script>
+
+    <script src="/js-test-resources/js-test.js"></script>
+    <script src="http://127.0.0.1:8000/resources/slow-script.pl?delay=101&test=picture-source-loading-lazy"></script>
+</head>
+<body>
+<script>
+    description("The speculative preload scanner must not preload &lt;source&gt; candidates inside a &lt;picture&gt; whose &lt;img&gt; has loading=lazy.");
+
+    if (window.testRunner && window.internals) {
+        // Sanity / control: a picture with a non-lazy <img> still preloads its matched <source>.
+        shouldBeTrue("internals.isPreloaded('/resources/square20.jpg?0&control&preload');");
+        shouldBeFalse("internals.isPreloaded('/resources/square20.jpg?0');");
+
+        // Bug under test: <source> inside a <picture> with <img loading=lazy> must NOT be preloaded.
+        shouldBeFalse("internals.isPreloaded('/resources/square20.jpg?1&jxl');");
+        shouldBeFalse("internals.isPreloaded('/resources/square20.jpg?1&webp');");
+        shouldBeFalse("internals.isPreloaded('/resources/square20.jpg?1');");
+
+        // Resolution-switching srcset on a <source> with a lazy <img> must also not be preloaded.
+        shouldBeFalse("internals.isPreloaded('/resources/square20.jpg?2&100w');");
+        shouldBeFalse("internals.isPreloaded('/resources/square20.jpg?2&800w');");
+        shouldBeFalse("internals.isPreloaded('/resources/square20.jpg?2&1000w');");
+        shouldBeFalse("internals.isPreloaded('/resources/square20.jpg?2');");
+
+        // loading=eager (and lazy=missing) must keep the existing preload behavior intact.
+        shouldBeTrue("internals.isPreloaded('/resources/square20.jpg?3&eager&preload');");
+        shouldBeFalse("internals.isPreloaded('/resources/square20.jpg?3');");
+    }
+</script>
+<!-- Control: matched <source> with non-lazy <img>: must still be preloaded. -->
+<picture>
+    <source type="image/jpeg" srcset="/resources/square20.jpg?0&control&preload">
+    <img src="/resources/square20.jpg?0">
+</picture>
+
+<!-- Bug under test: <source> alternatives must NOT be preloaded when <img loading=lazy>. -->
+<picture>
+    <source type="image/jxl" srcset="/resources/square20.jpg?1&jxl">
+    <source type="image/webp" srcset="/resources/square20.jpg?1&webp">
+    <img src="/resources/square20.jpg?1" loading="lazy">
+</picture>
+
+<!-- Bug under test, resolution-switching <source> form. -->
+<picture>
+    <source type="image/jpeg" sizes="200px" srcset="/resources/square20.jpg?2&100w 100w, /resources/square20.jpg?2&800w 800w, /resources/square20.jpg?2&1000w 1000w">
+    <img src="/resources/square20.jpg?2" loading="lazy">
+</picture>
+
+<!-- Control: loading=eager keeps the source preload. -->
+<picture>
+    <source type="image/jpeg" srcset="/resources/square20.jpg?3&eager&preload">
+    <img src="/resources/square20.jpg?3" loading="eager">
+</picture>
+</body>
+</html>

--- a/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/picture-source-no-img.tentative-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/picture-source-no-img.tentative-expected.txt
@@ -1,4 +1,4 @@
 
 
-FAIL Speculative parsing, page load: picture-source-no-img Unhandled rejection: assert_equals: speculative case incorrectly fetched expected "" but got "param-encodingcheck: %C4%9E\r\nAccept: image/webp,image/png,image/svg+xml,image/*;q=0.8,video/*;q=0.8,*/*;q=0.5\r\nReferer: http://localhost:8800/html/syntax/speculative-parsing/generated/page-load/resources/picture-source-no-img-framed.sub.html?uuid=56375487-b238-44ad-bf69-0ca58431aa04"
+PASS Speculative parsing, page load: picture-source-no-img
 

--- a/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
+++ b/Source/WebCore/html/parser/HTMLPreloadScanner.cpp
@@ -121,7 +121,7 @@ public:
     {
     }
 
-    void processAttributes(const HTMLToken::AttributeList& attributes, Vector<bool>& pictureState)
+    void processAttributes(const HTMLToken::AttributeList& attributes, Vector<PreloadScannerPictureState>& pictureState)
     {
         ASSERT(isMainThread());
         if (m_tagId >= TagId::Unknown)
@@ -132,11 +132,11 @@ public:
             processAttribute(knownAttributeName, attribute.value.span(), pictureState);
         }
 
-        if (m_tagId == TagId::Source && !pictureState.isEmpty() && !pictureState.last() && m_mediaMatched && m_typeMatched && !m_srcSetAttribute.isEmpty()) {
+        if (m_tagId == TagId::Source && !pictureState.isEmpty() && !pictureState.last().sourceMatched && m_mediaMatched && m_typeMatched && !m_srcSetAttribute.isEmpty()) {
             auto sourceSize = SizesAttributeParser(m_sizesAttribute, m_document).effectiveSize();
             ImageCandidate imageCandidate = bestFitSourceForImageAttributes(m_deviceScaleFactor, m_urlToLoad, m_srcSetAttribute, sourceSize);
             if (!imageCandidate.isEmpty()) {
-                pictureState.last() = true;
+                pictureState.last().sourceMatched = true;
                 setURLToLoadAllowingReplacement(imageCandidate.string.view);
             }
         }
@@ -193,6 +193,11 @@ public:
         return request;
     }
 
+    bool isLazyloadingImage() const
+    {
+        return m_tagId == TagId::Img && HTMLImageElement::hasLazyLoadableAttributeValue(m_lazyloadAttribute);
+    }
+
     static bool NODELETE match(const AtomString& name, const QualifiedName& qName)
     {
         ASSERT(isMainThread());
@@ -218,12 +223,20 @@ private:
             m_crossOriginMode = attributeValue.trim(isASCIIWhitespace<char16_t>).toString();
     }
 
-    void processAttribute(const AtomString& attributeName, StringView attributeValue, const Vector<bool>& pictureState)
+    void processAttribute(const AtomString& attributeName, StringView attributeValue, const Vector<PreloadScannerPictureState>& pictureState)
     {
         bool inPicture = !pictureState.isEmpty();
-        bool alreadyMatchedSource = inPicture && pictureState.last();
+        bool alreadyMatchedSource = inPicture && pictureState.last().sourceMatched;
         switch (m_tagId) {
         case TagId::Img:
+            // Even when a sibling <source> already matched, the <img>'s loading attribute
+            // still governs whether the matched source's preload should fire — read it first.
+            if (m_document->settings().lazyImageLoadingEnabled()) {
+                if (match(attributeName, loadingAttr) && m_lazyloadAttribute.isNull()) {
+                    m_lazyloadAttribute = attributeValue.toString();
+                    break;
+                }
+            }
             if (inPicture && alreadyMatchedSource)
                 break;
             if (match(attributeName, srcsetAttr) && m_srcSetAttribute.isNull()) {
@@ -241,12 +254,6 @@ private:
             if (match(attributeName, referrerpolicyAttr)) {
                 m_referrerPolicy = parseReferrerPolicy(attributeValue, ReferrerPolicySource::ReferrerPolicyAttribute).value_or(ReferrerPolicy::EmptyString);
                 break;
-            }
-            if (m_document->settings().lazyImageLoadingEnabled()) {
-                if (match(attributeName, loadingAttr) && m_lazyloadAttribute.isNull()) {
-                    m_lazyloadAttribute = attributeValue.toString();
-                    break;
-                }
             }
             processImageAndScriptAttribute(attributeName, attributeValue);
             break;
@@ -491,9 +498,14 @@ void TokenPreloadScanner::scan(const HTMLToken& token, Vector<std::unique_ptr<Pr
             if (m_inStyle)
                 m_cssScanner.reset();
             m_inStyle = false;
-        } else if (tagId == TagId::Picture && !m_pictureSourceState.isEmpty())
+        } else if (tagId == TagId::Picture && !m_pictureSourceState.isEmpty()) {
+            // If the <picture> closes without an <img> the buffered <source>
+            // preload is orphaned and we drop it. A picture with no <img> has
+            // no rendering, so the speculative fetch is wasted and would also
+            // diverge from the non-speculative case (matches WPT
+            // html/syntax/speculative-parsing/.../picture-source-no-img).
             m_pictureSourceState.removeLast();
-        else if (tagId == TagId::Svg && m_foreignContentCount)
+        } else if (tagId == TagId::Svg && m_foreignContentCount)
             --m_foreignContentCount;
 
         return;
@@ -528,7 +540,7 @@ void TokenPreloadScanner::scan(const HTMLToken& token, Vector<std::unique_ptr<Pr
             return;
         }
         if (tagId == TagId::Picture) {
-            m_pictureSourceState.append(false);
+            m_pictureSourceState.append({ });
             return;
         }
         if (tagId == TagId::Svg) {
@@ -553,7 +565,27 @@ void TokenPreloadScanner::scan(const HTMLToken& token, Vector<std::unique_ptr<Pr
 
         StartTagScanner scanner(document, tagId, m_deviceScaleFactor);
         scanner.processAttributes(token.attributes(), m_pictureSourceState);
-        if (auto request = scanner.createPreloadRequest(m_predictedBaseElementURL))
+        auto request = scanner.createPreloadRequest(m_predictedBaseElementURL);
+
+        // Inside a <picture>, defer matched-source preloads until the inner <img>
+        // is seen. If the <img> has loading=lazy we discard the buffered request;
+        // otherwise we flush it. This prevents speculatively fetching alternative
+        // <source> candidates (JXL/WebP/AVIF/srcset) for off-screen lazy images.
+        if (tagId == TagId::Source && !m_pictureSourceState.isEmpty()) {
+            if (request)
+                m_pictureSourceState.last().bufferedSourceRequest = WTF::move(request);
+            return;
+        }
+
+        if (tagId == TagId::Img && !m_pictureSourceState.isEmpty()) {
+            auto& pictureState = m_pictureSourceState.last();
+            if (scanner.isLazyloadingImage())
+                pictureState.bufferedSourceRequest.reset();
+            else if (auto buffered = WTF::move(pictureState.bufferedSourceRequest))
+                requests.append(WTF::move(buffered));
+        }
+
+        if (request)
             requests.append(WTF::move(request));
         return;
     }

--- a/Source/WebCore/html/parser/HTMLPreloadScanner.h
+++ b/Source/WebCore/html/parser/HTMLPreloadScanner.h
@@ -29,9 +29,21 @@
 #include "CSSPreloadScanner.h"
 #include "HTMLTokenizer.h"
 #include "SegmentedString.h"
+#include <memory>
 #include <wtf/TZoneMalloc.h>
 
 namespace WebCore {
+
+// Per-<picture> state used by the preload scanner. The matched <source>
+// candidate's preload is buffered here until we see the inner <img>: if the
+// <img> has loading=lazy we discard it, otherwise we flush it to the request
+// stream. This avoids speculatively fetching alternative-format <source>
+// candidates (e.g. JXL/WebP/AVIF) for images that are still far below the
+// viewport.
+struct PreloadScannerPictureState {
+    bool sourceMatched { false };
+    std::unique_ptr<PreloadRequest> bufferedSourceRequest;
+};
 
 class TokenPreloadScanner {
     WTF_MAKE_TZONE_ALLOCATED(TokenPreloadScanner);
@@ -42,7 +54,7 @@ public:
     void scan(const HTMLToken&, PreloadRequestStream&, Document&);
 
     void setPredictedBaseElementURL(const URL& url) { m_predictedBaseElementURL = url; }
-    
+
     bool inPicture() { return !m_pictureSourceState.isEmpty(); }
 
 private:
@@ -80,7 +92,7 @@ private:
     URL m_predictedBaseElementURL;
     bool m_inStyle { false };
     
-    Vector<bool> m_pictureSourceState;
+    Vector<PreloadScannerPictureState> m_pictureSourceState;
 
     unsigned m_templateCount { 0 };
     unsigned m_foreignContentCount { 0 };


### PR DESCRIPTION
#### d166513e8cf28fb3cc4e03f03a078d562ac084c4
<pre>
&lt;picture&gt; &lt;source&gt; candidates are speculatively preloaded even when the inner &lt;img&gt; has loading=&quot;lazy&quot;
<a href="https://bugs.webkit.org/show_bug.cgi?id=315466">https://bugs.webkit.org/show_bug.cgi?id=315466</a>
<a href="https://rdar.apple.com/177833110">rdar://177833110</a>

Reviewed by Chris Dumez.

This patch aligns WebKit with Gecko / Firefox and Blink / Chromium.

The preload scanner emits a fetch for a matched &lt;source&gt; inside a
&lt;picture&gt; as soon as it is selected, without consulting the inner
&lt;img&gt;&apos;s loading attribute. Because &lt;source&gt; appears before &lt;img&gt; in
source order, the lazy-load short-circuit in
StartTagScanner::createPreloadRequest never sees loading=&quot;lazy&quot;, and
alternative-format / srcset candidates for off-screen lazy images are
fetched up front — then fetched again when the image approaches the
viewport.

Defer the matched &lt;source&gt; preload in per-&lt;picture&gt; state instead of
emitting it immediately. Flush it when the inner &lt;img&gt; is seen and is
not loading=&quot;lazy&quot;; drop it if the &lt;img&gt; is lazy or if the &lt;picture&gt;
closes without an &lt;img&gt;. Also read the &lt;img&gt;&apos;s loading attribute even
when a sibling &lt;source&gt; already matched (the previous code bailed out
on alreadyMatchedSource before reaching it).

* LayoutTests/imported/w3c/web-platform-tests/html/syntax/speculative-parsing/generated/page-load/picture-source-no-img.tentative-expected.txt: Progression
* Source/WebCore/html/parser/HTMLPreloadScanner.cpp:
(WebCore::TokenPreloadScanner::StartTagScanner::processAttributes):
(WebCore::TokenPreloadScanner::StartTagScanner::isLazyloadingImage const):
(WebCore::TokenPreloadScanner::StartTagScanner::processAttribute):
(WebCore::TokenPreloadScanner::scan):
* Source/WebCore/html/parser/HTMLPreloadScanner.h:
* LayoutTests/http/tests/preload/picture-source-loading-lazy-expected.txt
* LayoutTests/http/tests/preload/picture-source-loading-lazy.html:

Canonical link: <a href="https://commits.webkit.org/313833@main">https://commits.webkit.org/313833@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/36a94033484be6fce29e8cab8f651f8aefb5aeac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164218 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37702 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31327 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173247 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121470 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c6866c2a-7df6-4679-9fda-06478452066d) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166087 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38036 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37702 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127578 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89763 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/3da41329-aaaf-4ab4-aee3-fff11db6febd) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167177 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29876 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147656 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108126 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/6df364ce-7fbb-4eca-b1f7-68334ff49c7d) 
| [✅ 🧪 webkitpy](https://ews-build.webkit.org/#/builders/6/builds/163539 "Passed tests") | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28923 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27547 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21011 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/156369 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138825 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25373 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175773 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/25110 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28594 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27041 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135889 "Passed tests") | | 
| [✅ 🧪 services](https://ews-build.webkit.org/#/builders/28/builds/163615 "Passed tests") | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37427 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31662 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135859 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36616 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38213 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147168 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100471 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31217 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24024 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/196621 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36968 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110013 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51652 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36365 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2080 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36615 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36515 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->