### PR TITLE
Use OrderedHashSet instead of ListHashSet in Document.h

### DIFF
--- a/Source/WTF/wtf/OrderedHashSet.h
+++ b/Source/WTF/wtf/OrderedHashSet.h
@@ -206,6 +206,9 @@ public:
 
     TakeType takeAny() { return take(begin()); }
 
+    const ValueType& first() const { ASSERT(!isEmpty()); return *begin(); }
+    const ValueType& last() const { ASSERT(!isEmpty()); return *rbegin(); }
+
     static bool isValidValue(const ValueType& value)
     {
         if (ValueTraits::isDeletedValue(value))

--- a/Source/WTF/wtf/OrderedHashTable.h
+++ b/Source/WTF/wtf/OrderedHashTable.h
@@ -631,7 +631,7 @@ private:
 template<typename TableType, typename ValueType>
 class OrderedHashTableIterator {
 public:
-    using iterator_category = std::forward_iterator_tag;
+    using iterator_category = std::bidirectional_iterator_tag;
     using value_type = ValueType;
     using difference_type = ptrdiff_t;
     using pointer = ValueType*;
@@ -662,6 +662,24 @@ public:
     {
         auto result = *this;
         ++*this;
+        return result;
+    }
+
+    OrderedHashTableIterator& operator--()
+    {
+        ASSERT(m_table);
+        ASSERT(m_index > 0);
+        --m_index;
+        while (m_index > 0 && m_table->isDeletedEntry(m_table->entries()[m_index]))
+            --m_index;
+        ASSERT(!m_table->isDeletedEntry(m_table->entries()[m_index]));
+        return *this;
+    }
+
+    OrderedHashTableIterator operator--(int)
+    {
+        auto result = *this;
+        --*this;
         return result;
     }
 
@@ -696,7 +714,7 @@ private:
 template<typename TableType, typename ValueType>
 class OrderedHashTableConstIterator {
 public:
-    using iterator_category = std::forward_iterator_tag;
+    using iterator_category = std::bidirectional_iterator_tag;
     using value_type = ValueType;
     using difference_type = ptrdiff_t;
     using pointer = const ValueType*;
@@ -733,6 +751,24 @@ public:
     {
         auto result = *this;
         ++*this;
+        return result;
+    }
+
+    OrderedHashTableConstIterator& operator--()
+    {
+        ASSERT(m_table);
+        ASSERT(m_index > 0);
+        --m_index;
+        while (m_index > 0 && m_table->isDeletedEntry(m_table->entries()[m_index]))
+            --m_index;
+        ASSERT(!m_table->isDeletedEntry(m_table->entries()[m_index]));
+        return *this;
+    }
+
+    OrderedHashTableConstIterator operator--(int)
+    {
+        auto result = *this;
+        --*this;
         return result;
     }
 

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -64,6 +64,7 @@
 #include <wtf/HashSet.h>
 #include <wtf/Logger.h>
 #include <wtf/Observer.h>
+#include <wtf/OrderedHashSet.h>
 #include <wtf/RobinHoodHashMap.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/UniqueRef.h>
@@ -1871,12 +1872,12 @@ public:
 
     void addTopLayerElement(Element&);
     void removeTopLayerElement(Element&);
-    const ListHashSet<Ref<Element>>& topLayerElements() const LIFETIME_BOUND { return m_topLayerElements; }
+    const OrderedHashSet<Ref<Element>>& topLayerElements() const LIFETIME_BOUND { return m_topLayerElements; }
     bool hasTopLayerElement() const { return !m_topLayerElements.isEmpty(); }
 
-    const ListHashSet<Ref<HTMLElement>>& autoPopoverList() const LIFETIME_BOUND { return m_autoPopoverList; }
+    const OrderedHashSet<Ref<HTMLElement>>& autoPopoverList() const LIFETIME_BOUND { return m_autoPopoverList; }
 
-    ListHashSet<Ref<HTMLDialogElement>>& openDialogsList() { return m_openDialogsList; }
+    OrderedHashSet<Ref<HTMLDialogElement>>& openDialogsList() { return m_openDialogsList; }
 
     HTMLDialogElement* activeModalDialog() const;
     HTMLDialogElement* activeCloseableDialog() const;
@@ -2608,9 +2609,9 @@ private:
 
     const Ref<FragmentDirective> m_fragmentDirectiveForBindings;
 
-    ListHashSet<Ref<Element>> m_topLayerElements;
-    ListHashSet<Ref<HTMLElement>> m_autoPopoverList;
-    ListHashSet<Ref<HTMLDialogElement>> m_openDialogsList;
+    OrderedHashSet<Ref<Element>> m_topLayerElements;
+    OrderedHashSet<Ref<HTMLElement>> m_autoPopoverList;
+    OrderedHashSet<Ref<HTMLDialogElement>> m_openDialogsList;
 
     WeakPtr<HTMLElement, WeakPtrImplWithEventTargetData> m_popoverPointerDownTarget;
     WeakPtr<HTMLDialogElement, WeakPtrImplWithEventTargetData> m_dialogPointerDownTarget;


### PR DESCRIPTION
#### efd1eb035a9aa5cc177b0b6c68df8f98ad658238
<pre>
Use OrderedHashSet instead of ListHashSet in Document.h
<a href="https://bugs.webkit.org/show_bug.cgi?id=315467">https://bugs.webkit.org/show_bug.cgi?id=315467</a>
<a href="https://rdar.apple.com/177833384">rdar://177833384</a>

Reviewed by Darin Adler.

* Source/WTF/wtf/OrderedHashSet.h:
* Source/WTF/wtf/OrderedHashTable.h:
(WTF::OrderedHashTableIterator::operator--):
(WTF::OrderedHashTableConstIterator::operator--):
* Source/WebCore/dom/Document.h:
(WebCore::Document::openDialogsList):

Canonical link: <a href="https://commits.webkit.org/313902@main">https://commits.webkit.org/313902@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/c82417e5a5eb73d058b96844de691598988c0ed4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164474 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37958 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31529 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173504 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121726 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f9d0700d-3f5e-4c73-8621-07c489d47bec) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166343 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38292 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37960 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127797 "Passed tests") | [![loading-orange](https://github-production-user-asset-6210df.s3.amazonaws.com/3098702/291015173-08c448be-ac0a-4fd6-92a3-8165057445b7.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89964 "Build is in progress. Recent messages:Printed configuration; Skipping applying patch since patch_id isn't provided; Checked out pull request; Running run-layout-tests-in-stress-mode; layout-tests (failure); Uploaded test results; layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/09d3e7cb-1d14-4ba5-b2f4-a0c3b47dd8f2) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167433 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30100 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147833 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108342 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d4eabae1-8ffc-4b35-91c2-68d0bf2ca447) 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29147 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27770 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21267 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/156625 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139049 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25549 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176030 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/25366 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28853 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27217 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136114 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38027 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31892 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136079 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36656 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38717 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147344 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100864 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31374 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24200 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/196877 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37225 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110269 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51707 "Passed tests") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36623 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2261 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36871 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36771 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->