### PR TITLE
[GStreamer][WebRTC][Rice] imported/w3c/web-platform-tests/webrtc/RTCDataChannel-send-close-array-buffer.window.html flaky crashes

### DIFF
--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.cpp
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.cpp
@@ -90,7 +90,8 @@ typedef struct _WebKitGstIceAgentPrivate {
     RefPtr<SocketProvider> socketProvider;
     GRefPtr<RiceAgent> agent;
 
-    StreamHashMap streams;
+    Lock streamsLock;
+    StreamHashMap streams WTF_GUARDED_BY_LOCK(streamsLock);
 
     RefPtr<RunLoop> runLoop;
 
@@ -379,6 +380,7 @@ static GstWebRTCICEStream* webkitGstWebRTCIceAgentAddStream(GstWebRTCICE* ice, g
     if (!backend->priv->iceBackend)
         return nullptr;
 
+    Locker locker { backend->priv->streamsLock };
     if (backend->priv->streams.contains(sessionId)) {
         GST_ERROR_OBJECT(ice, "Stream already added for session %u", sessionId);
         return nullptr;
@@ -551,6 +553,7 @@ static void webkitGstWebRTCIceAgentSetTos(GstWebRTCICE* ice, GstWebRTCICEStream*
     if (!backend) [[unlikely]]
         return;
 
+    Locker locker { self->priv->streamsLock };
     for (auto& riceStream : self->priv->streams.values()) {
         if (riceStream->stream->stream_id != stream->stream_id)
             continue;
@@ -639,7 +642,10 @@ void webkitGstWebRTCIceAgentClosed(WebKitGstIceAgent* agent)
     Locker locker { priv->stateLock };
     priv->state = AgentState::Closed;
 
-    priv->streams.clear();
+    {
+        Locker locker { priv->streamsLock };
+        priv->streams.clear();
+    }
 
     if (!priv->closePromise)
         return;
@@ -720,13 +726,16 @@ static void webkitGstWebRTCIceAgentConstructed(GObject* object)
     priv->agent = adoptGRef(rice_agent_new(true, true));
 }
 
-static void findStreamAndApply(const StreamHashMap& streams, unsigned streamId, Function<void(const WebKitGstIceStream*)> callback)
+static void findStreamAndApply(WebKitGstIceAgent* agent, unsigned streamId, Function<void(const WebKitGstIceStream*)> callback)
 {
-    for (auto& riceStream : streams.values()) {
+    Locker locker { agent->priv->streamsLock };
+    for (auto& riceStream : agent->priv->streams.values()) {
         if (riceStream->riceStreamId != streamId)
             continue;
 
-        callback(WEBKIT_GST_WEBRTC_ICE_STREAM(riceStream->stream.get()));
+        GRefPtr stream = riceStream->stream;
+        locker.unlockEarly();
+        callback(WEBKIT_GST_WEBRTC_ICE_STREAM(stream.get()));
         return;
     }
 }
@@ -745,7 +754,7 @@ static bool webkitGstWebRTCIceAgentConfigure(WebKitGstIceAgent* backend, RefPtr<
         auto self = weakThis.get();
         if (!self)
             return;
-        findStreamAndApply(self->priv->streams, streamId, [protocol, from = WTF::move(from), to = WTF::move(to), data = WTF::move(data)](const auto* stream) mutable {
+        findStreamAndApply(self.get(), streamId, [protocol, from = WTF::move(from), to = WTF::move(to), data = WTF::move(data)](const auto* stream) mutable {
             webkitGstWebRTCIceStreamHandleIncomingData(stream, protocol, WTF::move(from), WTF::move(to), WTF::move(data));
         });
     });
@@ -754,7 +763,7 @@ static bool webkitGstWebRTCIceAgentConfigure(WebKitGstIceAgent* backend, RefPtr<
         auto self = weakThis.get();
         if (!self)
             return;
-        findStreamAndApply(self->priv->streams, streamId, [componentId, protocol, from = WTF::move(from), to = WTF::move(to), socket = WTF::move(socket)](const auto* stream) mutable {
+        findStreamAndApply(self.get(), streamId, [componentId, protocol, from = WTF::move(from), to = WTF::move(to), socket = WTF::move(socket)](const auto* stream) mutable {
             webkitGstWebRTCIceStreamHandleAllocatedSocket(stream, componentId, protocol, WTF::move(from), WTF::move(to), WTF::move(socket));
         });
         webkitGstWebRTCIceAgentWakeup(self.get());
@@ -874,7 +883,7 @@ void webkitGstWebRTCIceAgentWakeup(WebKitGstIceAgent* agent)
 
 void webkitGstWebRTCIceAgentGatheringDoneForStream(WebKitGstIceAgent* agent, unsigned streamId)
 {
-    findStreamAndApply(agent->priv->streams, streamId, [](const auto* stream) {
+    findStreamAndApply(agent, streamId, [](const auto* stream) {
         webkitGstWebRTCIceStreamGatheringDone(stream);
     });
 }
@@ -891,7 +900,7 @@ void webkitGstWebRTCIceAgentLocalCandidateGatheredForStream(WebKitGstIceAgent* a
         }
     }
 
-    findStreamAndApply(agent->priv->streams, streamId, [&](const auto* stream) {
+    findStreamAndApply(agent, streamId, [&](const auto* stream) {
         Locker locker { priv->stateLock };
         if (priv->state >= AgentState::Closing) {
             GST_DEBUG_OBJECT(agent, "Agent %s, no need to notify gathered candidate anymore", priv->state == AgentState::Closed ? "was closed" : "is closing");
@@ -915,14 +924,14 @@ void webkitGstWebRTCIceAgentLocalCandidateGatheredForStream(WebKitGstIceAgent* a
 
 void webkitGstWebRTCIceAgentNewSelectedPairForStream(WebKitGstIceAgent* agent, unsigned streamId, RiceAgentSelectedPair& selectedPair)
 {
-    findStreamAndApply(agent->priv->streams, streamId, [&](const auto* stream) {
+    findStreamAndApply(agent, streamId, [&](const auto* stream) {
         webkitGstWebRTCIceStreamNewSelectedPair(stream, selectedPair);
     });
 }
 
 void webkitGstWebRTCIceAgentComponentStateChangedForStream(WebKitGstIceAgent* agent, unsigned streamId, RiceAgentComponentStateChange& change)
 {
-    findStreamAndApply(agent->priv->streams, streamId, [&](const auto* stream) {
+    findStreamAndApply(agent, streamId, [&](const auto* stream) {
         webkitGstWebRTCIceStreamComponentStateChanged(stream, change);
     });
 }


### PR DESCRIPTION
#### f9a8c97fce947ff4cd233f47cebe1863d2b4ba1c
<pre>
[GStreamer][WebRTC][Rice] imported/w3c/web-platform-tests/webrtc/RTCDataChannel-send-close-array-buffer.window.html flaky crashes
<a href="https://bugs.webkit.org/show_bug.cgi?id=315469">https://bugs.webkit.org/show_bug.cgi?id=315469</a>

Reviewed by Xabier Rodriguez-Calvar.

Protect access to the streams hashmap using a mutex, otherwise we might crash when being notified of
incoming data while a close procedure is on-going.

* Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.cpp:
(webkitGstWebRTCIceAgentAddStream):
(webkitGstWebRTCIceAgentSetTos):
(webkitGstWebRTCIceAgentClosed):
(findStreamAndApply):
(webkitGstWebRTCIceAgentConfigure):
(webkitGstWebRTCIceAgentGatheringDoneForStream):
(webkitGstWebRTCIceAgentLocalCandidateGatheredForStream):
(webkitGstWebRTCIceAgentNewSelectedPairForStream):
(webkitGstWebRTCIceAgentComponentStateChangedForStream):

Canonical link: <a href="https://commits.webkit.org/313836@main">https://commits.webkit.org/313836@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/43b0407690f3ce324c427f04a39c2f97c32c008c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164300 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37784 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31355 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173329 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121552 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166169 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38118 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37784 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127652 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89831 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167259 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29948 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147683 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108197 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28995 "Passed tests") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/27617 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21093 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138897 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25399 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175855 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28676 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27067 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135963 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37455 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31735 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135932 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36618 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38241 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147194 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100596 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31244 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24050 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37050 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110095 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36447 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2107 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36697 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36597 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->