### PR TITLE
Resync `focus` from WPT Upstream

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/focus/WEB_FEATURES.yml
+++ b/LayoutTests/imported/w3c/web-platform-tests/focus/WEB_FEATURES.yml
@@ -1,0 +1,4 @@
+features:
+- name: focus-events
+  files:
+  - focus-event-*

--- a/LayoutTests/imported/w3c/web-platform-tests/focus/anchor-remove-href-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/focus/anchor-remove-href-expected.txt
@@ -1,0 +1,4 @@
+anchor tag
+
+PASS anchor element should remain focused after removing href attribute.
+

--- a/LayoutTests/imported/w3c/web-platform-tests/focus/anchor-remove-href.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/focus/anchor-remove-href.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<link rel=author href="mailto:jarhar@chromium.org">
+<link rel=help href="https://issues.chromium.org/issues/443585794">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+
+<a href="#">anchor tag</a>
+
+<script>
+promise_test(async () => {
+  const anchor = document.querySelector('a');
+  anchor.focus();
+  assert_equals(document.activeElement, anchor,
+    'anchor should be focused at the start of the test.');
+
+  anchor.removeAttribute('href');
+  anchor.setAttribute('tabindex', '0');
+  assert_equals(document.activeElement, anchor,
+    'anchor should be focused after removing href.');
+
+  await new Promise(requestAnimationFrame);
+  await new Promise(requestAnimationFrame);
+
+  assert_equals(document.activeElement, anchor,
+    'anchor should still be focused after a double rAF.');
+}, 'anchor element should remain focused after removing href attribute.');
+</script>

--- a/LayoutTests/imported/w3c/web-platform-tests/focus/synthetic-focus-event-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/focus/synthetic-focus-event-crash.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<link rel="assert" href="Synthetic focus events sent to form controls should not cause a crash">
+<link rel="help" href="https://github.com/servo/servo/issues/44865">
+
+<input id="input">
+<textarea id="textarea"></textarea>
+
+<script>
+  let event = document.createEvent("FocusEvent");
+  event.initEvent('', true);
+  input.dispatchEvent(event);
+
+  let event2 = document.createEvent("FocusEvent");
+  event2.initEvent('', true);
+  textarea.dispatchEvent(event2);
+</script>
+

--- a/LayoutTests/imported/w3c/web-platform-tests/focus/w3c-import.log
+++ b/LayoutTests/imported/w3c/web-platform-tests/focus/w3c-import.log
@@ -14,6 +14,7 @@ Property values requiring vendor prefixes:
 None
 ------------------------------------------------------------------------
 List of files:
+/LayoutTests/imported/w3c/web-platform-tests/focus/WEB_FEATURES.yml
 /LayoutTests/imported/w3c/web-platform-tests/focus/activeelement-after-calling-window-focus.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/focus/activeelement-after-focusing-different-site-iframe-contentwindow.html
 /LayoutTests/imported/w3c/web-platform-tests/focus/activeelement-after-focusing-different-site-iframe-then-immediately-focusing-back.html
@@ -26,6 +27,7 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/focus/activeelement-after-immediately-focusing-same-site-iframe.html
 /LayoutTests/imported/w3c/web-platform-tests/focus/activeelement-after-nested-loses-focus.html
 /LayoutTests/imported/w3c/web-platform-tests/focus/ancestor-activeelement-after-child-lose-focus.html
+/LayoutTests/imported/w3c/web-platform-tests/focus/anchor-remove-href.html
 /LayoutTests/imported/w3c/web-platform-tests/focus/cross-origin-ancestor-activeelement-after-child-lose-focus.sub.html
 /LayoutTests/imported/w3c/web-platform-tests/focus/focus-already-focused-iframe-deep-different-site.html
 /LayoutTests/imported/w3c/web-platform-tests/focus/focus-already-focused-iframe-deep-same-site.html
@@ -59,3 +61,4 @@ List of files:
 /LayoutTests/imported/w3c/web-platform-tests/focus/iframe-focuses-parent-same-site.html
 /LayoutTests/imported/w3c/web-platform-tests/focus/nested-focus-within-iframe-focus-event.html
 /LayoutTests/imported/w3c/web-platform-tests/focus/scroll-matches-focus.html
+/LayoutTests/imported/w3c/web-platform-tests/focus/synthetic-focus-event-crash.html


### PR DESCRIPTION
#### ba820064782d34c5f461d167809e549912bc0127
<pre>
Resync `focus` from WPT Upstream
<a href="https://bugs.webkit.org/show_bug.cgi?id=315472">https://bugs.webkit.org/show_bug.cgi?id=315472</a>
<a href="https://rdar.apple.com/177836573">rdar://177836573</a>

Reviewed by Brandon Stewart.

Upstream commit: <a href="https://github.com/web-platform-tests/wpt/commit/a3ae179ab5822f1651d174e1ec22e7d3323867ed">https://github.com/web-platform-tests/wpt/commit/a3ae179ab5822f1651d174e1ec22e7d3323867ed</a>

* LayoutTests/imported/w3c/web-platform-tests/focus/WEB_FEATURES.yml: Added.
* LayoutTests/imported/w3c/web-platform-tests/focus/anchor-remove-href-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/focus/anchor-remove-href.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/focus/synthetic-focus-event-crash.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/focus/w3c-import.log:

Canonical link: <a href="https://commits.webkit.org/313819@main">https://commits.webkit.org/313819@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/96420231d53760abaf9807fd757ee99b7e4ceef5

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164232 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37716 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31284 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173261 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121484 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/2eafad12-4ace-44f4-a42a-15e6bab910a0) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38050 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37716 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127588 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89774 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/bef76550-a470-46ca-9224-311e12d34f2e) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167191 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29887 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147620 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108136 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/e8ea15dd-116d-41bb-80b8-5f55d2523d0c) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28934 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27556 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21025 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138836 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25337 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175787 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27005 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135899 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37386 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31671 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135869 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36608 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38172 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147132 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100492 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31183 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/23988 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/36982 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36379 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2043 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36629 "Built successfully") | | | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36529 "Build is in progress. Recent messages:OS: Tahoe (26.4.1), Xcode: 26.4.1; Running apply-patch; Checked out pull request; Compiled WebKit (warnings)") | | | | 
<!--EWS-Status-Bubble-End-->