### PR TITLE
[Navigation API] [iOS] signal-abort-window-stop-in-onnavigate.html is a flaky timeout

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/signal-abort-replaceState-crash.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/signal-abort-replaceState-crash.html
@@ -12,8 +12,8 @@
       );
     }
 
-    history.go(0);
-  });
+    navigation.navigate("#3");
+  }, {once: true});
 
   history.pushState(null, "", "#2");
 </script>

--- a/LayoutTests/navigation-api/navigation-api-rate-limit-history-api-expected.txt
+++ b/LayoutTests/navigation-api/navigation-api-rate-limit-history-api-expected.txt
@@ -1,0 +1,10 @@
+Tests that History API navigations triggered from a navigate event listener are rate-limited, so they cannot create an infinite navigation loop
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+
+PASS navigateEventCount is 5
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/navigation-api/navigation-api-rate-limit-history-api.html
+++ b/LayoutTests/navigation-api/navigation-api-rate-limit-history-api.html
@@ -1,0 +1,36 @@
+<!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
+<!DOCTYPE html>
+<script src="../resources/js-test.js"></script>
+<script>
+description("Tests that History API navigations triggered from a navigate event listener are rate-limited, so they cannot create an infinite navigation loop");
+
+jsTestIsAsync = true;
+
+var navigateEventCount = 0;
+
+navigation.addEventListener("navigate", () => {
+    navigateEventCount++;
+    history.go(0);
+});
+
+onload = () => {
+    if (!window.internals) {
+        testFailed("window.internals is required to configure the rate limiter");
+        finishJSTest();
+        return;
+    }
+
+    // Lower the navigation rate limit so the test runs faster.
+    internals.setNavigationRateLimiterParameters(window, 5, 10);
+
+    // Kick off the loop.
+    history.pushState(null, "", "#start");
+
+    // Give the (rate-limited) loop time to run, then confirm it was capped
+    // instead of running forever.
+    setTimeout(() => {
+        shouldBe("navigateEventCount", "5");
+        finishJSTest();
+    }, 50);
+};
+</script>

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -8293,7 +8293,7 @@ webkit.org/b/304298 accessibility/text-stitching-inside-links.html [ Failure ]
 
 webkit.org/b/304427 fast/html/HTMLPluginElement-renderer-destroyed-crash.html [ Skip ]
 
-webkit.org/b/313562 imported/w3c/web-platform-tests/navigation-api/navigate-event/signal-abort-replaceState-crash.html [ Pass Crash Timeout ]
+
 
 webkit.org/b/304851 imported/w3c/web-platform-tests/workers/worker-performance.worker.html [ Pass Failure ]
 

--- a/Source/WebCore/page/Navigation.cpp
+++ b/Source/WebCore/page/Navigation.cpp
@@ -1231,8 +1231,7 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
     }
 
     // Enforce rate limiting to prevent excessive navigation requests.
-    // Only check for script-initiated navigations (those with an API method tracker).
-    if (ongoingAPIMethodTracker && !m_rateLimiter.navigationAllowed()) {
+    if (!m_rateLimiter.navigationAllowed()) {
         // Log a warning once per window when the limit is reached.
         if (!m_rateLimiter.wasReported()) {
             m_rateLimiter.markReported();
@@ -1240,11 +1239,13 @@ Navigation::DispatchResult Navigation::innerDispatchNavigateEvent(NavigationNavi
                 document->addConsoleMessage(MessageSource::JS, MessageLevel::Warning, "Excessive navigation attempts blocked."_s);
         }
 
-        // Reject the promises and clean up.
-        auto exception = Exception { ExceptionCode::QuotaExceededError, "Navigation rate limit exceeded"_s };
-        protect(ongoingAPIMethodTracker->committedPromise())->reject(exception);
-        protect(ongoingAPIMethodTracker->finishedPromise())->reject(exception);
-        cleanupAPIMethodTracker(ongoingAPIMethodTracker.get());
+        if (ongoingAPIMethodTracker) {
+            // Reject the promises and clean up.
+            auto exception = Exception { ExceptionCode::QuotaExceededError, "Navigation rate limit exceeded"_s };
+            protect(ongoingAPIMethodTracker->committedPromise())->reject(exception);
+            protect(ongoingAPIMethodTracker->finishedPromise())->reject(exception);
+            cleanupAPIMethodTracker(ongoingAPIMethodTracker.get());
+        }
 
         return DispatchResult::Aborted;
     }


### PR DESCRIPTION
#### fc6c7ee22f164fda87d9c7768d1d30501a7c3348
<pre>
[Navigation API] [iOS] signal-abort-window-stop-in-onnavigate.html is a flaky timeout
<a href="https://bugs.webkit.org/show_bug.cgi?id=313562">https://bugs.webkit.org/show_bug.cgi?id=313562</a>
<a href="https://rdar.apple.com/175779061">rdar://175779061</a>

Reviewed by Basuke Suzuki.

The test signal-abort-window-stop-in-onnavigate.html times out--but only if it&apos;s
run after signal-abort-replaceState-crash.html.

The issue is that signal-abort-replaceState-crash.html has a navigation event
listener which does a history navigation, which causes the navigation event to
fire again. There is an infinite loop of navigation + navigation event. Although
this test does seem to pass, it kicks off an infinite loop that seems to prevent
the test runner from properly resetting state between this test and the next. We
see the output:

Failed to load &apos;about:blank&apos;, terminating process and trying again.
...
Failed to load &apos;about:blank&apos; again after termination.

and then the second test appears to begin, but never finish.

Even putting aside this test, it is problematic that the navigation event listener
can be used to create an infinite loop of navigations. This can cause the web
process to totally consume the CPU (we do see this when running that test). This
is the very reason that the Navigation::RateLimiter exists. It caps the number of
navigations to 200 per 10 seconds (the same limit as Chrome). But it only does
this for navigations initiated by the Navigation API. In this case, the navigation
is initiated by the History API.

So we fix this by allowing the RateLimiter to limit non-NavigationAPI-initiated
navigations as well. This prevents the infinite loop and fixes our test.

This test has actually been changed upstream in WPT to use a Navigation API initiated
navigation, so this test doesn&apos;t actually create an infinite loop anymore. So we also
add a new test that checks the History API case that this test originally contained.

* LayoutTests/imported/w3c/web-platform-tests/navigation-api/navigate-event/signal-abort-replaceState-crash.html:
* LayoutTests/navigation-api/navigation-api-rate-limit-history-api-expected.txt: Added.
* LayoutTests/navigation-api/navigation-api-rate-limit-history-api.html: Added.
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/page/Navigation.cpp:
(WebCore::Navigation::innerDispatchNavigateEvent):

Canonical link: <a href="https://commits.webkit.org/314652@main">https://commits.webkit.org/314652@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/54ceb3f9d97eedbe4e66603a703f6f394a27d61d

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/166584 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40074 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/33655 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/175632 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/123840 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/d4e8fc2c-ce27-4532-875e-e140afacefc9) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/168450 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/40507 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40082 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/129515 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91214 "Build is in progress. Recent messages:") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/557599c2-069b-445e-8cc6-f39cd2639e58) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/169543 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/31903 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/149681 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110040 "Passed tests") | | ⏳ 🛠 vision-apple 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/30880 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/29582 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/23773 "Built successfully") | | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/158741 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/140851 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27378 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178166 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31066 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29085 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/137869 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40144 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/33729 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/137787 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/40832 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149176 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/103567 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25378 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33090 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26041 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/39342 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/112417 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/38739 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4131 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/38984 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/38882 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->