### PR TITLE
Cherry-pick 305413.664@safari-7624-branch (db05eacaeb0c). rdar://176058395

### DIFF
--- a/LayoutTests/fast/text/fontface-setstatus-crash-expected.txt
+++ b/LayoutTests/fast/text/fontface-setstatus-crash-expected.txt
@@ -1,0 +1,2 @@
+This tests that FontFaceSet.load does not crash when resolving the loaded promise triggers a thenable check whose getter removes a font-face rule.
+WebKit should not crash or hit any assertions under ASAN.

--- a/LayoutTests/fast/text/fontface-setstatus-crash.html
+++ b/LayoutTests/fast/text/fontface-setstatus-crash.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html>
+<head>
+<style id="s">
+@font-face { font-family: x; src: url(nonexistent-font.woff); unicode-range: U+0042; }
+</style>
+</head>
+<body>
+<p>This tests that FontFaceSet.load does not crash when resolving the loaded
+promise triggers a thenable check whose getter removes a font-face rule.<br>
+WebKit should not crash or hit any assertions under ASAN.</p>
+<script>
+if (window.testRunner) {
+    testRunner.dumpAsText();
+    testRunner.waitUntilDone();
+}
+
+window.onload = () => {
+    // JS-created face with a local source so it resolves synchronously.
+    let A = new FontFace('x', 'local(Helvetica)', { unicodeRange: 'U+0041' });
+    document.fonts.add(A);
+
+    // Register a DeferredPromise on A.
+    void A.loaded;
+
+    let fired = false;
+    Object.defineProperty(FontFace.prototype, 'then', {
+        configurable: true,
+        get() {
+            if (!fired && this === A) {
+                fired = true;
+                // Allocate to help ASAN detect freed memory reuse.
+                new FontFace('y', 'local(Helvetica Bold)', { unicodeRange: 'U+0041' });
+                new FontFace('z', 'local(Helvetica Italic)', { unicodeRange: 'U+0041' });
+                // Remove the CSS @font-face rule and force style recalc.
+                // This frees the CSS-backed CSSFontFace while FontFaceSet::load
+                // still holds a raw reference to it in matchingFaces.
+                document.getElementById('s').sheet.deleteRule(0);
+                document.body.offsetTop;
+            }
+            return undefined;
+        }
+    });
+
+    // Loading 'AB' needs both U+0041 (from A) and U+0042 (from the CSS rule).
+    // A resolves synchronously, firing the thenable check getter above.
+    document.fonts.load('1em x', 'AB');
+    setTimeout(() => {
+        if (window.testRunner)
+            testRunner.notifyDone();
+    }, 0);
+};
+</script>
+</body>
+</html>

--- a/Source/WebCore/css/CSSFontFaceSet.cpp
+++ b/Source/WebCore/css/CSSFontFaceSet.cpp
@@ -407,7 +407,7 @@ static CodePointsMap codePointsFromString(StringView stringView)
     return result;
 }
 
-ExceptionOr<Vector<std::reference_wrapper<CSSFontFace>>> CSSFontFaceSet::matchingFacesExcludingPreinstalledFonts(ScriptExecutionContext& context, const String& fontShorthand, const String& string)
+ExceptionOr<Vector<Ref<CSSFontFace>>> CSSFontFaceSet::matchingFacesExcludingPreinstalledFonts(ScriptExecutionContext& context, const String& fontShorthand, const String& string)
 {
     auto font = CSSPropertyParserHelpers::parseUnresolvedFont(fontShorthand, context);
     if (!font)
@@ -453,7 +453,7 @@ ExceptionOr<Vector<std::reference_wrapper<CSSFontFace>>> CSSFontFaceSet::matchin
         }
     }
 
-    return WTF::map(resultConstituents, [](auto* constituent) -> std::reference_wrapper<CSSFontFace> {
+    return WTF::map(resultConstituents, [](auto* constituent) -> Ref<CSSFontFace> {
         return *constituent;
     });
 }

--- a/Source/WebCore/css/CSSFontFaceSet.h
+++ b/Source/WebCore/css/CSSFontFaceSet.h
@@ -89,7 +89,7 @@ public:
 
     size_t facesPartitionIndex() const { return m_facesPartitionIndex; }
 
-    ExceptionOr<Vector<std::reference_wrapper<CSSFontFace>>> matchingFacesExcludingPreinstalledFonts(ScriptExecutionContext&, const String& font, const String& text);
+    ExceptionOr<Vector<Ref<CSSFontFace>>> matchingFacesExcludingPreinstalledFonts(ScriptExecutionContext&, const String& font, const String& text);
 
     // FIXME: Should this be implemented?
     void updateStyleIfNeeded(CSSFontFace&) final { }

--- a/Source/WebCore/css/FontFaceSet.cpp
+++ b/Source/WebCore/css/FontFaceSet.cpp
@@ -166,8 +166,8 @@ void FontFaceSet::load(ScriptExecutionContext& context, const String& font, cons
         return;
     }
 
-    for (auto& face : matchingFaces)
-        face.get().load();
+    for (Ref face : matchingFaces)
+        face->load();
 
     if (CheckedPtr document = dynamicDowncast<Document>(scriptExecutionContext())) {
         if (document->quirks().shouldEnableFontLoadingAPIQuirk()) {
@@ -180,23 +180,23 @@ void FontFaceSet::load(ScriptExecutionContext& context, const String& font, cons
             // See also: https://github.com/w3c/csswg-drafts/issues/7680
 
             bool hasSource = false;
-            for (auto& face : matchingFaces) {
-                if (face.get().sourceCount()) {
+            for (Ref face : matchingFaces) {
+                if (face->sourceCount()) {
                     hasSource = true;
                     break;
                 }
             }
             if (!hasSource) {
                 promise.resolve(matchingFaces.map([scriptExecutionContext = CheckedPtr { scriptExecutionContext() }] (const auto& matchingFace) {
-                    return matchingFace.get().wrapper(scriptExecutionContext.get());
+                    return matchingFace->wrapper(scriptExecutionContext.get());
                 }));
                 return;
             }
         }
     }
 
-    for (auto& face : matchingFaces) {
-        if (face.get().status() == CSSFontFace::Status::Failure) {
+    for (Ref face : matchingFaces) {
+        if (face->status() == CSSFontFace::Status::Failure) {
             promise.reject(ExceptionCode::NetworkError);
             return;
         }
@@ -205,13 +205,13 @@ void FontFaceSet::load(ScriptExecutionContext& context, const String& font, cons
     auto pendingPromise = PendingPromise::create(WTF::move(promise));
     bool waiting = false;
 
-    for (auto& face : matchingFaces) {
-        pendingPromise->faces.append(face.get().wrapper(protect(scriptExecutionContext()).get()));
-        if (face.get().status() == CSSFontFace::Status::Success)
+    for (Ref face : matchingFaces) {
+        pendingPromise->faces.append(face->wrapper(protect(scriptExecutionContext()).get()));
+        if (face->status() == CSSFontFace::Status::Success)
             continue;
         waiting = true;
-        ASSERT(face.get().existingWrapper());
-        m_pendingPromises.add(*face.get().existingWrapper(), Vector<Ref<PendingPromise>>()).iterator->value.append(pendingPromise.copyRef());
+        ASSERT(face->existingWrapper());
+        m_pendingPromises.add(*face->existingWrapper(), Vector<Ref<PendingPromise>>()).iterator->value.append(pendingPromise.copyRef());
     }
 
     if (!waiting)


### PR DESCRIPTION
#### 5f0480f771ba1749663a8257eafca70af17b7cec
<pre>
Cherry-pick 305413.664@safari-7624-branch (db05eacaeb0c). <a href="https://rdar.apple.com/176058395">rdar://176058395</a>

      Use-after-free in CSSFontFace::setStatus and CSSFontFace::pump
      <a href="https://bugs.webkit.org/show_bug.cgi?id=312202">https://bugs.webkit.org/show_bug.cgi?id=312202</a>
      <a href="https://rdar.apple.com/174525579">rdar://174525579</a>

      Reviewed by Simon Fraser.

      Fixed the bug by using Ref instead of std::reference_wrapper in the return value of
      CSSFontFaceSet::matchingFacesExcludingPreinstalledFonts and local variables in
      FontFaceSet::load to keep CSSFontFace objects alive long enough.

      Test: fast/text/fontface-setstatus-crash.html

      * LayoutTests/fast/text/fontface-setstatus-crash-expected.txt: Added.
      * LayoutTests/fast/text/fontface-setstatus-crash.html: Added.
      * Source/WebCore/css/CSSFontFaceSet.cpp:
      (WebCore::CSSFontFaceSet::matchingFacesExcludingPreinstalledFonts):
      * Source/WebCore/css/CSSFontFaceSet.h:
      * Source/WebCore/css/FontFaceSet.cpp:
      (WebCore::FontFaceSet::load):

      Identifier: 305413.664@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/313821@main">https://commits.webkit.org/313821@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0cb9ed8c335fdc336f1129e513a09e7392a2cec9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164260 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37744 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31308 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173289 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121512 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/cb6ed379-2d9d-4496-86e3-a5fb51b4bd23) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166129 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38078 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37744 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127610 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89794 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/fab1da34-66f6-480a-9e29-b367d3502c10) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167219 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29909 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147634 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108157 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b90995da-1645-40b8-92fb-645ab07fcbd8) 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28956 "Build is in progress. Recent messages:OS: Tahoe (26.2), Xcode: 26.2; Running apply-patch; Checked out pull request; Passed layout tests; 4 new passes") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27579 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21053 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138858 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25351 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175815 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28636 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27019 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135922 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37414 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31695 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135892 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38200 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147146 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100529 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25005 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31205 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24002 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37010 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110055 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36407 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2057 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36657 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36557 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->