### PR TITLE
Cherry-pick(s) 97ed68c66545. rdar://176062693

### DIFF
--- a/Source/WebCore/bindings/js/JSXPathResultCustom.cpp
+++ b/Source/WebCore/bindings/js/JSXPathResultCustom.cpp
@@ -32,7 +32,11 @@ namespace WebCore {
 template<typename Visitor>
 void JSXPathResult::visitAdditionalChildrenInGCThread(Visitor& visitor)
 {
+<<<<<<< HEAD
     wrapped().visitAdditionalChildrenInGCThread(visitor);
+=======
+    wrapped().visitAdditionalChildren(visitor);
+>>>>>>> 97ed68c66545 (Race condition in JSXPathResult::visitAdditionalChildren during GC)
 }
 
 DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(JSXPathResult);

--- a/Source/WebCore/xml/XPathResult.cpp
+++ b/Source/WebCore/xml/XPathResult.cpp
@@ -39,6 +39,7 @@ namespace WebCore {
 XPathResult::XPathResult(Document& document, const XPath::Value& value)
     : m_value(value)
 {
+<<<<<<< HEAD
     WTF::switchOn(m_value,
         [&](bool) {
             m_resultType = BOOLEAN_TYPE;
@@ -60,6 +61,30 @@ XPathResult::XPathResult(Document& document, const XPath::Value& value)
             m_domTreeVersion = document.domTreeVersion();
         }
     );
+=======
+    switch (m_value.type()) {
+    case XPath::Value::Type::Boolean:
+        m_resultType = BOOLEAN_TYPE;
+        return;
+    case XPath::Value::Type::Number:
+        m_resultType = NUMBER_TYPE;
+        return;
+    case XPath::Value::Type::String:
+        m_resultType = STRING_TYPE;
+        return;
+    case XPath::Value::Type::NodeSet:
+        m_resultType = UNORDERED_NODE_ITERATOR_TYPE;
+        m_nodeSetPosition = 0;
+        {
+            Locker locker { m_nodeSetLock };
+            m_nodeSet = m_value.toNodeSet();
+        }
+        m_document = document;
+        m_domTreeVersion = document.domTreeVersion();
+        return;
+    }
+    ASSERT_NOT_REACHED();
+>>>>>>> 97ed68c66545 (Race condition in JSXPathResult::visitAdditionalChildren during GC)
 }
 
 XPathResult::~XPathResult()
@@ -72,9 +97,15 @@ XPathResult::~XPathResult()
     ASSERT(valueNodeSet.size() == m_nodeSet.size());
     HashSet<const Node*> set;
     for (auto& node : m_nodeSet)
+<<<<<<< HEAD
         set.add(node.ptr());
     for (auto& node : valueNodeSet)
         ASSERT(set.contains(node.ptr()));
+=======
+        set.add(node.get());
+    for (auto& node : valueNodeSet)
+        ASSERT(set.contains(node.get()));
+>>>>>>> 97ed68c66545 (Race condition in JSXPathResult::visitAdditionalChildren during GC)
 #endif
 }
 
@@ -205,13 +236,21 @@ ExceptionOr<Node*> XPathResult::snapshotItem(unsigned index)
 }
 
 template<typename Visitor>
+<<<<<<< HEAD
 void XPathResult::visitAdditionalChildrenInGCThread(Visitor& visitor)
+=======
+void XPathResult::visitAdditionalChildren(Visitor& visitor)
+>>>>>>> 97ed68c66545 (Race condition in JSXPathResult::visitAdditionalChildren during GC)
 {
     Locker locker { m_nodeSetLock };
     for (auto& node : m_nodeSet)
         addWebCoreOpaqueRoot(visitor, node.get());
 }
 
+<<<<<<< HEAD
 DEFINE_VISIT_ADDITIONAL_CHILDREN_IN_GC_THREAD(XPathResult);
+=======
+DEFINE_VISIT_ADDITIONAL_CHILDREN(XPathResult);
+>>>>>>> 97ed68c66545 (Race condition in JSXPathResult::visitAdditionalChildren during GC)
 
 } // namespace WebCore

--- a/Source/WebCore/xml/XPathResult.h
+++ b/Source/WebCore/xml/XPathResult.h
@@ -70,6 +70,9 @@ public:
     template<typename Visitor>
     void visitAdditionalChildrenInGCThread(Visitor&);
 
+    template<typename Visitor>
+    void visitAdditionalChildren(Visitor&);
+
 private:
     XPathResult(Document&, const XPath::Value&);
 


### PR DESCRIPTION
Integration has hit a merge conflict while cherry-picking rdar://176062693 to main. The following sources [e8db86ea1203] will still need to be cherry-picked once the conflict is resolved.

```Race condition in JSXPathResult::visitAdditionalChildren during GC
https://bugs.webkit.org/show_bug.cgi?id=309776
<rdar://172263146>

Reviewed by Chris Dumez.

This PR fixes a race condition in JSXPathResult::visitAdditionalChildren
which results in a use-after-free. The issue is that this function
iterates over XPathNodeList's internal vector but XPathNodeList's member
functions such as XPathNodeList::firstNode could mutate the vector via
XPathNodeList::sort, letting a GC thread to do a use-after-free.

Fixed the bug by guarding the access to m_nodeSet with a lock.

No new tests since there is no reliable reproduction.

* Source/WebCore/bindings/js/JSXPathResultCustom.cpp:
(WebCore::JSXPathResult::visitAdditionalChildren):
* Source/WebCore/xml/XPathResult.cpp:
(WebCore::XPathResult::XPathResult):
(WebCore::XPathResult::~XPathResult):
(WebCore::XPathResult::convertTo):
(WebCore::XPathResult::visitAdditionalChildren):
* Source/WebCore/xml/XPathResult.h:

Originally-landed-as: 305413.475@rapid/safari-7624.2.5.110-branch (97ed68c66545). rdar://176062693

```

