### PR TITLE
fix fuziness issue for imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-thickness-from-font-variable.html

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-thickness-from-font-variable.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-thickness-from-font-variable.html
@@ -7,6 +7,7 @@
 <meta name="assert" content="text-decoration-thickness from-font respects MVAR table of variable fonts for variable metrics">
 <link rel="author" title="Dominik Röttsches" href="mailto:drott@chromium.org">
 <link rel="match" href="reference/text-decoration-thickness-from-font-variable-ref.html">
+<meta name="fuzzy" content="maxDifference=0-10;totalPixels=0-20">
 <style>
 @font-face {
 font-family: underline-variable;


### PR DESCRIPTION
#### d3aa42497feb58552a0fd52f6d6ffc08e202753e
<pre>
fix fuziness issue for imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-thickness-from-font-variable.html
<a href="https://bugs.webkit.org/show_bug.cgi?id=315488">https://bugs.webkit.org/show_bug.cgi?id=315488</a>
<a href="https://rdar.apple.com/177852965">rdar://177852965</a>

Reviewed by Dan Glastonbury.

The test is passing locally. This is just tweaking the fuziness to take
into account the failures on wpt.fyi
<a href="https://wpt.fyi/results/css/css-text-decor/text-decoration-thickness-from-font-variable.html">https://wpt.fyi/results/css/css-text-decor/text-decoration-thickness-from-font-variable.html</a>
maxDifference: 8
totalPixels: 12

* LayoutTests/imported/w3c/web-platform-tests/css/css-text-decor/text-decoration-thickness-from-font-variable.html:

Canonical link: <a href="https://commits.webkit.org/313823@main">https://commits.webkit.org/313823@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/f8feef5e3297a168ec8e22906eabe9bb624dcfd8

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164280 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37764 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31335 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173309 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121532 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f16c3155-c606-4068-96d8-8594410350c4) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38098 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37764 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127630 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89812 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/9b9e7340-f190-459c-a159-0cb3be9ef928) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167239 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29929 "Passed tests") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/147664 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108177 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/80c8f85e-9f51-4a41-a98e-e8621e1c1f39) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28976 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27599 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21073 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138878 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25381 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175835 "Built successfully") | | 
| | | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27049 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135942 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37435 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31717 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135912 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38221 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147176 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100565 "Built successfully") | | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25006 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31226 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24032 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37030 "Built successfully") | | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36427 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2088 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36677 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36577 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->