### PR TITLE
Don't update opener for self-navigation

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -1207,7 +1207,6 @@ imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-
 imported/w3c/web-platform-tests/content-security-policy/gen/top.meta/worker-src-wildcard/worker-import.https.html [ Skip ]
 imported/w3c/web-platform-tests/content-security-policy/generic/filesystem-urls-do-not-match-self.sub.html [ Skip ]
 imported/w3c/web-platform-tests/content-security-policy/img-src/icon-blocked.sub.html [ Skip ]
-webkit.org/b/246421 imported/w3c/web-platform-tests/content-security-policy/inheritance/javascript-url-open-in-main-window.html [ Skip ]
 imported/w3c/web-platform-tests/content-security-policy/inside-worker/dedicatedworker-connect-src.html [ Skip ]
 imported/w3c/web-platform-tests/content-security-policy/inside-worker/dedicatedworker-report-only.html [ Skip ]
 imported/w3c/web-platform-tests/content-security-policy/inside-worker/dedicatedworker-script-src.html [ Skip ]

--- a/LayoutTests/fast/dom/Window/resources/window-opens-self.html
+++ b/LayoutTests/fast/dom/Window/resources/window-opens-self.html
@@ -2,7 +2,7 @@
 <html>
 <body>
 <script>
-function setOpenerAsSelf() {
+function openSelf() {
     open("", "_self");
 }
 </script>

--- a/LayoutTests/fast/dom/Window/window-open-self-preserves-opener-expected.txt
+++ b/LayoutTests/fast/dom/Window/window-open-self-preserves-opener-expected.txt
@@ -1,10 +1,10 @@
-Tests navigating a window whose opener is itself
+Tests that open('', '_self') does not change the opener
 
 On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
 
 
 PASS w.opener is self
-PASS w.opener is w
+PASS w.opener is self
 PASS w.opener is self
 PASS successfullyParsed is true
 

--- a/LayoutTests/fast/dom/Window/window-open-self-preserves-opener.html
+++ b/LayoutTests/fast/dom/Window/window-open-self-preserves-opener.html
@@ -3,15 +3,15 @@
 <body>
 <script src="../../../resources/js-test.js"></script>
 <script>
-description("Tests navigating a window whose opener is itself");
+description("Tests that open('', '_self') does not change the opener");
 jsTestIsAsync = true;
 
 onload = function() {
     w = window.open("resources/window-opens-self.html", "foo");
     shouldBe("w.opener", "self");
     w.onload = function() {
-        w.setOpenerAsSelf();
-        shouldBe("w.opener", "w");
+        w.openSelf();
+        shouldBe("w.opener", "self");
 
         w = window.open("about:blank", "foo");
         shouldBe("w.opener", "self");

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/inheritance/javascript-url-open-in-main-window-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/inheritance/javascript-url-open-in-main-window-expected.txt
@@ -1,5 +1,3 @@
 
-Harness Error (TIMEOUT), message = null
-
-TIMEOUT Executing Javascript URL keeps enforcing previous CSPs of the document. Test timed out
+PASS Executing Javascript URL keeps enforcing previous CSPs of the document.
 

--- a/Source/WebCore/loader/FrameLoader.cpp
+++ b/Source/WebCore/loader/FrameLoader.cpp
@@ -4998,7 +4998,9 @@ std::pair<RefPtr<Frame>, CreatedNewPage> createWindow(LocalFrame& openerFrame, F
                 if (RefPtr page = frame->page(); page && isInVisibleAndActivePage(openerFrame))
                     page->chrome().focus();
             }
-            frame->updateOpener(openerFrame);
+            bool isSelfNavigation = isSelfTargetFrameName(request.frameName());
+            if (!isSelfNavigation)
+                frame->updateOpener(openerFrame);
             return { frame, CreatedNewPage::No };
         }
     }

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -2905,7 +2905,7 @@ ExceptionOr<RefPtr<Frame>> LocalDOMWindow::createWindow(const String& urlString,
         activeWindow.consumeTransientActivation();
 
     if (!noopener) {
-        ASSERT(!newFrame->opener() || newFrame->opener() == &openerFrame);
+        ASSERT(!newFrame->opener() || newFrame->opener() == &openerFrame || newFrame.get() == &openerFrame);
         if (auto* page = newFrame->page())
             page->setOpenedByDOMWithOpener(true);
     }


### PR DESCRIPTION
#### 45c5fe8e7eea2040d4dd5836c4af0209fd65d081
<pre>
Don&apos;t update opener for self-navigation
<a href="https://bugs.webkit.org/show_bug.cgi?id=246421">https://bugs.webkit.org/show_bug.cgi?id=246421</a>
<a href="https://rdar.apple.com/101094129">rdar://101094129</a>

Reviewed by NOBODY (OOPS!).

WebCore::createWindow() unconditionally calls updateOpener on the frame found by
findFrameForNavigation. When the target is _self, the found frame is the calling
frame itself, so its opener gets set to itself and the real opener is lost. The
WPT test javascript-url-open-in-main-window.html requires that the popup&apos;s opener
still point to the original opening window after a call to open(&quot;javascript:...&quot;, &quot;_self&quot;)
so the resulting document can postMessage back to it.

Add an isSelfTargetFrameName check to skip updateOpener when the target is _self as
self-navigation shouldn&apos;t establish an opener relationship.

* LayoutTests/TestExpectations:
* LayoutTests/fast/dom/Window/resources/window-opens-self.html:
* LayoutTests/fast/dom/Window/window-open-self-preserves-opener-expected.txt: Renamed from LayoutTests/fast/dom/Window/window-open-self-as-opener-expected.txt.
* LayoutTests/fast/dom/Window/window-open-self-preserves-opener.html: Renamed from LayoutTests/fast/dom/Window/window-open-self-as-opener.html.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/inheritance/javascript-url-open-in-main-window-expected.txt:
* Source/WebCore/loader/FrameLoader.cpp:
(WebCore::createWindow):
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::LocalDOMWindow::createWindow):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/45c5fe8e7eea2040d4dd5836c4af0209fd65d081

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/168437 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41994 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/35581 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/177765 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/126138 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/c6bd4527-c88f-46f2-ae01-c02edb58bb5b) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/170303 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/42370 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41955 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/131095 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/92193 "1 flakes 4 failures") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/30c1400d-6f04-4cfd-b979-12eda1abd0cf) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/171396 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/33557 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/151367 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/111606 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/64a083ce-476b-48e0-83df-c00df4b8d7d6) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/32543 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/31247 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/26461 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/142529 "Passed tests") | [⏳ 🧪 mac-wk1 ](https://ews-build.webkit.org/#/builders/macOS-Sequoia-Release-WK1-Tests-EWS "Waiting in queue, processing has not started yet") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/180365 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/33089 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/30771 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/139530 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/42006 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/35409 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/139394 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/42694 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/150843 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/106330 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/34682 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/27742 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/41198 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/114454 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/40595 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5826 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/40846 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/40740 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->