### PR TITLE
CSP wasm-unsafe-eval directive is not enforced during WebAssembly byte compilation

### DIFF
--- a/LayoutTests/http/tests/security/contentSecurityPolicy/WebAssembly-blocked-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/WebAssembly-blocked-expected.txt
@@ -1,3 +1,5 @@
 CONSOLE MESSAGE: CompileError: Refused to create a WebAssembly object because 'unsafe-eval' or 'wasm-unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
- (evaluating 'new WebAssembly.Instance(new WebAssembly.Module(empty))')
+ (evaluating 'new WebAssembly.Module(empty)')
+CONSOLE MESSAGE: CompileError: Refused to create a WebAssembly object because 'unsafe-eval' or 'wasm-unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+ (evaluating 'new WebAssembly.Module(empty)')
 

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/WebAssembly-blocked-in-about-blank-iframe-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/WebAssembly-blocked-in-about-blank-iframe-expected.txt
@@ -1,4 +1,4 @@
 ALERT: /PASS/
 CONSOLE MESSAGE: CompileError: Refused to create a WebAssembly object because 'unsafe-eval' or 'wasm-unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
- (evaluating 'new WebAssembly.Instance(new WebAssembly.Module(Uint8Array.of(0x0, 0x61, 0x73, 0x6d, 0x1, 0x00, 0x00, 0x00)))')
+ (evaluating 'new WebAssembly.Module(Uint8Array.of(0x0, 0x61, 0x73, 0x6d, 0x1, 0x00, 0x00, 0x00))')
  WebAssembly should be blocked in the iframe, but inline script should be allowed.

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/WebAssembly-blocked-in-external-script-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/WebAssembly-blocked-in-external-script-expected.txt
@@ -1,3 +1,3 @@
 CONSOLE MESSAGE: CompileError: Refused to create a WebAssembly object because 'unsafe-eval' or 'wasm-unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'self' 'unsafe-inline'".
- (evaluating 'new WebAssembly.Instance(new WebAssembly.Module(Uint8Array.of(0x0, 0x61, 0x73, 0x6d, 0x1, 0x00, 0x00, 0x00)))')
+ (evaluating 'new WebAssembly.Module(Uint8Array.of(0x0, 0x61, 0x73, 0x6d, 0x1, 0x00, 0x00, 0x00))')
 

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/WebAssembly-blocked-in-subframe-expected.txt
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/WebAssembly-blocked-in-subframe-expected.txt
@@ -1,5 +1,7 @@
 CONSOLE MESSAGE: CompileError: Refused to create a WebAssembly object because 'unsafe-eval' or 'wasm-unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
- (evaluating 'new WebAssembly.Instance(new WebAssembly.Module(empty))')
+ (evaluating 'new WebAssembly.Module(empty)')
+CONSOLE MESSAGE: CompileError: Refused to create a WebAssembly object because 'unsafe-eval' or 'wasm-unsafe-eval' is not an allowed source of script in the following Content Security Policy directive: "script-src 'unsafe-inline'".
+ (evaluating 'new WebAssembly.Module(empty)')
 Tests that WebAssembly is blocked in a subframe that disallows WebAssembly when the parent frame allows WebAssembly.
 
 

--- a/LayoutTests/http/tests/security/contentSecurityPolicy/WebAssembly-blocked.html
+++ b/LayoutTests/http/tests/security/contentSecurityPolicy/WebAssembly-blocked.html
@@ -13,16 +13,14 @@ const empty = Uint8Array.of(0x0, 0x61, 0x73, 0x6d, 0x1, 0x00, 0x00, 0x00);
 <script>if (typeof WebAssembly !== "object") throw new Error(`Expected WebAssembly object to be accessible under CSP`)</script>
 <script>new WebAssembly.CompileError(`This is OK`)</script>
 <script>new WebAssembly.LinkError(`This is OK`)</script>
-<script>new WebAssembly.Module(empty)</script>
 <script>if (!WebAssembly.validate(empty)) throw new Error(`Expected validation to succeed`)</script>
 <!-- The following APIs aren't accessible under CSP. -->
+<script>new WebAssembly.Module(empty)</script>
 <script>new WebAssembly.Memory({ initial: 1 })</script>
 <script>new WebAssembly.Memory({ initial: 1, maximum: 1 })</script>
 <script>new WebAssembly.Memory({ initial: 1, maximum: 1, shared: true })</script>
 <script>new WebAssembly.Table({ element: "anyfunc", initial: 1 })</script>
 <script>new WebAssembly.Table({ element: "anyfunc", initial: 1, maximum: 1 })</script>
 <script>new WebAssembly.Instance(new WebAssembly.Module(empty))</script>
-<!-- FIXME: add WebAssembly.compile and WebAssembly.instantiate https://bugs.webkit.org/show_bug.cgi?id=173977 -->
-<!-- FIXME: add WebAssembly.compileStreaming and WebAssembly.instantiateStreaming https://bugs.webkit.org/show_bug.cgi?id=173105 -->
 </body>
 </html>

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm-streaming.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm-streaming.any-expected.txt
@@ -1,0 +1,4 @@
+
+PASS WebAssembly.compileStreaming() is blocked
+PASS WebAssembly.instantiateStreaming() is blocked
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm-streaming.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm-streaming.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm-streaming.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm-streaming.any.js
@@ -1,0 +1,17 @@
+// META: global=window,worker
+
+const bytes = new Uint8Array([0, 0x61, 0x73, 0x6d, 0x1, 0, 0, 0]);
+
+promise_test(t => {
+  const response = new Response(bytes, { headers: { "Content-Type": "application/wasm" } });
+  return promise_rejects_js(
+      t, WebAssembly.CompileError,
+      WebAssembly.compileStreaming(response));
+}, "WebAssembly.compileStreaming() is blocked");
+
+promise_test(t => {
+  const response = new Response(bytes, { headers: { "Content-Type": "application/wasm" } });
+  return promise_rejects_js(
+      t, WebAssembly.CompileError,
+      WebAssembly.instantiateStreaming(response));
+}, "WebAssembly.instantiateStreaming() is blocked");

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm-streaming.any.js.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm-streaming.any.js.headers
@@ -1,0 +1,1 @@
+Content-Security-Policy: default-src 'self' 'unsafe-inline'

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm-streaming.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm-streaming.any.worker-expected.txt
@@ -1,0 +1,4 @@
+
+PASS WebAssembly.compileStreaming() is blocked
+PASS WebAssembly.instantiateStreaming() is blocked
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm-streaming.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm-streaming.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm.any-expected.txt
@@ -1,3 +1,5 @@
 
-PASS default-src-blocks-wasm
+PASS WebAssembly.instantiate() is blocked
+PASS WebAssembly.compile() is blocked
+PASS new WebAssembly.Module() is blocked
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm.any.js
@@ -1,8 +1,21 @@
 // META: global=window,worker
 
+const bytes = new Uint8Array([0, 0x61, 0x73, 0x6d, 0x1, 0, 0, 0]);
+
 promise_test(t => {
   return promise_rejects_js(
       t, WebAssembly.CompileError,
-      WebAssembly.instantiate(
-          new Uint8Array([0, 0x61, 0x73, 0x6d, 0x1, 0, 0, 0])));
-});
+      WebAssembly.instantiate(bytes));
+}, "WebAssembly.instantiate() is blocked");
+
+promise_test(t => {
+  return promise_rejects_js(
+      t, WebAssembly.CompileError,
+      WebAssembly.compile(bytes));
+}, "WebAssembly.compile() is blocked");
+
+test(() => {
+  assert_throws_js(
+      WebAssembly.CompileError,
+      () => new WebAssembly.Module(bytes));
+}, "new WebAssembly.Module() is blocked");

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm.any.serviceworker-expected.txt
@@ -1,3 +1,5 @@
 
-PASS default-src-blocks-wasm
+PASS WebAssembly.instantiate() is blocked
+PASS WebAssembly.compile() is blocked
+PASS new WebAssembly.Module() is blocked
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm.any.sharedworker-expected.txt
@@ -1,3 +1,5 @@
 
-PASS default-src-blocks-wasm
+PASS WebAssembly.instantiate() is blocked
+PASS WebAssembly.compile() is blocked
+PASS new WebAssembly.Module() is blocked
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm.any.worker-expected.txt
@@ -1,3 +1,5 @@
 
-PASS default-src-blocks-wasm
+PASS WebAssembly.instantiate() is blocked
+PASS WebAssembly.compile() is blocked
+PASS new WebAssembly.Module() is blocked
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-unsafe-eval-allows-wasm.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-unsafe-eval-allows-wasm.any-expected.txt
@@ -1,3 +1,7 @@
 
-PASS default-src-unsafe-eval-allows-wasm
+PASS WebAssembly.instantiate() is allowed
+PASS WebAssembly.compile() is allowed
+PASS new WebAssembly.Module() is allowed
+PASS WebAssembly.compileStreaming() is allowed
+PASS WebAssembly.instantiateStreaming() is allowed
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-unsafe-eval-allows-wasm.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-unsafe-eval-allows-wasm.any.js
@@ -1,6 +1,25 @@
 // META: global=window,worker
 
+const bytes = new Uint8Array([0, 0x61, 0x73, 0x6d, 0x1, 0, 0, 0]);
+
 promise_test(t => {
-  return WebAssembly.instantiate(
-      new Uint8Array([0, 0x61, 0x73, 0x6d, 0x1, 0, 0, 0]));
-});
+  return WebAssembly.instantiate(bytes);
+}, "WebAssembly.instantiate() is allowed");
+
+promise_test(t => {
+  return WebAssembly.compile(bytes);
+}, "WebAssembly.compile() is allowed");
+
+test(() => {
+  new WebAssembly.Module(bytes);
+}, "new WebAssembly.Module() is allowed");
+
+promise_test(t => {
+  const response = new Response(bytes, { headers: { "Content-Type": "application/wasm" } });
+  return WebAssembly.compileStreaming(response);
+}, "WebAssembly.compileStreaming() is allowed");
+
+promise_test(t => {
+  const response = new Response(bytes, { headers: { "Content-Type": "application/wasm" } });
+  return WebAssembly.instantiateStreaming(response);
+}, "WebAssembly.instantiateStreaming() is allowed");

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-unsafe-eval-allows-wasm.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-unsafe-eval-allows-wasm.any.serviceworker-expected.txt
@@ -1,3 +1,7 @@
 
-PASS default-src-unsafe-eval-allows-wasm
+PASS WebAssembly.instantiate() is allowed
+PASS WebAssembly.compile() is allowed
+PASS new WebAssembly.Module() is allowed
+PASS WebAssembly.compileStreaming() is allowed
+PASS WebAssembly.instantiateStreaming() is allowed
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-unsafe-eval-allows-wasm.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-unsafe-eval-allows-wasm.any.sharedworker-expected.txt
@@ -1,3 +1,7 @@
 
-PASS default-src-unsafe-eval-allows-wasm
+PASS WebAssembly.instantiate() is allowed
+PASS WebAssembly.compile() is allowed
+PASS new WebAssembly.Module() is allowed
+PASS WebAssembly.compileStreaming() is allowed
+PASS WebAssembly.instantiateStreaming() is allowed
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-unsafe-eval-allows-wasm.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-unsafe-eval-allows-wasm.any.worker-expected.txt
@@ -1,3 +1,7 @@
 
-PASS default-src-unsafe-eval-allows-wasm
+PASS WebAssembly.instantiate() is allowed
+PASS WebAssembly.compile() is allowed
+PASS new WebAssembly.Module() is allowed
+PASS WebAssembly.compileStreaming() is allowed
+PASS WebAssembly.instantiateStreaming() is allowed
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-wasm-unsafe-eval-allows-wasm.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-wasm-unsafe-eval-allows-wasm.any-expected.txt
@@ -1,3 +1,7 @@
 
-PASS default-src-wasm-unsafe-eval-allows-wasm
+PASS WebAssembly.instantiate() is allowed
+PASS WebAssembly.compile() is allowed
+PASS new WebAssembly.Module() is allowed
+PASS WebAssembly.compileStreaming() is allowed
+PASS WebAssembly.instantiateStreaming() is allowed
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-wasm-unsafe-eval-allows-wasm.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-wasm-unsafe-eval-allows-wasm.any.js
@@ -1,6 +1,25 @@
 // META: global=window,worker
 
+const bytes = new Uint8Array([0, 0x61, 0x73, 0x6d, 0x1, 0, 0, 0]);
+
 promise_test(t => {
-  return WebAssembly.instantiate(
-      new Uint8Array([0, 0x61, 0x73, 0x6d, 0x1, 0, 0, 0]));
-});
+  return WebAssembly.instantiate(bytes);
+}, "WebAssembly.instantiate() is allowed");
+
+promise_test(t => {
+  return WebAssembly.compile(bytes);
+}, "WebAssembly.compile() is allowed");
+
+test(() => {
+  new WebAssembly.Module(bytes);
+}, "new WebAssembly.Module() is allowed");
+
+promise_test(t => {
+  const response = new Response(bytes, { headers: { "Content-Type": "application/wasm" } });
+  return WebAssembly.compileStreaming(response);
+}, "WebAssembly.compileStreaming() is allowed");
+
+promise_test(t => {
+  const response = new Response(bytes, { headers: { "Content-Type": "application/wasm" } });
+  return WebAssembly.instantiateStreaming(response);
+}, "WebAssembly.instantiateStreaming() is allowed");

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-wasm-unsafe-eval-allows-wasm.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-wasm-unsafe-eval-allows-wasm.any.serviceworker-expected.txt
@@ -1,3 +1,7 @@
 
-PASS default-src-wasm-unsafe-eval-allows-wasm
+PASS WebAssembly.instantiate() is allowed
+PASS WebAssembly.compile() is allowed
+PASS new WebAssembly.Module() is allowed
+PASS WebAssembly.compileStreaming() is allowed
+PASS WebAssembly.instantiateStreaming() is allowed
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-wasm-unsafe-eval-allows-wasm.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-wasm-unsafe-eval-allows-wasm.any.sharedworker-expected.txt
@@ -1,3 +1,7 @@
 
-PASS default-src-wasm-unsafe-eval-allows-wasm
+PASS WebAssembly.instantiate() is allowed
+PASS WebAssembly.compile() is allowed
+PASS new WebAssembly.Module() is allowed
+PASS WebAssembly.compileStreaming() is allowed
+PASS WebAssembly.instantiateStreaming() is allowed
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-wasm-unsafe-eval-allows-wasm.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-wasm-unsafe-eval-allows-wasm.any.worker-expected.txt
@@ -1,3 +1,7 @@
 
-PASS default-src-wasm-unsafe-eval-allows-wasm
+PASS WebAssembly.instantiate() is allowed
+PASS WebAssembly.compile() is allowed
+PASS new WebAssembly.Module() is allowed
+PASS WebAssembly.compileStreaming() is allowed
+PASS WebAssembly.instantiateStreaming() is allowed
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm-streaming.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm-streaming.any-expected.txt
@@ -1,0 +1,4 @@
+
+PASS WebAssembly.compileStreaming() is blocked
+PASS WebAssembly.instantiateStreaming() is blocked
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm-streaming.any.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm-streaming.any.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm-streaming.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm-streaming.any.js
@@ -1,0 +1,17 @@
+// META: global=window,worker
+
+const bytes = new Uint8Array([0, 0x61, 0x73, 0x6d, 0x1, 0, 0, 0]);
+
+promise_test(t => {
+  const response = new Response(bytes, { headers: { "Content-Type": "application/wasm" } });
+  return promise_rejects_js(
+      t, WebAssembly.CompileError,
+      WebAssembly.compileStreaming(response));
+}, "WebAssembly.compileStreaming() is blocked");
+
+promise_test(t => {
+  const response = new Response(bytes, { headers: { "Content-Type": "application/wasm" } });
+  return promise_rejects_js(
+      t, WebAssembly.CompileError,
+      WebAssembly.instantiateStreaming(response));
+}, "WebAssembly.instantiateStreaming() is blocked");

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm-streaming.any.js.headers
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm-streaming.any.js.headers
@@ -1,0 +1,1 @@
+Content-Security-Policy: script-src 'self' 'unsafe-inline'

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm-streaming.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm-streaming.any.worker-expected.txt
@@ -1,0 +1,4 @@
+
+PASS WebAssembly.compileStreaming() is blocked
+PASS WebAssembly.instantiateStreaming() is blocked
+

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm-streaming.any.worker.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm-streaming.any.worker.html
@@ -1,0 +1,1 @@
+<!-- This file is required for WebKit test infrastructure to run the templated test -->

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm.any-expected.txt
@@ -1,3 +1,5 @@
 
-PASS script-src-blocks-wasm
+PASS WebAssembly.instantiate() is blocked
+PASS WebAssembly.compile() is blocked
+PASS new WebAssembly.Module() is blocked
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm.any.js
@@ -1,8 +1,21 @@
 // META: global=window,worker
 
+const bytes = new Uint8Array([0, 0x61, 0x73, 0x6d, 0x1, 0, 0, 0]);
+
 promise_test(t => {
   return promise_rejects_js(
       t, WebAssembly.CompileError,
-      WebAssembly.instantiate(
-          new Uint8Array([0, 0x61, 0x73, 0x6d, 0x1, 0, 0, 0])));
-});
+      WebAssembly.instantiate(bytes));
+}, "WebAssembly.instantiate() is blocked");
+
+promise_test(t => {
+  return promise_rejects_js(
+      t, WebAssembly.CompileError,
+      WebAssembly.compile(bytes));
+}, "WebAssembly.compile() is blocked");
+
+test(() => {
+  assert_throws_js(
+      WebAssembly.CompileError,
+      () => new WebAssembly.Module(bytes));
+}, "new WebAssembly.Module() is blocked");

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm.any.serviceworker-expected.txt
@@ -1,3 +1,5 @@
 
-PASS script-src-blocks-wasm
+PASS WebAssembly.instantiate() is blocked
+PASS WebAssembly.compile() is blocked
+PASS new WebAssembly.Module() is blocked
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm.any.sharedworker-expected.txt
@@ -1,3 +1,5 @@
 
-PASS script-src-blocks-wasm
+PASS WebAssembly.instantiate() is blocked
+PASS WebAssembly.compile() is blocked
+PASS new WebAssembly.Module() is blocked
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm.any.worker-expected.txt
@@ -1,3 +1,5 @@
 
-PASS script-src-blocks-wasm
+PASS WebAssembly.instantiate() is blocked
+PASS WebAssembly.compile() is blocked
+PASS new WebAssembly.Module() is blocked
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-unsafe-eval-allows-wasm.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-unsafe-eval-allows-wasm.any-expected.txt
@@ -1,3 +1,7 @@
 
-PASS script-src-unsafe-eval-allows-wasm
+PASS WebAssembly.instantiate() is allowed
+PASS WebAssembly.compile() is allowed
+PASS new WebAssembly.Module() is allowed
+PASS WebAssembly.compileStreaming() is allowed
+PASS WebAssembly.instantiateStreaming() is allowed
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-unsafe-eval-allows-wasm.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-unsafe-eval-allows-wasm.any.js
@@ -1,6 +1,25 @@
 // META: global=window,worker
 
+const bytes = new Uint8Array([0, 0x61, 0x73, 0x6d, 0x1, 0, 0, 0]);
+
 promise_test(t => {
-  return WebAssembly.instantiate(
-      new Uint8Array([0, 0x61, 0x73, 0x6d, 0x1, 0, 0, 0]));
-});
+  return WebAssembly.instantiate(bytes);
+}, "WebAssembly.instantiate() is allowed");
+
+promise_test(t => {
+  return WebAssembly.compile(bytes);
+}, "WebAssembly.compile() is allowed");
+
+test(() => {
+  new WebAssembly.Module(bytes);
+}, "new WebAssembly.Module() is allowed");
+
+promise_test(t => {
+  const response = new Response(bytes, { headers: { "Content-Type": "application/wasm" } });
+  return WebAssembly.compileStreaming(response);
+}, "WebAssembly.compileStreaming() is allowed");
+
+promise_test(t => {
+  const response = new Response(bytes, { headers: { "Content-Type": "application/wasm" } });
+  return WebAssembly.instantiateStreaming(response);
+}, "WebAssembly.instantiateStreaming() is allowed");

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-unsafe-eval-allows-wasm.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-unsafe-eval-allows-wasm.any.serviceworker-expected.txt
@@ -1,3 +1,7 @@
 
-PASS script-src-unsafe-eval-allows-wasm
+PASS WebAssembly.instantiate() is allowed
+PASS WebAssembly.compile() is allowed
+PASS new WebAssembly.Module() is allowed
+PASS WebAssembly.compileStreaming() is allowed
+PASS WebAssembly.instantiateStreaming() is allowed
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-unsafe-eval-allows-wasm.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-unsafe-eval-allows-wasm.any.sharedworker-expected.txt
@@ -1,3 +1,7 @@
 
-PASS script-src-unsafe-eval-allows-wasm
+PASS WebAssembly.instantiate() is allowed
+PASS WebAssembly.compile() is allowed
+PASS new WebAssembly.Module() is allowed
+PASS WebAssembly.compileStreaming() is allowed
+PASS WebAssembly.instantiateStreaming() is allowed
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-unsafe-eval-allows-wasm.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-unsafe-eval-allows-wasm.any.worker-expected.txt
@@ -1,3 +1,7 @@
 
-PASS script-src-unsafe-eval-allows-wasm
+PASS WebAssembly.instantiate() is allowed
+PASS WebAssembly.compile() is allowed
+PASS new WebAssembly.Module() is allowed
+PASS WebAssembly.compileStreaming() is allowed
+PASS WebAssembly.instantiateStreaming() is allowed
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-wasm-unsafe-eval-allows-wasm.any-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-wasm-unsafe-eval-allows-wasm.any-expected.txt
@@ -1,3 +1,7 @@
 
-PASS script-src-wasm-unsafe-eval-allows-wasm
+PASS WebAssembly.instantiate() is allowed
+PASS WebAssembly.compile() is allowed
+PASS new WebAssembly.Module() is allowed
+PASS WebAssembly.compileStreaming() is allowed
+PASS WebAssembly.instantiateStreaming() is allowed
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-wasm-unsafe-eval-allows-wasm.any.js
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-wasm-unsafe-eval-allows-wasm.any.js
@@ -1,6 +1,25 @@
 // META: global=window,worker
 
+const bytes = new Uint8Array([0, 0x61, 0x73, 0x6d, 0x1, 0, 0, 0]);
+
 promise_test(t => {
-  return WebAssembly.instantiate(
-      new Uint8Array([0, 0x61, 0x73, 0x6d, 0x1, 0, 0, 0]));
-});
+  return WebAssembly.instantiate(bytes);
+}, "WebAssembly.instantiate() is allowed");
+
+promise_test(t => {
+  return WebAssembly.compile(bytes);
+}, "WebAssembly.compile() is allowed");
+
+test(() => {
+  new WebAssembly.Module(bytes);
+}, "new WebAssembly.Module() is allowed");
+
+promise_test(t => {
+  const response = new Response(bytes, { headers: { "Content-Type": "application/wasm" } });
+  return WebAssembly.compileStreaming(response);
+}, "WebAssembly.compileStreaming() is allowed");
+
+promise_test(t => {
+  const response = new Response(bytes, { headers: { "Content-Type": "application/wasm" } });
+  return WebAssembly.instantiateStreaming(response);
+}, "WebAssembly.instantiateStreaming() is allowed");

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-wasm-unsafe-eval-allows-wasm.any.serviceworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-wasm-unsafe-eval-allows-wasm.any.serviceworker-expected.txt
@@ -1,3 +1,7 @@
 
-PASS script-src-wasm-unsafe-eval-allows-wasm
+PASS WebAssembly.instantiate() is allowed
+PASS WebAssembly.compile() is allowed
+PASS new WebAssembly.Module() is allowed
+PASS WebAssembly.compileStreaming() is allowed
+PASS WebAssembly.instantiateStreaming() is allowed
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-wasm-unsafe-eval-allows-wasm.any.sharedworker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-wasm-unsafe-eval-allows-wasm.any.sharedworker-expected.txt
@@ -1,3 +1,7 @@
 
-PASS script-src-wasm-unsafe-eval-allows-wasm
+PASS WebAssembly.instantiate() is allowed
+PASS WebAssembly.compile() is allowed
+PASS new WebAssembly.Module() is allowed
+PASS WebAssembly.compileStreaming() is allowed
+PASS WebAssembly.instantiateStreaming() is allowed
 

--- a/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-wasm-unsafe-eval-allows-wasm.any.worker-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-wasm-unsafe-eval-allows-wasm.any.worker-expected.txt
@@ -1,3 +1,7 @@
 
-PASS script-src-wasm-unsafe-eval-allows-wasm
+PASS WebAssembly.instantiate() is allowed
+PASS WebAssembly.compile() is allowed
+PASS new WebAssembly.Module() is allowed
+PASS WebAssembly.compileStreaming() is allowed
+PASS WebAssembly.instantiateStreaming() is allowed
 

--- a/Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp
@@ -140,6 +140,11 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyCompileFunc, (JSGlobalObject* globalObject, 
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    if (!globalObject->webAssemblyEnabled()) [[unlikely]] {
+        auto error = createJSWebAssemblyCompileError(globalObject, vm, globalObject->webAssemblyDisabledErrorMessage());
+        RELEASE_AND_RETURN(scope, JSValue::encode(JSPromise::rejectedPromise(globalObject, error)));
+    }
+
     auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
     RETURN_IF_EXCEPTION(scope, { });
 
@@ -334,6 +339,11 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyInstantiateFunc, (JSGlobalObject* globalObje
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    if (!globalObject->webAssemblyEnabled()) [[unlikely]] {
+        auto error = createJSWebAssemblyCompileError(globalObject, vm, globalObject->webAssemblyDisabledErrorMessage());
+        RELEASE_AND_RETURN(scope, JSValue::encode(JSPromise::rejectedPromise(globalObject, error)));
+    }
+
     auto [taintedness, url] = sourceTaintedOriginFromStack(vm, callFrame);
     RefPtr<SourceProvider> provider = StringSourceProvider::create("[wasm code]"_s, SourceOrigin(url), String(), taintedness, TextPosition(), SourceProviderSourceType::Program);
 
@@ -433,6 +443,11 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyCompileStreamingFunc, (JSGlobalObject* globa
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
 
+    if (!globalObject->webAssemblyEnabled()) [[unlikely]] {
+        auto error = createJSWebAssemblyCompileError(globalObject, vm, globalObject->webAssemblyDisabledErrorMessage());
+        RELEASE_AND_RETURN(scope, JSValue::encode(JSPromise::rejectedPromise(globalObject, error)));
+    }
+
     auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
 
     std::optional<WebAssemblyCompileOptions> compileOptions;
@@ -469,6 +484,11 @@ JSC_DEFINE_HOST_FUNCTION(webAssemblyInstantiateStreamingFunc, (JSGlobalObject* g
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
+
+    if (!globalObject->webAssemblyEnabled()) [[unlikely]] {
+        auto error = createJSWebAssemblyCompileError(globalObject, vm, globalObject->webAssemblyDisabledErrorMessage());
+        RELEASE_AND_RETURN(scope, JSValue::encode(JSPromise::rejectedPromise(globalObject, error)));
+    }
 
     auto* promise = JSPromise::create(vm, globalObject->promiseStructure());
 

--- a/Source/JavaScriptCore/wasm/js/WebAssemblyModuleConstructor.cpp
+++ b/Source/JavaScriptCore/wasm/js/WebAssemblyModuleConstructor.cpp
@@ -290,7 +290,10 @@ JSC_DEFINE_HOST_FUNCTION(constructJSWebAssemblyModule, (JSGlobalObject* globalOb
 {
     VM& vm = globalObject->vm();
     auto scope = DECLARE_THROW_SCOPE(vm);
-    
+
+    if (!globalObject->webAssemblyEnabled()) [[unlikely]]
+        return JSValue::encode(throwException(globalObject, scope, createJSWebAssemblyCompileError(globalObject, vm, globalObject->webAssemblyDisabledErrorMessage())));
+
     Vector<uint8_t> source = createSourceBufferFromValue(vm, globalObject, callFrame->argument(0));
     RETURN_IF_EXCEPTION(scope, { });
 


### PR DESCRIPTION
#### 4003087f20b3fb38523cd7c92c804ba44d9405fc
<pre>
CSP wasm-unsafe-eval directive is not enforced during WebAssembly byte compilation
<a href="https://bugs.webkit.org/show_bug.cgi?id=315489">https://bugs.webkit.org/show_bug.cgi?id=315489</a>
<a href="https://rdar.apple.com/175340639">rdar://175340639</a>

Reviewed by Anne van Kesteren.

CSP wasm-unsafe-eval check (globalObject-&gt;webAssemblyEnabled()) is only performed during WebAssembly instance
creation in JSWebAssemblyInstance::tryCreate(), not during byte compilation. WebAssembly.compile(),
new WebAssembly.Module(), WebAssembly.compileStreaming(), and WebAssembly.instantiateStreaming() all proceed
without consulting the CSP policy. A compiled Module can then be transferred via postMessage to a same-origin
Worker where instantiation succeeds unchecked.

Add the same webAssemblyEnabled() check to webAssemblyCompileFunc, constructJSWebAssemblyModule,
webAssemblyCompileStreamingFunc, and webAssemblyInstantiateStreamingFunc in JSWebAssembly.cpp and
WebAssemblyModuleConstructor.cpp. Each rejects with CompileError before any compilation or fetch work begins.

Tests: imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm-streaming.any.html
       imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm-streaming.any.worker.html
       imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm-streaming.any.html
       imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm-streaming.any.worker.html

* LayoutTests/http/tests/security/contentSecurityPolicy/WebAssembly-blocked-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/WebAssembly-blocked-in-about-blank-iframe-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/WebAssembly-blocked-in-external-script-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/WebAssembly-blocked-in-subframe-expected.txt:
* LayoutTests/http/tests/security/contentSecurityPolicy/WebAssembly-blocked.html:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm-streaming.any-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm-streaming.any.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm-streaming.any.js: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm-streaming.any.js.headers: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm-streaming.any.worker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm-streaming.any.worker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm.any.js:
(test):
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-blocks-wasm.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-unsafe-eval-allows-wasm.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-unsafe-eval-allows-wasm.any.js:
(test):
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-unsafe-eval-allows-wasm.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-unsafe-eval-allows-wasm.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-unsafe-eval-allows-wasm.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-wasm-unsafe-eval-allows-wasm.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-wasm-unsafe-eval-allows-wasm.any.js:
(test):
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-wasm-unsafe-eval-allows-wasm.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-wasm-unsafe-eval-allows-wasm.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/default-src-wasm-unsafe-eval-allows-wasm.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm-streaming.any-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm-streaming.any.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm-streaming.any.js: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm-streaming.any.js.headers: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm-streaming.any.worker-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm-streaming.any.worker.html: Added.
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm.any.js:
(test):
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-blocks-wasm.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-unsafe-eval-allows-wasm.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-unsafe-eval-allows-wasm.any.js:
(test):
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-unsafe-eval-allows-wasm.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-unsafe-eval-allows-wasm.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-unsafe-eval-allows-wasm.any.worker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-wasm-unsafe-eval-allows-wasm.any-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-wasm-unsafe-eval-allows-wasm.any.js:
(test):
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-wasm-unsafe-eval-allows-wasm.any.serviceworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-wasm-unsafe-eval-allows-wasm.any.sharedworker-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/content-security-policy/wasm-unsafe-eval/script-src-wasm-unsafe-eval-allows-wasm.any.worker-expected.txt:
* Source/JavaScriptCore/wasm/js/JSWebAssembly.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):
* Source/JavaScriptCore/wasm/js/WebAssemblyModuleConstructor.cpp:
(JSC::JSC_DEFINE_HOST_FUNCTION):

Canonical link: <a href="https://commits.webkit.org/314092@main">https://commits.webkit.org/314092@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ccbb40ca18370ba687b02516bfd0a7505f785c58

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/165023 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/38514 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/32091 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/174065 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/122279 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/44f284d5-e5df-4f4a-8f7b-18f3e882af71) 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38848 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/38515 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/128240 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/90270 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/000c8b01-8216-45c3-b9ec-37c5a77a0a3d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167982 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30550 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/148289 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108766 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/816cb5d1-0491-4abb-b6ec-8e32a3973f18) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29598 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/28212 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21820 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/157182 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139493 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25988 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176588 "Built successfully") | | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/25918 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/29442 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27692 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136561 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38582 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/32348 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136505 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36804 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/39272 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147784 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/101571 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31778 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24650 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/197426 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37782 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110853 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/52916 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/37179 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2726 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/37425 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/37323 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->