### PR TITLE
Subgrid with large column-gap overflows max-width-constrained parent

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-own-column-gap-does-not-inflate-intrinsic-width-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-own-column-gap-does-not-inflate-intrinsic-width-expected.txt
@@ -1,0 +1,3 @@
+
+PASS Subgrid's own column-gap must not inflate intrinsic width in the subgridded axis
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-own-column-gap-does-not-inflate-intrinsic-width.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-own-column-gap-does-not-inflate-intrinsic-width.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<meta charset="utf-8">
+<title>CSS Grid Test: subgrid's own gap must not inflate intrinsic width in the subgridded axis</title>
+<link rel="author" title="Ahmad Saleem" href="mailto:ahmadsaleem@apple.com">
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#subgrids">
+<link rel="help" href="https://drafts.csswg.org/css-grid-2/#gutters">
+<meta name="assert" content="A subgrid with a large column-gap and a max-width constraint must not be inflated past its parent grid's track sum: items spanning the full subgrid in the subgridded axis must not overflow.">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<style>
+#wrapper { width: 400px; }
+#outer {
+  display: grid;
+  grid-template-columns: repeat(13, 1fr);
+}
+#subgrid {
+  grid-column: 1 / -1;
+  max-width: 70ch;
+  display: grid;
+  grid-template-columns: subgrid;
+  gap: 10rem;
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
+}
+#child {
+  grid-column: 1 / -1;
+  height: 50px;
+  background: red;
+}
+</style>
+<div id="log"></div>
+<div id="wrapper">
+  <div id="outer">
+    <div id="subgrid">
+      <div id="child"></div>
+    </div>
+  </div>
+</div>
+<script>
+test(() => {
+  const wrapper = document.getElementById("wrapper");
+  const outer = document.getElementById("outer");
+  const subgrid = document.getElementById("subgrid");
+  const child = document.getElementById("child");
+
+  assert_less_than_equal(outer.offsetWidth, wrapper.offsetWidth,
+    "outer grid must not exceed its containing block (subgrid's own column-gap must not inflate parent's intrinsic width)");
+  assert_less_than_equal(subgrid.offsetWidth, outer.offsetWidth,
+    "subgrid must fit within its parent grid");
+  assert_less_than_equal(child.offsetLeft + child.offsetWidth,
+    subgrid.offsetLeft + subgrid.offsetWidth,
+    "item spanning the full subgrid must not overflow the subgrid in the subgridded axis");
+}, "Subgrid's own column-gap must not inflate intrinsic width in the subgridded axis");
+</script>

--- a/Source/WebCore/rendering/RenderGrid.cpp
+++ b/Source/WebCore/rendering/RenderGrid.cpp
@@ -882,7 +882,7 @@ std::pair<LayoutUnit, LayoutUnit> RenderGrid::computeTrackSizesForIndefiniteSize
     algorithm.run(direction, numTracks(direction), SizingOperation::IntrinsicSizeComputation, std::nullopt, gridLayoutState);
 
     size_t numberOfTracks = algorithm.tracks(direction).size();
-    auto totalGuttersSize = direction == Style::GridTrackSizingDirection::Columns && explicitIntrinsicInnerLogicalSize(direction).has_value() ? 0_lu : guttersSize(direction, 0, numberOfTracks, std::nullopt);
+    auto totalGuttersSize = (direction == Style::GridTrackSizingDirection::Columns && explicitIntrinsicInnerLogicalSize(direction).has_value()) || isSubgrid(direction) ? 0_lu : guttersSize(direction, 0, numberOfTracks, std::nullopt);
 
     ASSERT(algorithm.tracksAreWiderThanMinTrackBreadth());
     return { algorithm.minContentSize() + totalGuttersSize, algorithm.maxContentSize() + totalGuttersSize };
@@ -1720,8 +1720,10 @@ LayoutUnit RenderGrid::gridAreaBreadthForGridItemIncludingAlignmentOffsets(const
     auto initialTrackPosition = positions[span.startLine()];
     auto finalTrackPosition = positions[span.endLine() - 1];
 
-    // Track Positions vector stores the 'start' grid line of each track, so we have to add last track's baseSize.
-    return finalTrackPosition - initialTrackPosition + tracks[span.endLine() - 1]->baseSize();
+    // Track Positions vector stores the 'start' grid line of each track, so we have to add last track's
+    // unclamped base size, matching populateGridPositionsForDirection() (a subgrid track's base size can
+    // be negative; clamping it here would overstate the breadth).
+    return finalTrackPosition - initialTrackPosition + tracks[span.endLine() - 1]->unclampedBaseSize();
 }
 
 void RenderGrid::populateGridPositionsForDirection(const GridTrackSizingAlgorithm& algorithm, Style::GridTrackSizingDirection direction)


### PR DESCRIPTION
#### 9bb7a30a2ff78ca1732dd096e6c14c054677f615
<pre>
Subgrid with large column-gap overflows max-width-constrained parent
<a href="https://bugs.webkit.org/show_bug.cgi?id=280613">https://bugs.webkit.org/show_bug.cgi?id=280613</a>
<a href="https://rdar.apple.com/137422489">rdar://137422489</a>

Reviewed by Sammy Gill.

This patch aligns WebKit with Blink / Chromium.

Per CSS Grid Level 2 [1], a subgrid &quot;acts as if it was completely empty
for track sizing purposes in the subgridded dimension&quot; and &quot;its track
sizes are governed by the parent grid.&quot; So a subgrid must not contribute
its own gap to that axis. WebKit did, twice, overflowing a
max-width-constrained parent and any item spanning the subgrid:

    parent grid (max-width) |--------------|
    +---------------------------------------+
    | subgrid  [t0].gap.[t1].gap.[t2]... ----+--&gt; overflow: + 12 x 10rem
    +---------------------------------------+   (subgrid&apos;s own gap, wrongly
      tracks governed by parent --+             added on top of parent tracks)

1. computeTrackSizesForIndefiniteSize() unconditionally added
   guttersSize() to the container&apos;s min/max-content width. In a
   subgridded axis this injected the subgrid&apos;s own gap (13 inherited
   tracks, gap: 10rem -&gt; +12 x 10rem), forcing the parent wider than its
   containing block. Fix: skip gutters when isSubgrid(direction).

2. gridAreaBreadthForGridItemIncludingAlignmentOffsets() used
   tracks[end-1]-&gt;baseSize(). To realize [1]&apos;s rule that &quot;half the
   difference between the subgrid&apos;s gutters and its parent grid&apos;s
   gutters is applied as an extra layer of (potentially negative)
   margin,&quot; copyUsedTrackSizesForSubgrid() stores negative base sizes;
   baseSize() clamps them to zero, overstating the breadth. Fix: use
   unclampedBaseSize(), matching populateGridPositionsForDirection().

[1] <a href="https://drafts.csswg.org/css-grid-2/#subgrids">https://drafts.csswg.org/css-grid-2/#subgrids</a>

Test: imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-own-column-gap-does-not-inflate-intrinsic-width.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-own-column-gap-does-not-inflate-intrinsic-width-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-grid/subgrid/subgrid-own-column-gap-does-not-inflate-intrinsic-width.html: Added.
* Source/WebCore/rendering/RenderGrid.cpp:
(WebCore::RenderGrid::computeTrackSizesForIndefiniteSize const):
(WebCore::RenderGrid::gridAreaBreadthForGridItemIncludingAlignmentOffsets const):

Canonical link: <a href="https://commits.webkit.org/318009@main">https://commits.webkit.org/318009@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b8352480b3a8f057488cc43866fff3791d564bed

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/176543 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/50478 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/44268 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/186144 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/138826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/9219fa71-9d36-4da3-a60c-55d796d0f531) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/178406 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/51770 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/50162 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/137514 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/138826 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/973ab310-12e2-402a-8d6f-f5c991e1a05b) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/179499 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/41006 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/158296 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/117989 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/92699e7b-e2c4-41dd-8b79-0fc7c00d5b52/e3798d00-4220-4911-8c98-44c001dac216) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/39656 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/38030 "Passed tests") | [⏳ 🧪 jsc-wpe](https://ews-build.webkit.org/#/builders/JSC-Tests-WPE-EWS "Waiting to run tests") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/150071 "Passed tests") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/37794 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/34612 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/42211 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/42241 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/188567 "Built successfully") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/50143 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/157841 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/146572 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/39514 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/50827 "Built successfully") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/34417 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/146382 "Passed tests") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/41142 "Passed tests") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/123031 "Built successfully") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/117104 "Built successfully") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/49331 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/12769 "Passed tests") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/48733 "Built successfully") | | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/48967 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/48792 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->