### PR TITLE
[JSC] Cache language tag canonicalization results in `IntlCache`

### DIFF
--- a/Source/JavaScriptCore/runtime/IntlCache.cpp
+++ b/Source/JavaScriptCore/runtime/IntlCache.cpp
@@ -25,6 +25,7 @@
 
 #include "config.h"
 #include "IntlCache.h"
+#include "IntlObject.h"
 
 #include <wtf/TZoneMallocInlines.h>
 #include <wtf/Vector.h>
@@ -66,6 +67,28 @@ Vector<char16_t, 32> IntlCache::getFieldDisplayName(const CString& locale, UDate
     if (U_FAILURE(status))
         return { };
     return buffer;
+}
+
+String IntlCache::canonicalizeUnicodeLocaleID(const String& languageTag)
+{
+    constexpr unsigned maxCachedTagLength = 100;
+    constexpr unsigned maxCacheEntries = 64;
+
+    if (languageTag.isEmpty() || languageTag.length() > maxCachedTagLength || !languageTag.containsOnlyASCII())
+        return JSC::canonicalizeUnicodeLocaleID(languageTag.utf8());
+
+    auto cached = m_cachedCanonicalizedLocaleIDs.find(languageTag);
+    if (cached != m_cachedCanonicalizedLocaleIDs.end())
+        return cached->value;
+
+    String canonicalized = JSC::canonicalizeUnicodeLocaleID(languageTag.ascii());
+    if (canonicalized.isNull())
+        return canonicalized;
+
+    if (m_cachedCanonicalizedLocaleIDs.size() >= maxCacheEntries)
+        m_cachedCanonicalizedLocaleIDs.clear();
+    m_cachedCanonicalizedLocaleIDs.add(languageTag, canonicalized);
+    return canonicalized;
 }
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/IntlCache.h
+++ b/Source/JavaScriptCore/runtime/IntlCache.h
@@ -26,9 +26,12 @@
 #pragma once
 
 #include <unicode/udatpg.h>
+#include <wtf/HashMap.h>
 #include <wtf/Noncopyable.h>
 #include <wtf/TZoneMalloc.h>
 #include <wtf/text/CString.h>
+#include <wtf/text/StringHash.h>
+#include <wtf/text/WTFString.h>
 #include <wtf/unicode/icu/ICUHelpers.h>
 
 namespace JSC {
@@ -41,6 +44,8 @@ public:
 
     Vector<char16_t, 32> getBestDateTimePattern(const CString& locale, std::span<const char16_t> skeleton, UErrorCode&);
     Vector<char16_t, 32> getFieldDisplayName(const CString& locale, UDateTimePatternField, UDateTimePGDisplayWidth, UErrorCode&);
+
+    String canonicalizeUnicodeLocaleID(const String& languageTag);
 
 private:
     UDateTimePatternGenerator* getSharedPatternGenerator(const CString& locale, UErrorCode& status)
@@ -56,6 +61,7 @@ private:
 
     std::unique_ptr<UDateTimePatternGenerator, ICUDeleter<udatpg_close>> m_cachedDateTimePatternGenerator;
     CString m_cachedDateTimePatternGeneratorLocale;
+    UncheckedKeyHashMap<String, String> m_cachedCanonicalizedLocaleIDs;
 };
 
 } // namespace JSC

--- a/Source/JavaScriptCore/runtime/IntlObject.cpp
+++ b/Source/JavaScriptCore/runtime/IntlObject.cpp
@@ -33,6 +33,7 @@
 #include "FunctionPrototype.h"
 #include "GlobalObjectMethodTable.h"
 #include "ISO8601.h"
+#include "IntlCache.h"
 #include "IntlCollator.h"
 #include "IntlCollatorConstructor.h"
 #include "IntlCollatorPrototype.h"
@@ -803,7 +804,7 @@ Vector<String> canonicalizeLocaleList(JSGlobalObject* globalObject, JSValue loca
 
             if (isStructurallyValidLanguageTag(tag)) {
                 ASSERT(tag.containsOnlyASCII());
-                String canonicalizedTag = canonicalizeUnicodeLocaleID(tag.ascii());
+                String canonicalizedTag = vm.intlCache().canonicalizeUnicodeLocaleID(tag);
                 if (!canonicalizedTag.isNull()) {
                     if (seenSet.add(canonicalizedTag).isNewEntry)
                         seen.append(canonicalizedTag);
@@ -839,15 +840,16 @@ String defaultLocale(JSGlobalObject* globalObject)
     // WebCore's global objects will have their own ideas of how to determine the language. It may
     // be determined by WebCore-specific logic like some WK settings. Usually this will return the
     // same thing as userPreferredLanguages()[0].
+    VM& vm = globalObject->vm();
     if (auto defaultLanguage = globalObject->globalObjectMethodTable()->defaultLanguage) {
-        String locale = canonicalizeUnicodeLocaleID(defaultLanguage().utf8());
+        String locale = vm.intlCache().canonicalizeUnicodeLocaleID(defaultLanguage());
         if (!locale.isEmpty())
             return locale;
     }
 
     Vector<String> languages = userPreferredLanguages();
     for (const auto& language : languages) {
-        String locale = canonicalizeUnicodeLocaleID(language.utf8());
+        String locale = vm.intlCache().canonicalizeUnicodeLocaleID(language);
         if (!locale.isEmpty())
             return locale;
     }


### PR DESCRIPTION
#### 99cab5c03916729d11da4f7af39d99192e32936a
<pre>
[JSC] Cache language tag canonicalization results in `IntlCache`
<a href="https://bugs.webkit.org/show_bug.cgi?id=315495">https://bugs.webkit.org/show_bug.cgi?id=315495</a>

Reviewed by Justin Michaud.

CanonicalizeUnicodeLocaleId currently calls into ICU three times per requested
locale (uloc_forLanguageTag, uloc_canonicalize / ualoc_canonicalForm, and
uloc_toLanguageTag), which costs roughly 640ns per tag. Since every Intl
constructor, Intl.getCanonicalLocales, and supportedLocalesOf goes through
CanonicalizeLocaleList, this dominates the construction cost of cheap Intl
objects: profiling shows it accounts for about 37% of `new Intl.NumberFormat(&quot;en-US&quot;)`.
Real-world code keeps passing the same handful of tags, so the work is highly
repetitive.

This patch adds a small per-VM memoization cache to IntlCache which maps an
input language tag to its canonicalized form. The cache is consulted from
canonicalizeLocaleList and defaultLocale. The first lookup for a tag still goes
through ICU, so cached results are always identical to what ICU would produce;
ICU data does not change during the lifetime of a process and canonicalization
does not depend on the default locale. The cache is bounded to 64 entries with
a 100-character key limit and is cleared when full, so the worst-case footprint
is a few KB per VM. Tags that are empty, non-ASCII, overly long, or fail
canonicalization are not cached and take the existing path.

                                             TipOfTree                  Patched

intl-constructor-relativetimeformat       54.0186+-3.7287     ^     47.1160+-0.4646        ^ definitely 1.1465x faster
intl-constructor-datetimeformat          134.8669+-3.8817          126.5803+-4.8759          might be 1.0655x faster
intl-constructor-durationformat            8.9282+-1.2051     ^      3.6653+-0.3256        ^ definitely 2.4359x faster
intl-constructor-numberformat             20.4467+-0.4620     ^     13.7747+-0.1421        ^ definitely 1.4844x faster
intl-constructor-collator                 13.9827+-1.3982     ^      7.0707+-0.1931        ^ definitely 1.9776x faster

* Source/JavaScriptCore/runtime/IntlCache.cpp:
(JSC::IntlCache::canonicalizeUnicodeLocaleID):
* Source/JavaScriptCore/runtime/IntlCache.h:
* Source/JavaScriptCore/runtime/IntlObject.cpp:
(JSC::canonicalizeLocaleList):
(JSC::defaultLocale):

Canonical link: <a href="https://commits.webkit.org/313929@main">https://commits.webkit.org/313929@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/77cf3791b5335d1c73c7e8417e11053c89de4662

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164296 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37780 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31351 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173325 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121548 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38114 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37780 "Built successfully") | [❌ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127645 "") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89827 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167255 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29942 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147680 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108192 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28989 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27614 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21089 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/156447 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138891 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25396 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175851 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/25188 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28672 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27064 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135956 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37451 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31732 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135926 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36673 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38237 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147191 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100588 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31240 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24047 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/196699 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37046 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110091 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/51668 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36443 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2104 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36693 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36593 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->