### PR TITLE
Cherry-pick 305413.505@safari-7624-branch (ec665bbbbe8b). https://bugs.webkit.org/show_bug.cgi?id=309868

### DIFF
--- a/LayoutTests/ipc/fecolormatrix-type-values-mismatch-crash-expected.txt
+++ b/LayoutTests/ipc/fecolormatrix-type-values-mismatch-crash-expected.txt
@@ -1,0 +1,1 @@
+This test passes if WebKit does not crash.

--- a/LayoutTests/ipc/fecolormatrix-type-values-mismatch-crash.html
+++ b/LayoutTests/ipc/fecolormatrix-type-values-mismatch-crash.html
@@ -1,0 +1,123 @@
+<!-- webkit-test-runner [ IPCTestingAPIEnabled=true ] -->
+<body>
+    <script>
+        window.testRunner?.dumpAsText();
+        window.testRunner?.waitUntilDone();
+
+        window.setTimeout(async () => {
+            if (!window.IPC)
+                return window.testRunner?.notifyDone();
+
+            const { CoreIPC } = await import('./coreipc.js');
+
+            const streamConnection = CoreIPC.newStreamConnection();
+
+            const renderingBackendIdentifier = Math.floor(Math.random() * 0x1000000);
+            CoreIPC.GPU.GPUConnectionToWebProcess.CreateRenderingBackend(0, {
+                renderingBackendIdentifier: renderingBackendIdentifier,
+                connectionHandle: streamConnection
+            });
+            const remoteRenderingBackend = streamConnection.newInterface("RemoteRenderingBackend", renderingBackendIdentifier);
+            const didInitializeReply = streamConnection.connection.waitForMessage(renderingBackendIdentifier, IPC.messages.RemoteRenderingBackendProxy_DidInitialize.name, 1);
+
+            const imageBufferIdentifier = Math.floor(Math.random() * 0x1000000);
+            const contextIdentifier = Math.floor(Math.random() * 0x1000000);
+            remoteRenderingBackend.CreateImageBuffer({
+                logicalSize: {
+                    width: 32,
+                    height: 82
+                },
+                renderingMode: 1,
+                renderingPurpose: 0,
+                resolutionScale: 10,
+                colorSpace: {
+                    serializableColorSpace: {
+                        alias: {
+                            optionalValue: {
+                                m_cgColorSpace: {
+                                    alias: {
+                                        variantType: 'WebCore::ColorSpace',
+                                        variant: 1
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                pixelFormat: 1,
+                bufferFormat: { pixelFormat: 1, useLosslessCompression: 0 },
+                identifier: imageBufferIdentifier,
+                contextIdentifier: contextIdentifier
+            });
+            const remoteImageBuffer = streamConnection.newInterface("RemoteImageBuffer", imageBufferIdentifier);
+
+            const srgbColorSpace = {serializableColorSpace: {alias: {optionalValue: {m_cgColorSpace: {alias: {variantType: 'WebCore::ColorSpace', variant: 1}}}}}};
+
+            try {
+                remoteImageBuffer.FilteredNativeImage({
+                    filter: {
+                        subclasses: {
+                            variantType: 'WebCore::SVGFilterRenderer',
+                            variant: {
+                                primitiveUnits: 0,
+                                expression: {
+                                    alias: [
+                                        {index: 0, level: 0, geometry: {}},
+                                        {index: 1, level: 0, geometry: {}}
+                                    ]
+                                },
+                                effects: [
+                                    {
+                                        subclasses: {
+                                            variantType: 'WebCore::SourceGraphic',
+                                            variant: {
+                                                operatingColorSpace: srgbColorSpace
+                                            }
+                                        }
+                                    },
+                                    {
+                                        subclasses: {
+                                            variantType: 'WebCore::FEColorMatrix',
+                                            variant: {
+                                                type: 2,    // FECOLORMATRIX_TYPE_SATURATE
+                                                values: [], // Empty â€” should have at least 1 value
+                                                operatingColorSpace: srgbColorSpace
+                                            }
+                                        }
+                                    }
+                                ],
+                                geometry: {
+                                    referenceBox: {
+                                        location: {x: 0, y: 0},
+                                        size: {width: 128, height: 128}
+                                    },
+                                    filterRegion: {
+                                        location: {x: 0, y: 0},
+                                        size: {width: 128, height: 128}
+                                    },
+                                    scale: {width: 1, height: 1}
+                                },
+                                filterRenderingModes: 1,
+                                isShowingDebugOverlay: false,
+                                renderingResourceIdentifierIfExists: {}
+                            }
+                        }
+                    }
+                });
+            } catch(err) {
+                if(!(err instanceof TypeError)) {
+                    console.log("Test failed: expected TypeError, got " + err);
+                }
+            }
+
+            streamConnection.connection.invalidate();
+
+            // Allow some time for the GPUP to receive the FilteredNativeImage message, otherwise we can finish
+            // the test before we detect a possible GPUP crash.
+            setTimeout(()=>{
+                window.testRunner?.notifyDone();
+            }, 500);
+        }, 20);
+    </script>
+    <p>This test passes if WebKit does not crash.</p>
+</body>

--- a/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.h
+++ b/Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.h
@@ -59,7 +59,7 @@ namespace WebCore {
 class ScriptExecutionContext;
 class SocketProvider;
 
-class RiceBackendClient : public RefCounted<RiceBackendClient> {
+class RiceBackendClient : public ThreadSafeRefCounted<RiceBackendClient> {
     WTF_MAKE_NONCOPYABLE(RiceBackendClient);
 public:
     static Ref<RiceBackendClient> create() { return adoptRef(*new RiceBackendClient); }

--- a/Source/WebCore/platform/graphics/filters/FEColorMatrix.cpp
+++ b/Source/WebCore/platform/graphics/filters/FEColorMatrix.cpp
@@ -41,6 +41,7 @@ namespace WebCore {
 
 Ref<FEColorMatrix> FEColorMatrix::create(ColorMatrixType type, Vector<float>&& values, DestinationColorSpace colorSpace)
 {
+    ASSERT(areValuesValidForType(type, values));
     return adoptRef(*new FEColorMatrix(type, WTF::move(values), colorSpace));
 }
 
@@ -72,6 +73,22 @@ bool FEColorMatrix::setValues(const Vector<float> &values)
         return false;
     m_values = values;
     return true;
+}
+
+bool FEColorMatrix::areValuesValidForType(ColorMatrixType type, const Vector<float>& values)
+{
+    switch (type) {
+    case ColorMatrixType::FECOLORMATRIX_TYPE_MATRIX:
+        return values.size() == 20;
+    case ColorMatrixType::FECOLORMATRIX_TYPE_SATURATE:
+    case ColorMatrixType::FECOLORMATRIX_TYPE_HUEROTATE:
+        return values.size() == 1;
+    case ColorMatrixType::FECOLORMATRIX_TYPE_LUMINANCETOALPHA:
+        return true;
+    case ColorMatrixType::FECOLORMATRIX_TYPE_UNKNOWN:
+        return false;
+    }
+    RELEASE_ASSERT_NOT_REACHED();
 }
 
 void FEColorMatrix::calculateSaturateComponents(std::span<float, 9> components, float value)

--- a/Source/WebCore/platform/graphics/filters/FEColorMatrix.h
+++ b/Source/WebCore/platform/graphics/filters/FEColorMatrix.h
@@ -49,6 +49,7 @@ public:
     const Vector<float>& values() const { return m_values; }
     bool setValues(const Vector<float>&);
 
+    WEBCORE_EXPORT static bool areValuesValidForType(ColorMatrixType, const Vector<float>& values);
     static void calculateSaturateComponents(std::span<float, 9> components, float value);
     static void calculateHueRotateComponents(std::span<float, 9> components, float value);
     static Vector<float> normalizedFloats(const Vector<float>& values);

--- a/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp
@@ -54,7 +54,12 @@ GST_DEBUG_CATEGORY_STATIC(webkit_gl_video_sink_debug);
 struct _WebKitGLVideoSinkPrivate {
     ~_WebKitGLVideoSinkPrivate()
     {
-        ASSERT(isMainThread());
+        // Here we are either in the main thread or in a thread created by the gst_async_call_pool.
+        // The latter case happens when the player has been destructed while the sink was in an
+        // ASYNC state change. The last reference of the sink would then be held by the
+        // gst_object_call_async() call made from gstbin's bin_push_state_continue. After the async task
+        // completed there would be no reference left and the sink would be finalized, from a thread
+        // managed by the thread pool.
         webKitVideoSinkDisconnectSignalHandlers(appSink.get(), signalIdentifiers);
         GST_DEBUG_OBJECT(appSink.get(), "WebKitGLVideoSink finalized.");
     }

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoSinkCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoSinkCommon.cpp
@@ -209,7 +209,7 @@ WebKitVideoSinkSignalIdentifiers webKitVideoSinkSetMediaPlayerPrivate(GstElement
 
     GRefPtr<GstPad> pad = adoptGRef(gst_element_get_static_pad(appSink, "sink"));
 
-    gst_pad_add_probe(pad.get(), static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_PUSH | GST_PAD_PROBE_TYPE_QUERY_DOWNSTREAM
+    identifiers.padProbeId = gst_pad_add_probe(pad.get(), static_cast<GstPadProbeType>(GST_PAD_PROBE_TYPE_PUSH | GST_PAD_PROBE_TYPE_QUERY_DOWNSTREAM
         | GST_PAD_PROBE_TYPE_EVENT_FLUSH | GST_PAD_PROBE_TYPE_EVENT_DOWNSTREAM),
         WebKitVideoSinkProbe::doProbe, new WebKitVideoSinkProbe(player), WebKitVideoSinkProbe::deleteUserData);
 
@@ -234,11 +234,12 @@ void webKitVideoSinkDisconnectSignalHandlers(GstElement* appSink, const WebKitVi
     g_signal_handler_disconnect(appSink, identifiers.newPreroll);
     g_signal_handler_disconnect(appSink, identifiers.newSample);
 
-    if (!identifiers.notifyCaps)
-        return;
-
     auto pad = adoptGRef(gst_element_get_static_pad(appSink, "sink"));
-    g_signal_handler_disconnect(pad.get(), identifiers.notifyCaps);
+    if (identifiers.notifyCaps)
+        g_signal_handler_disconnect(pad.get(), identifiers.notifyCaps);
+
+    if (identifiers.padProbeId)
+        gst_pad_remove_probe(pad.get(), identifiers.padProbeId);
 }
 
 #undef GST_CAT_DEFAULT

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoSinkCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerVideoSinkCommon.h
@@ -30,6 +30,7 @@ struct WebKitVideoSinkSignalIdentifiers {
     unsigned long newSample { 0 };
     unsigned long newPreroll { 0 };
     unsigned long notifyCaps { 0 };
+    unsigned long padProbeId { 0 };
 };
 
 } // namespace WebCore

--- a/Source/WebCore/svg/SVGFEColorMatrixElement.cpp
+++ b/Source/WebCore/svg/SVGFEColorMatrixElement.cpp
@@ -51,16 +51,6 @@ Ref<SVGFEColorMatrixElement> SVGFEColorMatrixElement::create(const QualifiedName
     return adoptRef(*new SVGFEColorMatrixElement(tagName, document));
 }
 
-bool SVGFEColorMatrixElement::isInvalidValuesLength() const
-{
-    auto filterType = type();
-    auto size = values().size();
-
-    return (filterType == ColorMatrixType::FECOLORMATRIX_TYPE_MATRIX    && size != 20)
-        || (filterType == ColorMatrixType::FECOLORMATRIX_TYPE_HUEROTATE && size != 1)
-        || (filterType == ColorMatrixType::FECOLORMATRIX_TYPE_SATURATE  && size != 1);
-}
-
 void SVGFEColorMatrixElement::attributeChanged(const QualifiedName& name, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason attributeModificationReason)
 {
     switch (name.nodeName()) {
@@ -107,7 +97,7 @@ void SVGFEColorMatrixElement::svgAttributeChanged(const QualifiedName& attrName)
     case AttributeNames::typeAttr:
     case AttributeNames::valuesAttr: {
         InstanceInvalidationGuard guard(*this);
-        if (isInvalidValuesLength())
+        if (!FEColorMatrix::areValuesValidForType(type(), values()))
             markFilterEffectForRebuild();
         else
             primitiveAttributeChanged(attrName);
@@ -144,11 +134,11 @@ RefPtr<FilterEffect> SVGFEColorMatrixElement::createFilterEffect(const FilterEff
             break;
         }
     } else {
-        if (isInvalidValuesLength())
-            return nullptr;
-
         filterValues = values();
         filterValues.shrinkToFit();
+
+        if (!FEColorMatrix::areValuesValidForType(type(), filterValues))
+            return nullptr;
     }
 
     return FEColorMatrix::create(filterType, WTF::move(filterValues));

--- a/Source/WebCore/svg/SVGFEColorMatrixElement.h
+++ b/Source/WebCore/svg/SVGFEColorMatrixElement.h
@@ -83,8 +83,6 @@ public:
 private:
     SVGFEColorMatrixElement(const QualifiedName&, Document&);
 
-    bool isInvalidValuesLength() const;
-
     void attributeChanged(const QualifiedName&, const AtomString& oldValue, const AtomString& newValue, AttributeModificationReason) override;
     void svgAttributeChanged(const QualifiedName&) override;
 

--- a/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
+++ b/Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in
@@ -3871,7 +3871,7 @@ enum class WebCore::ApplePayButtonStyle : uint8_t {
 
 [RefCounted, AdditionalEncoder=StreamConnectionEncoder] class WebCore::FEColorMatrix {
     WebCore::ColorMatrixType type();
-    Vector<float> values();
+    [Validator='WebCore::FEColorMatrix::areValuesValidForType(*type, *values)'] Vector<float> values();
 
     WebCore::DestinationColorSpace operatingColorSpace();
 };


### PR DESCRIPTION
#### f08217b73040a989a1fdb061a3a57b303a00ed97
<pre>
Cherry-pick 305413.505@safari-7624-branch (ec665bbbbe8b). <a href="https://bugs.webkit.org/show_bug.cgi?id=309868">https://bugs.webkit.org/show_bug.cgi?id=309868</a>

    [GPU Process]: Before decoding FEColorMatrix validate the length of the `values` vector
    <a href="https://bugs.webkit.org/show_bug.cgi?id=309868">https://bugs.webkit.org/show_bug.cgi?id=309868</a>
    <a href="https://rdar.apple.com/172397794">rdar://172397794</a>

    Reviewed by Kimmo Kinnunen.

    SVGFEColorMatrixElement checks the length of `values` attribute before creating
    the FEColorMatrix. Similarly the IPC should check the length of decoded `values`
    before creating the FEColorMatrix. In both cases the `type` attribute should be
    used to decide whether the length of `values` is valid or not.

    Test: ipc/fecolormatrix-type-values-mismatch-crash.html

    * LayoutTests/ipc/fecolormatrix-type-values-mismatch-crash-expected.txt: Added.
    * LayoutTests/ipc/fecolormatrix-type-values-mismatch-crash.html: Added.
    * Source/WebCore/platform/graphics/filters/FEColorMatrix.cpp:
    (WebCore::FEColorMatrix::create):
    (WebCore::FEColorMatrix::areValuesValidForType):
    * Source/WebCore/platform/graphics/filters/FEColorMatrix.h:
    * Source/WebCore/svg/SVGFEColorMatrixElement.cpp:
    (WebCore::SVGFEColorMatrixElement::svgAttributeChanged):
    (WebCore::SVGFEColorMatrixElement::createFilterEffect const):
    (WebCore::SVGFEColorMatrixElement::isInvalidValuesLength const): Deleted.
    * Source/WebCore/svg/SVGFEColorMatrixElement.h:
    * Source/WebKit/Shared/WebCoreArgumentCoders.serialization.in:

    Identifier: 305413.505@safari-7624-branch

Canonical link: <a href="https://commits.webkit.org/305877.673@webkitglib/2.52">https://commits.webkit.org/305877.673@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 4258a0e2e2b51a0bdf84b9fbdb89d5a30f1dedfd
<pre>
Cherry-pick 313827@main (71f768520877). <a href="https://bugs.webkit.org/show_bug.cgi?id=313410">https://bugs.webkit.org/show_bug.cgi?id=313410</a>

    [GStreamer] Several tests crash with assertions enabled due to deref&apos;ing WebCore::RiceBackendClient from the wrong thread
    <a href="https://bugs.webkit.org/show_bug.cgi?id=313410">https://bugs.webkit.org/show_bug.cgi?id=313410</a>

    Reviewed by Xabier Rodriguez-Calvar.

    The GStreamer ICE agent can be finalized from a non-main thread, when the pipeline it belongs to was
    in an ASYNC state change while it was destructed. The only non-threadsafe smart pointer in
    _WebKitGstIceAgentPrivate was the RiceBackendClient, so make it so in order to prevent
    false-positive asserts at runtime.

    * Source/WebCore/Modules/mediastream/gstreamer/GStreamerIceAgent.h:

    Canonical link: <a href="https://commits.webkit.org/313827@main">https://commits.webkit.org/313827@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.672@webkitglib/2.52">https://commits.webkit.org/305877.672@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 03125b1d93594f70ebf7f266af266d8c0d2e7a21
<pre>
Cherry-pick 313829@main (36e289cd26dc). <a href="https://bugs.webkit.org/show_bug.cgi?id=315460">https://bugs.webkit.org/show_bug.cgi?id=315460</a>

    [GStreamer] Clean-up the video sink pad pad probe when finalizing the sink
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315460">https://bugs.webkit.org/show_bug.cgi?id=315460</a>

    Reviewed by Xabier Rodriguez-Calvar.

    This isn&apos;t strictly needed because probes are removed during pad disposal, but doesn&apos;t hurt either
    ;)

    * Source/WebCore/platform/graphics/gstreamer/GStreamerVideoSinkCommon.cpp:
    (webKitVideoSinkSetMediaPlayerPrivate):
    (webKitVideoSinkDisconnectSignalHandlers):
    * Source/WebCore/platform/graphics/gstreamer/GStreamerVideoSinkCommon.h:

    Canonical link: <a href="https://commits.webkit.org/313829@main">https://commits.webkit.org/313829@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.671@webkitglib/2.52">https://commits.webkit.org/305877.671@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 10b34fbebfbb0aa8a19126c6c0cf71c3f0c6afd3
<pre>
Cherry-pick 313828@main (a3972609ade7). <a href="https://bugs.webkit.org/show_bug.cgi?id=308119">https://bugs.webkit.org/show_bug.cgi?id=308119</a>

    [GStreamer] WebKitGLVideoSink finalized from wrong thread
    <a href="https://bugs.webkit.org/show_bug.cgi?id=308119">https://bugs.webkit.org/show_bug.cgi?id=308119</a>

    Reviewed by Xabier Rodriguez-Calvar.

    Remove the ASSERT(isMainThread()) from ~_WebKitGLVideoSinkPrivate() because it is invalid, the sink
    can be finalized from a non-main thread when the player it belongs to has been destructed while the
    pipeline was in an ASYNC state change.

    * Source/WebCore/platform/graphics/gstreamer/GLVideoSinkGStreamer.cpp:
    (_WebKitGLVideoSinkPrivate::~_WebKitGLVideoSinkPrivate):

    Canonical link: <a href="https://commits.webkit.org/313828@main">https://commits.webkit.org/313828@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.670@webkitglib/2.52">https://commits.webkit.org/305877.670@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b3e182a96119b48546579c25f85c658ff718b9c6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164297 "Passed style check") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/37781 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/31352 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173326 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121549 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166166 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/38115 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/37781 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127648 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121549 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167256 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/38115 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/31352 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108194 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/38115 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/37781 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21090 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/38115 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/31352 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175852 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/28673 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/31352 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135959 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/37452 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/37781 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135929 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/38238 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/31352 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/100589 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25013 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/38238 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/31352 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/37047 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/110092 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/36444 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/31352 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 watch~~](https://ews-build.webkit.org/#/builders/163/builds/36694 "The change is no longer eligible for processing.") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/36594 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->