### PR TITLE
@container style() does not match custom property whose var() fallback spans multiple lines

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/custom-property-style-query-multiline-var-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/custom-property-style-query-multiline-var-expected.txt
@@ -1,0 +1,7 @@
+
+PASS single-line var() fallback
+PASS multi-line var() fallback
+PASS newline after comma in var() fallback
+PASS newline before closing parentheses in var() fallback
+PASS newline before var() and around fallback
+

--- a/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/custom-property-style-query-multiline-var.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/custom-property-style-query-multiline-var.html
@@ -1,0 +1,88 @@
+<!doctype html>
+<title>CSS Container Queries Test: style() query against custom property with multi-line var() fallback</title>
+<link rel="help" href="https://drafts.csswg.org/css-conditional-5/#style-container">
+<link rel="help" href="https://drafts.csswg.org/css-variables/#using-variables">
+<script src="/resources/testharness.js"></script>
+<script src="/resources/testharnessreport.js"></script>
+<script src="support/cq-testcommon.js"></script>
+<style>
+  /*
+    Each container declares the same logical value:
+        var(<undefined-var>, "my-default-value")
+    once on a single line and several times split across multiple lines
+    (the shapes a code formatter such as Prettier produces). The container
+    query asks whether the custom property equals "my-default-value", which
+    is the fallback every container is expected to resolve to.
+  */
+
+  .single-line {
+    --my-container-var: var(--my-undefined-var, "my-default-value");
+  }
+
+  .multi-line {
+    --my-container-var: var(
+      --my-undefined-var,
+      "my-default-value"
+    );
+  }
+
+  .multi-line-newline-after-comma {
+    --my-container-var: var(--my-undefined-var,
+      "my-default-value");
+  }
+
+  .multi-line-newline-before-paren {
+    --my-container-var: var(--my-undefined-var, "my-default-value"
+    );
+  }
+
+  .multi-line-mixed {
+    --my-container-var:
+      var(
+        --my-undefined-var,
+        "my-default-value"
+      )
+    ;
+  }
+
+  @container style(--my-container-var: "my-default-value") {
+    .target { --matched: true; }
+  }
+</style>
+
+<div class="single-line">
+  <div class="target" id="t-single"></div>
+</div>
+<div class="multi-line">
+  <div class="target" id="t-multi"></div>
+</div>
+<div class="multi-line-newline-after-comma">
+  <div class="target" id="t-multi-after-comma"></div>
+</div>
+<div class="multi-line-newline-before-paren">
+  <div class="target" id="t-multi-before-paren"></div>
+</div>
+<div class="multi-line-mixed">
+  <div class="target" id="t-multi-mixed"></div>
+</div>
+
+<script>
+  setup(() => {
+    assert_implements_style_container_queries();
+  });
+
+  function assertMatched(id, label) {
+    test(() => {
+      const value = getComputedStyle(document.getElementById(id))
+                      .getPropertyValue("--matched").trim();
+      assert_equals(value, "true",
+        `style(--my-container-var: "my-default-value") should match for ${label}`);
+    }, label);
+  }
+
+  assertMatched("t-single", "single-line var() fallback");
+  assertMatched("t-multi", "multi-line var() fallback");
+  assertMatched("t-multi-after-comma", "newline after comma in var() fallback");
+  assertMatched("t-multi-before-paren", "newline before closing parentheses in var() fallback");
+  assertMatched("t-multi-mixed", "newline before var() and around fallback");
+</script>

--- a/Source/WebCore/style/StyleSubstitutionResolver.cpp
+++ b/Source/WebCore/style/StyleSubstitutionResolver.cpp
@@ -95,6 +95,7 @@ auto SubstitutionResolver::substituteVariableFallback(const AtomString& variable
         return { FallbackResult::None, { } };
 
     range.consumeIncludingWhitespace();
+    range.trimTrailingWhitespace();
 
     auto tokens = substituteTokenRange(range, context);
 


### PR DESCRIPTION
#### 2f8d1192d466f5a687fd01e50bfa428ebe9bf37a
<pre>
@container style() does not match custom property whose var() fallback spans multiple lines
<a href="https://bugs.webkit.org/show_bug.cgi?id=303059">https://bugs.webkit.org/show_bug.cgi?id=303059</a>
<a href="https://rdar.apple.com/165627262">rdar://165627262</a>

Reviewed by Antti Koivisto.

This patch aligns WebKit with Blink / Chromium.

When a declaration such as:

    --my-container-var: var(--my-undefined-var, &quot;my-default-value&quot;);

is reformatted across multiple lines (for example by Prettier),

    --my-container-var: var(
        --my-undefined-var,
        &quot;my-default-value&quot;
    );

the var() fallback no longer matched a style container query of
@container style(--my-container-var: &quot;my-default-value&quot;). Whitespace
introduced after the comma was correctly skipped (consumeIncludingWhitespace
already handled that), but whitespace before the closing parenthesis was
folded into the substituted token stream, leaving a trailing newline /
space token on the resolved custom-property value. Style container query
evaluation compares CSSVariableData token-by-token in valueEquals(), so
the otherwise-equivalent value failed to match.

Trim trailing whitespace from the var() fallback range before substitution,
mirroring the leading-whitespace handling already done by consumeIncludingWhitespace().

Test: imported/w3c/web-platform-tests/css/css-conditional/container-queries/custom-property-style-query-multiline-var.html

* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/custom-property-style-query-multiline-var-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/css/css-conditional/container-queries/custom-property-style-query-multiline-var.html: Added.
* Source/WebCore/style/StyleSubstitutionResolver.cpp:
(WebCore::Style::SubstitutionResolver::substituteVariableFallback):

Canonical link: <a href="https://commits.webkit.org/313957@main">https://commits.webkit.org/313957@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/b1ea4ab4b2242a5b4a4a42c51d5bd89ccd8838f4

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164298 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37782 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31353 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173327 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121550 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/ff11b62e-074d-4d65-8de5-dedf35d206d3) 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166167 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38116 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37782 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127650 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89829 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/5cf976a5-0899-4cd7-9806-105038c4a11d) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167257 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29945 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147678 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108195 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0e33973f-192b-4d54-bdf9-0b12402f3c54) 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28992 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27615 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21091 "Built successfully") | | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138894 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25394 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175853 "Built successfully") | | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28674 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27062 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135960 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37453 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31733 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135930 "Passed tests") | | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36694 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38239 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147189 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100592 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31241 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24045 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37048 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110093 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36445 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2102 "Passed tests") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36695 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36595 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->