### PR TITLE
[Skia] Add SkiaSerializedImageBuffer to properly transfer ImageBuffer to other threads

### DIFF
--- a/Source/WebCore/platform/SourcesSkia.txt
+++ b/Source/WebCore/platform/SourcesSkia.txt
@@ -72,6 +72,7 @@ platform/graphics/skia/SkiaPaintingEngine.cpp
 platform/graphics/skia/SkiaRecordingResult.cpp
 platform/graphics/skia/SkiaReplayAtlas.cpp
 platform/graphics/skia/SkiaReplayCanvas.cpp
+platform/graphics/skia/SkiaSerializedImageBuffer.cpp
 platform/graphics/skia/SkiaSystemFallbackFontCache.cpp
 platform/graphics/skia/SkiaTextureAtlasPacker.cpp
 platform/graphics/skia/SkiaUtilities.cpp

--- a/Source/WebCore/platform/graphics/ImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/ImageBuffer.cpp
@@ -52,6 +52,7 @@
 #include "GLContext.h"
 #include "ImageBufferSkiaAcceleratedBackend.h"
 #include "PlatformDisplay.h"
+#include "SkiaSerializedImageBuffer.h"
 
 WTF_IGNORE_WARNINGS_IN_THIRD_PARTY_CODE_BEGIN
 #include <skia/gpu/ganesh/GrBackendSurface.h>
@@ -156,6 +157,7 @@ RefPtr<ImageBuffer> SerializedImageBuffer::sinkIntoImageBuffer(std::unique_ptr<S
     return buffer->sinkIntoImageBuffer();
 }
 
+#if !USE(SKIA)
 // The default serialization of an ImageBuffer just assumes that we can
 // pass it as-is, as long as this is the only reference.
 class DefaultSerializedImageBuffer : public SerializedImageBuffer {
@@ -164,10 +166,6 @@ public:
     DefaultSerializedImageBuffer(ImageBuffer* image)
         : m_buffer(image)
     {
-#if USE(SKIA)
-        if (image->renderingMode() == RenderingMode::Accelerated)
-            image->flushDrawingContext();
-#endif
     }
 
     RefPtr<ImageBuffer> sinkIntoImageBuffer() final
@@ -183,12 +181,17 @@ public:
 private:
     RefPtr<ImageBuffer> m_buffer;
 };
+#endif
 
 std::unique_ptr<SerializedImageBuffer> ImageBuffer::sinkIntoSerializedImageBuffer()
 {
     ASSERT(hasOneRef());
     ASSERT(!controlBlock().weakRefCount());
+#if USE(SKIA)
+    return makeUnique<SkiaSerializedImageBuffer>(*this);
+#else
     return makeUnique<DefaultSerializedImageBuffer>(this);
+#endif
 }
 
 std::unique_ptr<SerializedImageBuffer> ImageBuffer::sinkIntoSerializedImageBuffer(RefPtr<ImageBuffer>&& image)

--- a/Source/WebCore/platform/graphics/skia/SkiaSerializedImageBuffer.cpp
+++ b/Source/WebCore/platform/graphics/skia/SkiaSerializedImageBuffer.cpp
@@ -1,0 +1,82 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+#include "SkiaSerializedImageBuffer.h"
+
+#if USE(SKIA)
+#include "GraphicsContext.h"
+#include "NativeImage.h"
+#include "PlatformDisplay.h"
+#include <wtf/TZoneMallocInlines.h>
+
+namespace WebCore {
+
+WTF_MAKE_TZONE_ALLOCATED_IMPL(SkiaSerializedImageBuffer);
+
+SkiaSerializedImageBuffer::SkiaSerializedImageBuffer(ImageBuffer& imageBuffer)
+    : m_imageBuffer(imageBuffer)
+{
+    if (m_imageBuffer->renderingMode() != RenderingMode::Accelerated)
+        return;
+
+    m_imageBuffer->flushDrawingContext();
+    m_image = m_imageBuffer->createNativeImageReference();
+}
+
+SkiaSerializedImageBuffer::~SkiaSerializedImageBuffer() = default;
+
+RefPtr<ImageBuffer> SkiaSerializedImageBuffer::sinkIntoImageBuffer()
+{
+    if (!m_image)
+        return m_imageBuffer.get();
+
+    if (!PlatformDisplay::sharedDisplay().skiaGLContext()->makeContextCurrent())
+        return nullptr;
+
+    auto* grContext = PlatformDisplay::sharedDisplay().skiaGrContext();
+    if (grContext == m_image->grContext())
+        return m_imageBuffer.get();
+
+    auto copiedImageBuffer = m_imageBuffer->context().createImageBuffer(m_imageBuffer->logicalSize(), m_imageBuffer->resolutionScale(),
+        m_imageBuffer->colorSpace(), RenderingMode::Accelerated, std::nullopt, { m_imageBuffer->pixelFormat() });
+    if (!copiedImageBuffer)
+        return nullptr;
+
+    FloatRect destination({ }, m_imageBuffer->logicalSize());
+    FloatRect source = destination;
+    source.scale(m_imageBuffer->resolutionScale());
+    copiedImageBuffer->context().drawNativeImage(*m_image, destination, source, { CompositeOperator::Copy });
+    return copiedImageBuffer;
+}
+
+size_t SkiaSerializedImageBuffer::memoryCost() const
+{
+    return m_imageBuffer->memoryCost();
+}
+
+} // namespace WebCore
+
+#endif // USE(SKIA)

--- a/Source/WebCore/platform/graphics/skia/SkiaSerializedImageBuffer.h
+++ b/Source/WebCore/platform/graphics/skia/SkiaSerializedImageBuffer.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2026 Igalia S.L.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. ``AS IS'' AND ANY
+ * EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL APPLE INC. OR
+ * CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+ * EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+ * PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+ * PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+ * OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if USE(SKIA)
+#include "ImageBuffer.h"
+#include <wtf/TZoneMalloc.h>
+
+namespace WebCore {
+class ImageBuffer;
+class Nativeimage;
+
+class SkiaSerializedImageBuffer final : public SerializedImageBuffer {
+    WTF_MAKE_TZONE_ALLOCATED(SkiaSerializedImageBuffer);
+public:
+    explicit SkiaSerializedImageBuffer(ImageBuffer&);
+    virtual ~SkiaSerializedImageBuffer();
+
+private:
+    RefPtr<ImageBuffer> sinkIntoImageBuffer() override;
+    size_t memoryCost() const override;
+
+    Ref<ImageBuffer> m_imageBuffer;
+    RefPtr<NativeImage> m_image;
+};
+
+} // namespace WebCore
+
+#endif // USE(SKIA)


### PR DESCRIPTION
#### 284cb84712010a40007790ae4db69cc0076eda9e
<pre>
[Skia] Add SkiaSerializedImageBuffer to properly transfer ImageBuffer to other threads
<a href="https://bugs.webkit.org/show_bug.cgi?id=315499">https://bugs.webkit.org/show_bug.cgi?id=315499</a>

Reviewed by Nikolas Zimmermann.

In DefaultSerializedImageBuffer we flush the drawing context to make
sure all pending operations are done, but the ImageBuffer is
transferred to another thread as is. If the worker thread wants to
transfer the ImageBuffer back to the main thread (which is what test
imported/w3c/web-platform-tests/html/canvas/element/manual/imagebitmap/createImageBitmap-transfer.html
does) a new DefaultSerializedImageBuffer is created trying to flush a
skia gr context from a different thread. This patch adds
SkiaSerializedImageBuffer that also implements sinkIntoImageBuffer()
that is called when the buffer is deserialized in the destination thead.
If the destination thread is different than the original one, the
ImageBuffer is copied by rewrapping the SkImage that is painted into the
copy. This ensures that when transferring an imageBitmap, the skia gr
context used is always the one from the current thread.

* Source/WebCore/platform/SourcesSkia.txt:
* Source/WebCore/platform/graphics/ImageBuffer.cpp:
(WebCore::DefaultSerializedImageBuffer::DefaultSerializedImageBuffer):
(WebCore::ImageBuffer::sinkIntoSerializedImageBuffer):
* Source/WebCore/platform/graphics/skia/SkiaSerializedImageBuffer.cpp: Added.
(WebCore::SkiaSerializedImageBuffer::SkiaSerializedImageBuffer):
(WebCore::SkiaSerializedImageBuffer::sinkIntoImageBuffer):
(WebCore::SkiaSerializedImageBuffer::memoryCost const):
* Source/WebCore/platform/graphics/skia/SkiaSerializedImageBuffer.h: Added.

Canonical link: <a href="https://commits.webkit.org/313868@main">https://commits.webkit.org/313868@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/718971e3e1ce1e74287d7e658c7807d664695bab

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164307 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37791 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31362 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173336 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121559 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166176 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38125 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37792 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127658 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89837 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167266 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29951 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147689 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108203 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/28998 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27623 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21100 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138900 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25405 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175862 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28683 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27073 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135969 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37462 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31741 "Found 1 new test failure: media/media-source/media-source-real-scrub-then-play.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135938 "Passed tests") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38248 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147200 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100606 "Built successfully") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25022 "Built successfully and passed tests") | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31249 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24056 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37058 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110102 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36454 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2113 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36704 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36604 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->