### PR TITLE
Cherry-pick 312802@main (74a41b5f4ec4). https://bugs.webkit.org/show_bug.cgi?id=314201

### DIFF
--- a/LayoutTests/compositing/clipping/border-radius-async-overflow-stacking.html
+++ b/LayoutTests/compositing/clipping/border-radius-async-overflow-stacking.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html> <!-- webkit-test-runner [ AsyncOverflowScrollingEnabled=true ] -->
 <html>
 <head>
-    <meta name="fuzzy" content="maxDifference=0-42; totalPixels=0-47" />
+    <meta name="fuzzy" content="maxDifference=0-42; totalPixels=0-400" />
     <style>
         .scroller {
             margin: 10px;

--- a/LayoutTests/http/tests/websocket/tests/hybi/handshake-fail-with-200-ok_wsh.py
+++ b/LayoutTests/http/tests/websocket/tests/hybi/handshake-fail-with-200-ok_wsh.py
@@ -1,0 +1,21 @@
+from pywebsocket3 import handshake
+from pywebsocket3.handshake.hybi import compute_accept_from_unicode
+
+
+def web_socket_do_extra_handshake(request):
+    # Reply with 200 OK instead of 101 Switching Protocols. The handshake
+    # validation in the network stack fails on the wrong status code, so the
+    # client surfaces an error and tears down the connection.
+    msg = b"HTTP/1.1 200 OK\r\n"
+    msg += b"Upgrade: websocket\r\n"
+    msg += b"Connection: Upgrade\r\n"
+    msg += b"Sec-WebSocket-Accept: "
+    msg += compute_accept_from_unicode(request.headers_in["Sec-WebSocket-Key"])
+    msg += b"\r\n"
+    msg += b"\r\n"
+    request.connection.write(msg)
+    raise handshake.AbortedByUserException("Abort the connection")
+
+
+def web_socket_transfer_data(request):
+    pass

--- a/LayoutTests/http/tests/websocket/tests/hybi/worker-handshake-failure-cleanup-expected.txt
+++ b/LayoutTests/http/tests/websocket/tests/hybi/worker-handshake-failure-cleanup-expected.txt
@@ -1,0 +1,9 @@
+Verifies that NetworkSocketChannel is cleaned up in the network process when a worker WebSocket fails the handshake and the worker self-terminates. https://bugs.webkit.org/show_bug.cgi?id=315342
+
+On success, you will see a series of "PASS" messages, followed by "TEST COMPLETE".
+
+PASS NetworkSocketChannel count returned to 0 after worker WebSockets terminated.
+PASS successfullyParsed is true
+
+TEST COMPLETE
+

--- a/LayoutTests/http/tests/websocket/tests/hybi/worker-handshake-failure-cleanup.html
+++ b/LayoutTests/http/tests/websocket/tests/hybi/worker-handshake-failure-cleanup.html
@@ -1,0 +1,58 @@
+<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML//EN"><!-- webkit-test-runner [ dumpJSConsoleLogInStdErr=true ] -->
+<html>
+<head>
+<script src="/js-test-resources/js-test.js"></script>
+</head>
+<body>
+<div id="description"></div>
+<div id="console"></div>
+<script type="text/javascript">
+description("Verifies that NetworkSocketChannel is cleaned up in the network process when a worker WebSocket fails the handshake and the worker self-terminates. https://bugs.webkit.org/show_bug.cgi?id=315342");
+
+window.jsTestIsAsync = true;
+
+if (!window.internals) {
+    testFailed("This test requires window.internals.");
+    finishJSTest();
+}
+
+const WORKER_COUNT = 5;
+let workersDone = 0;
+
+function spawnWorker()
+{
+    const blob = new Blob([
+        `const ws = new WebSocket("ws://127.0.0.1:8880/websocket/tests/hybi/handshake-fail-with-200-ok");
+         ws.onerror = () => {};
+         ws.onclose = () => { postMessage("done"); self.close(); };`
+    ], { type: "application/javascript" });
+    const w = new Worker(URL.createObjectURL(blob));
+    w.onmessage = () => {
+        if (++workersDone === WORKER_COUNT)
+            pollUntilCleanedUp();
+    };
+}
+
+async function pollUntilCleanedUp()
+{
+    // With the fix, the network-side count drops to 0 within milliseconds of
+    // the worker WebSockets terminating. With the leak, it never returns to 0.
+    for (let i = 0; i < 100; ++i) {
+        const count = await internals.numberOfWebSocketChannelsInNetworkProcess();
+        if (count === 0) {
+            testPassed("NetworkSocketChannel count returned to 0 after worker WebSockets terminated.");
+            finishJSTest();
+            return;
+        }
+        await new Promise(resolve => setTimeout(resolve, 50));
+    }
+    const finalCount = await internals.numberOfWebSocketChannelsInNetworkProcess();
+    testFailed(`NetworkSocketChannel count never returned to 0 (final count: ${finalCount}).`);
+    finishJSTest();
+}
+
+for (let i = 0; i < WORKER_COUNT; ++i)
+    spawnWorker();
+</script>
+</body>
+</html>

--- a/LayoutTests/svg/compositing/svg-poster-circle.html
+++ b/LayoutTests/svg/compositing/svg-poster-circle.html
@@ -2,7 +2,7 @@
 <html>
   <head>
     <!-- FIXME: SVG content slightly clipped (up to 1px) due to off-device-pixel-alignment issue, remove when fixed. -->
-    <meta name="fuzzy" content="maxDifference=0-92; totalPixels=0-11546" />
+    <meta name="fuzzy" content="maxDifference=0-110; totalPixels=0-12500" />
 
     <style>
       html, body {

--- a/Source/WebCore/page/SocketProvider.h
+++ b/Source/WebCore/page/SocketProvider.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <WebCore/WebTransportConnectionInfo.h>
+#include <wtf/CompletionHandler.h>
 #include <wtf/NativePromise.h>
 #include <wtf/Ref.h>
 #include <wtf/ThreadSafeRefCounted.h>
@@ -52,6 +53,8 @@ class WEBCORE_EXPORT SocketProvider : public ThreadSafeRefCounted<SocketProvider
 public:
     virtual RefPtr<ThreadableWebSocketChannel> createWebSocketChannel(Document&, WebSocketChannelClient&) = 0;
     virtual std::pair<RefPtr<WebTransportSession>, Ref<WebTransportSessionPromise>> initializeWebTransportSession(ScriptExecutionContext&, WebTransportSessionClient&, const URL&, const WebTransportOptions&) = 0;
+
+    virtual void countWebSocketChannelsForTesting(CompletionHandler<void(unsigned)>&& completionHandler) { completionHandler(0); }
 
 #if USE(LIBRICE)
     virtual RefPtr<RiceBackend> createRiceBackend(RiceBackendClient&) = 0;

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp
@@ -645,11 +645,15 @@ static HashMap<String, GRefPtr<GstElement>>& activePipelinesMap()
     return activePipelines.get();
 }
 
-void registerActivePipeline(const GRefPtr<GstElement>& pipeline)
+void registerActivePipeline(const GRefPtr<GstElement>& pipeline, const String& pipelineName)
 {
-    auto name = GMallocString::unsafeAdoptFromUTF8(gst_object_get_name(GST_OBJECT_CAST(pipeline.get())));
+    String key = pipelineName;
+    if (key.isEmpty()) {
+        auto name = GMallocString::unsafeAdoptFromUTF8(gst_object_get_name(GST_OBJECT_CAST(pipeline.get())));
+        key = name.span();
+    }
     Locker locker { s_activePipelinesMapLock };
-    activePipelinesMap().add(name.span(), GRefPtr<GstElement>(pipeline));
+    activePipelinesMap().add(key, GRefPtr<GstElement>(pipeline));
 }
 
 void unregisterPipeline(const GRefPtr<GstElement>& pipeline)
@@ -657,6 +661,12 @@ void unregisterPipeline(const GRefPtr<GstElement>& pipeline)
     auto name = GMallocString::unsafeAdoptFromUTF8(gst_object_get_name(GST_OBJECT_CAST(pipeline.get())));
     Locker locker { s_activePipelinesMapLock };
     activePipelinesMap().remove(name.span());
+}
+
+void unregisterPipeline(const String& pipelineName)
+{
+    Locker locker { s_activePipelinesMapLock };
+    activePipelinesMap().remove(pipelineName);
 }
 
 void WebCoreLogObserver::didLogMessage(const WTFLogChannel& channel, WTFLogLevel level, Vector<JSONLogValue>&& values)

--- a/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
+++ b/Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h
@@ -341,8 +341,9 @@ GRefPtr<GstBuffer> wrapSpanData(const std::span<const uint8_t>&);
 
 std::optional<unsigned> gstGetAutoplugSelectResult(ASCIILiteral);
 
-void registerActivePipeline(const GRefPtr<GstElement>&);
+void registerActivePipeline(const GRefPtr<GstElement>&, const String& = emptyString());
 void unregisterPipeline(const GRefPtr<GstElement>&);
+void unregisterPipeline(const String&);
 
 class WebCoreLogObserver : public Logger::Observer {
     WTF_MAKE_TZONE_ALLOCATED(WebCoreLogObserver);

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp
@@ -270,7 +270,7 @@ void MediaPlayerPrivateGStreamer::tearDown(bool clearMediaPlayer)
     // The change to GST_STATE_NULL state is always synchronous. So after this gets executed we don't need to worry
     // about handlers running in the GStreamer thread.
     if (m_pipeline) {
-        unregisterPipeline(m_pipeline);
+        unregisterPipeline(m_originalPipelineName);
         gst_element_set_state(m_pipeline.get(), GST_STATE_NULL);
 
         auto bus = adoptGRef(gst_pipeline_get_bus(GST_PIPELINE(m_pipeline.get())));
@@ -278,6 +278,10 @@ void MediaPlayerPrivateGStreamer::tearDown(bool clearMediaPlayer)
         disconnectSimpleBusMessageCallback(m_pipeline.get());
         g_signal_handlers_disconnect_matched(m_pipeline.get(), G_SIGNAL_MATCH_DATA, 0, 0, nullptr, nullptr, this);
 
+        m_source = nullptr;
+        m_videoSink = nullptr;
+        m_audioSink = nullptr;
+        m_textSink = nullptr;
         m_pipeline = nullptr;
     }
 
@@ -1377,8 +1381,9 @@ void MediaPlayerPrivateGStreamer::elementIdChanged(const String& elementId) cons
     auto currentName = String(objectName.span());
     auto tokens = currentName.split('-');
     auto newName = makeString(tokens[0], '-', elementId, '-', tokens.last());
-    GST_DEBUG_OBJECT(m_pipeline.get(), "Renaming to %s", newName.utf8().data());
-    gst_object_set_name(GST_OBJECT_CAST(m_pipeline.get()), newName.utf8().data());
+    auto nameCString = newName.utf8();
+    GST_DEBUG_OBJECT(m_pipeline.get(), "Renaming to %s", nameCString.data());
+    gst_object_set_name(GST_OBJECT_CAST(m_pipeline.get()), nameCString.data());
 }
 
 void MediaPlayerPrivateGStreamer::handleTextSample(GRefPtr<GstSample>&& sample, TrackID streamId)
@@ -3480,7 +3485,9 @@ void MediaPlayerPrivateGStreamer::createGSTPlayBin(const URL& url)
 
     static Atomic<uint32_t> pipelineId;
 
-    m_pipeline = makeGStreamerElement(playbinName, makeString(type, '-', elementId, '-', pipelineId.exchangeAdd(1)));
+    // Keep track of the original pipeline name because the MediaElement might be renamed, leading to the pipeline being renamed as well.
+    m_originalPipelineName = makeString(type, '-', elementId, '-', pipelineId.exchangeAdd(1));
+    m_pipeline = makeGStreamerElement(playbinName, m_originalPipelineName);
     if (!m_pipeline) {
         GST_WARNING("%s not found, make sure to install gst-plugins-base", playbinName.characters());
         loadingFailed(MediaPlayer::NetworkState::FormatError, MediaPlayer::ReadyState::HaveNothing, true);
@@ -3491,7 +3498,7 @@ void MediaPlayerPrivateGStreamer::createGSTPlayBin(const URL& url)
     auto identifier = makeString(LOGIDENTIFIER.objectIdentifier);
     GST_INFO_OBJECT(m_pipeline.get(), "WebCore logs identifier for this pipeline is: %s", identifier.convertToASCIIUppercase().ascii().data());
 #endif
-    registerActivePipeline(m_pipeline);
+    registerActivePipeline(m_pipeline, m_originalPipelineName);
 
     if (isMediaStream) {
         auto clock = adoptGRef(gst_system_clock_obtain());

--- a/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
+++ b/Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h
@@ -421,6 +421,8 @@ protected:
     GRefPtr<GstElement> m_pipeline;
     IntSize m_size;
 
+    String m_originalPipelineName;
+
     MediaPlayer::ReadyState m_readyState { MediaPlayer::ReadyState::HaveNothing };
     mutable MediaPlayer::NetworkState m_networkState { MediaPlayer::NetworkState::Empty };
 

--- a/Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.cpp
+++ b/Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.cpp
@@ -62,7 +62,7 @@ static const char* vertexTemplateLT320Vars =
         varying vec2 v_texCoord;
         varying vec2 v_transformedTexCoord;
         varying float v_antialias;
-        varying vec4 v_nonProjectedPosition;
+        varying highp vec4 v_nonProjectedPosition;
     );
 
 static const char* vertexTemplateCommon =
@@ -194,7 +194,7 @@ static const char* fragmentTemplateLT320Vars =
         varying float v_antialias;
         varying vec2 v_texCoord;
         varying vec2 v_transformedTexCoord;
-        varying vec4 v_nonProjectedPosition;
+        varying highp vec4 v_nonProjectedPosition;
     );
 
 // PQ tone-mapping function with conditional highp precision.
@@ -274,8 +274,8 @@ static const char* fragmentTemplateCommon =
         uniform int u_gaussianKernelHalfSize;
         uniform vec2 u_blurDirection;
         uniform int u_roundedRectNumber;
-        uniform vec4 u_roundedRect[ROUNDED_RECT_ARRAY_SIZE];
-        uniform mat4 u_roundedRectInverseTransformMatrix[ROUNDED_RECT_INVERSE_TRANSFORM_ARRAY_SIZE];
+        uniform highp vec4 u_roundedRect[ROUNDED_RECT_ARRAY_SIZE];
+        uniform highp mat4 u_roundedRectInverseTransformMatrix[ROUNDED_RECT_INVERSE_TRANSFORM_ARRAY_SIZE];
 
         void noop(inout vec4 dummyParameter) { }
         void noop(inout vec4 dummyParameter, vec2 texCoord) { }
@@ -480,32 +480,32 @@ static const char* fragmentTemplateCommon =
 
         void applySolidColor(inout vec4 color) { color *= u_color; }
 
-        float ellipsisDist(vec2 p, vec2 radius)
+        float ellipsisDist(highp vec2 p, highp vec2 radius)
         {
             if (radius == vec2(0, 0))
                 return 0.0;
 
-            vec2 p0 = p / radius;
-            vec2 p1 = 2.0 * p0 / radius;
+            highp vec2 p0 = p / radius;
+            highp vec2 p1 = 2.0 * p0 / radius;
 
             return (dot(p0, p0) - 1.0) / length (p1);
         }
 
-        float ellipsisCoverage(vec2 point, vec2 center, vec2 radius)
+        float ellipsisCoverage(highp vec2 point, highp vec2 center, highp vec2 radius)
         {
-            float d = ellipsisDist(point - center, radius);
+            highp float d = ellipsisDist(point - center, radius);
             return clamp(0.5 - d, 0.0, 1.0);
         }
 
-        float roundedRectCoverage(vec2 p, vec4 bounds, vec2 topLeftRadii, vec2 topRightRadii, vec2 bottomLeftRadii, vec2 bottomRightRadii)
+        float roundedRectCoverage(highp vec2 p, highp vec4 bounds, highp vec2 topLeftRadii, highp vec2 topRightRadii, highp vec2 bottomLeftRadii, highp vec2 bottomRightRadii)
         {
             if (p.x < bounds.x || p.y < bounds.y || p.x >= bounds.z || p.y >= bounds.w)
                 return 0.0;
 
-            vec2 topLeftCenter = bounds.xy + topLeftRadii;
-            vec2 topRightCenter = bounds.zy + (topRightRadii * vec2(-1, 1));
-            vec2 bottomLeftCenter = bounds.xw + (bottomLeftRadii * vec2(1, -1));
-            vec2 bottomRightCenter = bounds.zw + (bottomRightRadii * vec2(-1, -1));
+            highp vec2 topLeftCenter = bounds.xy + topLeftRadii;
+            highp vec2 topRightCenter = bounds.zy + (topRightRadii * vec2(-1, 1));
+            highp vec2 bottomLeftCenter = bounds.xw + (bottomLeftRadii * vec2(1, -1));
+            highp vec2 bottomRightCenter = bounds.zw + (bottomRightRadii * vec2(-1, -1));
 
             if (p.x < topLeftCenter.x && p.y < topLeftCenter.y)
                 return ellipsisCoverage(p, topLeftCenter, topLeftRadii);
@@ -533,17 +533,24 @@ static const char* fragmentTemplateCommon =
             //
             // This implementation is not optimal, but it's done this way in order to overcome rpi3's
             // proprietary video driver limitations (see https://bugs.webkit.org/show_bug.cgi?id=219739).
+            //
+            // The round-clip data, varying and locals carry highp because some proprietary GLES
+            // drivers mishandle the (dot(p0,p0) - 1.0) / length(p1) form in ellipsisDist() under
+            // mediump (fp16): on PowerVR B-Series (Imagination DDK) ellipsisCoverage returns 0
+            // for fragments deep inside the inscribed ellipse, turning the clipped descendant
+            // layers into solid coverage=0 (silent black). highp on the round-clip path only
+            // restores correct output and preserves mediump elsewhere.
 
             for (int rectIndex = 0; rectIndex < ROUNDED_RECT_MAX_RECTS; rectIndex++) {
                 if (rectIndex >= u_roundedRectNumber)
                     break;
 
-                vec4 fragCoord = u_roundedRectInverseTransformMatrix[rectIndex] * v_nonProjectedPosition;
-                vec4 bounds = vec4(u_roundedRect[rectIndex * 3].xy, u_roundedRect[rectIndex * 3].xy + u_roundedRect[rectIndex * 3].zw);
-                vec2 topLeftRadii = u_roundedRect[(rectIndex * 3) + 1].xy;
-                vec2 topRightRadii = u_roundedRect[(rectIndex * 3) + 1].zw;
-                vec2 bottomLeftRadii = u_roundedRect[(rectIndex * 3) + 2].xy;
-                vec2 bottomRightRadii = u_roundedRect[(rectIndex * 3) + 2].zw;
+                highp vec4 fragCoord = u_roundedRectInverseTransformMatrix[rectIndex] * v_nonProjectedPosition;
+                highp vec4 bounds = vec4(u_roundedRect[rectIndex * 3].xy, u_roundedRect[rectIndex * 3].xy + u_roundedRect[rectIndex * 3].zw);
+                highp vec2 topLeftRadii = u_roundedRect[(rectIndex * 3) + 1].xy;
+                highp vec2 topRightRadii = u_roundedRect[(rectIndex * 3) + 1].zw;
+                highp vec2 bottomLeftRadii = u_roundedRect[(rectIndex * 3) + 2].xy;
+                highp vec2 bottomRightRadii = u_roundedRect[(rectIndex * 3) + 2].zw;
                 float coverage = roundedRectCoverage(fragCoord.xy, bounds, topLeftRadii, topRightRadii, bottomLeftRadii, bottomRightRadii);
 
                 // Pixels outside the rect have coverage 0.0.

--- a/Source/WebCore/testing/Internals.cpp
+++ b/Source/WebCore/testing/Internals.cpp
@@ -235,6 +235,7 @@
 #include "Settings.h"
 #include "ShadowRoot.h"
 #include "ShouldPartitionCookie.h"
+#include "SocketProvider.h"
 #include "SourceBuffer.h"
 #include "SpeechSynthesisUtterance.h"
 #include "SpellChecker.h"
@@ -6860,6 +6861,23 @@ void Internals::whenServiceWorkerIsTerminated(ServiceWorker& worker, DOMPromiseD
 {
     return ServiceWorkerProvider::singleton().serviceWorkerConnection().whenServiceWorkerIsTerminatedForTesting(worker.identifier(), [promise = WTF::move(promise)]() mutable {
         promise.resolve();
+    });
+}
+
+void Internals::numberOfWebSocketChannelsInNetworkProcess(DOMPromiseDeferred<IDLUnsignedLong>&& promise)
+{
+    RefPtr document = contextDocument();
+    if (!document) {
+        promise.reject(ExceptionCode::InvalidStateError);
+        return;
+    }
+    RefPtr page = document->page();
+    if (!page) {
+        promise.reject(ExceptionCode::InvalidStateError);
+        return;
+    }
+    page->socketProvider().countWebSocketChannelsForTesting([promise = WTF::move(promise)](unsigned count) mutable {
+        promise.resolve(count);
     });
 }
 

--- a/Source/WebCore/testing/Internals.h
+++ b/Source/WebCore/testing/Internals.h
@@ -1130,6 +1130,8 @@ public:
     void whenServiceWorkerIsTerminated(ServiceWorker&, DOMPromiseDeferred<void>&&);
     NO_RETURN_DUE_TO_CRASH void terminateWebContentProcess();
 
+    void numberOfWebSocketChannelsInNetworkProcess(DOMPromiseDeferred<IDLUnsignedLong>&&);
+
 #if ENABLE(APPLE_PAY)
     ExceptionOr<Ref<MockPaymentCoordinator>> mockPaymentCoordinator(Document&);
 #endif

--- a/Source/WebCore/testing/Internals.idl
+++ b/Source/WebCore/testing/Internals.idl
@@ -1300,6 +1300,8 @@ enum ContentsFormat {
     Promise<undefined> whenServiceWorkerIsTerminated(ServiceWorker worker);
     undefined terminateWebContentProcess();
 
+    Promise<unsigned long> numberOfWebSocketChannelsInNetworkProcess();
+
 #if defined(ENABLE_APPLE_PAY) && ENABLE_APPLE_PAY
     [CallWith=CurrentDocument, Conditional=APPLE_PAY] readonly attribute MockPaymentCoordinator mockPaymentCoordinator;
 #endif

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp
@@ -542,6 +542,11 @@ void NetworkConnectionToWebProcess::removeSocketChannel(WebSocketIdentifier iden
     m_networkSocketChannels.remove(identifier);
 }
 
+void NetworkConnectionToWebProcess::countWebSocketChannelsForTesting(CompletionHandler<void(uint32_t)>&& completionHandler)
+{
+    completionHandler(static_cast<uint32_t>(m_networkSocketChannels.size()));
+}
+
 NetworkSession* NetworkConnectionToWebProcess::networkSession()
 {
     return m_networkProcess->networkSession(m_sessionID);

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h
@@ -347,6 +347,7 @@ private:
     void setCaptureExtraNetworkLoadMetricsEnabled(bool);
 
     void createSocketChannel(const WebCore::ResourceRequest&, const String& protocol, WebCore::WebSocketIdentifier, WebPageProxyIdentifier, std::optional<WebCore::FrameIdentifier>, std::optional<WebCore::PageIdentifier>, const WebCore::ClientOrigin&, bool hadMainFrameMainResourcePrivateRelayed, bool allowPrivacyProxy, OptionSet<WebCore::AdvancedPrivacyProtections>, WebCore::StoredCredentialsPolicy);
+    void countWebSocketChannelsForTesting(CompletionHandler<void(uint32_t)>&&);
 
     void establishSharedWorkerServerConnection();
     void unregisterSharedWorkerConnection();

--- a/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
+++ b/Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in
@@ -81,6 +81,8 @@ messages -> NetworkConnectionToWebProcess WantsDispatchMessage {
 
     [EnabledBy=WebSocketEnabled] CreateSocketChannel(WebCore::ResourceRequest request, String protocol, WebCore::WebSocketIdentifier identifier, WebKit::WebPageProxyIdentifier webPageProxyID, std::optional<WebCore::FrameIdentifier> frameID, std::optional<WebCore::PageIdentifier> pageID, struct WebCore::ClientOrigin clientOrigin, bool hadMainFrameMainResourcePrivateRelayed, bool allowPrivacyProxy, OptionSet<WebCore::AdvancedPrivacyProtections> protections, enum:uint8_t WebCore::StoredCredentialsPolicy storedCredentialsPolicy)
 
+    CountWebSocketChannelsForTesting() -> (uint32_t count)
+
     ClearPageSpecificData(WebCore::PageIdentifier pageID);
 
     [EnabledBy=StorageAccessAPIEnabled] RemoveStorageAccessForFrame(WebCore::FrameIdentifier frameID, WebCore::PageIdentifier pageID);

--- a/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
+++ b/Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp
@@ -503,6 +503,9 @@ void NetworkStorageManager::donePrepareForEviction(const std::optional<HashMap<W
 {
     assertIsCurrent(workQueue());
 
+    if (m_closed)
+        return;
+
     HashMap<WebCore::SecurityOriginData, AccessRecord> originRecords;
     uint64_t totalUsage = 0;
     for (auto& origin : getAllOrigins()) {

--- a/Source/WebKit/UIProcess/API/APIHTTPCookieStore.cpp
+++ b/Source/WebKit/UIProcess/API/APIHTTPCookieStore.cpp
@@ -80,7 +80,7 @@ void HTTPCookieStore::filterAppBoundCookies(Vector<WebCore::Cookie>&& cookies, C
 
 void HTTPCookieStore::cookies(CompletionHandler<void(Vector<WebCore::Cookie>&&)>&& completionHandler)
 {
-    if (RefPtr networkProcess = networkProcessIfExists()) {
+    if (RefPtr networkProcess = networkProcessLaunchingIfNecessary()) {
         networkProcess->sendWithAsyncReply(Messages::WebCookieManager::GetAllCookies(m_sessionID), [this, protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler)] (Vector<WebCore::Cookie>&& cookies) mutable {
             filterAppBoundCookies(WTF::move(cookies), WTF::move(completionHandler));
         });
@@ -90,7 +90,7 @@ void HTTPCookieStore::cookies(CompletionHandler<void(Vector<WebCore::Cookie>&&)>
 
 void HTTPCookieStore::cookiesForURL(WTF::URL&& url, CompletionHandler<void(Vector<WebCore::Cookie>&&)>&& completionHandler)
 {
-    if (RefPtr networkProcess = networkProcessIfExists()) {
+    if (RefPtr networkProcess = networkProcessLaunchingIfNecessary()) {
         networkProcess->sendWithAsyncReply(Messages::WebCookieManager::GetCookies(m_sessionID, url), [this, protectedThis = Ref { *this }, completionHandler = WTF::move(completionHandler)] (Vector<WebCore::Cookie>&& cookies) mutable {
             filterAppBoundCookies(WTF::move(cookies), WTF::move(completionHandler));
         });

--- a/Source/WebKit/WebProcess/Network/WebSocketChannel.cpp
+++ b/Source/WebKit/WebProcess/Network/WebSocketChannel.cpp
@@ -96,6 +96,17 @@ WebSocketChannel::WebSocketChannel(WebPageProxyIdentifier webPageProxyID, Docume
 
 WebSocketChannel::~WebSocketChannel()
 {
+    // Ensure the network process tears down its NetworkSocketChannel even when
+    // none of the explicit close/disconnect paths ran. This happens for worker
+    // WebSockets on a peer-initiated close: WorkerThreadableWebSocketChannel::Peer::didClose
+    // nulls its RefPtr<WebSocketChannel> before the worker can call disconnect(),
+    // so without this the Close IPC would never be sent and the network-side
+    // channel would leak. m_needsToCallClose is only true once connect()
+    // successfully sent a CreateSocketChannel IPC and Close hasn't been sent
+    // since, so the destructor doesn't send a stray Close for channels the
+    // network process never knew about.
+    if (m_needsToCallClose)
+        MessageSender::send(Messages::NetworkSocketChannel::Close { WebCore::ThreadableWebSocketChannel::CloseEventCodeGoingAway, { } });
     WebProcess::singleton().webSocketChannelManager().removeChannel(*this);
 }
 
@@ -167,6 +178,7 @@ WebSocketChannel::ConnectStatus WebSocketChannel::connect(const URL& url, const 
     m_inspector.didCreateWebSocket(url);
     m_url = request->url();
     MessageSender::send(Messages::NetworkConnectionToWebProcess::CreateSocketChannel { *request, protocol, identifier(), m_webPageProxyID, frameID, pageID, document->clientOrigin(), WebProcess::singleton().hadMainFrameMainResourcePrivateRelayed(), allowPrivacyProxy, advancedPrivacyProtections, storedCredentialsPolicy });
+    m_needsToCallClose = true;
     return ConnectStatus::OK;
 }
 
@@ -250,6 +262,7 @@ void WebSocketChannel::close(int code, const String& reason)
     m_inspector.didSendWebSocketFrame(closingFrame);
 
     MessageSender::send(Messages::NetworkSocketChannel::Close { code, reason });
+    m_needsToCallClose = false;
 }
 
 void WebSocketChannel::fail(String&& reason)
@@ -265,6 +278,7 @@ void WebSocketChannel::fail(String&& reason)
         return;
 
     MessageSender::send(Messages::NetworkSocketChannel::Close { WebCore::ThreadableWebSocketChannel::CloseEventCodeGoingAway, reason });
+    m_needsToCallClose = false;
     didClose(WebCore::ThreadableWebSocketChannel::CloseEventCodeAbnormalClosure, { });
 }
 
@@ -276,7 +290,10 @@ void WebSocketChannel::disconnect()
 
     m_inspector.didCloseWebSocket();
 
-    MessageSender::send(Messages::NetworkSocketChannel::Close { WebCore::ThreadableWebSocketChannel::CloseEventCodeGoingAway, { } });
+    if (m_needsToCallClose) {
+        MessageSender::send(Messages::NetworkSocketChannel::Close { WebCore::ThreadableWebSocketChannel::CloseEventCodeGoingAway, { } });
+        m_needsToCallClose = false;
+    }
 }
 
 void WebSocketChannel::didConnect(String&& subprotocol, String&& extensions)

--- a/Source/WebKit/WebProcess/Network/WebSocketChannel.h
+++ b/Source/WebKit/WebProcess/Network/WebSocketChannel.h
@@ -111,6 +111,7 @@ private:
     String m_extensions;
     size_t m_bufferedAmount { 0 };
     bool m_isClosing { false };
+    bool m_needsToCallClose { false };
     const Ref<WebCore::NetworkSendQueue> m_messageQueue;
     WebCore::WebSocketChannelInspector m_inspector;
     WebCore::ResourceRequest m_handshakeRequest;

--- a/Source/WebKit/WebProcess/Network/WebSocketProvider.cpp
+++ b/Source/WebKit/WebProcess/Network/WebSocketProvider.cpp
@@ -31,6 +31,7 @@
 #include "config.h"
 #include "WebSocketProvider.h"
 
+#include "NetworkConnectionToWebProcessMessages.h"
 #include "NetworkProcessConnection.h"
 #include "WebProcess.h"
 #include "WebSocketChannelManager.h"
@@ -50,6 +51,11 @@ using namespace WebCore;
 RefPtr<ThreadableWebSocketChannel> WebSocketProvider::createWebSocketChannel(Document& document, WebSocketChannelClient& client)
 {
     return WebKit::WebSocketChannel::create(m_webPageProxyID, document, client);
+}
+
+void WebSocketProvider::countWebSocketChannelsForTesting(CompletionHandler<void(unsigned)>&& completionHandler)
+{
+    WebProcess::singleton().ensureNetworkProcessConnection().connection().sendWithAsyncReply(Messages::NetworkConnectionToWebProcess::CountWebSocketChannelsForTesting { }, WTF::move(completionHandler));
 }
 
 WebSocketProvider::~WebSocketProvider() = default;

--- a/Source/WebKit/WebProcess/Network/WebSocketProvider.h
+++ b/Source/WebKit/WebProcess/Network/WebSocketProvider.h
@@ -42,6 +42,7 @@ public:
 private:
     RefPtr<WebCore::ThreadableWebSocketChannel> createWebSocketChannel(WebCore::Document&, WebCore::WebSocketChannelClient&) final;
     std::pair<RefPtr<WebCore::WebTransportSession>, Ref<WebCore::WebTransportSessionPromise>> initializeWebTransportSession(WebCore::ScriptExecutionContext&, WebCore::WebTransportSessionClient&, const URL&, const WebCore::WebTransportOptions&) final;
+    void countWebSocketChannelsForTesting(CompletionHandler<void(unsigned)>&&) final;
 
     explicit WebSocketProvider(WebPageProxyIdentifier);
 

--- a/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPICookies.mm
+++ b/Tools/TestWebKitAPI/Tests/WebKitCocoa/WKWebExtensionAPICookies.mm
@@ -28,7 +28,10 @@
 #if ENABLE(WK_WEB_EXTENSIONS)
 
 #import "WebExtensionUtilities.h"
+#import <WebKit/WKHTTPCookieStorePrivate.h>
 #import <WebKit/WKWebExtensionCommand.h>
+#import <WebKit/WKWebsiteDataStorePrivate.h>
+#import <signal.h>
 #import <wtf/darwin/DispatchExtras.h>
 
 namespace TestWebKitAPI {
@@ -713,6 +716,55 @@ TEST(WKWebExtensionAPICookies, ChangedEvent)
     [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];
 
     [manager run];
+}
+
+TEST(WKWebExtensionAPICookies, GetAllAfterNetworkProcessTermination)
+{
+    auto *backgroundScript = Util::constructScript(@[
+        @"const cookies = await browser.test.assertSafeResolve(() => browser.cookies.getAll({ url: 'http://example.com/' }))",
+        @"browser.test.assertTrue(Array.isArray(cookies), 'Cookies should be an array')",
+        @"browser.test.assertEq(cookies?.length, 1, 'There should be 1 cookie')",
+        @"browser.test.assertEq(cookies[0]?.name, 'testCookie')",
+        @"browser.test.assertEq(cookies[0]?.value, 'testValue')",
+        @"browser.test.notifyPass()"
+    ]);
+
+    auto manager = Util::loadExtension(cookiesManifest, @{ @"background.js": backgroundScript });
+
+    auto *matchPattern = [WKWebExtensionMatchPattern matchPatternWithString:@"*://*.example.com/*"];
+    [manager.get().context setPermissionStatus:WKWebExtensionContextPermissionStatusGrantedExplicitly forMatchPattern:matchPattern];
+
+    auto *cookieStore = WKWebsiteDataStore.defaultDataStore.httpCookieStore;
+    auto *cookie = [NSHTTPCookie cookieWithProperties:@{
+        NSHTTPCookieName: @"testCookie",
+        NSHTTPCookieValue: @"testValue",
+        NSHTTPCookieDomain: @".example.com",
+        NSHTTPCookiePath: @"/",
+        NSHTTPCookieExpires: [NSDate dateWithTimeIntervalSinceNow:3600]
+    }];
+
+    __block bool done = false;
+    [cookieStore setCookie:cookie completionHandler:^{
+        [cookieStore _flushCookiesToDiskWithCompletionHandler:^{
+            done = true;
+        }];
+    }];
+
+    Util::run(&done);
+
+    // Kill the network process to simulate a cold start (e.g. after app relaunch). With the fix,
+    // cookies.getAll() launches the network process on demand and reads the persisted cookie.
+    kill([WKWebsiteDataStore.defaultDataStore _networkProcessIdentifier], SIGKILL);
+    Util::runFor(0.1_s);
+
+    [manager run];
+
+    done = false;
+    [cookieStore deleteCookie:cookie completionHandler:^{
+        done = true;
+    }];
+
+    Util::run(&done);
 }
 
 } // namespace TestWebKitAPI


### PR DESCRIPTION
#### c6455697e7908d6b46ffc81741dabee2c7e349f5
<pre>
Cherry-pick 312802@main (74a41b5f4ec4). <a href="https://bugs.webkit.org/show_bug.cgi?id=314201">https://bugs.webkit.org/show_bug.cgi?id=314201</a>

    [TextureMapper] Round-clip shader needs highp on PowerVR B-Series
    <a href="https://bugs.webkit.org/show_bug.cgi?id=314201">https://bugs.webkit.org/show_bug.cgi?id=314201</a>

    Reviewed by Miguel Gomez.

    The GLSL helpers used by applyRoundedRectClip (ellipsisDist,
    ellipsisCoverage, roundedRectCoverage) compute corner coverage as
    (dot(p0,p0) - 1.0) / length(p1). On some proprietary GLES drivers this
    form is miscomputed under mediump (fp16). Reproduced on PowerVR
    B-Series (Imagination DDK 24.1@6554834): ellipsisCoverage returns 0
    for fragments well inside the inscribed ellipse, so descendants under
    a &apos;border-radius + overflow:hidden&apos; ancestor render as solid
    coverage=0 (silent black) instead of being correctly clipped.

    The fix here is to promote precision on the round-clip path only:

    * v_nonProjectedPosition varying (vertex + fragment templates)
    * u_roundedRect, u_roundedRectInverseTransformMatrix uniforms
    * parameters and locals in ellipsisDist, ellipsisCoverage,
    roundedRectCoverage
    * locals in applyRoundedRectClip (fragCoord, bounds, *Radii)

    This keeps mediump for the rest of the fragment shader (filters,
    blur, tone-map) so the cost is confined to the round-clip path.

    Tested on device, glitch is gone. The same issue can be reproduced using
    WebGL, so a separate bug to Imagination might need to be raised.
    Updated layout tests to add a bit more leeway due to the changes in the
    shader (no visual difference at plain sight).

    * LayoutTests/compositing/clipping/border-radius-async-overflow-stacking.html:
    * LayoutTests/svg/compositing/svg-poster-circle.html:
    * Source/WebCore/platform/graphics/texmap/TextureMapperShaderProgram.cpp:

    Canonical link: <a href="https://commits.webkit.org/312802@main">https://commits.webkit.org/312802@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.678@webkitglib/2.52">https://commits.webkit.org/305877.678@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 329f5aac08ad84a7bb7298b5102385428d2f96ae
<pre>
Cherry-pick 313830@main (cb7ccd0d2919). <a href="https://bugs.webkit.org/show_bug.cgi?id=315459">https://bugs.webkit.org/show_bug.cgi?id=315459</a>

    [GStreamer] Possible pipeline leak when the owning media element id is updated
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315459">https://bugs.webkit.org/show_bug.cgi?id=315459</a>

    Reviewed by Xabier Rodriguez-Calvar.

    Keep track of the initial player pipeline name and use it for storage in the global pipelines
    hashmap.

    Driving-by, clean-up some more GstElement smart pointers during tear-down and avoid one string copy
    when logging media element id updates.

    * Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.cpp:
    (WebCore::registerActivePipeline):
    (WebCore::unregisterPipeline):
    * Source/WebCore/platform/graphics/gstreamer/GStreamerCommon.h:
    * Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.cpp:
    (WebCore::MediaPlayerPrivateGStreamer::tearDown):
    (WebCore::MediaPlayerPrivateGStreamer::elementIdChanged const):
    (WebCore::MediaPlayerPrivateGStreamer::createGSTPlayBin):
    * Source/WebCore/platform/graphics/gstreamer/MediaPlayerPrivateGStreamer.h:

    Canonical link: <a href="https://commits.webkit.org/313830@main">https://commits.webkit.org/313830@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.677@webkitglib/2.52">https://commits.webkit.org/305877.677@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 69676a7d341e3c7bdc01d7f4a85d835b9fa68220
<pre>
Cherry-pick 313427@main (113cf2c7cf54). <a href="https://bugs.webkit.org/show_bug.cgi?id=314963">https://bugs.webkit.org/show_bug.cgi?id=314963</a>

    Check m_closed in NetworkStorageManager::donePrepareForEviction
    <a href="https://bugs.webkit.org/show_bug.cgi?id=314963">https://bugs.webkit.org/show_bug.cgi?id=314963</a>
    <a href="https://rdar.apple.com/177256813">rdar://177256813</a>

    Reviewed by Per Arne Vollan.

    donePrepareForEviction is dispatched to the work queue from an async callback on the main thread. Between the m_closed
    check in the callback and the execution on the work queue, close() can be called, setting m_closed and scheduling
    cleanup of m_originStorageManagers. Add the same m_closed early return that donePrepareForTimeBasedEviction already has
    for consistency and safety.

    * Source/WebKit/NetworkProcess/storage/NetworkStorageManager.cpp:
    (WebKit::NetworkStorageManager::donePrepareForEviction):

    Canonical link: <a href="https://commits.webkit.org/313427@main">https://commits.webkit.org/313427@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.676@webkitglib/2.52">https://commits.webkit.org/305877.676@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### 97e256a6203b8988e621d735da301b5dc1db8cc8
<pre>
Cherry-pick 313745@main (0148d3419af1). <a href="https://bugs.webkit.org/show_bug.cgi?id=315310">https://bugs.webkit.org/show_bug.cgi?id=315310</a>

    Web Extensions: cookies.get() and cookies.getAll() have empty results on first launch.
    <a href="https://webkit.org/b/315310">https://webkit.org/b/315310</a>
    <a href="https://rdar.apple.com/177380008">rdar://177380008</a>

    Reviewed by Brian Weinstein.

    When the network process hasn&apos;t launched yet — as is common on the first cookie query after
    app launch — the two cookie-reading methods silently returned empty results. They now launch
    the network process on demand, consistent with the write and observer methods in the same class.

    Test: Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPICookies.mm

    * Source/WebKit/UIProcess/API/APIHTTPCookieStore.cpp:
    (API::HTTPCookieStore::cookies): Use `networkProcessLaunchingIfNecessary()` to launch the network
    process on demand rather than silently returning empty results when it isn&apos;t running.
    (API::HTTPCookieStore::cookiesForURL): Ditto.

    * Tools/TestWebKitAPI/Tests/WebKit/WKWebView/WKWebExtensionAPICookies.mm:
    (TestWebKitAPI::TEST(WKWebExtensionAPICookies, GetAllAfterNetworkProcessTermination)):
    Added. Verifies `browser.cookies.getAll()` returns persisted cookies after the network process is
    killed, simulating a cold-start scenario.

    Canonical link: <a href="https://commits.webkit.org/313745@main">https://commits.webkit.org/313745@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.675@webkitglib/2.52">https://commits.webkit.org/305877.675@webkitglib/2.52</a>
</pre>
----------------------------------------------------------------------
#### e38a7cfe5f93bec26d99e4134b702c8b02bcdbe0
<pre>
Cherry-pick 313770@main (f391b9f442fc). <a href="https://bugs.webkit.org/show_bug.cgi?id=315342">https://bugs.webkit.org/show_bug.cgi?id=315342</a>

    NetworkSocketChannel leaks when a worker WebSocket is closed by the server
    <a href="https://bugs.webkit.org/show_bug.cgi?id=315342">https://bugs.webkit.org/show_bug.cgi?id=315342</a>
    <a href="https://rdar.apple.com/130167032">rdar://130167032</a>

    Reviewed by Youenn Fablet.

    When a worker-scoped WebSocket is closed by the peer, the
    WebProcess-side WebKit::WebSocketChannel never sends the Close IPC to
    the network process, so NetworkSocketChannel sits in State::Closing
    forever and its underlying NSURLSessionWebSocketTask leaks.

    The chain on a peer-initiated close (network process delivers DidClose):

      WebSocketChannel::didClose (main thread)
        -&gt; client-&gt;didClose, where client is WorkerThreadableWebSocketChannel::Peer
           -&gt; Peer::didClose sets m_mainWebSocketChannel = nullptr
              (drops the only strong ref to WebKit::WebSocketChannel)
        -&gt; WebSocketChannel::didClose returns
           -&gt; protectedThis goes out of scope, last ref drops
              -&gt; ~WebSocketChannel runs (currently does not send Close)

    The path that *would* send the Close IPC is
    Peer::~Peer -&gt; m_mainWebSocketChannel-&gt;disconnect(), but
    m_mainWebSocketChannel was already nulled in Peer::didClose, so ~Peer
    is a no-op. The worker-side WebSocket::didClose handler eventually
    calls socket.m_channel-&gt;disconnect(), but in the worker case
    m_channel is the WorkerThreadableWebSocketChannel, whose Bridge::disconnect
    only nullifies local state and does not send any IPC.

    The document-scoped path is unaffected because there
    WebSocket::m_channel is the WebKit::WebSocketChannel directly, and
    WebSocket::didClose&apos;s task does m_channel-&gt;disconnect() against it,
    which sends the IPC explicitly.

    Fix this by sending the Close IPC from ~WebSocketChannel when none of
    the explicit close/disconnect paths sent it. A new m_needsToCallClose
    flag is set to true in WebSocketChannel::connect() once the
    CreateSocketChannel IPC has actually been sent (so connect() failures
    that returned early don&apos;t leave a stale flag), and is cleared whenever
    close()/fail()/disconnect() send a Close IPC. The destructor then
    sends Close only when the flag is still set, ensuring a single Close
    IPC per network-process channel and none for channels the network
    process never knew about.

    TEST: http/tests/websocket/tests/hybi/worker-handshake-failure-cleanup.html

    * LayoutTests/http/tests/websocket/tests/hybi/handshake-fail-with-200-ok_wsh.py: Added.
    (web_socket_do_extra_handshake):
    (web_socket_transfer_data):
    * LayoutTests/http/tests/websocket/tests/hybi/worker-handshake-failure-cleanup-expected.txt: Added.
    * LayoutTests/http/tests/websocket/tests/hybi/worker-handshake-failure-cleanup.html: Added.
    * Source/WebCore/page/SocketProvider.h:
    * Source/WebCore/testing/Internals.cpp:
    (WebCore::Internals::numberOfWebSocketChannelsInNetworkProcess):
    * Source/WebCore/testing/Internals.h:
    * Source/WebCore/testing/Internals.idl:
    * Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.cpp:
    (WebKit::NetworkConnectionToWebProcess::countWebSocketChannelsForTesting):
    * Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.h:
    * Source/WebKit/NetworkProcess/NetworkConnectionToWebProcess.messages.in:
    * Source/WebKit/WebProcess/Network/WebSocketChannel.cpp:
    (WebKit::WebSocketChannel::~WebSocketChannel):
    (WebKit::WebSocketChannel::connect):
    (WebKit::WebSocketChannel::close):
    (WebKit::WebSocketChannel::fail):
    (WebKit::WebSocketChannel::disconnect):
    * Source/WebKit/WebProcess/Network/WebSocketChannel.h:
    * Source/WebKit/WebProcess/Network/WebSocketProvider.cpp:
    (WebKit::WebSocketProvider::countWebSocketChannelsForTesting):
    * Source/WebKit/WebProcess/Network/WebSocketProvider.h:

    Canonical link: <a href="https://commits.webkit.org/313770@main">https://commits.webkit.org/313770@main</a>

Canonical link: <a href="https://commits.webkit.org/305877.674@webkitglib/2.52">https://commits.webkit.org/305877.674@webkitglib/2.52</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/702f8f6add79903cd85452f0d567cb4044a88f3b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164309 "1 style error") | [  ~~🛠 ios~~](https://ews-build.webkit.org/#/builders/159/builds/37793 "The change is no longer eligible for processing.") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/31364 "The change is no longer eligible for processing.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173338 "Built successfully") | [  ~~🛠 win~~](https://ews-build.webkit.org/#/builders/59/builds/121561 "The change is no longer eligible for processing.") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166178 "Passed tests") | [  ~~🛠 ios-sim~~](https://ews-build.webkit.org/#/builders/155/builds/38127 "The change is no longer eligible for processing.") | [  ~~🛠 mac-AS-debug~~](https://ews-build.webkit.org/#/builders/156/builds/37794 "The change is no longer eligible for processing.") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127661 "Passed tests") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/59/builds/121561 "The change is no longer eligible for processing.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167268 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/155/builds/38127 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/168/builds/31364 "The change is no longer eligible for processing.") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108206 "Passed tests") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/155/builds/38127 "The change is no longer eligible for processing.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/156/builds/37794 "The change is no longer eligible for processing.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21102 "Built successfully") | 
| | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/155/builds/38127 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/168/builds/31364 "The change is no longer eligible for processing.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175864 "Built successfully") | 
| | [  ~~🛠 ios-safer-cpp~~](https://ews-build.webkit.org/#/builders/174/builds/28685 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/31364 "The change is no longer eligible for processing.") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135972 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/37464 "The change is no longer eligible for processing.") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/156/builds/37794 "The change is no longer eligible for processing.") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135941 "Passed tests") | 
| | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/38250 "The change is no longer eligible for processing.") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/168/builds/31364 "The change is no longer eligible for processing.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/100608 "The change is no longer eligible for processing.") | 
| [✅ 🛠 🧪 unsafe-merge](https://ews-build.webkit.org/#/builders/22/builds/25016 "Built successfully and passed tests") | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/38250 "The change is no longer eligible for processing.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/168/builds/31364 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv~~](https://ews-build.webkit.org/#/builders/158/builds/37060 "The change is no longer eligible for processing.") | [  ~~🛠 mac-safer-cpp~~](https://ews-build.webkit.org/#/builders/120/builds/110104 "The change is no longer eligible for processing.") | | 
| | [  ~~🛠 tv-sim~~](https://ews-build.webkit.org/#/builders/157/builds/36456 "The change is no longer eligible for processing.") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/168/builds/31364 "The change is no longer eligible for processing.") | | 
| | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36706 "Build is in progress. Recent messages:") | | | 
| | [  ~~🛠 watch-sim~~](https://ews-build.webkit.org/#/builders/152/builds/36606 "The change is no longer eligible for processing.") | | | 
<!--EWS-Status-Bubble-End-->