### PR TITLE
CloseWatcher.close() early returns if the cancel action is running

### DIFF
--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/inside-event-listeners-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/inside-event-listeners-expected.txt
@@ -1,8 +1,14 @@
 
 PASS destroy() inside oncancel
+PASS destroy() inside oncancel with preventDefault()
 PASS destroy() inside onclose
+PASS destroy() inside onclose with preventDefault()
 PASS close() inside oncancel
+PASS close() inside oncancel with preventDefault()
 PASS close() inside onclose
+PASS close() inside onclose with preventDefault()
 PASS requestClose() inside oncancel
+PASS requestClose() inside oncancel with preventDefault()
 PASS requestClose() inside onclose
+PASS requestClose() inside onclose with preventDefault()
 

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/inside-event-listeners.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/inside-event-listeners.html
@@ -1,27 +1,35 @@
 <!doctype html>
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
-<script src="/resources/testdriver.js"></script>
-<script src="/resources/testdriver-vendor.js"></script>
-<script src="/resources/testdriver-actions.js"></script>
 <script src="resources/helpers.js"></script>
 
 <body>
 <script>
-promise_test(async t => {
+test(t => {
   let events = [];
   let watcher = createRecordingCloseWatcher(t, events);
 
   watcher.oncancel = () => { watcher.destroy(); }
 
-  await test_driver.bless("give user activation so that cancel will fire", () => {
-    watcher.requestClose();
-  });
+  watcher.requestClose();
   assert_array_equals(events, ["cancel[cancelable=true]"]);
 
   watcher.requestClose();
   assert_array_equals(events, ["cancel[cancelable=true]"], "since it was inactive, no more events fired");
 }, "destroy() inside oncancel");
+
+test(t => {
+  let events = [];
+  let watcher = createRecordingCloseWatcher(t, events);
+
+  watcher.oncancel = (e) => { e.preventDefault(); watcher.destroy(); }
+
+  watcher.requestClose();
+  assert_array_equals(events, ["cancel[cancelable=true]"]);
+
+  watcher.requestClose();
+  assert_array_equals(events, ["cancel[cancelable=true]"], "since it was inactive, no more events fired");
+}, "destroy() inside oncancel with preventDefault()");
 
 test(t => {
   let events = [];
@@ -36,20 +44,44 @@ test(t => {
   assert_array_equals(events, ["cancel[cancelable=true]", "close"], "since it was inactive, no more events fired");
 }, "destroy() inside onclose");
 
-promise_test(async t => {
+test(t => {
+  let events = [];
+  let watcher = createRecordingCloseWatcher(t, events);
+
+  watcher.onclose = (e) => { e.preventDefault(); watcher.destroy(); }
+
+  watcher.requestClose();
+  assert_array_equals(events, ["cancel[cancelable=true]", "close"]);
+
+  watcher.requestClose();
+  assert_array_equals(events, ["cancel[cancelable=true]", "close"], "since it was inactive, no more events fired");
+}, "destroy() inside onclose with preventDefault()");
+
+test(t => {
   let events = [];
   let watcher = createRecordingCloseWatcher(t, events);
 
   watcher.oncancel = () => { watcher.close(); }
 
-  await test_driver.bless("give user activation so that cancel will fire", () => {
-    watcher.requestClose();
-  });
+  watcher.requestClose();
   assert_array_equals(events, ["cancel[cancelable=true]", "close"]);
 
   watcher.requestClose();
   assert_array_equals(events, ["cancel[cancelable=true]", "close"], "since it was inactive, no more events fired");
 }, "close() inside oncancel");
+
+test(t => {
+  let events = [];
+  let watcher = createRecordingCloseWatcher(t, events);
+
+  watcher.oncancel = (e) => { e.preventDefault(); watcher.close(); }
+
+  watcher.requestClose();
+  assert_array_equals(events, ["cancel[cancelable=true]", "close"]);
+
+  watcher.requestClose();
+  assert_array_equals(events, ["cancel[cancelable=true]", "close"], "since it was inactive, no more events fired");
+}, "close() inside oncancel with preventDefault()");
 
 test(t => {
   let events = [];
@@ -64,20 +96,44 @@ test(t => {
   assert_array_equals(events, ["cancel[cancelable=true]", "close"], "since it was inactive, no more events fired");
 }, "close() inside onclose");
 
-promise_test(async t => {
+test(t => {
+  let events = [];
+  let watcher = createRecordingCloseWatcher(t, events);
+
+  watcher.onclose = (e) => { e.preventDefault(); watcher.close(); }
+
+  watcher.requestClose();
+  assert_array_equals(events, ["cancel[cancelable=true]", "close"]);
+
+  watcher.requestClose();
+  assert_array_equals(events, ["cancel[cancelable=true]", "close"], "since it was inactive, no more events fired");
+}, "close() inside onclose with preventDefault()");
+
+test(t => {
   let events = [];
   let watcher = createRecordingCloseWatcher(t, events);
 
   watcher.oncancel = () => { watcher.requestClose(); }
 
-  await test_driver.bless("give user activation so that cancel will fire", () => {
-    watcher.requestClose();
-  });
+  watcher.requestClose();
   assert_array_equals(events, ["cancel[cancelable=true]", "close"]);
 
   watcher.requestClose();
   assert_array_equals(events, ["cancel[cancelable=true]", "close"], "since it was inactive, no more events fired");
 }, "requestClose() inside oncancel");
+
+test(t => {
+  let events = [];
+  let watcher = createRecordingCloseWatcher(t, events);
+
+  watcher.oncancel = (e) => { e.preventDefault(); watcher.requestClose(); }
+
+  watcher.requestClose();
+  assert_array_equals(events, ["cancel[cancelable=true]"]);
+
+  watcher.requestClose();
+  assert_array_equals(events, ["cancel[cancelable=true]", "cancel[cancelable=true]"], "since it was still active, more events fired");
+}, "requestClose() inside oncancel with preventDefault()");
 
 test(t => {
   let events = [];
@@ -91,4 +147,17 @@ test(t => {
   watcher.requestClose();
   assert_array_equals(events, ["cancel[cancelable=true]", "close"], "since it was inactive, no more events fired");
 }, "requestClose() inside onclose");
+
+test(t => {
+  let events = [];
+  let watcher = createRecordingCloseWatcher(t, events);
+
+  watcher.onclose = (e) => { e.preventDefault(); watcher.requestClose(); }
+
+  watcher.requestClose();
+  assert_array_equals(events, ["cancel[cancelable=true]", "close"]);
+
+  watcher.requestClose();
+  assert_array_equals(events, ["cancel[cancelable=true]", "close"], "since it was inactive, no more events fired");
+}, "requestClose() inside onclose with preventDefault()");
 </script>

--- a/Source/WebCore/html/closewatcher/CloseWatcher.cpp
+++ b/Source/WebCore/html/closewatcher/CloseWatcher.cpp
@@ -106,10 +106,10 @@ void CloseWatcher::requestClose()
 
 bool CloseWatcher::requestToClose(RequireHistoryActionActivation requireHistoryActionActivation)
 {
-    if (!canBeClosed())
+    RefPtr document = downcast<Document>(scriptExecutionContext());
+    if (!isActive() || m_isRunningCancelAction || !document || !document->isFullyActive())
         return true;
 
-    RefPtr document = dynamicDowncast<Document>(scriptExecutionContext());
     Ref manager = protect(document->window())->closeWatcherManager();
     bool canPreventClose = requireHistoryActionActivation == RequireHistoryActionActivation::No || (manager->canPreventClose() && document->window()->hasHistoryActionActivation());
     Ref cancelEvent = Event::create(eventNames().cancelEvent, Event::CanBubble::No, canPreventClose ? Event::IsCancelable::Yes : Event::IsCancelable::No);
@@ -127,7 +127,8 @@ bool CloseWatcher::requestToClose(RequireHistoryActionActivation requireHistoryA
 
 void CloseWatcher::close()
 {
-    if (!canBeClosed())
+    RefPtr document = downcast<Document>(scriptExecutionContext());
+    if (!isActive() || !document || !document->isFullyActive())
         return;
 
     destroy();
@@ -137,18 +138,12 @@ void CloseWatcher::close()
     dispatchEvent(closeEvent);
 }
 
-bool CloseWatcher::canBeClosed() const
-{
-    RefPtr document = dynamicDowncast<Document>(scriptExecutionContext());
-    return isActive() && !m_isRunningCancelAction && document && document->isFullyActive();
-}
-
 void CloseWatcher::destroy()
 {
     if (!isActive())
         return;
 
-    RefPtr document = dynamicDowncast<Document>(scriptExecutionContext());
+    RefPtr document = downcast<Document>(scriptExecutionContext());
     if (document && document->window()) {
         Ref manager = protect(document->window())->closeWatcherManager();
         manager->remove(*this);

--- a/Source/WebCore/html/closewatcher/CloseWatcher.h
+++ b/Source/WebCore/html/closewatcher/CloseWatcher.h
@@ -76,8 +76,6 @@ private:
     void derefEventTarget() final { deref(); }
     void eventListenersDidChange() final;
 
-    bool canBeClosed() const;
-
     bool m_active { true };
     bool m_isRunningCancelAction { false };
     bool m_hasCancelEventListener { false };


### PR DESCRIPTION
#### 211187e7fd2e5bd42079243ce1f0b8e606446147
<pre>
CloseWatcher.close() early returns if the cancel action is running
<a href="https://bugs.webkit.org/show_bug.cgi?id=315501">https://bugs.webkit.org/show_bug.cgi?id=315501</a>

Reviewed by Anne van Kesteren.

This removes the check for m_isRunningCancelAction from running when .close() is called.
Also adds WPT coverage over this behaviour.

* LayoutTests/imported/w3c/web-platform-tests/close-watcher/inside-event-listeners-expected.txt:
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/inside-event-listeners.html:
* Source/WebCore/html/closewatcher/CloseWatcher.cpp:
(WebCore::CloseWatcher::requestToClose):
(WebCore::CloseWatcher::close):
(WebCore::CloseWatcher::destroy):
(WebCore::CloseWatcher::canBeClosed const): Deleted.
* Source/WebCore/html/closewatcher/CloseWatcher.h:

Canonical link: <a href="https://commits.webkit.org/313888@main">https://commits.webkit.org/313888@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ed3ab091fa43f7f747b8f9d988ad9bc7a63ee8d9

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164443 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37927 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31498 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173473 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121695 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166312 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38261 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37929 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127771 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89943 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167402 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30072 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147808 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108316 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29119 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27745 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21236 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139021 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25524 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175998 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28821 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27192 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136084 "Passed tests") | 
| | [  ~~🛠 vision~~](https://ews-build.webkit.org/#/builders/153/builds/37996 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31865 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136052 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36649 "Built successfully and passed tests") | [  ~~🛠 vision-sim~~](https://ews-build.webkit.org/#/builders/160/builds/38686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147319 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100824 "Built successfully") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/160/builds/38686 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24175 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37194 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110238 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36591 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2233 "") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36840 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36740 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->