### PR TITLE
REGRESSION: 'displayLinkWithTarget:selector:' is deprecated - Use the equivalent display link API on UIWindowScene

### DIFF
--- a/Source/WebKit/UIProcess/PageClient.h
+++ b/Source/WebKit/UIProcess/PageClient.h
@@ -89,6 +89,7 @@ OBJC_CLASS UIScreen;
 OBJC_CLASS UIScrollView;
 OBJC_CLASS UIView;
 OBJC_CLASS UIViewController;
+OBJC_CLASS UIWindowScene;
 OBJC_CLASS WKBaseScrollView;
 OBJC_CLASS WKBEScrollViewScrollUpdate;
 OBJC_CLASS WKFullScreenWindowController;
@@ -635,6 +636,7 @@ public:
     virtual String sceneID() = 0;
 
     virtual UIScreen *screen() = 0;
+    virtual UIWindowScene *windowScene() = 0;
 
     virtual void beginTextRecognitionForFullscreenVideo(WebCore::ShareableBitmap::Handle&&, AVPlayerViewController *) = 0;
     virtual void cancelTextRecognitionForFullscreenVideo(AVPlayerViewController *) = 0;

--- a/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm
+++ b/Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm
@@ -282,14 +282,27 @@ ALLOW_DEPRECATED_DECLARATIONS_END
     return pageClient->screen();
 }
 
+- (UIWindowScene *)_windowSceneForDisplayLink
+{
+    RefPtr page = protect(_drawingAreaProxy)->page();
+    if (!page)
+        return nil;
+
+    RefPtr pageClient = page->pageClient();
+    if (!pageClient)
+        return nil;
+
+    return pageClient->windowScene();
+}
+
 - (void)_createDisplayLink
 {
     ASSERT(!_displayLink);
 
     _screenForDisplayLink = [self _screenForDisplayLink];
 
-    if (_screenForDisplayLink)
-        _displayLink = [protect(_screenForDisplayLink) displayLinkWithTarget:self selector:@selector(displayLinkFired:)];
+    if (RetainPtr windowScene = [self _windowSceneForDisplayLink])
+        _displayLink = [windowScene displayLinkWithTarget:self selector:@selector(displayLinkFired:)];
     else {
 ALLOW_DEPRECATED_DECLARATIONS_BEGIN
         // FIXME: CoreAnimation version deprecated rdar://164090713

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.h
@@ -37,6 +37,7 @@
 
 OBJC_CLASS PlatformTextAlternatives;
 OBJC_CLASS UIScreen;
+OBJC_CLASS UIWindowScene;
 OBJC_CLASS WKContentView;
 OBJC_CLASS WKEditorUndoTarget;
 
@@ -150,6 +151,7 @@ private:
 #endif
 
     UIScreen *screen() override;
+    UIWindowScene *windowScene() override;
 
 #if ENABLE(IMAGE_ANALYSIS)
     void requestTextRecognition(const URL& imageURL, WebCore::ShareableBitmap::Handle&& imageData, const String& sourceLanguageIdentifier, const String& targetLanguageIdentifier, CompletionHandler<void(WebCore::TextRecognitionResult&&)>&&) final;

--- a/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
+++ b/Source/WebKit/UIProcess/ios/PageClientImplIOS.mm
@@ -636,6 +636,11 @@ UIScreen *PageClientImpl::screen()
     return [contentView() _screen];
 }
 
+UIWindowScene *PageClientImpl::windowScene()
+{
+    return [contentView() window].windowScene;
+}
+
 #if ENABLE(IMAGE_ANALYSIS)
 
 void PageClientImpl::requestTextRecognition(const URL& imageURL, ShareableBitmap::Handle&& imageData, const String& sourceLanguageIdentifier, const String& targetLanguageIdentifier, CompletionHandler<void(TextRecognitionResult&&)>&& completion)


### PR DESCRIPTION
#### 90efcc788b5c8635fcc6e1888ff2313772534128
<pre>
REGRESSION: &apos;displayLinkWithTarget:selector:&apos; is deprecated - Use the equivalent display link API on UIWindowScene
<a href="https://bugs.webkit.org/show_bug.cgi?id=315505">https://bugs.webkit.org/show_bug.cgi?id=315505</a>
<a href="https://rdar.apple.com/177874054">rdar://177874054</a>

Reviewed by NOBODY (OOPS!).

* Source/WebKit/UIProcess/PageClient.h:
* Source/WebKit/UIProcess/RemoteLayerTree/ios/RemoteLayerTreeDrawingAreaProxyIOS.mm:
(-[WKDisplayLinkHandler _windowSceneForDisplayLink]):
(-[WKDisplayLinkHandler _createDisplayLink]):
* Source/WebKit/UIProcess/ios/PageClientImplIOS.h:
* Source/WebKit/UIProcess/ios/PageClientImplIOS.mm:
(WebKit::PageClientImpl::windowScene):
</pre><!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/90efcc788b5c8635fcc6e1888ff2313772534128

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows | Apple Internal |
| ----- | ---------------------- | ------- |  ----- |  --------- | ------ |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164317 "Passed style check") | [❌ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37801 "Hash 90efcc78 for PR 65616 does not build (failure)") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31372 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173346 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121569 "Built successfully") | [✅ 🛠 ios-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/f681bb5d-bfd0-4a92-afe8-86f1877f2759) 
| | [❌ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38135 "Hash 90efcc78 for PR 65616 does not build (failure)") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37802 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127666 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89845 "layout-tests (failure)") | [✅ 🛠 mac-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/b22bd07e-1546-443d-ba7a-bd46dbb81c13) 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167276 "Passed tests") | [❌ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/155/builds/38135 "Hash 90efcc78 for PR 65616 does not build (failure)") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147698 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108211 "Passed tests") | | [✅ 🛠 vision-apple](https://ews-bridge.webkit.apple.com/builds/sw/T-276/9e3e4f99-fedf-4da3-8a91-4b42e965e839/0e673fe3-ca25-4c29-b602-0fa773febf35) 
| | [❌ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/155/builds/38135 "Hash 90efcc78 for PR 65616 does not build (failure)") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27632 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21110 "Built successfully") | | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/155/builds/38135 "Hash 90efcc78 for PR 65616 does not build (failure)") | | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175872 "Built successfully") | | 
| | [❌ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28693 "Failed to build and analyze WebKit") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27082 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135977 "Passed tests") | | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37472 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31751 "Found 1 new test failure: http/tests/storage/storage-map-leaking.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135946 "Passed tests") | | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38258 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147209 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100619 "Built successfully") | | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31258 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24065 "Passed tests") | | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37068 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110112 "Built successfully") | | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36464 "Built successfully") | [❌ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2122 "") | | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36714 "Built successfully") | | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36614 "Built successfully") | | | | 
<!--EWS-Status-Bubble-End-->