### PR TITLE
Enable Close Watcher API in preview

### DIFF
--- a/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
+++ b/Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml
@@ -1840,24 +1840,10 @@ ClearSiteDataHTTPHeaderEnabled:
 
 CloseWatcherEnabled:
   type: bool
-  status: testable
-  category: html
-  humanReadableName: "Close Watcher API"
-  humanReadableDescription: "Enable Close Watcher API"
-  defaultValue:
-    WebKitLegacy:
-      default: false
-    WebKit:
-      default: false
-    WebCore:
-      default: false
-
-ClosedbyAttributeEnabled:
-  type: bool
   status: preview
   category: html
-  humanReadableName: "HTML closedby attribute"
-  humanReadableDescription: "Enable HTML closedby attribute support"
+  humanReadableName: "Close Watcher API"
+  humanReadableDescription: "Enable Close Watcher API including dialog closedby attribute"
   defaultValue:
     WebKitLegacy:
       default: false

--- a/Source/WebCore/dom/Document.cpp
+++ b/Source/WebCore/dom/Document.cpp
@@ -11012,16 +11012,6 @@ HTMLDialogElement* Document::activeModalDialog() const
     return nullptr;
 }
 
-HTMLDialogElement* Document::activeCloseableDialog() const
-{
-    for (auto& dialog : m_openDialogsList | std::views::reverse) {
-        if (dialog->computedClosedByState() != ClosedByState::None)
-            return &dialog.get();
-    }
-
-    return nullptr;
-}
-
 HTMLElement* Document::topmostAutoPopover() const
 {
     if (m_autoPopoverList.isEmpty())

--- a/Source/WebCore/dom/Document.h
+++ b/Source/WebCore/dom/Document.h
@@ -1891,7 +1891,6 @@ public:
     OrderedHashSet<Ref<HTMLDialogElement>>& openDialogsList() { return m_openDialogsList; }
 
     HTMLDialogElement* activeModalDialog() const;
-    HTMLDialogElement* activeCloseableDialog() const;
     HTMLElement* NODELETE topmostAutoPopover() const;
     RefPtr<HTMLDialogElement> nearestClickedDialog(const PointerEvent&, Node&) const;
 

--- a/Source/WebCore/html/HTMLDialogElement.cpp
+++ b/Source/WebCore/html/HTMLDialogElement.cpp
@@ -373,7 +373,7 @@ Node::NeedsPostConnectionSteps HTMLDialogElement::insertionSteps(InsertionType i
     if (!insertionType.connectedToDocument)
         return NeedsPostConnectionSteps::No;
     Ref document = this->document();
-    if (document->settings().closedbyAttributeEnabled() || document->settings().closeWatcherEnabled())
+    if (document->settings().closeWatcherEnabled())
         return NeedsPostConnectionSteps::Yes;
 
     return NeedsPostConnectionSteps::No;
@@ -383,7 +383,7 @@ void HTMLDialogElement::postConnectionSteps()
 {
     HTMLElement::postConnectionSteps();
     Ref document = this->document();
-    ASSERT(document->settings().closedbyAttributeEnabled() || document->settings().closeWatcherEnabled());
+    ASSERT(document->settings().closeWatcherEnabled());
     if (!document->isFullyActive())
         return;
     if (isOpen() && isConnected())
@@ -393,7 +393,7 @@ void HTMLDialogElement::postConnectionSteps()
 void HTMLDialogElement::removingSteps(RemovalType removalType, ContainerNode& oldParentOfRemovedTree)
 {
     HTMLElement::removingSteps(removalType, oldParentOfRemovedTree);
-    if ((document().settings().closedbyAttributeEnabled() || document().settings().closeWatcherEnabled()) && isOpen())
+    if (document().settings().closeWatcherEnabled() && isOpen())
         cleanupSteps();
     setIsModal(false);
 }
@@ -407,7 +407,7 @@ void HTMLDialogElement::attributeChanged(const QualifiedName& name, const AtomSt
         Style::PseudoClassChangeInvalidation styleInvalidation(*this, CSSSelector::PseudoClass::Open, isOpen);
         m_isOpen = isOpen;
 
-        if (document->settings().closedbyAttributeEnabled() || document->settings().closeWatcherEnabled()) {
+        if (document->settings().closeWatcherEnabled()) {
             if (newValue.isNull() && !oldValue.isNull())
                 cleanupSteps();
             if (!document->isFullyActive())
@@ -418,7 +418,7 @@ void HTMLDialogElement::attributeChanged(const QualifiedName& name, const AtomSt
                 setupSteps();
         }
     } else if (name == closedbyAttr) {
-        if (document->settings().closedbyAttributeEnabled() && document->settings().closeWatcherEnabled()) {
+        if (document->settings().closeWatcherEnabled()) {
             if (m_isOpen && newValue != oldValue)
                 setCloseWatcherEnabledState();
         }
@@ -443,7 +443,7 @@ void HTMLDialogElement::setupSteps()
 #endif
 
     if (document->settings().closeWatcherEnabled())
-        setTheCloseWatcher();
+        setCloseWatcher();
 }
 
 void HTMLDialogElement::cleanupSteps()
@@ -463,7 +463,8 @@ void HTMLDialogElement::cleanupSteps()
     }
 }
 
-void HTMLDialogElement::setTheCloseWatcher()
+// https://html.spec.whatwg.org/multipage/interactive-elements.html#set-the-dialog-close-watcher
+void HTMLDialogElement::setCloseWatcher()
 {
     Ref document = this->document();
     ASSERT(document->settings().closeWatcherEnabled());

--- a/Source/WebCore/html/HTMLDialogElement.h
+++ b/Source/WebCore/html/HTMLDialogElement.h
@@ -100,7 +100,7 @@ private:
 
     void setupSteps();
     void cleanupSteps();
-    void setTheCloseWatcher();
+    void setCloseWatcher();
     void setCloseWatcherEnabledState();
 
     String m_returnValue;

--- a/Source/WebCore/html/HTMLDialogElement.idl
+++ b/Source/WebCore/html/HTMLDialogElement.idl
@@ -28,7 +28,7 @@
 ] interface HTMLDialogElement : HTMLElement {
     [CEReactions=Needed, Reflect] attribute boolean open;
     attribute DOMString returnValue;
-    [CEReactions=Needed, ReflectSetter, EnabledBySetting=ClosedbyAttributeEnabled] attribute [AtomString] DOMString closedBy;
+    [CEReactions=Needed, ReflectSetter, EnabledBySetting=CloseWatcherEnabled] attribute [AtomString] DOMString closedBy;
     [CEReactions=Needed] undefined show();
     [CEReactions=Needed] undefined showModal();
     [CEReactions=Needed] undefined close(optional DOMString returnValue);

--- a/Source/WebCore/page/EventHandler.cpp
+++ b/Source/WebCore/page/EventHandler.cpp
@@ -4550,10 +4550,7 @@ void EventHandler::defaultKeyboardEventHandler(KeyboardEvent& event)
                 if (event.isTrusted())
                     frame->document()->window()->closeWatcherManager().processCloseWatchers();
             } else {
-                if (frame->settings().closedbyAttributeEnabled()) {
-                    if (RefPtr activeCloseableDialog = frame->document()->activeCloseableDialog())
-                        activeCloseableDialog->requestClose(nullString(), nullptr);
-                } else if (RefPtr activeModalDialog = frame->document()->activeModalDialog())
+                if (RefPtr activeModalDialog = frame->document()->activeModalDialog())
                     activeModalDialog->queueCancelTask();
                 if (RefPtr topmostAutoPopover = frame->document()->topmostAutoPopover())
                     topmostAutoPopover->hidePopover();

--- a/Source/WebCore/page/PointerCaptureController.cpp
+++ b/Source/WebCore/page/PointerCaptureController.cpp
@@ -499,7 +499,7 @@ void PointerCaptureController::pointerEventWillBeDispatched(const PointerEvent& 
         setPointerCapture(&element, event.pointerId());
     }
     element.document().handlePopoverLightDismiss(event, element);
-    if (element.document().settings().closedbyAttributeEnabled())
+    if (element.document().settings().closeWatcherEnabled())
         element.document().handleDialogLightDismiss(event, element);
 }
 


### PR DESCRIPTION
#### e7614b2ab45ae73216ade1edda829ffe0fb62392
<pre>
Enable Close Watcher API in preview
<a href="https://bugs.webkit.org/show_bug.cgi?id=315502">https://bugs.webkit.org/show_bug.cgi?id=315502</a>

Reviewed by Anne van Kesteren.

This enables the Close Watcher API flag in preview and merges the flag with
that for the closedby attribute.

Many closedby tests rely on the behaviour provided by close watchers,
so it doesn&apos;t make sense to keep them separate.

Rename the setTheCloseWatcher() to setCloseWatcher() per feedback.

* Source/WTF/Scripts/Preferences/UnifiedWebPreferences.yaml:
* Source/WebCore/dom/Document.cpp:
(WebCore::Document::activeCloseableDialog const): Deleted.
* Source/WebCore/dom/Document.h:
* Source/WebCore/html/HTMLDialogElement.cpp:
(WebCore::HTMLDialogElement::insertionSteps):
(WebCore::HTMLDialogElement::postConnectionSteps):
(WebCore::HTMLDialogElement::removingSteps):
(WebCore::HTMLDialogElement::attributeChanged):
(WebCore::HTMLDialogElement::setupSteps):
(WebCore::HTMLDialogElement::setCloseWatcher):
(WebCore::HTMLDialogElement::setTheCloseWatcher): Deleted.
* Source/WebCore/html/HTMLDialogElement.h:
* Source/WebCore/html/HTMLDialogElement.idl:
* Source/WebCore/page/EventHandler.cpp:
(WebCore::EventHandler::defaultKeyboardEventHandler):
* Source/WebCore/page/PointerCaptureController.cpp:
(WebCore::PointerCaptureController::pointerEventWillBeDispatched):

Canonical link: <a href="https://commits.webkit.org/315081@main">https://commits.webkit.org/315081@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/ba0a2d87a9adb4398214a5340ff8a17f6d9cff1b

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167546 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/41041 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34636 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176601 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/125227 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169412 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41477 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/41055 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130351 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/91652 "2 flakes 3 failures") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170505 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32763 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150540 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110868 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31745 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30443 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25334 "Built successfully") | 
| [✅ 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/159836 "Built successfully and passed tests") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141732 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/28235 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/179142 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/28534 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/32035 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29953 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138747 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/41115 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34600 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138633 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37442 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41803 "Built successfully") | | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104938 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33890 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26906 "Passed tests") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/200223 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40307 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113388 "Built successfully") | [✅ 🧪 jsc-armv7-tests](https://ews-build.webkit.org/#/builders/25/builds/53807 "Passed tests") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39704 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/5007 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39955 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39849 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->