### PR TITLE
[RISCV64] Enable WebAssembly BBQJIT

### DIFF
--- a/Source/JavaScriptCore/CMakeLists.txt
+++ b/Source/JavaScriptCore/CMakeLists.txt
@@ -635,7 +635,10 @@ set(JavaScriptCore_PRIVATE_FRAMEWORK_HEADERS
     assembler/MacroAssemblerARMv7.h
     assembler/MacroAssemblerCodeRef.h
     assembler/MacroAssemblerHelpers.h
+    assembler/MacroAssemblerRISCV64.h
     assembler/MacroAssemblerX86_64.h
+    assembler/RISCV64Assembler.h
+    assembler/RISCV64Registers.h
     assembler/MaxFrameExtentForSlowPathCall.h
     assembler/OSCheck.h
     assembler/Printer.h

--- a/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
@@ -199,6 +199,25 @@ public:
         m_assembler.maskRegister<32>(dest);
     }
 
+    void add8(TrustedImm32 imm, Address address)
+    {
+        auto temp = temps<Data, Memory>();
+        auto resolution = resolveAddress(address, temp.memory());
+        if (Imm::isValid<Imm::IType>(imm.m_value)) {
+            m_assembler.lbuInsn(temp.data(), resolution.base, Imm::I(resolution.offset));
+            m_assembler.addiInsn(temp.data(), temp.data(), Imm::I(imm.m_value));
+            m_assembler.sbInsn(resolution.base, temp.data(), Imm::S(resolution.offset));
+            return;
+        }
+
+        m_assembler.lbuInsn(temp.memory(), resolution.base, Imm::I(resolution.offset));
+        loadImmediate(imm, temp.data());
+        m_assembler.addInsn(temp.data(), temp.memory(), temp.data());
+
+        resolution = resolveAddress(address, temp.memory());
+        m_assembler.sbInsn(resolution.base, temp.data(), Imm::S(resolution.offset));
+    }
+
     void add32(TrustedImm32 imm, AbsoluteAddress address)
     {
         auto temp = temps<Data, Memory>();
@@ -1701,6 +1720,15 @@ public:
         m_assembler.swInsn(temp.memory(), temp.data(), Imm::S<0>());
     }
 
+    void or32(RegisterID src, Address address)
+    {
+        auto temp = temps<Data, Memory>();
+        auto resolution = resolveAddress(address, temp.memory());
+        m_assembler.lwInsn(temp.data(), resolution.base, Imm::I(resolution.offset));
+        m_assembler.orInsn(temp.data(), src, temp.data());
+        m_assembler.swInsn(resolution.base, temp.data(), Imm::S(resolution.offset));
+    }
+
     void or32(TrustedImm32 imm, AbsoluteAddress address)
     {
         auto temp = temps<Data, Memory>();
@@ -2005,6 +2033,28 @@ public:
     void move32ToFloat(RegisterID src, FPRegisterID dest)
     {
         m_assembler.fmvInsn<RISCV64Assembler::FMVType::W, RISCV64Assembler::FMVType::X>(dest, src);
+    }
+
+    // 64-bit integer arithmetic on values held in FP registers. Used by the
+    // JSValue double boxing / NaN purification paths, where the bit pattern of
+    // a double is offset by JSValue::DoubleEncodeOffset without leaving the FP
+    // register file. RISC-V has no integer ALU on FPRs, so move through GPRs.
+    void add64(FPRegisterID op1, FPRegisterID op2, FPRegisterID dest)
+    {
+        auto temp = temps<Data, Memory>();
+        m_assembler.fmvInsn<RISCV64Assembler::FMVType::X, RISCV64Assembler::FMVType::D>(temp.data(), op1);
+        m_assembler.fmvInsn<RISCV64Assembler::FMVType::X, RISCV64Assembler::FMVType::D>(temp.memory(), op2);
+        m_assembler.addInsn(temp.data(), temp.data(), temp.memory());
+        m_assembler.fmvInsn<RISCV64Assembler::FMVType::D, RISCV64Assembler::FMVType::X>(dest, temp.data());
+    }
+
+    void sub64(FPRegisterID op1, FPRegisterID op2, FPRegisterID dest)
+    {
+        auto temp = temps<Data, Memory>();
+        m_assembler.fmvInsn<RISCV64Assembler::FMVType::X, RISCV64Assembler::FMVType::D>(temp.data(), op1);
+        m_assembler.fmvInsn<RISCV64Assembler::FMVType::X, RISCV64Assembler::FMVType::D>(temp.memory(), op2);
+        m_assembler.subInsn(temp.data(), temp.data(), temp.memory());
+        m_assembler.fmvInsn<RISCV64Assembler::FMVType::D, RISCV64Assembler::FMVType::X>(dest, temp.data());
     }
 
     void moveDouble(FPRegisterID src, FPRegisterID dest)
@@ -3607,6 +3657,18 @@ public:
         auto temp = temps<Data>();
         loadImmediate(imm, temp.data());
         convertInt32ToDouble(temp.data(), dest);
+    }
+
+    void convertUInt32ToDouble(RegisterID src, FPRegisterID dest)
+    {
+        m_assembler.fcvtInsn<RISCV64Assembler::FCVTType::D, RISCV64Assembler::FCVTType::WU>(dest, src);
+    }
+
+    void convertUInt32ToDouble(TrustedImm32 imm, FPRegisterID dest)
+    {
+        auto temp = temps<Data>();
+        loadImmediate(imm, temp.data());
+        convertUInt32ToDouble(temp.data(), dest);
     }
 
     void convertInt64ToFloat(RegisterID src, FPRegisterID dest)

--- a/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
@@ -36,6 +36,16 @@
     template<typename... Args> void methodName(Args&&...) { }
 #define MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD_WITH_RETURN(methodName, returnType) \
     template<typename... Args> returnType methodName(Args&&...) { return { }; }
+// Atomic / FP-minmax / SIMD methods needed by BBQJIT for which no native
+// RISC-V code generation exists yet. These are deliberately runtime-fatal
+// rather than silent noops: wasm shared memory and SIMD are gated off on
+// RISCV64 (useSharedArrayBuffer / useWasmSIMD), so the BBQJIT codegen for
+// atomic and SIMD wasm opcodes must never run. If something does reach
+// these, we want to know with a loud crash, not a silent miscompilation.
+#define MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(methodName) \
+    template<typename... Args> void methodName(Args&&...) { RELEASE_ASSERT_NOT_REACHED(); }
+#define MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD_WITH_RETURN(methodName, returnType) \
+    template<typename... Args> returnType methodName(Args&&...) { RELEASE_ASSERT_NOT_REACHED(); return { }; }
 
 namespace JSC {
 
@@ -852,6 +862,123 @@ public:
     MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(rotateRight32);
     MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(rotateRight64);
 
+    // Scalar BBQJIT primitives: fused shift/add and rotate-left, used by the
+    // wasm bytecode-to-machine-code path. RISC-V's baseline rv64gc has no
+    // rotate instruction (Zbb's rolw/rol would do it in one), so synthesize
+    // via shift + shift + or.
+    void addLeftShift64(RegisterID n, RegisterID m, TrustedImm32 amount, RegisterID d)
+    {
+        auto temp = temps<Data>();
+        m_assembler.slliInsn(temp.data(), m, uint32_t(amount.m_value & 63));
+        m_assembler.addInsn(d, n, temp.data());
+    }
+
+    void multiplyAddZeroExtend32(RegisterID mulLeft, RegisterID mulRight, RegisterID summand, RegisterID dest)
+    {
+        auto temp = temps<Data>();
+        m_assembler.mulwInsn(temp.data(), mulLeft, mulRight);
+        m_assembler.maskRegister<32>(temp.data());
+        m_assembler.addInsn(dest, summand, temp.data());
+    }
+
+    void rotateLeft32(RegisterID src, TrustedImm32 imm, RegisterID dest)
+    {
+        int32_t shift = imm.m_value & 31;
+        if (!shift) {
+            if (src != dest)
+                move(src, dest);
+            m_assembler.maskRegister<32>(dest);
+            return;
+        }
+        auto temp = temps<Data, Memory>();
+        m_assembler.slliwInsn(temp.data(), src, uint32_t(shift));
+        m_assembler.srliwInsn(temp.memory(), src, uint32_t(32 - shift));
+        m_assembler.orInsn(dest, temp.data(), temp.memory());
+        m_assembler.maskRegister<32>(dest);
+    }
+
+    void rotateLeft32(RegisterID src, RegisterID shift, RegisterID dest)
+    {
+        auto temp = temps<Data, Memory>();
+        m_assembler.addiInsn(temp.data(), RISCV64Registers::zero, Imm::I<32>());
+        m_assembler.subInsn(temp.data(), temp.data(), shift);
+        m_assembler.sllwInsn(temp.memory(), src, shift);
+        m_assembler.srlwInsn(temp.data(), src, temp.data());
+        m_assembler.orInsn(dest, temp.memory(), temp.data());
+        m_assembler.maskRegister<32>(dest);
+    }
+
+    void rotateLeft64(RegisterID src, TrustedImm32 imm, RegisterID dest)
+    {
+        int32_t shift = imm.m_value & 63;
+        if (!shift) {
+            if (src != dest)
+                move(src, dest);
+            return;
+        }
+        auto temp = temps<Data, Memory>();
+        m_assembler.slliInsn(temp.data(), src, uint32_t(shift));
+        m_assembler.srliInsn(temp.memory(), src, uint32_t(64 - shift));
+        m_assembler.orInsn(dest, temp.data(), temp.memory());
+    }
+
+    void rotateLeft64(RegisterID src, RegisterID shift, RegisterID dest)
+    {
+        auto temp = temps<Data, Memory>();
+        m_assembler.addiInsn(temp.data(), RISCV64Registers::zero, Imm::I<64>());
+        m_assembler.subInsn(temp.data(), temp.data(), shift);
+        m_assembler.sllInsn(temp.memory(), src, shift);
+        m_assembler.srlInsn(temp.data(), src, temp.data());
+        m_assembler.orInsn(dest, temp.memory(), temp.data());
+    }
+
+    // Integer divide / modulo via the RISC-V M extension (in rv64gc).
+    // The 32-bit forms produce a sign-extended result; mask to 32 bits.
+    void div32(RegisterID dividend, RegisterID divisor, RegisterID dest)
+    {
+        m_assembler.divwInsn(dest, dividend, divisor);
+        m_assembler.maskRegister<32>(dest);
+    }
+
+    void uDiv32(RegisterID dividend, RegisterID divisor, RegisterID dest)
+    {
+        m_assembler.divuwInsn(dest, dividend, divisor);
+        m_assembler.maskRegister<32>(dest);
+    }
+
+    void div64(RegisterID dividend, RegisterID divisor, RegisterID dest)
+    {
+        m_assembler.divInsn(dest, dividend, divisor);
+    }
+
+    void uDiv64(RegisterID dividend, RegisterID divisor, RegisterID dest)
+    {
+        m_assembler.divuInsn(dest, dividend, divisor);
+    }
+
+    // dest = minuend - (mulLeft * mulRight). Used by wasm i32/i64 rem
+    // (rem == lhs - (lhs/rhs) * rhs). RISC-V has no fused mul-sub.
+    void multiplySub32(RegisterID mulLeft, RegisterID mulRight, RegisterID minuend, RegisterID dest)
+    {
+        auto temp = temps<Data>();
+        m_assembler.mulwInsn(temp.data(), mulLeft, mulRight);
+        m_assembler.subwInsn(dest, minuend, temp.data());
+        m_assembler.maskRegister<32>(dest);
+    }
+
+    void multiplySub64(RegisterID mulLeft, RegisterID mulRight, RegisterID minuend, RegisterID dest)
+    {
+        auto temp = temps<Data>();
+        m_assembler.mulInsn(temp.data(), mulLeft, mulRight);
+        m_assembler.subInsn(dest, minuend, temp.data());
+    }
+
+    // uint32 -> single-precision float, fcvt.s.wu (one instruction).
+    void convertUInt32ToFloat(RegisterID src, FPRegisterID dest)
+    {
+        m_assembler.fcvtInsn<RISCV64Assembler::FCVTType::S, RISCV64Assembler::FCVTType::WU>(dest, src);
+    }
+
     void load8(Address address, RegisterID dest)
     {
         auto resolution = resolveAddress(address, lazyTemp<Memory>());
@@ -1438,6 +1565,73 @@ public:
     void transferPtr(BaseIndex src, BaseIndex dest)
     {
         transfer64(src, dest);
+    }
+
+    // 8- and 16-bit mem-to-mem transfers, and Address->BaseIndex
+    // variants of the existing widths, needed by BBQJIT (wasm
+    // struct copy / memory init etc.). Implemented in the same shape
+    // as the existing transfer32 / transfer64: load to a scratch
+    // register, store from it.
+    void transfer8(Address src, Address dest)
+    {
+        auto temp = temps<Data>();
+        load8(src, temp.data());
+        store8(temp.data(), dest);
+    }
+
+    void transfer8(BaseIndex src, BaseIndex dest)
+    {
+        auto temp = temps<Data>();
+        load8(src, temp.data());
+        store8(temp.data(), dest);
+    }
+
+    void transfer8(Address src, BaseIndex dest)
+    {
+        auto temp = temps<Data>();
+        load8(src, temp.data());
+        store8(temp.data(), dest);
+    }
+
+    void transfer16(Address src, Address dest)
+    {
+        auto temp = temps<Data>();
+        load16(src, temp.data());
+        store16(temp.data(), dest);
+    }
+
+    void transfer16(BaseIndex src, BaseIndex dest)
+    {
+        auto temp = temps<Data>();
+        load16(src, temp.data());
+        store16(temp.data(), dest);
+    }
+
+    void transfer16(Address src, BaseIndex dest)
+    {
+        auto temp = temps<Data>();
+        load16(src, temp.data());
+        store16(temp.data(), dest);
+    }
+
+    void transfer32(Address src, BaseIndex dest)
+    {
+        auto temp = temps<Data>();
+        load32(src, temp.data());
+        store32(temp.data(), dest);
+    }
+
+    void transfer64(Address src, BaseIndex dest)
+    {
+        auto temp = temps<Data>();
+        load64(src, temp.data());
+        store64(temp.data(), dest);
+    }
+
+    void transferVector(Address src, BaseIndex dest)
+    {
+        loadVector(src, fpTempRegister);
+        storeVector(fpTempRegister, dest);
     }
 
     void storePair32(RegisterID src1, RegisterID src2, RegisterID dest)
@@ -2165,6 +2359,116 @@ public:
     MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorMulSat);
     MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorDotProduct);
     MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorSwizzle);
+    // Additional vector noop stubs needed by BBQJIT (kept unreachable via
+    // useWasmSIMD = false on RISCV64; see Options.cpp).
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(compareFloatingPointVectorUnordered);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(moveZeroToVector);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorAbsInt64);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorConvertLowSignedInt32);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorConvertLowUnsignedInt32);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorConvertUnsigned);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorExtaddPairwiseUnsignedInt16);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorExtractPair);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorHorizontalAdd);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorLoad8Splat);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorSshl);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorSshr8);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorUshl);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorUshr8);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorSwizzle2);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorTruncSatSignedFloat64);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorTruncSatUnsignedFloat32);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorTruncSatUnsignedFloat64);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorUnsignedMax);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorUnsignedMin);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorUnzipEven);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorZipUpper);
+
+    // Wasm atomics: the RISC-V A extension is available (the OpenWrt -march
+    // baseline is rv64gc, i.e. includes A), but the AMO/LR/SC instruction
+    // emitters in RISCV64Assembler.h have not been added yet. Stub the
+    // BBQJIT atomic API with hard-fault unimplemented methods: at runtime
+    // wasm shared memory is gated off via useSharedArrayBuffer = false, so
+    // wasm atomic opcodes are unreachable, and these stubs only ever exist
+    // for compile-time completeness. Filling these in (and adding the
+    // matching RISCV64Assembler.h emitters) is a follow-up that unlocks the
+    // wasm threads proposal on RISCV64.
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(loadLinkAcq8);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(loadLinkAcq16);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(loadLinkAcq32);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(loadLinkAcq64);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(storeCondRel8);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(storeCondRel16);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(storeCondRel32);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(storeCondRel64);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD_WITH_RETURN(branchAtomicStrongCAS8, Jump);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD_WITH_RETURN(branchAtomicStrongCAS16, Jump);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD_WITH_RETURN(branchAtomicStrongCAS32, Jump);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD_WITH_RETURN(branchAtomicStrongCAS64, Jump);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicXchg8);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicXchg16);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicXchg32);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicXchg64);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicXchgAdd8);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicXchgAdd16);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicXchgAdd32);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicXchgAdd64);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicXchgClear8);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicXchgClear16);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicXchgClear32);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicXchgClear64);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicXchgOr8);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicXchgOr16);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicXchgOr32);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicXchgOr64);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicXchgXor8);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicXchgXor16);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicXchgXor32);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicXchgXor64);
+    // atomicStrongCAS{N}: the non-branching CAS overloads used by BBQJIT
+    // when the caller only needs success/failure in resultGPR (rather
+    // than a JIT-emitted branch). Same runtime-unreachable rationale as
+    // branchAtomicStrongCAS{N} above.
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicStrongCAS8);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicStrongCAS16);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicStrongCAS32);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicStrongCAS64);
+    // Additional SIMD vector noop stubs uncovered by enabling BBQJIT.
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorSplat);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorUshl8);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorSshr);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorUshr);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorMulLow);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorMulHigh);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorFusedMulAdd);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorFusedNegMulAdd);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorLoad16Splat);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorLoad32Splat);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorLoad64Splat);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorLoad8Lane);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorLoad16Lane);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorLoad32Lane);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorLoad64Lane);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorStore8Lane);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorStore16Lane);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorStore32Lane);
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorStore64Lane);
+    // vectorExtractLane / vectorReplaceLane: by-value templated stubs.
+    // The MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD form uses
+    // Args&& forwarding references; binding a SIMDInfo::lane /
+    // SIMDInfo::signMode bit-field to a non-const reference is
+    // ill-formed, so use by-value template parameters instead.
+    // (The SIMD type names are not visible in this header without
+    // pulling in <JavaScriptCore/SIMDInfo.h>, which we avoid for
+    // pure stubs.) Same unreachability rationale as the other SIMD
+    // stubs: useWasmSIMD = false on RISCV64.
+    template<typename T1, typename T2, typename T3, typename T4>
+    void vectorExtractLane(T1, T2, T3, T4) { }
+    template<typename T1, typename T2, typename T3, typename T4, typename T5>
+    void vectorExtractLane(T1, T2, T3, T4, T5) { }
+    template<typename T1, typename T2, typename T3, typename T4>
+    void vectorReplaceLane(T1, T2, T3, T4) { }
+    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(move128ToVector);
 
     template<PtrTag resultTag, PtrTag locationTag>
     static CodePtr<resultTag> readCallTarget(CodeLocationCall<locationTag> call)
@@ -3533,6 +3837,26 @@ public:
     void absDouble(FPRegisterID src, FPRegisterID dest)
     {
         m_assembler.fsgnjxInsn<64>(dest, src, src);
+    }
+
+    void floatMin(FPRegisterID op1, FPRegisterID op2, FPRegisterID dest)
+    {
+        m_assembler.fminInsn<32>(dest, op1, op2);
+    }
+
+    void floatMax(FPRegisterID op1, FPRegisterID op2, FPRegisterID dest)
+    {
+        m_assembler.fmaxInsn<32>(dest, op1, op2);
+    }
+
+    void doubleMin(FPRegisterID op1, FPRegisterID op2, FPRegisterID dest)
+    {
+        m_assembler.fminInsn<64>(dest, op1, op2);
+    }
+
+    void doubleMax(FPRegisterID op1, FPRegisterID op2, FPRegisterID dest)
+    {
+        m_assembler.fmaxInsn<64>(dest, op1, op2);
     }
 
     void ceilFloat(FPRegisterID src, FPRegisterID dest)

--- a/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
@@ -572,36 +572,51 @@ public:
 
     void countTrailingZeros32(RegisterID src, RegisterID dest)
     {
-        auto temp = temps<Data>();
-        m_assembler.addiInsn(dest, RISCV64Registers::zero, Imm::I<32>());
+        // Previously used slli (64-bit left shift) on a zero-extended 32-bit
+        // value, looking for temp == 0. That never zeros the value until the
+        // set bits fall off bit 63 - so dest decremented past zero and
+        // returned a negative result for any nonzero src. Use the more
+        // direct "right-shift and test bit 0" loop, which terminates in at
+        // most 32 iterations.
+        auto temp = temps<Data, Memory>();
         m_assembler.zeroExtend<32>(temp.data(), src);
+        m_assembler.addiInsn(dest, RISCV64Registers::zero, Imm::I<32>());
 
-        JumpList zero(makeBranch(Equal, temp.data(), RISCV64Registers::zero));
+        JumpList done(makeBranch(Equal, temp.data(), RISCV64Registers::zero));
+
+        m_assembler.addiInsn(dest, RISCV64Registers::zero, Imm::I<0>());
 
         Label loop = label();
-        m_assembler.slliInsn<1>(temp.data(), temp.data());
-        m_assembler.addiInsn(dest, dest, Imm::I<-1>());
-        zero.append(makeBranch(Equal, temp.data(), RISCV64Registers::zero));
+        m_assembler.andiInsn(temp.memory(), temp.data(), Imm::I<1>());
+        done.append(makeBranch(NotEqual, temp.memory(), RISCV64Registers::zero));
+        m_assembler.srliInsn<1>(temp.data(), temp.data());
+        m_assembler.addiInsn(dest, dest, Imm::I<1>());
         jump().linkTo(loop, this);
 
-        zero.link(this);
+        done.link(this);
     }
 
     void countTrailingZeros64(RegisterID src, RegisterID dest)
     {
-        auto temp = temps<Data>();
-        m_assembler.addiInsn(dest, RISCV64Registers::zero, Imm::I<64>());
+        // Same fix as countTrailingZeros32 for the 64-bit case: scan from
+        // bit 0 upward using right-shift + andi 1, instead of left-shifting
+        // until the value falls off the register.
+        auto temp = temps<Data, Memory>();
         m_assembler.addiInsn(temp.data(), src, Imm::I<0>());
+        m_assembler.addiInsn(dest, RISCV64Registers::zero, Imm::I<64>());
 
-        JumpList zero(makeBranch(Equal, temp.data(), RISCV64Registers::zero));
+        JumpList done(makeBranch(Equal, temp.data(), RISCV64Registers::zero));
+
+        m_assembler.addiInsn(dest, RISCV64Registers::zero, Imm::I<0>());
 
         Label loop = label();
-        m_assembler.slliInsn<1>(temp.data(), temp.data());
-        m_assembler.addiInsn(dest, dest, Imm::I<-1>());
-        zero.append(makeBranch(Equal, temp.data(), RISCV64Registers::zero));
+        m_assembler.andiInsn(temp.memory(), temp.data(), Imm::I<1>());
+        done.append(makeBranch(NotEqual, temp.memory(), RISCV64Registers::zero));
+        m_assembler.srliInsn<1>(temp.data(), temp.data());
+        m_assembler.addiInsn(dest, dest, Imm::I<1>());
         jump().linkTo(loop, this);
 
-        zero.link(this);
+        done.link(this);
     }
 
     void byteSwap16(RegisterID reg)

--- a/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
@@ -2448,55 +2448,169 @@ public:
     MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorUnzipEven);
     MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorZipUpper);
 
-    // Wasm atomics: the RISC-V A extension is available (the OpenWrt -march
-    // baseline is rv64gc, i.e. includes A), but the AMO/LR/SC instruction
-    // emitters in RISCV64Assembler.h have not been added yet. Stub the
-    // BBQJIT atomic API with hard-fault unimplemented methods: at runtime
-    // wasm shared memory is gated off via useSharedArrayBuffer = false, so
-    // wasm atomic opcodes are unreachable, and these stubs only ever exist
-    // for compile-time completeness. Filling these in (and adding the
-    // matching RISCV64Assembler.h emitters) is a follow-up that unlocks the
-    // wasm threads proposal on RISCV64.
+    // RV64A standard A-extension (always present in rv64gc): real impls
+    // for 32/64-bit primitives. 8/16-bit primitives stay UNIMPLEMENTED
+    // because base RV64A has no byte/half AMOs (Zabha is optional, not
+    // in rv64gc); BBQJIT routes 8/16 atomic ops through the
+    // WasmIPIntSlowPaths.cpp C helpers (GCC __atomic_* builtins, which
+    // expand to LR.W byte-mask loops -- properly atomic on rv64gc).
     MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(loadLinkAcq8);
     MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(loadLinkAcq16);
-    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(loadLinkAcq32);
-    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(loadLinkAcq64);
+    void loadLinkAcq32(Address address, RegisterID dest)
+    {
+        ASSERT(!address.offset);
+        m_assembler.lr_wInsn(dest, address.base, { Assembler::MemoryAccess::Acquire });
+    }
+    void loadLinkAcq64(Address address, RegisterID dest)
+    {
+        ASSERT(!address.offset);
+        m_assembler.lr_dInsn(dest, address.base, { Assembler::MemoryAccess::Acquire });
+    }
     MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(storeCondRel8);
     MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(storeCondRel16);
-    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(storeCondRel32);
-    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(storeCondRel64);
+    void storeCondRel32(RegisterID value, Address address, RegisterID status)
+    {
+        ASSERT(!address.offset);
+        m_assembler.sc_wInsn(status, address.base, value, { Assembler::MemoryAccess::Release });
+    }
+    void storeCondRel64(RegisterID value, Address address, RegisterID status)
+    {
+        ASSERT(!address.offset);
+        m_assembler.sc_dInsn(status, address.base, value, { Assembler::MemoryAccess::Release });
+    }
     MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD_WITH_RETURN(branchAtomicStrongCAS8, Jump);
     MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD_WITH_RETURN(branchAtomicStrongCAS16, Jump);
     MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD_WITH_RETURN(branchAtomicStrongCAS32, Jump);
     MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD_WITH_RETURN(branchAtomicStrongCAS64, Jump);
     MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicXchg8);
     MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicXchg16);
-    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicXchg32);
-    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicXchg64);
+    void atomicXchg32(RegisterID value, Address address, RegisterID result)
+    {
+        ASSERT(!address.offset);
+        m_assembler.amoswap_wInsn(result, address.base, value,
+            { Assembler::MemoryAccess::Acquire, Assembler::MemoryAccess::Release });
+    }
+    void atomicXchg64(RegisterID value, Address address, RegisterID result)
+    {
+        ASSERT(!address.offset);
+        m_assembler.amoswap_dInsn(result, address.base, value,
+            { Assembler::MemoryAccess::Acquire, Assembler::MemoryAccess::Release });
+    }
+    // 2-arg X86-style overloads (input-and-result in the same register).
+    // Live only in BBQJIT's isX86_64() branch, which is never taken at
+    // runtime on RISC-V; provided so the source still compiles.
+    void atomicXchg32(RegisterID valueAndResult, Address address) { atomicXchg32(valueAndResult, address, valueAndResult); }
+    void atomicXchg64(RegisterID valueAndResult, Address address) { atomicXchg64(valueAndResult, address, valueAndResult); }
     MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicXchgAdd8);
     MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicXchgAdd16);
-    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicXchgAdd32);
-    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicXchgAdd64);
+    void atomicXchgAdd32(RegisterID value, Address address, RegisterID result)
+    {
+        ASSERT(!address.offset);
+        m_assembler.amoadd_wInsn(result, address.base, value,
+            { Assembler::MemoryAccess::Acquire, Assembler::MemoryAccess::Release });
+    }
+    void atomicXchgAdd64(RegisterID value, Address address, RegisterID result)
+    {
+        ASSERT(!address.offset);
+        m_assembler.amoadd_dInsn(result, address.base, value,
+            { Assembler::MemoryAccess::Acquire, Assembler::MemoryAccess::Release });
+    }
+    void atomicXchgAdd32(RegisterID valueAndResult, Address address) { atomicXchgAdd32(valueAndResult, address, valueAndResult); }
+    void atomicXchgAdd64(RegisterID valueAndResult, Address address) { atomicXchgAdd64(valueAndResult, address, valueAndResult); }
     MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicXchgClear8);
     MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicXchgClear16);
-    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicXchgClear32);
-    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicXchgClear64);
+    // atomicXchgClear is "atomic AND NOT": no AMOANDN in base A; xori-1 + AMOAND.
+    void atomicXchgClear32(RegisterID value, Address address, RegisterID result)
+    {
+        ASSERT(!address.offset);
+        auto t = temps<Data>();
+        m_assembler.xoriInsn(t.data(), value, Imm::I<-1>());
+        m_assembler.amoand_wInsn(result, address.base, t.data(),
+            { Assembler::MemoryAccess::Acquire, Assembler::MemoryAccess::Release });
+    }
+    void atomicXchgClear64(RegisterID value, Address address, RegisterID result)
+    {
+        ASSERT(!address.offset);
+        auto t = temps<Data>();
+        m_assembler.xoriInsn(t.data(), value, Imm::I<-1>());
+        m_assembler.amoand_dInsn(result, address.base, t.data(),
+            { Assembler::MemoryAccess::Acquire, Assembler::MemoryAccess::Release });
+    }
+    void atomicXchgClear32(RegisterID valueAndResult, Address address) { atomicXchgClear32(valueAndResult, address, valueAndResult); }
+    void atomicXchgClear64(RegisterID valueAndResult, Address address) { atomicXchgClear64(valueAndResult, address, valueAndResult); }
     MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicXchgOr8);
     MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicXchgOr16);
-    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicXchgOr32);
-    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicXchgOr64);
+    void atomicXchgOr32(RegisterID value, Address address, RegisterID result)
+    {
+        ASSERT(!address.offset);
+        m_assembler.amoor_wInsn(result, address.base, value,
+            { Assembler::MemoryAccess::Acquire, Assembler::MemoryAccess::Release });
+    }
+    void atomicXchgOr64(RegisterID value, Address address, RegisterID result)
+    {
+        ASSERT(!address.offset);
+        m_assembler.amoor_dInsn(result, address.base, value,
+            { Assembler::MemoryAccess::Acquire, Assembler::MemoryAccess::Release });
+    }
+    void atomicXchgOr32(RegisterID valueAndResult, Address address) { atomicXchgOr32(valueAndResult, address, valueAndResult); }
+    void atomicXchgOr64(RegisterID valueAndResult, Address address) { atomicXchgOr64(valueAndResult, address, valueAndResult); }
     MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicXchgXor8);
     MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicXchgXor16);
-    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicXchgXor32);
-    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicXchgXor64);
-    // atomicStrongCAS{N}: the non-branching CAS overloads used by BBQJIT
-    // when the caller only needs success/failure in resultGPR (rather
-    // than a JIT-emitted branch). Same runtime-unreachable rationale as
-    // branchAtomicStrongCAS{N} above.
+    void atomicXchgXor32(RegisterID value, Address address, RegisterID result)
+    {
+        ASSERT(!address.offset);
+        m_assembler.amoxor_wInsn(result, address.base, value,
+            { Assembler::MemoryAccess::Acquire, Assembler::MemoryAccess::Release });
+    }
+    void atomicXchgXor64(RegisterID value, Address address, RegisterID result)
+    {
+        ASSERT(!address.offset);
+        m_assembler.amoxor_dInsn(result, address.base, value,
+            { Assembler::MemoryAccess::Acquire, Assembler::MemoryAccess::Release });
+    }
+    void atomicXchgXor32(RegisterID valueAndResult, Address address) { atomicXchgXor32(valueAndResult, address, valueAndResult); }
+    void atomicXchgXor64(RegisterID valueAndResult, Address address) { atomicXchgXor64(valueAndResult, address, valueAndResult); }
+    // atomicStrongCAS{32,64}(expectedAndResult, newValue, address):
+    // Loads *address into expectedAndResult; if old == caller's expected,
+    // stores newValue. Same external contract as ARM64-LSE casa. Caller
+    // checks expectedAndResult == old-expected to detect success.
     MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicStrongCAS8);
     MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicStrongCAS16);
-    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicStrongCAS32);
-    MACRO_ASSEMBLER_RISCV64_TEMPLATED_UNIMPLEMENTED_METHOD(atomicStrongCAS64);
+    void atomicStrongCAS32(RegisterID expectedAndResult, RegisterID newValue, Address address)
+    {
+        ASSERT(!address.offset);
+        auto t = temps<Data, Memory>();
+        Label loop = label();
+        m_assembler.lr_wInsn(t.data(), address.base, { Assembler::MemoryAccess::Acquire });
+        m_assembler.addiwInsn(t.memory(), expectedAndResult, Imm::I<0>());
+        Jump mismatch = makeBranch(NotEqual, t.data(), t.memory());
+        m_assembler.sc_wInsn(t.memory(), address.base, newValue, { Assembler::MemoryAccess::Release });
+        Jump scFail = makeBranch(NotEqual, t.memory(), RISCV64Registers::zero);
+        scFail.linkTo(loop, this);
+        mismatch.link(this);
+        m_assembler.addiInsn(expectedAndResult, t.data(), Imm::I<0>());
+    }
+    void atomicStrongCAS64(RegisterID expectedAndResult, RegisterID newValue, Address address)
+    {
+        ASSERT(!address.offset);
+        auto t = temps<Data, Memory>();
+        Label loop = label();
+        m_assembler.lr_dInsn(t.data(), address.base, { Assembler::MemoryAccess::Acquire });
+        Jump mismatch = makeBranch(NotEqual, t.data(), expectedAndResult);
+        m_assembler.sc_dInsn(t.memory(), address.base, newValue, { Assembler::MemoryAccess::Release });
+        Jump scFail = makeBranch(NotEqual, t.memory(), RISCV64Registers::zero);
+        scFail.linkTo(loop, this);
+        mismatch.link(this);
+        m_assembler.addiInsn(expectedAndResult, t.data(), Imm::I<0>());
+    }
+    // 5-arg StatusCondition form (X86-style). Live only in BBQJIT's
+    // isX86_64() branch -- on RISC-V the surrounding code exits via
+    // an earlier `return;` so this never runs at runtime. Provide a
+    // viable overload so the source still compiles.
+    void atomicStrongCAS32(StatusCondition, RegisterID, RegisterID, Address, RegisterID)
+        { RELEASE_ASSERT_NOT_REACHED(); }
+    void atomicStrongCAS64(StatusCondition, RegisterID, RegisterID, Address, RegisterID)
+        { RELEASE_ASSERT_NOT_REACHED(); }
     // Additional SIMD vector noop stubs uncovered by enabling BBQJIT.
     MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorSplat);
     MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(vectorUshl8);

--- a/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
@@ -859,8 +859,72 @@ public:
         m_assembler.srliInsn(dest, src, uint32_t(imm.m_value & ((1 << 6) - 1)));
     }
 
-    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(rotateRight32);
-    MACRO_ASSEMBLER_RISCV64_TEMPLATED_NOOP_METHOD(rotateRight64);
+    // rotateRight32/64: native rv64gc has no rotate instruction (Zbb's
+    // rorw/ror would do it in one), so synthesise via shift + shift + or.
+    // These are called by BBQJIT's I32Rotl/I32Rotr/I64Rotl/I64Rotr handlers
+    // on every non-x86 path (the rotl variants are routed through
+    // rotateRight32 with a negated shift, so a broken or missing
+    // rotateRight* silently miscompiles both rotr and rotl).
+    void rotateRight32(RegisterID src, TrustedImm32 imm, RegisterID dest)
+    {
+        int32_t shift = imm.m_value & 31;
+        if (!shift) {
+            if (src != dest)
+                move(src, dest);
+            m_assembler.maskRegister<32>(dest);
+            return;
+        }
+        auto temp = temps<Data, Memory>();
+        m_assembler.srliwInsn(temp.data(), src, uint32_t(shift));
+        m_assembler.slliwInsn(temp.memory(), src, uint32_t(32 - shift));
+        m_assembler.orInsn(dest, temp.data(), temp.memory());
+        m_assembler.maskRegister<32>(dest);
+    }
+
+    void rotateRight32(RegisterID src, RegisterID shift, RegisterID dest)
+    {
+        auto temp = temps<Data, Memory>();
+        m_assembler.addiInsn(temp.data(), RISCV64Registers::zero, Imm::I<32>());
+        m_assembler.subInsn(temp.data(), temp.data(), shift);
+        m_assembler.srlwInsn(temp.memory(), src, shift);
+        m_assembler.sllwInsn(temp.data(), src, temp.data());
+        m_assembler.orInsn(dest, temp.memory(), temp.data());
+        m_assembler.maskRegister<32>(dest);
+    }
+
+    void rotateRight64(RegisterID src, TrustedImm32 imm, RegisterID dest)
+    {
+        int32_t shift = imm.m_value & 63;
+        if (!shift) {
+            if (src != dest)
+                move(src, dest);
+            return;
+        }
+        auto temp = temps<Data, Memory>();
+        m_assembler.srliInsn(temp.data(), src, uint32_t(shift));
+        m_assembler.slliInsn(temp.memory(), src, uint32_t(64 - shift));
+        m_assembler.orInsn(dest, temp.data(), temp.memory());
+    }
+
+    void rotateRight64(RegisterID src, RegisterID shift, RegisterID dest)
+    {
+        auto temp = temps<Data, Memory>();
+        m_assembler.addiInsn(temp.data(), RISCV64Registers::zero, Imm::I<64>());
+        m_assembler.subInsn(temp.data(), temp.data(), shift);
+        m_assembler.srlInsn(temp.memory(), src, shift);
+        m_assembler.sllInsn(temp.data(), src, temp.data());
+        m_assembler.orInsn(dest, temp.memory(), temp.data());
+    }
+
+    // Two-operand in-place variants used by MacroAssembler.h convenience
+    // wrappers (e.g. urshiftPtr / rolPtr / FastRotation::apply). These were
+    // matched by the previous templated NOOP overload and silently did
+    // nothing; forward to the three-operand form so callers see the real
+    // rotate.
+    void rotateRight32(TrustedImm32 imm, RegisterID srcDst) { rotateRight32(srcDst, imm, srcDst); }
+    void rotateRight64(TrustedImm32 imm, RegisterID srcDst) { rotateRight64(srcDst, imm, srcDst); }
+    void rotateRight32(RegisterID shift, RegisterID srcDst) { rotateRight32(srcDst, shift, srcDst); }
+    void rotateRight64(RegisterID shift, RegisterID srcDst) { rotateRight64(srcDst, shift, srcDst); }
 
     // Scalar BBQJIT primitives: fused shift/add and rotate-left, used by the
     // wasm bytecode-to-machine-code path. RISC-V's baseline rv64gc has no

--- a/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
+++ b/Source/JavaScriptCore/assembler/MacroAssemblerRISCV64.h
@@ -4708,6 +4708,7 @@ private:
     void testFinalize(ResultCondition cond, RegisterID src, RegisterID dest)
     {
         switch (cond) {
+        case Carry:
         case Overflow:
         case Signed:
         case PositiveOrZero:

--- a/Source/JavaScriptCore/assembler/RISCV64Assembler.h
+++ b/Source/JavaScriptCore/assembler/RISCV64Assembler.h
@@ -1832,6 +1832,37 @@ public:
     void remwInsn(RegisterID rd, RegisterID rs1, RegisterID rs2) { insn(RISCV64Instructions::REMW::construct(rd, rs1, rs2)); }
     void remuwInsn(RegisterID rd, RegisterID rs1, RegisterID rs2) { insn(RISCV64Instructions::REMUW::construct(rd, rs1, rs2)); }
 
+    // RV{32,64}A standard A-extension (always present in rv64gc).
+    // For sequential consistency pass { Acquire, Release } (.aqrl).
+    void lr_wInsn(RegisterID rd, RegisterID rs1, std::initializer_list<RISCV64Instructions::MemoryAccess> aqrl)
+        { insn(RISCV64Instructions::LR_W::construct(rd, rs1, RegisterID::zero, aqrl)); }
+    void lr_dInsn(RegisterID rd, RegisterID rs1, std::initializer_list<RISCV64Instructions::MemoryAccess> aqrl)
+        { insn(RISCV64Instructions::LR_D::construct(rd, rs1, RegisterID::zero, aqrl)); }
+    void sc_wInsn(RegisterID rd, RegisterID rs1, RegisterID rs2, std::initializer_list<RISCV64Instructions::MemoryAccess> aqrl)
+        { insn(RISCV64Instructions::SC_W::construct(rd, rs1, rs2, aqrl)); }
+    void sc_dInsn(RegisterID rd, RegisterID rs1, RegisterID rs2, std::initializer_list<RISCV64Instructions::MemoryAccess> aqrl)
+        { insn(RISCV64Instructions::SC_D::construct(rd, rs1, rs2, aqrl)); }
+    void amoswap_wInsn(RegisterID rd, RegisterID rs1, RegisterID rs2, std::initializer_list<RISCV64Instructions::MemoryAccess> aqrl)
+        { insn(RISCV64Instructions::AMOSWAP_W::construct(rd, rs1, rs2, aqrl)); }
+    void amoswap_dInsn(RegisterID rd, RegisterID rs1, RegisterID rs2, std::initializer_list<RISCV64Instructions::MemoryAccess> aqrl)
+        { insn(RISCV64Instructions::AMOSWAP_D::construct(rd, rs1, rs2, aqrl)); }
+    void amoadd_wInsn(RegisterID rd, RegisterID rs1, RegisterID rs2, std::initializer_list<RISCV64Instructions::MemoryAccess> aqrl)
+        { insn(RISCV64Instructions::AMOADD_W::construct(rd, rs1, rs2, aqrl)); }
+    void amoadd_dInsn(RegisterID rd, RegisterID rs1, RegisterID rs2, std::initializer_list<RISCV64Instructions::MemoryAccess> aqrl)
+        { insn(RISCV64Instructions::AMOADD_D::construct(rd, rs1, rs2, aqrl)); }
+    void amoxor_wInsn(RegisterID rd, RegisterID rs1, RegisterID rs2, std::initializer_list<RISCV64Instructions::MemoryAccess> aqrl)
+        { insn(RISCV64Instructions::AMOXOR_W::construct(rd, rs1, rs2, aqrl)); }
+    void amoxor_dInsn(RegisterID rd, RegisterID rs1, RegisterID rs2, std::initializer_list<RISCV64Instructions::MemoryAccess> aqrl)
+        { insn(RISCV64Instructions::AMOXOR_D::construct(rd, rs1, rs2, aqrl)); }
+    void amoand_wInsn(RegisterID rd, RegisterID rs1, RegisterID rs2, std::initializer_list<RISCV64Instructions::MemoryAccess> aqrl)
+        { insn(RISCV64Instructions::AMOAND_W::construct(rd, rs1, rs2, aqrl)); }
+    void amoand_dInsn(RegisterID rd, RegisterID rs1, RegisterID rs2, std::initializer_list<RISCV64Instructions::MemoryAccess> aqrl)
+        { insn(RISCV64Instructions::AMOAND_D::construct(rd, rs1, rs2, aqrl)); }
+    void amoor_wInsn(RegisterID rd, RegisterID rs1, RegisterID rs2, std::initializer_list<RISCV64Instructions::MemoryAccess> aqrl)
+        { insn(RISCV64Instructions::AMOOR_W::construct(rd, rs1, rs2, aqrl)); }
+    void amoor_dInsn(RegisterID rd, RegisterID rs1, RegisterID rs2, std::initializer_list<RISCV64Instructions::MemoryAccess> aqrl)
+        { insn(RISCV64Instructions::AMOOR_D::construct(rd, rs1, rs2, aqrl)); }
+
     using FCVTType = RISCV64Instructions::FCVTType;
     using FMVType = RISCV64Instructions::FMVType;
 

--- a/Source/JavaScriptCore/jit/FPRInfo.h
+++ b/Source/JavaScriptCore/jit/FPRInfo.h
@@ -366,7 +366,7 @@ public:
     static constexpr FPRReg argumentFPR7 = RISCV64Registers::f17; // fpRegT7
 
     static constexpr FPRReg returnValueFPR = RISCV64Registers::f10; // fpRegT0
-    static constexpr FPRReg nonPreservedNonArgumentFPR0 = RISCV64Registers::f11;
+    static constexpr FPRReg nonPreservedNonArgumentFPR0 = RISCV64Registers::f0;
 
     static FPRReg toRegister(unsigned index)
     {

--- a/Source/JavaScriptCore/jit/GdbJIT.cpp
+++ b/Source/JavaScriptCore/jit/GdbJIT.cpp
@@ -1164,6 +1164,11 @@ private:
 #elif CPU(ARM64)
         RegisterFP = 29,
         RegisterLR = 30,
+#elif CPU(RISCV64)
+        // RISC-V psABI: DWARF register numbers match x0..x31, so the frame
+        // pointer s0/x8 is 8 and the return-address register ra/x1 is 1.
+        RegisterFP = 8,
+        RegisterLR = 1,
 #else
         RegisterFP = 7,
         RegisterLR = 14,

--- a/Source/JavaScriptCore/jit/OperationResult.h
+++ b/Source/JavaScriptCore/jit/OperationResult.h
@@ -47,7 +47,7 @@ template<typename T>
 concept canMakeExceptionOperationResult =
     std::is_standard_layout_v<T>
     && std::is_trivial_v<T>
-#if CPU(ARM64) || CPU(ARM_THUMB2)
+#if CPU(ARM64) || CPU(ARM_THUMB2) || CPU(RISCV64)
     && !std::is_floating_point_v<T> // The ARM64 ABI says that this should be returned in x0 instead of d0. Seems unlikely it's worth it to do the extra fmov.
 #endif
     && sizeof(T) <= sizeof(CPURegister);

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
@@ -637,6 +637,11 @@ macro forEachWasmArgumentGPR(fn)
         fn(2, wa2, wa3)
         fn(4, wa4, wa5)
         fn(6, wa6, wa7)
+    elsif RISCV64
+        fn(0, wa0, wa1)
+        fn(2, wa2, wa3)
+        fn(4, wa4, wa5)
+        fn(6, wa6, wa7)
     elsif JSVALUE64
         fn(0, wa0, wa1)
         fn(2, wa2, wa3)

--- a/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
+++ b/Source/JavaScriptCore/llint/InPlaceInterpreter.asm
@@ -2743,4 +2743,20 @@ unimplementedInstruction(_i32_atomic_rmw16_cmpxchg_u)
 unimplementedInstruction(_i64_atomic_rmw8_cmpxchg_u)
 unimplementedInstruction(_i64_atomic_rmw16_cmpxchg_u)
 unimplementedInstruction(_i64_atomic_rmw32_cmpxchg_u)
+
+# LowLevelInterpreter.asm captures the addresses of these labels via
+# 'lla' / equivalent for the IPInt call sequence, so they have to exist
+# at link time on architectures that enable WEBASSEMBLY but have no
+# IPInt implementation. They should never be reached at run time.
+_wasm_trampoline_wasm_ipint_call:
+_wasm_trampoline_wasm_ipint_call_wide16:
+_wasm_trampoline_wasm_ipint_call_wide32:
+_wasm_trampoline_wasm_ipint_tail_call:
+_wasm_trampoline_wasm_ipint_tail_call_wide16:
+_wasm_trampoline_wasm_ipint_tail_call_wide32:
+
+_wasm_ipint_call_return_location:
+_wasm_ipint_call_return_location_wide16:
+_wasm_ipint_call_return_location_wide32:
+    crash()
 end

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.asm
@@ -365,6 +365,52 @@ elsif X86_64
     const wfa7 = ft7
 
     const fr = fa0
+elsif RISCV64
+    const a0 = t0
+    const a1 = t1
+    const a2 = t2
+    const a3 = t3
+    const a4 = t4
+    const a5 = t5
+    const a6 = t6
+    const a7 = t7
+
+    const wa0 = a0
+    const wa1 = a1
+    const wa2 = a2
+    const wa3 = a3
+    const wa4 = a4
+    const wa5 = a5
+    const wa6 = a6
+    const wa7 = a7
+
+    # RISCV64 uses all eight argument GPRs (a0-a7 == t0-t7); the only
+    # non-argument temporaries left for the WebAssembly scratch
+    # registers are t8 and t9. ws2/ws3 are unavailable, matching the
+    # X86_64 configuration above.
+    const ws0 = t8
+    const ws1 = t9
+    const ws2 = invalidGPR
+    const ws3 = invalidGPR
+
+    const r0 = a0
+    const r1 = a1
+
+    const fa0 = ft0
+    const fa1 = ft1
+    const fa2 = ft2
+    const fa3 = ft3
+
+    const wfa0 = fa0
+    const wfa1 = fa1
+    const wfa2 = fa2
+    const wfa3 = fa3
+    const wfa4 = ft4
+    const wfa5 = ft5
+    const wfa6 = ft6
+    const wfa7 = ft7
+
+    const fr = fa0
 else
     const a0 = t0
     const a1 = t1

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.cpp
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.cpp
@@ -569,15 +569,6 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
     ".thumb\n"                                   \
     ".thumb_func " THUMB_FUNC_PARAM(label) "\n"  \
     SYMBOL_STRING(label) ":\n"
-#elif CPU(RISCV64)
-#define OFFLINE_ASM_GLOBAL_LABEL_IMPL(label, ALT_ENTRY, ALIGNMENT, VISIBILITY) \
-    OFFLINE_ASM_TEXT_SECTION                    \
-    ALIGNMENT                                   \
-    ALT_ENTRY(label)                            \
-    ".globl " SYMBOL_STRING(label) "\n"         \
-    ".attribute arch, \"rv64gc\"" "\n"          \
-    VISIBILITY(label) "\n"                      \
-    SYMBOL_STRING(label) ":\n"
 #else
 #define OFFLINE_ASM_GLOBAL_LABEL_IMPL(label, ALT_ENTRY, ALIGNMENT, VISIBILITY) \
     OFFLINE_ASM_TEXT_SECTION                    \

--- a/Source/JavaScriptCore/llint/LowLevelInterpreter.cpp
+++ b/Source/JavaScriptCore/llint/LowLevelInterpreter.cpp
@@ -520,13 +520,30 @@ WTF_ALLOW_UNSAFE_BUFFER_USAGE_END
 // the jsc_llint_begin and jsc_llint_end labels help lldb_webkit.py find the
 // start and end of the llint instruction range quickly.
 
+// On RISC-V, the linker (mold) relaxes `auipc + jalr/addi` pairs into single
+// `j`/`addi`-via-gp instructions, shrinking IPInt opcode handlers by 4 bytes
+// each. The `.balignw 256` padding that follows each handler is not recomputed
+// after relaxation, so consecutive `ipint_*_validate` labels end up 252 bytes
+// apart instead of 256, and `IPInt::initialize()`'s `VALIDATE_IPINT_OPCODE`
+// asserts fire. Suppress relaxation across the entire LLInt asm to keep all
+// 256-byte-aligned dispatch slots intact.
+#if CPU(RISCV64)
+#define OFFLINE_ASM_BEGIN_OPTIONS ".option push\n.option norelax\n"
+#define OFFLINE_ASM_END_OPTIONS ".option pop\n"
+#else
+#define OFFLINE_ASM_BEGIN_OPTIONS ""
+#define OFFLINE_ASM_END_OPTIONS ""
+#endif
+
 #define OFFLINE_ASM_BEGIN   __asm__( \
+    OFFLINE_ASM_BEGIN_OPTIONS \
     OFFLINE_ASM_GLOBAL_LABEL_IMPL(jsc_llint_begin, OFFLINE_ASM_NO_ALT_ENTRY_DIRECTIVE, OFFLINE_ASM_ALIGN4B, HIDE_SYMBOL) \
     OFFLINE_ASM_BEGIN_SPACER
 
 #define OFFLINE_ASM_END \
     OFFLINE_ASM_BEGIN_SPACER \
     OFFLINE_ASM_GLOBAL_LABEL_IMPL(jsc_llint_end, OFFLINE_ASM_NO_ALT_ENTRY_DIRECTIVE, OFFLINE_ASM_ALIGN4B, HIDE_SYMBOL) \
+    OFFLINE_ASM_END_OPTIONS \
 );
 
 #if ENABLE(LLINT_EMBEDDED_OPCODE_ID)

--- a/Source/JavaScriptCore/offlineasm/riscv64.rb
+++ b/Source/JavaScriptCore/offlineasm/riscv64.rb
@@ -217,22 +217,32 @@ end
 class FPRegisterID
     def riscv64Operand
         case @name
+        # The LLInt convention assumes that ft0..ft7 are the platform's
+        # FP argument registers (used as scratches between calls). On X86
+        # and ARM64 the FP temp and FP arg registers happen to coincide
+        # (xmm0-7 / q0-7). RISC-V's ABI splits them: ft0..ft7 = f0..f7 are
+        # temps, fa0..fa7 = f10..f17 are args. To keep LLInt's wfa* aliases
+        # (which chain wfa0 -> fa0 -> ft0) resolving to the wasm arg FPRs,
+        # we map offlineasm's ft0..ft7 directly to physical f10..f17 here.
+        # Physical f0..f7 become unreachable from offlineasm, but JSC's
+        # C++-side FPRInfo still uses them as fpRegT8..fpRegT15 (the JIT
+        # and offlineasm don't share register state across call boundaries).
         when 'ft0'
-            'f0'
+            'f10'
         when 'ft1'
-            'f1'
+            'f11'
         when 'ft2'
-            'f2'
+            'f12'
         when 'ft3'
-            'f3'
+            'f13'
         when 'ft4'
-            'f4'
+            'f14'
         when 'ft5'
-            'f5'
+            'f15'
         when 'ft6'
-            'f6'
+            'f16'
         when 'ft7'
-            'f7'
+            'f17'
         when 'csfr0'
             'f8'
         when 'csfr1'

--- a/Source/JavaScriptCore/offlineasm/riscv64.rb
+++ b/Source/JavaScriptCore/offlineasm/riscv64.rb
@@ -34,9 +34,9 @@
 # x2  => sp (through alias sp) (RISC-V stack pointer register)
 # x3  => not used (RISC-V global pointer register)
 # x4  => not used (RISC-V thread pointer register)
-# x5  => not used
-# x6  => ws0
-# x7  => ws1
+# x5  => t8
+# x6  => t9
+# x7  => not used
 # x8  => cfr (through alias fp) (RISC-V frame pointer register)
 # x9  => csr0
 # x10 => t0, a0, wa0, r0
@@ -70,8 +70,8 @@
 # f3  => ft3
 # f4  => ft4
 # f5  => ft5
-# f6  => not used
-# f7  => not used
+# f6  => ft6
+# f7  => ft7
 # f8  => csfr0
 # f9  => csfr1
 # f10 => fa0, wfa0
@@ -170,10 +170,10 @@ class RegisterID
             'x16'
         when 't7', 'a7', 'wa7'
             'x17'
-        when 'ws0'
+        when 't8'
+            'x5'
+        when 't9'
             'x6'
-        when 'ws1'
-            'x7'
         when 'csr0'
             'x9'
         when 'csr1'
@@ -223,6 +223,10 @@ class FPRegisterID
             'f4'
         when 'ft5'
             'f5'
+        when 'ft6'
+            'f6'
+        when 'ft7'
+            'f7'
         when 'csfr0'
             'f8'
         when 'csfr1'
@@ -392,6 +396,22 @@ def riscv64LowerOperandIntoRegisterAndSignExtend(newList, node, operand, size, f
 
     riscv64LowerEmitSignExtension(newList, node, size, source, destination)
     destination
+end
+
+def riscv64LowerTransfer(list)
+    newList = []
+    list.each {
+        | node |
+        if node.is_a?(Instruction) and ["transferi", "transferp", "transferq"].include?(node.opcode)
+            size = node.opcode[-1, 1]
+            tmp = Tmp.new(node.codeOrigin, :gpr)
+            newList << Instruction.new(node.codeOrigin, "load#{size}", [node.operands[0], tmp])
+            newList << Instruction.new(node.codeOrigin, "store#{size}", [tmp, node.operands[1]])
+        else
+            newList << node
+        end
+    }
+    newList
 end
 
 def riscv64LowerMisplacedAddresses(list)
@@ -1541,6 +1561,7 @@ class Sequence
         result = @list
 
         result = riscDropTags(result)
+        result = riscv64LowerTransfer(result)
         result = riscLowerMalformedAddresses(result) {
             | node, address |
             if address.is_a? Address

--- a/Source/JavaScriptCore/offlineasm/riscv64.rb
+++ b/Source/JavaScriptCore/offlineasm/riscv64.rb
@@ -122,6 +122,12 @@ def riscv64OperandTypes(operands)
             else
                 raise "Invalid Tmp operand #{op.kind}"
             end
+        elsif op.is_a? VecRegisterID
+            # Vector registers are aliased to single FPRs on RISC-V (no V
+            # extension); treat them as FPRegisterID for validation so the
+            # existing [Address, FPRegisterID] / [FPRegisterID, Address]
+            # patterns match loadv/storev/pushv/popv operands.
+            FPRegisterID
         else
             op.class
         end
@@ -269,6 +275,40 @@ class FPRegisterID
             'f27'
         else
             raise "Bad register name #{@name} at #{codeOriginString}"
+        end
+    end
+end
+
+class VecRegisterID
+    # Pseudo-vector registers v0..v7 (and lane variants) for the IPInt
+    # interpreter, which stores every wasm operand-stack value in a
+    # 16-byte slot regardless of type. RISC-V baseline rv64gc has no V
+    # extension and no 128-bit register, so each v-reg is aliased to a
+    # single 64-bit FPR (the low half of the slot); pushv/popv/loadv/
+    # storev below operate on 16-byte slots but only move 8 bytes of
+    # payload. Safe because wasm SIMD is gated off at runtime
+    # (Options::useWasmSIMD = false on RISCV64) so the upper 8 bytes
+    # are pure padding.
+    def riscv64Operand
+        case @name
+        when 'v0', 'v0_b', 'v0_h', 'v0_i', 'v0_q'
+            'f0'
+        when 'v1', 'v1_b', 'v1_h', 'v1_i', 'v1_q'
+            'f1'
+        when 'v2', 'v2_b', 'v2_h', 'v2_i', 'v2_q'
+            'f2'
+        when 'v3', 'v3_b', 'v3_h', 'v3_i', 'v3_q'
+            'f3'
+        when 'v4', 'v4_b', 'v4_h', 'v4_i', 'v4_q'
+            'f4'
+        when 'v5', 'v5_b', 'v5_h', 'v5_i', 'v5_q'
+            'f5'
+        when 'v6', 'v6_b', 'v6_h', 'v6_i', 'v6_q'
+            'f6'
+        when 'v7', 'v7_b', 'v7_h', 'v7_i', 'v7_q'
+            'f7'
+        else
+            raise "Bad vector register name #{@name} at #{codeOriginString}"
         end
     end
 end
@@ -651,6 +691,43 @@ def riscv64LowerOperation(list)
         newList << Instruction.new(node.codeOrigin, "rv_addi", [sp, Immediate.new(node.codeOrigin, size), sp])
     end
 
+    # pushv / popv reserve 16 bytes per operand because the IPInt wasm
+    # operand stack uses 16-byte slots uniformly. RISC-V baseline rv64gc
+    # has no V extension, so each v-reg is aliased to a single 64-bit FPR;
+    # only the low 8 bytes are written/read, the upper 8 bytes are pure
+    # padding (wasm SIMD is disabled at runtime on this arch).
+    def emitPushv(newList, node)
+        sp = RegisterID.forName(node.codeOrigin, 'sp')
+        size = 16 * node.operands.size
+        newList << Instruction.new(node.codeOrigin, "rv_addi", [sp, Immediate.new(node.codeOrigin, -size), sp])
+        node.operands.reverse.each_with_index {
+            | op, index |
+            offset = size - 16 * (index + 1)
+            newList << Instruction.new(node.codeOrigin, "rv_fsd", [op, Address.new(node.codeOrigin, sp, Immediate.new(node.codeOrigin, offset))])
+        }
+    end
+
+    def emitPopv(newList, node)
+        sp = RegisterID.forName(node.codeOrigin, 'sp')
+        size = 16 * node.operands.size
+        node.operands.each_with_index {
+            | op, index |
+            offset = size - 16 * (index + 1)
+            newList << Instruction.new(node.codeOrigin, "rv_fld", [Address.new(node.codeOrigin, sp, Immediate.new(node.codeOrigin, offset)), op])
+        }
+        newList << Instruction.new(node.codeOrigin, "rv_addi", [sp, Immediate.new(node.codeOrigin, size), sp])
+    end
+
+    def emitLoadv(newList, node)
+        riscv64ValidateOperands(node.operands, [Address, FPRegisterID])
+        newList << Instruction.new(node.codeOrigin, "rv_fld", node.operands)
+    end
+
+    def emitStorev(newList, node)
+        riscv64ValidateOperands(node.operands, [FPRegisterID, Address])
+        newList << Instruction.new(node.codeOrigin, "rv_fsd", node.operands)
+    end
+
     def emitAdditionOperation(newList, node, operation, size)
         operands = node.operands
         if operands.size == 2
@@ -790,38 +867,56 @@ def riscv64LowerOperation(list)
     def emitBitExtensionOperation(newList, node, extension, fromSize, toSize)
         raise "Invalid operand types" unless riscv64OperandTypes(node.operands) == [RegisterID, RegisterID]
 
-        if [[:s, :i, :p], [:s, :i, :q]].include? [extension, fromSize, toSize]
-            newList << Instruction.new(node.codeOrigin, "rv_sext.w", node.operands)
-            return
-        end
-
         source = node.operands[0]
         dest = node.operands[1]
 
-        if [[:z, :i, :p], [:z, :i, :q]].include? [extension, fromSize, toSize]
+        # On RISC-V :p (pointer) is the same width as :q (64-bit).
+        targetSize = (toSize == :p) ? :q : toSize
+
+        case [extension, fromSize, targetSize]
+        when [:s, :i, :q]
+            newList << Instruction.new(node.codeOrigin, "rv_sext.w", [source, dest])
+            return
+        when [:s, :i, :i]
+            # Already an i32 in canonical RISC-V form (low 32 bits = value,
+            # upper 32 bits = sign-extension of bit 31). sext.w re-normalises
+            # in case the source was produced by a non-canonical sequence.
+            newList << Instruction.new(node.codeOrigin, "rv_sext.w", [source, dest])
+            return
+        when [:z, :i, :q]
+            newList << Instruction.new(node.codeOrigin, "rv_slli", [source, Immediate.new(node.codeOrigin, 32), dest])
+            newList << Instruction.new(node.codeOrigin, "rv_srli", [dest, Immediate.new(node.codeOrigin, 32), dest])
+            return
+        when [:z, :i, :i]
+            # Lower 32 bits of source already hold the value; clearing the
+            # upper 32 bits gives the :i canonical representation.
             newList << Instruction.new(node.codeOrigin, "rv_slli", [source, Immediate.new(node.codeOrigin, 32), dest])
             newList << Instruction.new(node.codeOrigin, "rv_srli", [dest, Immediate.new(node.codeOrigin, 32), dest])
             return
         end
 
-        raise "Invalid zero extension" unless extension == :s
-        case [fromSize, toSize]
-        when [:b, :i]
+        case [extension, fromSize, targetSize]
+        when [:s, :b, :i]
             newList << Instruction.new(node.codeOrigin, "rv_slli", [source, Immediate.new(node.codeOrigin, 56), dest])
             newList << Instruction.new(node.codeOrigin, "rv_srai", [dest, Immediate.new(node.codeOrigin, 24), dest])
             newList << Instruction.new(node.codeOrigin, "rv_srli", [dest, Immediate.new(node.codeOrigin, 32), dest])
-        when [:b, :q]
+        when [:s, :b, :q]
             newList << Instruction.new(node.codeOrigin, "rv_slli", [source, Immediate.new(node.codeOrigin, 56), dest])
             newList << Instruction.new(node.codeOrigin, "rv_srai", [dest, Immediate.new(node.codeOrigin, 56), dest])
-        when [:h, :i]
+        when [:s, :h, :i]
             newList << Instruction.new(node.codeOrigin, "rv_slli", [source, Immediate.new(node.codeOrigin, 48), dest])
             newList << Instruction.new(node.codeOrigin, "rv_srai", [dest, Immediate.new(node.codeOrigin, 16), dest])
             newList << Instruction.new(node.codeOrigin, "rv_srli", [dest, Immediate.new(node.codeOrigin, 32), dest])
-        when [:h, :q]
+        when [:s, :h, :q]
             newList << Instruction.new(node.codeOrigin, "rv_slli", [source, Immediate.new(node.codeOrigin, 48), dest])
             newList << Instruction.new(node.codeOrigin, "rv_srai", [dest, Immediate.new(node.codeOrigin, 48), dest])
+        when [:z, :b, :i], [:z, :b, :q]
+            newList << Instruction.new(node.codeOrigin, "rv_andi", [source, Immediate.new(node.codeOrigin, 0xff), dest])
+        when [:z, :h, :i], [:z, :h, :q]
+            newList << Instruction.new(node.codeOrigin, "rv_slli", [source, Immediate.new(node.codeOrigin, 48), dest])
+            newList << Instruction.new(node.codeOrigin, "rv_srli", [dest, Immediate.new(node.codeOrigin, 48), dest])
         else
-            raise "Invalid bit-extension combination"
+            raise "Invalid bit-extension combination #{[extension, fromSize, toSize]}"
         end
     end
 
@@ -882,6 +977,14 @@ def riscv64LowerOperation(list)
                 emitPush(newList, node)
             when "pop"
                 emitPop(newList, node)
+            when "pushv"
+                emitPushv(newList, node)
+            when "popv"
+                emitPopv(newList, node)
+            when "loadv"
+                emitLoadv(newList, node)
+            when "storev"
+                emitStorev(newList, node)
             when /^(add|sub)(i|p|q)$/
                 emitAdditionOperation(newList, node, $1.to_sym, $2.to_sym)
             when /^(mul|div|rem)(i|p|q)(s?)$/
@@ -1543,8 +1646,7 @@ def riscv64GenerateWASMPlaceholders(list)
         if node.is_a? Instruction
             case node.opcode
             when "loadlinkacqb", "loadlinkacqh", "loadlinkacqi", "loadlinkacqq",
-                 "storecondrelb", "storecondrelh", "storecondreli", "storecondrelq",
-                 "loadv", "storev"
+                 "storecondrelb", "storecondrelh", "storecondreli", "storecondrelq"
                 newList << Instruction.new(node.codeOrigin, "rv_ebreak", [], "WebAssembly placeholder for opcode #{node.opcode}")
             else
                 newList << node
@@ -1570,6 +1672,7 @@ class Sequence
                 false
             end
         }
+        result = riscLowerMalformedAddressesDouble(result)
         result = riscv64LowerMisplacedAddresses(result)
         result = riscLowerMisplacedAddresses(result)
         result = riscv64LowerAddressLoads(result)

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -802,7 +802,10 @@ void Options::notifyOptionsChanged()
     Options::forceUnlinkedDFG() = false;
     Options::useWasmSIMD() = false;
     Options::useWasmIPInt() = false;
-#if !CPU(ARM_THUMB2)
+#if !CPU(ARM_THUMB2) && !CPU(RISCV64)
+    // RISCV64 has BBQJIT (WEBASSEMBLY_BBQJIT enabled in PlatformEnable.h);
+    // wasm SIMD and IPInt are still off above, so BBQJIT is the only wasm
+    // tier on this architecture.
     Options::useBBQJIT() = false;
 #endif
 #endif

--- a/Source/JavaScriptCore/runtime/Options.cpp
+++ b/Source/JavaScriptCore/runtime/Options.cpp
@@ -810,6 +810,21 @@ void Options::notifyOptionsChanged()
 #endif
 #endif
 
+#if CPU(RISCV64)
+    // The base RISC-V ISA permits a faulting store to commit some of its
+    // bytes before raising the exception (single-copy atomicity is only
+    // guaranteed for naturally-aligned accesses up to XLEN, not for a
+    // store that straddles a page boundary into PROT_NONE). On hardware
+    // that does this (e.g. SiFive U74 in JH7110), JSC's signal-based
+    // bounds check sees the page fault but the in-bounds bytes have
+    // already been corrupted -- subsequent reads return wrong values.
+    // Force explicit bounds checking instead. Reproducer:
+    // spec-tests/memory_trap.wast.js #295 (i32.store at 65535 partially
+    // overwrites byte 65535 before trapping, then i64.load at 65528
+    // sees the corrupted high byte).
+    Options::useWasmFastMemory() = false;
+#endif
+
 #if !CPU(ARM64)
     Options::useRandomizingExecutableIslandAllocation() = false;
 #endif

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -4464,7 +4464,7 @@ void BBQJIT::emitTailCall(FunctionSpaceIndex functionIndexSpace, const RTT& sign
     m_jit.loadPtr(Address(MacroAssembler::framePointerRegister), callerFramePointer);
     resolvedArguments.append(Value::pinned(pointerType(), Location::fromStack(sizeof(Register))));
     parameterLocations.append(Location::fromStack(tailCallStackOffsetFromFP + Checked<int>(sizeof(Register))));
-#elif CPU(ARM64) || CPU(ARM_THUMB2)
+#elif CPU(ARM64) || CPU(ARM_THUMB2) || CPU(RISCV64)
     m_jit.loadPairPtr(MacroAssembler::framePointerRegister, callerFramePointer, MacroAssembler::linkRegister);
 #else
     UNUSED_PARAM(callerFramePointer);
@@ -4740,7 +4740,7 @@ void BBQJIT::emitIndirectTailCall(const char* opcode, const Value& callee, GPRRe
 
     resolvedArguments.append(Value::pinned(pointerType(), Location::fromStack(sizeof(Register))));
     parameterLocations.append(Location::fromStack(tailCallStackOffsetFromFP + Checked<int>(sizeof(Register))));
-#elif CPU(ARM64) || CPU(ARM_THUMB2)
+#elif CPU(ARM64) || CPU(ARM_THUMB2) || CPU(RISCV64)
     auto preserved = callingConvention.argumentGPRs();
     preserved.add(importableFunction, IgnoreVectors);
     if constexpr (isARM64E())
@@ -4797,7 +4797,7 @@ void BBQJIT::emitIndirectTailCall(const char* opcode, const Value& callee, GPRRe
     m_jit.loadPtr(Address(MacroAssembler::framePointerRegister, tailCallStackOffsetFromFP), wasmScratchGPR);
     m_jit.addPtr(TrustedImm32(tailCallStackOffsetFromFP + Checked<int>(sizeof(Register))), MacroAssembler::framePointerRegister, MacroAssembler::stackPointerRegister);
     m_jit.move(wasmScratchGPR, MacroAssembler::framePointerRegister);
-#elif CPU(ARM64) || CPU(ARM_THUMB2)
+#elif CPU(ARM64) || CPU(ARM_THUMB2) || CPU(RISCV64)
     m_jit.addPtr(TrustedImm32(tailCallStackOffsetFromFP + Checked<int>(sizeof(CallerFrameAndPC))), MacroAssembler::framePointerRegister, MacroAssembler::stackPointerRegister);
     m_jit.move(callerFramePointer, MacroAssembler::framePointerRegister);
 #else

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -737,6 +737,9 @@ BBQJIT::BBQJIT(CompilationContext& compilationContext, const RTT& signature, Mod
 
 bool BBQJIT::canTierUpToOMG() const
 {
+#if !ENABLE(WEBASSEMBLY_OMGJIT)
+    return false;
+#else
     if (!Options::useOMGJIT())
         return false;
 
@@ -748,6 +751,7 @@ bool BBQJIT::canTierUpToOMG() const
         return false;
     }
     return true;
+#endif
 }
 
 void BBQJIT::emitIncrementCallProfileCount(unsigned callProfileIndex)
@@ -3219,7 +3223,10 @@ void BBQJIT::emitEntryTierUpCheck()
         jit.jump(tierUpResume);
     });
 #else
-    RELEASE_ASSERT_NOT_REACHED();
+    // OMG/FTL tiering is unavailable on this architecture; canTierUpToOMG()
+    // can still return true (it is gated only on per-function thresholds, not
+    // on the OMG implementation being compiled in), so silently skip emitting
+    // the tier-up counter check rather than aborting.
 #endif
 }
 

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.cpp
@@ -4314,6 +4314,25 @@ void BBQJIT::slowPathRestoreBindings(const RegisterBindings& bindings)
     }
 }
 
+void BBQJIT::emitSignExtendI32ArgsForCCall(const CallInformation& callInfo, const RTT& signature)
+{
+#if CPU(RISCV64)
+    for (size_t i = 0; i < callInfo.params.size(); ++i) {
+        auto type = signature.argumentType(i);
+        if (type.kind != TypeKind::I32)
+            continue;
+        Location loc = Location::fromArgumentLocation(callInfo.params[i], type.kind);
+        if (!loc.isGPR())
+            continue;
+        // sext.w rd, rs lowers via signExtend32To64 -> rv_addiw rd, rs, 0
+        m_jit.signExtend32To64(loc.asGPR(), loc.asGPR());
+    }
+#else
+    UNUSED_PARAM(callInfo);
+    UNUSED_PARAM(signature);
+#endif
+}
+
 template<typename Args>
 void BBQJIT::saveValuesAcrossCallAndPassArguments(const Args& arguments, const CallInformation& callInfo, const RTT& signature)
 {
@@ -4567,6 +4586,7 @@ void BBQJIT::emitTailCall(FunctionSpaceIndex functionIndexSpace, const RTT& sign
     if (m_info.isImportedFunctionFromFunctionIndexSpace(functionIndexSpace)) {
         static_assert(sizeof(WasmOrJSImportableFunctionCallLinkInfo) * maxImports < std::numeric_limits<int32_t>::max());
         RELEASE_ASSERT(JSWebAssemblyInstance::offsetOfImportFunctionStub(m_module.moduleInformation(), functionIndexSpace) < std::numeric_limits<int32_t>::max());
+        emitSignExtendI32ArgsForCCall(callInfo, signature);
         m_jit.call(Address(GPRInfo::wasmContextInstancePointer, JSWebAssemblyInstance::offsetOfImportFunctionStub(m_module.moduleInformation(), functionIndexSpace)), WasmEntryPtrTag);
     } else {
         // Record the callee so the callee knows to look for it in updateCallsitesToCallUs.

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -1390,6 +1390,11 @@ public:
     template<typename Functor>
     void emitAtomicOpGeneric(ExtAtomicOpType op, Address address, Location old, Location cur, const Functor& functor);
 
+#if CPU(RISCV64) && USE(JSVALUE64)
+    template<typename Functor>
+    void emitAtomicOpGenericRISCV64ByteMask(ExtAtomicOpType op, Address address, GPRReg oldGPR, GPRReg scratchGPR, Location valueLocation, const Functor& functor);
+#endif
+
     [[nodiscard]] Value emitAtomicLoadOp(ExtAtomicOpType loadOp, Type valueType, Location pointer, uint64_t uoffset);
 
     [[nodiscard]] PartialResult atomicLoad(ExtAtomicOpType loadOp, Type valueType, ExpressionType pointer, ExpressionType& result, uint64_t uoffset, uint8_t memoryIndex);

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT.h
@@ -2085,6 +2085,13 @@ public:
     template<typename Args>
     void saveValuesAcrossCallAndPassArguments(const Args& arguments, const CallInformation&, const RTT& signature);
 
+    // On RISC-V the psABI requires 32-bit integer arguments to be sign-extended
+    // in their 64-bit argument registers; BBQ otherwise zero-extends them when
+    // loading from canonical i32 slots (lwu). Emit sext.w on any I32 arg that
+    // ends up in a register before a transition to a C ABI host function or
+    // wasm-to-host import. No-op on other architectures.
+    void emitSignExtendI32ArgsForCCall(const CallInformation& callInfo, const RTT& signature);
+
     void slowPathSpillBindings(const RegisterBindings&);
     void slowPathRestoreBindings(const RegisterBindings&);
     void NODELETE restoreValuesAfterCall(const CallInformation&);

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -546,6 +546,47 @@ void BBQJIT::emitSanitizeAtomicResult(ExtAtomicOpType op, TypeKind resultType, G
     emitSanitizeAtomicResult(op, resultType, result, result);
 }
 
+#if CPU(RISCV64)
+template<typename Functor>
+void BBQJIT::emitAtomicOpGenericRISCV64ByteMask(ExtAtomicOpType op, Address address, GPRReg oldGPR, GPRReg scratchGPR, Location valueLocation, const Functor& functor)
+{
+    Width accessWidth = this->accessWidth(op);
+    ASSERT(accessWidth == Width8 || accessWidth == Width16);
+
+    ScratchScope<4, 0> rvScratches(*this, Location::fromGPR(oldGPR), Location::fromGPR(scratchGPR), valueLocation);
+    GPRReg alignedAddr = rvScratches.gpr(0);
+    GPRReg shift = rvScratches.gpr(1);
+    GPRReg invMask = rvScratches.gpr(2);
+    GPRReg rawOld = rvScratches.gpr(3);
+    int32_t byteMask = (accessWidth == Width8) ? 0xFF : 0xFFFF;
+
+    m_jit.move(address.base, alignedAddr);
+    m_jit.and64(TrustedImm32(-4), alignedAddr);
+    m_jit.move(address.base, shift);
+    m_jit.and64(TrustedImm32(3), shift);
+    m_jit.lshift64(TrustedImm32(3), shift);
+
+    m_jit.move(TrustedImm32(byteMask), invMask);
+    m_jit.lshift64(shift, invMask);
+    m_jit.not64(invMask);
+
+    auto reloopLabel = m_jit.label();
+    m_jit.loadLinkAcq32(Address(alignedAddr), rawOld);
+    m_jit.urshift64(rawOld, shift, oldGPR);
+    m_jit.and64(TrustedImm32(byteMask), oldGPR);
+
+    functor(oldGPR, scratchGPR);
+
+    m_jit.and64(TrustedImm32(byteMask), scratchGPR);
+    m_jit.lshift64(shift, scratchGPR);
+    m_jit.and64(invMask, rawOld);
+    m_jit.or64(scratchGPR, rawOld);
+
+    m_jit.storeCondRel32(rawOld, Address(alignedAddr), scratchGPR);
+    m_jit.branchTest32(ResultCondition::NonZero, scratchGPR).linkTo(reloopLabel, &m_jit);
+}
+#endif
+
 template<typename Functor>
 void BBQJIT::emitAtomicOpGeneric(ExtAtomicOpType op, Address address, GPRReg oldGPR, GPRReg scratchGPR, const Functor& functor)
 {
@@ -579,14 +620,14 @@ void BBQJIT::emitAtomicOpGeneric(ExtAtomicOpType op, Address address, GPRReg old
 #endif
         break;
     case Width32:
-#if CPU(ARM64)
+#if CPU(ARM64) || CPU(RISCV64)
         m_jit.loadLinkAcq32(address, oldGPR);
 #else
         m_jit.load32(address, oldGPR);
 #endif
         break;
     case Width64:
-#if CPU(ARM64)
+#if CPU(ARM64) || CPU(RISCV64)
         m_jit.loadLinkAcq64(address, oldGPR);
 #else
         m_jit.load64(address, oldGPR);
@@ -634,6 +675,26 @@ void BBQJIT::emitAtomicOpGeneric(ExtAtomicOpType op, Address address, GPRReg old
         RELEASE_ASSERT_NOT_REACHED();
     }
     m_jit.branchTest32(ResultCondition::NonZero, scratchGPR).linkTo(reloopLabel, &m_jit);
+#elif CPU(RISCV64)
+    switch (accessWidth) {
+    case Width8:
+        m_jit.store8(scratchGPR, address);
+        m_jit.move(TrustedImm32(0), scratchGPR);
+        break;
+    case Width16:
+        m_jit.store16(scratchGPR, address);
+        m_jit.move(TrustedImm32(0), scratchGPR);
+        break;
+    case Width32:
+        m_jit.storeCondRel32(scratchGPR, address, scratchGPR);
+        break;
+    case Width64:
+        m_jit.storeCondRel64(scratchGPR, address, scratchGPR);
+        break;
+    case Width128:
+        RELEASE_ASSERT_NOT_REACHED();
+    }
+    m_jit.branchTest32(ResultCondition::NonZero, scratchGPR).linkTo(reloopLabel, &m_jit);
 #endif
 }
 
@@ -654,9 +715,16 @@ void BBQJIT::emitAtomicOpGeneric(ExtAtomicOpType op, Address address, GPRReg old
 
     if (!(isARM64_LSE() || isX86_64())) {
         ScratchScope<1, 0> scratches(*this);
-        emitAtomicOpGeneric(loadOp, address, resultLocation.asGPR(), scratches.gpr(0), [&](GPRReg oldGPR, GPRReg newGPR) {
+        auto opFunctor = [&](GPRReg oldGPR, GPRReg newGPR) {
             emitSanitizeAtomicResult(loadOp, canonicalWidth(accessWidth(loadOp)) == Width64 ? TypeKind::I64 : TypeKind::I32, oldGPR, newGPR);
-        });
+        };
+#if CPU(RISCV64)
+        Width w = accessWidth(loadOp);
+        if (w == Width8 || w == Width16)
+            emitAtomicOpGenericRISCV64ByteMask(loadOp, address, resultLocation.asGPR(), scratches.gpr(0), Location(), opFunctor);
+        else
+#endif
+        emitAtomicOpGeneric(loadOp, address, resultLocation.asGPR(), scratches.gpr(0), opFunctor);
         emitSanitizeAtomicResult(loadOp, valueType.kind, resultLocation.asGPR());
         return result;
     }
@@ -761,9 +829,16 @@ void BBQJIT::emitAtomicStoreOp(ExtAtomicOpType storeOp, Type, Location pointer, 
     consume(value);
 
     if (!(isARM64_LSE() || isX86_64())) {
-        emitAtomicOpGeneric(storeOp, address, scratch1GPR, scratch2GPR, [&](GPRReg, GPRReg newGPR) {
+        auto opFunctor = [&](GPRReg, GPRReg newGPR) {
             m_jit.move(valueLocation.asGPR(), newGPR);
-        });
+        };
+#if CPU(RISCV64)
+        Width w = accessWidth(storeOp);
+        if (w == Width8 || w == Width16)
+            emitAtomicOpGenericRISCV64ByteMask(storeOp, address, scratch1GPR, scratch2GPR, valueLocation, opFunctor);
+        else
+#endif
+        emitAtomicOpGeneric(storeOp, address, scratch1GPR, scratch2GPR, opFunctor);
         return;
     }
 
@@ -1118,7 +1193,7 @@ Value BBQJIT::emitAtomicBinaryRMWOp(ExtAtomicOpType op, Type valueType, Location
         break;
     }
 
-    emitAtomicOpGeneric(op, address, resultLocation.asGPR(), scratchGPR, [&](GPRReg oldGPR, GPRReg newGPR) {
+    auto rmwFunctor = [&](GPRReg oldGPR, GPRReg newGPR) {
         switch (op) {
         case ExtAtomicOpType::I32AtomicRmw16AddU:
         case ExtAtomicOpType::I32AtomicRmw8AddU:
@@ -1188,7 +1263,13 @@ Value BBQJIT::emitAtomicBinaryRMWOp(ExtAtomicOpType op, Type valueType, Location
             RELEASE_ASSERT_NOT_REACHED();
             break;
         }
-    });
+    };
+#if CPU(RISCV64)
+    if (accessWidth(op) == Width8 || accessWidth(op) == Width16)
+        emitAtomicOpGenericRISCV64ByteMask(op, address, resultLocation.asGPR(), scratchGPR, valueLocation, rmwFunctor);
+    else
+#endif
+    emitAtomicOpGeneric(op, address, resultLocation.asGPR(), scratchGPR, rmwFunctor);
     emitSanitizeAtomicResult(op, valueType.kind, resultLocation.asGPR());
     return result;
 }
@@ -1266,6 +1347,60 @@ Value BBQJIT::emitAtomicBinaryRMWOp(ExtAtomicOpType op, Type valueType, Location
             }
             return;
         }
+
+#if CPU(RISCV64)
+        // rv64gc A-extension. For 32/64 atomicStrongCAS uses LR/SC.aqrl.
+        // For 8/16 the base A-ext has no byte/half AMOs (Zabha is
+        // optional, not in rv64gc); emit a word-aligned LR.W/SC.W
+        // byte-mask CAS loop -- properly atomic.
+        if (accessWidth == Width8 || accessWidth == Width16) {
+            ScratchScope<4, 0> rvScratches(*this, valueLocation, expectedLocation, resultLocation);
+            GPRReg alignedAddr = rvScratches.gpr(0);
+            GPRReg shift = rvScratches.gpr(1);
+            GPRReg invMask = rvScratches.gpr(2);
+            GPRReg rawOld = rvScratches.gpr(3);
+            int32_t byteMask = (accessWidth == Width8) ? 0xFF : 0xFFFF;
+
+            m_jit.move(address.base, alignedAddr);
+            m_jit.and64(TrustedImm32(-4), alignedAddr);
+            m_jit.move(address.base, shift);
+            m_jit.and64(TrustedImm32(3), shift);
+            m_jit.lshift64(TrustedImm32(3), shift);
+
+            m_jit.move(TrustedImm32(byteMask), invMask);
+            m_jit.lshift64(shift, invMask);
+            m_jit.not64(invMask);
+
+            auto loop = m_jit.label();
+            m_jit.loadLinkAcq32(Address(alignedAddr), rawOld);
+            m_jit.urshift64(rawOld, shift, resultGPR);
+            m_jit.and64(TrustedImm32(byteMask), resultGPR);
+            Jump mismatch = m_jit.branch64(MacroAssembler::NotEqual, resultGPR, expectedGPR);
+            m_jit.and64(TrustedImm32(byteMask), valueGPR, scratchGPR);
+            m_jit.lshift64(shift, scratchGPR);
+            m_jit.and64(invMask, rawOld);
+            m_jit.or64(scratchGPR, rawOld);
+            m_jit.storeCondRel32(rawOld, Address(alignedAddr), scratchGPR);
+            m_jit.branchTest32(ResultCondition::NonZero, scratchGPR).linkTo(loop, &m_jit);
+            mismatch.link(&m_jit);
+            return;
+        }
+        switch (accessWidth) {
+        case Width32:
+            m_jit.move(expectedGPR, resultGPR);
+            m_jit.atomicStrongCAS32(resultGPR, valueGPR, address);
+            break;
+        case Width64:
+            m_jit.move(expectedGPR, resultGPR);
+            m_jit.atomicStrongCAS64(resultGPR, valueGPR, address);
+            break;
+        default:
+            RELEASE_ASSERT_NOT_REACHED();
+            break;
+        }
+        UNUSED_PARAM(scratchGPR);
+        return;
+#endif
 
         m_jit.move(expectedGPR, resultGPR);
         switch (accessWidth) {

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.cpp
@@ -3652,6 +3652,11 @@ void NODELETE BBQJIT::notifyFunctionUsesSIMD()
     clobber(ARM64Registers::q28);
     clobber(ARM64Registers::q29);
     ScratchScope<0, 0> scratches(*this, Location::fromFPR(ARM64Registers::q28), Location::fromFPR(ARM64Registers::q29));
+#else
+    // Other architectures (e.g. RISCV64) have no wasm SIMD codegen and
+    // never reach this function at runtime (useWasmSIMD is forced off).
+    // Declare scratches so the if-constexpr(isX86()) block below parses.
+    ScratchScope<0, 1> scratches(*this);
 #endif
     Location aLocation = loadIfNecessary(a);
     Location bLocation = loadIfNecessary(b);
@@ -3709,6 +3714,11 @@ void NODELETE BBQJIT::notifyFunctionUsesSIMD()
     // Clobber and preserve RCX on x86, since we need it to do shifts.
     clobber(shiftRCX);
     ScratchScope<2, 2> scratches(*this, Location::fromGPR(shiftRCX));
+#elif !CPU(ARM64)
+    // RISCV64 / other archs: no wasm SIMD codegen exists; this function
+    // is unreachable at runtime via useWasmSIMD = false. Declare a
+    // ScratchScope so the X86-only sub-block below still parses.
+    ScratchScope<2, 2> scratches(*this);
 #endif
     Location srcLocation = loadIfNecessary(src);
     Location shiftLocation;

--- a/Source/JavaScriptCore/wasm/WasmBBQJIT64.h
+++ b/Source/JavaScriptCore/wasm/WasmBBQJIT64.h
@@ -561,6 +561,7 @@ void BBQJIT::emitCCall(Func function, std::span<const Value> arguments)
     // Preserve caller-saved registers and other info
     prepareForExceptions();
     saveValuesAcrossCallAndPassArguments(arguments, callInfo, functionRTT.get());
+    emitSignExtendI32ArgsForCCall(callInfo, functionRTT.get());
 
     // Materialize address of native function and call register
     void* taggedFunctionPtr = tagCFunctionPtr<void*, OperationPtrTag>(function);
@@ -591,6 +592,7 @@ void BBQJIT::emitCCall(Func function, std::span<const Value> arguments, Value& r
     // Preserve caller-saved registers and other info
     prepareForExceptions();
     saveValuesAcrossCallAndPassArguments(arguments, callInfo, functionRTT.get());
+    emitSignExtendI32ArgsForCCall(callInfo, functionRTT.get());
 
     // Materialize address of native function and call register
     void* taggedFunctionPtr = tagCFunctionPtr<void*, OperationPtrTag>(function);

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.cpp
@@ -1350,6 +1350,123 @@ WASM_IPINT_EXTERN_CPP_DECL(ref_func, unsigned index)
     IPINT_RETURN(Wasm::refFunc(instance, index));
 }
 
+// ------------------------------------------------------------------
+// Slow-path atomic ops (currently used by IPInt on RISC-V64; rv64gc
+// does include the A-extension but offlineasm's atomicloadq /
+// atomicxchg* family has no RISC-V backend yet, so we route through C
+// helpers using __atomic_* builtins. The asm caller passes the
+// already-bounds-checked, alignment-checked host pointer.
+//
+// All ops are __ATOMIC_SEQ_CST, matching the wasm spec.
+// ------------------------------------------------------------------
+
+WASM_IPINT_EXTERN_CPP_DECL(atomic_load8, uint64_t address)
+{
+    UNUSED_PARAM(instance);
+    uint8_t v = __atomic_load_n(reinterpret_cast<uint8_t*>(address), __ATOMIC_SEQ_CST);
+    WASM_RETURN_TWO(std::bit_cast<void*>(static_cast<uintptr_t>(v)), nullptr);
+}
+
+WASM_IPINT_EXTERN_CPP_DECL(atomic_load16, uint64_t address)
+{
+    UNUSED_PARAM(instance);
+    uint16_t v = __atomic_load_n(reinterpret_cast<uint16_t*>(address), __ATOMIC_SEQ_CST);
+    WASM_RETURN_TWO(std::bit_cast<void*>(static_cast<uintptr_t>(v)), nullptr);
+}
+
+WASM_IPINT_EXTERN_CPP_DECL(atomic_load32, uint64_t address)
+{
+    UNUSED_PARAM(instance);
+    uint32_t v = __atomic_load_n(reinterpret_cast<uint32_t*>(address), __ATOMIC_SEQ_CST);
+    WASM_RETURN_TWO(std::bit_cast<void*>(static_cast<uintptr_t>(v)), nullptr);
+}
+
+WASM_IPINT_EXTERN_CPP_DECL(atomic_load64, uint64_t address)
+{
+    UNUSED_PARAM(instance);
+    uint64_t v = __atomic_load_n(reinterpret_cast<uint64_t*>(address), __ATOMIC_SEQ_CST);
+    WASM_RETURN_TWO(std::bit_cast<void*>(static_cast<uintptr_t>(v)), nullptr);
+}
+
+WASM_IPINT_EXTERN_CPP_DECL(atomic_store8, uint64_t address, uint64_t value)
+{
+    UNUSED_PARAM(instance);
+    __atomic_store_n(reinterpret_cast<uint8_t*>(address), static_cast<uint8_t>(value), __ATOMIC_SEQ_CST);
+    WASM_RETURN_TWO(nullptr, nullptr);
+}
+
+WASM_IPINT_EXTERN_CPP_DECL(atomic_store16, uint64_t address, uint64_t value)
+{
+    UNUSED_PARAM(instance);
+    __atomic_store_n(reinterpret_cast<uint16_t*>(address), static_cast<uint16_t>(value), __ATOMIC_SEQ_CST);
+    WASM_RETURN_TWO(nullptr, nullptr);
+}
+
+WASM_IPINT_EXTERN_CPP_DECL(atomic_store32, uint64_t address, uint64_t value)
+{
+    UNUSED_PARAM(instance);
+    __atomic_store_n(reinterpret_cast<uint32_t*>(address), static_cast<uint32_t>(value), __ATOMIC_SEQ_CST);
+    WASM_RETURN_TWO(nullptr, nullptr);
+}
+
+WASM_IPINT_EXTERN_CPP_DECL(atomic_store64, uint64_t address, uint64_t value)
+{
+    UNUSED_PARAM(instance);
+    __atomic_store_n(reinterpret_cast<uint64_t*>(address), value, __ATOMIC_SEQ_CST);
+    WASM_RETURN_TWO(nullptr, nullptr);
+}
+
+#define IPINT_RMW_OP(name, builtin, type)                                                                 \
+WASM_IPINT_EXTERN_CPP_DECL(name, uint64_t address, uint64_t value)                                        \
+{                                                                                                         \
+    UNUSED_PARAM(instance);                                                                               \
+    type prev = builtin(reinterpret_cast<type*>(address), static_cast<type>(value), __ATOMIC_SEQ_CST);    \
+    WASM_RETURN_TWO(std::bit_cast<void*>(static_cast<uintptr_t>(prev)), nullptr);                         \
+}
+
+IPINT_RMW_OP(atomic_rmw_add8,  __atomic_fetch_add, uint8_t)
+IPINT_RMW_OP(atomic_rmw_add16, __atomic_fetch_add, uint16_t)
+IPINT_RMW_OP(atomic_rmw_add32, __atomic_fetch_add, uint32_t)
+IPINT_RMW_OP(atomic_rmw_add64, __atomic_fetch_add, uint64_t)
+IPINT_RMW_OP(atomic_rmw_sub8,  __atomic_fetch_sub, uint8_t)
+IPINT_RMW_OP(atomic_rmw_sub16, __atomic_fetch_sub, uint16_t)
+IPINT_RMW_OP(atomic_rmw_sub32, __atomic_fetch_sub, uint32_t)
+IPINT_RMW_OP(atomic_rmw_sub64, __atomic_fetch_sub, uint64_t)
+IPINT_RMW_OP(atomic_rmw_and8,  __atomic_fetch_and, uint8_t)
+IPINT_RMW_OP(atomic_rmw_and16, __atomic_fetch_and, uint16_t)
+IPINT_RMW_OP(atomic_rmw_and32, __atomic_fetch_and, uint32_t)
+IPINT_RMW_OP(atomic_rmw_and64, __atomic_fetch_and, uint64_t)
+IPINT_RMW_OP(atomic_rmw_or8,   __atomic_fetch_or,  uint8_t)
+IPINT_RMW_OP(atomic_rmw_or16,  __atomic_fetch_or,  uint16_t)
+IPINT_RMW_OP(atomic_rmw_or32,  __atomic_fetch_or,  uint32_t)
+IPINT_RMW_OP(atomic_rmw_or64,  __atomic_fetch_or,  uint64_t)
+IPINT_RMW_OP(atomic_rmw_xor8,  __atomic_fetch_xor, uint8_t)
+IPINT_RMW_OP(atomic_rmw_xor16, __atomic_fetch_xor, uint16_t)
+IPINT_RMW_OP(atomic_rmw_xor32, __atomic_fetch_xor, uint32_t)
+IPINT_RMW_OP(atomic_rmw_xor64, __atomic_fetch_xor, uint64_t)
+IPINT_RMW_OP(atomic_rmw_xchg8,  __atomic_exchange_n, uint8_t)
+IPINT_RMW_OP(atomic_rmw_xchg16, __atomic_exchange_n, uint16_t)
+IPINT_RMW_OP(atomic_rmw_xchg32, __atomic_exchange_n, uint32_t)
+IPINT_RMW_OP(atomic_rmw_xchg64, __atomic_exchange_n, uint64_t)
+#undef IPINT_RMW_OP
+
+#define IPINT_CMPXCHG_OP(name, type)                                                                      \
+WASM_IPINT_EXTERN_CPP_DECL(name, uint64_t address, uint64_t expected, uint64_t replacement)               \
+{                                                                                                         \
+    UNUSED_PARAM(instance);                                                                               \
+    type exp = static_cast<type>(expected);                                                               \
+    type rep = static_cast<type>(replacement);                                                            \
+    __atomic_compare_exchange_n(reinterpret_cast<type*>(address), &exp, rep, /*weak=*/false,              \
+                                __ATOMIC_SEQ_CST, __ATOMIC_SEQ_CST);                                      \
+    WASM_RETURN_TWO(std::bit_cast<void*>(static_cast<uintptr_t>(exp)), nullptr);                          \
+}
+
+IPINT_CMPXCHG_OP(atomic_rmw_cmpxchg8,  uint8_t)
+IPINT_CMPXCHG_OP(atomic_rmw_cmpxchg16, uint16_t)
+IPINT_CMPXCHG_OP(atomic_rmw_cmpxchg32, uint32_t)
+IPINT_CMPXCHG_OP(atomic_rmw_cmpxchg64, uint64_t)
+#undef IPINT_CMPXCHG_OP
+
 extern "C" void SYSV_ABI wasm_log_crash(CallFrame*, JSWebAssemblyInstance* instance)
 {
     dataLogLn("Reached IPInt code that should never have been executed.");

--- a/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h
+++ b/Source/JavaScriptCore/wasm/WasmIPIntSlowPaths.h
@@ -143,6 +143,46 @@ WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_atomic_wait32, IPIntStackEntry*);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_atomic_wait64, IPIntStackEntry*);
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(memory_atomic_notify, IPIntStackEntry*);
 
+// Slow-path atomic ops. The IPInt asm on architectures lacking direct
+// offlineasm atomic primitives (currently RISC-V64) routes here. The asm
+// caller passes the already-bounds-checked, page-aligned host pointer.
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(atomic_load8, uint64_t address);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(atomic_load16, uint64_t address);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(atomic_load32, uint64_t address);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(atomic_load64, uint64_t address);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(atomic_store8, uint64_t address, uint64_t value);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(atomic_store16, uint64_t address, uint64_t value);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(atomic_store32, uint64_t address, uint64_t value);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(atomic_store64, uint64_t address, uint64_t value);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(atomic_rmw_add8, uint64_t address, uint64_t value);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(atomic_rmw_add16, uint64_t address, uint64_t value);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(atomic_rmw_add32, uint64_t address, uint64_t value);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(atomic_rmw_add64, uint64_t address, uint64_t value);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(atomic_rmw_sub8, uint64_t address, uint64_t value);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(atomic_rmw_sub16, uint64_t address, uint64_t value);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(atomic_rmw_sub32, uint64_t address, uint64_t value);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(atomic_rmw_sub64, uint64_t address, uint64_t value);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(atomic_rmw_and8, uint64_t address, uint64_t value);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(atomic_rmw_and16, uint64_t address, uint64_t value);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(atomic_rmw_and32, uint64_t address, uint64_t value);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(atomic_rmw_and64, uint64_t address, uint64_t value);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(atomic_rmw_or8, uint64_t address, uint64_t value);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(atomic_rmw_or16, uint64_t address, uint64_t value);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(atomic_rmw_or32, uint64_t address, uint64_t value);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(atomic_rmw_or64, uint64_t address, uint64_t value);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(atomic_rmw_xor8, uint64_t address, uint64_t value);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(atomic_rmw_xor16, uint64_t address, uint64_t value);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(atomic_rmw_xor32, uint64_t address, uint64_t value);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(atomic_rmw_xor64, uint64_t address, uint64_t value);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(atomic_rmw_xchg8, uint64_t address, uint64_t value);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(atomic_rmw_xchg16, uint64_t address, uint64_t value);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(atomic_rmw_xchg32, uint64_t address, uint64_t value);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(atomic_rmw_xchg64, uint64_t address, uint64_t value);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(atomic_rmw_cmpxchg8, uint64_t address, uint64_t expected, uint64_t replacement);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(atomic_rmw_cmpxchg16, uint64_t address, uint64_t expected, uint64_t replacement);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(atomic_rmw_cmpxchg32, uint64_t address, uint64_t expected, uint64_t replacement);
+WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(atomic_rmw_cmpxchg64, uint64_t address, uint64_t expected, uint64_t replacement);
+
 WASM_IPINT_EXTERN_CPP_HIDDEN_DECL(check_stack_and_vm_traps, void* candidateNewStackPointer, Wasm::IPIntCallee*, CallFrame*);
 WASM_IPINT_EXTERN_CPP_DECL(handle_debugger_trap_if_needed, CallFrame*, Register*);
 

--- a/Source/JavaScriptCore/wasm/WasmOperations.cpp
+++ b/Source/JavaScriptCore/wasm/WasmOperations.cpp
@@ -133,8 +133,17 @@ JSC_DEFINE_JIT_OPERATION(operationJSToWasmEntryWrapperBuildFrame, JSToWasmCallee
 
             dataLogLnIf(WasmOperationsInternal::verbose, "* Register Arg ", i, " ", dst);
 
-            if (type.isI32() || type.isF32())
+            if (type.isI32())
                 value = static_cast<uint64_t>(static_cast<uint32_t>(value));
+            else if (type.isF32()) {
+                // Pack as NaN-boxed single (high 32 = 0xFFFFFFFF) so that
+                // the shared trampoline's loadDouble into the FPR yields a
+                // properly NaN-boxed single. Otherwise on architectures
+                // that enforce NaN-boxing for single-precision ops
+                // (RV64GC), the wasm body's subsequent flw/fsw on the f-arg
+                // sees the canonical NaN instead of the actual f32 value.
+                value = static_cast<uint64_t>(static_cast<uint32_t>(value)) | 0xFFFFFFFF00000000ULL;
+            }
             *access.operator()<uint64_t>(registerSpace, dst) = value;
         }
     }

--- a/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
+++ b/Source/JavaScriptCore/wasm/WasmTypeDefinition.h
@@ -29,6 +29,7 @@
 
 #if ENABLE(WEBASSEMBLY)
 
+#include <JavaScriptCore/B3Type.h>
 #include <JavaScriptCore/JITCompilation.h>
 #include <JavaScriptCore/SIMDInfo.h>
 #include <JavaScriptCore/WasmLimits.h>
@@ -296,7 +297,7 @@ ALWAYS_INLINE Width Type::width() const
     RELEASE_ASSERT_NOT_REACHED();
 }
 
-#if ENABLE(WEBASSEMBLY_OMGJIT) || ENABLE(WEBASSEMBLY_BBQJIT)
+#if ENABLE(B3_JIT)
 #define CREATE_CASE(name, id, b3type, ...) case TypeKind::name: return b3type;
 inline B3::Type toB3Type(Type type)
 {

--- a/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
+++ b/Source/JavaScriptCore/wasm/js/JSToWasm.cpp
@@ -324,6 +324,15 @@ MacroAssemblerCodeRef<JITThunkPtrTag> createJSToWasmJITShared()
         jit.loadPair64(CCallHelpers::Address(CCallHelpers::stackPointerRegister, 0 * 8), GPRInfo::regWA0, GPRInfo::regWA1);
         jit.loadPair64(CCallHelpers::Address(CCallHelpers::stackPointerRegister, 2 * 8), GPRInfo::regWA2, GPRInfo::regWA3);
         jit.loadPair64(CCallHelpers::Address(CCallHelpers::stackPointerRegister, 4 * 8), GPRInfo::regWA4, GPRInfo::regWA5);
+#elif CPU(RISCV64)
+        jit.load64(CCallHelpers::Address(CCallHelpers::stackPointerRegister, 0 * 8), GPRInfo::regWA0);
+        jit.load64(CCallHelpers::Address(CCallHelpers::stackPointerRegister, 1 * 8), GPRInfo::regWA1);
+        jit.load64(CCallHelpers::Address(CCallHelpers::stackPointerRegister, 2 * 8), GPRInfo::regWA2);
+        jit.load64(CCallHelpers::Address(CCallHelpers::stackPointerRegister, 3 * 8), GPRInfo::regWA3);
+        jit.load64(CCallHelpers::Address(CCallHelpers::stackPointerRegister, 4 * 8), GPRInfo::regWA4);
+        jit.load64(CCallHelpers::Address(CCallHelpers::stackPointerRegister, 5 * 8), GPRInfo::regWA5);
+        jit.load64(CCallHelpers::Address(CCallHelpers::stackPointerRegister, 6 * 8), GPRInfo::regWA6);
+        jit.load64(CCallHelpers::Address(CCallHelpers::stackPointerRegister, 7 * 8), GPRInfo::regWA7);
 #elif USE(JSVALUE64)
         jit.load64(CCallHelpers::Address(CCallHelpers::stackPointerRegister, 0 * 8), GPRInfo::regWA0);
         jit.load64(CCallHelpers::Address(CCallHelpers::stackPointerRegister, 1 * 8), GPRInfo::regWA1);
@@ -410,6 +419,15 @@ MacroAssemblerCodeRef<JITThunkPtrTag> createJSToWasmJITShared()
         jit.storePair64(GPRInfo::regWA0, GPRInfo::regWA1, CCallHelpers::Address(CCallHelpers::stackPointerRegister, 0 * 8));
         jit.storePair64(GPRInfo::regWA2, GPRInfo::regWA3, CCallHelpers::Address(CCallHelpers::stackPointerRegister, 2 * 8));
         jit.storePair64(GPRInfo::regWA4, GPRInfo::regWA5, CCallHelpers::Address(CCallHelpers::stackPointerRegister, 4 * 8));
+#elif CPU(RISCV64)
+        jit.store64(GPRInfo::regWA0, CCallHelpers::Address(CCallHelpers::stackPointerRegister, 0 * 8));
+        jit.store64(GPRInfo::regWA1, CCallHelpers::Address(CCallHelpers::stackPointerRegister, 1 * 8));
+        jit.store64(GPRInfo::regWA2, CCallHelpers::Address(CCallHelpers::stackPointerRegister, 2 * 8));
+        jit.store64(GPRInfo::regWA3, CCallHelpers::Address(CCallHelpers::stackPointerRegister, 3 * 8));
+        jit.store64(GPRInfo::regWA4, CCallHelpers::Address(CCallHelpers::stackPointerRegister, 4 * 8));
+        jit.store64(GPRInfo::regWA5, CCallHelpers::Address(CCallHelpers::stackPointerRegister, 5 * 8));
+        jit.store64(GPRInfo::regWA6, CCallHelpers::Address(CCallHelpers::stackPointerRegister, 6 * 8));
+        jit.store64(GPRInfo::regWA7, CCallHelpers::Address(CCallHelpers::stackPointerRegister, 7 * 8));
 #elif USE(JSVALUE64)
         jit.store64(GPRInfo::regWA0, CCallHelpers::Address(CCallHelpers::stackPointerRegister, 0 * 8));
         jit.store64(GPRInfo::regWA1, CCallHelpers::Address(CCallHelpers::stackPointerRegister, 1 * 8));

--- a/Source/WTF/wtf/PlatformEnable.h
+++ b/Source/WTF/wtf/PlatformEnable.h
@@ -731,12 +731,28 @@
 #endif
 
 #if CPU(RISCV64)
+// RISCV64 wasm execution tiers:
+//   - IPInt (LLInt in-place interpreter): not ported; left disabled.
+//     LowLevelInterpreter.asm's IPInt call-trampoline labels are stubbed
+//     to crash() so the link still succeeds.
+//   - BBQJIT: enabled. The arch-conditional sites in WasmBBQJIT64.cpp
+//     that have no #else fall through to portable MacroAssembler
+//     primitives; the remaining gaps (wasm SIMD codegen, wasm atomics
+//     codegen) are addressed by gating both off at runtime:
+//       Options::useWasmSIMD = false (already set in Options.cpp for
+//       !X86_64 && !ARM64),
+//       Options::useSharedArrayBuffer = false (the default), which in
+//       turn keeps wasm atomic opcodes off the JIT codepath.
+//     MacroAssemblerRISCV64.h carries hard-fault stubs for the wasm
+//     atomic / SIMD MacroAssembler entry points so they trap loudly if
+//     the runtime gating is ever bypassed.
+//   - OMGJIT: not ported.
 #undef ENABLE_WEBASSEMBLY
 #define ENABLE_WEBASSEMBLY 1
 #undef ENABLE_WEBASSEMBLY_OMGJIT
 #define ENABLE_WEBASSEMBLY_OMGJIT 0
 #undef ENABLE_WEBASSEMBLY_BBQJIT
-#define ENABLE_WEBASSEMBLY_BBQJIT 0
+#define ENABLE_WEBASSEMBLY_BBQJIT 1
 #endif
 
 #if !defined(ENABLE_C_LOOP)

--- a/Source/bmalloc/bmalloc/BPlatform.h
+++ b/Source/bmalloc/bmalloc/BPlatform.h
@@ -176,6 +176,11 @@
 #endif
 #endif
 
+/* BCPU(RISCV64) - RISC-V 64-bit */
+#if defined(__riscv) && __riscv_xlen == 64
+#define BCPU_RISCV64 1
+#endif
+
 /* BCPU(ARM) - ARM, any version*/
 #define BARM_ARCH_AT_LEAST(N) (BCPU(ARM) && BARM_ARCH_VERSION >= N)
 
@@ -397,7 +402,7 @@
 
 /* BENABLE(LIBPAS) is enabling libpas build. But this does not mean we use libpas for bmalloc replacement. */
 #if !defined(BENABLE_LIBPAS)
-#if (!BUSE(MIMALLOC) && !BUSE(SYSTEM_MALLOC)) && BCPU(ADDRESS64) && (BOS(DARWIN) || BOS(WINDOWS) || (BOS(LINUX) && (BCPU(X86_64) || BCPU(ARM64))) || BPLATFORM(PLAYSTATION))
+#if (!BUSE(MIMALLOC) && !BUSE(SYSTEM_MALLOC)) && BCPU(ADDRESS64) && (BOS(DARWIN) || BOS(WINDOWS) || (BOS(LINUX) && (BCPU(X86_64) || BCPU(ARM64) || BCPU(RISCV64))) || BPLATFORM(PLAYSTATION))
 #define BENABLE_LIBPAS 1
 #ifndef PAS_BMALLOC
 #define PAS_BMALLOC 1


### PR DESCRIPTION
Tracking bug: https://bugs.webkit.org/show_bug.cgi?id=315509

This PR flips `ENABLE(WEBASSEMBLY_BBQJIT)` from 0 to 1 on RISCV64 in `Source/WTF/wtf/PlatformEnable.h` and lands the supporting JSC / WTF changes that make the newly-reachable BBQ codegen paths and the JS-to-Wasm / Wasm-to-JS bridges produce correct code on this architecture.

The 28 commits are ordered so that every intermediate state builds. The first 17 introduce infrastructure compiled either unconditionally or inside `#if !ENABLE(WEBASSEMBLY_BBQJIT)`-guarded code. Commit 17 ("WTF: enable WebAssembly and BBQJIT on RISCV64") flips the gate. The remaining 11 commits fix bugs that become reachable after the flip. `git bisect` through the series will narrow correctly to any regression.

Test results on the environment described in the bug ticket (StarFive VisionFive 2, rv64gc, OpenWrt master, WPE WebKit 2.52.x rebased on origin/main):

    JSTests/wasm.yaml: 7693 PASS / 9 FAIL = 99.88% pass rate.

The 9 residual failures are in 2 base test files (executable-memory-oom and references/multitable) that deliberately exhaust executable memory and expect a fallback wasm tier (IPInt) to keep executing. IPInt on RISCV64 is out of scope here and will land as a follow-up.

See the bug for the full breakdown of the five failure categories this PR addresses.
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/2587ed29d6d83c5712b5d1bf3c631034856d9e52

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [❌ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164326 "8 style errors") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37810 "Built successfully") | [  ~~🛠 mac~~](https://ews-build.webkit.org/#/builders/168/builds/31381 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173355 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121578 "Built successfully") 
| | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38144 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37811 "Built successfully") | [  ~~🧪 wpe-wk2~~](https://ews-build.webkit.org/#/builders/34/builds/127676 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | [  ~~🧪 win-tests~~](https://ews-build.webkit.org/#/builders/60/builds/89854 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167285 "Passed tests") | [  ~~🧪 ios-wk2~~](https://ews-build.webkit.org/#/builders/162/builds/29970 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac~~](https://ews-build.webkit.org/#/builders/18/builds/147705 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-wpe~~](https://ews-build.webkit.org/#/builders/41/builds/108221 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [  ~~🧪 ios-wk2-wpt~~](https://ews-build.webkit.org/#/builders/154/builds/29017 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-mac-debug~~](https://ews-build.webkit.org/#/builders/165/builds/27641 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21119 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/156477 "Build is in progress. Recent messages:OS: Sequoia (15.7.3), Xcode: 26.2; Skipping applying patch since patch_id isn't provided; Checked out pull request; Compiled JSC (warnings); Running jscore-test") | [  ~~🧪 api-ios~~](https://ews-build.webkit.org/#/builders/13/builds/138919 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-wk1~~](https://ews-build.webkit.org/#/builders/167/builds/25421 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175881 "Built successfully") | 
| [✅ 🛠 🧪 jsc-debug-arm64](https://ews-build.webkit.org/#/builders/171/builds/25218 "Built successfully and passed tests") | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28702 "Built successfully") | [  ~~🧪 mac-wk2~~](https://ews-build.webkit.org/#/builders/169/builds/27089 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 gtk-wk2~~](https://ews-build.webkit.org/#/builders/1/builds/135987 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37481 "Built successfully") | [  ~~🧪 mac-AS-debug-wk2~~](https://ews-build.webkit.org/#/builders/161/builds/31760 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 api-gtk~~](https://ews-build.webkit.org/#/builders/21/builds/135956 "The change is no longer eligible for processing. Pull Request was already closed when EWS attempted to process it.") | 
| | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38267 "Built successfully") | [  ~~🧪 mac-wk2-stress~~](https://ews-build.webkit.org/#/builders/8/builds/147216 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🛠 playstation~~](https://ews-build.webkit.org/#/builders/134/builds/100638 "The change is no longer eligible for processing.") | 
| | [  ~~🧪 vision-wk2~~](https://ews-build.webkit.org/#/builders/164/builds/31267 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [  ~~🧪 mac-intel-wk2~~](https://ews-build.webkit.org/#/builders/170/builds/24072 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | [✅ 🛠 jsc-armv7](https://ews-build.webkit.org/#/builders/35/builds/196729 "Built successfully") | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37077 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110121 "Built successfully") | [  ~~🧪 jsc-armv7-tests~~](https://ews-build.webkit.org/#/builders/25/builds/51674 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36473 "Built successfully") | [  ~~🧪 mac-site-isolation~~](https://ews-build.webkit.org/#/builders/185/builds/2129 "The change is no longer eligible for processing. Commit was outdated when EWS attempted to process it.") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36723 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36623 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->