### PR TITLE
CloseWatcherManagers inside iframes aren't notified about user activation

### DIFF
--- a/LayoutTests/TestExpectations
+++ b/LayoutTests/TestExpectations
@@ -6102,11 +6102,6 @@ imported/w3c/web-platform-tests/trusted-types/trusted-types-reporting-for-Shared
 imported/w3c/web-platform-tests/trusted-types/should-sink-type-mismatch-violation-be-blocked-by-csp-002-worker.html [ Skip ]
 imported/w3c/web-platform-tests/trusted-types/should-trusted-type-policy-creation-be-blocked-by-csp-004-worker.html [ Skip ]
 
-# Close watchers aren't finished yet
-webkit.org/b/315510 imported/w3c/web-platform-tests/close-watcher/iframes/dialog-same-origin-nn.html [ Skip ]
-webkit.org/b/315510 imported/w3c/web-platform-tests/close-watcher/iframes/dialog-same-origin-ynn.html [ Skip ]
-webkit.org/b/315510 imported/w3c/web-platform-tests/close-watcher/iframes/dialog-same-origin-ynyn.html [ Skip ]
-
 # Needs moveBefore support
 webkit.org/b/281223 imported/w3c/web-platform-tests/dom/nodes/moveBefore/focus-preserve-render.html [ Skip ]
 webkit.org/b/281223 imported/w3c/web-platform-tests/dom/nodes/moveBefore/moveBefore-as-flex-item.html [ Skip ]

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-cross-origin-nn-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-cross-origin-nn-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS dialog-cross-origin-nn
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-cross-origin-nn.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-cross-origin-nn.html
@@ -1,18 +1,28 @@
 <!doctype html>
 <meta name="timeout" content="long">
-<link rel="author" href="mailto:wpt@keithcirkel.co.uk" />
+<link rel="author" href="mailto:lwarlow@igalia.com" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
 <script src="/resources/testdriver-actions.js"></script>
 <script src="../resources/helpers.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
 
 <body>
-  <iframe id="iframe1" src="resources/dialog-prevents-close.html"></iframe>
-  <iframe id="iframe2" src="resources/dialog-prevents-close.html"></iframe>
+  <iframe id="iframe1"></iframe>
+  <iframe id="iframe2"></iframe>
 
   <script>
+    const host_info = get_host_info();
+
+    iframe1.src =
+        `${host_info.HTTP_REMOTE_ORIGIN}` +
+        `/close-watcher/iframes/resources/dialog-prevents-close.html`;
+    iframe2.src =
+        `${host_info.HTTP_REMOTE_ORIGIN}` +
+        `/close-watcher/iframes/resources/dialog-prevents-close.html`;
+
     function awaitEvent(el, type, signal) {
       return new Promise((resolve) =>
         el.addEventListener(type, resolve, { once: true, signal }),

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-cross-origin-ynn-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-cross-origin-ynn-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS dialog-cross-origin-ynn
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-cross-origin-ynn.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-cross-origin-ynn.html
@@ -1,18 +1,28 @@
 <!doctype html>
 <meta name="timeout" content="long">
-<link rel="author" href="mailto:wpt@keithcirkel.co.uk" />
+<link rel="author" href="mailto:lwarlow@igalia.com" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
 <script src="/resources/testdriver-actions.js"></script>
 <script src="../resources/helpers.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
 
 <body>
-  <iframe id="iframe1" src="resources/dialog-prevents-close.html"></iframe>
-  <iframe id="iframe2" src="resources/dialog-prevents-close.html"></iframe>
+  <iframe id="iframe1"></iframe>
+  <iframe id="iframe2"></iframe>
 
   <script>
+    const host_info = get_host_info();
+
+    iframe1.src =
+        `${host_info.HTTP_REMOTE_ORIGIN}` +
+        `/close-watcher/iframes/resources/dialog-prevents-close.html`;
+    iframe2.src =
+        `${host_info.HTTP_REMOTE_ORIGIN}` +
+        `/close-watcher/iframes/resources/dialog-prevents-close.html`;
+
     function awaitEvent(el, type, signal) {
       return new Promise((resolve) =>
         el.addEventListener(type, resolve, { once: true, signal }),
@@ -34,6 +44,8 @@
           awaitEvent(iframe1, "load", t.get_signal()),
           awaitEvent(iframe2, "load", t.get_signal()),
       ]);
+
+      await test_driver.bless();
 
       assert_true(await iframeDialogIsOpen(iframe1, t.get_signal()), "Dialog 1 is open");
       assert_true(await iframeDialogIsOpen(iframe2, t.get_signal()), "Dialog 2 is open");

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-cross-origin-ynyn-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-cross-origin-ynyn-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS dialog-cross-origin-ynyn
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-cross-origin-ynyn.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-cross-origin-ynyn.html
@@ -1,18 +1,28 @@
 <!doctype html>
 <meta name="timeout" content="long">
-<link rel="author" href="mailto:wpt@keithcirkel.co.uk" />
+<link rel="author" href="mailto:lwarlow@igalia.com" />
 <script src="/resources/testharness.js"></script>
 <script src="/resources/testharnessreport.js"></script>
 <script src="/resources/testdriver.js"></script>
 <script src="/resources/testdriver-vendor.js"></script>
 <script src="/resources/testdriver-actions.js"></script>
 <script src="../resources/helpers.js"></script>
+<script src="/common/get-host-info.sub.js"></script>
 
 <body>
-  <iframe id="iframe1" src="resources/dialog-prevents-close.html"></iframe>
-  <iframe id="iframe2" src="resources/dialog-prevents-close.html"></iframe>
+  <iframe id="iframe1"></iframe>
+  <iframe id="iframe2"></iframe>
 
   <script>
+    const host_info = get_host_info();
+
+    iframe1.src =
+        `${host_info.HTTP_REMOTE_ORIGIN}` +
+        `/close-watcher/iframes/resources/dialog-prevents-close.html`;
+    iframe2.src =
+        `${host_info.HTTP_REMOTE_ORIGIN}` +
+        `/close-watcher/iframes/resources/dialog-prevents-close.html`;
+
     function awaitEvent(el, type, signal) {
       return new Promise((resolve) =>
         el.addEventListener(type, resolve, { once: true, signal }),
@@ -35,6 +45,8 @@
           awaitEvent(iframe2, "load", t.get_signal()),
       ]);
 
+      await test_driver.bless();
+
       assert_true(await iframeDialogIsOpen(iframe1, t.get_signal()), "Dialog 1 is open");
       assert_true(await iframeDialogIsOpen(iframe2, t.get_signal()), "Dialog 2 is open");
 
@@ -42,6 +54,8 @@
 
       assert_false(await iframeDialogIsOpen(iframe1, t.get_signal()), "Dialog 1 is now closed");
       assert_true(await iframeDialogIsOpen(iframe2, t.get_signal()), "Dialog 2 is still open");
+
+      await test_driver.bless();
 
       await test_driver.send_keys(iframe2, "\uE00C");
 

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-same-origin-nn-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-same-origin-nn-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS dialog-same-origin-nn
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-same-origin-ynn-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-same-origin-ynn-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS dialog-same-origin-ynn
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-same-origin-ynn.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-same-origin-ynn.html
@@ -28,10 +28,14 @@
     }
 
     promise_test(async (t) => {
-      await awaitEvent(iframe1, "load", t.get_signal());
-      await awaitEvent(iframe2, "load", t.get_signal());
+      // The order the iframes load is inconsistent across engines,
+      // and not the subject of this test, so just await independent of ordering.
+      await Promise.all([
+          awaitEvent(iframe1, "load", t.get_signal()),
+          awaitEvent(iframe2, "load", t.get_signal()),
+      ]);
 
-      test_driver.bless();
+      await test_driver.bless();
 
       assert_true(await iframeDialogIsOpen(iframe1, t.get_signal()), "Dialog 1 is open");
       assert_true(await iframeDialogIsOpen(iframe2, t.get_signal()), "Dialog 2 is open");

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-same-origin-ynyn-expected.txt
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-same-origin-ynyn-expected.txt
@@ -1,0 +1,4 @@
+
+
+PASS dialog-same-origin-ynyn
+

--- a/LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-same-origin-ynyn.html
+++ b/LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-same-origin-ynyn.html
@@ -28,10 +28,14 @@
     }
 
     promise_test(async (t) => {
-      await awaitEvent(iframe1, "load", t.get_signal());
-      await awaitEvent(iframe2, "load", t.get_signal());
+      // The order the iframes load is inconsistent across engines,
+      // and not the subject of this test, so just await independent of ordering.
+      await Promise.all([
+          awaitEvent(iframe1, "load", t.get_signal()),
+          awaitEvent(iframe2, "load", t.get_signal()),
+      ]);
 
-      test_driver.bless();
+      await test_driver.bless();
 
       assert_true(await iframeDialogIsOpen(iframe1, t.get_signal()), "Dialog 1 is open");
       assert_true(await iframeDialogIsOpen(iframe2, t.get_signal()), "Dialog 2 is open");
@@ -46,7 +50,7 @@
       assert_false(await iframeDialogIsOpen(iframe1, t.get_signal()), "Dialog 1 is now closed");
       assert_true(await iframeDialogIsOpen(iframe2, t.get_signal()), "Dialog 2 is still open");
 
-      test_driver.bless();
+      await test_driver.bless();
 
       await test_driver.send_keys(iframe2, "\uE00C");
 

--- a/LayoutTests/platform/ios/TestExpectations
+++ b/LayoutTests/platform/ios/TestExpectations
@@ -4039,6 +4039,7 @@ imported/w3c/web-platform-tests/css/css-ui/compute-kind-widget-generated/kind-of
 # Close Watcher tests rely on sending escape keys from test_driver which doesn't work on iOS webkit.org/b/274832
 webkit.org/b/274832 imported/w3c/web-platform-tests/close-watcher/esc-key [ Skip ]
 webkit.org/b/274832 imported/w3c/web-platform-tests/close-watcher/user-activation [ Skip ]
+webkit.org/b/274832 imported/w3c/web-platform-tests/close-watcher/iframes [ Skip ]
 webkit.org/b/274832 imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-closedby-show-stacked.html [ Skip ]
 webkit.org/b/274832 imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-closedby-corner-cases.html [ Skip ]
 webkit.org/b/274832 imported/w3c/web-platform-tests/html/semantics/interactive-elements/the-dialog-element/dialog-closedby-start-open.html [ Skip ]

--- a/Source/WebCore/page/LocalDOMWindow.cpp
+++ b/Source/WebCore/page/LocalDOMWindow.cpp
@@ -1633,22 +1633,28 @@ std::optional<LocalDOMWindow::ClickEventData> LocalDOMWindow::consumeLastUserCli
     return std::exchange(m_lastUserClickEvent, std::nullopt);
 }
 
+static void updateActivationTimestampAndNotify(LocalDOMWindow& window, MonotonicTime activationTime, bool closeWatcherEnabled)
+{
+    window.setLastActivationTimestamp(activationTime);
+    if (closeWatcherEnabled)
+        window.closeWatcherManager().notifyAboutUserActivation();
+}
+
 // https://html.spec.whatwg.org/multipage/interaction.html#activation-notification
 void LocalDOMWindow::notifyActivated(MonotonicTime activationTime)
 {
-    setLastActivationTimestamp(activationTime);
     RefPtr frame = this->frame();
+    bool closeWatcherEnabled = frame && frame->settings().closeWatcherEnabled();
+    updateActivationTimestampAndNotify(*this, activationTime, closeWatcherEnabled);
     if (!frame)
         return;
-    if (frame->settings().closeWatcherEnabled())
-        closeWatcherManager().notifyAboutUserActivation();
 
-    for (auto* ancestor = frame->tree().parent(); ancestor; ancestor = ancestor->tree().parent()) {
-        auto* localAncestor = dynamicDowncast<LocalFrame>(ancestor);
+    for (RefPtr ancestor = frame->tree().parent(); ancestor; ancestor = ancestor->tree().parent()) {
+        RefPtr localAncestor = dynamicDowncast<LocalFrame>(ancestor);
         if (!localAncestor)
             continue;
-        if (auto* window = localAncestor->window())
-            window->setLastActivationTimestamp(activationTime);
+        if (RefPtr window = localAncestor->window())
+            updateActivationTimestampAndNotify(*window, activationTime, closeWatcherEnabled);
     }
 
     RefPtr securityOrigin = this->securityOrigin();
@@ -1668,7 +1674,7 @@ void LocalDOMWindow::notifyActivated(MonotonicTime activationTime)
         if (!descendantSecurityOrigin || !descendantSecurityOrigin->isSameOriginAs(*securityOrigin))
             continue;
 
-        descendantWindow->setLastActivationTimestamp(activationTime);
+        updateActivationTimestampAndNotify(*descendantWindow, activationTime, closeWatcherEnabled);
     }
 
     if (frame->settings().siteIsolationEnabled())


### PR DESCRIPTION
#### ac990c068174c5571cde09377edc09c53991320e
<pre>
CloseWatcherManagers inside iframes aren&apos;t notified about user activation
<a href="https://bugs.webkit.org/show_bug.cgi?id=315510">https://bugs.webkit.org/show_bug.cgi?id=315510</a>

Reviewed by Anne van Kesteren.

Per the HTML spec, user activation should propagate to the close watcher managers of child windows.
This updates notifyActivated to do this, mirroring how transient user activation is handled.

This can only really be tested via dialogs because CloseWatchers don&apos;t expose their &quot;open&quot; state,
and popovers cannot be prevented from closing.

The existing tests for dialog are also updated to fix issues that caused timeouts and flaky results.

* LayoutTests/TestExpectations:
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-cross-origin-nn-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-cross-origin-nn.html: Copied from LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-same-origin-ynn.html.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-cross-origin-ynn-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-cross-origin-ynn.html: Copied from LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-same-origin-ynn.html.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-cross-origin-ynyn-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-cross-origin-ynyn.html: Copied from LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-same-origin-ynn.html.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-same-origin-nn-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-same-origin-nn.html:
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-same-origin-ynn-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-same-origin-ynn.html:
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-same-origin-ynyn-expected.txt: Added.
* LayoutTests/imported/w3c/web-platform-tests/close-watcher/iframes/dialog-same-origin-ynyn.html:
* LayoutTests/platform/ios/TestExpectations:
* Source/WebCore/page/LocalDOMWindow.cpp:
(WebCore::updateActivationTimestampAndNotify):
(WebCore::LocalDOMWindow::notifyActivated):

Canonical link: <a href="https://commits.webkit.org/314884@main">https://commits.webkit.org/314884@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/6d9fd40c0cb8378c696845d4075d1218ecf5c9b6

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/167281 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/40776 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/34368 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/176330 "Built successfully") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/124962 "Build is in progress. Recent messages:") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/169147 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/41209 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/40789 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/130126 "Passed tests") | [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🧪 win-tests](https://ews-build.webkit.org/#/builders/59/builds/124962 "Build is in progress. Recent messages:") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/170240 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/32528 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/150301 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/110643 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/31511 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/30210 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/25069 "Built successfully") | 
| | [❌ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/141493 "Found 1 new API test failure: TestWebKitAPI.SiteIsolation.FindStringSelectionSameOriginFrameBeforeWrap (failure)") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/27994 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/178872 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/31770 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/29711 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/138513 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/40850 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/34365 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/138403 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/37316 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/41538 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/149788 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/104572 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/33653 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/26664 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/40042 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/113123 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/39439 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/4762 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/39689 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/39584 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->