### PR TITLE
Add missing CSSValue::addDerivedHash implementations to types that formerly were part of CSSPrimitiveValue

### DIFF
--- a/Source/WebCore/css/CSSCustomIdentValue.cpp
+++ b/Source/WebCore/css/CSSCustomIdentValue.cpp
@@ -28,6 +28,7 @@
 #include "CSSPrimitiveNumericTypes+CSSValueVisitation.h"
 #include "CSSPrimitiveNumericTypes+ComputedStyleDependencies.h"
 #include "CSSPrimitiveNumericTypes+Serialization.h"
+#include <wtf/Hasher.h>
 
 namespace WebCore {
 
@@ -55,6 +56,12 @@ bool CSSCustomIdentValue::equals(const CSSCustomIdentValue& other) const
 IterationStatus CSSCustomIdentValue::customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
 {
     return CSS::visitCSSValueChildren(func, m_customIdent);
+}
+
+bool CSSCustomIdentValue::addDerivedHash(Hasher& hasher) const
+{
+    add(hasher, m_customIdent);
+    return true;
 }
 
 String CSSCustomIdentValue::stringValue() const

--- a/Source/WebCore/css/CSSCustomIdentValue.h
+++ b/Source/WebCore/css/CSSCustomIdentValue.h
@@ -38,6 +38,7 @@ public:
     String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSCustomIdentValue&) const;
     IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>&) const;
+    bool NODELETE addDerivedHash(Hasher&) const;
 
     String stringValue() const;
 

--- a/Source/WebCore/css/CSSFontFamilyNameValue.cpp
+++ b/Source/WebCore/css/CSSFontFamilyNameValue.cpp
@@ -25,6 +25,8 @@
 #include "config.h"
 #include "CSSFontFamilyNameValue.h"
 
+#include <wtf/Hasher.h>
+
 namespace WebCore {
 
 Ref<CSSFontFamilyNameValue> CSSFontFamilyNameValue::create(CSS::FontFamilyName fontFamilyName)
@@ -51,6 +53,12 @@ bool CSSFontFamilyNameValue::equals(const CSSFontFamilyNameValue& other) const
 IterationStatus CSSFontFamilyNameValue::customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
 {
     return CSS::visitCSSValueChildren(func, m_fontFamilyName);
+}
+
+bool CSSFontFamilyNameValue::addDerivedHash(Hasher& hasher) const
+{
+    add(hasher, m_fontFamilyName);
+    return true;
 }
 
 String CSSFontFamilyNameValue::stringValue() const

--- a/Source/WebCore/css/CSSFontFamilyNameValue.h
+++ b/Source/WebCore/css/CSSFontFamilyNameValue.h
@@ -38,6 +38,7 @@ public:
     String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSFontFamilyNameValue&) const;
     IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>&) const;
+    bool NODELETE addDerivedHash(Hasher&) const;
 
     String stringValue() const;
 

--- a/Source/WebCore/css/CSSKeywordValue.cpp
+++ b/Source/WebCore/css/CSSKeywordValue.cpp
@@ -25,7 +25,7 @@
 #include "config.h"
 #include "CSSKeywordValue.h"
 
-#include "CSSValueKeywords.h"
+#include <wtf/Hasher.h>
 
 namespace WebCore {
 
@@ -55,6 +55,12 @@ bool CSSKeywordValue::equals(const CSSKeywordValue& other) const
 IterationStatus CSSKeywordValue::customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>& func) const
 {
     return CSS::visitCSSValueChildren(func, m_keyword);
+}
+
+bool CSSKeywordValue::addDerivedHash(Hasher& hasher) const
+{
+    add(hasher, m_keyword);
+    return true;
 }
 
 String CSSKeywordValue::stringValue() const

--- a/Source/WebCore/css/CSSKeywordValue.h
+++ b/Source/WebCore/css/CSSKeywordValue.h
@@ -41,6 +41,7 @@ public:
     String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSKeywordValue&) const;
     IterationStatus customVisitChildren(NOESCAPE const Function<IterationStatus(CSSValue&)>&) const;
+    bool NODELETE addDerivedHash(Hasher&) const;
 
     String stringValue() const;
 

--- a/Source/WebCore/css/CSSStringValue.cpp
+++ b/Source/WebCore/css/CSSStringValue.cpp
@@ -25,6 +25,8 @@
 #include "config.h"
 #include "CSSStringValue.h"
 
+#include <wtf/Hasher.h>
+
 namespace WebCore {
 
 Ref<CSSStringValue> CSSStringValue::create(CSS::String string)
@@ -51,6 +53,12 @@ bool CSSStringValue::equals(const CSSStringValue& other) const
 IterationStatus CSSStringValue::customVisitChildren(const Function<IterationStatus(CSSValue&)>& func) const
 {
     return CSS::visitCSSValueChildren(func, m_string);
+}
+
+bool CSSStringValue::addDerivedHash(Hasher& hasher) const
+{
+    add(hasher, m_string);
+    return true;
 }
 
 String CSSStringValue::stringValue() const

--- a/Source/WebCore/css/CSSStringValue.h
+++ b/Source/WebCore/css/CSSStringValue.h
@@ -38,6 +38,7 @@ public:
     String customCSSText(const CSS::SerializationContext&) const;
     bool equals(const CSSStringValue&) const;
     IterationStatus customVisitChildren(const Function<IterationStatus(CSSValue&)>&) const;
+    bool NODELETE addDerivedHash(Hasher&) const;
 
     String stringValue() const;
 


### PR DESCRIPTION
#### e3c460f943a83d5f57c5adb2326a437a3d98110d
<pre>
Add missing CSSValue::addDerivedHash implementations to types that formerly were part of CSSPrimitiveValue
<a href="https://bugs.webkit.org/show_bug.cgi?id=315514">https://bugs.webkit.org/show_bug.cgi?id=315514</a>

Reviewed by Antti Koivisto.

Implements `addDerivedHash` on ident and string-like CSSValue
subtypes that have been extracted from CSSPrimitiveValue by
hooking them up to the `add(Hasher&amp;, {type})` implementations
for their underlying strong type.

This hashing is used by ImmutableStyleProperties::createDeduplicating
to deduplicate style property lists.

* Source/WebCore/css/CSSCustomIdentValue.cpp:
* Source/WebCore/css/CSSCustomIdentValue.h:
* Source/WebCore/css/CSSFontFamilyNameValue.cpp:
* Source/WebCore/css/CSSFontFamilyNameValue.h:
* Source/WebCore/css/CSSKeywordValue.cpp:
* Source/WebCore/css/CSSKeywordValue.h:
* Source/WebCore/css/CSSStringValue.cpp:
* Source/WebCore/css/CSSStringValue.h:

Canonical link: <a href="https://commits.webkit.org/313858@main">https://commits.webkit.org/313858@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/a5038dab2c4a1824149a2ff30b7c525ba928639c

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164337 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37821 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31392 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173366 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121589 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166206 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38155 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37822 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127687 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89863 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167296 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/29982 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147717 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108232 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29029 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27652 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21130 "Built successfully") | 
| [![loading](https://user-images.githubusercontent.com/3098702/171232313-daa606f1-8fd6-4b0f-a20b-2cb93c43d19b.png) 🛠 🧪 jsc-x86-64](https://ews-build.webkit.org/#/builders/20/builds/156488 "Build is in progress. Recent messages:") | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/138931 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25433 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/175892 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28714 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27101 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/135999 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/37492 "Built successfully") | [❌ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31771 "Found 1 new test failure: http/tests/storage/storage-map-leaking.html (failure)") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/135968 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36630 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38278 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147228 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100653 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31278 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24084 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37088 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110132 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36484 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2141 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36734 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36634 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->