### PR TITLE
[WebXR Layers] Refactor startFrame/endFrame/recomputePose in composition layers

### DIFF
--- a/Source/WebCore/Headers.cmake
+++ b/Source/WebCore/Headers.cmake
@@ -815,6 +815,7 @@ set(WebCore_PRIVATE_FRAMEWORK_HEADERS
     Modules/webtransport/WorkerWebTransportSession.h
 
     Modules/webxr/XRCanvasConfiguration.h
+    Modules/webxr/XRCompositionLayerPose.h
     Modules/webxr/XRGPUProjectionLayerInit.h
     Modules/webxr/XRHitTestTrackableType.h
     Modules/webxr/XRLayerBacking.h

--- a/Source/WebCore/Modules/webxr/XRCompositionLayer.cpp
+++ b/Source/WebCore/Modules/webxr/XRCompositionLayer.cpp
@@ -28,8 +28,13 @@
 
 #if ENABLE(WEBXR_LAYERS)
 
+#include "Logging.h"
+#include "TransformationMatrix.h"
 #include "WebGLOpaqueTexture.h"
+#include "WebXRRigidTransform.h"
 #include "WebXRSession.h"
+#include "WebXRSpace.h"
+#include "XRCompositionLayerPose.h"
 #include "XRLayerBacking.h"
 #include <wtf/TZoneMallocInlines.h>
 
@@ -42,6 +47,16 @@ XRCompositionLayer::XRCompositionLayer(ScriptExecutionContext* scriptExecutionCo
     , m_backing(WTF::move(backing))
     , m_init(init)
     , m_session(session)
+{
+}
+
+XRCompositionLayer::XRCompositionLayer(ScriptExecutionContext* scriptExecutionContext, WebXRSession& session, Ref<XRLayerBacking>&& backing, const WebXRLayerInit& init, Ref<WebXRSpace> space, RefPtr<WebXRRigidTransform> transform)
+    : WebXRLayer(scriptExecutionContext)
+    , m_backing(WTF::move(backing))
+    , m_init(init)
+    , m_session(session)
+    , m_space(WTF::move(space))
+    , m_transform(transform ? WTF::move(transform) : RefPtr<WebXRRigidTransform> { WebXRRigidTransform::create() })
 {
 }
 
@@ -76,6 +91,102 @@ void XRCompositionLayer::fillInCommonDeviceLayerData(PlatformXR::DeviceLayer& da
 {
     data.blendTextureSourceAlpha = m_blendTextureSourceAlpha;
     data.forceMonoPresentation = m_forceMonoPresentation;
+}
+
+const WebXRSpace& XRCompositionLayer::space() const
+{
+    ASSERT(m_space);
+    return *m_space;
+}
+
+void XRCompositionLayer::setSpace(WebXRSpace& space)
+{
+    if (m_space == &space)
+        return;
+
+    m_space = space;
+    setNeedsRedraw(true);
+}
+
+const WebXRRigidTransform& XRCompositionLayer::transform() const
+{
+    ASSERT(m_transform);
+    return *m_transform;
+}
+
+void XRCompositionLayer::setTransform(WebXRRigidTransform& transform)
+{
+    if (m_transform == &transform)
+        return;
+
+    m_transform = transform;
+    setNeedsRedraw(true);
+}
+
+void XRCompositionLayer::startFrame(PlatformXR::FrameData& frameData)
+{
+#if PLATFORM(GTK) || PLATFORM(WPE)
+    auto it = frameData.layers.find(m_backing->handle());
+    if (it == frameData.layers.end())
+        return;
+
+    if (needsRedraw())
+        m_backing->startFrame(frameData);
+#else
+    UNUSED_PARAM(frameData);
+#endif
+}
+
+std::optional<PlatformXR::FrameData::Pose> computeXRCompositionLayerPose(const TransformationMatrix& spaceTransform, const TransformationMatrix* layerTransform)
+{
+    // nativeOrigin() returns the transform that maps from the layer's reference space into the session's local space.
+    auto transformInLocalSpace = layerTransform ? spaceTransform * *layerTransform : spaceTransform;
+    TransformationMatrix::Decomposed4Type decomposed;
+    if (!transformInLocalSpace.decompose4(decomposed))
+        return std::nullopt;
+
+    return PlatformXR::FrameData::Pose {
+        .position = { static_cast<float>(decomposed.translateX), static_cast<float>(decomposed.translateY), static_cast<float>(decomposed.translateZ) },
+        .orientation = { static_cast<float>(decomposed.quaternion.x), static_cast<float>(decomposed.quaternion.y), static_cast<float>(decomposed.quaternion.z), static_cast<float>(decomposed.quaternion.w) },
+    };
+}
+
+void XRCompositionLayer::recomputePose()
+{
+    std::optional<TransformationMatrix> spaceTransform;
+    if (m_space)
+        spaceTransform = m_space->nativeOrigin();
+    if (!spaceTransform)
+        spaceTransform = TransformationMatrix();
+
+    auto pose = computeXRCompositionLayerPose(*spaceTransform, m_transform ? &m_transform->rawTransform() : nullptr);
+    if (!pose) {
+        RELEASE_LOG_ERROR(XR, "Failed to decompose space transform, using identity transform for layer pose");
+        m_poseInLocalSpace = PlatformXR::FrameData::Pose { .position = { 0, 0, 0 }, .orientation = { 0, 0, 0, 1 } };
+        return;
+    }
+    m_poseInLocalSpace = *pose;
+}
+
+PlatformXR::DeviceLayer XRCompositionLayer::endFrame()
+{
+#if PLATFORM(GTK) || PLATFORM(WPE)
+    PlatformXR::DeviceLayer layerData;
+    if (needsRedraw())
+        m_backing->endFrame(layerData);
+
+    layerData.handle = m_backing->handle();
+    layerData.visible = true;
+
+    if (needsRedraw())
+        recomputePose();
+
+    fillInCommonDeviceLayerData(layerData);
+    fillInTypeSpecificDeviceLayerData(layerData);
+    return layerData;
+#else
+    return PlatformXR::DeviceLayer { };
+#endif
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webxr/XRCompositionLayer.h
+++ b/Source/WebCore/Modules/webxr/XRCompositionLayer.h
@@ -37,6 +37,7 @@
 namespace WebCore {
 
 class WebGLOpaqueTexture;
+class WebXRRigidTransform;
 class WebXRSession;
 class WebXRSpace;
 class XRLayerBacking;
@@ -88,16 +89,34 @@ public:
     const Vector<RefPtr<WebGLOpaqueTexture>>& depthStencilTextures() const { return m_depthStencilTextures; }
     void setDepthStencilTextures(Vector<RefPtr<WebGLOpaqueTexture>>&&);
 
+    const WebXRSpace& space() const;
+    void setSpace(WebXRSpace&);
+    const WebXRRigidTransform& transform() const;
+    void setTransform(WebXRRigidTransform&);
+
 protected:
-    explicit XRCompositionLayer(ScriptExecutionContext*, WebXRSession&, Ref<XRLayerBacking>&&, const WebXRLayerInit&);
+    // Used by XRProjectionLayer, which has no associated reference space or transform.
+    XRCompositionLayer(ScriptExecutionContext*, WebXRSession&, Ref<XRLayerBacking>&&, const WebXRLayerInit&);
+    // Used by non-projection composition layers.
+    XRCompositionLayer(ScriptExecutionContext*, WebXRSession&, Ref<XRLayerBacking>&&, const WebXRLayerInit&, Ref<WebXRSpace>, RefPtr<WebXRRigidTransform>);
 
     void fillInCommonDeviceLayerData(PlatformXR::DeviceLayer&) const;
+
+    void startFrame(PlatformXR::FrameData&) override;
+    PlatformXR::DeviceLayer endFrame() override;
+
+    // Composition layers fill in their specific data in their overrides.
+    virtual void fillInTypeSpecificDeviceLayerData(PlatformXR::DeviceLayer&) const { }
+
+    const PlatformXR::FrameData::Pose& poseInLocalSpace() const { return m_poseInLocalSpace; }
 
     const Ref<XRLayerBacking> m_backing;
     const WebXRLayerInit m_init;
 
 private:
     bool isXRCompositionLayer() const final { return true; }
+
+    void recomputePose();
 
     WeakPtr<WebXRSession> m_session;
 
@@ -109,6 +128,10 @@ private:
 
     Vector<RefPtr<WebGLOpaqueTexture>> m_colorTextures;
     Vector<RefPtr<WebGLOpaqueTexture>> m_depthStencilTextures;
+
+    RefPtr<WebXRSpace> m_space;
+    RefPtr<WebXRRigidTransform> m_transform;
+    PlatformXR::FrameData::Pose m_poseInLocalSpace;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webxr/XRCompositionLayerPose.h
+++ b/Source/WebCore/Modules/webxr/XRCompositionLayerPose.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2026 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#pragma once
+
+#if ENABLE(WEBXR_LAYERS)
+
+#include "PlatformXR.h"
+#include <optional>
+
+namespace WebCore {
+
+class TransformationMatrix;
+
+// Composes layerInLocal = spaceTransform * layerTransform and returns the composed translation+rotation, or std::nullopt in case of error.
+// Requires its own header (rather than as a static method on XRCompositionLayer) so the math can be unit tested without exposing way too many headers.
+WEBCORE_EXPORT std::optional<PlatformXR::FrameData::Pose> computeXRCompositionLayerPose(const TransformationMatrix& spaceTransform, const TransformationMatrix* layerTransform);
+
+} // namespace WebCore
+
+#endif // ENABLE(WEBXR_LAYERS)

--- a/Source/WebCore/Modules/webxr/XRCylinderLayer.cpp
+++ b/Source/WebCore/Modules/webxr/XRCylinderLayer.cpp
@@ -27,14 +27,9 @@
 #include "XRCylinderLayer.h"
 
 #if ENABLE(WEBXR_LAYERS)
-#include "EventTargetInlines.h"
-#include "Logging.h"
-#include "TransformationMatrix.h"
 #include "WebXRRigidTransform.h"
 #include "WebXRSession.h"
 #include "XRLayerBacking.h"
-#include "XRWebGLBinding.h"
-#include <wtf/Scope.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -42,9 +37,7 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(XRCylinderLayer);
 
 XRCylinderLayer::XRCylinderLayer(ScriptExecutionContext& scriptExecutionContext, WebXRSession& session, Ref<XRLayerBacking>&& backing, const XRCylinderLayerInit& init)
-    : XRCompositionLayer(&scriptExecutionContext, session, WTF::move(backing), init)
-    , m_space(init.space)
-    , m_transform((init.transform) ? init.transform : WebXRRigidTransform::create())
+    : XRCompositionLayer(&scriptExecutionContext, session, WTF::move(backing), init, init.space, init.transform)
 {
     // Explicitly call setters to add validation.
     setRadius(init.radius);
@@ -55,36 +48,6 @@ XRCylinderLayer::XRCylinderLayer(ScriptExecutionContext& scriptExecutionContext,
 }
 
 XRCylinderLayer::~XRCylinderLayer() = default;
-
-const WebXRSpace& XRCylinderLayer::space() const
-{
-    ASSERT(m_space);
-    return *m_space;
-}
-
-void XRCylinderLayer::setSpace(WebXRSpace& space)
-{
-    if (m_space == &space)
-        return;
-
-    m_space = space;
-    setNeedsRedraw(true);
-}
-
-const WebXRRigidTransform& XRCylinderLayer::transform() const
-{
-    ASSERT(m_transform);
-    return *m_transform;
-}
-
-void XRCylinderLayer::setTransform(WebXRRigidTransform& transform)
-{
-    if (m_transform == &transform)
-        return;
-
-    m_transform = transform;
-    setNeedsRedraw(true);
-}
 
 void XRCylinderLayer::setRadius(float radius)
 {
@@ -107,67 +70,17 @@ void XRCylinderLayer::setAspectRatio(float ratio)
     setNeedsRedraw(true);
 }
 
-void XRCylinderLayer::startFrame(PlatformXR::FrameData& frameData)
+void XRCylinderLayer::fillInTypeSpecificDeviceLayerData(PlatformXR::DeviceLayer& layerData) const
 {
 #if PLATFORM(GTK) || PLATFORM(WPE)
-    auto it = frameData.layers.find(m_backing->handle());
-    if (it == frameData.layers.end())
-        return;
-
-    if (needsRedraw())
-        m_backing->startFrame(frameData);
-#else
-    UNUSED_PARAM(frameData);
-#endif
-}
-
-void XRCylinderLayer::recomputePose()
-{
-    auto scopeExit = makeScopeExit([&]() {
-        RELEASE_LOG_ERROR(XR, "Failed to decompose space transform, using identity transform for layer pose");
-        m_poseInLocalSpace = PlatformXR::FrameData::Pose { .position = { 0, 0, 0 }, .orientation = { 0, 0, 0, 1 } };
-    });
-
-    std::optional<TransformationMatrix> spaceTransform;
-    if (m_space)
-        spaceTransform = m_space->nativeOrigin();
-    if (!spaceTransform)
-        spaceTransform = TransformationMatrix();
-
-    auto transformInLocalSpace = m_transform ? *spaceTransform * m_transform->rawTransform() : *spaceTransform;
-    TransformationMatrix::Decomposed4Type decomposed;
-    if (!transformInLocalSpace.decompose4(decomposed))
-        return;
-
-    scopeExit.release();
-    m_poseInLocalSpace.position = { static_cast<float>(decomposed.translateX), static_cast<float>(decomposed.translateY), static_cast<float>(decomposed.translateZ) };
-    m_poseInLocalSpace.orientation = { static_cast<float>(decomposed.quaternion.x), static_cast<float>(decomposed.quaternion.y), static_cast<float>(decomposed.quaternion.z), static_cast<float>(decomposed.quaternion.w) };
-}
-
-PlatformXR::DeviceLayer XRCylinderLayer::endFrame()
-{
-#if PLATFORM(GTK) || PLATFORM(WPE)
-    PlatformXR::DeviceLayer layerData;
-    if (needsRedraw())
-        m_backing->endFrame(layerData);
-
-    layerData.handle = m_backing->handle();
-    layerData.visible = true;
-
-    if (needsRedraw())
-        recomputePose();
-
-    fillInCommonDeviceLayerData(layerData);
-
     layerData.cylinderLayerData = {
         .radius = m_radius,
         .centralAngle = m_centralAngle,
         .aspectRatio = m_aspectRatio,
-        .poseInLocalSpace = m_poseInLocalSpace,
+        .poseInLocalSpace = poseInLocalSpace(),
     };
-    return layerData;
 #else
-    return PlatformXR::DeviceLayer { };
+    UNUSED_PARAM(layerData);
 #endif
 }
 

--- a/Source/WebCore/Modules/webxr/XRCylinderLayer.h
+++ b/Source/WebCore/Modules/webxr/XRCylinderLayer.h
@@ -31,13 +31,10 @@
 #include "XRCompositionLayer.h"
 #include "XRCylinderLayerInit.h"
 #include <wtf/Ref.h>
-#include <wtf/RefPtr.h>
 
 namespace WebCore {
 
-class WebXRRigidTransform;
 class WebXRSession;
-class WebXRSpace;
 class XRLayerBacking;
 
 // https://immersive-web.github.io/layers/#xrcylinderayertype
@@ -51,11 +48,6 @@ public:
 
     virtual ~XRCylinderLayer();
 
-    const WebXRSpace& space() const;
-    void setSpace(WebXRSpace&);
-    const WebXRRigidTransform& transform() const;
-    void setTransform(WebXRRigidTransform&);
-
     float radius() const { return m_radius; }
     void setRadius(float);
     float centralAngle() const { return m_centralAngle; }
@@ -66,18 +58,12 @@ public:
 private:
     XRCylinderLayer(ScriptExecutionContext&, WebXRSession&, Ref<XRLayerBacking>&&, const XRCylinderLayerInit&);
     bool isXRCylinderLayer() const final { return true; }
-    void recomputePose();
 
-    RefPtr<WebXRSpace> m_space;
-    RefPtr<WebXRRigidTransform> m_transform;
+    void fillInTypeSpecificDeviceLayerData(PlatformXR::DeviceLayer&) const final;
+
     float m_radius;
     float m_centralAngle;
     float m_aspectRatio;
-    PlatformXR::FrameData::Pose m_poseInLocalSpace;
-
-    // WebXRLayer.
-    void startFrame(PlatformXR::FrameData&) final;
-    PlatformXR::DeviceLayer endFrame() final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webxr/XREquirectLayer.cpp
+++ b/Source/WebCore/Modules/webxr/XREquirectLayer.cpp
@@ -25,17 +25,14 @@
 
 #include "config.h"
 #include "XREquirectLayer.h"
-#include <cmath>
 
 #if ENABLE(WEBXR_LAYERS)
 
-#include "Logging.h"
 #include "WebXRRigidTransform.h"
 #include "WebXRSession.h"
 #include "XRLayerBacking.h"
-#include "XRWebGLBinding.h"
+#include <numbers>
 #include <wtf/MathExtras.h>
-#include <wtf/Scope.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -43,9 +40,7 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(XREquirectLayer);
 
 XREquirectLayer::XREquirectLayer(ScriptExecutionContext& scriptExecutionContext, WebXRSession& session, Ref<XRLayerBacking>&& backing, const XREquirectLayerInit& init)
-    : XRCompositionLayer(&scriptExecutionContext, session, WTF::move(backing), init)
-    , m_space(init.space)
-    , m_transform((init.transform) ? init.transform : WebXRRigidTransform::create())
+    : XRCompositionLayer(&scriptExecutionContext, session, WTF::move(backing), init, init.space, init.transform)
 {
     // Explicitly call setters to add validation.
     setRadius(init.radius);
@@ -57,36 +52,6 @@ XREquirectLayer::XREquirectLayer(ScriptExecutionContext& scriptExecutionContext,
 }
 
 XREquirectLayer::~XREquirectLayer() = default;
-
-const WebXRSpace& XREquirectLayer::space() const
-{
-    ASSERT(m_space);
-    return *m_space;
-}
-
-void XREquirectLayer::setSpace(WebXRSpace& space)
-{
-    if (m_space == &space)
-        return;
-
-    m_space = space;
-    setNeedsRedraw(true);
-}
-
-const WebXRRigidTransform& XREquirectLayer::transform() const
-{
-    ASSERT(m_transform);
-    return *m_transform;
-}
-
-void XREquirectLayer::setTransform(WebXRRigidTransform& transform)
-{
-    if (m_transform == &transform)
-        return;
-
-    m_transform = transform;
-    setNeedsRedraw(true);
-}
 
 void XREquirectLayer::setRadius(float radius)
 {
@@ -113,68 +78,18 @@ void XREquirectLayer::setLowerVerticalAngle(float angle)
     setNeedsRedraw(true);
 }
 
-void XREquirectLayer::startFrame(PlatformXR::FrameData& frameData)
+void XREquirectLayer::fillInTypeSpecificDeviceLayerData(PlatformXR::DeviceLayer& layerData) const
 {
 #if PLATFORM(GTK) || PLATFORM(WPE)
-    auto it = frameData.layers.find(m_backing->handle());
-    if (it == frameData.layers.end())
-        return;
-
-    if (needsRedraw())
-        m_backing->startFrame(frameData);
-#else
-    UNUSED_PARAM(frameData);
-#endif
-}
-
-void XREquirectLayer::recomputePose()
-{
-    auto scopeExit = makeScopeExit([&]() {
-        RELEASE_LOG_ERROR(XR, "Failed to decompose space transform, using identity transform for layer pose");
-        m_poseInLocalSpace = PlatformXR::FrameData::Pose { .position = { 0, 0, 0 }, .orientation = { 0, 0, 0, 1 } };
-    });
-
-    std::optional<TransformationMatrix> spaceTransform;
-    if (m_space)
-        spaceTransform = m_space->nativeOrigin();
-    if (!spaceTransform)
-        spaceTransform = TransformationMatrix();
-
-    auto transformInLocalSpace = m_transform ? *spaceTransform * m_transform->rawTransform() : *spaceTransform;
-    TransformationMatrix::Decomposed4Type decomposed;
-    if (!transformInLocalSpace.decompose4(decomposed))
-        return;
-
-    scopeExit.release();
-    m_poseInLocalSpace.position = { static_cast<float>(decomposed.translateX), static_cast<float>(decomposed.translateY), static_cast<float>(decomposed.translateZ) };
-    m_poseInLocalSpace.orientation = { static_cast<float>(decomposed.quaternion.x), static_cast<float>(decomposed.quaternion.y), static_cast<float>(decomposed.quaternion.z), static_cast<float>(decomposed.quaternion.w) };
-}
-
-PlatformXR::DeviceLayer XREquirectLayer::endFrame()
-{
-#if PLATFORM(GTK) || PLATFORM(WPE)
-    PlatformXR::DeviceLayer layerData;
-    if (needsRedraw())
-        m_backing->endFrame(layerData);
-
-    layerData.handle = m_backing->handle();
-    layerData.visible = true;
-
-    if (needsRedraw())
-        recomputePose();
-
-    fillInCommonDeviceLayerData(layerData);
-
     layerData.equirectLayerData = {
         .radius = m_radius,
         .centralHorizontalAngle = m_centralHorizontalAngle,
         .upperVerticalAngle = m_upperVerticalAngle,
         .lowerVerticalAngle = m_lowerVerticalAngle,
-        .poseInLocalSpace = m_poseInLocalSpace,
+        .poseInLocalSpace = poseInLocalSpace(),
     };
-    return layerData;
 #else
-    return PlatformXR::DeviceLayer { };
+    UNUSED_PARAM(layerData);
 #endif
 }
 

--- a/Source/WebCore/Modules/webxr/XREquirectLayer.h
+++ b/Source/WebCore/Modules/webxr/XREquirectLayer.h
@@ -31,13 +31,10 @@
 #include "XRCompositionLayer.h"
 #include "XREquirectLayerInit.h"
 #include <wtf/Ref.h>
-#include <wtf/RefPtr.h>
 
 namespace WebCore {
 
-class WebXRRigidTransform;
 class WebXRSession;
-class WebXRSpace;
 class XRLayerBacking;
 
 // https://immersive-web.github.io/layers/#xrequirectlayertype
@@ -51,11 +48,6 @@ public:
 
     virtual ~XREquirectLayer();
 
-    const WebXRSpace& space() const;
-    void setSpace(WebXRSpace&);
-    const WebXRRigidTransform& transform() const;
-    void setTransform(WebXRRigidTransform&);
-
     float radius() const { return m_radius; }
     void setRadius(float);
     float centralHorizontalAngle() const { return m_centralHorizontalAngle; }
@@ -68,19 +60,13 @@ public:
 private:
     XREquirectLayer(ScriptExecutionContext&, WebXRSession&, Ref<XRLayerBacking>&&, const XREquirectLayerInit&);
     bool isXREquirectLayer() const final { return true; }
-    void recomputePose();
 
-    RefPtr<WebXRSpace> m_space;
-    RefPtr<WebXRRigidTransform> m_transform;
+    void fillInTypeSpecificDeviceLayerData(PlatformXR::DeviceLayer&) const final;
+
     float m_radius;
     float m_centralHorizontalAngle;
     float m_upperVerticalAngle;
     float m_lowerVerticalAngle;
-    PlatformXR::FrameData::Pose m_poseInLocalSpace;
-
-    // WebXRLayer.
-    void startFrame(PlatformXR::FrameData&) final;
-    PlatformXR::DeviceLayer endFrame() final;
 };
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webxr/XRProjectionLayer.cpp
+++ b/Source/WebCore/Modules/webxr/XRProjectionLayer.cpp
@@ -167,12 +167,12 @@ void XRProjectionLayer::setFixedFoveation(std::optional<float>)
 
 WebXRRigidTransform* XRProjectionLayer::deltaPose() const
 {
-    return m_transform.get();
+    return m_deltaPose.get();
 }
 
 void XRProjectionLayer::setDeltaPose(WebXRRigidTransform* deltaPose)
 {
-    m_transform = deltaPose;
+    m_deltaPose = deltaPose;
 }
 
 } // namespace WebCore

--- a/Source/WebCore/Modules/webxr/XRProjectionLayer.h
+++ b/Source/WebCore/Modules/webxr/XRProjectionLayer.h
@@ -80,7 +80,7 @@ private:
 #if ENABLE(WEBGPU)
     std::optional<PlatformXR::FrameData::LayerData> m_layerData;
 #endif
-    RefPtr<WebXRRigidTransform> m_transform;
+    RefPtr<WebXRRigidTransform> m_deltaPose;
     Vector<IntRect> m_viewports;
 };
 

--- a/Source/WebCore/Modules/webxr/XRQuadLayer.cpp
+++ b/Source/WebCore/Modules/webxr/XRQuadLayer.cpp
@@ -28,12 +28,9 @@
 
 #if ENABLE(WEBXR_LAYERS)
 
-#include "Logging.h"
 #include "WebXRRigidTransform.h"
 #include "WebXRSession.h"
 #include "XRLayerBacking.h"
-#include "XRWebGLBinding.h"
-#include <wtf/Scope.h>
 #include <wtf/TZoneMallocInlines.h>
 
 namespace WebCore {
@@ -41,9 +38,7 @@ namespace WebCore {
 WTF_MAKE_TZONE_ALLOCATED_IMPL(XRQuadLayer);
 
 XRQuadLayer::XRQuadLayer(ScriptExecutionContext& scriptExecutionContext, WebXRSession& session, Ref<XRLayerBacking>&& backing, const XRQuadLayerInit& init)
-    : XRCompositionLayer(&scriptExecutionContext, session, WTF::move(backing), init)
-    , m_space(init.space)
-    , m_transform((init.transform) ? init.transform : WebXRRigidTransform::create())
+    : XRCompositionLayer(&scriptExecutionContext, session, WTF::move(backing), init, init.space, init.transform)
     , m_worldSize(FloatSize { init.width, init.height })
 {
     setIsStatic(init.isStatic);
@@ -51,95 +46,15 @@ XRQuadLayer::XRQuadLayer(ScriptExecutionContext& scriptExecutionContext, WebXRSe
 
 XRQuadLayer::~XRQuadLayer() = default;
 
-const WebXRSpace& XRQuadLayer::space() const
-{
-    ASSERT(m_space);
-    return *m_space;
-}
-
-void XRQuadLayer::setSpace(WebXRSpace& space)
-{
-    if (m_space == &space)
-        return;
-
-    m_space = space;
-    setNeedsRedraw(true);
-}
-
-const WebXRRigidTransform& XRQuadLayer::transform() const
-{
-    ASSERT(m_transform);
-    return *m_transform;
-}
-
-void XRQuadLayer::setTransform(WebXRRigidTransform& transform)
-{
-    if (m_transform == &transform)
-        return;
-
-    m_transform = transform;
-    setNeedsRedraw(true);
-}
-
-void XRQuadLayer::startFrame(PlatformXR::FrameData& frameData)
+void XRQuadLayer::fillInTypeSpecificDeviceLayerData(PlatformXR::DeviceLayer& layerData) const
 {
 #if PLATFORM(GTK) || PLATFORM(WPE)
-    auto it = frameData.layers.find(m_backing->handle());
-    if (it == frameData.layers.end())
-        return;
-
-    if (needsRedraw())
-        m_backing->startFrame(frameData);
-#else
-    UNUSED_PARAM(frameData);
-#endif
-}
-
-void XRQuadLayer::recomputePose()
-{
-    auto scopeExit = makeScopeExit([&]() {
-        RELEASE_LOG_ERROR(XR, "Failed to decompose space transform, using identity transform for layer pose");
-        m_poseInLocalSpace = PlatformXR::FrameData::Pose { .position = { 0, 0, 0 }, .orientation = { 0, 0, 0, 1 } };
-    });
-
-    std::optional<TransformationMatrix> spaceTransform;
-    if (m_space)
-        spaceTransform = m_space->nativeOrigin();
-    if (!spaceTransform)
-        spaceTransform = TransformationMatrix();
-
-    auto transformInLocalSpace = m_transform ? *spaceTransform * m_transform->rawTransform() : *spaceTransform;
-    TransformationMatrix::Decomposed4Type decomposed;
-    if (!transformInLocalSpace.decompose4(decomposed))
-        return;
-
-    scopeExit.release();
-    m_poseInLocalSpace.position = { static_cast<float>(decomposed.translateX), static_cast<float>(decomposed.translateY), static_cast<float>(decomposed.translateZ) };
-    m_poseInLocalSpace.orientation = { static_cast<float>(decomposed.quaternion.x), static_cast<float>(decomposed.quaternion.y), static_cast<float>(decomposed.quaternion.z), static_cast<float>(decomposed.quaternion.w) };
-}
-
-PlatformXR::DeviceLayer XRQuadLayer::endFrame()
-{
-#if PLATFORM(GTK) || PLATFORM(WPE)
-    PlatformXR::DeviceLayer layerData;
-    if (needsRedraw())
-        m_backing->endFrame(layerData);
-
-    layerData.handle = m_backing->handle();
-    layerData.visible = true;
-
-    if (needsRedraw())
-        recomputePose();
-
-    fillInCommonDeviceLayerData(layerData);
-
     layerData.quadLayerData = {
         .worldSize = m_worldSize,
-        .poseInLocalSpace = m_poseInLocalSpace,
+        .poseInLocalSpace = poseInLocalSpace(),
     };
-    return layerData;
 #else
-    return PlatformXR::DeviceLayer { };
+    UNUSED_PARAM(layerData);
 #endif
 }
 

--- a/Source/WebCore/Modules/webxr/XRQuadLayer.h
+++ b/Source/WebCore/Modules/webxr/XRQuadLayer.h
@@ -32,13 +32,10 @@
 #include "XRCompositionLayer.h"
 #include "XRQuadLayerInit.h"
 #include <wtf/Ref.h>
-#include <wtf/RefPtr.h>
 
 namespace WebCore {
 
-class WebXRRigidTransform;
 class WebXRSession;
-class WebXRSpace;
 class XRLayerBacking;
 
 // https://immersive-web.github.io/layers/#xrquadlayertype
@@ -51,11 +48,6 @@ public:
     }
     virtual ~XRQuadLayer();
 
-    const WebXRSpace& space() const;
-    void setSpace(WebXRSpace&);
-    const WebXRRigidTransform& transform() const;
-    void setTransform(WebXRRigidTransform&);
-
     float width() const { return m_worldSize.width(); }
     void setWidth(float width) { m_worldSize.setWidth(width); }
     float height() const { return m_worldSize.height(); }
@@ -64,16 +56,10 @@ public:
 private:
     XRQuadLayer(ScriptExecutionContext&, WebXRSession&, Ref<XRLayerBacking>&&, const XRQuadLayerInit&);
     bool isXRQuadLayer() const final { return true; }
-    void recomputePose();
 
-    RefPtr<WebXRSpace> m_space;
-    RefPtr<WebXRRigidTransform> m_transform;
+    void fillInTypeSpecificDeviceLayerData(PlatformXR::DeviceLayer&) const final;
+
     FloatSize m_worldSize;
-    PlatformXR::FrameData::Pose m_poseInLocalSpace;
-
-    // WebXRLayer.
-    void startFrame(PlatformXR::FrameData&) final;
-    PlatformXR::DeviceLayer endFrame() final;
 };
 
 } // namespace WebCore

--- a/Tools/TestWebKitAPI/CMakeLists.txt
+++ b/Tools/TestWebKitAPI/CMakeLists.txt
@@ -252,6 +252,7 @@ if (ENABLE_WEBCORE)
         Tests/WebCore/TransformationMatrix.cpp
         Tests/WebCore/URLParserTextEncoding.cpp
         Tests/WebCore/WritingModeTests.cpp
+        Tests/WebCore/XRCompositionLayer.cpp
     )
 
     if (USE_SKIA)

--- a/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
+++ b/Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
@@ -779,6 +779,7 @@
 				WebCore/U2fCommandConstructorTest.cpp,
 				WebCore/URLParserTextEncoding.cpp,
 				WebCore/WritingModeTests.cpp,
+				WebCore/XRCompositionLayer.cpp,
 				WebCore/YouTubePluginReplacement.cpp,
 				WebKit/WKPage/AboutBlankLoad.cpp,
 				WebKit/WKPage/CanHandleRequest.cpp,

--- a/Tools/TestWebKitAPI/Tests/WebCore/XRCompositionLayer.cpp
+++ b/Tools/TestWebKitAPI/Tests/WebCore/XRCompositionLayer.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2026 Igalia S.L. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in the
+ *    documentation and/or other materials provided with the distribution.
+ *
+ * THIS SOFTWARE IS PROVIDED BY APPLE INC. AND ITS CONTRIBUTORS ``AS IS''
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+ * THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+ * PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL APPLE INC. OR ITS CONTRIBUTORS
+ * BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+ * THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "config.h"
+
+#if ENABLE(WEBXR_LAYERS)
+
+#include <WebCore/TransformationMatrix.h>
+#include <WebCore/XRCompositionLayerPose.h>
+
+namespace TestWebKitAPI {
+
+// A 'local-floor' reference space's nativeOrigin places the floor at y = -height in local space, matching the default WebXRReferenceSpace::floorOriginTransform() fallback.
+static constexpr double DefaultUserHeight = 1.7;
+
+TEST(XRCompositionLayer, LocalFloorSpaceTranslatesLayerToFloor)
+{
+    // Regression guard for https://bugs.webkit.org/show_bug.cgi?id=314634, a layer placed at the origin of a 'local-floor' reference space
+    // must land at y = -DefaultUserHeight in local space.
+    WebCore::TransformationMatrix floorOrigin;
+    floorOrigin.translate3d(0.0, -DefaultUserHeight, 0.0);
+
+    auto pose = WebCore::computeXRCompositionLayerPose(floorOrigin, nullptr);
+    ASSERT_TRUE(pose.has_value());
+    EXPECT_FLOAT_EQ(0.0f, pose->position.x());
+    EXPECT_FLOAT_EQ(static_cast<float>(-DefaultUserHeight), pose->position.y());
+    EXPECT_FLOAT_EQ(0.0f, pose->position.z());
+}
+
+TEST(XRCompositionLayer, ComposesSpaceAndLayerTranslationsInTheRightOrder)
+{
+    // A floor-anchored space combined with a layer one meter above the floor should land at y = -DefaultUserHeight + 1, not at -DefaultUserHeight - 1.
+    // This would catch a multiply-order bug independently from the sign-flip above.
+    WebCore::TransformationMatrix floorOrigin;
+    floorOrigin.translate3d(0.0, -DefaultUserHeight, 0.0);
+
+    WebCore::TransformationMatrix oneMeterHeight;
+    oneMeterHeight.translate3d(0.0, 1.0, 0.0);
+
+    auto pose = WebCore::computeXRCompositionLayerPose(floorOrigin, &oneMeterHeight);
+    ASSERT_TRUE(pose.has_value());
+    EXPECT_FLOAT_EQ(static_cast<float>(-DefaultUserHeight + 1.0), pose->position.y());
+}
+
+} // namespace TestWebKitAPI
+
+#endif // ENABLE(WEBXR_LAYERS)


### PR DESCRIPTION
#### fbd06f9be9076f8c623add8448271c98ef6076ec
<pre>
[WebXR Layers] Refactor startFrame/endFrame/recomputePose in composition layers
<a href="https://bugs.webkit.org/show_bug.cgi?id=315511">https://bugs.webkit.org/show_bug.cgi?id=315511</a>

Reviewed by Dan Glastonbury.

XRQuadLayer, XRCylinderLayer and XREquirectLayer were carrying three
near identical copies of:
  * m_space / m_transform / m_poseInLocalSpace members and accessors
  * startFrame()/endFrame()/recomputePose() implementations

This was already a maintenance hazard (the recent b9704aae@main for the
recomputePose() sign error had to be triplicated) and would have kept
diverging as new shared behavior was added.

Move all of the above to XRCompositionLayer. The members mentioned above
became base members and the accessors were moved there too.
  * startFrame() and endFrame() are concrete on the base (still
    declared override, not final, because XRProjectionLayer has its
    own implementation).
  * endFrame() calls a new virtual method after computing the common
    DeviceLayer fields and recomputing the pose. Quad/Cylinder/Equirect
    override this hook to assign their respective LayerData field on
    the DeviceLayer. The base method has an empty default so
    XRProjectionLayer does not have to provide a stub.

Each subclass now keeps only its own type-specific properties (size
for Quad, radius/centralAngle/aspectRatio for Cylinder, etc.) and the
override for the new method. Apart from that XRProjectionLayer&apos;s private
m_transform was renamed to m_deltaPose to match its meaning and avoid
shadowing XRCompositionLayer::m_transform.

No behavior change and we save ~150 lines of code.

Added a new unit test that would detect regressions in the code fixed by
the aforementioned b9704aae@main. This unit test requires a new class
in order not to export way too many headers just for testing purposes.

Tests: Tools/TestWebKitAPI/CMakeLists.txt
       Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj
       Tools/TestWebKitAPI/Tests/WebCore/XRCompositionLayer.cpp

* Source/WebCore/Headers.cmake:
* Source/WebCore/Modules/webxr/XRCompositionLayer.cpp:
(WebCore::XRCompositionLayer::XRCompositionLayer):
(WebCore::XRCompositionLayer::space const):
(WebCore::XRCompositionLayer::setSpace):
(WebCore::XRCompositionLayer::transform const):
(WebCore::XRCompositionLayer::setTransform):
(WebCore::XRCompositionLayer::startFrame):
(WebCore::computeXRCompositionLayerPose):
(WebCore::XRCompositionLayer::recomputePose):
(WebCore::XRCompositionLayer::endFrame):
* Source/WebCore/Modules/webxr/XRCompositionLayer.h:
(WebCore::XRCompositionLayer::fillInTypeSpecificDeviceLayerData const):
(WebCore::XRCompositionLayer::poseInLocalSpace const):
* Source/WebCore/Modules/webxr/XRCompositionLayerPose.h: Added.
* Source/WebCore/Modules/webxr/XRCylinderLayer.cpp:
(WebCore::XRCylinderLayer::XRCylinderLayer):
(WebCore::XRCylinderLayer::fillInTypeSpecificDeviceLayerData const):
(WebCore::XRCylinderLayer::space const): Deleted.
(WebCore::XRCylinderLayer::setSpace): Deleted.
(WebCore::XRCylinderLayer::transform const): Deleted.
(WebCore::XRCylinderLayer::setTransform): Deleted.
(WebCore::XRCylinderLayer::startFrame): Deleted.
(WebCore::XRCylinderLayer::recomputePose): Deleted.
(WebCore::XRCylinderLayer::endFrame): Deleted.
* Source/WebCore/Modules/webxr/XRCylinderLayer.h:
* Source/WebCore/Modules/webxr/XREquirectLayer.cpp:
(WebCore::XREquirectLayer::XREquirectLayer):
(WebCore::XREquirectLayer::fillInTypeSpecificDeviceLayerData const):
(WebCore::XREquirectLayer::space const): Deleted.
(WebCore::XREquirectLayer::setSpace): Deleted.
(WebCore::XREquirectLayer::transform const): Deleted.
(WebCore::XREquirectLayer::setTransform): Deleted.
(WebCore::XREquirectLayer::startFrame): Deleted.
(WebCore::XREquirectLayer::recomputePose): Deleted.
(WebCore::XREquirectLayer::endFrame): Deleted.
* Source/WebCore/Modules/webxr/XREquirectLayer.h:
* Source/WebCore/Modules/webxr/XRProjectionLayer.cpp:
(WebCore::XRProjectionLayer::deltaPose const):
(WebCore::XRProjectionLayer::setDeltaPose):
* Source/WebCore/Modules/webxr/XRProjectionLayer.h:
* Source/WebCore/Modules/webxr/XRQuadLayer.cpp:
(WebCore::XRQuadLayer::XRQuadLayer):
(WebCore::XRQuadLayer::fillInTypeSpecificDeviceLayerData const):
(WebCore::XRQuadLayer::space const): Deleted.
(WebCore::XRQuadLayer::setSpace): Deleted.
(WebCore::XRQuadLayer::transform const): Deleted.
(WebCore::XRQuadLayer::setTransform): Deleted.
(WebCore::XRQuadLayer::startFrame): Deleted.
(WebCore::XRQuadLayer::recomputePose): Deleted.
(WebCore::XRQuadLayer::endFrame): Deleted.
* Source/WebCore/Modules/webxr/XRQuadLayer.h:
* Source/WebCore/WebCore.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/CMakeLists.txt:
* Tools/TestWebKitAPI/TestWebKitAPI.xcodeproj/project.pbxproj:
* Tools/TestWebKitAPI/Tests/WebCore/XRCompositionLayer.cpp: Added.
(TestWebKitAPI::TEST(XRCompositionLayer, LocalFloorSpaceTranslatesLayerToFloor)):
(TestWebKitAPI::TEST(XRCompositionLayer, ComposesSpaceAndLayerTranslationsInTheRightOrder)):

Canonical link: <a href="https://commits.webkit.org/314348@main">https://commits.webkit.org/314348@main</a>
</pre>
<!--EWS-Status-Bubble-Start-->
https://github.com/WebKit/WebKit/commit/0d7a1d49d48537b6dbc92ef1b72685d32252bdac

| Misc | iOS, visionOS, tvOS & watchOS  | macOS  | Linux |  Windows |
| ----- | ---------------------- | ------- |  ----- |  --------- |
| [✅ 🧪 style](https://ews-build.webkit.org/#/builders/38/builds/164483 "Passed style check") | [✅ 🛠 ios](https://ews-build.webkit.org/#/builders/159/builds/37967 "Built successfully") | [✅ 🛠 mac](https://ews-build.webkit.org/#/builders/168/builds/31538 "Built successfully") | [✅ 🛠 wpe](https://ews-build.webkit.org/#/builders/5/builds/173513 "Built successfully") | [✅ 🛠 win](https://ews-build.webkit.org/#/builders/59/builds/121735 "Built successfully") 
| [✅ 🧪 bindings](https://ews-build.webkit.org/#/builders/9/builds/166352 "Passed tests") | [✅ 🛠 ios-sim](https://ews-build.webkit.org/#/builders/155/builds/38301 "Built successfully") | [✅ 🛠 mac-AS-debug](https://ews-build.webkit.org/#/builders/156/builds/37969 "Built successfully") | [✅ 🧪 wpe-wk2](https://ews-build.webkit.org/#/builders/34/builds/127805 "Passed tests") | [❌ 🧪 win-tests](https://ews-build.webkit.org/#/builders/60/builds/89968 "layout-tests (failure)") 
| [✅ 🧪 webkitperl](https://ews-build.webkit.org/#/builders/11/builds/167442 "Passed tests") | [✅ 🧪 ios-wk2](https://ews-build.webkit.org/#/builders/162/builds/30106 "Passed tests") | [✅ 🧪 api-mac](https://ews-build.webkit.org/#/builders/18/builds/147843 "Passed tests") | [✅ 🧪 api-wpe](https://ews-build.webkit.org/#/builders/41/builds/108350 "Passed tests") | 
| | [✅ 🧪 ios-wk2-wpt](https://ews-build.webkit.org/#/builders/154/builds/29153 "Passed tests") | [✅ 🧪 api-mac-debug](https://ews-build.webkit.org/#/builders/165/builds/27779 "Passed tests") | [✅ 🛠 gtk3-libwebrtc](https://ews-build.webkit.org/#/builders/173/builds/21276 "Built successfully") | 
| | [✅ 🧪 api-ios](https://ews-build.webkit.org/#/builders/13/builds/139055 "Passed tests") | [✅ 🧪 mac-wk1](https://ews-build.webkit.org/#/builders/167/builds/25559 "Passed tests") | [✅ 🛠 gtk](https://ews-build.webkit.org/#/builders/2/builds/176039 "Built successfully") | 
| | [✅ 🛠 ios-safer-cpp](https://ews-build.webkit.org/#/builders/174/builds/28862 "Built successfully") | [✅ 🧪 mac-wk2](https://ews-build.webkit.org/#/builders/169/builds/27227 "Passed tests") | [✅ 🧪 gtk-wk2](https://ews-build.webkit.org/#/builders/1/builds/136122 "Passed tests") | 
| | [✅ 🛠 vision](https://ews-build.webkit.org/#/builders/153/builds/38036 "Built successfully") | [✅ 🧪 mac-AS-debug-wk2](https://ews-build.webkit.org/#/builders/161/builds/31901 "Passed tests") | [✅ 🧪 api-gtk](https://ews-build.webkit.org/#/builders/21/builds/136087 "Passed tests") | 
| [✅ 🛠 🧪 merge](https://ews-build.webkit.org/#/builders/19/builds/36959 "Built successfully and passed tests") | [✅ 🛠 vision-sim](https://ews-build.webkit.org/#/builders/160/builds/38726 "Built successfully") | [✅ 🧪 mac-wk2-stress](https://ews-build.webkit.org/#/builders/8/builds/147354 "Passed tests") | [✅ 🛠 playstation](https://ews-build.webkit.org/#/builders/134/builds/100875 "Built successfully") | 
| | [✅ 🧪 vision-wk2](https://ews-build.webkit.org/#/builders/164/builds/31377 "Passed tests") | [✅ 🧪 mac-intel-wk2](https://ews-build.webkit.org/#/builders/170/builds/24210 "Passed tests") | | 
| | [✅ 🛠 tv](https://ews-build.webkit.org/#/builders/158/builds/37234 "Built successfully") | [✅ 🛠 mac-safer-cpp](https://ews-build.webkit.org/#/builders/120/builds/110278 "Built successfully") | | 
| | [✅ 🛠 tv-sim](https://ews-build.webkit.org/#/builders/157/builds/36632 "Built successfully") | [✅ 🧪 mac-site-isolation](https://ews-build.webkit.org/#/builders/185/builds/2271 "Passed tests") | | 
| | [✅ 🛠 watch](https://ews-build.webkit.org/#/builders/163/builds/36880 "Built successfully") | | | 
| | [✅ 🛠 watch-sim](https://ews-build.webkit.org/#/builders/152/builds/36780 "Built successfully") | | | 
<!--EWS-Status-Bubble-End-->